### PR TITLE
Pages: Show count on Jetpack and Atomic sites

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -44,13 +44,12 @@ export class PostTypeFilter extends Component {
 			type: PropTypes.string.isRequired,
 		} ),
 		typeLabel: PropTypes.string,
-		jetpack: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		counts: PropTypes.object,
 	};
 
 	getNavItems() {
-		const { query, siteId, siteSlug, statusSlug, jetpack, counts } = this.props;
+		const { query, siteId, siteSlug, statusSlug, counts } = this.props;
 
 		const isPostOrPage = query.type === 'post' || query.type === 'page';
 
@@ -97,8 +96,8 @@ export class PostTypeFilter extends Component {
 
 				return memo.concat( {
 					key: `filter-${ status }`,
-					// Hide count in all sites mode; and in Jetpack mode for non-posts
-					count: ! siteId || ( jetpack && query.type !== 'post' ) ? null : count,
+					// Hide count in all sites mode.
+					count: ! siteId ? null : count,
 					path: compact( [
 						basePath,
 						isPostOrPage && query.author && 'my',
@@ -114,14 +113,7 @@ export class PostTypeFilter extends Component {
 	}
 
 	render() {
-		const {
-			authorToggleHidden,
-			jetpack,
-			query,
-			siteId,
-			statusSlug,
-			searchPagesPlaceholder,
-		} = this.props;
+		const { authorToggleHidden, query, siteId, statusSlug, searchPagesPlaceholder } = this.props;
 
 		if ( ! query ) {
 			return null;
@@ -144,7 +136,7 @@ export class PostTypeFilter extends Component {
 
 		return (
 			<div className="post-type-filter">
-				{ siteId && false === jetpack && <QueryPostCounts siteId={ siteId } type={ query.type } /> }
+				{ siteId && <QueryPostCounts siteId={ siteId } type={ query.type } /> }
 				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				<SectionNav
 					selectedText={
@@ -216,7 +208,6 @@ export default flow(
 		const props = {
 			siteId,
 			authorToggleHidden,
-			jetpack: isJetpackSite( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to align the behavior with Simple sites, this PR displays the pages count in the tabs/filters on Jetpack and Atomic sites.

Before | After
--- | ---
<img width="966" alt="Screen Shot 2021-05-25 at 12 11 07" src="https://user-images.githubusercontent.com/1233880/119481157-b1082100-bd52-11eb-8f98-bee7f6b5d312.png"> | <img width="976" alt="Screen Shot 2021-05-25 at 12 10 53" src="https://user-images.githubusercontent.com/1233880/119481139-ad749a00-bd52-11eb-9657-e8e261acbe33.png">

#### Testing instructions

- Switch to a Simple site.
- Go to pages.
- Note how the pages count is displayed in the tabs/filters.
- Switch to an Atomic site.
- Make sure the pages count is displayed.
- Switch to a Jetpack site.
- Make sure the pages count is displayed.

Fixes https://github.com/Automattic/wp-calypso/issues/47437
