### PR TITLE
Prevent users from purchasing additional mailboxes when the associated subscription expires/is expiring

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -288,6 +288,13 @@ function isExpiring( purchase ) {
 	return includes( [ 'manualRenew', 'expiring' ], purchase.expiryStatus );
 }
 
+function isExpiringSoon( purchase, expiresWithinDays ) {
+	return (
+		! isExpired( purchase ) &&
+		moment.utc( purchase.expiryDate ).isBefore( moment.utc().add( expiresWithinDays, 'days' ) )
+	);
+}
+
 function isIncludedWithPlan( purchase ) {
 	return 'included' === purchase.expiryStatus;
 }
@@ -795,6 +802,7 @@ export {
 	isCloseToExpiration,
 	isExpired,
 	isExpiring,
+	isExpiringSoon,
 	isIncludedWithPlan,
 	isMonthlyPurchase,
 	isOneTimePurchase,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -288,13 +288,6 @@ function isExpiring( purchase ) {
 	return includes( [ 'manualRenew', 'expiring' ], purchase.expiryStatus );
 }
 
-function isExpiringSoon( purchase, expiresWithinDays ) {
-	return (
-		! isExpired( purchase ) &&
-		moment.utc( purchase.expiryDate ).isBefore( moment.utc().add( expiresWithinDays, 'days' ) )
-	);
-}
-
 function isIncludedWithPlan( purchase ) {
 	return 'included' === purchase.expiryStatus;
 }
@@ -802,7 +795,6 @@ export {
 	isCloseToExpiration,
 	isExpired,
 	isExpiring,
-	isExpiringSoon,
 	isIncludedWithPlan,
 	isMonthlyPurchase,
 	isOneTimePurchase,

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -123,6 +123,7 @@ class EmailPlan extends React.Component {
 		event.preventDefault();
 
 		const { purchase, selectedSite } = this.props;
+
 		handleRenewNowClick( purchase, selectedSite.slug, {
 			tracksProps: { source: 'email-plan-view' },
 		} );
@@ -202,7 +203,7 @@ class EmailPlan extends React.Component {
 			return null;
 		}
 
-		if ( ! selectedSite || ! purchase ) {
+		if ( ! purchase ) {
 			return <VerticalNavItem isPlaceholder />;
 		}
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -173,11 +173,13 @@ class EmailPlan extends React.Component {
 		const { domain } = this.props;
 
 		if ( hasTitanMailWithUs( domain ) ) {
-			return 5;
+			return 3;
 		}
+
 		if ( hasGSuiteWithUs( domain ) ) {
-			return 30;
+			return 20;
 		}
+
 		return 0;
 	}
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { needsToRenewSoon } from 'calypso/lib/purchases';
+import { handleRenewNowClick, needsToRenewSoon } from 'calypso/lib/purchases';
 import page from 'page';
 import PropTypes from 'prop-types';
 
@@ -44,7 +44,6 @@ import {
 } from 'calypso/state/purchases/selectors';
 import HeaderCake from 'calypso/components/header-cake';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
@@ -118,6 +117,13 @@ class EmailPlan extends React.Component {
 	handleBack = () => {
 		const { selectedSite } = this.props;
 		page( emailManagement( selectedSite.slug ) );
+	};
+
+	handleRenew = () => {
+		const { purchase, selectedSite } = this.props;
+		handleRenewNowClick( purchase, selectedSite.slug, {
+			tracksProps: { source: 'email-plan-view' },
+		} );
 	};
 
 	getAddMailboxProps() {
@@ -256,22 +262,6 @@ class EmailPlan extends React.Component {
 		);
 	}
 
-	renderRenewalNavItem() {
-		const { purchase, selectedSite, translate } = this.props;
-
-		return (
-			<VerticalNavItem>
-				<RenewButton
-					purchase={ purchase }
-					selectedSite={ selectedSite }
-					subscriptionId={ parseInt( purchase.id, 10 ) }
-					tracksProps={ { source: 'email-plan-view' } }
-					customLabel={ translate( 'Renew now to add new mailboxes' ) }
-				/>
-			</VerticalNavItem>
-		);
-	}
-
 	renderAddNewMailboxOrRenewalNavItem() {
 		const { domain, hasSubscription, purchase, selectedSite, translate } = this.props;
 
@@ -284,13 +274,17 @@ class EmailPlan extends React.Component {
 		}
 
 		if ( needsToRenewSoon( purchase ) ) {
-			return this.renderRenewalNavItem();
+			return (
+				<VerticalNavItem onClick={ this.handleRenew }>
+					{ translate( 'Renew to add new mailboxes' ) }
+				</VerticalNavItem>
+			);
 		}
 
-		const addMailboxProps = this.getAddMailboxProps();
-
 		return (
-			<VerticalNavItem { ...addMailboxProps }>{ translate( 'Add new mailbox' ) }</VerticalNavItem>
+			<VerticalNavItem { ...this.getAddMailboxProps() }>
+				{ translate( 'Add new mailboxes' ) }
+			</VerticalNavItem>
 		);
 	}
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { handleRenewNowClick, isExpired, isExpiringSoon } from 'calypso/lib/purchases';
+import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
 import page from 'page';
 import PropTypes from 'prop-types';
 
@@ -169,20 +169,6 @@ class EmailPlan extends React.Component {
 		};
 	}
 
-	getExpiryThresholdInDays() {
-		const { domain } = this.props;
-
-		if ( hasTitanMailWithUs( domain ) ) {
-			return 3;
-		}
-
-		if ( hasGSuiteWithUs( domain ) ) {
-			return 20;
-		}
-
-		return 0;
-	}
-
 	getHeaderText() {
 		const { domain, translate } = this.props;
 
@@ -255,16 +241,6 @@ class EmailPlan extends React.Component {
 		};
 	}
 
-	needsToRenewSoon() {
-		const { purchase } = this.props;
-
-		if ( isExpired( purchase ) ) {
-			return true;
-		}
-
-		return isExpiringSoon( purchase, this.getExpiryThresholdInDays() );
-	}
-
 	renderManageAllNavItem() {
 		const { domain, translate } = this.props;
 
@@ -299,7 +275,7 @@ class EmailPlan extends React.Component {
 			return <VerticalNavItem isPlaceholder />;
 		}
 
-		if ( this.needsToRenewSoon() ) {
+		if ( isExpired( purchase ) ) {
 			return (
 				<VerticalNavItem onClick={ this.handleRenew } path="#">
 					{ translate( 'Renew to add new mailboxes' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The email plan page checks the expiry status of the plan's subscription to determine if the user should be allowed to purchase additional mailboxes.
* In the event that the subscription is very close to expiry or expired, a renew button is shown instead.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally or use the [live branch](https://calypso.live/?branch=fix/prevent-new-mailboxes-for-expired-subs)
* View the email plan page for any email subscription i.e. Professional Email, or Google Workspace
* Confirm that you are prompted to renew when the subscription has expired
    

<img width="1060" alt="Screenshot 2021-06-01 at 5 00 23 AM" src="https://user-images.githubusercontent.com/277661/120264856-94aa3e00-c296-11eb-963f-44cdbc822dae.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


