### PR TITLE
With Plugin Redirect: fix i18n string

### DIFF
--- a/client/my-sites/plugins/with-plugin-redirect/index.js
+++ b/client/my-sites/plugins/with-plugin-redirect/index.js
@@ -157,11 +157,14 @@ const withPluginRedirect = createHigherOrderComponent(
 					return ( window.location.href = shouldRedirect );
 				}, 6000 );
 
-				const redirectMessage = translate( 'Redirecting to setup %(pluginName)s in five seconds.', {
-					args: {
-						pluginName: redirectHandler.name,
-					},
-				} );
+				const redirectMessage = translate(
+					'Redirecting to the setup for %(pluginName)s in five seconds.',
+					{
+						args: {
+							pluginName: redirectHandler.name,
+						},
+					}
+				);
 
 				dispatch(
 					successNotice( redirectMessage, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the i18n string defined by the plugin, replacing `'Redirecting to setup %(pluginName)s in five seconds.'` by `'Redirecting to setup for %(pluginName)s in five seconds.'`

#### Testing instructions

Check the i18n string is correct.