### PR TITLE
FollowButton: refactor away from `UNSAFE_componentWillMount`

### DIFF
--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -33,12 +33,8 @@ class FollowButton extends React.Component {
 		disabled: false,
 	};
 
-	UNSAFE_componentWillMount() {
-		this.strings = {
-			FOLLOW: this.props.translate( 'Follow' ),
-			FOLLOWING: this.props.translate( 'Following' ),
-		};
-	}
+	FOLLOW = this.props.translate( 'Follow' );
+	FOLLOWING = this.props.translate( 'Following' );
 
 	toggleFollow = ( event ) => {
 		if ( event ) {
@@ -55,13 +51,13 @@ class FollowButton extends React.Component {
 	};
 
 	render() {
-		let label = this.props.followLabel ? this.props.followLabel : this.strings.FOLLOW;
+		let label = this.props.followLabel ? this.props.followLabel : this.FOLLOW;
 		const menuClasses = [ 'button', 'follow-button', 'has-icon', this.props.className ];
 		const iconSize = this.props.iconSize;
 
 		if ( this.props.following ) {
 			menuClasses.push( 'is-following' );
-			label = this.props.followingLabel ? this.props.followingLabel : this.strings.FOLLOWING;
+			label = this.props.followingLabel ? this.props.followingLabel : this.FOLLOWING;
 		}
 
 		if ( this.props.disabled ) {

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -33,9 +33,6 @@ class FollowButton extends React.Component {
 		disabled: false,
 	};
 
-	FOLLOW = this.props.translate( 'Follow' );
-	FOLLOWING = this.props.translate( 'Following' );
-
 	toggleFollow = ( event ) => {
 		if ( event ) {
 			event.preventDefault();
@@ -51,13 +48,15 @@ class FollowButton extends React.Component {
 	};
 
 	render() {
-		let label = this.props.followLabel ? this.props.followLabel : this.FOLLOW;
+		let label = this.props.followLabel ? this.props.followLabel : this.props.translate( 'Follow' );
 		const menuClasses = [ 'button', 'follow-button', 'has-icon', this.props.className ];
 		const iconSize = this.props.iconSize;
 
 		if ( this.props.following ) {
 			menuClasses.push( 'is-following' );
-			label = this.props.followingLabel ? this.props.followingLabel : this.FOLLOWING;
+			label = this.props.followingLabel
+				? this.props.followingLabel
+				: this.props.translate( 'Following' );
 		}
 
 		if ( this.props.disabled ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* FollowButton: remove usage of `UNSAFE_componentWillMount`

#### Testing instructions

I think a plain code review should be enough in this case but if you want to test it you can open the Reader and click the three-dots icon on any post shown and make sure the `Follow | Following` button there works as expected.
