### PR TITLE
Emails: Fix wrong mailbox labels and titles for Google Workspace in emails management pages

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -101,7 +101,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 			<div className="gsuite-new-user-list__actions">
 				<Button className="gsuite-new-user-list__add-another-user-button" onClick={ onUserAdd }>
 					<Gridicon icon="plus" />
-					<span>{ translate( 'Add another user' ) }</span>
+					<span>{ translate( 'Add another mailbox' ) }</span>
 				</Button>
 
 				{ children }

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -113,7 +113,7 @@ class GSuiteUsersCard extends React.Component {
 				) }
 				onClick={ this.goToAddGoogleApps }
 			>
-				{ translate( 'Add New Users' ) }
+				{ translate( 'Add New Mailboxes' ) }
 			</Button>
 		);
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -208,9 +208,10 @@ class EmailPlan extends React.Component {
 		}
 
 		const managePurchaseUrl = getManagePurchaseUrlFor( selectedSite.slug, purchase.id );
+
 		return (
 			<VerticalNavItem path={ managePurchaseUrl }>
-				{ translate( 'Billing and payment settings' ) }
+				{ translate( 'View billing and payment settings' ) }
 			</VerticalNavItem>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -196,7 +196,7 @@ class EmailPlan extends React.Component {
 		return translate( 'Email forwarding settings' );
 	}
 
-	renderBillingNavItem() {
+	renderViewBillingAndPaymentSettingsNavItem() {
 		const { hasSubscription, purchase, selectedSite, translate } = this.props;
 
 		if ( ! hasSubscription ) {
@@ -242,7 +242,7 @@ class EmailPlan extends React.Component {
 		};
 	}
 
-	renderManageAllNavItem() {
+	renderManageAllMailboxesNavItem() {
 		const { domain, translate } = this.props;
 
 		if ( ! domain ) {
@@ -265,7 +265,7 @@ class EmailPlan extends React.Component {
 		);
 	}
 
-	renderAddNewMailboxOrRenewalNavItem() {
+	renderAddNewMailboxesOrRenewNavItem() {
 		const { domain, hasSubscription, purchase, selectedSite, translate } = this.props;
 
 		if ( ! domain.currentUserCanManage || ! hasSubscription ) {
@@ -322,9 +322,11 @@ class EmailPlan extends React.Component {
 
 				<div className="email-plan__actions">
 					<VerticalNav>
-						{ this.renderAddNewMailboxOrRenewalNavItem() }
-						{ this.renderManageAllNavItem() }
-						{ this.renderBillingNavItem() }
+						{ this.renderAddNewMailboxesOrRenewNavItem() }
+
+						{ this.renderManageAllMailboxesNavItem() }
+
+						{ this.renderViewBillingAndPaymentSettingsNavItem() }
 					</VerticalNav>
 				</div>
 			</>

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -31,7 +31,8 @@ import {
 export function getNumberOfMailboxesText( domain ) {
 	if ( hasGSuiteWithUs( domain ) ) {
 		const count = getGSuiteMailboxCount( domain );
-		return translate( '%(count)d user', '%(count)d users', {
+
+		return translate( '%(count)d mailbox', '%(count)d mailboxes', {
 			count,
 			args: {
 				count,
@@ -41,6 +42,7 @@ export function getNumberOfMailboxesText( domain ) {
 
 	if ( hasTitanMailWithUs( domain ) ) {
 		const count = getMaxTitanMailboxCount( domain );
+
 		return translate( '%(count)d mailbox', '%(count)d mailboxes', {
 			count,
 			args: {
@@ -51,6 +53,7 @@ export function getNumberOfMailboxesText( domain ) {
 
 	if ( hasEmailForwards( domain ) ) {
 		const count = getEmailForwardsCount( domain );
+
 		return translate( '%(count)d email forward', '%(count)d email forwards', {
 			count,
 			args: {
@@ -58,6 +61,7 @@ export function getNumberOfMailboxesText( domain ) {
 			},
 		} );
 	}
+
 	return '';
 }
 

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -103,7 +103,7 @@ class TitanManageMailboxes extends Component {
 				{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 
 				<Main wideLayout={ true }>
-					<DocumentHead title={ translate( 'Manage all mailboxes' ) } />
+					<DocumentHead title={ translate( 'Manage All Mailboxes' ) } />
 
 					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -225,7 +225,7 @@ class GSuiteAddUsers extends React.Component {
 					} ) }
 
 				<SectionHeader
-					label={ translate( 'Add New Users', {
+					label={ translate( 'Add New Mailboxes', {
 						comment: 'This refers to Google Workspace user accounts',
 					} ) }
 				/>
@@ -286,11 +286,13 @@ class GSuiteAddUsers extends React.Component {
 				{ selectedSite && <QueryGSuiteUsers siteId={ selectedSite.ID } /> }
 
 				<Main wideLayout={ true }>
-					<DocumentHead title={ translate( 'Add New Users' ) } />
+					<DocumentHead title={ translate( 'Add New Mailboxes' ) } />
 
 					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 
-					<HeaderCake onClick={ this.goToEmail }>{ translate( 'Add new users' ) }</HeaderCake>
+					<HeaderCake onClick={ this.goToEmail }>
+						{ googleMailServiceFamily + ': ' + selectedDomainName }
+					</HeaderCake>
 
 					<EmailVerificationGate
 						noticeText={ translate( 'You must verify your email to purchase %(productFamily)s.', {

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -24,7 +24,7 @@ function resolveRootPath( relativeTo ) {
 }
 
 /**
- * Retrieves the url of the Add New Users page either for G Suite or Google Workspace:
+ * Retrieves the url of the Add New Mailboxes page either for G Suite or Google Workspace:
  *
  * https://wordpress.com/email/:domainName/google-workspace/add-users/:siteName
  * https://wordpress.com/email/:domainName/gsuite/add-users/:siteName

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -256,6 +256,7 @@ class TitanAddMailboxes extends React.Component {
 			selectedDomainName,
 			selectedSite,
 			titanMonthlyProduct,
+			translate,
 		} = this.props;
 
 		if ( ! isLoadingDomains && ! isSelectedDomainNameValid ) {
@@ -264,7 +265,6 @@ class TitanAddMailboxes extends React.Component {
 		}
 
 		const analyticsPath = emailManagementNewTitanAccount( ':site', ':domain', currentRoute );
-		const pageTitle = getTitanProductName() + ': ' + selectedDomainName;
 		const finishSetupLinkIsExternal = ! isEnabled( 'titan/iframe-control-panel' );
 
 		return (
@@ -276,11 +276,13 @@ class TitanAddMailboxes extends React.Component {
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 				<Main wideLayout={ true }>
-					<DocumentHead title={ pageTitle } />
+					<DocumentHead title={ translate( 'Add New Mailboxes' ) } />
 
 					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 
-					<HeaderCake onClick={ this.goToEmail }>{ pageTitle }</HeaderCake>
+					<HeaderCake onClick={ this.goToEmail }>
+						{ getTitanProductName() + ': ' + selectedDomainName }
+					</HeaderCake>
 
 					<TitanExistingForwardsNotice domainsWithForwards={ domainsWithForwards } />
 					{ selectedDomain && (


### PR DESCRIPTION
This pull request updates several pages from the emails management section in order to use `mailbox` instead of `user` for G Suite and Google Workspace. It also refines a few headers and page titles. The ultimate goal is obviously consistency:

##### `Emails` page

<img width="623" alt="01" src="https://user-images.githubusercontent.com/594356/119700157-2e1abf80-be53-11eb-9b9f-d0fdaeaac21d.png">

##### `Email Plan` page for G Suite / Google Workspace

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/119700479-8ea9fc80-be53-11eb-8def-48a00999d666.png">

##### `Add New Mailboxes` page for G Suite / Google Workspace

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/119700569-aa150780-be53-11eb-94e7-4d6c56ab739a.png">

#### Testing instructions

1. Run `git checkout fix/wrong-mailbox-types` and start your server, or open a [live branch](https://calypso.live/?branch=fix/wrong-mailbox-types)
2. Open the [`Email` page](http://calypso.localhost:3000/email)
3. Check that `user` is no longer mentioned
