### PR TITLE
Notifications: Remove lodash

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -31,7 +31,6 @@
 		"classnames": "^2.2.6",
 		"debug": "^4.1.1",
 		"i18n-calypso": "^5.0.0",
-		"lodash": "^4.17.21",
 		"moment": "^2.26.0",
 		"page": "^1.11.5",
 		"prop-types": "^15.7.2",

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, pick, range } from 'lodash';
+import { difference, range } from 'lodash';
 
 /**
  * Internal dependencies
@@ -221,7 +221,7 @@ function getNotes() {
 		// Store id/hash pairs for now until properly reduxified
 		// this is used as a network optimization to quickly determine
 		// changes without downloading all the data
-		this.noteList = data.notes.map( ( note ) => pick( note, [ 'id', 'note_hash' ] ) );
+		this.noteList = data.notes.map( ( note ) => ( { id: note.id, note_hash: note.note_hash } ) );
 
 		this.updateLastSeenTime( Number( data.last_seen_time ) );
 		if ( parameters.number === settings.max_limit ) {

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, get, pick, property, range } from 'lodash';
+import { difference, pick, property, range } from 'lodash';
 
 /**
  * Internal dependencies
@@ -113,7 +113,7 @@ function reschedule( refresh_ms ) {
 }
 
 function pinghubCallback( err, event ) {
-	const responseType = get( event, 'response.type' );
+	const responseType = event?.response?.type;
 
 	this.subscribing = false;
 
@@ -135,7 +135,7 @@ function pinghubCallback( err, event ) {
 		// WebSocket message: add to inbox, call main() to trigger API call
 		let message = true;
 		try {
-			message = JSON.parse( get( event, 'response.data' ) );
+			message = JSON.parse( event?.response?.data );
 		} catch ( e ) {}
 		this.inbox.push( message );
 		debug( 'pinghubCallback: received message', event.response, 'this.inbox =', this.inbox );
@@ -324,7 +324,7 @@ function ready() {
 		newNotes = [];
 	}
 
-	const latestType = get( notes.slice( -1 )[ 0 ], 'type', null );
+	const latestType = notes.slice( -1 )[ 0 ]?.type ?? null;
 	store.dispatch( { type: 'APP_RENDER_NOTES', newNoteCount, latestType } );
 
 	this.hasNewNoteData = false;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, range } from 'lodash';
+import { difference } from 'lodash';
 
 /**
  * Internal dependencies
@@ -340,19 +340,11 @@ const safelyRemoveKey = ( key ) => {
 	} catch ( e ) {}
 };
 
-const getLocalKeys = () => {
-	try {
-		return range( localStorage.length ).map( ( index ) => localStorage.key( index ) );
-	} catch ( e ) {
-		return [];
-	}
-};
-
 function cleanupLocalCache() {
 	const notes = getAllNotes( store.getState() );
 	const currentNoteIds = notes.map( ( n ) => n.id );
 
-	getLocalKeys()
+	Object.keys( localStorage )
 		.map( ( key ) => obsoleteKeyPattern.exec( key ) )
 		.filter( ( match ) => match && ! currentNoteIds.includes( match[ 1 ] ) )
 		.forEach( safelyRemoveKey );

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, pick, property, range } from 'lodash';
+import { difference, pick, range } from 'lodash';
 
 /**
  * Internal dependencies
@@ -211,8 +211,8 @@ function getNotes() {
 
 		store.dispatch( actions.ui.loadedNotes() );
 
-		const oldNotes = getAllNotes( store.getState() ).map( property( 'id' ) );
-		const newNotes = data.notes.map( property( 'id' ) );
+		const oldNotes = getAllNotes( store.getState() ).map( ( n ) => n.id );
+		const newNotes = data.notes.map( ( n ) => n.id );
 		const notesToRemove = difference( oldNotes, newNotes );
 
 		notesToRemove.length && store.dispatch( actions.notes.removeNotes( notesToRemove ) );
@@ -273,8 +273,8 @@ function getNotesList() {
 		this.retries = 0;
 
 		/* Compare list of notes from server to local copy */
-		const newerNoteList = data.notes.map( property( 'id' ) );
-		const localNoteList = this.noteList.map( property( 'id' ) );
+		const newerNoteList = data.notes.map( ( n ) => n.id );
+		const localNoteList = this.noteList.map( ( n ) => n.id );
 		const notesToRemove = difference( localNoteList, newerNoteList );
 
 		this.hasNewNoteData = difference( newerNoteList, localNoteList ).length;
@@ -282,8 +282,8 @@ function getNotesList() {
 		const serverHasChanges =
 			this.hasNewNoteData ||
 			difference(
-				data.notes.map( property( 'note_hash' ) ),
-				this.noteList.map( property( 'note_hash' ) )
+				data.notes.map( ( n ) => n.note_hash ),
+				this.noteList.map( ( n ) => n.note_hash )
 			).length > 0;
 
 		/* Actually remove the notes from the local copy */
@@ -350,7 +350,7 @@ const getLocalKeys = () => {
 
 function cleanupLocalCache() {
 	const notes = getAllNotes( store.getState() );
-	const currentNoteIds = notes.map( property( 'id' ) );
+	const currentNoteIds = notes.map( ( n ) => n.id );
 
 	getLocalKeys()
 		.map( ( key ) => obsoleteKeyPattern.exec( key ) )

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -205,7 +205,7 @@ function getNotes() {
 
 		store.dispatch( actions.ui.loadedNotes() );
 
-		const oldNotes = getAllNotes( store.getState() ).map( ( n ) => n.id );
+		const oldNotes = getAllNotes( store.getState() ).map( ( { id } ) => id );
 		const newNotes = data.notes.map( ( n ) => n.id );
 		const notesToRemove = oldNotes.filter( ( old ) => ! newNotes.includes( old ) );
 
@@ -215,7 +215,7 @@ function getNotes() {
 		// Store id/hash pairs for now until properly reduxified
 		// this is used as a network optimization to quickly determine
 		// changes without downloading all the data
-		this.noteList = data.notes.map( ( note ) => ( { id: note.id, note_hash: note.note_hash } ) );
+		this.noteList = data.notes.map( ( { id, note_hash } ) => ( { id, note_hash } ) );
 
 		this.updateLastSeenTime( Number( data.last_seen_time ) );
 		if ( parameters.number === settings.max_limit ) {

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -488,24 +488,6 @@ function setVisibility( { isShowing, isVisible } ) {
 	}
 }
 
-// Persists the latest note timestamp sent to the Desktop app.
-function setlatestTimestampSeen( timestamp ) {
-	const parsedTimestamp = Date.parse( timestamp );
-	const latestTimestamp = localStorage.getItem( 'desktop_latest_timestamp_seen' ) || 0;
-
-	if ( parsedTimestamp > latestTimestamp ) {
-		debug( 'Update desktop_latest_timestamp_seen: ', parsedTimestamp );
-
-		try {
-			localStorage.setItem( 'desktop_latest_timestamp_seen', parsedTimestamp );
-			return true;
-		} catch ( e ) {
-			debug( 'Failed to set desktop_latest_timestamp_seen: ', e.message );
-		}
-	}
-	return false;
-}
-
 Client.prototype.main = main;
 Client.prototype.reschedule = reschedule;
 Client.prototype.getNote = getNote;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,3 +1,4 @@
+/* global localStorage */
 /**
  * Internal dependencies
  */

--- a/apps/notifications/src/panel/state/action-middleware/utils.js
+++ b/apps/notifications/src/panel/state/action-middleware/utils.js
@@ -1,28 +1,36 @@
 /**
- * External dependencies
+ * @typedef {Object.<string, Array.<Function>>} ActionHandler
+ * 		An object that maps action types to arrays of handler methods.
  */
-import { mergeWith } from 'lodash';
 
 /**
- * Merge handler for lodash.mergeWith
+ * Combines an array of action types and handler methods into one larger object,
+ * containing one key for each action type and an associated array that
+ * contains all that type's handler methods.
  *
- * Note that a return value of `undefined`
- * indicates to lodash that it should use
- * its normal merge algorithm.
- *
- * In this case, we want to merge keys if
- * they don't exists but when they do, we
- * prefer to concatenate lists instead of
- * overwriting them.
- *
- * @param {?Array<Function>} left existing handlers
- * @param {Array<Function>} right new handlers to add
- * @returns {Array<Function>} combined handlers
+ * @param  {Array.<ActionHandler>} handlers An array of ActionHandlers.
+ * @returns {ActionHandler} A combined representation of the inputs in one object.
  */
-const concatHandlers = ( left, right ) =>
-	Array.isArray( left ) ? left.concat( right ) : undefined;
+export const mergeHandlers = ( ...handlers ) => {
+	if ( handlers.length === 1 ) {
+		return handlers[ 0 ];
+	}
 
-export const mergeHandlers = ( ...handlers ) =>
-	handlers.length > 1
-		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
-		: handlers[ 0 ];
+	// For every handler passed in,
+	return handlers.reduce( ( merged, nextHandler ) => {
+		// get each of its action types and methods;
+		Object.entries( nextHandler ).forEach( ( [ key, vals ] ) => {
+			// if the current key doesn't exist in the reduced object,
+			// initialize it to an empty array
+			if ( ! ( key in merged ) ) {
+				merged[ key ] = [];
+			}
+
+			// ... and add all those methods to that action type's key
+			// in the reduced object
+			merged[ key ].push( ...vals );
+		} );
+
+		return merged;
+	}, {} );
+};

--- a/apps/notifications/src/panel/state/notes/reducer.js
+++ b/apps/notifications/src/panel/state/notes/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { keyBy, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +11,11 @@ import * as types from '../action-types';
 
 export const allNotes = ( state = {}, { type, notes, noteIds } ) => {
 	if ( types.NOTES_ADD === type ) {
-		return { ...state, ...keyBy( notes, 'id' ) };
+		return {
+			...state,
+			// Transform the notes array into an object with IDs as the keys
+			...Object.fromEntries( notes.map( ( note ) => [ note.id, note ] ) ),
+		};
 	}
 
 	if ( types.NOTES_REMOVE === type ) {

--- a/apps/notifications/src/panel/state/notes/reducer.js
+++ b/apps/notifications/src/panel/state/notes/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +18,9 @@ export const allNotes = ( state = {}, { type, notes, noteIds } ) => {
 	}
 
 	if ( types.NOTES_REMOVE === type ) {
-		return omit( state, noteIds );
+		const nextState = { ...state };
+		noteIds.forEach( ( id ) => delete nextState[ id ] );
+		return nextState;
 	}
 
 	return state;
@@ -31,7 +32,9 @@ export const hiddenNoteIds = ( state = {}, { type, noteId } ) => {
 	}
 
 	if ( types.UNDO_ACTION === type ) {
-		return omit( state, [ noteId ] );
+		const nextState = { ...state };
+		delete nextState[ noteId ];
+		return nextState;
 	}
 
 	return state;
@@ -43,7 +46,9 @@ export const noteApprovals = ( state = {}, { type, noteId, isApproved } ) => {
 	}
 
 	if ( types.RESET_LOCAL_APPROVAL === type ) {
-		return omit( state, [ noteId ] );
+		const nextState = { ...state };
+		delete nextState[ noteId ];
+		return nextState;
 	}
 
 	return state;
@@ -55,7 +60,9 @@ export const noteLikes = ( state = {}, { type, noteId, isLiked } ) => {
 	}
 
 	if ( types.RESET_LOCAL_LIKE === type ) {
-		return omit( state, [ noteId ] );
+		const nextState = { ...state };
+		delete nextState[ noteId ];
+		return nextState;
 	}
 
 	return state;

--- a/apps/notifications/src/panel/state/selectors/get-all-notes.js
+++ b/apps/notifications/src/panel/state/selectors/get-all-notes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sortBy, values } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +35,7 @@ export const getAllNotes = ( notesState ) => {
 	}
 
 	prevAllNotes = nextAllNotes;
-	sortedNotes = sortBy( values( nextAllNotes ), [ parsedTimestamp, noteId ] ).reverse();
+	sortedNotes = sortBy( Object.values( nextAllNotes ), [ parsedTimestamp, noteId ] ).reverse();
 	return sortedNotes;
 };
 

--- a/apps/notifications/src/panel/state/selectors/get-all-notes.js
+++ b/apps/notifications/src/panel/state/selectors/get-all-notes.js
@@ -6,29 +6,8 @@ import getNotes from './get-notes';
 let prevAllNotes;
 let sortedNotes = [];
 
-const byTimestamp = ( a, b ) => {
-	const difference = Date.parse( a.timestamp ) - Date.parse( b.timestamp );
-	if ( difference < 0 ) {
-		return -1;
-	}
-
-	if ( difference > 0 ) {
-		return 1;
-	}
-
-	return 0;
-};
-const byId = ( a, b ) => {
-	if ( a.id < b.id ) {
-		return -1;
-	}
-
-	if ( a.id > b.id ) {
-		return 1;
-	}
-
-	return 0;
-};
+const byTimestamp = ( a, b ) => Date.parse( a.timestamp ) - Date.parse( b.timestamp );
+const byId = ( a, b ) => a.id - b.id;
 
 /**
  * Returns all available notification data

--- a/apps/notifications/src/panel/state/selectors/get-all-notes.js
+++ b/apps/notifications/src/panel/state/selectors/get-all-notes.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { sortBy } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getNotes from './get-notes';
@@ -11,8 +6,29 @@ import getNotes from './get-notes';
 let prevAllNotes;
 let sortedNotes = [];
 
-const noteId = ( { id } ) => id;
-const parsedTimestamp = ( { timestamp } ) => Date.parse( timestamp );
+const byTimestamp = ( a, b ) => {
+	const difference = Date.parse( a.timestamp ) - Date.parse( b.timestamp );
+	if ( difference < 0 ) {
+		return -1;
+	}
+
+	if ( difference > 0 ) {
+		return 1;
+	}
+
+	return 0;
+};
+const byId = ( a, b ) => {
+	if ( a.id < b.id ) {
+		return -1;
+	}
+
+	if ( a.id > b.id ) {
+		return 1;
+	}
+
+	return 0;
+};
 
 /**
  * Returns all available notification data
@@ -35,7 +51,16 @@ export const getAllNotes = ( notesState ) => {
 	}
 
 	prevAllNotes = nextAllNotes;
-	sortedNotes = sortBy( Object.values( nextAllNotes ), [ parsedTimestamp, noteId ] ).reverse();
+	sortedNotes = Object.values( nextAllNotes )
+		.sort( ( a, b ) => {
+			const chronologicalOrder = byTimestamp( a, b );
+			if ( chronologicalOrder === 0 ) {
+				return byId( a, b );
+			}
+
+			return chronologicalOrder;
+		} )
+		.reverse();
 	return sortedNotes;
 };
 

--- a/apps/notifications/src/panel/state/selectors/get-is-note-read.js
+++ b/apps/notifications/src/panel/state/selectors/get-is-note-read.js
@@ -1,3 +1,4 @@
+/* global localStorage */
 /**
  * Internal dependencies
  */

--- a/apps/notifications/src/panel/state/selectors/note-has-filtered-read.js
+++ b/apps/notifications/src/panel/state/selectors/note-has-filtered-read.js
@@ -1,14 +1,9 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getNotes from './get-notes';
 
 export const noteHasFilteredRead = ( noteState, noteId ) =>
-	includes( noteState.filteredNoteReads, noteId );
+	noteState.filteredNoteReads.includes( noteId );
 
 export default ( state, noteId ) => noteHasFilteredRead( getNotes( state ), noteId );

--- a/apps/notifications/src/panel/suggestions/index.jsx
+++ b/apps/notifications/src/panel/suggestions/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { escapeRegExp, find, findIndex } from 'lodash';
+import { escapeRegExp, findIndex } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -168,7 +168,7 @@ class Suggestions extends React.Component {
 		}
 
 		return (
-			find( this.props.suggestions, ( { ID } ) => ID === this.state.selectedSuggestionId ) || null
+			this.props.suggestions.find( ( { ID } ) => ID === this.state.selectedSuggestionId ) || null
 		);
 	}
 

--- a/apps/notifications/src/panel/suggestions/index.jsx
+++ b/apps/notifications/src/panel/suggestions/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { escapeRegExp, findIndex } from 'lodash';
+import { escapeRegExp } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -47,7 +47,7 @@ const getSuggestionIndexBySelectedId = function ( suggestions ) {
 		return 0;
 	}
 
-	const index = findIndex( suggestions, ( { ID } ) => ID === this.state.selectedSuggestionId );
+	const index = suggestions.findIndex( ( { ID } ) => ID === this.state.selectedSuggestionId );
 
 	return index > -1 ? index : null;
 };

--- a/apps/notifications/src/panel/suggestions/index.jsx
+++ b/apps/notifications/src/panel/suggestions/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { escapeRegExp } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -26,6 +25,13 @@ const KEY_DOWN = 40;
  * @type {RegExp} matches @mentions
  */
 const suggestionMatcher = /(?:^|\s)@([^\s]*)$/i;
+
+/**
+ * This pattern looks for special regex characters.
+ * Extracted directly from lodash@4.17.21.
+ */
+const reRegExpChars = /[\\^$.*+?()[\]{}|]/g;
+const reHasRegExpChars = RegExp( reRegExpChars.source );
 
 /**
  * This pattern looks for a query
@@ -122,7 +128,12 @@ class Suggestions extends React.Component {
 
 		const [ , suggestion ] = match;
 
-		return escapeRegExp( suggestion );
+		// NOTE: This test logic was extracted directly from lodash@4.17.21.
+		if ( suggestion && reHasRegExpChars.test( suggestion ) ) {
+			return suggestion.replace( reRegExpChars, '\\$&' );
+		}
+
+		return suggestion;
 	}
 
 	handleSuggestionsKeyDown = ( event ) => {

--- a/apps/notifications/src/panel/templates/button-edit.jsx
+++ b/apps/notifications/src/panel/templates/button-edit.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +15,7 @@ import { getEditCommentLink } from '../helpers/notes';
 import { editComment } from '../state/ui/actions';
 
 const EditButton = ( { editComment, note, translate } ) => {
-	const { site: siteId, post: postId, comment: commentId } = get( note, 'meta.ids', {} );
+	const { site: siteId, post: postId, comment: commentId } = note?.meta?.ids ?? {};
 	return (
 		<ActionButton
 			{ ...{

--- a/apps/notifications/src/panel/templates/filter-bar-controller.js
+++ b/apps/notifications/src/panel/templates/filter-bar-controller.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import actions from '../state/actions';
@@ -44,10 +39,8 @@ FilterBarController.prototype.getFilteredNotes = function ( notes ) {
 	}
 
 	const filterFunction = ( note ) =>
-		some( [
-			'unread' === filterName && noteHasFilteredRead( state, note.id ),
-			activeTab().filter( note ),
-		] );
+		( 'unread' === filterName && noteHasFilteredRead( state, note.id ) ) ||
+		activeTab().filter( note );
 
 	return notes.filter( filterFunction );
 };

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -289,12 +288,14 @@ export const linkProps = ( note, block ) => {
 		case 'site':
 		case 'post':
 		case 'comment':
-			return pickBy( {
-				'data-link-type': type,
-				'data-site-id': site,
-				'data-post-id': post,
-				'data-comment-id': comment,
-			} );
+			return Object.fromEntries(
+				[
+					[ 'data-link-type', type ],
+					[ 'data-site-id', site ],
+					[ 'data-post-id', post ],
+					[ 'data-comment-id', comment ],
+				].filter( ( [ , val ] ) => !! val )
+			);
 		default:
 			return {};
 	}

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { pickBy, get } from 'lodash';
+import { pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -265,8 +265,8 @@ export function zipWithSignature( blocks, note ) {
 export const validURL = /^(?:http(?:s?):\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |/.,*:;=]|%[a-f\d]{2})*)?$/i;
 
 export const linkProps = ( note, block ) => {
-	const { site: noteSite, comment, post } = get( note, 'meta.ids', {} );
-	const { site: blockSite } = get( block, 'meta.ids', {} );
+	const { site: noteSite, comment, post } = note?.meta?.ids ?? {};
+	const { site: blockSite } = block?.meta?.ids ?? {};
 
 	const site = block ? blockSite : noteSite;
 

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { findIndex, matchesProperty } from 'lodash';
+import { matchesProperty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -58,7 +58,7 @@ export const findNextNoteId = ( noteId, notes ) => {
 		return null;
 	}
 
-	const index = findIndex( notes, noteId );
+	const index = notes.indexOf( noteId );
 	if ( -1 === index ) {
 		return null;
 	}
@@ -121,7 +121,7 @@ class Layout extends React.Component {
 			return;
 		}
 
-		const index = findIndex( nextProps.notes, matchesProperty( 'id', nextProps.selectedNoteId ) );
+		const index = nextProps.notes.findIndex( matchesProperty( 'id', nextProps.selectedNoteId ) );
 		this.setState( {
 			index: index >= 0 ? index : null,
 			lastSelectedIndex: index === null ? 0 : index,
@@ -213,7 +213,7 @@ class Layout extends React.Component {
 		};
 
 		/* Find the currently selected note */
-		let currentIndex = findIndex( filteredNotes, matchesProperty( 'id', this.state.selectedNote ) );
+		let currentIndex = filteredNotes.findIndex( matchesProperty( 'id', this.state.selectedNote ) );
 
 		/*
 		 * Sometimes it can occur that a note disappears

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { find, findIndex, matchesProperty } from 'lodash';
+import { findIndex, matchesProperty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -155,7 +155,7 @@ class Layout extends React.Component {
 			return;
 		}
 
-		if ( ! find( nextProps.notes, matchesProperty( 'id', nextProps.selectedNoteId ) ) ) {
+		if ( ! nextProps.notes.find( matchesProperty( 'id', nextProps.selectedNoteId ) ) ) {
 			this.props.unselectNote();
 		}
 	}
@@ -421,7 +421,7 @@ class Layout extends React.Component {
 		const notes = this.filterController.getFilteredNotes( allNotes );
 		if (
 			this.state.selectedNote &&
-			find( notes, matchesProperty( 'id', this.state.selectedNoteId ) ) === null
+			notes.find( matchesProperty( 'id', this.state.selectedNoteId ) ) === null
 		) {
 			this.props.unselectNote();
 		}
@@ -442,10 +442,7 @@ class Layout extends React.Component {
 	};
 
 	render() {
-		const currentNote = find(
-			this.props.notes,
-			matchesProperty( 'id', this.props.selectedNoteId )
-		);
+		const currentNote = this.props.notes.find( matchesProperty( 'id', this.props.selectedNoteId ) );
 		const filteredNotes = this.filterController.getFilteredNotes( this.props.notes );
 
 		return (

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { matchesProperty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -121,7 +120,7 @@ class Layout extends React.Component {
 			return;
 		}
 
-		const index = nextProps.notes.findIndex( matchesProperty( 'id', nextProps.selectedNoteId ) );
+		const index = nextProps.notes.findIndex( ( n ) => n.id === nextProps.selectedNoteId );
 		this.setState( {
 			index: index >= 0 ? index : null,
 			lastSelectedIndex: index === null ? 0 : index,
@@ -155,7 +154,7 @@ class Layout extends React.Component {
 			return;
 		}
 
-		if ( ! nextProps.notes.find( matchesProperty( 'id', nextProps.selectedNoteId ) ) ) {
+		if ( ! nextProps.notes.find( ( n ) => n.id === nextProps.selectedNoteId ) ) {
 			this.props.unselectNote();
 		}
 	}
@@ -213,7 +212,7 @@ class Layout extends React.Component {
 		};
 
 		/* Find the currently selected note */
-		let currentIndex = filteredNotes.findIndex( matchesProperty( 'id', this.state.selectedNote ) );
+		let currentIndex = filteredNotes.findIndex( ( n ) => n.id === this.state.selectedNote );
 
 		/*
 		 * Sometimes it can occur that a note disappears
@@ -421,7 +420,7 @@ class Layout extends React.Component {
 		const notes = this.filterController.getFilteredNotes( allNotes );
 		if (
 			this.state.selectedNote &&
-			notes.find( matchesProperty( 'id', this.state.selectedNoteId ) ) === null
+			notes.find( ( n ) => n.id === this.state.selectedNoteId ) === undefined
 		) {
 			this.props.unselectNote();
 		}
@@ -442,7 +441,7 @@ class Layout extends React.Component {
 	};
 
 	render() {
-		const currentNote = this.props.notes.find( matchesProperty( 'id', this.props.selectedNoteId ) );
+		const currentNote = this.props.notes.find( ( n ) => n.id === this.props.selectedNoteId );
 		const filteredNotes = this.filterController.getFilteredNotes( this.props.notes );
 
 		return (

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { findIndex, groupBy, reduce, zip } from 'lodash';
+import { groupBy, reduce, zip } from 'lodash';
 
 /**
  * Internal dependencies
@@ -276,7 +276,7 @@ export class NoteList extends React.Component {
 		// Create new groups of messages by time periods
 		const noteGroups = groupBy( this.props.notes, ( { timestamp } ) => {
 			const time = new Date( timestamp );
-			return findIndex( timeGroups, ( [ after, before ] ) => before < time && time <= after );
+			return timeGroups.findIndex( ( [ after, before ] ) => before < time && time <= after );
 		} );
 
 		let [ notes ] = reduce(

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { groupBy, reduce, zip } from 'lodash';
+import { groupBy, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -239,7 +239,9 @@ export class NoteList extends React.Component {
 			new Date( now - DAY_MILLISECONDS * 30 ),
 			-Infinity,
 		];
-		const timeGroups = zip( timeBoundaries.slice( 0, -1 ), timeBoundaries.slice( 1 ) );
+		const timeGroups = timeBoundaries
+			.slice( 0, -1 )
+			.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
 
 		const createNoteComponent = ( note ) => {
 			if ( this.state.undoNote && note.id === this.state.undoNote.id ) {

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { groupBy, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -229,20 +228,6 @@ export class NoteList extends React.Component {
 			} ),
 		];
 
-		// create groups of (before, after) times for grouping notes
-		const now = new Date().setHours( 0, 0, 0, 0 );
-		const timeBoundaries = [
-			Infinity,
-			now,
-			new Date( now - DAY_MILLISECONDS ),
-			new Date( now - DAY_MILLISECONDS * 6 ),
-			new Date( now - DAY_MILLISECONDS * 30 ),
-			-Infinity,
-		];
-		const timeGroups = timeBoundaries
-			.slice( 0, -1 )
-			.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
-
 		const createNoteComponent = ( note ) => {
 			if ( this.state.undoNote && note.id === this.state.undoNote.id ) {
 				return (
@@ -275,19 +260,41 @@ export class NoteList extends React.Component {
 			}
 		};
 
-		// Create new groups of messages by time periods
-		const noteGroups = groupBy( this.props.notes, ( { timestamp } ) => {
-			const time = new Date( timestamp );
-			return timeGroups.findIndex( ( [ after, before ] ) => before < time && time <= after );
-		} );
+		// create groups of (before, after) times for grouping notes
+		const now = new Date().setHours( 0, 0, 0, 0 );
+		const timeBoundaries = [
+			Infinity,
+			now,
+			new Date( now - DAY_MILLISECONDS ),
+			new Date( now - DAY_MILLISECONDS * 6 ),
+			new Date( now - DAY_MILLISECONDS * 30 ),
+			-Infinity,
+		];
+		const timeGroups = timeBoundaries
+			.slice( 0, -1 )
+			.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
 
-		let [ notes ] = reduce(
-			noteGroups,
-			( [ list, isFirst ], group, index ) => {
-				const title = groupTitles[ index ];
+		// Create new groups of messages by time periods
+		const noteGroups = this.props.notes.reduce( ( groups, note ) => {
+			const time = new Date( note.timestamp );
+			const groupKey = timeGroups.findIndex(
+				( [ after, before ] ) => before < time && time <= after
+			);
+
+			if ( ! ( groupKey in groups ) ) {
+				groups[ groupKey ] = [];
+			}
+
+			groups[ groupKey ].push( note );
+			return groups;
+		}, {} );
+
+		let [ notes ] = Object.entries( noteGroups ).reduce(
+			( [ list, isFirst ], [ timeGroupKey, timeGroupNotes ] ) => {
+				const title = groupTitles[ timeGroupKey ];
 				const header = <ListHeader { ...{ key: title, title, isFirst } } />;
 
-				return [ [ ...list, header, ...group.map( createNoteComponent ) ], false ];
+				return [ [ ...list, header, ...timeGroupNotes.map( createNoteComponent ) ], false ];
 			},
 			[ [], true ]
 		);

--- a/apps/notifications/src/panel/templates/summary-in-list.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-list.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { flowRight as compose } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,15 +24,13 @@ export class SummaryInList extends React.Component {
 
 		if ( event.metaKey || event.shiftKey ) {
 			window.open( this.props.note.url, '_blank' );
+		} else if ( this.props.currentNote == this.props.note.id ) {
+			this.props.unselectNote();
 		} else {
-			if ( this.props.currentNote == this.props.note.id ) {
-				this.props.unselectNote();
-			} else {
-				recordTracksEvent( 'calypso_notification_note_open', {
-					note_type: this.props.note.type,
-				} );
-				this.props.selectNote( this.props.note.id );
-			}
+			recordTracksEvent( 'calypso_notification_note_open', {
+				note_type: this.props.note.type,
+			} );
+			this.props.selectNote( this.props.note.id );
 		}
 	};
 
@@ -69,9 +66,9 @@ export class SummaryInList extends React.Component {
 	}
 }
 
-const mapDispatchToProps = ( dispatch ) => ( {
-	selectNote: compose( dispatch, actions.ui.selectNote ),
-	unselectNote: compose( dispatch, actions.ui.unselectNote ),
-} );
+const mapDispatchToProps = {
+	selectNote: actions.ui.selectNote,
+	unselectNote: actions.ui.unselectNote,
+};
 
 export default connect( null, mapDispatchToProps, null, { pure: false } )( SummaryInList );

--- a/apps/notifications/src/panel/utils/noticon2gridicon.js
+++ b/apps/notifications/src/panel/utils/noticon2gridicon.js
@@ -1,27 +1,18 @@
-/**
- * External dependencies
- */
-import { get } from 'lodash';
-
-export const noticon2gridicon = ( c ) =>
-	get(
-		{
-			'\uf814': 'mention',
-			'\uf300': 'comment',
-			'\uf801': 'add',
-			'\uf455': 'info',
-			'\uf470': 'lock',
-			'\uf806': 'stats-alt',
-			'\uf805': 'reblog',
-			'\uf408': 'star',
-			'\uf804': 'trophy',
-			'\uf467': 'reply',
-			'\uf414': 'warning',
-			'\uf418': 'checkmark',
-			'\uf447': 'cart',
-		},
-		c,
-		'info'
-	);
+const noticon2gridicon = ( c ) =>
+	( {
+		'\uf814': 'mention',
+		'\uf300': 'comment',
+		'\uf801': 'add',
+		'\uf455': 'info',
+		'\uf470': 'lock',
+		'\uf806': 'stats-alt',
+		'\uf805': 'reblog',
+		'\uf408': 'star',
+		'\uf804': 'trophy',
+		'\uf467': 'reply',
+		'\uf414': 'warning',
+		'\uf418': 'checkmark',
+		'\uf447': 'cart',
+	}[ c ] ?? 'info' );
 
 export default noticon2gridicon;

--- a/apps/notifications/src/panel/utils/noticon2gridicon.js
+++ b/apps/notifications/src/panel/utils/noticon2gridicon.js
@@ -1,18 +1,19 @@
-const noticon2gridicon = ( c ) =>
-	( {
-		'\uf814': 'mention',
-		'\uf300': 'comment',
-		'\uf801': 'add',
-		'\uf455': 'info',
-		'\uf470': 'lock',
-		'\uf806': 'stats-alt',
-		'\uf805': 'reblog',
-		'\uf408': 'star',
-		'\uf804': 'trophy',
-		'\uf467': 'reply',
-		'\uf414': 'warning',
-		'\uf418': 'checkmark',
-		'\uf447': 'cart',
-	}[ c ] ?? 'info' );
+const iconMap = {
+	'\uf814': 'mention',
+	'\uf300': 'comment',
+	'\uf801': 'add',
+	'\uf455': 'info',
+	'\uf470': 'lock',
+	'\uf806': 'stats-alt',
+	'\uf805': 'reblog',
+	'\uf408': 'star',
+	'\uf804': 'trophy',
+	'\uf467': 'reply',
+	'\uf414': 'warning',
+	'\uf418': 'checkmark',
+	'\uf447': 'cart',
+};
+
+const noticon2gridicon = ( c ) => iconMap[ c ] ?? 'info';
 
 export default noticon2gridicon;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove all imports and references to lodash from the `@automattic/notifications` package, replacing with ES6- or React-standard methods.

NOTE: I split each commit by the method being replaced. If it makes more sense for you to review changes method-by-method, I recommend looking at each commit separately.

##### Implementation notes

(Update: I figured it out, see comments below.)
~Curiously, after removing lodash as a dependency in package.json, the production bundle size went up slightly for me by about 600 bytes. I was expecting it to get somewhat smaller? Interested to know if anyone has any theories on this.~

#### Testing instructions

To test as if you're in production:
* Run `yarn` to refresh package dependencies, then `NODE_ENV=production yarn build` to build the production bundle.
* Upload the entire `apps/notifications/dist/` directory to your sandbox environment.
* Alias `widgets.wp.com` to point to your sandbox environment.
* Navigate to a self-hosted WordPress site and sign in with your WordPress.com account. The notifications panel in the masterbar should now be running code from this pull request.

You can also test in "development mode" by running `yarn start` on your local machine and navigating to `notifications.localhost:8888` after setting up a DNS alias to this host for 127.0.0.1. Be advised that this method _should_ have the same notifications experience from a user perspective, but it uses OAuth for authentication instead of the normal means.

Test all aspects of the notifications panel, looking for regressions. Check out:
* all notification types (posts, comments, likes, etc.)
* notifications from today, the recent past, and as long ago as a few months
* selecting, opening, and marking notifications as read
* taking actions on different notification types (e.g., clicking 'Like' on a comment notification, etc.)