### PR TITLE
Signup: Remove disabled newUsersWithFreePlan test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -48,15 +48,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
-	newUsersWithFreePlan: {
-		datestamp: '20210107',
-		variations: {
-			newOnboarding: 0,
-			control: 100,
-		},
-		localeTargets: 'any',
-		localeExceptions: [ 'en', 'es' ],
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -69,20 +69,6 @@ const removeWhiteBackground = function () {
 	document.body.classList.remove( 'is-white-signup' );
 };
 
-const gutenbergRedirect = function ( flowName, locale ) {
-	const url = new URL( window.location );
-	let path = '/new';
-	if ( [ 'free', 'personal', 'premium', 'business', 'ecommerce' ].includes( flowName ) ) {
-		path += `/${ flowName }`;
-	}
-	if ( locale ) {
-		path += `/${ locale }`;
-	}
-
-	url.pathname = path;
-	window.location.replace( url.toString() );
-};
-
 export const addP2SignupClassName = () => {
 	if ( ! document ) {
 		return;
@@ -138,12 +124,6 @@ export default {
 				.then( ( { geo } ) => {
 					const countryCode = geo.data;
 					const localeFromParams = context.params.lang;
-					const flowName = getFlowName( context.params );
-
-					if ( flowName === 'free' && 'newOnboarding' === abtest( 'newUsersWithFreePlan' ) ) {
-						gutenbergRedirect( flowName, localeFromParams );
-						return;
-					}
 
 					if (
 						( ! user() || ! user().get() ) &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `newUsersWithFreePlan` A/B test was disabled several months ago in #50482. This PR cleans up the actual test and any remnants of it.

#### Testing instructions

Verify the removed test is not referenced anywhere.

#### Context

I stumbled upon this while I was looking for opportunities and blockers for refactoring the Calypso user library away from its current `Emitter` pattern.