### PR TITLE
Login to mapped domain when added as a user

### DIFF
--- a/client/lib/logmein/index.ts
+++ b/client/lib/logmein/index.ts
@@ -24,7 +24,7 @@ type Host = string;
 
 let reduxStore: Store;
 
-export function logmeinUrl( url: string ): string {
+export function logmeinUrl( url: string, redirectTo = '' ): string {
 	// Disable feature if not enabled
 	if ( ! isEnabled( 'logmein' ) ) {
 		return url;
@@ -53,7 +53,7 @@ export function logmeinUrl( url: string ): string {
 	// using INVALID_URL here to prevent the possibility of exceptions, if site.URL ever contains an invalid url
 	// the filtering will fail
 	const isValid = sites.some( ( site ) => {
-		return isValidLogmeinSite( site ) && new URL( site.URL, INVALID_URL ).host === newurl.host;
+		return new URL( site.URL, INVALID_URL ).host === newurl.host && isValidLogmeinSite( site );
 	} );
 	if ( ! isValid ) {
 		return url;
@@ -64,6 +64,7 @@ export function logmeinUrl( url: string ): string {
 
 	// Set the param
 	newurl.searchParams.set( 'logmein', 'direct' );
+	redirectTo && newurl.searchParams.set( 'redirect_to', redirectTo );
 
 	return newurl.toString();
 }

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -160,10 +160,10 @@ export function getRedirectAfterAccept( invite ) {
 	const postsListPath = '/posts/' + invite.site.ID;
 	const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
 	const remoteLoginBackUrl = ( destinationUri ) =>
-		`https://${ invite.site.domain }/remote-login.php/?r_login_redirect=https://wordpress.com${ destinationUri }`;
+		`https://${ invite.site.domain }/remote-login.php/?action=r_login_redirect&r_login_back=https://wordpress.com${ destinationUri }`;
 	const remoteLoginUrl = ( destinationUri ) =>
-		`https://r-login.wordpress.com/remote-login.php?action=link&back=${ remoteLoginBackUrl(
-			destinationUri
+		`https://r-login.wordpress.com/remote-login.php?action=link&back=${ encodeURIComponent(
+			remoteLoginBackUrl( destinationUri )
 		) }`;
 
 	if ( invite.site.is_vip ) {
@@ -180,10 +180,10 @@ export function getRedirectAfterAccept( invite ) {
 	switch ( invite.role ) {
 		case 'viewer':
 		case 'follower':
-			return subdomainRegExp.test( invite.site.URL ) ? readerPath : remoteLoginUrl( readerPath );
+			return subdomainRegExp.test( invite.site.domain ) ? readerPath : remoteLoginUrl( readerPath );
 
 		default:
-			return subdomainRegExp.test( invite.site.URL )
+			return subdomainRegExp.test( invite.site.domain )
 				? postsListPath
 				: remoteLoginUrl( postsListPath );
 	}

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -158,6 +158,12 @@ export function getRedirectAfterAccept( invite ) {
 
 	const readerPath = '/read';
 	const postsListPath = '/posts/' + invite.site.ID;
+	const remoteLoginBackUrl = ( destinationUri ) =>
+		`https://${ invite.site.domain }/remote-login.php/?r_login_redirect=https://wordpress.com${ destinationUri }`;
+	const remoteLoginUrl = ( destinationUri ) =>
+		`https://r-login.wordpress.com/remote-login.php?action=link&back=${ remoteLoginBackUrl(
+			destinationUri
+		) }`;
 
 	if ( invite.site.is_vip ) {
 		switch ( invite.role ) {
@@ -173,9 +179,9 @@ export function getRedirectAfterAccept( invite ) {
 	switch ( invite.role ) {
 		case 'viewer':
 		case 'follower':
-			return readerPath;
+			return remoteLoginUrl( readerPath );
 
 		default:
-			return postsListPath;
+			return remoteLoginUrl( postsListPath );
 	}
 }

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -158,6 +158,7 @@ export function getRedirectAfterAccept( invite ) {
 
 	const readerPath = '/read';
 	const postsListPath = '/posts/' + invite.site.ID;
+	const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
 	const remoteLoginBackUrl = ( destinationUri ) =>
 		`https://${ invite.site.domain }/remote-login.php/?r_login_redirect=https://wordpress.com${ destinationUri }`;
 	const remoteLoginUrl = ( destinationUri ) =>
@@ -179,9 +180,11 @@ export function getRedirectAfterAccept( invite ) {
 	switch ( invite.role ) {
 		case 'viewer':
 		case 'follower':
-			return remoteLoginUrl( readerPath );
+			return subdomainRegExp.test( invite.site.URL ) ? readerPath : remoteLoginUrl( readerPath );
 
 		default:
-			return remoteLoginUrl( postsListPath );
+			return subdomainRegExp.test( invite.site.URL )
+				? postsListPath
+				: remoteLoginUrl( postsListPath );
 	}
 }

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -166,7 +166,7 @@ export function getRedirectAfterAccept( invite ) {
 	const postsListPath = '/posts/' + invite.site.ID;
 	const getDestinationUrl = ( redirect ) => {
 		const remoteLoginHost = `https://${ invite.site.domain }`;
-		const remoteLoginBackUrl = ( destinationUri ) => `https://wordpress.com${ destinationUri }`;
+		const remoteLoginBackUrl = ( destinationPath ) => `https://wordpress.com${ destinationPath }`;
 		const destination = logmeinUrl( remoteLoginHost, remoteLoginBackUrl( redirect ) );
 		const isMissingLogmein = destination === remoteLoginHost;
 		return isMissingLogmein ? redirect : destination;

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -159,12 +159,12 @@ export function getRedirectAfterAccept( invite ) {
 	const readerPath = '/read';
 	const postsListPath = '/posts/' + invite.site.ID;
 	const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
-	const remoteLoginBackUrl = ( destinationUri ) =>
-		`https://${ invite.site.domain }/remote-login.php/?action=r_login_redirect&r_login_back=https://wordpress.com${ destinationUri }`;
+	const remoteLoginBackUrl = ( destinationUri ) => `https://wordpress.com${ destinationUri }`;
+	const remoteLoginHost = `https://${ invite.site.domain }`;
 	const remoteLoginUrl = ( destinationUri ) =>
-		`https://r-login.wordpress.com/remote-login.php?action=link&back=${ encodeURIComponent(
-			remoteLoginBackUrl( destinationUri )
-		) }`;
+		`https://r-login.wordpress.com/remote-login.php?action=link&host=${ encodeURIComponent(
+			remoteLoginHost
+		) }&back=${ encodeURIComponent( remoteLoginBackUrl( destinationUri ) ) }`;
 
 	if ( invite.site.is_vip ) {
 		switch ( invite.role ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user logged into WP.com is added as a user to another site(with a mapped domain), this PR and the associated patch(code-D61790) will login the user to the mapped domain site.

When the user is added to a site, they will receive an email to accept invitation. Following the invite link will bounce them through the r-login redirects and setup the login cookies for the mapped domain site.

**What is the effect of this change?**

When a user logged into WPCOM accepts invitation to be added as a user on another site with a mapped domain, their first visit to that site will be a logged in experience. 

**NOTE**

This PR will not login the user to their mapped domain if they are added as a "Viewer" or "Follower". This is because, currently `logmein()` only works for sites of the user, and "viwer/follower" roles won't show up as a site of the user. We will have to handle this case separately when scope of `logmein()` expands to any WP.com site.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply code-D61790.

* On a site with a mapped domain, click on "Invite" button in https://wordpress.com/people/team/ and add a user with role "Editor" role.
* In a different browser or incognito window, disable 3rd party cookies and login to calypso.localhost:3000. Then navigate to the accept invitation page for the user you just added by following the link in the email invitation sent to this user. 
* When you are on the accept invitation page, change the wordpress.com host name in the browser with calypso.localhost:3000 and reload the page with the new URL, so that this branch's changes are applied.
* In a new tab, navigate to this new site and confirm that you are logged out for this domain.
* Ensure that you're sandboxed to https://r-login.wordpress.com and the new site for which the user got the invitation link.
* Click on the Accept CTA and verify that you are taken to the /posts page in WP.com. Observe the link redirects and confirm that you were taken through logmein redirect for the new site. 
* Visit the new site and confirm that you get the logged in experience.
* Repeat above steps for other roles - "Administrator", "Author" and "Contributor"
* Test on Chrome, Firefox, and Safari. 

**Other scenarios to test**

* Repeat all steps for a site on a *.wordpress.com subdomain, and confirm that you are _not_ taken through logmein redirect after clicking on the Accept CTA in the invitation page. This is because `logmein` is not required for wordpress.com subdomains.
* Repeat all the steps for an atomic site and confirm that you are not taken through logmein redirect after clicking on the Accept CTA in the invitation page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/52763
