### PR TITLE
Emails: Fix wrong error color on Email Plan page

### DIFF
--- a/client/my-sites/email/email-management/home/email-list-active.jsx
+++ b/client/my-sites/email/email-management/home/email-list-active.jsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { CompactCard } from '@automattic/components';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -17,18 +19,35 @@ import {
 } from 'calypso/my-sites/email/email-management/home/utils';
 import MaterialIcon from 'calypso/components/material-icon';
 
+const EmailListActiveWarning = ( { domain } ) => {
+	const { icon, statusClass, text } = resolveEmailPlanStatus( domain );
+
+	if ( statusClass === 'success' ) {
+		return null;
+	}
+
+	return (
+		<div className={ classnames( 'email-list-active__warning', statusClass ) }>
+			<MaterialIcon icon={ icon } />
+
+			<span>{ text }</span>
+		</div>
+	);
+};
+
+EmailListActiveWarning.propTypes = {
+	domain: PropTypes.object.isRequired,
+};
+
 class EmailListActive extends React.Component {
 	render() {
-		const { selectedSiteSlug, currentRoute, domains, translate } = this.props;
+		const { currentRoute, domains, selectedSiteSlug, translate } = this.props;
 
 		if ( domains.length < 1 ) {
 			return null;
 		}
 
 		const emailListItems = domains.map( ( domain ) => {
-			const { statusClass, text: warningText } = resolveEmailPlanStatus( domain );
-			const showWarning = statusClass !== 'success';
-
 			return (
 				<CompactCard
 					href={ emailManagement( selectedSiteSlug, domain.name, currentRoute ) }
@@ -37,16 +56,14 @@ class EmailListActive extends React.Component {
 					<span className="email-list-active__item-icon">
 						<EmailTypeIcon domain={ domain } />
 					</span>
-					<div>
+
+					<div className="email-list-active__item-domain">
 						<h2>{ domain.name }</h2>
+
 						<span>{ getNumberOfMailboxesText( domain ) }</span>
 					</div>
-					{ showWarning && (
-						<div className="email-list-active__warning">
-							<MaterialIcon icon="info" />
-							<span>{ warningText }</span>
-						</div>
-					) }
+
+					<EmailListActiveWarning domain={ domain } />
 				</CompactCard>
 			);
 		} );
@@ -54,10 +71,21 @@ class EmailListActive extends React.Component {
 		return (
 			<div className="email-list-active">
 				<SectionHeader label={ translate( 'Domains with emails' ) } />
+
 				{ emailListItems }
 			</div>
 		);
 	}
 }
+
+EmailListActive.propTypes = {
+	// Props passed to this component
+	currentRoute: PropTypes.string.isRequired,
+	domains: PropTypes.array.isRequired,
+	selectedSiteSlug: PropTypes.string.isRequired,
+
+	// Props injected via connect()
+	translate: PropTypes.func.isRequired,
+};
 
 export default localize( EmailListActive );

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -105,14 +105,14 @@ export function hasEmailSubscription( domain ) {
 }
 
 export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) {
-	const defaultActiveStatus = {
+	const activeStatus = {
 		statusClass: 'success',
 		icon: isLoadingEmails ? 'cached' : 'check_circle',
 		text: isLoadingEmails ? translate( 'Loading details' ) : translate( 'Active' ),
 	};
 
-	const defaultWarningStatus = {
-		statusClass: 'warning',
+	const errorStatus = {
+		statusClass: 'error',
 		icon: 'info',
 		text: translate( 'Action required' ),
 	};
@@ -123,49 +123,50 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 			isPendingGSuiteTOSAcceptance( domain ) ||
 			( emailAccount && hasGoogleAccountTOSWarning( emailAccount ) )
 		) {
-			return defaultWarningStatus;
+			return errorStatus;
 		}
 
 		if ( hasPendingGSuiteUsers( domain ) ) {
-			return defaultWarningStatus;
+			return errorStatus;
 		}
 
-		return defaultActiveStatus;
+		return activeStatus;
 	}
 
 	if ( hasTitanMailWithUs( domain ) ) {
-		// Check for expired subscription.
+		// Check for expired subscription
 		const titanExpiryDateString = getTitanExpiryDate( domain );
+
 		if ( titanExpiryDateString ) {
 			const titanExpiryDate = new Date( titanExpiryDateString );
 			const startOfToday = new Date();
 			startOfToday.setUTCHours( 0, 0, 0, 0 );
+
 			if ( titanExpiryDate < startOfToday ) {
-				return defaultWarningStatus;
+				return errorStatus;
 			}
 		}
+
 		// Check for unused mailboxes
 		if ( emailAccount && hasUnusedMailboxWarning( emailAccount ) ) {
-			return defaultWarningStatus;
+			return errorStatus;
 		}
 
-		// Fallback logic if we don't have an emailAccount - this will initially be the case for the email home page.
+		// Fallback logic if we don't have an emailAccount - this will initially be the case for the email home page
 		if (
 			! isLoadingEmails &&
 			! emailAccount &&
 			getMaxTitanMailboxCount( domain ) > getConfiguredTitanMailboxCount( domain )
 		) {
-			return defaultWarningStatus;
+			return errorStatus;
 		}
 
-		return defaultActiveStatus;
+		return activeStatus;
 	}
 
-	if ( hasEmailForwards( domain ) && emailAccount ) {
-		if ( hasUnverifiedEmailForward( emailAccount ) ) {
-			return defaultWarningStatus;
-		}
+	if ( hasEmailForwards( domain ) && emailAccount && hasUnverifiedEmailForward( emailAccount ) ) {
+		return errorStatus;
 	}
 
-	return defaultActiveStatus;
+	return activeStatus;
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -17,60 +17,6 @@
 	> .card {
 		color: var( --color-text );
 		display: flex;
-
-		> div > h2 {
-			word-break: break-all;
-		}
-
-		> div > span {
-			font-size: $font-body-small;
-			color: var( --color-text-subtle );
-		}
-
-		.email-list-active__warning {
-			font-size: $font-body-extra-small;
-			margin-left: 14px;
-
-			> span {
-				color: var( --color-error-50 );
-				display: none;
-				vertical-align: middle;
-
-				@include break-small {
-					display: unset;
-				}
-
-				@include break-medium {
-					display: none;
-				}
-
-				@include break-large {
-					display: unset;
-				}
-			}
-
-			> svg {
-				fill: var( --color-error-50 );
-				height: 18px;
-				margin-right: 6px;
-				/* Push the icon down when there is no warning text */
-				margin-top: 3px;
-				vertical-align: middle;
-				width: 18px;
-
-				@include break-small {
-					margin-top: 0;
-				}
-
-				@include break-medium {
-					margin-top: 3px;
-				}
-
-				@include break-large {
-					margin-top: 0;
-				}
-			}
-		}
 	}
 
 	> .card.is-card-link:hover {
@@ -92,8 +38,83 @@
 			margin-right: 24px;
 		}
 	}
+
 	> .gridicon.gridicons-my-sites {
 		fill: var( --color-wordpress-com );
+	}
+}
+
+.email-list-active__item-domain {
+	h2 {
+		word-break: break-all;
+	}
+
+	span {
+		font-size: $font-body-small;
+		color: var( --color-text-subtle );
+	}
+}
+
+.email-list-active__warning {
+	font-size: $font-body-small;
+	margin-left: 14px;
+
+	> span {
+		display: none;
+		vertical-align: middle;
+
+		@include break-small {
+			display: unset;
+		}
+
+		@include break-medium {
+			display: none;
+		}
+
+		@include break-large {
+			display: unset;
+		}
+	}
+
+	> svg {
+		height: 18px;
+		margin-right: 6px;
+		/* Push the icon down when there is no warning text */
+		margin-top: 3px;
+		vertical-align: middle;
+		width: 18px;
+
+		@include break-small {
+			margin-top: 0;
+		}
+
+		@include break-medium {
+			margin-top: 3px;
+		}
+
+		@include break-large {
+			margin-top: 0;
+		}
+	}
+
+	&.error {
+		> span {
+			color: var( --color-error );
+		}
+
+		> svg {
+			fill: var( --color-error );
+		}
+	}
+
+	&.warning {
+		> span {
+			color: var( --color-warning );
+		}
+
+		> svg {
+			fill: var( --color-warning );
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request fixes an inconsistency in the header of the `Email Plan` page where account-level errors would be displayed in brown while they would be displayed in red in the `Emails` page:

`Emails` page | `Email Plan` page
------ | -----
<img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/119542015-5fca5280-bd8f-11eb-8d2e-d87a053a558a.png"> <br/><br/>| <img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/119542273-a4ee8480-bd8f-11eb-9430-ac3c2a18f79e.png">

With this pull request, account-level errors will now be displayed in red in the `Email Plan` page.

Note the code was refactored to rely on the severity of the warning/error provided by `resolveEmailPlanStatus()`, which will make it easier to switch to another colors if we ever need it. Apart from extracting code that deals with warnings in a new component, this pull request also:

* Better aligns the icon with the text of the warning
* Fixes missing prop types
* Gets rid of some unnecessary indentation in the stylesheets

#### Testing instructions

1. Run `git checkout fix/wrong-warning-color-emails-page` and start your server, or open a [live branch](https://calypso.live/?branch=fix/wrong-warning-color-emails-page)
2. Open the [`Emails` page](http://calypso.localhost:3000/emails)
3. Assert that warnings are now displayed in brown