### PR TITLE
Tests: Cleanup unnecessary user library mocking

### DIFF
--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -23,7 +23,6 @@ jest.mock( 'calypso/reader/stats', () => ( {
 	recordGaEvent: () => {},
 	recordTrackForPost: () => {},
 } ) );
-jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => require( 'sinon' ).spy() );
 const markPostSeen = jest.fn();
 const noop = () => {};

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -25,7 +25,6 @@ jest.mock( 'event', () => require( 'component-event' ), { virtual: true } );
 jest.mock( 'calypso/lib/oauth-token', () => ( {
 	getToken: () => 'bearerToken',
 } ) );
-jest.mock( 'calypso/lib/user', () => () => {} );
 
 const noop = () => {};
 

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -19,9 +19,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: ( x ) => x,
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'EU Address Fieldset', () => {
 	const defaultProps = {
 		getFieldProps: ( name ) => ( { name, value: '' } ),

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -23,9 +23,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: ( x ) => x,
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'Region Address Fieldsets', () => {
 	const defaultProps = {
 		getFieldProps: ( name ) => ( {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -19,9 +19,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: ( x ) => x,
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'UK Address Fieldset', () => {
 	const defaultProps = {
 		getFieldProps: ( name ) => ( { name, value: '' } ),

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -19,9 +19,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: ( x ) => x,
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'US Address Fieldset', () => {
 	const defaultProps = {
 		countryCode: 'US',

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -23,9 +23,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: ( x ) => x,
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'ContactDetailsFormFields', () => {
 	const defaultProps = {
 		contactDetails: {

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -15,8 +15,6 @@ import sinon from 'sinon';
  */
 import { SitesDropdown } from '..';
 
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const noop = () => {};
 
 describe( 'index', () => {

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -20,7 +20,6 @@ import { Theme } from '../';
 
 jest.mock( 'calypso/components/popover/menu', () => 'components--popover--menu' );
 jest.mock( 'calypso/components/popover/menu-item', () => 'components--popover--menu-item' );
-jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'Theme', () => {
 	let props;

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -14,13 +14,6 @@ jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );
-jest.mock( 'calypso/lib/user', () => () => {
-	return {
-		get() {
-			return {};
-		},
-	};
-} );
 
 describe( 'index', () => {
 	describe( 'when trying to renderToString() LayoutLoggedOut', () => {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -18,9 +18,6 @@ import {
 } from '@automattic/calypso-products';
 import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const cartItems = require( '../cart-items' );
 const { getPlan, getTermDuration } = require( '@automattic/calypso-products' );
 const {

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -9,9 +9,6 @@ import assert from 'assert';
 import * as cartValues from '../index';
 import * as cartItems from '../cart-items';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'index', () => {
 	const TEST_BLOG_ID = 1;
 	let DOMAIN_REGISTRATION_PRODUCT;

--- a/client/lib/purchases/test/assembler.js
+++ b/client/lib/purchases/test/assembler.js
@@ -8,9 +8,6 @@ import { expect } from 'chai';
  */
 import { createPurchasesArray } from '../assembler';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'assembler', () => {
 	test( 'should be a function', () => {
 		expect( createPurchasesArray ).to.be.an( 'function' );

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -35,8 +35,6 @@ const {
 	PLAN_PURCHASE_WITH_PAYPAL,
 } = data;
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
 jest.mock( 'page', () => jest.fn() );
 

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -31,7 +31,6 @@ import {
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'calypso/components/main', () => 'Main' );
 jest.mock( 'calypso/components/section-header', () => 'SectionHeader' );
 jest.mock( 'calypso/me/sidebar-navigation', () => 'MeSidebarNavigation' );

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -31,7 +31,6 @@ import { mapStateToProps } from '../main';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
-jest.mock( 'calypso/lib/user', () => jest.fn() );
 jest.mock( '../help-unverified-warning', () => 'HelpUnverifiedWarning' );
 jest.mock( 'calypso/components/main', () => 'Main' );
 jest.mock( 'calypso/components/section-header', () => 'SectionHeader' );

--- a/client/me/purchases/track-purchase-page-view/test/index.js
+++ b/client/me/purchases/track-purchase-page-view/test/index.js
@@ -10,9 +10,6 @@ import deepFreeze from 'deep-freeze';
  */
 import { TrackPurchasePageView } from '..';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const baseProps = deepFreeze( {
 	eventName: 'calypso_testtracking_purchase_view',
 	productSlug: 'my-fancy-product',

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -34,9 +34,6 @@ jest.mock( 'calypso/lib/rebrand-cities', () => ( {
 	isRebrandCitiesSiteUrl: jest.fn( () => false ),
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const translate = ( x ) => x;
 
 describe( 'CheckoutThankYouHeader', () => {

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -56,9 +56,6 @@ jest.mock( 'calypso/lib/rebrand-cities', () => ( {
 	isRebrandCitiesSiteUrl: jest.fn( () => false ),
 } ) );
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const translate = ( x ) => x;
 
 const defaultProps = {

--- a/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
+++ b/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
@@ -13,9 +13,6 @@ import { shallow } from 'enzyme';
 
 import { CountrySpecificPaymentFields } from '../country-specific-payment-fields';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const defaultProps = {
 	countryCode: 'BR',
 	countriesList: [

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -11,9 +11,6 @@ import React from 'react';
 
 import { HiddenInput } from '../hidden-input';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'HiddenInput', () => {
 	const defaultProps = {
 		text: 'Love cannot be hidden.',

--- a/client/my-sites/domains/components/form/test/select.js
+++ b/client/my-sites/domains/components/form/test/select.js
@@ -13,9 +13,6 @@ import React from 'react';
  */
 import Select from '../select';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( '<Select />', () => {
 	const defaultProps = {
 		label: 'Select label',

--- a/client/my-sites/domains/map-domain/test/map-domain.js
+++ b/client/my-sites/domains/map-domain/test/map-domain.js
@@ -17,7 +17,6 @@ import MapDomainStep from 'calypso/components/domains/map-domain-step';
 import HeaderCake from 'calypso/components/header-cake';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 
-jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => {
 	const sinon = require( 'sinon' );
 	const spy = sinon.spy();

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -25,7 +25,6 @@ import fixtures from './fixtures';
 const DUMMY_SITE_ID = 2916284;
 const mockSelectedItems = [];
 
-jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'calypso/components/infinite-list', () =>
 	require( 'calypso/components/empty-component' )
 );

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -15,8 +15,6 @@ import { MySitesSidebar } from '..';
 import config from '@automattic/calypso-config';
 import { abtest } from 'calypso/lib/abtest';
 
-jest.mock( 'calypso/lib/user', () => () => null );
-jest.mock( 'calypso/lib/user/index', () => () => {} );
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/abtest', () => ( {

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -9,8 +9,6 @@ import moment from 'moment';
  */
 import { sameDay, sameSite, combine, combineCards, injectRecommendations } from '../utils';
 
-jest.mock( 'calypso/lib/user/utils', () => ( {} ) );
-
 describe( 'reader stream', () => {
 	const today = moment().toDate();
 	const postKey1 = { feedId: 'feed1', postId: 'postId1', date: today };

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -13,7 +13,6 @@ import page from 'page';
  */
 import { showSelectedPost } from '../utils';
 
-jest.mock( 'calypso/lib/user', () => () => {} );
 jest.mock( 'page', () => ( {
 	show: require( 'sinon' ).spy(),
 } ) );

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -13,13 +13,6 @@ jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );
-jest.mock( 'calypso/lib/user', () => () => {
-	return {
-		get() {
-			return {};
-		},
-	};
-} );
 
 describe( 'index', () => {
 	// eslint-disable-next-line jest/expect-expect

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -22,9 +22,6 @@ import flows from 'calypso/signup/config/flows';
 jest.mock( 'calypso/lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
-jest.mock( 'calypso/lib/user', () => () => ( {
-	get: () => {},
-} ) );
 
 jest.mock( 'calypso/signup/config/flows-pure', () => ( {
 	generateFlows: () => require( './fixtures/flows' ).default,

--- a/client/state/guided-tours/test/contexts.js
+++ b/client/state/guided-tours/test/contexts.js
@@ -16,7 +16,6 @@ import { isUserNewerThan } from '../contexts';
 jest.mock( 'calypso/layout/guided-tours/config', () => {
 	return require( 'calypso/state/guided-tours/test/fixtures/config' );
 } );
-jest.mock( 'calypso/lib/user', () => () => {} );
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 

--- a/client/state/guided-tours/test/selectors.js
+++ b/client/state/guided-tours/test/selectors.js
@@ -16,7 +16,6 @@ import { findEligibleTour, getGuidedTourState, hasTourJustBeenVisible } from '..
 jest.mock( 'calypso/layout/guided-tours/config', () => {
 	return require( 'calypso/state/guided-tours/test/fixtures/config' );
 } );
-jest.mock( 'calypso/lib/user', () => () => {} );
 
 describe( 'selectors', () => {
 	describe( '#hasTourJustBeenVisible', () => {

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -13,9 +13,6 @@ import {
 	siteHasBackupProductPurchase,
 } from '../selectors';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'selectors', () => {
 	describe( 'getPurchases', () => {
 		test( 'should return different purchases when the purchase data changes', () => {

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -27,7 +27,6 @@ import {
 } from '../reducer';
 
 jest.mock( '@wordpress/warning', () => () => {} );
-jest.mock( 'calypso/lib/user', () => () => {} );
 
 const TIME1 = '2018-01-01T00:00:00.000Z';
 const TIME2 = '2018-01-02T00:00:00.000Z';

--- a/client/state/selectors/test/is-business-plan-user.js
+++ b/client/state/selectors/test/is-business-plan-user.js
@@ -9,9 +9,6 @@ import deepFreeze from 'deep-freeze';
 import isBusinessPlanUser from 'calypso/state/selectors/is-business-plan-user';
 import { PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS } from '@automattic/calypso-products';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'isBusinessPlanUser()', () => {
 	test( 'should return true if any purchase is a business plan.', () => {
 		const state = deepFreeze( {

--- a/client/state/sites/domains/test/actions.js
+++ b/client/state/sites/domains/test/actions.js
@@ -26,9 +26,6 @@ import {
 import useNock from 'calypso/test-helpers/use-nock';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'actions', () => {
 	let sandbox;
 	let spy;

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -38,9 +38,6 @@ import { serialize, deserialize } from 'calypso/state/utils';
 
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'reducer', () => {
 	let sandbox;
 

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -15,9 +15,6 @@ import {
 	getStateInstance,
 } from './fixture';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'selectors', () => {
 	describe( '#getDomainsBySite()', () => {
 		test( 'should return domains by site', () => {

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -4,9 +4,6 @@
 import { createReduxStore } from '../';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const noop = () => {};
 
 describe( 'index', () => {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -62,9 +62,6 @@ import {
 } from 'calypso/state/themes/action-types';
 import useNock from 'calypso/test-helpers/use-nock';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 describe( 'actions', () => {
 	const spy = sinon.spy();
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -51,9 +51,6 @@ import {
 } from '@automattic/calypso-products';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 
-// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
-jest.mock( 'calypso/lib/user', () => () => {} );
-
 const twentyfifteen = {
 	id: 'twentyfifteen',
 	name: 'Twenty Fifteen',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the mocking of `lib/user` in tests that is no longer necessary since we removed localforage in #33948. There are more similar instances to remove, but I'll be gradually removing them in subsequent PRs.

#### Testing instructions

Verify all test pass and there are no new errors / warnings

#### Notes

There are pre-existing linting errors that we're not addressing in this PR.