### PR TITLE
requestSite should return a rejected promise on error

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -30,7 +30,8 @@ import { getSiteAddressAvailabilityPending } from 'calypso/state/site-address-ch
 import { getSiteAddressValidationError } from 'calypso/state/site-address-change/selectors/get-site-address-validation-error';
 import { isRequestingSiteAddressChange } from 'calypso/state/site-address-change/selectors/is-requesting-site-address-change';
 import { isSiteAddressValidationAvailable } from 'calypso/state/site-address-change/selectors/is-site-address-validation-available';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 /**
  * Style dependencies
@@ -371,13 +372,11 @@ export class SiteAddressChanger extends Component {
 
 export default connect(
 	( state ) => {
-		const selectedSite = getSelectedSite( state );
-		const siteId = selectedSite.ID;
-		const selectedSiteSlug = selectedSite.slug;
+		const siteId = getSelectedSiteId( state );
 
 		return {
 			siteId,
-			selectedSiteSlug,
+			selectedSiteSlug: getSiteSlug( state, siteId ),
 			isAvailable: isSiteAddressValidationAvailable( state, siteId ),
 			isSiteAddressChangeRequesting: isRequestingSiteAddressChange( state, siteId ),
 			isAvailabilityPending: getSiteAddressAvailabilityPending( state, siteId ),

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -52,10 +52,12 @@ const fetchSite = (
 ): Promise< { id: number | undefined; slug: string | undefined } > => {
 	const { getState, dispatch } = context.store;
 
-	return dispatch( requestSite( siteIdOrSlug ) ).then( () => ( {
-		id: getSiteId( getState(), siteIdOrSlug ),
-		slug: getSiteSlug( getState(), siteIdOrSlug ),
-	} ) );
+	return dispatch( requestSite( siteIdOrSlug ) )
+		.catch( () => null )
+		.then( () => ( {
+			id: getSiteId( getState(), siteIdOrSlug ),
+			slug: getSiteSlug( getState(), siteIdOrSlug ),
+		} ) );
 };
 
 /**

--- a/client/my-sites/checkout/checkout/test/maybe-jetpack-authorize.js
+++ b/client/my-sites/checkout/checkout/test/maybe-jetpack-authorize.js
@@ -23,13 +23,13 @@ describe( 'redirectToJetpack', () => {
 
 	test( 'redirect needed', () => {
 		const context = { query: { unlinked: '1' } };
-		const response = { site: { URL: 'https://example.org' } };
+		const site = { URL: 'https://example.org' };
 		const expectedRedirectURLMatch = /^https:\/\/example.org\/wp-admin\/\?(.*)&action=authorize_redirect&dest_url=/i;
 
-		const needsRedirect = shouldRedirectToJetpackAuthorize( context, response );
+		const needsRedirect = shouldRedirectToJetpackAuthorize( context, site );
 		expect( needsRedirect ).toBe( true );
 
-		const initiateRedirect = getJetpackAuthorizeURL( context, response );
+		const initiateRedirect = getJetpackAuthorizeURL( context, site );
 		expect( initiateRedirect ).toMatch( expectedRedirectURLMatch );
 	} );
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -422,16 +422,18 @@ export function siteSelection( context, next ) {
 			redirectToPrimary( context, primarySiteSlug );
 		} else {
 			// Fetch the primary site by ID and then try to determine its slug again.
-			dispatch( requestSite( primarySiteId ) ).then( () => {
-				const freshPrimarySiteSlug = getSiteSlug( getState(), primarySiteId );
-				if ( freshPrimarySiteSlug ) {
-					redirectToPrimary( context, freshPrimarySiteSlug );
-				} else {
-					// If the primary site does not exist, skip redirect
-					// and display a useful error notification
-					showMissingPrimaryError( currentUser, dispatch );
-				}
-			} );
+			dispatch( requestSite( primarySiteId ) )
+				.catch( () => null )
+				.then( () => {
+					const freshPrimarySiteSlug = getSiteSlug( getState(), primarySiteId );
+					if ( freshPrimarySiteSlug ) {
+						redirectToPrimary( context, freshPrimarySiteSlug );
+					} else {
+						// If the primary site does not exist, skip redirect
+						// and display a useful error notification
+						showMissingPrimaryError( currentUser, dispatch );
+					}
+				} );
 		}
 
 		return;
@@ -453,35 +455,37 @@ export function siteSelection( context, next ) {
 		}
 	} else {
 		// Fetch the site by siteFragment and then try to select again
-		dispatch( requestSite( siteFragment ) ).then( ( response ) => {
-			let freshSiteId = getSiteId( getState(), siteFragment );
+		dispatch( requestSite( siteFragment ) )
+			.catch( () => null )
+			.then( ( site ) => {
+				let freshSiteId = getSiteId( getState(), siteFragment );
 
-			if ( ! freshSiteId ) {
-				const wpcomStagingFragment = siteFragment.replace(
-					/\b.wordpress.com/,
-					'.wpcomstaging.com'
-				);
-				freshSiteId = getSiteId( getState(), wpcomStagingFragment );
-			}
-
-			if ( freshSiteId ) {
-				// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
-				// to wp-admin. In that case, don't continue handling the route.
-				dispatch( setSelectedSiteId( freshSiteId ) );
-				if ( onSelectedSiteAvailable( context, basePath ) ) {
-					next();
+				if ( ! freshSiteId ) {
+					const wpcomStagingFragment = siteFragment.replace(
+						/\b.wordpress.com/,
+						'.wpcomstaging.com'
+					);
+					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
 				}
-			} else if ( shouldRedirectToJetpackAuthorize( context, response ) ) {
-				externalRedirect( getJetpackAuthorizeURL( context, response ) );
-			} else {
-				// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
-				const allSitesPath = addQueryArgs(
-					{ site: siteFragment },
-					sectionify( context.path, siteFragment )
-				);
-				page.redirect( allSitesPath );
-			}
-		} );
+
+				if ( freshSiteId ) {
+					// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
+					// to wp-admin. In that case, don't continue handling the route.
+					dispatch( setSelectedSiteId( freshSiteId ) );
+					if ( onSelectedSiteAvailable( context, basePath ) ) {
+						next();
+					}
+				} else if ( shouldRedirectToJetpackAuthorize( context, site ) ) {
+					externalRedirect( getJetpackAuthorizeURL( context, site ) );
+				} else {
+					// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
+					const allSitesPath = addQueryArgs(
+						{ site: siteFragment },
+						sectionify( context.path, siteFragment )
+					);
+					page.redirect( allSitesPath );
+				}
+			} );
 	}
 }
 
@@ -646,27 +650,27 @@ export function wpForTeamsGeneralNotSupportedRedirect( context, next ) {
  * Whether we need to redirect user to the Jetpack site for authorization.
  *
  * @param {object} context -- The context object.
- * @param {object} response -- The site information HTTP response.
+ * @param {object} site -- The site information.
  * @returns {boolean} shouldRedirect -- Whether we need to redirect user to the Jetpack site for authorization.
  */
-export function shouldRedirectToJetpackAuthorize( context, response ) {
-	return '1' === context.query?.unlinked && !! response?.site?.URL;
+export function shouldRedirectToJetpackAuthorize( context, site ) {
+	return '1' === context.query?.unlinked && !! site?.URL;
 }
 
 /**
  * Get redirect URL to the Jetpack site for authorization.
  *
  * @param {object} context -- The context object.
- * @param {object} response -- The site information HTTP response.
+ * @param {object} site -- The site information.
  * @returns {string} redirectURL -- The redirect URL.
  */
-export function getJetpackAuthorizeURL( context, response ) {
+export function getJetpackAuthorizeURL( context, site ) {
 	return addQueryArgs(
 		{
 			page: 'jetpack',
 			action: 'authorize_redirect',
 			dest_url: removeQueryArgs( window.origin + context.path, 'unlinked' ),
 		},
-		trailingslashit( response?.site?.URL ) + 'wp-admin/'
+		trailingslashit( site?.URL ) + 'wp-admin/'
 	);
 }

--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -41,7 +41,11 @@ export const redirectDefaultConnectionsDomain = async ( context ) => {
 
 	let recentSiteSlug = getSiteSlug( state, recentSiteId );
 	if ( ! recentSiteSlug ) {
-		await dispatch( requestSite( recentSiteId ) );
+		try {
+			await dispatch( requestSite( recentSiteId ) );
+		} catch {
+			// proceed despite a failed site request
+		}
 		recentSiteSlug = getSiteSlug( getState(), recentSiteId );
 		if ( ! recentSiteSlug ) {
 			// TODO Maybe get the primary site slug, but for now redirect to site selection.

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -354,19 +354,24 @@ export default {
 			next();
 		} else {
 			// Fetch the site by siteSlug and then try to select again
-			dispatch( requestSite( siteSlug ) ).then( () => {
-				let freshSiteId = getSiteId( getState(), siteSlug );
+			dispatch( requestSite( siteSlug ) )
+				.catch( () => null )
+				.then( () => {
+					let freshSiteId = getSiteId( getState(), siteSlug );
 
-				if ( ! freshSiteId ) {
-					const wpcomStagingFragment = siteSlug.replace( /\.wordpress\.com$/, '.wpcomstaging.com' );
-					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
-				}
+					if ( ! freshSiteId ) {
+						const wpcomStagingFragment = siteSlug.replace(
+							/\.wordpress\.com$/,
+							'.wpcomstaging.com'
+						);
+						freshSiteId = getSiteId( getState(), wpcomStagingFragment );
+					}
 
-				if ( freshSiteId ) {
-					dispatch( setSelectedSiteId( freshSiteId ) );
-					next();
-				}
-			} );
+					if ( freshSiteId ) {
+						dispatch( setSelectedSiteId( freshSiteId ) );
+						next();
+					}
+				} );
 			next();
 		}
 	},

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -23,6 +23,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 import 'calypso/state/site-address-change/init';
 
@@ -111,7 +112,7 @@ export const requestSiteAddressChange = (
 	oldDomain,
 	siteType,
 	discard = true
-) => async ( dispatch ) => {
+) => async ( dispatch, getState ) => {
 	dispatch( {
 		type: SITE_ADDRESS_CHANGE_REQUEST,
 		siteId,
@@ -157,8 +158,11 @@ export const requestSiteAddressChange = (
 				} )
 			);
 
-			const newAddress = newSlug + '.' + domain;
-			page( domainManagementEdit( newAddress, newAddress ) );
+			// site slug, potentially freshly updated by the `requestSite` above
+			const siteSlug = getSiteSlug( getState(), siteId );
+			// new name of the `*.wordpress.com` domain that we just changed
+			const newDomain = newSlug + '.' + domain;
+			page( domainManagementEdit( siteSlug, newDomain ) );
 		}
 	} catch ( error ) {
 		dispatch(

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -115,55 +115,52 @@ export function requestSites() {
  * a site.
  *
  * @param {number|string} siteFragment Site ID or slug
- * @param {boolean} forceWpcom explicitly get info from WPCOM vs Jetpack site
  * @returns {Function}              Action thunk
  */
-export function requestSite( siteFragment, forceWpcom = false ) {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITE_REQUEST,
-			siteId: siteFragment,
-		} );
+export function requestSite( siteFragment ) {
+	function doRequest( forceWpcom = false ) {
+		const query = { apiVersion: '1.2' };
+		if ( forceWpcom ) {
+			query.force = 'wpcom';
+		}
+
 		const siteFilter = config( 'site_filter' );
-		return wpcom
-			.site( siteFragment )
-			.get( {
-				apiVersion: '1.2',
-				filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
-				force: forceWpcom ? 'wpcom' : undefined,
-			} )
+		if ( siteFilter.length > 0 ) {
+			query.filters = siteFilter.join( ',' );
+		}
+
+		return wpcom.site( siteFragment ).get( query );
+	}
+
+	return ( dispatch ) => {
+		dispatch( { type: SITE_REQUEST, siteId: siteFragment } );
+
+		const result = doRequest( siteFragment ).catch( ( error ) => {
+			// if there is Jetpack JSON API module error, retry with force: 'wpcom'
+			if (
+				error?.status === 403 &&
+				error?.message === 'API calls to this blog have been disabled.'
+			) {
+				return doRequest( siteFragment, true );
+			}
+
+			return Promise.reject( error );
+		} );
+
+		result
 			.then( ( site ) => {
 				// If we can't manage the site, don't add it to state.
-				if ( ! ( site && site.capabilities ) ) {
-					return dispatch( {
-						type: SITE_REQUEST_FAILURE,
-						siteId: siteFragment,
-						site,
-						error: translate( 'No access to manage the site' ),
-					} );
+				if ( site && site.capabilities ) {
+					dispatch( receiveSite( omit( site, '_headers' ) ) );
 				}
 
-				dispatch( receiveSite( omit( site, '_headers' ) ) );
-
-				dispatch( {
-					type: SITE_REQUEST_SUCCESS,
-					siteId: siteFragment,
-				} );
+				dispatch( { type: SITE_REQUEST_SUCCESS, siteId: siteFragment } );
 			} )
-			.catch( ( error ) => {
-				if (
-					error?.status === 403 &&
-					error?.message === 'API calls to this blog have been disabled.' &&
-					! forceWpcom
-				) {
-					return dispatch( requestSite( siteFragment, true ) );
-				}
-				dispatch( {
-					type: SITE_REQUEST_FAILURE,
-					siteId: siteFragment,
-					error,
-				} );
+			.catch( () => {
+				dispatch( { type: SITE_REQUEST_FAILURE, siteId: siteFragment } );
 			} );
+
+		return result;
 	};
 }
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -118,7 +118,7 @@ export function requestSites() {
  * @returns {Function}              Action thunk
  */
 export function requestSite( siteFragment ) {
-	function doRequest( forceWpcom = false ) {
+	function doRequest( forceWpcom ) {
 		const query = { apiVersion: '1.2' };
 		if ( forceWpcom ) {
 			query.force = 'wpcom';
@@ -135,13 +135,13 @@ export function requestSite( siteFragment ) {
 	return ( dispatch ) => {
 		dispatch( { type: SITE_REQUEST, siteId: siteFragment } );
 
-		const result = doRequest( siteFragment ).catch( ( error ) => {
+		const result = doRequest( false ).catch( ( error ) => {
 			// if there is Jetpack JSON API module error, retry with force: 'wpcom'
 			if (
 				error?.status === 403 &&
 				error?.message === 'API calls to this blog have been disabled.'
 			) {
-				return doRequest( siteFragment, true );
+				return doRequest( true );
 			}
 
 			return Promise.reject( error );


### PR DESCRIPTION
This PRs improves the `requestSite` action to return more reasonable values when being dispatched:
- when the site request succeeds, the action returns a promise that resolves to the `site` object.
- when the site request fails, the action returns a rejected promise with the error.

Additionally, when the REST request returns a Jetpack JSON API module error, the request is re-tried with a `force: 'wpcom'` parameter that serves the information from the shadow site and avoid sending a request to the actual Jetpack site.

The action also won't store the `site` into Redux state if the user doesn't have manage capabilities there. But the `site` will be returned in the promise, as there are many use cases that use it.

The previous version of `requestSite` never returned a rejected promise, and resolved either to `undefined` in case of success, and to a `SITE_REQUEST_FAILURE` action object in case of error or unmanaged site. That's rather confusing IMO.

Several usages of `dispatch( requestSite( id ) ).then( ... )` need to be modified to handle the rejected promise with an empty `catch` handler. In these cases, we wait until the `requestSite` action completes, either successfully or not, and then figure out the result by looking at Redux state for the requested site.

This PR was inspired by reviewing #52979 by @Aurorum and seeing `requestSite` patches they needed to do there.
