### PR TITLE
Plans: Update FAQ with new email options

### DIFF
--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -93,9 +93,9 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Do you offer email accounts?' ) }
 				answer={ translate(
-					'Yes. If you register a new domain with our Personal, Premium, Business, or eCommerce plans, you can' +
-						' add Google-powered G Suite. You can also set up email forwarding for any custom domain' +
-						' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
+					'Yes. We offer Professional Email which is a robust hosted email solution for any custom domain ' +
+						'registered through WordPress.com. You can also set up free email forwarding, or use our Google ' +
+						'Workspace integration to power your emails. {{a}}Learn more about our email solutions{{/a}}.',
 					{
 						components: {
 							a: (


### PR DESCRIPTION
This pull request updates the FAQ shown at the bottom of the `Plans` page with more accurate information about our email offering:

<img width="1108" alt="Screenshot 2021-06-02 at 13 15 07" src="https://user-images.githubusercontent.com/3376401/120471578-2902c680-c3a5-11eb-8366-65f63bcc0cae.png">

##### Before

> **Do you offer email accounts?**
> Yes. If you register a new domain with our Personal, Premium, Business, or eCommerce plans, you can add Google-powered G Suite. You can also set up email forwarding for any custom domain registered through WordPress.com. Find out more about email.

##### After

> **Do you offer email accounts?**
> Yes. You can set up email forwarding for free for any custom domain registered through WordPress.com. We also offers robust hosted email solutions such as Professional Email or Google Workspace. Find out more about email.

#### Testing instructions

1. Run `git checkout update/plans-page-faq` and start your server, or open a [live branch](https://calypso.live/?branch=update/plans-page-faq)
2. Open the [`Plans` page](http://calypso.localhost:3000/me/plans)
3. Check that the FAQ shows the new copy