### PR TITLE
Renamed blank-canvas-blocks to blockbase

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -438,9 +438,9 @@
 		},
 		{
 			"title": "Start with an empty page",
-			"slug": "blank-canvas-blocks",
-			"template": "blank-canvas-blocks",
-			"theme": "blank-canvas-blocks",
+			"slug": "blockbase",
+			"template": "blockbase",
+			"theme": "blockbase",
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The theme previously known as Blank Canvas Blocks has been renamed Blockbase. This PR updates the design config json to use the renamed version of the theme.


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### In Gutenboarding:
* Apply D60806-code
* Sandbox public-api.
* Visit [/new/design?flags=gutenboarding/site-editor](https://hash-90fcf479a5798ca0c774122e904b1917aaa31505.calypso.live/new/design?flags=gutenboarding/site-editor), pick the Blank Canvas design option and create a new site
* Verify that:
    * [ ] The new site is created correctly, without errors
    * [ ] The new site uses the Blank Canvas Blocks theme (and therefore, it uses FSE)
    * [ ] The homepage is prepopulated with an _empty page template_ (Note: this A/C needs revision)


Related to https://github.com/Automattic/themes/pull/3918