### PR TITLE
Add Template Editor tracking

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -20,6 +20,7 @@ import {
 	buildGlobalStylesContentEvents,
 	getFlattenedBlockNames,
 	getBlockEventContextProperties,
+	getIsEditingCustomPostTemplate,
 } from './utils';
 
 // Debugger.
@@ -304,6 +305,7 @@ const trackBlockInsertion = ( blocks, ...args ) => {
 	const context = getBlockEventContextProperties( rootClientId );
 
 	const insert_method = getBlockInserterUsed();
+	const is_editing_custom_post_template = getIsEditingCustomPostTemplate();
 
 	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
 		block_name: name,
@@ -311,6 +313,7 @@ const trackBlockInsertion = ( blocks, ...args ) => {
 		pattern_name: patternName,
 		insert_method,
 		...context,
+		is_editing_custom_post_template,
 	} ) );
 };
 
@@ -353,6 +356,7 @@ const trackBlockReplacement = ( originalBlockIds, blocks, ...args ) => {
 	const context = getBlockEventContextProperties( rootClientId );
 
 	const insert_method = getBlockInserterUsed( originalBlockIds );
+	const is_editing_custom_post_template = getIsEditingCustomPostTemplate();
 
 	trackBlocksHandler( blocks, 'wpcom_block_picker_block_inserted', ( { name } ) => ( {
 		block_name: name,
@@ -360,6 +364,7 @@ const trackBlockReplacement = ( originalBlockIds, blocks, ...args ) => {
 		pattern_name: patternName,
 		insert_method,
 		...context,
+		is_editing_custom_post_template,
 	} ) );
 };
 
@@ -404,6 +409,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		}
 	}
 	const context = getBlockEventContextProperties( rootClientId );
+	const is_editing_custom_post_template = getIsEditingCustomPostTemplate();
 
 	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
 		block_name: name,
@@ -414,7 +420,21 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 			applyFilters( 'isInsertingPagePattern', false ) ||
 			applyFilters( 'isInsertingPageTemplate', false ),
 		...context,
+		is_editing_custom_post_template,
 	} ) );
+};
+
+/**
+ * Track templates created via template UI. (Page editor)
+ *
+ * @param {object} template template object to be created
+ */
+const trackEditPostCreateTemplate = ( template ) => {
+	const isCreatingTemplate = !! template;
+
+	if ( isCreatingTemplate ) {
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_created', {} );
+	}
 };
 
 /**
@@ -696,6 +716,7 @@ const REDUX_TRACKING = {
 	},
 	'core/edit-post': {
 		setIsListViewOpened: trackListViewToggle,
+		__unstableSwitchToTemplateMode: trackEditPostCreateTemplate,
 	},
 	'core/interface': {
 		enableComplementaryArea: trackEnableComplementaryArea,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -434,6 +434,23 @@ const trackEditPostCreateTemplate = ( template ) => {
 
 	if ( isCreatingTemplate ) {
 		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_created', {} );
+	} else {
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_editing', {} );
+	}
+};
+
+/**
+ * Track when templates created via template UI are saved.
+ *
+ * @param {string} kind     Kind of the received entity.
+ * @param {string} name     Name of the received entity.
+ * @param {Object} recordId ID of the record.
+ */
+const trackEditPostSaveTemplate = ( kind, name, recordId ) => {
+	const editedEntity = select( 'core' ).getEditedEntityRecord( kind, name, recordId );
+
+	if ( editedEntity?.slug.startsWith( 'wp-custom-template' ) ) {
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_saved', {} );
 	}
 };
 
@@ -689,7 +706,10 @@ const REDUX_TRACKING = {
 		redo: 'wpcom_block_editor_redo_performed',
 		saveEntityRecord: trackSaveEntityRecord,
 		editEntityRecord: trackEditEntityRecord,
-		saveEditedEntityRecord: trackSaveEditedEntityRecord,
+		saveEditedEntityRecord: ( ...args ) => {
+			trackSaveEditedEntityRecord( ...args );
+			trackEditPostSaveTemplate( ...args );
+		},
 	},
 	'core/block-editor': {
 		moveBlocksUp: getBlocksTracker( 'wpcom_block_moved_up' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -431,14 +431,13 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
  */
 const trackEditPostCreateTemplate = ( template ) => {
 	const isCreatingTemplate = !! template;
-	const editedTemplate = select( 'core/edit-post' ).getEditedPostTemplate();
 
 	if ( isCreatingTemplate ) {
 		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_created', {
-			template_theme: editedTemplate.theme,
-			template_slug: editedTemplate.slug,
+			template_slug: template.slug,
 		} );
 	} else {
+		const editedTemplate = select( 'core/edit-post' ).getEditedPostTemplate();
 		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_editing', {
 			template_theme: editedTemplate.theme,
 			template_slug: editedTemplate.slug,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -431,11 +431,18 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
  */
 const trackEditPostCreateTemplate = ( template ) => {
 	const isCreatingTemplate = !! template;
+	const editedTemplate = select( 'core/edit-post' ).getEditedPostTemplate();
 
 	if ( isCreatingTemplate ) {
-		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_created', {} );
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_created', {
+			template_theme: editedTemplate.theme,
+			template_slug: editedTemplate.slug,
+		} );
 	} else {
-		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_editing', {} );
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_editing', {
+			template_theme: editedTemplate.theme,
+			template_slug: editedTemplate.slug,
+		} );
 	}
 };
 
@@ -449,8 +456,11 @@ const trackEditPostCreateTemplate = ( template ) => {
 const trackEditPostSaveTemplate = ( kind, name, recordId ) => {
 	const editedEntity = select( 'core' ).getEditedEntityRecord( kind, name, recordId );
 
-	if ( editedEntity?.slug.startsWith( 'wp-custom-template' ) ) {
-		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_saved', {} );
+	if ( kind === 'postType' && name === 'wp_template' ) {
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_saved', {
+			template_theme: editedEntity.theme,
+			template_slug: editedEntity.slug,
+		} );
 	}
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -22,6 +22,8 @@ import {
 import wpcomTemplatePartChooseExisting from './wpcom-template-part-choose-existing';
 import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
 import wpcomBlockEditorTemplatePartDetachBlocks from './wpcom-block-editor-template-part-detach-blocks';
+import wpcomBlockEditorCustomPostTemplateSave from './wpcom-block-editor-custom-post-template-save';
+import wpcomBlockEditorCustomPostTemplateActionsClick from './wpcom-block-editor-custom-post-template-actions-click';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -64,6 +66,8 @@ const EVENTS_MAPPING = [
 	wpcomTemplatePartChooseExisting(),
 	wpcomBlockEditorListViewSelect(),
 	wpcomBlockEditorTemplatePartDetachBlocks(),
+	wpcomBlockEditorCustomPostTemplateSave(),
+	wpcomBlockEditorCustomPostTemplateActionsClick(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-actions-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-actions-click.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_custom_post_template_save`.
+ *
+ * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.edit-post-sidebar .edit-post-template__actions',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_editor_custom_post_template_actions_click' ),
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-actions-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-actions-click.js
@@ -3,13 +3,19 @@
  */
 import tracksRecordEvent from './track-record-event';
 
+const TRACKABLE_TAG_NAMES = [ 'BUTTON', 'SELECT' ];
+
 /**
  * Return the event definition object to track `wpcom_block_editor_custom_post_template_save`.
  *
  * @returns {{handler: Function, selector: string, type: string}} event object definition.
  */
 export default () => ( {
-	selector: '.edit-post-sidebar .edit-post-template__actions',
+	selector: '.edit-post-sidebar .components-panel__body',
 	type: 'click',
-	handler: () => tracksRecordEvent( 'wpcom_block_editor_custom_post_template_actions_click' ),
+	handler: ( event ) => {
+		if ( TRACKABLE_TAG_NAMES.includes( event.target.tagName ) ) {
+			tracksRecordEvent( 'wpcom_block_editor_custom_post_template_actions_click' );
+		}
+	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-actions-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-actions-click.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import tracksRecordEvent from './track-record-event';
@@ -8,14 +13,30 @@ const TRACKABLE_TAG_NAMES = [ 'BUTTON', 'SELECT' ];
 /**
  * Return the event definition object to track `wpcom_block_editor_custom_post_template_save`.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
 	selector: '.edit-post-sidebar .components-panel__body',
 	type: 'click',
+	capture: true,
 	handler: ( event ) => {
-		if ( TRACKABLE_TAG_NAMES.includes( event.target.tagName ) ) {
-			tracksRecordEvent( 'wpcom_block_editor_custom_post_template_actions_click' );
+		if ( ! TRACKABLE_TAG_NAMES.includes( event.target.tagName ) ) {
+			return;
 		}
+
+		let clickedElement;
+		if ( event.target.classList.contains( 'components-panel__body-toggle' ) ) {
+			clickedElement = 'panel-toggle';
+		} else if ( event.target.classList.contains( 'components-select-control__input' ) ) {
+			clickedElement = 'dropdown';
+		} else if ( event.target.innerText === __( 'Edit' ) ) {
+			clickedElement = 'button-edit';
+		} else if ( event.target.innerText === __( 'New' ) ) {
+			clickedElement = 'button-new';
+		}
+
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_actions_click', {
+			clicked_element: clickedElement,
+		} );
 	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-save.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-custom-post-template-save.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+import { getIsEditingCustomPostTemplate } from '../utils';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_custom_post_template_save`.
+ *
+ * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.entities-saved-states__panel .editor-entities-saved-states__save-button',
+	type: 'click',
+	handler: () => {
+		if ( ! getIsEditingCustomPostTemplate() ) {
+			return;
+		}
+
+		tracksRecordEvent( 'wpcom_block_editor_custom_post_template_save' );
+	},
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -264,3 +264,13 @@ export const getFlattenedBlockNames = ( block ) => {
 
 	return blockNames;
 };
+
+/**
+ * Returns whether the user is currently editing a custom page template in the block editor.
+ *
+ * `wp-custom-template` is used as a prefix for custom page templates currently in Gutenberg.
+ *
+ * @returns {boolean} is editing a custom page template or not
+ */
+export const getIsEditingCustomPostTemplate = () =>
+	select( 'core/edit-post' ).getEditedPostTemplate()?.slug.startsWith( 'wp-custom-template' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds tracking to the template editor. Tracks the following actions:

* Click on Template panel toggle `wpcom_block_editor_custom_post_template_actions_click`
  * `clicked_element` = `panel-toggle`
* Click on dropdown `wpcom_block_editor_custom_post_template_actions_click`
  * `clicked_element` = `dropdown`
* Click on New button `wpcom_block_editor_custom_post_template_actions_click`
  * `clicked_element` = `button-new`
* Click on Edit button `wpcom_block_editor_custom_post_template_actions_click`
  * `clicked_element` = `button-edit`
* Template editing activated `wpcom_block_editor_custom_post_template_editing`
* Template created `wpcom_block_editor_custom_post_template_created`
* Template saved `wpcom_block_editor_custom_post_template_saved`

The last three events include information about the template saved/editing/created:
*  `template_theme` associated theme of the themplate
* `template_slug` slug of the template

Adds a new event property (`is_editing_custom_post_template`) to these events:
* Block insertion `wpcom_block_inserted`
* Block replacement `wpcom_block_picker_block_inserted`
* Inner block replacement `wpcom_block_inserted`

The new event property is `is_editing_custom_post_template`. Which is a boolean, so either `false` or `true`. It's true when the user is editing a post template which's slug starts with 'wp-custom-template'.

#### Testing instructions

Follow debugging instructions here PCYsg-nrf-p2 to make sure all the actions above are tracked.

Fixes https://github.com/Automattic/wp-calypso/issues/52571