### PR TITLE
Remove the always-enabled login feature flags

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -95,9 +95,7 @@ class Login extends Component {
 	componentDidMount() {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {
 			// Disallow access to the 2FA pages unless the user has 2FA enabled
-			page(
-				login( { isNative: true, isJetpack: this.props.isJetpack, locale: this.props.locale } )
-			);
+			page( login( { isJetpack: this.props.isJetpack, locale: this.props.locale } ) );
 		}
 
 		window.scrollTo( 0, 0 );
@@ -150,7 +148,6 @@ class Login extends Component {
 		} else {
 			page(
 				login( {
-					isNative: true,
 					isJetpack: this.props.isJetpack,
 					isGutenboarding: this.props.isGutenboarding,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
@@ -165,13 +162,7 @@ class Login extends Component {
 		if ( this.props.onSocialConnectStart ) {
 			this.props.onSocialConnectStart();
 		} else {
-			page(
-				login( {
-					isNative: true,
-					socialConnect: true,
-					locale: this.props.locale,
-				} )
-			);
+			page( login( { socialConnect: true, locale: this.props.locale } ) );
 		}
 	};
 

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -165,7 +165,7 @@ class SocialLoginForm extends Component {
 
 	getRedirectUrl = ( service ) => {
 		const host = typeof window !== 'undefined' && window.location.host;
-		return `https://${ host + login( { isNative: true, socialService: service } ) }`;
+		return `https://${ host + login( { socialService: service } ) }`;
 	};
 
 	renderSocialTos = () => {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -43,6 +43,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import Notice from 'calypso/components/notice';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { login } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/url';
 import formState from 'calypso/lib/form-state';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
@@ -419,7 +420,6 @@ class SignupForm extends Component {
 		return login( {
 			isJetpack: this.isJetpack(),
 			from: this.props.from,
-			isNative: true,
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
@@ -428,8 +428,6 @@ class SignupForm extends Component {
 	}
 
 	getNoticeMessageWithLogin( notice ) {
-		const link = this.getLoginLink();
-
 		if ( notice.error === '2FA_enabled' ) {
 			return (
 				<span>
@@ -438,7 +436,7 @@ class SignupForm extends Component {
 						&nbsp;
 						{ this.props.translate( '{{a}}Log in now{{/a}} to finish signing up.', {
 							components: {
-								a: <a href={ link } onClick={ this.props.trackLoginMidFlow } />,
+								a: <a href={ this.getLoginLink() } onClick={ this.props.trackLoginMidFlow } />,
 							},
 						} ) }
 					</p>
@@ -481,12 +479,10 @@ class SignupForm extends Component {
 			return;
 		}
 
-		let link = this.getLoginLink();
-
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
 				const fieldValue = formState.getFieldValue( this.state.form, fieldName );
-				link += '&email_address=' + encodeURIComponent( fieldValue );
+				const link = addQueryArgs( { email_address: fieldValue }, this.getLoginLink() );
 				return (
 					<span key={ error_code }>
 						<p>
@@ -862,13 +858,11 @@ class SignupForm extends Component {
 	footerLink() {
 		const { flowName, showRecaptchaToS, translate } = this.props;
 
-		const logInUrl = this.getLoginLink();
-
 		return (
 			<>
 				{ ! this.props.isReskinned && (
 					<LoggedOutFormLinks>
-						<LoggedOutFormLinkItem href={ logInUrl }>
+						<LoggedOutFormLinkItem href={ this.getLoginLink() }>
 							{ flowName === 'onboarding'
 								? translate( 'Log in to create a site for your existing account.' )
 								: translate( 'Already have a WordPress.com account?' ) }
@@ -921,14 +915,12 @@ class SignupForm extends Component {
 				'socialServiceResponse',
 			] );
 
-			const logInUrl = this.getLoginLink();
-
 			return (
 				<CrowdsignalSignupForm
 					disabled={ this.props.disabled }
 					formFields={ this.formFields() }
 					handleSubmit={ this.handleSubmit }
-					loginLink={ logInUrl }
+					loginLink={ this.getLoginLink() }
 					oauth2Client={ this.props.oauth2Client }
 					recordBackLinkClick={ this.recordBackLinkClick }
 					submitting={ this.props.submitting }
@@ -945,8 +937,6 @@ class SignupForm extends Component {
 				isWooOAuth2Client( this.props.oauth2Client ) &&
 				this.props.wccomFrom )
 		) {
-			const logInUrl = this.getLoginLink();
-
 			return (
 				<div className={ classNames( 'signup-form__woocommerce', this.props.className ) }>
 					<LoggedOutForm onSubmit={ this.handleWooCommerceSubmit } noValidate={ true }>
@@ -966,7 +956,7 @@ class SignupForm extends Component {
 					</LoggedOutForm>
 
 					{ this.props.footerLink || (
-						<LoggedOutFormLinkItem href={ logInUrl }>
+						<LoggedOutFormLinkItem href={ this.getLoginLink() }>
 							{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
 						</LoggedOutFormLinkItem>
 					) }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -208,7 +208,7 @@ class SignupForm extends Component {
 			this.props.createSocialUserFailed( socialInfo, userExistsError );
 			page(
 				login( {
-					isNative: config.isEnabled( 'login/native-login-links' ),
+					isNative: true,
 					redirectTo: this.props.redirectToAfterLoginUrl,
 				} )
 			);
@@ -424,7 +424,7 @@ class SignupForm extends Component {
 		return login( {
 			isJetpack: this.isJetpack(),
 			from: this.props.from,
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
@@ -867,9 +867,7 @@ class SignupForm extends Component {
 	footerLink() {
 		const { flowName, showRecaptchaToS, translate } = this.props;
 
-		const logInUrl = config.isEnabled( 'login/native-login-links' )
-			? this.getLoginLink()
-			: localizeUrl( config( 'login_url' ), this.props.locale );
+		const logInUrl = this.getLoginLink();
 
 		return (
 			<>
@@ -928,9 +926,7 @@ class SignupForm extends Component {
 				'socialServiceResponse',
 			] );
 
-			const logInUrl = config.isEnabled( 'login/native-login-links' )
-				? this.getLoginLink()
-				: localizeUrl( config( 'login_url' ), this.props.locale );
+			const logInUrl = this.getLoginLink();
 
 			return (
 				<CrowdsignalSignupForm
@@ -954,9 +950,7 @@ class SignupForm extends Component {
 				isWooOAuth2Client( this.props.oauth2Client ) &&
 				this.props.wccomFrom )
 		) {
-			const logInUrl = config.isEnabled( 'login/native-login-links' )
-				? this.getLoginLink()
-				: localizeUrl( config( 'login_url' ), this.props.locale );
+			const logInUrl = this.getLoginLink();
 
 			return (
 				<div className={ classNames( 'signup-form__woocommerce', this.props.className ) }>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -206,12 +206,7 @@ class SignupForm extends Component {
 			const socialInfo = { service, id_token, access_token };
 
 			this.props.createSocialUserFailed( socialInfo, userExistsError );
-			page(
-				login( {
-					isNative: true,
-					redirectTo: this.props.redirectToAfterLoginUrl,
-				} )
-			);
+			page( login( { redirectTo: this.props.redirectToAfterLoginUrl } ) );
 		}
 	}
 

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -114,7 +114,7 @@ export function redirectLoggedOut( context, next ) {
 		const siteFragment = context.params.site || getSiteFragment( context.path );
 
 		const loginParameters = {
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			redirectTo: context.path,
 			site: siteFragment,
 		};

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -114,7 +114,6 @@ export function redirectLoggedOut( context, next ) {
 		const siteFragment = context.params.site || getSiteFragment( context.path );
 
 		const loginParameters = {
-			isNative: true,
 			redirectTo: context.path,
 			site: siteFragment,
 		};

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -9,7 +9,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 // This is a custom AsyncLoad component for devdocs that includes a
 // `props.component`-aware placeholder. It still needs to be imported as
 // `AsyncLoad` though–see https://github.com/Automattic/babel-plugin-transform-wpcalypso-async/blob/HEAD/index.js#L12
@@ -147,7 +146,7 @@ const devdocs = {
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
 				actionURL: login( {
-					isNative: config.isEnabled( 'login/native-login-links' ),
+					isNative: true,
 					redirectTo,
 				} ),
 				secondaryAction: 'Register',

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -145,10 +145,7 @@ const devdocs = {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
-				actionURL: login( {
-					isNative: true,
-					redirectTo,
-				} ),
+				actionURL: login( { redirectTo } ),
 				secondaryAction: 'Register',
 				secondaryActionURL: '/start/developer',
 				illustration: '/calypso/images/illustrations/illustration-nosites.svg',

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -713,7 +713,7 @@ export class JetpackAuthorize extends Component {
 				<LoggedOutFormLinkItem
 					href={ login( {
 						isJetpack: true,
-						isNative: config.isEnabled( 'login/native-login-links' ),
+						isNative: true,
 						redirectTo: window.location.href,
 						from,
 					} ) }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -711,12 +711,7 @@ export class JetpackAuthorize extends Component {
 			<LoggedOutFormLinks>
 				{ this.renderBackToWpAdminLink() }
 				<LoggedOutFormLinkItem
-					href={ login( {
-						isJetpack: true,
-						isNative: true,
-						redirectTo: window.location.href,
-						from,
-					} ) }
+					href={ login( { isJetpack: true, redirectTo: window.location.href, from } ) }
 					onClick={ this.handleSignIn }
 				>
 					{ translate( 'Sign in as a different user' ) }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -234,7 +234,7 @@ export function loginBeforeJetpackSearch( context, next ) {
 	// Log in to WP.com happens at the start of the flow for Search products
 	// ( to facilitate site selection ).
 	if ( JETPACK_SEARCH_PRODUCTS.includes( type ) && isLoggedOut ) {
-		return page( login( { isNative: true, isJetpack: true, redirectTo: path } ) );
+		return page( login( { isJetpack: true, redirectTo: path } ) );
 	}
 	next();
 }
@@ -304,7 +304,7 @@ export function signupForm( context, next ) {
 	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
 		// Force login for mobile app flow. App will intercept this request and prompt native login.
-		return window.location.replace( login( { isNative: true, redirectTo: context.path } ) );
+		return window.location.replace( login( { redirectTo: context.path } ) );
 	}
 
 	const { query } = context;

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -116,7 +116,7 @@ export default function () {
 
 	if ( isLoggedOut ) {
 		page( '/jetpack/connect/plans/:interval(yearly|monthly)?/:site', ( { path } ) =>
-			page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
+			page( login( { isJetpack: true, redirectTo: path } ) )
 		);
 	}
 

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -383,7 +383,7 @@ export class JetpackSignup extends Component {
 					</LoggedOutFormLinkItem>
 				);
 				footerLinks.push(
-					<LoggedOutFormLinkItem key="lostpassword" href={ lostPassword( locale ) }>
+					<LoggedOutFormLinkItem key="lostpassword" href={ lostPassword( { locale } ) }>
 						{ translate( 'Lost your password?' ) }
 					</LoggedOutFormLinkItem>
 				);

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -55,6 +55,7 @@ import { resetAuthAccountType as resetAuthAccountTypeAction } from 'calypso/stat
 import FormattedHeader from 'calypso/components/formatted-header';
 import wooDnaConfig from './woo-dna-config';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 const noop = () => {};
@@ -149,7 +150,6 @@ export class JetpackSignup extends Component {
 			emailAddress,
 			from: this.props.authQuery.from,
 			isJetpack: true,
-			isNative: true,
 			locale: this.props.locale,
 			redirectTo: window.location.href,
 			allowSiteConnection: this.props.authQuery?.allowSiteConnection,
@@ -344,7 +344,7 @@ export class JetpackSignup extends Component {
 	}
 
 	renderWooDna() {
-		const { authQuery, isFullLoginFormVisible, translate, usernameOrEmail } = this.props;
+		const { authQuery, isFullLoginFormVisible, locale, translate, usernameOrEmail } = this.props;
 		const {
 			isCreatingAccount,
 			signUpUsernameOrEmail,
@@ -380,18 +380,15 @@ export class JetpackSignup extends Component {
 				pageTitle = translate( 'Login to WordPress.com' );
 				footerLinks.push(
 					<LoggedOutFormLinkItem key="signup" onClick={ this.showWooDnaSignupView }>
-						{ this.props.translate( 'Create a new account' ) }
+						{ translate( 'Create a new account' ) }
 					</LoggedOutFormLinkItem>
 				);
 				footerLinks.push(
 					<LoggedOutFormLinkItem
 						key="lostpassword"
-						href={ addQueryArgs(
-							{ action: 'lostpassword' },
-							login( { locale: this.props.locale } )
-						) }
+						href={ localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', locale ) }
 					>
-						{ this.props.translate( 'Lost your password?' ) }
+						{ translate( 'Lost your password?' ) }
 					</LoggedOutFormLinkItem>
 				);
 			} else {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -35,7 +35,7 @@ import {
 	warningNotice as warningNoticeAction,
 } from 'calypso/state/notices/actions';
 import { isEnabled } from '@automattic/calypso-config';
-import { login } from 'calypso/lib/paths';
+import { login, lostPassword } from 'calypso/lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { sendEmailLogin as sendEmailLoginAction } from 'calypso/state/auth/actions';
 import {
@@ -55,7 +55,6 @@ import { resetAuthAccountType as resetAuthAccountTypeAction } from 'calypso/stat
 import FormattedHeader from 'calypso/components/formatted-header';
 import wooDnaConfig from './woo-dna-config';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 const noop = () => {};
@@ -384,10 +383,7 @@ export class JetpackSignup extends Component {
 					</LoggedOutFormLinkItem>
 				);
 				footerLinks.push(
-					<LoggedOutFormLinkItem
-						key="lostpassword"
-						href={ localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', locale ) }
-					>
+					<LoggedOutFormLinkItem key="lostpassword" href={ lostPassword( locale ) }>
 						{ translate( 'Lost your password?' ) }
 					</LoggedOutFormLinkItem>
 				);

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -149,7 +149,7 @@ export class JetpackSignup extends Component {
 			emailAddress,
 			from: this.props.authQuery.from,
 			isJetpack: true,
-			isNative: isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			locale: this.props.locale,
 			redirectTo: window.location.href,
 			allowSiteConnection: this.props.authQuery?.allowSiteConnection,

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -59,7 +59,6 @@ class MasterbarLoggedOut extends React.Component {
 			// We may know the email from Jetpack connection details
 			emailAddress: isJetpack && get( currentQuery, 'user_email', false ),
 			isJetpack,
-			isNative: true,
 			locale: getLocaleSlug(),
 			redirectTo,
 		} );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -59,7 +59,7 @@ class MasterbarLoggedOut extends React.Component {
 			// We may know the email from Jetpack connection details
 			emailAddress: isJetpack && get( currentQuery, 'user_email', false ),
 			isJetpack,
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			locale: getLocaleSlug(),
 			redirectTo,
 		} );

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 export { login } from './login';
+export { lostPassword } from './lost-password';
 
 function editorPathFromSite( site ) {
 	if ( ! site ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -3,7 +3,7 @@
  */
 import { addQueryArgs } from 'calypso/lib/url';
 import { addLocaleToPath, localizeUrl } from 'calypso/lib/i18n-utils';
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 
 export function login( {
 	isJetpack = undefined,
@@ -24,7 +24,7 @@ export function login( {
 } = {} ) {
 	let url = config( 'login_url' );
 
-	if ( isNative && isEnabled( 'login/wp-login' ) ) {
+	if ( isNative ) {
 		url = '/log-in';
 
 		if ( socialService ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -2,13 +2,11 @@
  * Internal dependencies
  */
 import { addQueryArgs } from 'calypso/lib/url';
-import { addLocaleToPath, localizeUrl } from 'calypso/lib/i18n-utils';
-import config from '@automattic/calypso-config';
+import { addLocaleToPath } from 'calypso/lib/i18n-utils';
 
 export function login( {
 	isJetpack = undefined,
 	isGutenboarding = undefined,
-	isNative = undefined,
 	locale = undefined,
 	redirectTo = undefined,
 	twoFactorAuthType = undefined,
@@ -22,36 +20,28 @@ export function login( {
 	from = undefined,
 	allowSiteConnection = undefined,
 } = {} ) {
-	let url = config( 'login_url' );
+	let url = '/log-in';
 
-	if ( isNative ) {
-		url = '/log-in';
-
-		if ( socialService ) {
-			url += '/' + socialService + '/callback';
-		} else if ( twoFactorAuthType && isJetpack ) {
-			url += '/jetpack/' + twoFactorAuthType;
-		} else if ( twoFactorAuthType && isGutenboarding ) {
-			url += '/new/' + twoFactorAuthType;
-		} else if ( twoFactorAuthType ) {
-			url += '/' + twoFactorAuthType;
-		} else if ( socialConnect ) {
-			url += '/social-connect';
-		} else if ( isJetpack ) {
-			url += '/jetpack';
-		} else if ( isGutenboarding ) {
-			url += '/new';
-		} else if ( useMagicLink ) {
-			url += '/link';
-		}
+	if ( socialService ) {
+		url += '/' + socialService + '/callback';
+	} else if ( twoFactorAuthType && isJetpack ) {
+		url += '/jetpack/' + twoFactorAuthType;
+	} else if ( twoFactorAuthType && isGutenboarding ) {
+		url += '/new/' + twoFactorAuthType;
+	} else if ( twoFactorAuthType ) {
+		url += '/' + twoFactorAuthType;
+	} else if ( socialConnect ) {
+		url += '/social-connect';
+	} else if ( isJetpack ) {
+		url += '/jetpack';
+	} else if ( isGutenboarding ) {
+		url += '/new';
+	} else if ( useMagicLink ) {
+		url += '/link';
 	}
 
 	if ( locale && locale !== 'en' ) {
-		if ( isNative ) {
-			url = addLocaleToPath( url, locale );
-		} else {
-			url = localizeUrl( url, locale );
-		}
+		url = addLocaleToPath( url, locale );
 	}
 
 	if ( site ) {

--- a/client/lib/paths/login/test/__snapshots__/index.js.snap
+++ b/client/lib/paths/login/test/__snapshots__/index.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`index #login() should return the login url for Gutenboarding specific login 1`] = `"/log-in/new"`;

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -1,106 +1,68 @@
 /**
  * Internal dependencies
  */
-import { login } from '../';
+import { login } from '..';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	__esModule: true,
-	default: jest.fn( ( key ) => {
-		if ( 'login_url' === key ) {
-			return 'https://wordpress.com/wp-login.php';
-		}
-	} ),
-} ) );
+describe( 'login', () => {
+	test( 'should return the login url', () => {
+		const url = login();
+		expect( url ).toBe( '/log-in' );
+	} );
 
-describe( 'index', () => {
-	describe( '#login()', () => {
-		test( 'should return the legacy login url', () => {
-			const url = login();
+	test( 'should return the login url when the two factor auth page is supplied', () => {
+		const url = login( { twoFactorAuthType: 'code' } );
+		expect( url ).toBe( '/log-in/code' );
+	} );
 
-			expect( url ).toEqual( 'https://wordpress.com/wp-login.php' );
-		} );
+	test( 'should return the login url with encoded redirect url param', () => {
+		const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
+		expect( url ).toBe(
+			'/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
+		);
+	} );
 
-		test( 'should return the legacy login url with encoded redirect url param', () => {
-			const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
+	test( 'should return the login url with encoded email_address param', () => {
+		const url = login( { emailAddress: 'foo@bar.com' } );
+		expect( url ).toBe( '/log-in?email_address=foo%40bar.com' );
+	} );
 
-			expect( url ).toEqual(
-				'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
-			);
-		} );
+	test( 'should return the login url with encoded OAuth2 client ID param', () => {
+		const url = login( { oauth2ClientId: 12345 } );
+		expect( url ).toBe( '/log-in?client_id=12345' );
+	} );
 
-		test( 'should return the login url', () => {
-			const url = login( { isNative: true } );
+	test( 'should return the login url for Jetpack specific login', () => {
+		const url = login( { isJetpack: true } );
+		expect( url ).toBe( '/log-in/jetpack' );
+	} );
 
-			expect( url ).toEqual( '/log-in' );
-		} );
+	test( 'should return the login url preserving the "form" parameter', () => {
+		const url = login( { isJetpack: true, from: 'potato' } );
+		expect( url ).toBe( '/log-in/jetpack?from=potato' );
+	} );
 
-		test( 'should return the login url when the two factor auth page is supplied', () => {
-			const url = login( { isNative: true, twoFactorAuthType: 'code' } );
+	test( 'should return the login url for Gutenboarding specific login', () => {
+		const url = login( { isGutenboarding: true } );
+		expect( url ).toBe( '/log-in/new' );
+	} );
 
-			expect( url ).toEqual( '/log-in/code' );
-		} );
+	test( 'should return the login url with WooCommerce.com handler', () => {
+		const url = login( { oauth2ClientId: 12345, wccomFrom: 'testing' } );
+		expect( url ).toBe( '/log-in?client_id=12345&wccom-from=testing' );
+	} );
 
-		test( 'should return the login url with encoded redirect url param', () => {
-			const url = login( {
-				isNative: true,
-				redirectTo: 'https://wordpress.com/?search=test&foo=bar',
-			} );
+	test( 'should return the login url for requesting a magic login link', () => {
+		const url = login( { useMagicLink: true } );
+		expect( url ).toBe( '/log-in/link' );
+	} );
 
-			expect( url ).toEqual(
-				'/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
-			);
-		} );
+	test( 'should return the login url for requesting a magic login link with encoded email_address param', () => {
+		const url = login( { useMagicLink: true, emailAddress: 'foo@bar.com' } );
+		expect( url ).toBe( '/log-in/link?email_address=foo%40bar.com' );
+	} );
 
-		test( 'should return the login url with encoded email_address param', () => {
-			const url = login( { isNative: true, emailAddress: 'foo@bar.com' } );
-
-			expect( url ).toEqual( '/log-in?email_address=foo%40bar.com' );
-		} );
-
-		test( 'should return the login url with encoded OAuth2 client ID param', () => {
-			const url = login( { isNative: true, oauth2ClientId: 12345 } );
-
-			expect( url ).toEqual( '/log-in?client_id=12345' );
-		} );
-
-		test( 'should return the login url for Jetpack specific login', () => {
-			const url = login( { isNative: true, isJetpack: true } );
-
-			expect( url ).toEqual( '/log-in/jetpack' );
-		} );
-
-		test( 'should return the login url preserving the "form" parameter', () => {
-			const url = login( { isNative: true, isJetpack: true, from: 'potato' } );
-			expect( url ).toEqual( '/log-in/jetpack?from=potato' );
-		} );
-
-		test( 'should return the login url for Gutenboarding specific login', () => {
-			const url = login( { isNative: true, isGutenboarding: true } );
-			expect( url ).toMatchSnapshot();
-		} );
-
-		test( 'should return the login url with WooCommerce.com handler', () => {
-			const url = login( { isNative: true, oauth2ClientId: 12345, wccomFrom: 'testing' } );
-
-			expect( url ).toEqual( '/log-in?client_id=12345&wccom-from=testing' );
-		} );
-
-		test( 'should return the login url for requesting a magic login link', () => {
-			const url = login( { isNative: true, useMagicLink: true } );
-
-			expect( url ).toEqual( '/log-in/link' );
-		} );
-
-		test( 'should return the login url for requesting a magic login link with encoded email_address param', () => {
-			const url = login( { isNative: true, useMagicLink: true, emailAddress: 'foo@bar.com' } );
-
-			expect( url ).toEqual( '/log-in/link?email_address=foo%40bar.com' );
-		} );
-
-		test( 'should return the login url for Jetpack, ignoring useMagicLink parameter', () => {
-			const url = login( { isNative: true, isJetpack: true, useMagicLink: true } );
-
-			expect( url ).toEqual( '/log-in/jetpack' );
-		} );
+	test( 'should return the login url for Jetpack, ignoring useMagicLink parameter', () => {
+		const url = login( { isJetpack: true, useMagicLink: true } );
+		expect( url ).toBe( '/log-in/jetpack' );
 	} );
 } );

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -10,11 +10,6 @@ jest.mock( '@automattic/calypso-config', () => ( {
 			return 'https://wordpress.com/wp-login.php';
 		}
 	} ),
-	isEnabled: jest.fn( ( key ) => {
-		if ( 'login/wp-login' === key ) {
-			return true;
-		}
-	} ),
 } ) );
 
 describe( 'index', () => {

--- a/client/lib/paths/lost-password.ts
+++ b/client/lib/paths/lost-password.ts
@@ -3,6 +3,10 @@
  */
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
-export function lostPassword( locale?: string ): string {
+type LostPasswordOptions = {
+	locale?: string;
+};
+
+export function lostPassword( { locale }: LostPasswordOptions = {} ): string {
 	return localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', locale );
 }

--- a/client/lib/paths/lost-password.ts
+++ b/client/lib/paths/lost-password.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+
+export function lostPassword( locale?: string ): string {
+	return localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', locale );
+}

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -81,25 +81,23 @@ export default ( router ) => {
 		);
 	}
 
-	if ( config.isEnabled( 'login/wp-login' ) ) {
-		router(
-			[
-				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
-				`/log-in/:flow(social-connect|private-site)/${ lang }`,
-				`/log-in/:socialService(google|apple)/callback/${ lang }`,
-				`/log-in/:isJetpack(jetpack)/${ lang }`,
-				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
-				`/log-in/:isGutenboarding(new)/${ lang }`,
-				`/log-in/:isGutenboarding(new)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
-				`/log-in/${ lang }`,
-			],
-			redirectJetpack,
-			redirectDefaultLocale,
-			setLocaleMiddleware,
-			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
-			login,
-			setShouldServerSideRenderLogin,
-			makeLoggedOutLayout
-		);
-	}
+	router(
+		[
+			`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:flow(social-connect|private-site)/${ lang }`,
+			`/log-in/:socialService(google|apple)/callback/${ lang }`,
+			`/log-in/:isJetpack(jetpack)/${ lang }`,
+			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:isGutenboarding(new)/${ lang }`,
+			`/log-in/:isGutenboarding(new)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/${ lang }`,
+		],
+		redirectJetpack,
+		redirectDefaultLocale,
+		setLocaleMiddleware,
+		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		login,
+		setShouldServerSideRenderLogin,
+		makeLoggedOutLayout
+	);
 };

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -10,7 +10,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { login } from 'calypso/lib/paths';
+import { login, lostPassword } from 'calypso/lib/paths';
 import EmptyContent from 'calypso/components/empty-content';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
@@ -21,7 +21,7 @@ import {
 import { withEnhancers } from 'calypso/state/utils';
 
 const nativeLoginUrl = login( { twoFactorAuthType: 'link' } );
-const lostPasswordUrl = 'https://wordpress.com/wp-login.php?action=lostpassword';
+const lostPasswordUrl = lostPassword();
 
 class EmailedLoginLinkExpired extends React.Component {
 	static propTypes = {

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -20,9 +19,6 @@ import {
 } from 'calypso/state/analytics/actions';
 import { withEnhancers } from 'calypso/state/utils';
 
-const nativeLoginUrl = login( { twoFactorAuthType: 'link' } );
-const lostPasswordUrl = lostPassword();
-
 class EmailedLoginLinkExpired extends React.Component {
 	static propTypes = {
 		hideMagicLoginRequestForm: PropTypes.func.isRequired,
@@ -34,12 +30,8 @@ class EmailedLoginLinkExpired extends React.Component {
 		this.props.recordPageView( '/log-in/link/use', 'Login > Link > Expired' );
 	}
 
-	onClickTryAgainLink = ( event ) => {
-		event.preventDefault();
-
+	onClickTryAgainLink = () => {
 		this.props.hideMagicLoginRequestForm();
-
-		page( nativeLoginUrl );
 	};
 
 	render() {
@@ -56,13 +48,13 @@ class EmailedLoginLinkExpired extends React.Component {
 				<EmptyContent
 					action={ translate( 'Try again' ) }
 					actionCallback={ this.onClickTryAgainLink }
-					actionURL={ nativeLoginUrl }
+					actionURL={ login( { twoFactorAuthType: 'link' } ) }
 					className="magic-login__link-expired"
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 500 }
 					line={ translate( 'Maybe try resetting your password instead' ) }
 					secondaryAction={ translate( 'Reset my password' ) }
-					secondaryActionURL={ lostPasswordUrl }
+					secondaryActionURL={ lostPassword() }
 					title={ translate( 'Login link is expired or invalid' ) }
 				/>
 			</div>

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -11,7 +11,6 @@ import page from 'page';
  * Internal dependencies
  */
 import { login } from 'calypso/lib/paths';
-import { addQueryArgs } from 'calypso/lib/route';
 import EmptyContent from 'calypso/components/empty-content';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
@@ -21,14 +20,8 @@ import {
 } from 'calypso/state/analytics/actions';
 import { withEnhancers } from 'calypso/state/utils';
 
-const nativeLoginUrl = login( { isNative: true, twoFactorAuthType: 'link' } );
-
-const lostPasswordURL = addQueryArgs(
-	{
-		action: 'lostpassword',
-	},
-	login()
-);
+const nativeLoginUrl = login( { twoFactorAuthType: 'link' } );
+const lostPasswordUrl = 'https://wordpress.com/wp-login.php?action=lostpassword';
 
 class EmailedLoginLinkExpired extends React.Component {
 	static propTypes = {
@@ -69,7 +62,7 @@ class EmailedLoginLinkExpired extends React.Component {
 					illustrationWidth={ 500 }
 					line={ translate( 'Maybe try resetting your password instead' ) }
 					secondaryAction={ translate( 'Reset my password' ) }
-					secondaryActionURL={ lostPasswordURL }
+					secondaryActionURL={ lostPasswordUrl }
 					title={ translate( 'Login link is expired or invalid' ) }
 				/>
 			</div>

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -45,9 +45,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 
 		this.props.hideMagicLoginRequestForm();
 
-		page(
-			login( { isNative: true, isJetpack: this.props.isJetpackLogin, locale: this.props.locale } )
-		);
+		page( login( { isJetpack: this.props.isJetpackLogin, locale: this.props.locale } ) );
 	};
 
 	render() {
@@ -82,7 +80,6 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 				<div className="magic-login__footer">
 					<a
 						href={ login( {
-							isNative: true,
 							isJetpack: this.props.isJetpackLogin,
 							isGutenboarding: this.props.isGutenboardingLogin,
 							locale: this.props.locale,

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -73,7 +73,6 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 		} else {
 			page(
 				login( {
-					isNative: true,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: twoFactorNotificationSent.replace( 'none', 'authenticator' ),
 					redirectTo: redirectToSanitized,

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -102,7 +102,6 @@ class HandleEmailedLinkForm extends React.Component {
 		} else {
 			page(
 				login( {
-					isNative: true,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: twoFactorNotificationSent.replace( 'none', 'authenticator' ),
 					redirectTo: redirectToSanitized,

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -67,7 +67,6 @@ class MagicLogin extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_email_link_page_click_back' );
 
 		const loginParameters = {
-			isNative: true,
 			isJetpack: this.props.isJetpackLogin,
 			isGutenboarding: this.props.isGutenboardingLogin,
 			locale: this.props.locale,
@@ -97,7 +96,6 @@ class MagicLogin extends React.Component {
 		// here deliberately, to ensure that if someone copies this link to
 		// paste somewhere else, their email address isn't included in it.
 		const loginParameters = {
-			isNative: true,
 			isJetpack: isJetpackLogin,
 			isGutenboarding: isGutenboardingLogin,
 			locale: locale,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -27,11 +27,10 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { login } from 'calypso/lib/paths';
+import { login, lostPassword } from 'calypso/lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -258,10 +257,7 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
-		let lostPasswordUrl = localizeUrl(
-			'https://wordpress.com/wp-login.php?action=lostpassword',
-			this.props.locale
-		);
+		let lostPasswordUrl = lostPassword( this.props.locale );
 
 		// If we got here coming from Jetpack Cloud login page, we want to go back
 		// to it after we finish the process

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -257,7 +257,7 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
-		let lostPasswordUrl = lostPassword( this.props.locale );
+		let lostPasswordUrl = lostPassword( { locale: this.props.locale } );
 
 		// If we got here coming from Jetpack Cloud login page, we want to go back
 		// to it after we finish the process

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -31,6 +31,7 @@ import { login } from 'calypso/lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -74,13 +75,7 @@ export class LoginLinks extends React.Component {
 
 		this.props.recordTracksEvent( 'calypso_login_lost_phone_link_click' );
 
-		page(
-			login( {
-				isNative: true,
-				twoFactorAuthType: 'backup',
-				isGutenboarding: this.props.isGutenboarding,
-			} )
-		);
+		page( login( { twoFactorAuthType: 'backup', isGutenboarding: this.props.isGutenboarding } ) );
 	};
 
 	handleMagicLoginLinkClick = ( event ) => {
@@ -113,7 +108,6 @@ export class LoginLinks extends React.Component {
 		// here deliberately, to ensure that if someone copies this link to
 		// paste somewhere else, their email address isn't included in it.
 		const loginParameters = {
-			isNative: true,
 			locale: this.props.locale,
 			twoFactorAuthType: 'link',
 		};
@@ -264,24 +258,30 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
-		const queryArgs = { action: 'lostpassword' };
+		let lostPasswordUrl = localizeUrl(
+			'https://wordpress.com/wp-login.php?action=lostpassword',
+			this.props.locale
+		);
 
 		// If we got here coming from Jetpack Cloud login page, we want to go back
 		// to it after we finish the process
 		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
 			const currentUrl = new URL( window.location.href );
 			currentUrl.searchParams.append( 'lostpassword_flow', true );
-			queryArgs.redirect_to = currentUrl.toString();
+			const queryArgs = {
+				redirect_to: currentUrl.toString(),
 
-			// This parameter tells WPCOM that we are coming from Jetpack.com,
-			// so it can present the user a Lost password page that works in
-			// the context of Jetpack.com.
-			queryArgs.client_id = this.props.oauth2Client.id;
+				// This parameter tells WPCOM that we are coming from Jetpack.com,
+				// so it can present the user a Lost password page that works in
+				// the context of Jetpack.com.
+				client_id: this.props.oauth2Client.id,
+			};
+			lostPasswordUrl = addQueryArgs( queryArgs, lostPasswordUrl );
 		}
 
 		return (
 			<a
-				href={ addQueryArgs( queryArgs, login( { locale: this.props.locale } ) ) }
+				href={ lostPasswordUrl }
 				key="lost-password-link"
 				onClick={ this.recordResetPasswordLinkClick }
 				rel="external"

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -49,17 +49,13 @@ class MeSidebar extends React.Component {
 			redirectTo = '/?apppromo';
 		}
 
-		if ( config.isEnabled( 'login/wp-login' ) ) {
-			try {
-				const { redirect_to } = await this.props.logoutUser( redirectTo );
-				await user().clear();
-				window.location.href = redirect_to || '/';
-			} catch {
-				// The logout endpoint might fail if the nonce has expired.
-				// In this case, redirect to wp-login.php?action=logout to get a new nonce generated
-				userUtilities.logout( redirectTo );
-			}
-		} else {
+		try {
+			const { redirect_to } = await this.props.logoutUser( redirectTo );
+			await user().clear();
+			window.location.href = redirect_to || '/';
+		} catch {
+			// The logout endpoint might fail if the nonce has expired.
+			// In this case, redirect to wp-login.php?action=logout to get a new nonce generated
 			userUtilities.logout( redirectTo );
 		}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -179,11 +179,7 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const emailTakenLoginRedirectMessage = ( emailAddress: string ) => {
-		const loginUrl = login( {
-			redirectTo: '/checkout/no-site?cart=no-user',
-			emailAddress,
-			isNative: true,
-		} );
+		const loginUrl = login( { redirectTo: '/checkout/no-site?cart=no-user', emailAddress } );
 
 		return translate(
 			'That email address is already in use. If you have an existing account, {{a}}please log in{{/a}}.',

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -49,7 +49,6 @@ import {
 	getGSuiteValidationResult,
 } from 'calypso/my-sites/checkout/composite-checkout/contact-validation';
 import { login } from 'calypso/lib/paths';
-import config from '@automattic/calypso-config';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import {
@@ -180,9 +179,11 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const emailTakenLoginRedirectMessage = ( emailAddress: string ) => {
-		const redirectTo = '/checkout/no-site?cart=no-user';
-		const isNative = config.isEnabled( 'login/native-login-links' );
-		const loginUrl = login( { redirectTo, emailAddress, isNative } );
+		const loginUrl = login( {
+			redirectTo: '/checkout/no-site?cart=no-user',
+			emailAddress,
+			isNative: true,
+		} );
 
 		return translate(
 			'That email address is already in use. If you have an existing account, {{a}}please log in{{/a}}.',

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -23,7 +23,7 @@ export default function () {
 	if ( isLoggedOut ) {
 		page(
 			'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
-			( { path } ) => page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
+			( { path } ) => page( login( { isJetpack: true, redirectTo: path } ) )
 		);
 	} else {
 		page(

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -294,7 +294,6 @@ function setUpLoggedInRoute( req, res, next ) {
 		const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
 
 		redirectUrl = login( {
-			isNative: true,
 			redirectTo: protocol + '://' + config( 'hostname' ) + req.originalUrl,
 		} );
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -294,7 +294,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
 
 		redirectUrl = login( {
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			redirectTo: protocol + '://' + config( 'hostname' ) + req.originalUrl,
 		} );
 

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -941,26 +941,24 @@ const assertSection = ( { url, entry, sectionName, sectionGroup } ) => {
 			expect( request.context.languageRevisions ).toEqual( { en: 1234 } );
 		} );
 
-		it( 'gets the redirect url for https requestss', async () => {
+		it( 'gets the redirect url for https requests', async () => {
 			await app.run( {
 				request: {
 					get: jest.fn( ( header ) => ( header === 'X-Forwarded-Proto' ? 'https' : undefined ) ),
 				},
 			} );
 			expect( app.getMocks().login ).toHaveBeenCalledWith( {
-				isNative: true,
 				redirectTo: `https://valid.hostname${ url }`,
 			} );
 		} );
 
-		it( 'gets the redirect url for http requestss', async () => {
+		it( 'gets the redirect url for http requests', async () => {
 			await app.run( {
 				request: {
 					get: jest.fn( ( header ) => ( header === 'X-Forwarded-Proto' ? 'http' : undefined ) ),
 				},
 			} );
 			expect( app.getMocks().login ).toHaveBeenCalledWith( {
-				isNative: true,
 				redirectTo: `http://valid.hostname${ url }`,
 			} );
 		} );

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -918,7 +918,6 @@ const assertSection = ( { url, entry, sectionName, sectionGroup } ) => {
 			app.withConfigEnabled( {
 				'wpcom-user-bootstrap': true,
 				'use-translation-chunks': true,
-				'login/native-login-links': true,
 			} );
 			app.withBootstrapUser( {} );
 			app.withReduxStore( theStore );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -253,7 +253,7 @@ export default {
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
 		if ( ! userLoggedIn && shouldForceLogin( flowName ) ) {
-			return page.redirect( login( { isNative: true, redirectTo: context.path } ) );
+			return page.redirect( login( { redirectTo: context.path } ) );
 		}
 
 		// if flow can be resumed, use saved locale

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -25,11 +25,7 @@ function getRedirectToAfterLoginUrl( { flowName } ) {
 }
 
 function getLoginLink( { flowName, locale } ) {
-	return login( {
-		redirectTo: getRedirectToAfterLoginUrl( { flowName } ),
-		isNative: true,
-		locale: locale,
-	} );
+	return login( { redirectTo: getRedirectToAfterLoginUrl( { flowName } ), locale } );
 }
 
 function P2Details( {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -324,10 +324,7 @@ class P2Site extends React.Component {
 	};
 
 	getErrorMessagesWithLogin = ( fieldName ) => {
-		const link = login( {
-			isNative: true,
-			redirectTo: window.location.href,
-		} );
+		const link = login( { redirectTo: window.location.href } );
 		const messages = formState.getFieldErrorMessages( this.state.form, fieldName );
 
 		if ( ! messages ) {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -10,7 +10,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
@@ -326,7 +325,7 @@ class P2Site extends React.Component {
 
 	getErrorMessagesWithLogin = ( fieldName ) => {
 		const link = login( {
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			redirectTo: window.location.href,
 		} );
 		const messages = formState.getFieldErrorMessages( this.state.form, fieldName );

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -200,10 +200,7 @@ class Site extends React.Component {
 	};
 
 	getErrorMessagesWithLogin = ( fieldName ) => {
-		const link = login( {
-			isNative: true,
-			redirectTo: window.location.href,
-		} );
+		const link = login( { redirectTo: window.location.href } );
 		const messages = formState.getFieldErrorMessages( this.state.form, fieldName );
 
 		if ( ! messages ) {

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -10,7 +10,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
@@ -202,7 +201,7 @@ class Site extends React.Component {
 
 	getErrorMessagesWithLogin = ( fieldName ) => {
 		const link = login( {
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			redirectTo: window.location.href,
 		} );
 		const messages = formState.getFieldErrorMessages( this.state.form, fieldName );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -115,7 +115,6 @@ export class UserStep extends Component {
 		return login( {
 			isJetpack: 'jetpack-connect' === this.props.sectionName,
 			from: this.props.from,
-			isNative: true,
 			redirectTo: this.getRedirectToAfterLoginUrl(),
 			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -115,7 +115,7 @@ export class UserStep extends Component {
 		return login( {
 			isJetpack: 'jetpack-connect' === this.props.sectionName,
 			from: this.props.from,
-			isNative: config.isEnabled( 'login/native-login-links' ),
+			isNative: true,
 			redirectTo: this.getRedirectToAfterLoginUrl(),
 			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -261,7 +261,7 @@ export const requestNotice = ( state = null, action ) => {
 			return null;
 		case ROUTE_SET: {
 			// if we just navigated to the sms 2fa page, keep the notice (if any) from the loginUser action
-			if ( action.path === login( { isNative: true, twoFactorAuthType: 'sms' } ) ) {
+			if ( action.path === login( { twoFactorAuthType: 'sms' } ) ) {
 				return state;
 			}
 			return null;

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -9,6 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { lostPassword } from 'calypso/lib/paths';
 
 export function getSMSMessageFromResponse( response ) {
 	const phoneNumber = get( response, 'body.data.phone_number' );
@@ -66,22 +67,19 @@ export function getErrorFromHTTPError( httpError ) {
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
 		} else if ( code === 'compromisable_account' ) {
-			const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
 			return {
 				code,
 				message: (
 					<p>
 						{ translate(
 							'Your account has been blocked as a security precaution. To continue, you must {{a}}reset your password{{/a}}.',
-							{ components: { a: <a href={ url } rel="external" /> } }
+							{ components: { a: <a href={ lostPassword() } rel="external" /> } }
 						) }
 					</p>
 				),
 				field,
 			};
 		} else if ( code === 'admin_login_attempt' ) {
-			const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
-
 			return {
 				code,
 				message: (
@@ -112,7 +110,7 @@ export function getErrorFromHTTPError( httpError ) {
 									'by providing your email address.',
 								{
 									components: {
-										a: <a href={ url } rel="external" />,
+										a: <a href={ lostPassword() } rel="external" />,
 									},
 								}
 							) }

--- a/config/development.json
+++ b/config/development.json
@@ -107,8 +107,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": true,
 		"login/magic-login": true,
-		"login/native-login-links": true,
-		"login/wp-login": true,
 		"happychat": true,
 		"mailchimp": true,
 		"manage/comments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,8 +76,6 @@
 		"layout/support-article-dialog": true,
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
-		"login/native-login-links": true,
-		"login/wp-login": true,
 		"mailchimp": false,
 		"manage/comments": true,
 		"manage/custom-post-types": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,8 +77,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,
-		"login/native-login-links": true,
-		"login/wp-login": true,
 		"mailchimp": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -79,8 +79,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,
-		"login/native-login-links": true,
-		"login/wp-login": true,
 		"mailchimp": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,

--- a/config/test.json
+++ b/config/test.json
@@ -65,8 +65,6 @@
 		"layout/support-article-dialog": true,
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": true,
-		"login/native-login-links": true,
-		"login/wp-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,8 +82,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,
-		"login/native-login-links": true,
-		"login/wp-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/comments": true,


### PR DESCRIPTION
Remove two feature flags that are always true since desktop build was removed: `login/wp-login` and `login/native-login-links`.
