### PR TITLE
Add A/B experiment showing clearer total discount in JP pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -90,6 +90,8 @@ const DisplayPrice = ( {
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'calypso_jetpack_yearly_total_discount'
 	);
+	const withTreatmentVariation =
+		experimentAssignment?.variationName === 'treatment' && billingTerm === TERM_ANNUALLY;
 
 	if ( isDeprecated ) {
 		return (
@@ -156,20 +158,19 @@ const DisplayPrice = ( {
 	const couponDiscountedPrice = parseFloat(
 		( ( discountedPrice ?? originalPrice ) * FRESHPACK_PERCENTAGE ).toFixed( 2 )
 	);
-	const discountElt =
-		experimentAssignment?.variationName === 'treatment' && billingTerm === TERM_ANNUALLY
-			? translate( '* Save %(percent)d%% for the first year', {
-					args: {
-						percent: ( ( originalPrice - couponDiscountedPrice ) / originalPrice ) * 100,
-					},
-					comment: 'Asterisk clause describing the displayed price adjustment',
-			  } )
-			: translate( '* You Save %(percent)d%%', {
-					args: {
-						percent: INTRO_PRICING_DISCOUNT_PERCENTAGE,
-					},
-					comment: 'Asterisk clause describing the displayed price adjustment',
-			  } );
+	const discountElt = withTreatmentVariation
+		? translate( '* Save %(percent)d%% for the first year', {
+				args: {
+					percent: ( ( originalPrice - couponDiscountedPrice ) / originalPrice ) * 100,
+				},
+				comment: 'Asterisk clause describing the displayed price adjustment',
+		  } )
+		: translate( '* You Save %(percent)d%%', {
+				args: {
+					percent: INTRO_PRICING_DISCOUNT_PERCENTAGE,
+				},
+				comment: 'Asterisk clause describing the displayed price adjustment',
+		  } );
 
 	return (
 		<div className="jetpack-product-card__price">
@@ -179,7 +180,7 @@ const DisplayPrice = ( {
 					<PlanPrice
 						original
 						className="jetpack-product-card__original-price"
-						rawPrice={ couponOriginalPrice as number }
+						rawPrice={ ( withTreatmentVariation ? originalPrice : couponOriginalPrice ) as number }
 						currencyCode={ currencyCode }
 					/>
 					<PlanPrice


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements an A/B experiment whose goal is to determine if showing a clearer total discount in the Jetpack pricing page (for the yearly term) increases click rate.

Fixes 1196108640073826-as-1200317017749670

### Implementation notes

Unlike previous experiments, we didn't use `getCurrentCROIterationName`. The easiest way to get the variation with the new ExPlat framework is to use hooks, which isn't compatible with the aforementioned function.

### Testing instructions

- Download the PR and run cloud
- Visit `/pricing`
    - Check that the discount message in the product cards is `* You Save 40%` for both monthly and yearly terms
    - Check that the original and discount prices are the same as in production, for both terms
- Change the variation of the `calypso_jetpack_yearly_total_discount` experiment to `treatment` (you'll find the experiment in the _Hypothesis Link_ field of the linked task - ping me if you need further help with that)
- Visit `/pricing`
    - Check that the discount message in the product cards is `* Save XX% for the first year` for the yearly term, and hasn't change for the monthly term
    - When the yearly term is selected, check that the struck-through price is the original monthly price (in other words, the discount percentage should represent the discount between the actual price and the struck-through price)

### Screenshots

#### Control
<img width="1072" alt="Screen Shot 2021-05-25 at 11 55 22 AM" src="https://user-images.githubusercontent.com/1620183/119529468-23c3cd00-bd50-11eb-8da6-9b789e44b80b.png">



#### Treatment

<img width="1064" alt="Screen Shot 2021-05-25 at 11 54 51 AM" src="https://user-images.githubusercontent.com/1620183/119529444-1f97af80-bd50-11eb-9632-d30ea5c130a0.png">
