### PR TITLE
New Onboarding: Use Redux for users in `EditorCheckoutModal`

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -16,7 +16,7 @@ import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-ch
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
-import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import wp from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
@@ -55,7 +55,6 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 
 	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );
-	const locale = useSelector( getCurrentUserLocale );
 
 	const cartKey = useMemo( () => getCartKey( { selectedSite: site, isLoggedOutCart } ), [
 		site,
@@ -96,7 +95,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			<CalypsoShoppingCartProvider cartKey={ cartKey }>
 				<StripeHookProvider
 					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-					locale={ locale }
+					locale={ translate.locale }
 				>
 					<CompositeCheckout
 						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useMemo, useEffect } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { Icon, wordpress } from '@wordpress/icons';
 import { Modal } from '@wordpress/components';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
@@ -17,8 +17,7 @@ import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/comp
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
-import userFactory from 'calypso/lib/user';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import wp from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
@@ -56,8 +55,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 
 	const translate = useTranslate();
 
-	const user = userFactory();
-	const isLoggedOutCart = ! user?.get();
+	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
 
 	const cartKey = useMemo( () => getCartKey( { selectedSite: site, isLoggedOutCart } ), [
 		site,

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useMemo, useEffect } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Icon, wordpress } from '@wordpress/icons';
 import { Modal } from '@wordpress/components';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
@@ -16,7 +16,6 @@ import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-ch
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
-import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import wp from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -44,7 +43,6 @@ function removeHashFromUrl(): void {
 
 const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 	const {
-		site,
 		isOpen,
 		onClose,
 		cartData,
@@ -56,6 +54,8 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
 
 	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
+	const site = useSelector( getSelectedSite );
+	const locale = useSelector( getCurrentUserLocale );
 
 	const cartKey = useMemo( () => getCartKey( { selectedSite: site, isLoggedOutCart } ), [
 		site,
@@ -96,7 +96,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			<CalypsoShoppingCartProvider cartKey={ cartKey }>
 				<StripeHookProvider
 					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-					locale={ props.locale }
+					locale={ locale }
 				>
 					<CompositeCheckout
 						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
@@ -114,10 +114,8 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 };
 
 interface Props {
-	site: SiteData | null;
 	onClose: () => void;
 	isOpen: boolean;
-	locale: string | undefined;
 	checkoutOnSuccessCallback?: () => void;
 	isFocusedLaunch?: boolean;
 	cartData?: RequestCart;
@@ -125,14 +123,10 @@ interface Props {
 }
 
 EditorCheckoutModal.defaultProps = {
-	site: null,
 	isOpen: false,
 	onClose: () => {
 		return;
 	},
 };
 
-export default connect( ( state ) => ( {
-	site: getSelectedSite( state ),
-	locale: getCurrentUserLocale( state ),
-} ) )( EditorCheckoutModal );
+export default EditorCheckoutModal;

--- a/client/lib/gsuite/can-domain-add-gsuite.js
+++ b/client/lib/gsuite/can-domain-add-gsuite.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
-
-/**
  * Determines whether G Suite is allowed for the specified domain.
  *
  * @param {string} domainName - domain name
@@ -14,5 +9,5 @@ export function canDomainAddGSuite( domainName ) {
 		return false;
 	}
 
-	return canUserPurchaseGSuite();
+	return true;
 }

--- a/client/lib/gsuite/can-user-purchase-gsuite.js
+++ b/client/lib/gsuite/can-user-purchase-gsuite.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import userFactory from 'calypso/lib/user';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { reduxGetState } from 'calypso/lib/redux-bridge';
 
 /**
  * Determines whether G Suite can be purchased by the user based on their country.
@@ -14,7 +10,6 @@ import userFactory from 'calypso/lib/user';
  * @returns {boolean} true if the user is allowed to purchase G Suite, false otherwise
  */
 export function canUserPurchaseGSuite() {
-	const user = userFactory();
-
-	return get( user.get(), 'is_valid_google_apps_country', false );
+	const user = getCurrentUser( reduxGetState() );
+	return user?.is_valid_google_apps_country ?? false;
 }

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,5 +1,4 @@
 export { canDomainAddGSuite } from './can-domain-add-gsuite';
-export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 export { getAnnualPrice } from './get-annual-price';
 export { getEligibleGSuiteDomain } from './get-eligible-gsuite-domain';
 export {

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -13,13 +13,13 @@ import {
 	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
 
-jest.mock( 'calypso/lib/user/', () => {
-	return () => {
-		return {
-			get: () => {
-				return { is_valid_google_apps_country: true };
+jest.mock( 'calypso/lib/redux-bridge', () => {
+	return {
+		reduxGetState: () => ( {
+			currentUser: {
+				user: { is_valid_google_apps_country: true },
 			},
-		};
+		} ),
 	};
 } );
 

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -3,7 +3,6 @@
  */
 import {
 	canDomainAddGSuite,
-	canUserPurchaseGSuite,
 	getAnnualPrice,
 	getEligibleGSuiteDomain,
 	getGSuiteSupportedDomains,
@@ -12,16 +11,6 @@ import {
 	hasGSuiteWithUs,
 	hasPendingGSuiteUsers,
 } from 'calypso/lib/gsuite';
-
-jest.mock( 'calypso/lib/redux-bridge', () => {
-	return {
-		reduxGetState: () => ( {
-			currentUser: {
-				user: { is_valid_google_apps_country: true },
-			},
-		} ),
-	};
-} );
 
 describe( 'index', () => {
 	describe( '#canDomainAddGSuite', () => {
@@ -257,12 +246,6 @@ describe( 'index', () => {
 			expect(
 				hasPendingGSuiteUsers( { googleAppsSubscription: { pendingUsers: [ 'foo' ] } } )
 			).toEqual( true );
-		} );
-	} );
-
-	describe( '#canUserPurchaseGSuite', () => {
-		test( 'returns true if the user is allowed to purchase G Suite', () => {
-			expect( canUserPurchaseGSuite() ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -26,7 +26,7 @@ import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
 import CheckoutThankYouComponent from './checkout-thank-you';
-import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
 import userFactory from 'calypso/lib/user';
@@ -213,7 +213,7 @@ export function gsuiteNudge( context, next ) {
 		return null;
 	}
 
-	if ( ! canUserPurchaseGSuite() ) {
+	if ( ! canUserPurchaseGSuite( context.store.getState() ) ) {
 		next();
 	}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import FoldableCard from 'calypso/components/foldable-card';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	getSiteFrontPage,
@@ -297,7 +298,8 @@ const mapStateToProps = ( state ) => {
 		menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 		isNewlyCreatedSite: isNewSite( state, siteId ),
 		showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
-		hasCustomDomain: getGSuiteSupportedDomains( domains ).length > 0,
+		hasCustomDomain:
+			getGSuiteSupportedDomains( domains ).length > 0 && canUserPurchaseGSuite( state ),
 		siteSlug,
 		isStaticHomePage,
 		editHomePageUrl,

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import FoldableCard from 'calypso/components/foldable-card';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	getSiteFrontPage,
@@ -201,7 +202,8 @@ const mapStateToProps = ( state ) => {
 		menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 		isNewlyCreatedSite: isNewSite( state, siteId ),
 		showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
-		hasCustomDomain: getGSuiteSupportedDomains( domains ).length > 0,
+		hasCustomDomain:
+			getGSuiteSupportedDomains( domains ).length > 0 && canUserPurchaseGSuite( state ),
 		siteSlug,
 		isStaticHomePage,
 		editHomePageUrl,

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -37,7 +37,7 @@ import { isATEnabled } from 'calypso/lib/automated-transfer';
 import JetpackManageErrorPage from 'calypso/my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { canUserPurchaseGSuite } from 'calypso/lib/gsuite';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 const noop = () => {};
@@ -190,7 +190,7 @@ const transferDomainPrecheck = ( context, next ) => {
 };
 
 const googleAppsWithRegistration = ( context, next ) => {
-	if ( canUserPurchaseGSuite() ) {
+	if ( canUserPurchaseGSuite( context.store.getState() ) ) {
 		context.primary = (
 			<Main>
 				<PageViewTracker

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -20,6 +20,7 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import Main from 'calypso/components/main';
 import FormattedHeader from 'calypso/components/formatted-header';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { canDomainAddGSuite, getProductType } from 'calypso/lib/gsuite';
 import {
 	hasPlan,
@@ -163,7 +164,7 @@ class DomainSearch extends Component {
 				fillInSingleCartItemAttributes( registration, this.props.productsList ),
 			] )
 			.then( () => {
-				if ( canDomainAddGSuite( domain ) ) {
+				if ( this.props.userCanPurchaseGSuite && canDomainAddGSuite( domain ) ) {
 					const gSuiteProductSlug = config.isEnabled( 'google-workspace-migration' )
 						? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
 						: GSUITE_BASIC_SLUG;
@@ -315,6 +316,7 @@ export default connect(
 			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 			isSiteUpgradeable: isSiteUpgradeable( state, siteId ),
 			productsList: getProductsList( state ),
+			userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 		};
 	},
 	{

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -85,7 +85,7 @@ class EmailManagementHome extends React.Component {
 					<EmailProvidersComparison
 						domain={ selectedDomain }
 						isGSuiteSupported={
-							hasGSuiteSupportedDomain( [ selectedDomain ] ) && userCanPurchaseGSuite
+							userCanPurchaseGSuite && hasGSuiteSupportedDomain( [ selectedDomain ] )
 						}
 					/>
 				);
@@ -110,7 +110,7 @@ class EmailManagementHome extends React.Component {
 				<EmailProvidersComparison
 					domain={ firstDomainWithNoEmail }
 					isGSuiteSupported={
-						hasGSuiteSupportedDomain( [ firstDomainWithNoEmail ] ) && userCanPurchaseGSuite
+						userCanPurchaseGSuite && hasGSuiteSupportedDomain( [ firstDomainWithNoEmail ] )
 					}
 				/>
 			);

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -11,6 +11,7 @@ import React from 'react';
  */
 import { Card } from '@automattic/components';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
@@ -60,6 +61,7 @@ class EmailManagementHome extends React.Component {
 			selectedSite,
 			selectedDomainName,
 			currentRoute,
+			userCanPurchaseGSuite,
 		} = this.props;
 
 		if ( ! hasSiteDomainsLoaded || ! hasSitesLoaded || ! selectedSite ) {
@@ -82,7 +84,9 @@ class EmailManagementHome extends React.Component {
 				return this.renderContentWithHeader(
 					<EmailProvidersComparison
 						domain={ selectedDomain }
-						isGSuiteSupported={ hasGSuiteSupportedDomain( [ selectedDomain ] ) }
+						isGSuiteSupported={
+							hasGSuiteSupportedDomain( [ selectedDomain ] ) && userCanPurchaseGSuite
+						}
 					/>
 				);
 			}
@@ -105,7 +109,9 @@ class EmailManagementHome extends React.Component {
 			return this.renderContentWithHeader(
 				<EmailProvidersComparison
 					domain={ firstDomainWithNoEmail }
-					isGSuiteSupported={ hasGSuiteSupportedDomain( [ firstDomainWithNoEmail ] ) }
+					isGSuiteSupported={
+						hasGSuiteSupportedDomain( [ firstDomainWithNoEmail ] ) && userCanPurchaseGSuite
+					}
 				/>
 			);
 		}
@@ -180,5 +186,6 @@ export default connect( ( state ) => {
 		selectedSite: getSelectedSite( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
+		userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 	};
 } )( localize( EmailManagementHome ) );

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -21,6 +21,7 @@ import {
 	hasGSuiteWithAnotherProvider,
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
@@ -128,7 +129,13 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const { domains, hasGSuiteUsersLoaded, hasSiteDomainsLoaded, selectedDomainName } = this.props;
+		const {
+			domains,
+			hasGSuiteUsersLoaded,
+			hasSiteDomainsLoaded,
+			selectedDomainName,
+			userCanPurchaseGSuite,
+		} = this.props;
 
 		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded ) {
 			return <Placeholder />;
@@ -155,7 +162,7 @@ class EmailManagement extends React.Component {
 			<CalypsoShoppingCartProvider>
 				<EmailProvidersComparison
 					domain={ selectedDomain }
-					isGSuiteSupported={ isGSuiteSupported }
+					isGSuiteSupported={ isGSuiteSupported && userCanPurchaseGSuite }
 				/>
 			</CalypsoShoppingCartProvider>
 		);
@@ -275,5 +282,6 @@ export default connect( ( state ) => {
 		previousRoute: getPreviousRoute( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
+		userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 	};
 } )( localize( EmailManagement ) );

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -16,6 +16,7 @@ import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
 import { Button, Card } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailHeader from 'calypso/my-sites/email/email-header';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import {
 	emailManagementAddGSuiteUsers,
 	emailManagementNewGSuiteAccount,
@@ -66,10 +67,10 @@ class GSuiteAddUsers extends React.Component {
 	isMounted = false;
 
 	static getDerivedStateFromProps(
-		{ domains, isRequestingDomains, selectedDomainName },
+		{ domains, isRequestingDomains, selectedDomainName, userCanPurchaseGSuite },
 		{ users }
 	) {
-		if ( ! isRequestingDomains && 0 === users.length ) {
+		if ( ! isRequestingDomains && 0 === users.length && userCanPurchaseGSuite ) {
 			const domainName = getEligibleGSuiteDomain( selectedDomainName, domains );
 			if ( '' !== domainName ) {
 				return {
@@ -187,6 +188,7 @@ class GSuiteAddUsers extends React.Component {
 			isRequestingDomains,
 			selectedDomainName,
 			translate,
+			userCanPurchaseGSuite,
 		} = this.props;
 
 		const { users } = this.state;
@@ -217,9 +219,10 @@ class GSuiteAddUsers extends React.Component {
 					''
 				) }
 
-				{ selectedDomainInfo.map( ( domain ) => {
-					return <QueryEmailForwards key={ domain.domain } domainName={ domain.domain } />;
-				} ) }
+				{ userCanPurchaseGSuite &&
+					selectedDomainInfo.map( ( domain ) => {
+						return <QueryEmailForwards key={ domain.domain } domainName={ domain.domain } />;
+					} ) }
 
 				<SectionHeader
 					label={ translate( 'Add New Users', {
@@ -227,7 +230,7 @@ class GSuiteAddUsers extends React.Component {
 					} ) }
 				/>
 
-				{ gsuiteUsers && selectedDomainInfo && ! isRequestingDomains ? (
+				{ gsuiteUsers && userCanPurchaseGSuite && selectedDomainInfo && ! isRequestingDomains ? (
 					<Card>
 						<GSuiteNewUserList
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
@@ -331,6 +334,7 @@ export default connect(
 			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
 			productsList: getProductsList( state ),
 			selectedSite,
+			userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 		};
 	},
 	{ recordTracksEvent: recordTracksEventAction }

--- a/client/state/selectors/can-user-purchase-gsuite.js
+++ b/client/state/selectors/can-user-purchase-gsuite.js
@@ -2,14 +2,14 @@
  * Internal dependencies
  */
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { reduxGetState } from 'calypso/lib/redux-bridge';
 
 /**
  * Determines whether G Suite can be purchased by the user based on their country.
  *
+ * @param {object} state Global state tree
  * @returns {boolean} true if the user is allowed to purchase G Suite, false otherwise
  */
-export function canUserPurchaseGSuite() {
-	const user = getCurrentUser( reduxGetState() );
+export default function canUserPurchaseGSuite( state ) {
+	const user = getCurrentUser( state );
 	return user?.is_valid_google_apps_country ?? false;
 }

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -101,7 +101,7 @@ declare namespace i18nCalypso {
 
 	export function localize< C >( component: C ): LocalizedComponent< C >;
 
-	export function useTranslate(): typeof translate;
+	export function useTranslate(): typeof translate & { locale: string | undefined };
 
 	export function reRenderTranslations(): void;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In `EditorCheckoutModal` we use `lib/user` to check whether the user is logged in. That is necessary to build a proper cart key. This PR refactors this usage to use the Redux version of the current user instead. 

However, I was unable to reproduce a use case that displays `EditorCheckoutModal` for a logged-out user. Seems like the logged-out scenario isn't testable unless I'm missing something. 

This PR is part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go to `/new`
* Input a site title.
* Pick a paid domain.
* Pick some theme and font on the following steps.
* Stick with the "Custom domains" on the features step.
* Pick the "Free" plan on the plans step
* When you're redirected to the editor, click "Launch"
* Select your paid domain again.
* Pick a paid plan.
* Click "Launch your site"
* You should now see the editor checkout modal.
* Verify it works alright by completing the checkout process and looking out for errors.