### PR TITLE
Themes: Removed unused theme-options from install-theme-button.jsx

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  */
 
 import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
-import { connectOptions } from './theme-options';
 import { translate } from 'i18n-calypso';
 import { trackClick } from './helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -36,28 +35,33 @@ function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 	return `/themes/upload/${ siteSlug }`;
 }
 
-const InstallThemeButton = connectOptions(
-	( { isMultisite, isLoggedIn, siteSlug, dispatchTracksEvent, canUploadThemesOrPlugins } ) => {
-		if ( ! isLoggedIn || isMultisite ) {
-			return null;
-		}
-
-		const clickHandler = () => {
-			trackClick( 'upload theme' );
-			dispatchTracksEvent();
-		};
-
-		return (
-			<Button
-				className="themes__upload-button"
-				onClick={ clickHandler }
-				href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
-			>
-				{ translate( 'Install theme' ) }
-			</Button>
-		);
+const InstallThemeButton = ( props ) => {
+	const {
+		isMultisite,
+		isLoggedIn,
+		siteSlug,
+		dispatchTracksEvent,
+		canUploadThemesOrPlugins,
+	} = props;
+	if ( ! isLoggedIn || isMultisite ) {
+		return null;
 	}
-);
+
+	const clickHandler = () => {
+		trackClick( 'upload theme' );
+		dispatchTracksEvent();
+	};
+
+	return (
+		<Button
+			className="themes__upload-button"
+			onClick={ clickHandler }
+			href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
+		>
+			{ translate( 'Install theme' ) }
+		</Button>
+	);
+};
 
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [Install themes button](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/themes/install-theme-button.jsx) used to be connected to [theme options](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/themes/theme-options.js). This connection was made by mistake and isn't needed, since the theme options props aren't used in the component.

Theme-options props:

- defaultOption
- getScreenshotOption
- options
- secondaryOption

#### Testing instructions

Previously existing behavior from trunk for install theme button should be maintained, for example:
- For any view which used to have an install theme button on trunk, it should still be there on my branch.
- For any view which did NOT used to have an install theme button on trunk, it should NOT be there on my branch.
- Just as it works on trunk, when a site is selected, install theme button should link to: /themes/upload/SITE_SLUG
- Just as it works on trunk, when a site is NOT selected, install theme button should link to: /themes/upload. Clicking it will prompt you to select a site.
- Clicking the install theme button should record an `upload theme` Google analytics event
- Clicking the install theme button should record a `calypso_click_theme_upload` tracks event
- The "Install theme" text on the button should translate to other languages
- Test different browsers, screen sizes and devices at your own discretion

Views to consider:
- /themes/SITE_SLUG page for a simple site
- /themes/SITE_SLUG page for an atomic site
- /themes/SITE_SLUG page for a self-hosted multisite install connected via jetpack
- /themes page rendered via Server-side rendering
- /themes page while logged out