### PR TITLE
Checkout: update logic for "Site:" indicator

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -16,7 +16,11 @@ import { useSelector } from 'react-redux';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
-import { isDomainRegistration, isDomainTransfer } from '@automattic/calypso-products';
+import {
+	isDomainMapping,
+	isDomainRegistration,
+	isDomainTransfer,
+} from '@automattic/calypso-products';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -91,7 +95,8 @@ export default function WPCheckoutOrderReview( {
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 
 	const firstDomainItem = responseCart.products.find(
-		( product ) => isDomainTransfer( product ) || isDomainRegistration( product )
+		( product ) =>
+			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
 	);
 	const domainUrl = firstDomainItem ? firstDomainItem.meta : siteUrl;
 	const removeCouponAndClearField = () => {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -99,13 +99,11 @@ export default function WPCheckoutOrderReview( {
 	const primaryDomain = selectedSiteData?.options?.is_mapped_domain
 		? selectedSiteData?.domain
 		: null;
-	const domainUrl =
-		primaryDomain ??
-		responseCart.products.find(
-			( product ) =>
-				isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
-		)?.meta ??
-		siteUrl;
+	const firstDomainProduct = responseCart.products.find(
+		( product ) =>
+			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
+	);
+	const domainUrl = primaryDomain ?? firstDomainProduct?.meta ?? siteUrl;
 
 	const removeCouponAndClearField = () => {
 		couponFieldStateProps.setCouponFieldValue( '' );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -94,18 +94,25 @@ export default function WPCheckoutOrderReview( {
 	const { responseCart, removeCoupon, couponStatus } = useShoppingCart();
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 
-	const firstDomainItem = responseCart.products.find(
-		( product ) =>
-			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
-	);
-	const domainUrl = firstDomainItem ? firstDomainItem.meta : siteUrl;
+	const selectedSiteData = useSelector( getSelectedSite );
+
+	const primaryDomain = selectedSiteData?.options?.is_mapped_domain
+		? selectedSiteData?.domain
+		: null;
+	const domainUrl =
+		primaryDomain ??
+		responseCart.products.find(
+			( product ) =>
+				isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
+		)?.meta ??
+		siteUrl;
+
 	const removeCouponAndClearField = () => {
 		couponFieldStateProps.setCouponFieldValue( '' );
 		setCouponFieldVisible( false );
 		return removeCoupon();
 	};
 
-	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const planIsP2Plus = hasP2PlusPlan( responseCart );
 
 	return (

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -15,5 +15,6 @@ export interface SiteData {
 
 export interface SiteDataOptions {
 	admin_url: string | undefined;
+	is_mapped_domain: boolean;
 	// TODO: fill out the rest of this
 }


### PR DESCRIPTION
When a user visits Checkout, the "Site: example.com" logic needs to be a little more intelligent.

- If a user has a primary custom domain, that domain should be shown no matter the cart makeup
- If a user does not have a primary custom domain, but has a domain product in their cart (i.e. mapping, registration, transfer), we should show the domain product
- If a user does not have a primary custom domain and is not purchasing a domain product, we should show the simple site address

Reported: p58i-az5-p2

**Primary domain:**
<img width="571" alt="Screen Shot 2021-05-25 at 3 44 14 PM" src="https://user-images.githubusercontent.com/942359/119581011-b3d53700-bd8f-11eb-99ca-5a962a6ce2a8.png">

**Primary domain with domain product in cart:**
<img width="571" alt="Screen Shot 2021-05-25 at 3 43 29 PM" src="https://user-images.githubusercontent.com/942359/119581012-b3d53700-bd8f-11eb-9210-f8486770cbde.png">

**No primary domain:**
<img width="571" alt="Screen Shot 2021-05-25 at 3 43 16 PM" src="https://user-images.githubusercontent.com/942359/119581013-b46dcd80-bd8f-11eb-99ab-05222b9643f3.png">

**No primary domain with domain product in cart:**
<img width="574" alt="Screen Shot 2021-05-25 at 3 43 02 PM" src="https://user-images.githubusercontent.com/942359/119581014-b46dcd80-bd8f-11eb-8268-7ee5921ac3e2.png">

**To test:**
- on a site without a primary domain, add a non-domain product to your cart
- verify that Checkout displays your simple site address (i.e. `Site: example.wordpress.com`)
- on a site without a primary domain, add a domain product (registration, mapping, transfer) to your cart
- verify that Checkout displays the first domain product domain name (i.e. `Site: example.com`)
- on a site with a primary domain, add a non-domain product to your cart
- verify that Checkout displays your primary domain address (i.e. `Site: example.com`)
- on a site with a primary domain, add a domain product (registration, mapping, transfer) to your cart
- verify that Checkout displays your primary domain address (i.e. `Site: example.com`)
