### PR TITLE
Remove all cart products when starting the  marketplace flow

### DIFF
--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
@@ -63,6 +63,10 @@ function MarketplacePluginDetails( {
 		return replaceProductsInCart( [ yoastProduct ] );
 	};
 
+	const onRemoveEverythingFromCart = () => {
+		return replaceProductsInCart( [] );
+	};
+
 	return (
 		<div>
 			{ ! wporgFetching ? (
@@ -72,6 +76,7 @@ function MarketplacePluginDetails( {
 					displayCost={ displayCost }
 					wporgPluginName={ wporgPlugin?.name }
 					onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
+					onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
 					onNavigateToCheckout={ () =>
 						page( `/checkout${ selectedSite?.slug ? `/${ selectedSite?.slug }` : '' }` )
 					}

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/purchase-area.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/purchase-area.tsx
@@ -7,16 +7,17 @@ import React, { useState } from 'react';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
-interface PurchseArea {
+interface PurchaseArea {
 	siteDomains: any[];
 	isProductListLoading: boolean;
 	displayCost?: string | null;
 	wporgPluginName?: string;
-	onAddYoastPremiumToCart: () => void;
+	onAddYoastPremiumToCart: () => Promise< ResponseCart >;
 	onNavigateToCheckout: () => void;
 	onNavigateToDomainsSelection: () => void;
-	onRemoveEverythingFromCart: () => void;
+	onRemoveEverythingFromCart: () => Promise< ResponseCart >;
 }
 
 export default function PurchaseArea( {
@@ -28,7 +29,7 @@ export default function PurchaseArea( {
 	onNavigateToCheckout,
 	onNavigateToDomainsSelection,
 	onRemoveEverythingFromCart,
-}: PurchseArea ): JSX.Element {
+}: PurchaseArea ): JSX.Element {
 	const [ isButtonClicked, setIsButtonClicked ] = useState( false );
 
 	const isCustomDomain = ( {

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/purchase-area.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/purchase-area.tsx
@@ -16,6 +16,7 @@ interface PurchseArea {
 	onAddYoastPremiumToCart: () => void;
 	onNavigateToCheckout: () => void;
 	onNavigateToDomainsSelection: () => void;
+	onRemoveEverythingFromCart: () => void;
 }
 
 export default function PurchaseArea( {
@@ -26,6 +27,7 @@ export default function PurchaseArea( {
 	onAddYoastPremiumToCart,
 	onNavigateToCheckout,
 	onNavigateToDomainsSelection,
+	onRemoveEverythingFromCart,
 }: PurchseArea ): JSX.Element {
 	const [ isButtonClicked, setIsButtonClicked ] = useState( false );
 
@@ -51,6 +53,7 @@ export default function PurchaseArea( {
 		setIsButtonClicked( true );
 		const isCustomDomainAvailable = evaluateIsCustomDomainAvailable( siteDomains );
 		const isCustomDomainPrimary = evaluateIsCustomDomainPrimary( siteDomains );
+		await onRemoveEverythingFromCart();
 		if ( isProductPurchased ) {
 			await onAddYoastPremiumToCart();
 		}

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/test/index.js
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/test/index.js
@@ -23,7 +23,9 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 	const customDomain = { isWpcomStagingDomain: false };
 	const primaryWpcomDomain = { isPrimary: true, ...wpcomDomain };
 	const primaryCustomDomain = { isPrimary: true, ...customDomain };
-
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
 	test( 'If user has a primary custom domain and purchases a paid product, redirects to checkout', async () => {
 		const marketplacePluginDetails = render(
 			<PurchaseArea
@@ -39,7 +41,7 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 		);
 		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
 		await fireEvent.click( yoastPremiumButton );
-		//onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise  for the following mocks to be called
+		// onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise for the following mocks to be called
 		await Promise.resolve();
 
 		expect( onAddYoastPremiumToCart ).toHaveBeenCalled();
@@ -65,7 +67,7 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 		);
 		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
 		await fireEvent.click( yoastPremiumButton );
-		//onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise  for the following mocks to be called
+		// onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise for the following mocks to be called
 		await Promise.resolve();
 
 		expect( onAddYoastPremiumToCart ).toHaveBeenCalled();

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/test/index.js
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/test/index.js
@@ -39,6 +39,9 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 		);
 		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
 		await fireEvent.click( yoastPremiumButton );
+		//onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise  for the following mocks to be called
+		await Promise.resolve();
+
 		expect( onAddYoastPremiumToCart ).toHaveBeenCalled();
 		expect( onNavigateToCheckoutMockFunction ).toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).not.toHaveBeenCalled();
@@ -61,9 +64,10 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 			/>
 		);
 		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
-		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
-
 		await fireEvent.click( yoastPremiumButton );
+		//onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise  for the following mocks to be called
+		await Promise.resolve();
+
 		expect( onAddYoastPremiumToCart ).toHaveBeenCalled();
 		expect( onNavigateToCheckoutMockFunction ).not.toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).toHaveBeenCalled();
@@ -71,7 +75,11 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 		await onNavigateToCheckoutMockFunction.mockReset();
 		await onNavigateToDomainsSelectionMockFunction.mockReset();
 
+		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
 		await fireEvent.click( yoastFreeButton );
+		//onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise  for the following mocks to be called
+		await Promise.resolve();
+
 		expect( onAddYoastPremiumToCart ).not.toHaveBeenCalled();
 		expect( onNavigateToCheckoutMockFunction ).not.toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).toHaveBeenCalled();

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/test/index.js
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/test/index.js
@@ -16,6 +16,7 @@ import PurchaseArea from '../purchase-area';
 const onNavigateToCheckoutMockFunction = jest.fn();
 const onNavigateToDomainsSelectionMockFunction = jest.fn();
 const onAddYoastPremiumToCart = jest.fn();
+const onRemoveEverythingFromCart = jest.fn();
 
 describe( '<PurchaseArea/> Plugin details next step tests', () => {
 	const wpcomDomain = { isWpcomStagingDomain: true };
@@ -33,6 +34,7 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
 				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
 				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
+				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
 			/>
 		);
 		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
@@ -55,6 +57,7 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
 				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
 				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
+				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
 			/>
 		);
 		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
@@ -72,5 +75,29 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 		expect( onAddYoastPremiumToCart ).not.toHaveBeenCalled();
 		expect( onNavigateToCheckoutMockFunction ).not.toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).toHaveBeenCalled();
+	} );
+
+	test( 'Remove all other products from basket when adding a marketplace plugin', async () => {
+		const marketplacePluginDetails = render(
+			<PurchaseArea
+				siteDomains={ [ primaryWpcomDomain ] }
+				isProductListLoading={ false }
+				displayCost={ '$ 100' }
+				wporgPluginName={ 'Yoast SEO' }
+				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
+				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
+				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
+				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
+			/>
+		);
+		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
+		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
+
+		await fireEvent.click( yoastPremiumButton );
+		expect( onRemoveEverythingFromCart ).toHaveBeenCalled();
+		await onRemoveEverythingFromCart.mockReset();
+
+		await fireEvent.click( yoastFreeButton );
+		expect( onRemoveEverythingFromCart ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The marketplace flow need to remove all other products when it starts, this requirement is not certain so I would like @JanaMW27 @southp @dzver to weigh in. The other alternative is to remove yoast-premium if it exists in the basket when going into the yoast free flow.
* Also did a minor fix on unit tests in a seperate commit so that it can be cherry picked dd5be20e8259c1f86d6182317dc3684cfe9a4fea

#### Testing instructions
1. Add several items to the basket before going into the product details page.
2. Click on one of the options yoast premium or yoast free
3. Make sure the basket is empty checking out
