### PR TITLE
My Home: Record tracks event for celebration notices

### DIFF
--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -31,6 +31,7 @@ const CelebrateNotice = ( {
 	skipText,
 	siteId,
 	title,
+	tracksEventExtras = {},
 } ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( true );
@@ -50,6 +51,7 @@ const CelebrateNotice = ( {
 			composeAnalytics(
 				recordTracksEvent( 'calypso_customer_home_notice_show_next', {
 					notice: noticeId,
+					...tracksEventExtras,
 				} )
 			)
 		);
@@ -64,6 +66,7 @@ const CelebrateNotice = ( {
 			composeAnalytics(
 				recordTracksEvent( 'calypso_customer_home_notice_skip', {
 					notice: noticeId,
+					...tracksEventExtras,
 				} )
 			)
 		);

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -14,6 +14,7 @@ import Spinner from 'calypso/components/spinner';
 import { skipCurrentViewHomeLayout } from 'calypso/state/home/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Image dependencies
@@ -44,12 +45,28 @@ const CelebrateNotice = ( {
 	const showNextTask = () => {
 		setIsLoading( true );
 		dispatch( skipCurrentViewHomeLayout( siteId ) );
+
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_customer_home_notice_show_next', {
+					notice: noticeId,
+				} )
+			)
+		);
 	};
 
 	const skip = () => {
 		setIsVisible( false );
 		dispatch( savePreference( dismissalPreferenceKey, true ) );
 		onSkip && onSkip();
+
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_customer_home_notice_skip', {
+					notice: noticeId,
+				} )
+			)
+		);
 	};
 
 	return (

--- a/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
@@ -62,6 +62,7 @@ const CelebrateSiteLaunch = ( { isSiteSetupComplete, pendingSiteSetupTasks, site
 			showSkip={ true }
 			skipText={ isSiteSetupComplete ? translate( 'Dismiss' ) : translate( 'Skip site setup' ) }
 			onSkip={ ! isSiteSetupComplete ? skipSiteSetup : null }
+			tracksEventExtras={ { is_site_setup_complete: isSiteSetupComplete } }
 		/>
 	);
 };


### PR DESCRIPTION
In this discussion https://github.com/Automattic/wp-calypso/issues/47334#issuecomment-847279812 we wondered how often users choose to "Show site setup" or "Skip site setup" in the "You launched your site!" post-launch banner. Surprisingly we didn't have tracks data for that.

![image](https://user-images.githubusercontent.com/5665959/119597876-365c0600-be25-11eb-9be2-21b9834130ed.png)


#### Changes proposed in this Pull Request

* Records an event when the "show next" or "skip" buttons are pressed on My Home notices ("show next" is the generic term for the primary CTA on notices, of which the post-launch banner is only one).
* All notices to provide their own custom even props so we can distinguish between variations

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch a site where the checklist isn't complete
* After returning to My Home check the `calypso_customer_home_notice_show_next` (or `calypso_customer_home_notice_skip`) event is sent to tracks and the `is_site_setup_complete` prop is `false`
* Test the same but with a site where the checklist was complete and confirm the `is_site_setup_complete` prop is `true`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

