### PR TITLE
TeamCity: Add build type for Smart Builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,4 +1,5 @@
 import _self.bashNodeScript
+import _self.yarn_install_cmd
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
@@ -9,6 +10,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 
 /*
 The settings script is an entry point for defining a TeamCity

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -43,6 +43,7 @@ project {
 	subProject(_self.projects.WebApp)
 	buildType(BuildBaseImages)
 	buildType(CheckCodeStyle)
+	buildType(SmartBuildLauncher)
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
@@ -262,6 +263,54 @@ object CheckCodeStyle : BuildType({
 			param("xmlReportParsing.verboseOutput", "true")
 		}
 		perfmon {
+		}
+	}
+})
+
+object SmartBuildLauncher : BuildType({
+	name = "Smart Build Launcher"
+	description = "Launches TeamCity builds based on which files were modified in VCS."
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	features {
+		pullRequests {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Install and build dependencies"
+			scriptContent = """
+				$yarn_install_cmd
+				yarn workspace @automattic/dependency-finder build
+			"""
+		}
+		bashNodeScript {
+			name = "Launch relevant builds"
+			scriptContent = """
+				node ./packages/dependency-finder/dist/esm/index.js
+			"""
 		}
 	}
 })


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds a top-level build type which will be used for the smarter builds project. Just a basic placeholder to build off of.
- No VCS trigger yet (will be added once we have something basic ready for production)
- Launches the dependency finder tool. (This does not exist yet, but since the build is not triggered either, that's ok)

My current plan is to build a script which does the following:
1. Accepts a list of files modified. These will be passed from the TeamCity environment into the script
2. Runs a loop on that list and determines if any jobs match a specific file.
3. We'll have a list of "projects" with an initial basic data structure like the following. Project is kind of vague, but I think it would be useful to allow one set of files to be able to trigger multiple related jobs
```
project {
  teamcityJobIds: Array<string>
  knownFiles: Array<string>
}
```
4. A file matches a job if the file is in the list of known files. At that point, the script will trigger each of the specified `jobIds` using the TeamCity API.

That will be the first pass, after which we will add support for internal and external dependencies.

My current plan is to implement this script inside the dependency finder, at least at first. Another option would be trying to implement it in Kotlin and tie it into the actual TeamCity configuration rather than launching jobs using the TeamCity API.

#### Testing instructions
Only testable after deployment

Related to #52471
