### PR TITLE
Media Library: don't allow uploading videos for free sites from the UI

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -28,6 +28,7 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
@@ -165,6 +166,7 @@ export default connect( ( state, ownProps ) => {
 		jetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
+		isAtomic: isAtomicSite( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -53,7 +53,7 @@ export const UpsellNudge = ( {
 	horizontal,
 	href,
 	isJetpackDevDocs,
-	jetpack,
+	isJetpack,
 	isAtomic,
 	isVip,
 	siteIsWPForTeams,
@@ -85,8 +85,8 @@ export const UpsellNudge = ( {
 		( feature && planHasFeature ) ||
 		( ! feature && ! isFreePlanProduct( site.plan ) ) ||
 		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
-		( ! jetpack && site.jetpack ) ||
-		( jetpack && ! site.jetpack );
+		( ! isJetpack && site.jetpack ) ||
+		( isJetpack && ! site.jetpack );
 
 	if ( shouldNotDisplay && ! forceDisplay ) {
 		return null;
@@ -130,7 +130,8 @@ export const UpsellNudge = ( {
 			horizontal={ horizontal }
 			href={ href }
 			icon="star"
-			jetpack={ ( jetpack && ! isAtomic ) || isJetpackDevDocs } //Force show Jetpack example in Devdocs
+			jetpack={ isJetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
+			isAtomic={ isAtomic }
 			list={ list }
 			onClick={ onClick }
 			onDismissClick={ onDismissClick }
@@ -163,6 +164,7 @@ export default connect( ( state, ownProps ) => {
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		jetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -28,8 +28,8 @@ import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -163,7 +163,7 @@ export default connect( ( state, ownProps ) => {
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		isJetpack: isJetpackSite( state, siteId ),
-		isAtomic: isAtomicSite( state, siteId ),
+		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -30,7 +30,6 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -163,8 +162,6 @@ export default connect( ( state, ownProps ) => {
 		site: getSite( state, siteId ),
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
-		jetpack: isJetpackSite( state, siteId ),
-		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
 		isAtomic: isAtomicSite( state, siteId ),
 		isVip: isVipSite( state, siteId ),

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -272,6 +272,7 @@ export class Banner extends Component {
 			forceHref,
 			horizontal,
 			jetpack,
+			isAtomic,
 			plan,
 		} = this.props;
 
@@ -294,7 +295,8 @@ export class Banner extends Component {
 			{ 'is-compact': compact },
 			{ 'is-dismissible': dismissPreferenceName },
 			{ 'is-horizontal': horizontal },
-			{ 'is-jetpack': jetpack }
+			{ 'is-jetpack': jetpack },
+			{ 'is-atomic': isAtomic }
 		);
 
 		if ( dismissPreferenceName ) {

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -59,6 +59,7 @@ export class Banner extends Component {
 		icon: PropTypes.string,
 		iconPath: PropTypes.string,
 		jetpack: PropTypes.bool,
+		isAtomic: PropTypes.bool,
 		compact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
@@ -88,6 +89,7 @@ export class Banner extends Component {
 		compact: false,
 		horizontal: false,
 		jetpack: false,
+		isAtomic: false,
 		onClick: noop,
 		onDismiss: noop,
 		primaryButton: true,
@@ -150,13 +152,13 @@ export class Banner extends Component {
 	};
 
 	getIcon() {
-		const { disableCircle, icon, iconPath, jetpack, showIcon } = this.props;
+		const { disableCircle, icon, iconPath, jetpack, showIcon, isAtomic } = this.props;
 
 		if ( ! showIcon ) {
 			return;
 		}
 
-		if ( jetpack ) {
+		if ( jetpack && ! isAtomic ) {
 			return (
 				<div className="banner__icon-plan">
 					<JetpackLogo size={ 32 } />

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -22,7 +22,7 @@
 
 	@include banner-color( var( --color-accent ) );
 
-	&.is-jetpack {
+	&.is-jetpack:not(.is-atomic) {
 		@include banner-color( var( --color-jetpack ) );
 	}
 

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { includes, isEqual, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { FEATURE_VIDEO_UPLOADS } from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -26,9 +27,9 @@ import {
 } from 'calypso/state/sharing/keyring/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import { selectMediaItems } from 'calypso/state/media/actions';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
 
 /**
  * Style dependencies
@@ -130,7 +131,7 @@ class MediaLibrary extends Component {
 	};
 
 	filterRequiresUpgrade() {
-		const { filter, site, source, isJetpack, isAtomic } = this.props;
+		const { filter, site, source, isJetpack, isAtomic, hasVideoUploadFeature } = this.props;
 		if ( source ) {
 			return false;
 		}
@@ -140,7 +141,11 @@ class MediaLibrary extends Component {
 				return ! ( ( site && site.options.upgraded_filetypes_enabled ) || isJetpack );
 
 			case 'videos':
-				return ! ( ( site && site.options.videopress_enabled ) || ( isJetpack && ! isAtomic ) );
+				return ! (
+					( site && site.options.videopress_enabled ) ||
+					( isJetpack && ! isAtomic ) ||
+					( isAtomic && hasVideoUploadFeature )
+				);
 		}
 
 		return false;
@@ -219,6 +224,7 @@ export default connect(
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isJetpack: isJetpackSite( state, site?.ID ),
 		isAtomic: isAtomicSite( state, site?.ID ),
+		hasVideoUploadFeature: hasFeature( state, site?.ID, FEATURE_VIDEO_UPLOADS ),
 	} ),
 	{
 		requestKeyringConnections,

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -29,7 +29,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import { selectMediaItems } from 'calypso/state/media/actions';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import { hasSiteFeature } from 'calypso/lib/site/utils';
 
 /**
  * Style dependencies

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -224,7 +224,7 @@ export default connect(
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isJetpack: isJetpackSite( state, site?.ID ),
 		isAtomic: isAtomicSite( state, site?.ID ),
-		hasVideoUploadFeature: hasFeature( state, site?.ID, FEATURE_VIDEO_UPLOADS ),
+		hasVideoUploadFeature: hasSiteFeature( site, FEATURE_VIDEO_UPLOADS ),
 	} ),
 	{
 		requestKeyringConnections,

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -24,6 +24,9 @@ import {
 	isKeyringConnectionsFetching,
 	getKeyringConnections,
 } from 'calypso/state/sharing/keyring/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import { selectMediaItems } from 'calypso/state/media/actions';
 
@@ -127,17 +130,17 @@ class MediaLibrary extends Component {
 	};
 
 	filterRequiresUpgrade() {
-		const { filter, site, source } = this.props;
+		const { filter, site, source, isJetpack, isAtomic } = this.props;
 		if ( source ) {
 			return false;
 		}
 
 		switch ( filter ) {
 			case 'audio':
-				return ! ( ( site && site.options.upgraded_filetypes_enabled ) || site.jetpack );
+				return ! ( ( site && site.options.upgraded_filetypes_enabled ) || isJetpack );
 
 			case 'videos':
-				return ! ( ( site && site.options.videopress_enabled ) || site.jetpack );
+				return ! ( ( site && site.options.videopress_enabled ) || ( isJetpack && ! isAtomic ) );
 		}
 
 		return false;
@@ -214,6 +217,8 @@ export default connect(
 		mediaValidationErrors: getMediaErrors( state, site?.ID ),
 		needsKeyring: needsKeyring( state, source ),
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
+		isJetpack: isJetpackSite( state, site?.ID ),
+		isAtomic: isAtomicSite( state, site?.ID ),
 	} ),
 	{
 		requestKeyringConnections,

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -43,6 +43,7 @@ describe( 'MediaLibrary', () => {
 				queries: {},
 				selectedItems: {},
 			},
+			sites: [],
 		} ),
 		dispatch: () => false,
 		subscribe: () => false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds changes that don't allow uploading videos for sites with a Free plan, beyond its platform (Simple or Atomic)

#### Testing instructions

* Test with Simple, Atomic, and Jetpack sites, with a Free plan. Confirm the following:

Simple | Atomic | Jetpack
------|------|------
![image](https://user-images.githubusercontent.com/77539/120369595-dfa17100-c2e9-11eb-9c32-76fbb5d85c42.png) | ![image](https://user-images.githubusercontent.com/77539/120369655-f647c800-c2e9-11eb-93c5-e9bae9a096f4.png) | ![image](https://user-images.githubusercontent.com/77539/120369722-1081a600-c2ea-11eb-9370-0c3bdcf2b23f.png)


* Test with paid plans. The app should allow you to upload media files.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
