### PR TITLE
QueryTicketSupportConfiguration: refactor to hooks

### DIFF
--- a/client/components/data/query-ticket-support-configuration/index.jsx
+++ b/client/components/data/query-ticket-support-configuration/index.jsx
@@ -1,32 +1,27 @@
 /**
  * External dependencies
  */
-
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { ticketSupportConfigurationRequest } from 'calypso/state/help/ticket/actions';
-
 import { isRequestingTicketSupportConfiguration } from 'calypso/state/help/ticket/selectors';
 
-class QueryTicketSupportConfiguration extends Component {
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.isRequesting ) {
-			this.props.ticketSupportConfigurationRequest();
-		}
+const request = () => ( dispatch, getState ) => {
+	if ( ! isRequestingTicketSupportConfiguration( getState() ) ) {
+		dispatch( ticketSupportConfigurationRequest() );
 	}
+};
 
-	render() {
-		return null;
-	}
+export default function QueryTicketSupportConfiguration() {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( request() );
+	}, [ dispatch ] );
+
+	return null;
 }
-
-export default connect(
-	( state ) => ( {
-		isRequesting: isRequestingTicketSupportConfiguration( state ),
-	} ),
-	{ ticketSupportConfigurationRequest }
-)( QueryTicketSupportConfiguration );


### PR DESCRIPTION
Refactors the query component to a functional one with a `useDispatch` hook.

**How to test:**
Go to `/help/contact` and verify (in Network panel) that a REST request to `/help/tickets/kayako/mine` is issued.