### PR TITLE
Upgrades: Fix Activity Log banner on Atomic sites

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -29,6 +29,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 /**
  * Style dependencies
@@ -53,6 +54,7 @@ export const UpsellNudge = ( {
 	href,
 	isJetpackDevDocs,
 	jetpack,
+	isAtomic,
 	isVip,
 	siteIsWPForTeams,
 	list,
@@ -128,7 +130,7 @@ export const UpsellNudge = ( {
 			horizontal={ horizontal }
 			href={ href }
 			icon="star"
-			jetpack={ jetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
+			jetpack={ ( jetpack && ! isAtomic ) || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 			list={ list }
 			onClick={ onClick }
 			onDismissClick={ onDismissClick }
@@ -160,6 +162,7 @@ export default connect( ( state, ownProps ) => {
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		jetpack: isJetpackSite( state, siteId ),
+		isAtomic: isSiteWpcomAtomic( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -29,7 +29,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -29,7 +29,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -162,7 +162,7 @@ export default connect( ( state, ownProps ) => {
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		jetpack: isJetpackSite( state, siteId ),
-		isAtomic: isSiteWpcomAtomic( state, siteId ),
+		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -29,7 +29,7 @@ import {
 	siteHasBackupProductPurchase,
 	siteHasScanProductPurchase,
 } from 'calypso/state/purchases/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -29,6 +29,7 @@ import {
 	siteHasBackupProductPurchase,
 	siteHasScanProductPurchase,
 } from 'calypso/state/purchases/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 /**
  * Style dependencies
@@ -49,10 +50,11 @@ class IntroBanner extends Component {
 	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
 
 	renderCardContent() {
-		const { siteIsJetpack, siteSlug, translate, siteHasActivityLog } = this.props;
-		const buttonHref = siteIsJetpack
-			? `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }`
-			: `/plans/${ siteSlug }?feature=${ FEATURE_JETPACK_ESSENTIAL }&plan=${ PLAN_PERSONAL }`;
+		const { siteIsAtomic, siteIsJetpack, siteSlug, translate, siteHasActivityLog } = this.props;
+		const buttonHref =
+			siteIsJetpack && ! siteIsAtomic
+				? `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }`
+				: `/plans/${ siteSlug }?feature=${ FEATURE_JETPACK_ESSENTIAL }&plan=${ PLAN_PERSONAL }`;
 
 		return (
 			<>
@@ -144,6 +146,7 @@ export default connect(
 		return {
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),
+			siteIsAtomic: isSiteWpcomAtomic( state, siteId ),
 			siteIsJetpack: isJetpackSite( state, siteId ),
 
 			// TODO: Eventually use getRewindCapabilities to determine this?

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -29,7 +29,7 @@ import {
 	siteHasBackupProductPurchase,
 	siteHasScanProductPurchase,
 } from 'calypso/state/purchases/selectors';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -146,7 +146,7 @@ export default connect(
 		return {
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),
-			siteIsAtomic: isSiteWpcomAtomic( state, siteId ),
+			siteIsAtomic: isSiteAutomatedTransfer( state, siteId ),
 			siteIsJetpack: isJetpackSite( state, siteId ),
 
 			// TODO: Eventually use getRewindCapabilities to determine this?

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -17,6 +17,7 @@ import {
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 /**
  * Style dependencies
@@ -25,10 +26,10 @@ import './upgrade-banner.scss';
 
 class UpgradeBanner extends Component {
 	render() {
-		const { translate, isJetpack, siteSlug } = this.props;
+		const { translate, isAtomic, isJetpack, siteSlug } = this.props;
 		return (
 			<div className="activity-log-banner__upgrade">
-				{ isJetpack ? (
+				{ isJetpack && ! isAtomic ? (
 					<UpsellNudge
 						callToAction={ translate( 'Learn more' ) }
 						event="activity_log_upgrade_click_jetpack"
@@ -72,6 +73,7 @@ class UpgradeBanner extends Component {
 }
 
 export default connect( ( state, { siteId } ) => ( {
+	isAtomic: isSiteWpcomAtomic( state, siteId ),
 	isJetpack: isJetpackSite( state, siteId ),
 	siteId: siteId,
 	siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -17,7 +17,7 @@ import {
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -17,7 +17,7 @@ import {
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 /**
  * Style dependencies
@@ -73,7 +73,7 @@ class UpgradeBanner extends Component {
 }
 
 export default connect( ( state, { siteId } ) => ( {
-	isAtomic: isSiteWpcomAtomic( state, siteId ),
+	isAtomic: isSiteAutomatedTransfer( state, siteId ),
 	isJetpack: isJetpackSite( state, siteId ),
 	siteId: siteId,
 	siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -74,6 +74,7 @@ export class PlanFeaturesHeader extends Component {
 
 	renderPlansHeader() {
 		const {
+			availableForPurchase,
 			newPlan,
 			bestValue,
 			planType,
@@ -104,7 +105,7 @@ export class PlanFeaturesHeader extends Component {
 				{ ! isInSignup && isCurrent && (
 					<PlanPill isInSignup={ isInSignup }>{ translate( 'Your Plan' ) }</PlanPill>
 				) }
-				{ planLevelsMatch( selectedPlan, planType ) && ! isCurrent && (
+				{ planLevelsMatch( selectedPlan, planType ) && ! isCurrent && availableForPurchase && (
 					<PlanPill isInSignup={ isInSignup }>{ translate( 'Suggested' ) }</PlanPill>
 				) }
 				{ popular && ! selectedPlan && ! isCurrent && (
@@ -122,6 +123,7 @@ export class PlanFeaturesHeader extends Component {
 
 	renderPlansHeaderNoTabs() {
 		const {
+			availableForPurchase,
 			newPlan,
 			bestValue,
 			planType,
@@ -140,7 +142,7 @@ export class PlanFeaturesHeader extends Component {
 				<header className={ headerClasses }>
 					<h4 className="plan-features__header-title">{ title }</h4>
 					<div className="plan-features__audience">{ audience }</div>
-					{ planLevelsMatch( selectedPlan, planType ) && (
+					{ planLevelsMatch( selectedPlan, planType ) && availableForPurchase && (
 						<PlanPill isInSignup={ isPillInCorner }>{ translate( 'Suggested' ) }</PlanPill>
 					) }
 					{ popular && ! selectedPlan && (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -750,7 +750,7 @@ export class PlanFeatures extends Component {
 		const { planProperties, selectedFeature, withScroll } = this.props;
 
 		return map( planProperties, ( properties ) => {
-			const { features, planName } = properties;
+			const { availableForPurchase, features, planName } = properties;
 
 			const featureKeys = Object.keys( features );
 			const key = featureKeys[ rowIndex ];
@@ -760,7 +760,10 @@ export class PlanFeatures extends Component {
 				'has-partial-border': ! withScroll && rowIndex + 1 < featureKeys.length,
 				'is-last-feature': rowIndex + 1 === featureKeys.length,
 				'is-highlighted':
-					selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
+					selectedFeature &&
+					currentFeature &&
+					selectedFeature === currentFeature.getSlug() &&
+					availableForPurchase,
 			} );
 
 			return currentFeature ? (

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -543,7 +543,11 @@ export default connect(
 		} );
 
 		// Make sure the plans for the default customer type can be purchased.
-		if ( customerType === 'personal' && ! canUpgradeToPlan( state, siteId, PLAN_PERSONAL ) ) {
+		if (
+			! props.customerType &&
+			customerType === 'personal' &&
+			! canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
+		) {
 			customerType = 'business';
 		}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -67,6 +67,7 @@ import { getTld } from 'calypso/lib/domains';
 import { isDiscountActive } from 'calypso/state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/actions';
 import PlanTypeSelector from './plan-type-selector';
+import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 
 /**
  * Style dependencies
@@ -535,11 +536,16 @@ export default connect(
 		const eligibleForWpcomMonthlyPlans =
 			isWpComFreePlan( sitePlanSlug ) || isWpComMonthlyPlan( sitePlanSlug );
 
-		const customerType = chooseDefaultCustomerType( {
+		let customerType = chooseDefaultCustomerType( {
 			currentCustomerType: props.customerType,
 			selectedPlan: props.selectedPlan,
 			currentPlan,
 		} );
+
+		// Make sure the plans for the default customer type can be purchased.
+		if ( customerType === 'personal' && ! canUpgradeToPlan( state, siteId, PLAN_PERSONAL ) ) {
+			customerType = 'business';
+		}
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renders the WP.com upgrade banner of the Activity Log feature for Atomic sites on a Free plan.
* Removes the "Suggested" label from plans that cannot be purchased.
* Removes the highlighted features from plans that cannot be purchased.
* Defaults to "Business sites and online stores" plans if the Personal plan cannot be purchased.

Before | After
--- | ---
<img width="997" alt="Screen Shot 2021-05-25 at 15 38 16" src="https://user-images.githubusercontent.com/1233880/119508998-875df280-bd70-11eb-8d3b-1742d3a79299.png"> | <img width="975" alt="Screen Shot 2021-05-25 at 15 38 22" src="https://user-images.githubusercontent.com/1233880/119509042-8fb62d80-bd70-11eb-8210-d9a0fe5f61f4.png">
<img width="992" alt="Screen Shot 2021-05-25 at 15 37 53" src="https://user-images.githubusercontent.com/1233880/119508970-80cf7b00-bd70-11eb-8829-fc1988b4b14b.png"> | <img width="978" alt="Screen Shot 2021-05-25 at 15 43 51" src="https://user-images.githubusercontent.com/1233880/119509073-95ac0e80-bd70-11eb-9bbd-86499e5123fe.png">

#### Testing instructions

* Switch to an Atomic site on a Free plan.
* Go to Jetpack > Activity log.
* Make sure you have not dismissed the Activity Log intro banner. If you have done so, you can make it to appear again by removing the `dismissible-card-activity-introduction-banner` Calypso preference: <img width="400" alt="Screen Shot 2021-05-26 at 13 01 02" src="https://user-images.githubusercontent.com/1233880/119650084-b2ede500-be23-11eb-8e9e-d73d00d86347.png">
* Click on "Upgrade now".
* Make sure you're redirected to the Plans page with the "Business sites and online stores" option selected.
* Click on "Blogs and personal sites".
* Make sure the Personal plan does not have the "Suggested" label.
* Make sure the "Jetpack essential features" items are not highlighted.
* Go back to Jetpack > Activity log.
* Make sure the WP.com upgrade bander (the one with a star as icon) gets rendered.
* Click on "Learn more".
* Make sure you're redirected to the Plans page with the "Business sites and online stores" option selected.

Fixes https://github.com/Automattic/wp-calypso/issues/51585
