### PR TITLE
Playwright: Part 1. Implement components, pages and flows and migrate part of wp-likes spec.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -780,6 +780,7 @@ object RunCalypsoPlaywrightE2eTests : BuildType({
 				export VIEWPORT_SIZE="mobile"
 				export LOCALE="en"
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
+				export DEBUG=pw:api
 
 				xvfb-run yarn magellan --config=magellan-playwright.json --max_workers=%E2E_WORKERS% --local_browser=chrome --mocha_args="--reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter.json"
 			""".trimIndent()

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -22,7 +22,8 @@
 	"devDependencies": {
 		"@types/config": "^0.0.38",
 		"@types/jest": "^25.2.3",
-		"@types/node": "^15.0.2"
+		"@types/node": "^15.0.2",
+		"asana-phrase": "^0.0.8"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -49,7 +49,7 @@ export async function start(): Promise< Page > {
  */
 export async function launchPage(): Promise< Page > {
 	const browserContext = await launchBrowserContext();
-	browserContext.setDefaultTimeout( 5000 );
+	browserContext.setDefaultTimeout( playwrightTimeoutMS );
 	return await browserContext.newPage();
 }
 

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -1,7 +1,23 @@
 /**
  * External dependencies
  */
+import phrase from 'asana-phrase';
 import config from 'config';
+
+/**
+ *
+ */
+declare global {
+	interface String {
+		toProperCase(): string;
+	}
+}
+
+String.prototype.toProperCase = function (): string {
+	return this.replace( /\w\S*/g, function ( txt ) {
+		return txt.charAt( 0 ).toUpperCase() + txt.substr( 1 ).toLowerCase();
+	} );
+};
 
 /**
  * Assembles and returns the URL to a specific route/asset/query in Calypso.
@@ -48,4 +64,14 @@ export function getAccountCredential( username: string ): string {
  */
 export function getJetpackHost(): string {
 	return process.env.JETPACKHOST || 'WPCOM';
+}
+
+/**
+ * Generates a random phrase in proper case (Sample Sentence Text).
+ *
+ * @returns {string} Generated text.
+ */
+export function randomPhrase(): string {
+	const gen: Array< string > = phrase.default32BitFactory().randomPhrase();
+	return `${ gen[ 1 ].toProperCase() } ${ gen[ 2 ].toProperCase() } ${ gen[ 3 ].toProperCase() } ${ gen[ 4 ].toProperCase() }`;
 }

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -5,21 +5,6 @@ import phrase from 'asana-phrase';
 import config from 'config';
 
 /**
- *
- */
-declare global {
-	interface String {
-		toProperCase(): string;
-	}
-}
-
-String.prototype.toProperCase = function (): string {
-	return this.replace( /\w\S*/g, function ( txt ) {
-		return txt.charAt( 0 ).toUpperCase() + txt.substr( 1 ).toLowerCase();
-	} );
-};
-
-/**
  * Assembles and returns the URL to a specific route/asset/query in Calypso.
  *
  * @param {string} route Additional state or page to build into the returned URL.
@@ -67,11 +52,25 @@ export function getJetpackHost(): string {
 }
 
 /**
+ * Given an array of strings, returns a single string with each word in TitleCase.
+ *
+ * @param {string[]} words Array of strings to be converted to TitleCase.
+ * @returns {string} Array of strings converted to TitleCase.
+ */
+export function toTitleCase( words: string[] ): string {
+	const result = words.map( function ( word ) {
+		return word.charAt( 0 ).toUpperCase() + word.slice( 1 ).toLowerCase();
+	} );
+
+	return result.join( ' ' );
+}
+
+/**
  * Generates a random phrase in proper case (Sample Sentence Text).
  *
  * @returns {string} Generated text.
  */
 export function randomPhrase(): string {
-	const gen: Array< string > = phrase.default32BitFactory().randomPhrase();
-	return `${ gen[ 1 ].toProperCase() } ${ gen[ 2 ].toProperCase() } ${ gen[ 3 ].toProperCase() } ${ gen[ 4 ].toProperCase() }`;
+	const generated: Array< string > = phrase.default32BitFactory().randomPhrase();
+	return toTitleCase( generated );
 }

--- a/packages/calypso-e2e/src/decs.d.ts
+++ b/packages/calypso-e2e/src/decs.d.ts
@@ -1,0 +1,1 @@
+declare module 'asana-phrase';

--- a/packages/calypso-e2e/src/lib/base-container.ts
+++ b/packages/calypso-e2e/src/lib/base-container.ts
@@ -7,6 +7,7 @@ import { Page } from 'playwright';
  * Base class for asynchronously initializing objects.
  */
 export class BaseContainer {
+	[ x: string ]: any;
 	page: Page;
 	url: string;
 	selector: string;

--- a/packages/calypso-e2e/src/lib/base-container.ts
+++ b/packages/calypso-e2e/src/lib/base-container.ts
@@ -15,10 +15,10 @@ export class BaseContainer {
 	 * Constructs an instance of a class.
 	 *
 	 * @param {Page} page The page on which interactions take place.
-	 * @param {string} [url] URL of the page represented by the object.
 	 * @param {string} [selector] CSS selector that is expected to be located on page.
+	 * @param {string} [url] URL of the page represented by the object.
 	 */
-	constructor( page: Page, url = '', selector = '' ) {
+	constructor( page: Page, selector = '', url = '' ) {
 		this.page = page;
 		this.url = url;
 		this.selector = selector;

--- a/packages/calypso-e2e/src/lib/base-container.ts
+++ b/packages/calypso-e2e/src/lib/base-container.ts
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { Page } from 'playwright';
+
+/**
+ * Base class for asynchronously initializing objects.
+ */
+export class BaseContainer {
+	page: Page;
+	url: string;
+	selector: string;
+
+	/**
+	 * Constructs an instance of a class.
+	 *
+	 * @param {Page} page The page on which interactions take place.
+	 * @param {string} [url] URL of the page represented by the object.
+	 * @param {string} [selector] CSS selector that is expected to be located on page.
+	 */
+	constructor( page: Page, url = '', selector = '' ) {
+		this.page = page;
+		this.url = url;
+		this.selector = selector;
+	}
+
+	/**
+	 * Constructs an instance of the object then waits for additional
+	 * initialization steps to complete asynchronously.
+	 *
+	 * @param {Page} page The page on which interactions take place.
+	 * @returns {Promise<BaseContainer} Initialized object.
+	 */
+	static async Expect( page: Page ): Promise< BaseContainer > {
+		const base = new this( page );
+		await base._init();
+		return base;
+	}
+
+	/**
+	 * Completes initialization of the object.
+	 *
+	 * There is provision to execute actions before and after the
+	 * page is determined to have finished loading and the optional
+	 * selector located.
+	 *
+	 * Note that the page is considered 'loaded' once the `load`
+	 * event has fired.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async _init(): Promise< void > {
+		await this._visit();
+		await this._preInit();
+		await this.page.waitForLoadState( 'load' );
+		if ( this.selector ) {
+			await this.page.waitForSelector( this.selector );
+		}
+		await this._postInit();
+	}
+
+	/**
+	 * Executes additional actions before page lod is completed.
+	 *
+	 * By default, no addition action is defined.
+	 * To specify an initialization step after the page has loaded,
+	 * override this class from the child class and define actions.
+	 */
+	async _preInit(): Promise< void > {
+		return;
+	}
+
+	/**
+	 * Executes additional actions after the page load is completed.
+	 *
+	 * By default, no addition action is defined.
+	 * To specify an initialization step after the page has loaded,
+	 * override this class from the child class and define actions.
+	 */
+	async _postInit(): Promise< void > {
+		return;
+	}
+
+	/**
+	 * Visits the URL if present. Do nothing otherwise.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async _visit(): Promise< void > {
+		if ( ! this.url ) {
+			return;
+		}
+		await this.page.goto( this.url );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -3,3 +3,4 @@
  */
 export * from './navbar-component';
 export * from './likes-component';
+export * from './sidebar-component';

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Internal dependencies
+ */
+export * from './navbar-component';
+export * from './likes-component';

--- a/packages/calypso-e2e/src/lib/components/likes-component.ts
+++ b/packages/calypso-e2e/src/lib/components/likes-component.ts
@@ -48,27 +48,8 @@ export class LikesComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickLike(): Promise< void > {
-		const state = await this._isLiked();
-
-		try {
-			await this.frame.click( this.likeButtonSelector );
-		} catch {
-			await this.frame.click( this.likedButtonSelector );
-		}
-
-		const newState = await this._isLiked();
-		if ( state === newState ) {
-			throw new Error( `Liked state did not change.` );
-		}
-	}
-
-	/**
-	 * Gets state of the Like button.
-	 *
-	 * @returns {Promise<boolean} True if liked. False otherwise.
-	 */
-	async _isLiked(): Promise< boolean > {
-		const state = await this.frame.isVisible( this.likeButtonSelector );
-		return !! state;
+		await Promise.race(
+			[ 'text=Like', 'text=Liked' ].map( ( selector ) => this.frame.click( selector ) )
+		);
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/likes-component.ts
+++ b/packages/calypso-e2e/src/lib/components/likes-component.ts
@@ -8,6 +8,17 @@ import { BaseContainer } from '../base-container';
  */
 import { Frame, Page, ElementHandle } from 'playwright';
 
+const selectors = {
+	// Note the variation of 'Like' button for when the button is already clicked.
+	likeWidgetSelector: 'iframe.post-likes-widget',
+
+	// Selectors within the Like Widget iframe.
+	likeBoxSelector: '.sd-content wpl-likebox',
+	likeButtonSelector: 'text=Like',
+	likedButtonSelector: 'text=Liked',
+	likedText: 'text="You like this."',
+};
+
 /**
  * Component representing the like component on a post/page.
  *
@@ -16,19 +27,13 @@ import { Frame, Page, ElementHandle } from 'playwright';
 export class LikesComponent extends BaseContainer {
 	frame!: Frame;
 
-	// Selectors for the widget and buttons.
-	// Note the variation of 'Like'.
-	likeWidgetSelector = 'iframe.post-likes-widget';
-	likeButtonSelector = 'text=Like';
-	likedButtonSelector = 'text=Liked';
-
 	/**
 	 * Constructs an instance of the object.
 	 *
 	 * @param {Page} page Instance of the page on which the component resides.
 	 */
 	constructor( page: Page ) {
-		super( page, 'iframe.post-likes-widget' );
+		super( page, selectors.likeWidgetSelector );
 	}
 
 	/**
@@ -38,18 +43,46 @@ export class LikesComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async _postInit(): Promise< void > {
-		const handle = ( await this.page.$( this.likeWidgetSelector ) ) as ElementHandle;
+		const handle = ( await this.page.$( selectors.likeWidgetSelector ) ) as ElementHandle;
 		this.frame = ( await handle.contentFrame() ) as Frame;
+		await this.page.waitForLoadState( 'networkidle' );
 	}
 
 	/**
-	 * Clicks and toggles the state of the Like button.
+	 * Clicks the Like button and toggles the state.
+	 *
+	 * This function will also confirm that click action on the Like button
+	 * had the intended effect.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickLike(): Promise< void > {
-		await Promise.race(
-			[ 'text=Like', 'text=Liked' ].map( ( selector ) => this.frame.click( selector ) )
-		);
+		const isLiked = await this.frame.isVisible( selectors.likedText );
+
+		// Build the list of promises to be resolved at end.
+		const promises: any = [
+			// Clicking the Like triggers an navigation event.
+			// Wait for this event to complete, as the response typically takes
+			// ~1.5s.
+			this.frame.waitForLoadState( 'networkidle' ),
+		];
+
+		// Depending on the state of the Like button, request endpoints vary
+		// and so do the selector itself.
+		if ( isLiked ) {
+			promises.push( this.frame.click( selectors.likedButtonSelector ) );
+			promises.push(
+				this.page.waitForEvent( 'request', ( request ) =>
+					request.url().includes( 'likes/mine/delete' )
+				)
+			);
+		} else {
+			promises.push( this.frame.click( selectors.likeButtonSelector ) );
+			promises.push(
+				this.page.waitForEvent( 'request', ( request ) => request.url().includes( 'likes/new' ) )
+			);
+		}
+
+		await Promise.all( promises );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/likes-component.ts
+++ b/packages/calypso-e2e/src/lib/components/likes-component.ts
@@ -49,11 +49,13 @@ export class LikesComponent extends BaseContainer {
 	 */
 	async clickLike(): Promise< void > {
 		const state = await this._isLiked();
+
 		try {
 			await this.frame.click( this.likeButtonSelector );
 		} catch {
 			await this.frame.click( this.likedButtonSelector );
 		}
+
 		const newState = await this._isLiked();
 		if ( state === newState ) {
 			throw new Error( `Liked state did not change.` );

--- a/packages/calypso-e2e/src/lib/components/likes-component.ts
+++ b/packages/calypso-e2e/src/lib/components/likes-component.ts
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Frame, Page, ElementHandle } from 'playwright';
+
+/**
+ * Component representing the like component on a post/page.
+ */
+export class LikesComponent extends BaseContainer {
+	frame!: Frame;
+
+	// Selectors for the widget and buttons.
+	// Note the variation of 'Like'.
+	likeWidgetSelector = 'iframe.post-likes-widget';
+	likeButtonSelector = 'text=Like';
+	likedButtonSelector = 'text=Liked';
+
+	/**
+	 * Constructs an instance of the object.
+	 *
+	 * @param {Page} page Instance of the page on which the component resides.
+	 */
+	constructor( page: Page ) {
+		super( page, 'iframe.post-likes-widget' );
+	}
+
+	/**
+	 * Overrides the parent method for post-initialization steps.
+	 * This ensures the iframe is enabled and interactable.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async _postInit(): Promise< void > {
+		const handle = ( await this.page.$( this.likeWidgetSelector ) ) as ElementHandle;
+		this.frame = ( await handle.contentFrame() ) as Frame;
+	}
+
+	/**
+	 * Clicks and toggles the state of the Like button.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async clickLike(): Promise< void > {
+		const state = await this._isLiked();
+		try {
+			await this.frame.click( this.likeButtonSelector );
+		} catch {
+			await this.frame.click( this.likedButtonSelector );
+		}
+		const newState = await this._isLiked();
+		if ( state === newState ) {
+			throw new Error( `Liked state did not change.` );
+		}
+	}
+
+	/**
+	 * Gets state of the Like button.
+	 *
+	 * @returns {Promise<boolean} True if liked. False otherwise.
+	 */
+	async _isLiked(): Promise< boolean > {
+		const state = await this.frame.isVisible( this.likeButtonSelector );
+		return !! state;
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/likes-component.ts
+++ b/packages/calypso-e2e/src/lib/components/likes-component.ts
@@ -58,23 +58,21 @@ export class LikesComponent extends BaseContainer {
 	async clickLike(): Promise< void > {
 		const isLiked = await this.frame.isVisible( selectors.likedText );
 
-		// Build the list of promises to be resolved at end.
-		const promises: any = [
-			// Clicking the Like triggers an navigation event.
-			// Wait for this event to complete, as the response typically takes
-			// ~1.5s.
-			this.frame.waitForLoadState( 'networkidle' ),
-		];
+		// In subsequent statement this will be assigned an ElementHandler
+		// of the Like/Liked button.
+		let button;
 
 		if ( isLiked ) {
-			// Like button is already clicked. Check for unlike status at end.
-			promises.push( this.frame.waitForSelector( selectors.likeButton ) );
-			promises.push( this.frame.click( selectors.likedButton ) );
+			// Post is liked. Click to unlike.
+			await this.frame.click( selectors.likedButton );
+			button = await this.frame.waitForSelector( selectors.likeButton );
 		} else {
-			promises.push( this.frame.waitForSelector( selectors.likedButton ) );
-			promises.push( this.frame.click( selectors.likeButton ) );
+			// Post is not yet liked. Click to like.
+			await this.frame.click( selectors.likeButton );
+			button = await this.frame.waitForSelector( selectors.likedButton );
 		}
 
-		await Promise.all( promises );
+		await button.waitForElementState( 'stable' );
+		await this.frame.waitForLoadState( 'networkidle' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/likes-component.ts
+++ b/packages/calypso-e2e/src/lib/components/likes-component.ts
@@ -10,6 +10,8 @@ import { Frame, Page, ElementHandle } from 'playwright';
 
 /**
  * Component representing the like component on a post/page.
+ *
+ * @augments {BaseContainer}
  */
 export class LikesComponent extends BaseContainer {
 	frame!: Frame;

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -31,12 +31,7 @@ export class NavbarComponent extends BaseContainer {
 	async __postInit(): Promise< void > {
 		// Ensure that navigation is completed and the required
 		// elements are visible on page.
-		await Promise.all( [
-			this.page.waitForLoadState( 'domcontentloaded' ),
-			this.page.waitForSelector( selectors.navbar ),
-			this.page.waitForSelector( selectors.publishButton ),
-			this.page.waitForSelector( selectors.newPostButton ),
-		] );
+		await this.page.waitForLoadState( 'domcontentloaded' );
 	}
 
 	/**
@@ -46,10 +41,13 @@ export class NavbarComponent extends BaseContainer {
 	 */
 	async clickNewPost(): Promise< void > {
 		// Series of promises that ensure editor page is loaded.
-		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
+		await this.page.waitForSelector( selectors.newPostButton );
+		await this.page.waitForSelector( selectors.publishButton );
+		await Promise.race( [
 			this.page.click( selectors.newPostButton ),
 			this.page.click( selectors.publishButton ),
+			this.page.click( 'text=Write' ),
 		] );
+		await this.page.waitForLoadState( 'networkidle' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -17,6 +17,7 @@ export class NavbarComponent extends BaseContainer {
 	// Selectors
 	navBarSelector = '.masterbar';
 	newPostButtonSelector = '.masterbar__item-new';
+	newPostContentSelector = '.masterbar__item-new';
 
 	/**
 	 * Constructs an instance of the component.
@@ -35,7 +36,15 @@ export class NavbarComponent extends BaseContainer {
 	async clickNewPost(): Promise< void > {
 		await Promise.all( [
 			this.page.isVisible( this.navBarSelector ),
-			this.page.click( this.newPostButtonSelector ),
+			this.page.isVisible( this.newPostButtonSelector ),
+			this.page.waitForNavigation(),
+		] );
+
+		await Promise.all( [
+			Promise.race( [
+				this.page.click( this.newPostButtonSelector ),
+				this.page.click( this.newPostContentSelector ),
+			] ),
 			this.page.waitForNavigation(),
 		] );
 	}

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -27,10 +27,11 @@ export class NavbarComponent extends BaseContainer {
 		super( page, selectors.navbar );
 	}
 
-	async __postInit(): Promise< void > {
+	async _postInit(): Promise< void > {
 		// Ensure that navigation is completed and the required
 		// elements are visible on page.
 		await this.page.waitForLoadState( 'domcontentloaded' );
+		await this.page.waitForSelector( selectors.newPostButton );
 	}
 
 	/**
@@ -39,11 +40,6 @@ export class NavbarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await Promise.all( [
-			this.page.waitForSelector( selectors.newPostButton ),
-			this.page.waitForNavigation(),
-		] );
-
 		await Promise.all( [
 			this.page.waitForLoadState( 'networkidle' ),
 			this.page.waitForNavigation(),

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -10,6 +10,8 @@ import { Page } from 'playwright';
 
 /**
  * Component representing the navbar/masterbar at top of WPCOM.
+ *
+ * @augments {BaseContainer}
  */
 export class NavbarComponent extends BaseContainer {
 	// Selectors

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -47,7 +47,7 @@ export class NavbarComponent extends BaseContainer {
 		await Promise.all( [
 			this.page.waitForLoadState( 'networkidle' ),
 			this.page.waitForNavigation(),
-			this.page.click( selectors.newPostButton, { timeout: 120, clickCount: 10 } ),
+			this.page.click( selectors.newPostButton, { timeout: 120000, clickCount: 10 } ),
 		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -15,8 +15,8 @@ import { Page } from 'playwright';
  */
 export class NavbarComponent extends BaseContainer {
 	// Selectors
-	barSelector = '.masterbar';
-	newPostSelector = 'a.masterbar__item-new';
+	navBarSelector = '.masterbar';
+	newPostButtonSelector = '.masterbar__item-new';
 
 	/**
 	 * Constructs an instance of the component.
@@ -33,7 +33,10 @@ export class NavbarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await this.page.click( this.newPostSelector );
-		await Promise.all( [ this.page.waitForNavigation() ] );
+		await Promise.all( [
+			this.page.isVisible( this.navBarSelector ),
+			this.page.click( this.newPostButtonSelector ),
+			this.page.waitForNavigation(),
+		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -27,19 +27,14 @@ export class NavbarComponent extends BaseContainer {
 		super( page, selectors.navbar );
 	}
 
-	async _postInit(): Promise< void > {
-		// Ensure that navigation is completed and the required
-		// elements are visible on page.
-		await this.page.waitForLoadState( 'domcontentloaded' );
-		await this.page.waitForSelector( selectors.newPostButton );
-	}
-
 	/**
 	 * Locates and clicks on the new post button on the nav bar.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
+		await this.page.waitForSelector( selectors.newPostButton );
+
 		await Promise.all( [
 			this.page.waitForLoadState( 'networkidle' ),
 			this.page.waitForNavigation(),

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -10,7 +10,6 @@ import { Page } from 'playwright';
 
 const selectors = {
 	navbar: '.masterbar',
-	publishButton: '.masterbar__publish',
 	newPostButton: '.masterbar__item-new',
 };
 /**
@@ -40,14 +39,15 @@ export class NavbarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		// Series of promises that ensure editor page is loaded.
-		await this.page.waitForSelector( selectors.newPostButton );
-		await this.page.waitForSelector( selectors.publishButton );
-		await Promise.race( [
-			this.page.click( selectors.newPostButton ),
-			this.page.click( selectors.publishButton ),
-			this.page.click( 'text=Write' ),
+		await Promise.all( [
+			this.page.waitForSelector( selectors.newPostButton ),
+			this.page.waitForNavigation(),
 		] );
-		await this.page.waitForLoadState( 'networkidle' );
+
+		await Promise.all( [
+			this.page.waitForLoadState( 'networkidle' ),
+			this.page.waitForNavigation(),
+			this.page.click( selectors.newPostButton, { timeout: 120, clickCount: 10 } ),
+		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -8,24 +8,24 @@ import { BaseContainer } from '../base-container';
  */
 import { Page } from 'playwright';
 
+const selectors = {
+	navBarSelector: '.masterbar',
+	newPostButtonSelector: '.masterbar__item-new',
+	newPostContentSelector: '.masterbar__item-content',
+};
 /**
  * Component representing the navbar/masterbar at top of WPCOM.
  *
  * @augments {BaseContainer}
  */
 export class NavbarComponent extends BaseContainer {
-	// Selectors
-	navBarSelector = '.masterbar';
-	newPostButtonSelector = '.masterbar__item-new';
-	newPostContentSelector = '.masterbar__item-new';
-
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
 	 */
 	constructor( page: Page ) {
-		super( page, '.masterbar' );
+		super( page, selectors.navBarSelector );
 	}
 
 	/**
@@ -35,15 +35,19 @@ export class NavbarComponent extends BaseContainer {
 	 */
 	async clickNewPost(): Promise< void > {
 		await Promise.all( [
-			this.page.isVisible( this.navBarSelector ),
-			this.page.isVisible( this.newPostButtonSelector ),
+			this.page.isVisible( selectors.navBarSelector ),
+			this.page.isVisible( selectors.newPostButtonSelector ),
 			this.page.waitForNavigation(),
 		] );
 
+		// Note the nested Promise calls.
+		// Originally there were issues on TeamCity CI where
+		// this would fail to locate the newPostButtonSelector.
+		// The newPostContentSelector is clicked for redundancy.
 		await Promise.all( [
 			Promise.race( [
-				this.page.click( this.newPostButtonSelector ),
-				this.page.click( this.newPostContentSelector ),
+				this.page.click( selectors.newPostButtonSelector ),
+				this.page.click( selectors.newPostContentSelector ),
 			] ),
 			this.page.waitForNavigation(),
 		] );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+/**
+ * Component representing the navbar/masterbar at top of WPCOM.
+ */
+export class NavbarComponent extends BaseContainer {
+	// Selectors
+	barSelector = '.masterbar';
+	newPostSelector = 'a.masterbar__item-new';
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		super( page, '.masterbar' );
+	}
+
+	/**
+	 * Locates and clicks on the new post button on the nav bar.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async clickNewPost(): Promise< void > {
+		await this.page.click( this.newPostSelector );
+		await Promise.all( [ this.page.waitForNavigation() ] );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -34,11 +34,6 @@ export class NavbarComponent extends BaseContainer {
 	 */
 	async clickNewPost(): Promise< void > {
 		await this.page.waitForSelector( selectors.newPostButton );
-
-		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
-			this.page.waitForNavigation(),
-			this.page.click( selectors.newPostButton, { timeout: 120000, clickCount: 10 } ),
-		] );
+		await this.page.click( selectors.newPostButton, { timeout: 120000, clickCount: 10 } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	sidebar: '#secondary',
+};
+/**
+ * Component representing the navbar/masterbar at top of WPCOM.
+ *
+ * @augments {BaseContainer}
+ */
+export class SidebarComponent extends BaseContainer {
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		super( page, selectors.sidebar );
+	}
+}

--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 export * from './login-flow';
+export * from './new-post-flow';

--- a/packages/calypso-e2e/src/lib/flows/login-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/login-flow.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { LoginPage } from '../pages/login-page';
+import { LoginPage, MyHomePage } from '../pages';
 import { getAccountCredential } from '../../data-helper';
 
 /**
@@ -51,5 +51,6 @@ export class LoginFlow {
 	 */
 	async login(): Promise< void > {
 		await this.baseflow();
+		await MyHomePage.Expect( this.page );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -8,14 +8,27 @@ import { NavbarComponent } from '../components';
  */
 import { Page } from 'playwright';
 
+/**
+ * Handles all sorts of flows related to starting a new post.
+ */
 export class NewPostFlow {
 	page: Page;
 
+	/**
+	 * Constructs an instance of the flow.
+	 *
+	 * @param {Page} page Instance of a browser page.
+	 */
 	constructor( page: Page ) {
 		this.page = page;
 	}
 
-	async createPostFromNavbar() {
+	/**
+	 * Starts a new post from the navbar/masterbar button.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async newPostFromNavbar(): Promise< void > {
 		const navbar = new NavbarComponent( this.page );
 		await navbar.clickNewPost();
 	}

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { NavbarComponent } from '../components';
+import { NavbarComponent, SidebarComponent } from '../components';
+import { GutenbergEditorPage } from '../pages';
 
 /**
  * Type dependencies
@@ -29,7 +30,9 @@ export class NewPostFlow {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async newPostFromNavbar(): Promise< void > {
-		const navbar = await NavbarComponent.Expect( this.page );
-		await navbar.clickNewPost();
+		await SidebarComponent.Expect( this.page );
+		const navbarComponent = await NavbarComponent.Expect( this.page );
+		await navbarComponent.clickNewPost();
+		await GutenbergEditorPage.Expect( this.page );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { NavbarComponent } from '../components';
-import { GutenbergEditorPage } from '../pages';
 
 /**
  * Type dependencies
@@ -32,6 +31,5 @@ export class NewPostFlow {
 	async newPostFromNavbar(): Promise< void > {
 		const navbar = await NavbarComponent.Expect( this.page );
 		await navbar.clickNewPost();
-		await GutenbergEditorPage.Expect( this.page );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { NavbarComponent } from '../components';
+import { GutenbergEditorPage } from '../pages';
 
 /**
  * Type dependencies
@@ -29,7 +30,8 @@ export class NewPostFlow {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async newPostFromNavbar(): Promise< void > {
-		const navbar = new NavbarComponent( this.page );
+		const navbar = await NavbarComponent.Expect( this.page );
 		await navbar.clickNewPost();
+		await GutenbergEditorPage.Expect( this.page );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { NavbarComponent } from '../components';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+export class NewPostFlow {
+	page: Page;
+
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	async createPostFromNavbar() {
+		const navbar = new NavbarComponent( this.page );
+		await navbar.clickNewPost();
+	}
+}

--- a/packages/calypso-e2e/src/lib/index.ts
+++ b/packages/calypso-e2e/src/lib/index.ts
@@ -3,3 +3,4 @@
  */
 export * from './pages';
 export * from './flows';
+export * from './components';

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -96,10 +96,11 @@ export class GutenbergEditorPage extends BaseContainer {
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	async _visitPublishedPost() {
+	async _visitPublishedPost(): Promise< void > {
 		await Promise.all( [
 			this.frame.click( this.snackBarNoticeLinkSelector ),
 			this.page.waitForNavigation(),
+			this.page.waitForLoadState( 'networkidle' ),
 		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -56,6 +56,7 @@ export class GutenbergEditorPage extends BaseContainer {
 		const handle = ( await this.page.$( selectors.editorFrame ) ) as ElementHandle;
 		this.frame = ( await handle.contentFrame() ) as Frame;
 		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForSelector( selectors.editorBody );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -12,7 +12,7 @@ const selectors = {
 	// Editor selectors.
 	editorFrame: 'div.main.main-column.calypsoify.is-iframe > iframe',
 	editorTitle: '.editor-post-title__input',
-	editorBody: '.block-editor-block-list__layout is-root-container',
+	editorBody: '.edit-post-visual-editor',
 
 	// Within the editor body.
 	blockAppender: '.block-editor-default-block-appender',
@@ -56,7 +56,7 @@ export class GutenbergEditorPage extends BaseContainer {
 		const handle = ( await this.page.$( selectors.editorFrame ) ) as ElementHandle;
 		this.frame = ( await handle.contentFrame() ) as Frame;
 		await this.page.waitForLoadState( 'networkidle' );
-		await this.page.waitForSelector( selectors.editorBody );
+		await this.frame.waitForSelector( selectors.editorBody );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -74,21 +74,28 @@ export class GutenbergEditorPage extends BaseContainer {
 		await this.frame.fill( this.paragraphSelector, text );
 	}
 
+	/**
+	 * Publishes the post or page.
+	 *
+	 * @param {boolean} visit Whether to then visit the page.
+	 * @returns {Promise<void} No return value.
+	 */
 	async publish( visit = false ): Promise< void > {
 		await this.frame.click( this.firstPublishButtonSelector );
 		await this.frame.click( this.secondPublishButtonSelector );
 
-		await this._clickConfirmPublish();
+		await this.frame.waitForSelector( this.snackBarNoticeSelector );
 
 		if ( visit ) {
 			await this._visitPublishedPost();
 		}
 	}
 
-	async _clickConfirmPublish() {
-		await this.frame.waitForSelector( this.snackBarNoticeSelector );
-	}
-
+	/**
+	 * Visits the published post or page.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async _visitPublishedPost() {
 		await Promise.all( [
 			this.frame.click( this.snackBarNoticeLinkSelector ),

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,0 +1,98 @@
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+import { ElementHandle, Frame, Page } from 'playwright';
+import { BaseContainer } from '../base-container';
+
+/**
+ * Represents an instance of the WPCOM's Gutenberg editor page.
+ *
+ * @augments {BaseContainer}
+ */
+export class GutenbergEditorPage extends BaseContainer {
+	frame!: Frame;
+
+	// Page and Frame related selectors.
+	editorSelector = 'div.main.main-column.calypsoify.is-iframe > iframe';
+
+	// Editor element selectors.
+	titleSelector = `.editor-post-title__input`;
+	appenderSelector = '.block-editor-default-block-appender';
+	paragraphSelector = 'p.block-editor-rich-text__editable:first-of-type';
+
+	// Publish flow selectors.
+	firstPublishButtonSelector = '.editor-post-publish-panel__toggle';
+	secondPublishButtonSelector =
+		'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button';
+	snackBarNoticeSelector = '.components-snackbar';
+	snackBarNoticeLinkSelector = '.components-snackbar__content a';
+
+	/**
+	 * Constructs an instance of this object.
+	 *
+	 * @param {Page} page The page where actions take place.
+	 */
+	constructor( page: Page ) {
+		super( page, 'div.main.main-column.calypsoify.is-iframe > iframe' );
+	}
+
+	/**
+	 * Overrides the function of same name defined in the base class.
+	 * This ensures the iframe containing the editor is is fully loaded prior to
+	 * continuing with the test.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async _postInit(): Promise< void > {
+		const handle = ( await this.page.$( this.editorSelector ) ) as ElementHandle;
+		this.frame = ( await handle.contentFrame() ) as Frame;
+	}
+
+	/**
+	 * Enters text into the title block.
+	 *
+	 * @param {string} title Text to be used as the title.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async enterTitle( title: string ): Promise< void > {
+		await this.frame.click( this.titleSelector );
+		await this.frame.fill( this.titleSelector, title );
+	}
+
+	/**
+	 * Enters text into the body.
+	 *
+	 * @param {string} text Text to be entered into the body.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async enterText( text: string ): Promise< void > {
+		await this.frame.click( this.appenderSelector );
+		await this.frame.fill( this.paragraphSelector, text );
+	}
+
+	async publish( visit = false ): Promise< void > {
+		await this.frame.click( this.firstPublishButtonSelector );
+		await this.frame.click( this.secondPublishButtonSelector );
+
+		await this._clickConfirmPublish();
+
+		if ( visit ) {
+			await this._visitPublishedPost();
+		}
+	}
+
+	async _clickConfirmPublish() {
+		await this.frame.waitForSelector( this.snackBarNoticeSelector );
+	}
+
+	async _visitPublishedPost() {
+		await Promise.all( [
+			this.frame.click( this.snackBarNoticeLinkSelector ),
+			this.page.waitForNavigation(),
+		] );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,12 +1,17 @@
 /**
+ * External dependencies
+ */
+import assert from 'assert';
+
+/**
  * Internal dependencies
  */
+import { BaseContainer } from '../base-container';
 
 /**
  * Type dependencies
  */
 import { ElementHandle, Frame, Page } from 'playwright';
-import { BaseContainer } from '../base-container';
 
 const selectors = {
 	// Editor selectors.
@@ -60,12 +65,26 @@ export class GutenbergEditorPage extends BaseContainer {
 	}
 
 	/**
-	 * Enters text into the title block.
+	 * Enters the text into the title block and verifies the result.
+	 *
+	 * @param {string} title Text to be used as the title.
+	 * @returns {Promise<void>} No return value.
+	 * @throws {assert.AssertionError} If text entered and text read back do not match.
+	 */
+	async enterTitle( title: string ): Promise< void > {
+		const sanitizedTitle = title.trim();
+		await this.setTitle( sanitizedTitle );
+		const readBack = await this.getTitle();
+		assert( readBack === sanitizedTitle );
+	}
+
+	/**
+	 * Fills the title block with text.
 	 *
 	 * @param {string} title Text to be used as the title.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async enterTitle( title: string ): Promise< void > {
+	async setTitle( title: string ): Promise< void > {
 		await this.frame.click( selectors.editorTitle );
 		await this.frame.fill( selectors.editorTitle, title );
 	}
@@ -82,12 +101,25 @@ export class GutenbergEditorPage extends BaseContainer {
 	}
 
 	/**
+	 * Enters text into the paragraph block(s) and verifies the result.
+	 *
+	 * @param {string} text Text to be entered into the paragraph blocks, separated by newline characters.
+	 * @returns {Promise<void>} No return value.
+	 * @throws {assert.AssertionError} If text entered and text read back do not match.
+	 */
+	async enterText( text: string ): Promise< void > {
+		await this.setText( text );
+		const readBack = await this.getText();
+		assert( readBack === text );
+	}
+
+	/**
 	 * Enters text into the body, splitting newlines into new pragraph blocks as necessary.
 	 *
 	 * @param {string} text Text to be entered into the body.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async enterText( text: string ): Promise< void > {
+	async setText( text: string ): Promise< void > {
 		const lines = text.split( '\n' );
 		await this.frame.click( selectors.blockAppender );
 

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 export * from './login-page';
+export * from './gutenberg-editor-page';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -3,3 +3,4 @@
  */
 export * from './login-page';
 export * from './gutenberg-editor-page';
+export * from './my-home-page';

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	dashboard: '.customer-home__main',
+	statsCard: '.stats',
+};
+
+export class MyHomePage extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.dashboard );
+	}
+
+	async _postInit(): Promise< void > {
+		await this.page.waitForSelector( selectors.statsCard );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -17,8 +17,4 @@ export class MyHomePage extends BaseContainer {
 	constructor( page: Page ) {
 		super( page, selectors.dashboard );
 	}
-
-	// async _postInit(): Promise< void > {
-	// 	await this.page.waitForSelector( selectors.statsCard );
-	// }
 }

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -18,7 +18,7 @@ export class MyHomePage extends BaseContainer {
 		super( page, selectors.dashboard );
 	}
 
-	async _postInit(): Promise< void > {
-		await this.page.waitForSelector( selectors.statsCard );
-	}
+	// async _postInit(): Promise< void > {
+	// 	await this.page.waitForSelector( selectors.statsCard );
+	// }
 }

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -7,4 +7,4 @@ file:
 reporter:
   - 'spec-junit-reporter'
 # Timeout for mocha when starting up only.
-timeout: 9000
+timeout: 15000

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -7,7 +7,7 @@
 	"startBrowserTimeoutMS": 60000,
 	"startAppTimeoutMS": 240000,
 	"afterHookTimeoutMS": 60000,
-	"playwrightTimeoutMS": 9000,
+	"playwrightTimeoutMS": 15000,
 	"browser": "chrome",
 	"proxy": "direct",
 	"saveAllScreenshots": false,

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -17,7 +17,6 @@ import {
  */
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const host = DataHelper.getJetpackHost();
-DataHelper.createSuiteTitle( 'Likes' );
 const viewportName = BrowserHelper.getViewportName();
 const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import assert from 'assert';
 import config from 'config';
 import {
 	BrowserHelper,
@@ -17,6 +18,8 @@ import {
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const host = DataHelper.getJetpackHost();
 const viewportName = BrowserHelper.getViewportName();
+// const quote =
+// 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 
@@ -41,10 +44,14 @@ describe( `[${ host }] Likes: (${ viewportName }) @parallel`, function () {
 			gutenbergEditorPage = await GutenbergEditorPage.Expect( this.page );
 			const title = DataHelper.randomPhrase();
 			await gutenbergEditorPage.enterTitle( title );
+			const enteredTitle = await gutenbergEditorPage.getTitle();
+			assert( title === enteredTitle );
 		} );
 
 		it( 'Enter post text', async function () {
 			await gutenbergEditorPage.enterText( quote );
+			const enteredText = await gutenbergEditorPage.getText();
+			assert( quote === enteredText );
 		} );
 
 		it( 'Publish and visit post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import {
+	BrowserHelper,
+	DataHelper,
+	LoginFlow,
+	NewPostFlow,
+	GutenbergEditorPage,
+	LikesComponent,
+} from '@automattic/calypso-e2e';
+
+/**
+ * Constants
+ */
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const host = DataHelper.getJetpackHost();
+const viewportName = BrowserHelper.getViewportName();
+const quote =
+	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
+
+describe( `[${ host }] Likes: (${ viewportName }) @parallel`, function () {
+	this.timeout( mochaTimeOut );
+
+	describe( 'New post', function () {
+		let gEditor;
+		let likesComponent;
+
+		before( 'Can log in', async function () {
+			const loginFlow = new LoginFlow( this.page, 'gutenbergSimpleSiteUser' );
+			await loginFlow.login();
+		} );
+
+		it( 'Start new post', async function () {
+			const newPostFlow = new NewPostFlow( this.page );
+			await newPostFlow.newPostFromNavbar();
+		} );
+
+		it( 'Enter post title', async function () {
+			gEditor = await GutenbergEditorPage.Expect( this.page );
+			const title = DataHelper.randomPhrase();
+			await gEditor.enterTitle( title );
+			await gEditor.enterText( quote );
+		} );
+
+		it( 'Publish and visit post', async function () {
+			await gEditor.publish( true );
+		} );
+
+		it( 'Like post', async function () {
+			likesComponent = await LikesComponent.Expect( this.page );
+			await likesComponent.clickLike();
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -24,10 +24,10 @@ describe( `[${ host }] Likes: (${ viewportName }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'New post', function () {
-		let gEditor;
+		let gutenbergEditorPage;
 		let likesComponent;
 
-		before( 'Can log in', async function () {
+		it( 'Log in', async function () {
 			const loginFlow = new LoginFlow( this.page, 'gutenbergSimpleSiteUser' );
 			await loginFlow.login();
 		} );
@@ -38,14 +38,17 @@ describe( `[${ host }] Likes: (${ viewportName }) @parallel`, function () {
 		} );
 
 		it( 'Enter post title', async function () {
-			gEditor = await GutenbergEditorPage.Expect( this.page );
+			gutenbergEditorPage = await GutenbergEditorPage.Expect( this.page );
 			const title = DataHelper.randomPhrase();
-			await gEditor.enterTitle( title );
-			await gEditor.enterText( quote );
+			await gutenbergEditorPage.enterTitle( title );
+		} );
+
+		it( 'Enter post text', async function () {
+			await gutenbergEditorPage.enterText( quote );
 		} );
 
 		it( 'Publish and visit post', async function () {
-			await gEditor.publish( true );
+			await gutenbergEditorPage.publish( { visit: true } );
 		} );
 
 		it( 'Like post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -17,9 +17,8 @@ import {
  */
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const host = DataHelper.getJetpackHost();
+DataHelper.createSuiteTitle( 'Likes' );
 const viewportName = BrowserHelper.getViewportName();
-// const quote =
-// 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import assert from 'assert';
 import config from 'config';
 import {
 	BrowserHelper,
@@ -42,14 +41,10 @@ describe( `[${ host }] Likes: (${ viewportName }) @parallel`, function () {
 			gutenbergEditorPage = await GutenbergEditorPage.Expect( this.page );
 			const title = DataHelper.randomPhrase();
 			await gutenbergEditorPage.enterTitle( title );
-			const enteredTitle = await gutenbergEditorPage.getTitle();
-			assert( title === enteredTitle );
 		} );
 
 		it( 'Enter post text', async function () {
 			await gutenbergEditorPage.enterText( quote );
-			const enteredText = await gutenbergEditorPage.getText();
-			assert( quote === enteredText );
 		} );
 
 		it( 'Publish and visit post', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change implements multiple components, pages and flows in Playwright.

- pages and components, where appropriate, can inherit from a new `BaseContainer` (analogous to the `AsyncBaseContainer` in Selenium).
- a basic page object for GutenbergEditor.
- components and flows to support paths touched on by the `wp-likes-spec`.

#### Testing instructions

Ensure tests pass on TeamCity for Playwright (trigger manually).

Pull the changes locally and ensure they run with `mocha --config .mocharc_playwright.yml specs/specs-playwright/wp-likes-spec.js`.

Related to #53168
Child: #53291
