### PR TITLE
Change position of Mailbox menu to bottom

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -248,7 +248,7 @@ const ActionMenu = ( { account, domain, mailbox, selectedSite } ) => {
 		return null;
 	}
 	return (
-		<EllipsisMenu className="email-plan-mailboxes-list__mailbox-action-menu">
+		<EllipsisMenu position="bottom" className="email-plan-mailboxes-list__mailbox-action-menu">
 			{ menuItems.map(
 				( { href, image, imageAltText, isInternalLink = false, materialIcon, title } ) => (
 					<PopoverMenuItem


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The mailbox menu should open at the bottom of the `EllipsisMenu`, earlier the `positiion` prop was set to `auto` which is the default. It ended up opening the menu at the top by default.

#### Testing instructions

1. Open the `talk-to:fix/mailbox-list-options-position` branch on your local server and go to `Upgrades` -> `Domains.`
2. Click any email account to open its Domain view
3. Click on "Manage your email accounts."
4. Click on the `EllipsisMenu` on the right of your mailbox to see.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Before:
![image](https://user-images.githubusercontent.com/1598017/119635451-54c7fe80-be31-11eb-8494-059d1da6899c.png)

#### After:
![image](https://user-images.githubusercontent.com/1598017/119635164-09adeb80-be31-11eb-8a9e-2648a7ca5edd.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/52820

cc: @daledupreez 
