### PR TITLE
Me: Add VAT Info page

### DIFF
--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -10,7 +10,12 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-function FormSettingExplanation( { className, noValidate, isIndented, ...rest } ) {
+function FormSettingExplanation( {
+	className = undefined,
+	noValidate = false,
+	isIndented = false,
+	...rest
+} ) {
 	const classes = classNames( 'form-setting-explanation', className, {
 		'no-validate': noValidate,
 		'is-indented': isIndented,

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
+import { CompactCard, Card } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
-import { Card } from '@automattic/components';
+import { vatDetails as vatDetailsPath, billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import Main from 'calypso/components/main';
@@ -39,6 +39,8 @@ export function BillingHistoryContent( {
 }
 
 function BillingHistory(): JSX.Element {
+	const translate = useTranslate();
+
 	return (
 		<Main wideLayout className="billing-history">
 			<DocumentHead title={ titles.billingHistory } />
@@ -48,6 +50,8 @@ function BillingHistory(): JSX.Element {
 			<QueryBillingTransactions />
 			<PurchasesNavigation section="billingHistory" />
 			<BillingHistoryContent siteId={ null } getReceiptUrlFor={ billingHistoryReceipt } />
+
+			<CompactCard href={ vatDetailsPath }>{ translate( 'Edit VAT details' ) }</CompactCard>
 		</Main>
 	);
 }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -18,6 +18,7 @@ import QueryBillingTransactions from 'calypso/components/data/query-billing-tran
 import titles from 'calypso/me/purchases/titles';
 import FormattedHeader from 'calypso/components/formatted-header';
 import BillingHistoryList from 'calypso/me/purchases/billing-history/billing-history-list';
+import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 
 /**
  * Style dependencies
@@ -40,6 +41,8 @@ export function BillingHistoryContent( {
 
 function BillingHistory(): JSX.Element {
 	const translate = useTranslate();
+	const { vatDetails } = useVatDetails();
+	const vatText = vatDetails.id ? translate( 'Edit VAT details' ) : translate( 'Add VAT details' );
 
 	return (
 		<Main wideLayout className="billing-history">
@@ -51,7 +54,7 @@ function BillingHistory(): JSX.Element {
 			<PurchasesNavigation section="billingHistory" />
 			<BillingHistoryContent siteId={ null } getReceiptUrlFor={ billingHistoryReceipt } />
 
-			<CompactCard href={ vatDetailsPath }>{ translate( 'Edit VAT details' ) }</CompactCard>
+			<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
 		</Main>
 	);
 }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -43,8 +43,8 @@ export function BillingHistoryContent( {
 function BillingHistory(): JSX.Element {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const editVatText = translate( 'Edit VAT details' );
-	const addVatText = translate( 'Add VAT details' );
+	const editVatText = translate( 'Edit VAT details (for EU and UK only)' );
+	const addVatText = translate( 'Add VAT details (for EU and UK only)' );
 	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { localize, useTranslate } from 'i18n-calypso';
 import { CompactCard, Card } from '@automattic/components';
+import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -42,7 +43,9 @@ export function BillingHistoryContent( {
 function BillingHistory(): JSX.Element {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const vatText = vatDetails.id ? translate( 'Edit VAT details' ) : translate( 'Add VAT details' );
+	const editVatText = translate( 'Edit VAT details' );
+	const addVatText = translate( 'Add VAT details' );
+	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (
 		<Main wideLayout className="billing-history">
@@ -54,7 +57,9 @@ function BillingHistory(): JSX.Element {
 			<PurchasesNavigation section="billingHistory" />
 			<BillingHistoryContent siteId={ null } getReceiptUrlFor={ billingHistoryReceipt } />
 
-			<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
+			{ config.isEnabled( 'me/vat-details' ) && (
+				<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
+			) }
 		</Main>
 	);
 }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -43,8 +43,8 @@ export function BillingHistoryContent( {
 function BillingHistory(): JSX.Element {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const editVatText = translate( 'Edit VAT details (for EU and UK only)' );
-	const addVatText = translate( 'Add VAT details (for EU and UK only)' );
+	const editVatText = translate( 'Edit VAT details (for Europe only)' );
+	const addVatText = translate( 'Add VAT details (for Europe only)' );
 	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -35,6 +35,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
 import titles from 'calypso/me/purchases/titles';
 import FormattedHeader from 'calypso/components/formatted-header';
+import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 
 class BillingReceipt extends React.Component {
 	componentDidMount() {
@@ -138,6 +139,7 @@ export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
 					) : (
 						<EmptyReceiptDetails />
 					) }
+					<VatDetails />
 				</ul>
 				<ReceiptLineItems transaction={ transaction } />
 
@@ -186,6 +188,26 @@ function ReceiptPaymentMethod( { transaction } ) {
 		<li>
 			<strong>{ translate( 'Payment Method' ) }</strong>
 			<span>{ text }</span>
+		</li>
+	);
+}
+
+function VatDetails() {
+	const translate = useTranslate();
+	const { vatDetails, isLoading, fetchError } = useVatDetails();
+
+	if ( isLoading || fetchError || ! vatDetails.id ) {
+		return null;
+	}
+
+	return (
+		<li>
+			<strong>{ translate( 'Vat Details' ) }</strong>
+			{ vatDetails.name }
+			<br />
+			{ vatDetails.address }
+			<br />
+			{ vatDetails.id }
 		</li>
 	);
 }

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -203,7 +203,7 @@ function VatDetails() {
 	return (
 		<>
 			<li>
-				<strong>{ translate( 'Vat Details' ) }</strong>
+				<strong>{ translate( 'VAT Details' ) }</strong>
 				{ vatDetails.name }
 				<br />
 				{ vatDetails.address }

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -201,14 +201,32 @@ function VatDetails() {
 	}
 
 	return (
-		<li>
-			<strong>{ translate( 'Vat Details' ) }</strong>
-			{ vatDetails.name }
-			<br />
-			{ vatDetails.address }
-			<br />
-			{ vatDetails.id }
-		</li>
+		<>
+			<li>
+				<strong>{ translate( 'Vat Details' ) }</strong>
+				{ vatDetails.name }
+				<br />
+				{ vatDetails.address }
+				<br />
+				{ translate( 'VAT #: %(vatCountry)s %(vatId)s', {
+					args: {
+						vatCountry: vatDetails.country,
+						vatId: vatDetails.id,
+					},
+				} ) }
+			</li>
+			<li>
+				{ translate( '{{strong}}Vendor VAT #{{/strong}} %(ieVatNumber)s and %(ukVatNumber)s', {
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						ieVatNumber: 'IE 3255131SH',
+						ukVatNumber: 'UK 376 1703 88',
+					},
+				} ) }
+			</li>
+		</>
 	);
 }
 
@@ -332,7 +350,7 @@ function ReceiptLabels() {
 				id="billing-history__billing-details-description"
 			>
 				{ translate(
-					'Use this field to add your billing information (eg. VAT number, business address) before printing.'
+					'Use this field to add your billing information (eg. business address) before printing.'
 				) }
 			</div>
 		</div>

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import page from 'page';
 import { connect, useDispatch } from 'react-redux';
 import { localize, useTranslate } from 'i18n-calypso';
+import config from '@automattic/calypso-config';
 
 /**
  * Internal dependencies
@@ -140,7 +141,7 @@ export function ReceiptBody( { transaction, handlePrintLinkClick } ) {
 					) : (
 						<EmptyReceiptDetails />
 					) }
-					<VatDetails transaction={ transaction } />
+					{ config.isEnabled( 'me/vat-details' ) && <VatDetails transaction={ transaction } /> }
 				</ul>
 				<ReceiptLineItems transaction={ transaction } />
 
@@ -386,6 +387,15 @@ export function ReceiptPlaceholder() {
 
 function ReceiptLabels() {
 	const translate = useTranslate();
+
+	let labelContent = translate(
+		'Use this field to add your billing information (eg. VAT number, business address) before printing.'
+	);
+	if ( config.isEnabled( 'me/vat-details' ) ) {
+		labelContent = translate(
+			'Use this field to add your billing information (eg. business address) before printing.'
+		);
+	}
 	return (
 		<div>
 			<FormLabel htmlFor="billing-history__billing-details-textarea">
@@ -395,9 +405,7 @@ function ReceiptLabels() {
 				className="billing-history__billing-details-description"
 				id="billing-history__billing-details-description"
 			>
-				{ translate(
-					'Use this field to add your billing information (eg. business address) before printing.'
-				) }
+				{ labelContent }
 			</div>
 		</div>
 	);

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -210,6 +210,8 @@ textarea.billing-history__billing-details-editable {
 }
 
 .billing-history__billing-details-description {
+	display: block;
+	font-size: $font-body-small;
 	font-style: italic;
 }
 
@@ -248,6 +250,30 @@ textarea.billing-history__billing-details-editable {
 			font-weight: 600;
 			margin: 0 5px 0 0;
 			text-transform: uppercase;
+		}
+
+		.receipt__vat-vendor-details-number {
+			display: block;
+			margin-top: 8px;
+
+			strong {
+				display: inline;
+				margin: 0;
+			}
+		}
+
+		.receipt__vat-vendor-details-description {
+			display: block;
+			font-size: $font-body-small;
+			font-style: italic;
+			margin-bottom: 8px;
+
+			a,
+			.receipt__email-button {
+				color: var( --color-link );
+				font-style: italic;
+				text-decoration: underline;
+			}
 		}
 	}
 }
@@ -419,7 +445,8 @@ textarea.billing-history__billing-details-editable {
 		.billing-history__receipt-links,
 		.header-cake.card,
 		.inline-help,
-		.billing-history__billing-details-description {
+		.billing-history__billing-details-description,
+		.receipt__no-print {
 			display: none;
 		}
 	}

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -21,8 +21,13 @@ import titles from './titles';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
-import { managePurchase as managePurchaseUrl, purchasesRoot } from 'calypso/me/purchases/paths';
+import {
+	managePurchase as managePurchaseUrl,
+	purchasesRoot,
+	vatDetails as vatDetailsPath,
+} from 'calypso/me/purchases/paths';
 import FormattedHeader from 'calypso/components/formatted-header';
+import VatInfoPage from './vat-info';
 
 const PurchasesWrapper = ( { title = null, children } ) => {
 	return (
@@ -112,6 +117,25 @@ export function list( context, next ) {
 	} );
 
 	context.primary = <ListWrapper />;
+	next();
+}
+
+export function vatDetails( context, next ) {
+	const VatInfoWrapper = localize( () => {
+		const classes = 'manage-purchase';
+
+		return (
+			<PurchasesWrapper title={ titles.managePurchase }>
+				<Main wideLayout className={ classes }>
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<PageViewTracker path={ vatDetailsPath } title="Purchases > VAT Information" />
+					<VatInfoPage siteSlug={ context.params.site } />
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
+
+	context.primary = <VatInfoWrapper />;
 	next();
 }
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal Dependencies
@@ -20,11 +21,13 @@ import DocumentHead from 'calypso/components/data/document-head';
 import titles from './titles';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import HeaderCake from 'calypso/components/header-cake';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import {
 	managePurchase as managePurchaseUrl,
 	purchasesRoot,
 	vatDetails as vatDetailsPath,
+	billingHistory,
 } from 'calypso/me/purchases/paths';
 import FormattedHeader from 'calypso/components/formatted-header';
 import VatInfoPage from './vat-info';
@@ -122,13 +125,17 @@ export function list( context, next ) {
 
 export function vatDetails( context, next ) {
 	const VatInfoWrapper = localize( () => {
-		const classes = 'manage-purchase';
+		const goToBillingHistory = () => page( billingHistory );
+		const classes = 'vat-details';
 
 		return (
-			<PurchasesWrapper title={ titles.managePurchase }>
+			<PurchasesWrapper title={ titles.vatDetails }>
 				<Main wideLayout className={ classes }>
+					<PageViewTracker path={ vatDetailsPath } title="Purchases > VAT Details" />
+
 					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-					<PageViewTracker path={ vatDetailsPath } title="Purchases > VAT Information" />
+					<HeaderCake onClick={ goToBillingHistory }>{ titles.vatDetails }</HeaderCake>
+
 					<VatInfoPage siteSlug={ context.params.site } />
 				</Main>
 			</PurchasesWrapper>

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -49,6 +49,8 @@ export default ( router ) => {
 		} );
 	}
 
+	router( paths.vatDetails, sidebar, controller.vatDetails, makeLayout, clientRender );
+
 	router(
 		paths.billingHistory,
 		sidebar,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -49,7 +49,9 @@ export default ( router ) => {
 		} );
 	}
 
-	router( paths.vatDetails, sidebar, controller.vatDetails, makeLayout, clientRender );
+	if ( config.isEnabled( 'me/vat-details' ) ) {
+		router( paths.vatDetails, sidebar, controller.vatDetails, makeLayout, clientRender );
+	}
 
 	router(
 		paths.billingHistory,

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -10,6 +10,8 @@ export const paymentMethods = purchasesRoot + '/payment-methods';
 
 export const pendingPayments = purchasesRoot + '/pending';
 
+export const vatDetails = purchasesRoot + '/vat-details';
+
 export function billingHistoryReceipt( receiptId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof receiptId ) {

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -56,6 +56,9 @@ Object.defineProperties( titles, {
 	paymentMethods: {
 		get: () => i18n.translate( 'Payment Methods' ),
 	},
+	vatDetails: {
+		get: () => i18n.translate( 'VAT Details' ),
+	},
 	pendingPayments: {
 		get: () => i18n.translate( 'Pending Payments' ),
 	},

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -114,7 +114,7 @@ export default function VatInfoPage(): JSX.Element {
 					</CardHeading>
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(
-							"We currently only provide VAT invoices to users who are properly listed in the VIES (VAT Information Exchange System) or the UK VAT database. VAT information saved on this page will be applied to all of your account's receipts."
+							"We currently only provide VAT invoices to users who are properly listed in the VIES (VAT Information Exchange System) or the UK VAT databases. VAT information saved on this page will be applied to all of your account's receipts."
 						) }
 					</p>
 				</Card>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -3,43 +3,64 @@
  */
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-import { CompactCard } from '@automattic/components';
+import { CompactCard, Button } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
 import SectionHeader from 'calypso/components/section-header';
+import useVatDetails from './use-vat-details';
 
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
-	const { countryCode, vatId } = useVatInfo();
+	const { vatDetails, isLoading, error } = useVatDetails();
+
+	if ( error ) {
+		return (
+			<div className="vat-info">
+				<SectionHeader label={ translate( 'VAT Details' ) } />
+
+				<CompactCard>{ translate( 'An error occurred while fetching VAT details.' ) }</CompactCard>
+			</div>
+		);
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="vat-info">
+				<SectionHeader label={ translate( 'VAT Details' ) } />
+
+				<CompactCard>{ translate( 'Loading…' ) }</CompactCard>
+			</div>
+		);
+	}
+
+	const saveDetails = () => {};
 
 	return (
 		<div className="vat-info">
-			<SectionHeader label={ translate( 'VAT Information' ) } />
+			<SectionHeader label={ translate( 'VAT Details' ) } />
 
 			<CompactCard>
 				<div>
 					<label>{ translate( 'Country' ) }</label>
-					<input value={ countryCode } />
+					<input value={ vatDetails.country ?? '' } />
 				</div>
 				<div>
 					<label>{ translate( 'VAT' ) }</label>
-					<input value={ vatId } />
+					<input value={ vatDetails.id ?? '' } />
 				</div>
+				<div>
+					<label>{ translate( 'Name' ) }</label>
+					<input value={ vatDetails.name ?? '' } />
+				</div>
+				<div>
+					<label>{ translate( 'Address' ) }</label>
+					<input value={ vatDetails.address ?? '' } />
+				</div>
+
+				<Button onClick={ saveDetails }>{ translate( 'Validate and save' ) }</Button>
 			</CompactCard>
 		</div>
 	);
-}
-
-interface VatDetails {
-	countryCode: string;
-	vatId: string;
-}
-
-function useVatInfo(): VatDetails {
-	return {
-		countryCode: 'UK',
-		vatId: '12345',
-	};
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -9,7 +9,6 @@ import { CompactCard, Button } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import SectionHeader from 'calypso/components/section-header';
 import useVatDetails from './use-vat-details';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { VatDetails, UpdateError } from './use-vat-details';
@@ -37,8 +36,6 @@ export default function VatInfoPage(): JSX.Element {
 	if ( fetchError ) {
 		return (
 			<div className="vat-info">
-				<SectionHeader label={ translate( 'VAT Details' ) } />
-
 				<CompactCard>{ translate( 'An error occurred while fetching VAT details.' ) }</CompactCard>
 			</div>
 		);
@@ -47,8 +44,6 @@ export default function VatInfoPage(): JSX.Element {
 	if ( isLoading ) {
 		return (
 			<div className="vat-info">
-				<SectionHeader label={ translate( 'VAT Details' ) } />
-
 				<CompactCard>{ translate( 'Loading…' ) }</CompactCard>
 			</div>
 		);
@@ -56,8 +51,6 @@ export default function VatInfoPage(): JSX.Element {
 
 	return (
 		<div className="vat-info">
-			<SectionHeader label={ translate( 'VAT Details' ) } />
-
 			<VatUpdateErrorNotice error={ updateError } />
 
 			<CompactCard>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { CompactCard, Button, Card } from '@automattic/components';
@@ -135,24 +135,27 @@ function useDisplayVatNotices( {
 } ): void {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	if ( error?.error === 'validation_failed' ) {
-		reduxDispatch(
-			errorNotice(
-				translate( 'Your VAT details are not valid. Please check each field and try again.' )
-			)
-		);
-		return;
-	}
 
-	if ( error ) {
-		reduxDispatch(
-			errorNotice( translate( 'An error occurred while updating your VAT details.' ) )
-		);
-		return;
-	}
+	useEffect( () => {
+		if ( error?.error === 'validation_failed' ) {
+			reduxDispatch(
+				errorNotice(
+					translate( 'Your VAT details are not valid. Please check each field and try again.' )
+				)
+			);
+			return;
+		}
 
-	if ( success ) {
-		reduxDispatch( successNotice( translate( 'Your VAT details have been updated!' ) ) );
-		return;
-	}
+		if ( error ) {
+			reduxDispatch(
+				errorNotice( translate( 'An error occurred while updating your VAT details.' ) )
+			);
+			return;
+		}
+
+		if ( success ) {
+			reduxDispatch( successNotice( translate( 'Your VAT details have been updated!' ) ) );
+			return;
+		}
+	}, [ error, success, reduxDispatch, translate ] );
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -15,7 +15,14 @@ import type { VatDetails, UpdateError } from './use-vat-details';
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
 	const [ currentVatDetails, setCurrentVatDetails ] = useState< VatDetails >( {} );
-	const { vatDetails, isLoading, fetchError, updateError, setVatDetails } = useVatDetails();
+	const {
+		vatDetails,
+		isLoading,
+		isUpdating,
+		fetchError,
+		updateError,
+		setVatDetails,
+	} = useVatDetails();
 
 	const saveDetails = () => {
 		setVatDetails( { ...vatDetails, ...currentVatDetails } );
@@ -51,6 +58,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'Country' ) }</label>
 					<input
+						disabled={ isUpdating }
 						value={ currentVatDetails.country ?? vatDetails.country ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
@@ -60,6 +68,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'VAT' ) }</label>
 					<input
+						disabled={ isUpdating }
 						value={ currentVatDetails.id ?? vatDetails.id ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
@@ -69,6 +78,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'Name' ) }</label>
 					<input
+						disabled={ isUpdating }
 						value={ currentVatDetails.name ?? vatDetails.name ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
@@ -78,6 +88,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'Address' ) }</label>
 					<input
+						disabled={ isUpdating }
 						value={ currentVatDetails.address ?? vatDetails.address ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
@@ -85,7 +96,9 @@ export default function VatInfoPage(): JSX.Element {
 					/>
 				</div>
 
-				<Button onClick={ saveDetails }>{ translate( 'Validate and save' ) }</Button>
+				<Button busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
+					{ translate( 'Validate and save' ) }
+				</Button>
 			</CompactCard>
 		</div>
 	);

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { CompactCard, Button } from '@automattic/components';
 
@@ -12,6 +13,10 @@ import SectionHeader from 'calypso/components/section-header';
 import useVatDetails from './use-vat-details';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { VatDetails, UpdateError } from './use-vat-details';
+
+const VatActionArea = styled.div`
+	margin-top: 1em;
+`;
 
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
@@ -97,9 +102,11 @@ export default function VatInfoPage(): JSX.Element {
 					/>
 				</div>
 
-				<Button busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
-					{ translate( 'Validate and save' ) }
-				</Button>
+				<VatActionArea>
+					<Button busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
+						{ translate( 'Validate and save' ) }
+					</Button>
+				</VatActionArea>
 			</CompactCard>
 		</div>
 	);

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import { CompactCard, Button, Card } from '@automattic/components';
 
 /**
@@ -16,6 +17,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { VatDetails, UpdateError } from './use-vat-details';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 import './style.scss';
 
@@ -36,6 +38,8 @@ export default function VatInfoPage(): JSX.Element {
 		setVatDetails( { ...vatDetails, ...currentVatDetails } );
 	};
 
+	useDisplayVatNotices( { error: updateError, success: isUpdateSuccessful } );
+
 	if ( fetchError ) {
 		return (
 			<div className="vat-info">
@@ -55,8 +59,6 @@ export default function VatInfoPage(): JSX.Element {
 	return (
 		<Layout>
 			<Column type="main" className="vat-info">
-				<VatUpdateStatusNotice error={ updateError } success={ isUpdateSuccessful } />
-
 				<CompactCard>
 					<FormFieldset className="vat-info__country-field">
 						<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
@@ -124,37 +126,33 @@ export default function VatInfoPage(): JSX.Element {
 	);
 }
 
-function VatUpdateStatusNotice( {
+function useDisplayVatNotices( {
 	error,
 	success,
 }: {
 	error: UpdateError | null;
 	success: boolean;
-} ): JSX.Element | null {
+} ): void {
+	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	if ( error?.error === 'validation_failed' ) {
-		return (
-			<CompactCard highlight="error">
-				{ translate( 'Your VAT details are not valid. Please check each field and try again.' ) }
-			</CompactCard>
+		reduxDispatch(
+			errorNotice(
+				translate( 'Your VAT details are not valid. Please check each field and try again.' )
+			)
 		);
+		return;
 	}
 
 	if ( error ) {
-		return (
-			<CompactCard highlight="error">
-				{ translate( 'An error occurred while updating your VAT details.' ) }
-			</CompactCard>
+		reduxDispatch(
+			errorNotice( translate( 'An error occurred while updating your VAT details.' ) )
 		);
+		return;
 	}
 
 	if ( success ) {
-		return (
-			<CompactCard highlight="success">
-				{ translate( 'Your VAT details have been updated!' ) }
-			</CompactCard>
-		);
+		reduxDispatch( successNotice( translate( 'Your VAT details have been updated!' ) ) );
+		return;
 	}
-
-	return null;
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -10,6 +10,7 @@ import { CompactCard, Button } from '@automattic/components';
  */
 import SectionHeader from 'calypso/components/section-header';
 import useVatDetails from './use-vat-details';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { VatDetails, UpdateError } from './use-vat-details';
 
 export default function VatInfoPage(): JSX.Element {
@@ -57,40 +58,40 @@ export default function VatInfoPage(): JSX.Element {
 			<CompactCard>
 				<div>
 					<label>{ translate( 'Country' ) }</label>
-					<input
+					<FormTextInput
 						disabled={ isUpdating }
 						value={ currentVatDetails.country ?? vatDetails.country ?? '' }
-						onChange={ ( event ) =>
+						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 							setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
 						}
 					/>
 				</div>
 				<div>
 					<label>{ translate( 'VAT' ) }</label>
-					<input
+					<FormTextInput
 						disabled={ isUpdating }
 						value={ currentVatDetails.id ?? vatDetails.id ?? '' }
-						onChange={ ( event ) =>
+						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 							setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
 						}
 					/>
 				</div>
 				<div>
 					<label>{ translate( 'Name' ) }</label>
-					<input
+					<FormTextInput
 						disabled={ isUpdating }
 						value={ currentVatDetails.name ?? vatDetails.name ?? '' }
-						onChange={ ( event ) =>
+						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 							setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
 						}
 					/>
 				</div>
 				<div>
 					<label>{ translate( 'Address' ) }</label>
-					<input
+					<FormTextInput
 						disabled={ isUpdating }
 						value={ currentVatDetails.address ?? vatDetails.address ?? '' }
-						onChange={ ( event ) =>
+						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 							setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
 						}
 					/>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { CompactCard } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'calypso/components/section-header';
+
+export default function VatInfoPage(): JSX.Element {
+	const translate = useTranslate();
+	const { countryCode, vatId } = useVatInfo();
+
+	return (
+		<div className="vat-info">
+			<SectionHeader label={ translate( 'VAT Information' ) } />
+
+			<CompactCard>
+				<div>
+					<label>{ translate( 'Country' ) }</label>
+					<input value={ countryCode } />
+				</div>
+				<div>
+					<label>{ translate( 'VAT' ) }</label>
+					<input value={ vatId } />
+				</div>
+			</CompactCard>
+		</div>
+	);
+}
+
+interface VatDetails {
+	countryCode: string;
+	vatId: string;
+}
+
+function useVatInfo(): VatDetails {
+	return {
+		countryCode: 'UK',
+		vatId: '12345',
+	};
+}

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -10,18 +10,18 @@ import { CompactCard, Button } from '@automattic/components';
  */
 import SectionHeader from 'calypso/components/section-header';
 import useVatDetails from './use-vat-details';
-import type { VatDetails } from './use-vat-details';
+import type { VatDetails, UpdateError } from './use-vat-details';
 
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
 	const [ currentVatDetails, setCurrentVatDetails ] = useState< VatDetails >( {} );
-	const { vatDetails, isLoading, error, setVatDetails } = useVatDetails();
+	const { vatDetails, isLoading, fetchError, updateError, setVatDetails } = useVatDetails();
 
 	const saveDetails = () => {
 		setVatDetails( { ...vatDetails, ...currentVatDetails } );
 	};
 
-	if ( error ) {
+	if ( fetchError ) {
 		return (
 			<div className="vat-info">
 				<SectionHeader label={ translate( 'VAT Details' ) } />
@@ -44,6 +44,8 @@ export default function VatInfoPage(): JSX.Element {
 	return (
 		<div className="vat-info">
 			<SectionHeader label={ translate( 'VAT Details' ) } />
+
+			<VatUpdateErrorNotice error={ updateError } />
 
 			<CompactCard>
 				<div>
@@ -86,5 +88,26 @@ export default function VatInfoPage(): JSX.Element {
 				<Button onClick={ saveDetails }>{ translate( 'Validate and save' ) }</Button>
 			</CompactCard>
 		</div>
+	);
+}
+
+function VatUpdateErrorNotice( { error }: { error: UpdateError | null } ): JSX.Element | null {
+	const translate = useTranslate();
+	if ( ! error ) {
+		return null;
+	}
+
+	if ( error.error === 'validation_failed' ) {
+		return (
+			<CompactCard highlight="error">
+				{ translate( 'Your VAT details are not valid. Please check each field and try again.' ) }
+			</CompactCard>
+		);
+	}
+
+	return (
+		<CompactCard highlight="error">
+			{ translate( 'An error occurred while updating your VAT details.' ) }
+		</CompactCard>
 	);
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -58,7 +58,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'VAT' ) }</label>
 					<input
-						value={ vatDetails.id ?? '' }
+						value={ currentVatDetails.id ?? vatDetails.id ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
 						}
@@ -67,7 +67,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'Name' ) }</label>
 					<input
-						value={ vatDetails.name ?? '' }
+						value={ currentVatDetails.name ?? vatDetails.name ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
 						}
@@ -76,7 +76,7 @@ export default function VatInfoPage(): JSX.Element {
 				<div>
 					<label>{ translate( 'Address' ) }</label>
 					<input
-						value={ vatDetails.address ?? '' }
+						value={ currentVatDetails.address ?? vatDetails.address ?? '' }
 						onChange={ ( event ) =>
 							setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
 						}

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { CompactCard, Button } from '@automattic/components';
 
@@ -10,10 +10,16 @@ import { CompactCard, Button } from '@automattic/components';
  */
 import SectionHeader from 'calypso/components/section-header';
 import useVatDetails from './use-vat-details';
+import type { VatDetails } from './use-vat-details';
 
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
-	const { vatDetails, isLoading, error } = useVatDetails();
+	const [ currentVatDetails, setCurrentVatDetails ] = useState< VatDetails >( {} );
+	const { vatDetails, isLoading, error, setVatDetails } = useVatDetails();
+
+	const saveDetails = () => {
+		setVatDetails( { ...vatDetails, ...currentVatDetails } );
+	};
 
 	if ( error ) {
 		return (
@@ -35,8 +41,6 @@ export default function VatInfoPage(): JSX.Element {
 		);
 	}
 
-	const saveDetails = () => {};
-
 	return (
 		<div className="vat-info">
 			<SectionHeader label={ translate( 'VAT Details' ) } />
@@ -44,19 +48,39 @@ export default function VatInfoPage(): JSX.Element {
 			<CompactCard>
 				<div>
 					<label>{ translate( 'Country' ) }</label>
-					<input value={ vatDetails.country ?? '' } />
+					<input
+						value={ currentVatDetails.country ?? vatDetails.country ?? '' }
+						onChange={ ( event ) =>
+							setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
+						}
+					/>
 				</div>
 				<div>
 					<label>{ translate( 'VAT' ) }</label>
-					<input value={ vatDetails.id ?? '' } />
+					<input
+						value={ vatDetails.id ?? '' }
+						onChange={ ( event ) =>
+							setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
+						}
+					/>
 				</div>
 				<div>
 					<label>{ translate( 'Name' ) }</label>
-					<input value={ vatDetails.name ?? '' } />
+					<input
+						value={ vatDetails.name ?? '' }
+						onChange={ ( event ) =>
+							setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
+						}
+					/>
 				</div>
 				<div>
 					<label>{ translate( 'Address' ) }</label>
-					<input value={ vatDetails.address ?? '' } />
+					<input
+						value={ vatDetails.address ?? '' }
+						onChange={ ( event ) =>
+							setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
+						}
+					/>
 				</div>
 
 				<Button onClick={ saveDetails }>{ translate( 'Validate and save' ) }</Button>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -2,20 +2,22 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { CompactCard, Button } from '@automattic/components';
+import { CompactCard, Button, Card } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
+import Layout from 'calypso/components/layout';
+import Column from 'calypso/components/layout/column';
+import CardHeading from 'calypso/components/card-heading';
 import useVatDetails from './use-vat-details';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { VatDetails, UpdateError } from './use-vat-details';
 
-const VatActionArea = styled.div`
-	margin-top: 1em;
-`;
+import './style.scss';
 
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
@@ -50,58 +52,74 @@ export default function VatInfoPage(): JSX.Element {
 	}
 
 	return (
-		<div className="vat-info">
-			<VatUpdateErrorNotice error={ updateError } />
+		<Layout>
+			<Column type="main" className="vat-info">
+				<VatUpdateErrorNotice error={ updateError } />
 
-			<CompactCard>
-				<div>
-					<label>{ translate( 'Country' ) }</label>
-					<FormTextInput
-						disabled={ isUpdating }
-						value={ currentVatDetails.country ?? vatDetails.country ?? '' }
-						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-							setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
-						}
-					/>
-				</div>
-				<div>
-					<label>{ translate( 'VAT' ) }</label>
-					<FormTextInput
-						disabled={ isUpdating }
-						value={ currentVatDetails.id ?? vatDetails.id ?? '' }
-						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-							setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
-						}
-					/>
-				</div>
-				<div>
-					<label>{ translate( 'Name' ) }</label>
-					<FormTextInput
-						disabled={ isUpdating }
-						value={ currentVatDetails.name ?? vatDetails.name ?? '' }
-						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-							setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
-						}
-					/>
-				</div>
-				<div>
-					<label>{ translate( 'Address' ) }</label>
-					<FormTextInput
-						disabled={ isUpdating }
-						value={ currentVatDetails.address ?? vatDetails.address ?? '' }
-						onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-							setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
-						}
-					/>
-				</div>
+				<CompactCard>
+					<FormFieldset className="vat-info__country-field">
+						<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
+						<FormTextInput
+							name="country"
+							disabled={ isUpdating }
+							value={ currentVatDetails.country ?? vatDetails.country ?? '' }
+							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+								setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
+							}
+						/>
+					</FormFieldset>
+					<FormFieldset className="vat-info__vat-field">
+						<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
+						<FormTextInput
+							name="vat"
+							disabled={ isUpdating }
+							value={ currentVatDetails.id ?? vatDetails.id ?? '' }
+							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+								setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
+							}
+						/>
+					</FormFieldset>
+					<FormFieldset className="vat-info__name-field">
+						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+						<FormTextInput
+							name="name"
+							disabled={ isUpdating }
+							value={ currentVatDetails.name ?? vatDetails.name ?? '' }
+							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+								setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
+							}
+						/>
+					</FormFieldset>
+					<FormFieldset className="vat-info__address-field">
+						<FormLabel htmlFor="address">{ translate( 'Address' ) }</FormLabel>
+						<FormTextInput
+							name="address"
+							disabled={ isUpdating }
+							value={ currentVatDetails.address ?? vatDetails.address ?? '' }
+							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+								setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
+							}
+						/>
+					</FormFieldset>
 
-				<VatActionArea>
-					<Button busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
+					<Button primary busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
 						{ translate( 'Validate and save' ) }
 					</Button>
-				</VatActionArea>
-			</CompactCard>
-		</div>
+				</CompactCard>
+			</Column>
+			<Column type="sidebar">
+				<Card className="vat-info__sidebar-card">
+					<CardHeading tagName="h1" size={ 16 } isBold={ true } className="vat-info__sidebar-title">
+						{ translate( 'VAT Information' ) }
+					</CardHeading>
+					<p className="vat-info__sidebar-paragraph">
+						{ translate(
+							"We currently only provide VAT invoices to users who are properly listed in the VIES (VAT Information Exchange System) or the UK VAT database. VAT information saved on this page will be applied to all of your account's receipts."
+						) }
+					</p>
+				</Card>
+			</Column>
+		</Layout>
 	);
 }
 

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -26,6 +26,7 @@ export default function VatInfoPage(): JSX.Element {
 		vatDetails,
 		isLoading,
 		isUpdating,
+		isUpdateSuccessful,
 		fetchError,
 		updateError,
 		setVatDetails,
@@ -54,7 +55,7 @@ export default function VatInfoPage(): JSX.Element {
 	return (
 		<Layout>
 			<Column type="main" className="vat-info">
-				<VatUpdateErrorNotice error={ updateError } />
+				<VatUpdateStatusNotice error={ updateError } success={ isUpdateSuccessful } />
 
 				<CompactCard>
 					<FormFieldset className="vat-info__country-field">
@@ -123,13 +124,15 @@ export default function VatInfoPage(): JSX.Element {
 	);
 }
 
-function VatUpdateErrorNotice( { error }: { error: UpdateError | null } ): JSX.Element | null {
+function VatUpdateStatusNotice( {
+	error,
+	success,
+}: {
+	error: UpdateError | null;
+	success: boolean;
+} ): JSX.Element | null {
 	const translate = useTranslate();
-	if ( ! error ) {
-		return null;
-	}
-
-	if ( error.error === 'validation_failed' ) {
+	if ( error?.error === 'validation_failed' ) {
 		return (
 			<CompactCard highlight="error">
 				{ translate( 'Your VAT details are not valid. Please check each field and try again.' ) }
@@ -137,9 +140,21 @@ function VatUpdateErrorNotice( { error }: { error: UpdateError | null } ): JSX.E
 		);
 	}
 
-	return (
-		<CompactCard highlight="error">
-			{ translate( 'An error occurred while updating your VAT details.' ) }
-		</CompactCard>
-	);
+	if ( error ) {
+		return (
+			<CompactCard highlight="error">
+				{ translate( 'An error occurred while updating your VAT details.' ) }
+			</CompactCard>
+		);
+	}
+
+	if ( success ) {
+		return (
+			<CompactCard highlight="success">
+				{ translate( 'Your VAT details have been updated!' ) }
+			</CompactCard>
+		);
+	}
+
+	return null;
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -16,6 +16,7 @@ import useVatDetails from './use-vat-details';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormSelect from 'calypso/components/forms/form-select';
 import type { VatDetails, UpdateError } from './use-vat-details';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 
@@ -62,7 +63,7 @@ export default function VatInfoPage(): JSX.Element {
 				<CompactCard>
 					<FormFieldset className="vat-info__country-field">
 						<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
-						<FormTextInput
+						<CountryCodeInput
 							name="country"
 							disabled={ isUpdating }
 							value={ currentVatDetails.country ?? vatDetails.country ?? '' }
@@ -123,6 +124,69 @@ export default function VatInfoPage(): JSX.Element {
 				</Card>
 			</Column>
 		</Layout>
+	);
+}
+
+function CountryCodeInput( {
+	name,
+	disabled,
+	value,
+	onChange,
+}: {
+	name: string;
+	disabled?: boolean;
+	value: string;
+	onChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
+} ) {
+	const countries = [
+		'AT',
+		'BE',
+		'BG',
+		'CY',
+		'CZ',
+		'DE',
+		'DK',
+		'EE',
+		'EL',
+		'ES',
+		'FI',
+		'FR',
+		'HR',
+		'HU',
+		'IE',
+		'IT',
+		'LT',
+		'LU',
+		'LV',
+		'MT',
+		'NL',
+		'PL',
+		'PT',
+		'RO',
+		'SE',
+		'SI',
+		'SK',
+		'UK',
+		'XI',
+	];
+
+	return (
+		<FormSelect
+			name={ name }
+			disabled={ disabled }
+			value={ value }
+			onChange={ onChange }
+			className="vat-info__country-select"
+		>
+			<option value="">--</option>
+			{ countries.map( ( countryCode ) => {
+				return (
+					<option key={ countryCode } value={ countryCode }>
+						{ countryCode }
+					</option>
+				);
+			} ) }
+		</FormSelect>
 	);
 }
 

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -53,80 +53,86 @@ export default function VatInfoPage(): JSX.Element {
 		);
 	}
 
-	if ( isLoading ) {
-		return (
-			<div className="vat-info">
-				<CompactCard>{ translate( 'Loading…' ) }</CompactCard>
-			</div>
-		);
-	}
+	const loadingPlaceholder = (
+		<>
+			<div className="vat-info__form-placeholder"></div>
+			<div className="vat-info__form-placeholder"></div>
+			<div className="vat-info__form-placeholder"></div>
+			<div className="vat-info__form-placeholder"></div>
+		</>
+	);
 
 	return (
-		<Layout>
-			<Column type="main" className="vat-info">
-				<CompactCard>
-					<FormFieldset className="vat-info__country-field">
-						<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
-						<CountryCodeInput
-							name="country"
-							disabled={ isUpdating || isVatAlreadySet }
-							value={ currentVatDetails.country ?? vatDetails.country ?? '' }
-							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-								setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
-							}
-						/>
-					</FormFieldset>
-					<FormFieldset className="vat-info__vat-field">
-						<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
-						<FormTextInput
-							name="vat"
-							disabled={ isUpdating || isVatAlreadySet }
-							value={ currentVatDetails.id ?? vatDetails.id ?? '' }
-							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-								setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
-							}
-						/>
-						{ isVatAlreadySet && (
-							<FormSettingExplanation>
-								{ translate(
-									'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
-									{
-										components: {
-											contactSupportLink: (
-												<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />
-											),
-										},
+		<Layout className={ isLoading ? 'vat-info is-loading' : 'vat-info' }>
+			<Column type="main">
+				<CompactCard className="vat-info__form">
+					{ isLoading && loadingPlaceholder }
+					{ ! isLoading && (
+						<>
+							<FormFieldset className="vat-info__country-field">
+								<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
+								<CountryCodeInput
+									name="country"
+									disabled={ isUpdating || isVatAlreadySet }
+									value={ currentVatDetails.country ?? vatDetails.country ?? '' }
+									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+										setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
 									}
+								/>
+							</FormFieldset>
+							<FormFieldset className="vat-info__vat-field">
+								<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
+								<FormTextInput
+									name="vat"
+									disabled={ isUpdating || isVatAlreadySet }
+									value={ currentVatDetails.id ?? vatDetails.id ?? '' }
+									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+										setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
+									}
+								/>
+								{ isVatAlreadySet && (
+									<FormSettingExplanation>
+										{ translate(
+											'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+											{
+												components: {
+													contactSupportLink: (
+														<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />
+													),
+												},
+											}
+										) }
+									</FormSettingExplanation>
 								) }
-							</FormSettingExplanation>
-						) }
-					</FormFieldset>
-					<FormFieldset className="vat-info__name-field">
-						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
-						<FormTextInput
-							name="name"
-							disabled={ isUpdating }
-							value={ currentVatDetails.name ?? vatDetails.name ?? '' }
-							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-								setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
-							}
-						/>
-					</FormFieldset>
-					<FormFieldset className="vat-info__address-field">
-						<FormLabel htmlFor="address">{ translate( 'Address' ) }</FormLabel>
-						<FormTextInput
-							name="address"
-							disabled={ isUpdating }
-							value={ currentVatDetails.address ?? vatDetails.address ?? '' }
-							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-								setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
-							}
-						/>
-					</FormFieldset>
+							</FormFieldset>
+							<FormFieldset className="vat-info__name-field">
+								<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+								<FormTextInput
+									name="name"
+									disabled={ isUpdating }
+									value={ currentVatDetails.name ?? vatDetails.name ?? '' }
+									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+										setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
+									}
+								/>
+							</FormFieldset>
+							<FormFieldset className="vat-info__address-field">
+								<FormLabel htmlFor="address">{ translate( 'Address' ) }</FormLabel>
+								<FormTextInput
+									name="address"
+									disabled={ isUpdating }
+									value={ currentVatDetails.address ?? vatDetails.address ?? '' }
+									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+										setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
+									}
+								/>
+							</FormFieldset>
 
-					<Button primary busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
-						{ translate( 'Validate and save' ) }
-					</Button>
+							<Button primary busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
+								{ translate( 'Validate and save' ) }
+							</Button>
+						</>
+					) }
 				</CompactCard>
 			</Column>
 			<Column type="sidebar">

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -17,6 +17,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormSelect from 'calypso/components/forms/form-select';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import type { VatDetails, UpdateError } from './use-vat-details';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 
@@ -40,6 +41,8 @@ export default function VatInfoPage(): JSX.Element {
 	};
 
 	useDisplayVatNotices( { error: updateError, success: isUpdateSuccessful } );
+
+	const isVatAlreadySet = !! vatDetails.id;
 
 	if ( fetchError ) {
 		return (
@@ -65,7 +68,7 @@ export default function VatInfoPage(): JSX.Element {
 						<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
 						<CountryCodeInput
 							name="country"
-							disabled={ isUpdating }
+							disabled={ isUpdating || isVatAlreadySet }
 							value={ currentVatDetails.country ?? vatDetails.country ?? '' }
 							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 								setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
@@ -76,12 +79,17 @@ export default function VatInfoPage(): JSX.Element {
 						<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
 						<FormTextInput
 							name="vat"
-							disabled={ isUpdating }
+							disabled={ isUpdating || isVatAlreadySet }
 							value={ currentVatDetails.id ?? vatDetails.id ?? '' }
 							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 								setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
 							}
 						/>
+						{ isVatAlreadySet && (
+							<FormSettingExplanation>
+								{ translate( 'To change your VAT number, please contact support.' ) }
+							</FormSettingExplanation>
+						) }
 					</FormFieldset>
 					<FormFieldset className="vat-info__name-field">
 						<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -151,9 +151,14 @@ function useDisplayVatNotices( {
 		if ( error ) {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
-				errorNotice( translate( 'An error occurred while updating your VAT details.' ), {
-					id: 'vat_info_notice',
-				} )
+				errorNotice(
+					translate(
+						'An error occurred while updating your VAT details. Please try again or contact support.'
+					),
+					{
+						id: 'vat_info_notice',
+					}
+				)
 			);
 			return;
 		}

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -20,6 +20,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import type { VatDetails, UpdateError } from './use-vat-details';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 
 import './style.scss';
 
@@ -87,7 +88,16 @@ export default function VatInfoPage(): JSX.Element {
 						/>
 						{ isVatAlreadySet && (
 							<FormSettingExplanation>
-								{ translate( 'To change your VAT number, please contact support.' ) }
+								{ translate(
+									'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+									{
+										components: {
+											contactSupportLink: (
+												<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />
+											),
+										},
+									}
+								) }
 							</FormSettingExplanation>
 						) }
 					</FormFieldset>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -17,7 +17,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { VatDetails, UpdateError } from './use-vat-details';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 
 import './style.scss';
 
@@ -138,23 +138,33 @@ function useDisplayVatNotices( {
 
 	useEffect( () => {
 		if ( error?.error === 'validation_failed' ) {
+			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
 				errorNotice(
-					translate( 'Your VAT details are not valid. Please check each field and try again.' )
+					translate( 'Your VAT details are not valid. Please check each field and try again.' ),
+					{ id: 'vat_info_notice' }
 				)
 			);
 			return;
 		}
 
 		if ( error ) {
+			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
-				errorNotice( translate( 'An error occurred while updating your VAT details.' ) )
+				errorNotice( translate( 'An error occurred while updating your VAT details.' ), {
+					id: 'vat_info_notice',
+				} )
 			);
 			return;
 		}
 
 		if ( success ) {
-			reduxDispatch( successNotice( translate( 'Your VAT details have been updated!' ) ) );
+			reduxDispatch( removeNotice( 'vat_info_notice' ) );
+			reduxDispatch(
+				successNotice( translate( 'Your VAT details have been updated!' ), {
+					id: 'vat_info_notice',
+				} )
+			);
 			return;
 		}
 	}, [ error, success, reduxDispatch, translate ] );

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -26,24 +26,7 @@ import './style.scss';
 
 export default function VatInfoPage(): JSX.Element {
 	const translate = useTranslate();
-	const [ currentVatDetails, setCurrentVatDetails ] = useState< VatDetails >( {} );
-	const {
-		vatDetails,
-		isLoading,
-		isUpdating,
-		isUpdateSuccessful,
-		fetchError,
-		updateError,
-		setVatDetails,
-	} = useVatDetails();
-
-	const saveDetails = () => {
-		setVatDetails( { ...vatDetails, ...currentVatDetails } );
-	};
-
-	useDisplayVatNotices( { error: updateError, success: isUpdateSuccessful } );
-
-	const isVatAlreadySet = !! vatDetails.id;
+	const { isLoading, fetchError } = useVatDetails();
 
 	if ( fetchError ) {
 		return (
@@ -53,86 +36,12 @@ export default function VatInfoPage(): JSX.Element {
 		);
 	}
 
-	const loadingPlaceholder = (
-		<>
-			<div className="vat-info__form-placeholder"></div>
-			<div className="vat-info__form-placeholder"></div>
-			<div className="vat-info__form-placeholder"></div>
-			<div className="vat-info__form-placeholder"></div>
-		</>
-	);
-
 	return (
 		<Layout className={ isLoading ? 'vat-info is-loading' : 'vat-info' }>
 			<Column type="main">
 				<CompactCard className="vat-info__form">
-					{ isLoading && loadingPlaceholder }
-					{ ! isLoading && (
-						<>
-							<FormFieldset className="vat-info__country-field">
-								<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
-								<CountryCodeInput
-									name="country"
-									disabled={ isUpdating || isVatAlreadySet }
-									value={ currentVatDetails.country ?? vatDetails.country ?? '' }
-									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-										setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
-									}
-								/>
-							</FormFieldset>
-							<FormFieldset className="vat-info__vat-field">
-								<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
-								<FormTextInput
-									name="vat"
-									disabled={ isUpdating || isVatAlreadySet }
-									value={ currentVatDetails.id ?? vatDetails.id ?? '' }
-									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-										setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
-									}
-								/>
-								{ isVatAlreadySet && (
-									<FormSettingExplanation>
-										{ translate(
-											'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
-											{
-												components: {
-													contactSupportLink: (
-														<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />
-													),
-												},
-											}
-										) }
-									</FormSettingExplanation>
-								) }
-							</FormFieldset>
-							<FormFieldset className="vat-info__name-field">
-								<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
-								<FormTextInput
-									name="name"
-									disabled={ isUpdating }
-									value={ currentVatDetails.name ?? vatDetails.name ?? '' }
-									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-										setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
-									}
-								/>
-							</FormFieldset>
-							<FormFieldset className="vat-info__address-field">
-								<FormLabel htmlFor="address">{ translate( 'Address' ) }</FormLabel>
-								<FormTextInput
-									name="address"
-									disabled={ isUpdating }
-									value={ currentVatDetails.address ?? vatDetails.address ?? '' }
-									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-										setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
-									}
-								/>
-							</FormFieldset>
-
-							<Button primary busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
-								{ translate( 'Validate and save' ) }
-							</Button>
-						</>
-					) }
+					{ isLoading && <LoadingPlaceholder /> }
+					{ ! isLoading && <VatForm /> }
 				</CompactCard>
 			</Column>
 			<Column type="sidebar">
@@ -148,6 +57,93 @@ export default function VatInfoPage(): JSX.Element {
 				</Card>
 			</Column>
 		</Layout>
+	);
+}
+
+function VatForm(): JSX.Element {
+	const translate = useTranslate();
+	const [ currentVatDetails, setCurrentVatDetails ] = useState< VatDetails >( {} );
+	const {
+		vatDetails,
+		isUpdating,
+		isUpdateSuccessful,
+		setVatDetails,
+		updateError,
+	} = useVatDetails();
+
+	const saveDetails = () => {
+		setVatDetails( { ...vatDetails, ...currentVatDetails } );
+	};
+
+	useDisplayVatNotices( { error: updateError, success: isUpdateSuccessful } );
+
+	const isVatAlreadySet = !! vatDetails.id;
+
+	return (
+		<>
+			<FormFieldset className="vat-info__country-field">
+				<FormLabel htmlFor="country">{ translate( 'Country' ) }</FormLabel>
+				<CountryCodeInput
+					name="country"
+					disabled={ isUpdating || isVatAlreadySet }
+					value={ currentVatDetails.country ?? vatDetails.country ?? '' }
+					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+						setCurrentVatDetails( { ...currentVatDetails, country: event.target.value } )
+					}
+				/>
+			</FormFieldset>
+			<FormFieldset className="vat-info__vat-field">
+				<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
+				<FormTextInput
+					name="vat"
+					disabled={ isUpdating || isVatAlreadySet }
+					value={ currentVatDetails.id ?? vatDetails.id ?? '' }
+					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+						setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
+					}
+				/>
+				{ isVatAlreadySet && (
+					<FormSettingExplanation>
+						{ translate(
+							'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							{
+								components: {
+									contactSupportLink: (
+										<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />
+									),
+								},
+							}
+						) }
+					</FormSettingExplanation>
+				) }
+			</FormFieldset>
+			<FormFieldset className="vat-info__name-field">
+				<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+				<FormTextInput
+					name="name"
+					disabled={ isUpdating }
+					value={ currentVatDetails.name ?? vatDetails.name ?? '' }
+					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+						setCurrentVatDetails( { ...currentVatDetails, name: event.target.value } )
+					}
+				/>
+			</FormFieldset>
+			<FormFieldset className="vat-info__address-field">
+				<FormLabel htmlFor="address">{ translate( 'Address' ) }</FormLabel>
+				<FormTextInput
+					name="address"
+					disabled={ isUpdating }
+					value={ currentVatDetails.address ?? vatDetails.address ?? '' }
+					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+						setCurrentVatDetails( { ...currentVatDetails, address: event.target.value } )
+					}
+				/>
+			</FormFieldset>
+
+			<Button primary busy={ isUpdating } disabled={ isUpdating } onClick={ saveDetails }>
+				{ translate( 'Validate and save' ) }
+			</Button>
+		</>
 	);
 }
 
@@ -261,4 +257,15 @@ function useDisplayVatNotices( {
 			return;
 		}
 	}, [ error, success, reduxDispatch, translate ] );
+}
+
+function LoadingPlaceholder(): JSX.Element {
+	return (
+		<>
+			<div className="vat-info__form-placeholder"></div>
+			<div className="vat-info__form-placeholder"></div>
+			<div className="vat-info__form-placeholder"></div>
+			<div className="vat-info__form-placeholder"></div>
+		</>
+	);
 }

--- a/client/me/purchases/vat-info/style.scss
+++ b/client/me/purchases/vat-info/style.scss
@@ -1,0 +1,8 @@
+.vat-info__sidebar-title {
+	margin-top: 0;
+}
+
+.vat-info__sidebar-paragraph {
+	margin-bottom: 0;
+	font-size: 0.875rem;
+}

--- a/client/me/purchases/vat-info/style.scss
+++ b/client/me/purchases/vat-info/style.scss
@@ -1,3 +1,16 @@
+.is-loading {
+	.vat-info__form {
+		padding-top: 32px;
+	}
+	.vat-info__form-placeholder {
+		animation: pulse-light 1.8s ease-in-out infinite;
+		background-color: var( --color-neutral-10 );
+		height: 24px;
+		width: 100%;
+		margin-bottom: 16px;
+	}
+}
+
 .vat-info__sidebar-title {
 	margin-top: 0;
 }

--- a/client/me/purchases/vat-info/style.scss
+++ b/client/me/purchases/vat-info/style.scss
@@ -6,3 +6,7 @@
 	margin-bottom: 0;
 	font-size: 0.875rem;
 }
+
+.vat-info__country-select {
+	width: 100%;
+}

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -10,10 +10,10 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 export interface VatDetails {
-	country: string;
-	id: string;
-	name: string;
-	address: string;
+	country?: string | null;
+	id?: string | null;
+	name?: string | null;
+	address?: string | null;
 }
 
 type SetVatDetails = ( vatDetails: VatDetails ) => void;
@@ -36,12 +36,7 @@ async function setVatDetails( vatDetails: VatDetails ): Promise< VatDetails > {
 	} );
 }
 
-const emptyVatDetails = {
-	country: '',
-	id: '',
-	name: '',
-	address: '',
-};
+const emptyVatDetails = {};
 
 export default function useVatDetails(): VatDetailsManager {
 	const queryClient = useQueryClient();

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -27,6 +27,7 @@ export interface VatDetailsManager {
 	vatDetails: VatDetails;
 	isLoading: boolean;
 	isUpdating: boolean;
+	isUpdateSuccessful: boolean;
 	fetchError: Error | null;
 	updateError: UpdateError | null;
 	setVatDetails: SetVatDetails;
@@ -65,6 +66,7 @@ export default function useVatDetails(): VatDetailsManager {
 			vatDetails: query.data ?? emptyVatDetails,
 			isLoading: query.isLoading,
 			isUpdating: mutation.isLoading,
+			isUpdateSuccessful: mutation.isSuccess,
 			fetchError: query.error,
 			updateError: mutation.error,
 			setVatDetails: setDetails,

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+export interface VatDetails {
+	country: string;
+	id: string;
+	name: string;
+	address: string;
+}
+
+type SetVatDetails = ( vatDetails: VatDetails ) => void;
+
+interface VatDetailsManager {
+	vatDetails: VatDetails;
+	isLoading: boolean;
+	error: Error | null;
+	setVatDetails: SetVatDetails;
+}
+
+async function fetchVatDetails(): Promise< VatDetails > {
+	return await wpcom.req.get( '/me/vat-info' );
+}
+
+async function setVatDetails( vatDetails: VatDetails ): Promise< VatDetails > {
+	return await wpcom.req.post( {
+		path: '/me/vat-info',
+		body: vatDetails,
+	} );
+}
+
+const emptyVatDetails = {
+	country: '',
+	id: '',
+	name: '',
+	address: '',
+};
+
+export default function useVatDetails(): VatDetailsManager {
+	const queryClient = useQueryClient();
+	const query = useQuery< VatDetails, Error >( 'vat-details', fetchVatDetails );
+	const mutation = useMutation< VatDetails, Error, VatDetails >( setVatDetails, {
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( 'vat-details', data );
+		},
+	} );
+	const setDetails = useCallback(
+		( vatDetails: VatDetails ) => {
+			mutation.mutate( vatDetails );
+		},
+		[ mutation ]
+	);
+
+	return useMemo(
+		() => ( {
+			vatDetails: query.data ?? emptyVatDetails,
+			isLoading: query.isLoading || mutation.isLoading,
+			error: query.error || mutation.error,
+			setVatDetails: setDetails,
+		} ),
+		[ query, setDetails, mutation ]
+	);
+}

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -26,6 +26,7 @@ export interface UpdateError {
 export interface VatDetailsManager {
 	vatDetails: VatDetails;
 	isLoading: boolean;
+	isUpdating: boolean;
 	fetchError: Error | null;
 	updateError: UpdateError | null;
 	setVatDetails: SetVatDetails;
@@ -62,7 +63,8 @@ export default function useVatDetails(): VatDetailsManager {
 	return useMemo(
 		() => ( {
 			vatDetails: query.data ?? emptyVatDetails,
-			isLoading: query.isLoading || mutation.isLoading,
+			isLoading: query.isLoading,
+			isUpdating: mutation.isLoading,
 			fetchError: query.error,
 			updateError: mutation.error,
 			setVatDetails: setDetails,

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -16,12 +16,18 @@ export interface VatDetails {
 	address?: string | null;
 }
 
-type SetVatDetails = ( vatDetails: VatDetails ) => void;
+export type SetVatDetails = ( vatDetails: VatDetails ) => void;
 
-interface VatDetailsManager {
+export interface UpdateError {
+	message: string;
+	error: string;
+}
+
+export interface VatDetailsManager {
 	vatDetails: VatDetails;
 	isLoading: boolean;
-	error: Error | null;
+	fetchError: Error | null;
+	updateError: UpdateError | null;
 	setVatDetails: SetVatDetails;
 }
 
@@ -41,7 +47,7 @@ const emptyVatDetails = {};
 export default function useVatDetails(): VatDetailsManager {
 	const queryClient = useQueryClient();
 	const query = useQuery< VatDetails, Error >( 'vat-details', fetchVatDetails );
-	const mutation = useMutation< VatDetails, Error, VatDetails >( setVatDetails, {
+	const mutation = useMutation< VatDetails, UpdateError, VatDetails >( setVatDetails, {
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( 'vat-details', data );
 		},
@@ -57,7 +63,8 @@ export default function useVatDetails(): VatDetailsManager {
 		() => ( {
 			vatDetails: query.data ?? emptyVatDetails,
 			isLoading: query.isLoading || mutation.isLoading,
-			error: query.error || mutation.error,
+			fetchError: query.error,
+			updateError: mutation.error,
 			setVatDetails: setDetails,
 		} ),
 		[ query, setDetails, mutation ]

--- a/config/development.json
+++ b/config/development.json
@@ -129,6 +129,7 @@
 		"marketplace-yoast": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/vat-details": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,6 +94,7 @@
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,
 		"me/account/color-scheme-picker": true,
+		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"perfmon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -96,6 +96,7 @@
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/vat-details": false,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -97,6 +97,7 @@
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/vat-details": true,
 		"memberships": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,

--- a/config/test.json
+++ b/config/test.json
@@ -79,6 +79,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"me/account-close": true,
+		"me/vat-details": true,
 		"memberships": true,
 		"network-connection": true,
 		"perfmon": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -102,6 +102,7 @@
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/vat-details": true,
 		"memberships": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an experiment to try adding a VAT Info page to the /me section.

Worth noting that this uses [react-query](https://react-query.tanstack.com/) to access the new API endpoints which has been newly added to calypso and was recently recommended by the calypso team.

Requires D61272-code

<img width="1000" alt="Screen Shot 2021-06-01 at 8 10 07 PM" src="https://user-images.githubusercontent.com/2036909/120404908-628bf100-c315-11eb-9d19-1dc70b3c00cc.png">

#### To do

- [x] Add hook to fetch and update data from new API endpoint.
- [x] Move to `/me/purchases/vat-details`
- [x] Add text link to [receipt page where it mentions VAT](https://github.com/Automattic/wp-calypso/blob/d81896783e83fcbfeeadffcc034f306775f85d4d/client/me/purchases/billing-history/receipt.jsx#L313)
- [x] Add button to bottom of Billing History page
- [x] Style form
- [x] Add success notice
- [x] Handle validation failure with good UX
- [x] Fetch and show VAT details on receipt page (if set)
- [x] Add feature flag to hide this page and its links in production
- [x] Add text to VAT details button to clarify that it only applies to EU/UK customers.
- [x] Make country/number fields read-only if they are set when the page loads with a notice to contact support to change them

#### Testing instructions

- Apply D61272-code and sandbox the store
- Visit http://calypso.localhost:3000/me/purchases/vat-details
- Enter the County code `UK` and the VAT number `1234`.
- Submit the form.
- Verify that you receive a validation error.
- Enter the County code `UK` and the VAT number `553557881`. (Note: this is a test number that will only work when viewing the form sandboxed).
- Submit the form.
- Verify that the validation is successful and that the details are still correct.
- Verify that you can no longer edit the VAT number or country.
- Modify the Name field.
- Submit the form.
- Verify that the name field is successfully changed.