### PR TITLE
Signup: update Tracks events to record a skipped step 

### DIFF
--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -37,7 +37,7 @@ const object = {
 
 #### Actions
 
-- `submitSignupStep( step, providedDependencies )` — the user submits a step
+- `submitSignupStep( step, providedDependencies, isSkipped )` — the user submits a step
 - `completeSignupStep( step, errors, providedDependencies )` — a step processed by the API
 
 If `errors` has a non-zero length, it will be attached to the step and the step's status will be set to `invalid` as it is added to the store. If a `providedDependencies` object is included, its information will be added to the dependency store.

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -112,7 +112,8 @@ export class NavigationLink extends Component {
 		if ( this.props.direction === 'forward' ) {
 			this.props.submitSignupStep(
 				{ stepName: this.props.stepName },
-				this.props.defaultDependencies
+				this.props.defaultDependencies,
+				this.props.direction === 'forward'
 			);
 
 			this.props.goToNextStep();

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -113,7 +113,7 @@ export class NavigationLink extends Component {
 			this.props.submitSignupStep(
 				{ stepName: this.props.stepName },
 				this.props.defaultDependencies,
-				this.props.direction === 'forward'
+				true
 			);
 
 			this.props.goToNextStep();

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -271,7 +271,7 @@ class DomainsStep extends React.Component {
 		this.props.saveSignupStep( stepData );
 
 		defer( () => {
-			this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
+			this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan, true );
 		} );
 	};
 
@@ -285,7 +285,7 @@ class DomainsStep extends React.Component {
 		page( this.getUseYourDomainUrl() );
 	};
 
-	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
+	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false, isSkipped ) => {
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
@@ -326,7 +326,8 @@ class DomainsStep extends React.Component {
 				{ domainItem },
 				this.isDependencyShouldHideFreePlanProvided() ? { shouldHideFreePlan } : {},
 				useThemeHeadstartItem
-			)
+			),
+			isSkipped
 		);
 
 		this.props.setDesignType( this.getDesignType() );

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -30,7 +30,7 @@ function addProvidedDependencies( step, providedDependencies ) {
 	return { ...step, providedDependencies };
 }
 
-function recordSubmitStep( stepName, providedDependencies ) {
+function recordSubmitStep( stepName, providedDependencies, isSkipped ) {
 	// Transform the keys since tracks events only accept snaked prop names.
 	// And anonymize personally identifiable information.
 	const inputs = reduce(
@@ -77,6 +77,7 @@ function recordSubmitStep( stepName, providedDependencies ) {
 	return recordTracksEvent( 'calypso_signup_actions_submit_step', {
 		device,
 		step: stepName,
+		skipped: !! isSkipped,
 		...inputs,
 	} );
 }
@@ -93,13 +94,13 @@ export function saveSignupStep( step ) {
 	};
 }
 
-export function submitSignupStep( step, providedDependencies ) {
+export function submitSignupStep( step, providedDependencies, isSkipped ) {
 	assertValidDependencies( step.stepName, providedDependencies );
 	return ( dispatch, getState ) => {
 		const lastKnownFlow = getCurrentFlowName( getState() );
 		const lastUpdated = Date.now();
 
-		dispatch( recordSubmitStep( step.stepName, providedDependencies ) );
+		dispatch( recordSubmitStep( step.stepName, providedDependencies, isSkipped ) );
 
 		dispatch( {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `skipped` prop to `calypso_signup_actions_submit_step` event when using default navigation (Skip button)
* Add the same prop for Domains step custom navigation

#### Testing instructions

* Test skipping Design step in `/start/with-design-picker` flow (hint: when using JS console to debug, try switching off internet before skipping to prevent a redirect)
<img width="1521" alt="117257214-531fa200-ae54-11eb-8fb5-fbb203c56177" src="https://user-images.githubusercontent.com/14192054/119461054-012db600-bd48-11eb-92df-9383277db767.png">

* For an unlaunched site, test skipping Domains step in `/start/launch-site` flow
<img width="1032" alt="Screenshot 2021-05-25 at 10 45 00" src="https://user-images.githubusercontent.com/14192054/119460897-d2174480-bd47-11eb-8a12-ba741240f06c.png">

* In both cases, `calypso_signup_actions_submit_step` should fire with prop `skipped: true`. On all other steps, `skipped` prop should have the value `false`.

Related to p1621872569138900/1621869812.134800-slack-C01VA100LEA