### PR TITLE
Add `calypso_jetpack_product_click` tracking event

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -111,26 +111,25 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		isUpgradeableToYearly = false,
 		purchase
 	) => {
+		const trackingProps = {
+			site_id: siteId || undefined,
+			product_slug: product.productSlug,
+			duration: currentDuration,
+			path: viewTrackerPath,
+		};
+
 		if ( EXTERNAL_PRODUCTS_LIST.includes( product.productSlug ) ) {
-			dispatch(
-				recordTracksEvent( 'calypso_product_external_click', {
-					site_id: siteId || undefined,
-					product_slug: product.productSlug,
-					duration: currentDuration,
-				} )
-			);
+			dispatch( recordTracksEvent( 'calypso_product_external_click', trackingProps ) );
 			window.location.href = product.externalUrl || '';
 			return;
 		}
 
 		if ( purchase && isUpgradeableToYearly ) {
-			dispatch(
-				recordTracksEvent( 'calypso_product_checkout_click', {
-					site_id: siteId || undefined,
-					product_slug: product.productSlug,
-					duration: currentDuration,
-				} )
-			);
+			// Name of `calypso_product_checkout_click` is misleading, since it's only triggered
+			// for Jetpack products. Leaving it here to not break current analysis, but please
+			// use `calypso_jetpack_product_click` instead when using tracking tools.
+			dispatch( recordTracksEvent( 'calypso_product_checkout_click', trackingProps ) );
+			dispatch( recordTracksEvent( 'calypso_jetpack_product_click', trackingProps ) );
 
 			const { productSlug: slug } = product;
 			const yearlySlug = getYearlySlugFromMonthly( slug );
@@ -142,24 +141,16 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		}
 
 		if ( purchase ) {
-			dispatch(
-				recordTracksEvent( 'calypso_product_manage_click', {
-					site_id: siteId || undefined,
-					product_slug: product.productSlug,
-					duration: currentDuration,
-				} )
-			);
+			dispatch( recordTracksEvent( 'calypso_product_manage_click', trackingProps ) );
 			manageSitePurchase( siteSlug, purchase.id );
 			return;
 		}
 
-		dispatch(
-			recordTracksEvent( 'calypso_product_checkout_click', {
-				site_id: siteId || undefined,
-				product_slug: product.productSlug,
-				duration: currentDuration,
-			} )
-		);
+		// Name of `calypso_product_checkout_click` is misleading, since it's only triggered
+		// for Jetpack products. Leaving it here to not break current analysis, but please
+		// use `calypso_jetpack_product_click` instead when using tracking tools.
+		dispatch( recordTracksEvent( 'calypso_product_checkout_click', trackingProps ) );
+		dispatch( recordTracksEvent( 'calypso_jetpack_product_click', trackingProps ) );
 		checkout( siteSlug, product.productSlug, urlQueryArgs );
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR introduces a new tracking event, `calypso_jetpack_product_click`. It is triggered when a user clicks on a product card in the Jetpack pricing page.

In the long term, it should replace `calypso_product_checkout_click`, which is triggered by the same interactions in the Jetpack pricing page, but whose name is consequently misleading. Having a clear name is crucial in the event registration process.

### Implementation notes

Tracking properties were regrouped in the `trackingProps` constant.

### Testing instructions

- Download the PR and run both Calypso and cloud
- Make sure you can see tracking events in the dev tools

#### Cloud

- Visit `/pricing` and click on any product card
- Check that `calypso_jetpack_product_click` was dispatched with the proper `duration`, `path`, and `product_slug` properties
- Repeat at `/pricing/:site`

#### Calypso

- Visit `/plans/:site` and click on any product card
- Check that `calypso_jetpack_product_click` was dispatched with the proper `duration`, `path`, and `product_slug` properties
- Repeat at `/jetpack/connect/store`
