### PR TITLE
Prevent redirects from instantiating unwanted components

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -22,10 +22,12 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
 		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
+		return;
 	}
 
 	if ( /\/(pricing|plans)$/.test( pathname ) && siteFromUrl ) {
 		page.redirect( addQueryArgs( urlQueryArgs, `${ pathname }/${ siteFromUrl }` ) );
+		return;
 	}
 
 	context.store.dispatch( hideMasterbar() );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes sure that pricing page components are not rendered after hitting URLs that are redirected.

### Testing instructions

- Download the PR and run cloud
- Visit `/:locale/pricing/`
- Make sure that the tracking event `calypso_jetpack_pricing_page_visit` is triggered only once (you may need to make the console logs persistent), and that you're redirected to the pricing page in the proper locale
- Visit `/pricing?site=:site`
- Make sure that the tracking event `calypso_jetpack_pricing_page_visit` is triggered only once, and that you're redirected to `/pricing/:site?site=:site`