### PR TITLE
[ETK/wpcom-block-editor]  Use `__unstable` InserterMenuExtension if available, fallback to `__experimental`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -390,7 +390,13 @@ module.exports = {
 		'wpcalypso/no-unsafe-wp-apis': [
 			'error',
 			{
-				'@wordpress/block-editor': [ '__experimentalBlock', '__experimentalInserterMenuExtension' ],
+				'@wordpress/block-editor': [
+					'__experimentalBlock',
+					// InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.
+					// We need to support both symbols until we're sure Gutenberg < v10.7.x is not used anymore in WPCOM.
+					'__unstableInserterMenuExtension',
+					'__experimentalInserterMenuExtension',
+				],
 				'@wordpress/date': [ '__experimentalGetSettings' ],
 				'@wordpress/edit-post': [ '__experimentalMainDashboardButton' ],
 				'@wordpress/components': [ '__experimentalNavigationBackButton' ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips.js
@@ -7,7 +7,10 @@ import { debounce } from 'lodash';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { __experimentalInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
+import {
+	__unstableInserterMenuExtension,
+	__experimentalInserterMenuExtension,
+} from '@wordpress/block-editor';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -15,6 +18,13 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import ContextualTip from './contextual-tips/contextual-tip';
 import './contextual-tips/style.scss';
+
+// InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.
+// We need to support both symbols until we're sure Gutenberg < v10.7.x is not used anymore in WPCOM.
+const InserterMenuExtension =
+	typeof __unstableInserterMenuExtension !== 'undefined'
+		? __unstableInserterMenuExtension
+		: __experimentalInserterMenuExtension;
 
 const ContextualTips = function () {
 	const [ debouncedFilterValue, setFilterValue ] = useState( '' );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -8,12 +8,22 @@ import { debounce } from 'lodash';
  */
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { __experimentalInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
+import {
+	__unstableInserterMenuExtension,
+	__experimentalInserterMenuExtension,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import tracksRecordEvent from './track-record-event';
+
+// InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.
+// We need to support both symbols until we're sure Gutenberg < v10.7.x is not used anymore in WPCOM.
+const InserterMenuExtension =
+	typeof __unstableInserterMenuExtension !== 'undefined'
+		? __unstableInserterMenuExtension
+		: __experimentalInserterMenuExtension;
 
 const InserterMenuTrackingEvent = function () {
 	const [ searchTerm, setSearchTerm ] = useState( '' );

--- a/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
@@ -22,7 +22,7 @@ const gutenbergUser =
 // of the @wordpress/* packages. The purpose of these tests is to give us an early
 // warning if an experimental feature has been removed or renamed.
 const EXPERIMENTAL_FEATURES = {
-	'@wordpress/block-editor': [ '__experimentalBlock', '__unstableInserterMenuExtension' ],
+	'@wordpress/block-editor': [ '__experimentalBlock', '__experimentalInserterMenuExtension' ],
 	'@wordpress/date': [ '__experimentalGetSettings' ],
 	'@wordpress/components': [ '__experimentalNavigationBackButton' ],
 	'@wordpress/edit-post': [ '__experimentalMainDashboardButton' ],

--- a/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
@@ -22,7 +22,7 @@ const gutenbergUser =
 // of the @wordpress/* packages. The purpose of these tests is to give us an early
 // warning if an experimental feature has been removed or renamed.
 const EXPERIMENTAL_FEATURES = {
-	'@wordpress/block-editor': [ '__experimentalBlock', '__experimentalInserterMenuExtension' ],
+	'@wordpress/block-editor': [ '__experimentalBlock', '__unstableInserterMenuExtension' ],
 	'@wordpress/date': [ '__experimentalGetSettings' ],
 	'@wordpress/components': [ '__experimentalNavigationBackButton' ],
 	'@wordpress/edit-post': [ '__experimentalMainDashboardButton' ],


### PR DESCRIPTION
It has been renamed from `__experimentalInserterMenuExtension` to `__unstableInserterMenuExtension` here: https://github.com/WordPress/gutenberg/pull/31417.




### Changes proposed in this Pull Request

* Update the `wpcalypso/no-unsafe-wp-apis` to remove the exclusion for the old name and include the new name, in order to be able to use/import the new one;
* Update all occurrences of `__experimentalInserterMenuExtension` to `__unstableInserterMenuExtension`;
* Update the experimental features E2E test to fail if the new symbol can't be found, and remove the check for the old one.



### Testing instructions

* Sandbox `widgets.wp.com` (`wpcom-block-editor` is served from this domain);

#### Gutenberg v10.7.0-rc1:

* Sync a dev ETK (see: PCYsg-ly5-p2) build based off this branch to your WPCOM sandbox;
* [Sync](https://github.com/Automattic/wp-calypso/blob/trunk/apps/wpcom-block-editor/README.md#dev-workflow) a dev version of `wpcom-block-editor` based off this branch to your WPCOM sandbox;
* Apply D61797-code and D61822-code to your sandbox;
* Load the editor in your test edge simple site, the it should not crash with WSOD;
* Smoke-test the editor and make sure it works well, smoke test the main inserter menu.

#### Gutenberg v10.5.4:

* Sync a custom ETK build based off this branch to your WPCOM sandbox;
* Sync a dev version of `wpcom-block-editor` based off this branch to your WPCOM sandbox;
* Apply D61822-code to your sandbox;
* Load the editor in your test non-edge simple site, the it should not crash with WSOD;
* Smoke-test the editor and make sure it works well, smoke test the main inserter menu.

#### Wordpress on Atomic

### Install the editing toolkit plugin

* Create an Atomic site from a simple site by upgrading to the business plan and installing a plugin;
* SFTP to it and remove the Editing toolkit symlink;
* Also remove the gutenberg plugin symlink while you're at it;
* Get the zip fro the plugin by clicking the "Editing ToolKit (WPCom Plugins)" check below and getting it from TC:


![Screenshot from 2021-05-24 19-33-59](https://user-images.githubusercontent.com/81248/119422587-0bf43680-bcc7-11eb-9b85-0258111fdbff.png)

* Install the plugin in your AT site using wp-admin (or Calypso).
* Gutenberg v10.7.0 RC1 needs to be built locally (`npm run build:plugin-zip`) and you should then use the wp-admin plugin UI to upload and activate it;
* Smoke-test the editor and make sure it works well, smoke test the main inserter menu.

### Install the `wpcom-block-editor` plugin (?)

TBD

### Questions

This should fix the issue and still provide backward compatibility for Gutenberg versions < 10.7.x. Ideally we wouldn't be consuming `__experimental` or `__unstable` APIs, though. Is there a way to implement the same functionality in the `ContextualTips` components without doing so? cc @retrofox 