### PR TITLE
Pages: show blog callout when there are no pages

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -317,7 +317,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
+				<BlogPostsPage key="blog-posts-page" site={ site } />
 				{ site && this.renderSectionHeader() }
 				{ rows }
 				{ this.renderListEnd() }
@@ -354,9 +354,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
-				{ showBlogPostsPage && (
-					<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
-				) }
+				{ showBlogPostsPage && <BlogPostsPage key="blog-posts-page" site={ site } /> }
 				{ site && this.renderSectionHeader() }
 				{ rows }
 				<InfiniteScroll nextPageMethod={ this.fetchPages } />
@@ -366,8 +364,14 @@ class Pages extends Component {
 	}
 
 	renderNoContent() {
+		const { site } = this.props;
+		const { search, status } = this.props.query;
+
+		const showBlogPostsPage = site && status === 'publish,private' && ! search;
+
 		return (
 			<div id="pages" className="pages__page-list">
+				{ showBlogPostsPage && <BlogPostsPage key="blog-posts-page" site={ site } /> }
 				<div key="page-list-no-results">{ this.getNoContentMessage() }</div>
 			</div>
 		);


### PR DESCRIPTION
In testing something for #52799, I noticed that if a user has their homepage set to show a list of posts, we don't show the helpful callout on /pages if there are no pages published. This adds that callout to the empty content render.

**Callout when published page exists:**
<img width="1552" alt="Screen Shot 2021-05-24 at 1 20 03 PM" src="https://user-images.githubusercontent.com/942359/119385538-409aca80-bc94-11eb-9695-9e05980eb66f.png">

**Current behavior when no published page exists and homepage is a blog:**
<img width="1552" alt="Screen Shot 2021-05-24 at 1 20 26 PM" src="https://user-images.githubusercontent.com/942359/119385599-54463100-bc94-11eb-90e0-8175fa30f57b.png">

**New behavior when no published page exists and homepage is a blog:**
<img width="1552" alt="Screen Shot 2021-05-24 at 1 20 46 PM" src="https://user-images.githubusercontent.com/942359/119385639-67f19780-bc94-11eb-8b8a-283812c33ddb.png">

**To test:**
- on a site with `show_on_font: posts`
- verify that the callout is shown on /pages, regardless of whether or not there are published pages
- on a site with `show_on_front: page`
- verify that the callout is not shown on /pages