### PR TITLE
ci(unit): Refactor unit tests

### DIFF
--- a/client/lib/geocoding/test/index.js
+++ b/client/lib/geocoding/test/index.js
@@ -1,14 +1,9 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { geocode, reverseGeocode } from '../';
 
-jest.mock( '@automattic/load-script', () => require( './mocks/load-script' ) );
+jest.mock( '@automattic/load-script', () => require( './mocks/load-script' ).default );
 /**
  * Module variables
  */
@@ -22,18 +17,11 @@ describe( 'geocoding', () => {
 	describe( 'when converting a search string to location results', () => {
 		describe( '#geocode()', () => {
 			test( 'should return a promise', () => {
-				expect( geocode( TEST_ADDRESS ) ).to.be.an.instanceof( Promise );
+				expect( geocode( TEST_ADDRESS ) ).toBeInstanceOf( Promise );
 			} );
 
-			test( 'should call to the Google Maps API', () => {
-				return new Promise( ( done ) => {
-					geocode( TEST_ADDRESS )
-						.then( ( results ) => {
-							expect( results ).to.eql( [ 1, 2, 3 ] );
-							done();
-						} )
-						.catch( done );
-				} );
+			test( 'should call to the Google Maps API', async () => {
+				await expect( geocode( TEST_ADDRESS ) ).resolves.toEqual( [ 1, 2, 3 ] );
 			} );
 		} );
 	} );
@@ -41,18 +29,15 @@ describe( 'geocoding', () => {
 	describe( 'when converting from coordinates to address labels', () => {
 		describe( '#reverseGeocode()', () => {
 			test( 'should return a promise', () => {
-				expect( reverseGeocode( TEST_LATITUDE, TEST_LONGITUDE ) ).to.be.an.instanceof( Promise );
+				expect( reverseGeocode( TEST_LATITUDE, TEST_LONGITUDE ) ).toBeInstanceOf( Promise );
 			} );
 
-			test( 'should call to the Google Maps API', () => {
-				return new Promise( ( done ) => {
-					reverseGeocode( TEST_LATITUDE, TEST_LONGITUDE )
-						.then( ( results ) => {
-							expect( results ).to.eql( [ 1, 2, 3 ] );
-							done();
-						} )
-						.catch( done );
-				} );
+			test( 'should call to the Google Maps API', async () => {
+				await expect( reverseGeocode( TEST_LATITUDE, TEST_LONGITUDE ) ).resolves.toEqual( [
+					1,
+					2,
+					3,
+				] );
 			} );
 		} );
 	} );

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import sinon from 'sinon';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -14,7 +13,7 @@ import {
 	READER_RELATED_POSTS_REQUEST_FAILURE,
 	READER_RELATED_POSTS_RECEIVE,
 } from 'calypso/state/reader/action-types';
-import useNock from 'calypso/test-helpers/use-nock';
+
 jest.mock( 'calypso/state/reader/posts/actions', () => ( {
 	receivePosts( posts ) {
 		return Promise.resolve( posts );
@@ -23,7 +22,10 @@ jest.mock( 'calypso/state/reader/posts/actions', () => ( {
 
 describe( 'actions', () => {
 	describe( 'success', () => {
-		useNock( ( nock ) => {
+		let fakeDispatch;
+		let requestPromise;
+
+		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.2/read/site/1/post/1/related?meta=site' )
 				.reply( 200, {
@@ -35,18 +37,17 @@ describe( 'actions', () => {
 						},
 					],
 				} );
-		} );
 
-		let fakeDispatch;
-		let requestPromise;
-		beforeAll( () => {
-			fakeDispatch = sinon.stub();
-			fakeDispatch.withArgs( sinon.match.instanceOf( Promise ) ).returnsArg( 0 );
+			fakeDispatch = jest.fn( ( p ) => p );
 			requestPromise = requestRelatedPosts( 1, 1 )( fakeDispatch );
 		} );
 
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
 		test( 'should have dispatched request', () => {
-			expect( fakeDispatch ).to.have.been.calledWith( {
+			expect( fakeDispatch ).toHaveBeenCalledWith( {
 				type: READER_RELATED_POSTS_REQUEST,
 				payload: {
 					siteId: 1,
@@ -56,56 +57,57 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should return a promise which has dispatched related posts', () => {
-			return requestPromise.then( () => {
-				expect( fakeDispatch ).to.have.been.calledWith( {
-					type: READER_RELATED_POSTS_RECEIVE,
-					payload: {
-						siteId: 1,
-						postId: 1,
-						scope: 'all',
-						posts: [
-							{
-								ID: 1,
-								global_ID: 1,
-								site_ID: 1,
-							},
-						],
-					},
-				} );
+		test( 'should return a promise which has dispatched related posts', async () => {
+			await requestPromise;
+			expect( fakeDispatch ).toHaveBeenCalledWith( {
+				type: READER_RELATED_POSTS_RECEIVE,
+				payload: {
+					siteId: 1,
+					postId: 1,
+					scope: 'all',
+					posts: [
+						{
+							ID: 1,
+							global_ID: 1,
+							site_ID: 1,
+						},
+					],
+				},
 			} );
 		} );
 
-		test( 'should return a promise which has dispatched success', () => {
-			return requestPromise.then( () => {
-				expect( fakeDispatch ).to.have.been.calledWith( {
-					type: READER_RELATED_POSTS_REQUEST_SUCCESS,
-					payload: {
-						siteId: 1,
-						postId: 1,
-						scope: 'all',
-					},
-				} );
+		test( 'should return a promise which has dispatched success', async () => {
+			await requestPromise;
+			expect( fakeDispatch ).toHaveBeenCalledWith( {
+				type: READER_RELATED_POSTS_REQUEST_SUCCESS,
+				payload: {
+					siteId: 1,
+					postId: 1,
+					scope: 'all',
+				},
 			} );
 		} );
 	} );
 
 	describe( 'failure', () => {
-		useNock( ( nock ) => {
+		let fakeDispatch;
+		let requestPromise;
+
+		beforeAll( async () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.2/read/site/1/post/1/related?meta=site' )
 				.reply( 400, {} );
-		} );
 
-		let fakeDispatch;
-		let requestPromise;
-		beforeAll( () => {
-			fakeDispatch = sinon.spy();
+			fakeDispatch = jest.fn();
 			requestPromise = requestRelatedPosts( 1, 1 )( fakeDispatch );
 		} );
 
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
 		test( 'should have dispatched request', () => {
-			expect( fakeDispatch ).to.have.been.calledWith( {
+			expect( fakeDispatch ).toHaveBeenCalledWith( {
 				type: READER_RELATED_POSTS_REQUEST,
 				payload: {
 					siteId: 1,
@@ -115,32 +117,30 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should have dispatched receive with an empty array', () => {
-			return requestPromise.catch( () => {
-				expect( fakeDispatch ).to.have.been.calledWith( {
-					type: READER_RELATED_POSTS_RECEIVE,
-					payload: {
-						siteId: 1,
-						postId: 1,
-						scope: 'all',
-						posts: [],
-					},
-				} );
+		test( 'should have dispatched receive with an empty array', async () => {
+			await requestPromise;
+			expect( fakeDispatch ).toHaveBeenCalledWith( {
+				type: READER_RELATED_POSTS_RECEIVE,
+				payload: {
+					siteId: 1,
+					postId: 1,
+					scope: 'all',
+					posts: [],
+				},
 			} );
 		} );
 
-		test( 'should fail the promise and dispatch failure', () => {
-			return requestPromise.catch( () => {
-				expect( fakeDispatch ).to.have.been.calledWith( {
-					type: READER_RELATED_POSTS_REQUEST_FAILURE,
-					payload: {
-						siteId: 1,
-						postId: 1,
-						scope: 'all',
-						error: sinon.match.instanceOf( Error ),
-					},
-					error: true,
-				} );
+		test( 'should fail the promise and dispatch failure', async () => {
+			await requestPromise;
+			expect( fakeDispatch ).toHaveBeenCalledWith( {
+				type: READER_RELATED_POSTS_REQUEST_FAILURE,
+				payload: {
+					siteId: 1,
+					postId: 1,
+					scope: 'all',
+					error: expect.any( Error ),
+				},
+				error: true,
 			} );
 		} );
 	} );

--- a/client/state/reader/tags/images/test/actions.js
+++ b/client/state/reader/tags/images/test/actions.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -14,14 +13,13 @@ import {
 	READER_TAG_IMAGES_REQUEST_SUCCESS,
 	READER_TAG_IMAGES_RECEIVE,
 } from 'calypso/state/reader/action-types';
-import useNock from 'calypso/test-helpers/use-nock';
 import sampleSuccessResponse from './sample-responses.json';
 
 describe( 'actions', () => {
-	const spy = sinon.spy();
+	const spy = jest.fn();
 
-	beforeEach( () => {
-		spy.resetHistory();
+	afterEach( () => {
+		spy.mockClear();
 	} );
 
 	describe( '#receiveTagImages()', () => {
@@ -30,7 +28,7 @@ describe( 'actions', () => {
 			const tag = 'banana';
 			const action = receiveTagImages( tag, images );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: READER_TAG_IMAGES_RECEIVE,
 				images,
 				tag,
@@ -39,39 +37,37 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestTagImages', () => {
-		useNock( ( nock ) => {
+		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.2/read/tags/banana/images?number=5' )
 				.reply( 200, deepFreeze( sampleSuccessResponse ) );
 		} );
 
-		test( 'should dispatch properly when receiving a valid response', () => {
-			const dispatchSpy = sinon.stub();
-			dispatchSpy.withArgs( sinon.match.instanceOf( Promise ) ).returnsArg( 0 );
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
+		test( 'should dispatch properly when receiving a valid response', async () => {
+			const dispatchSpy = jest.fn( ( p ) => p );
 			const request = requestTagImages( 'banana' )( dispatchSpy );
 
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
 				type: READER_TAG_IMAGES_REQUEST,
 				tag: 'banana',
 			} );
 
-			return request
-				.then( () => {
-					expect( dispatchSpy ).to.have.been.calledWith( {
-						type: READER_TAG_IMAGES_REQUEST_SUCCESS,
-						data: sampleSuccessResponse,
-						tag: 'banana',
-					} );
+			await request;
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
+				type: READER_TAG_IMAGES_REQUEST_SUCCESS,
+				data: sampleSuccessResponse,
+				tag: 'banana',
+			} );
 
-					expect( dispatchSpy ).to.have.been.calledWith( {
-						type: READER_TAG_IMAGES_RECEIVE,
-						images: sampleSuccessResponse.images,
-						tag: 'banana',
-					} );
-				} )
-				.catch( ( err ) => {
-					assert.fail( err, undefined, 'errback should not have been called' );
-				} );
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
+				type: READER_TAG_IMAGES_RECEIVE,
+				images: sampleSuccessResponse.images,
+				tag: 'banana',
+			} );
 		} );
 	} );
 } );

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
+import nock from 'nock';
+
 // Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
 import 'jest-fetch-mock';
 
@@ -18,13 +18,12 @@ import {
 	READER_THUMBNAIL_REQUEST_FAILURE,
 	READER_THUMBNAIL_RECEIVE,
 } from 'calypso/state/reader/action-types';
-import useNock from 'calypso/test-helpers/use-nock';
 
 describe( 'actions', () => {
-	const spy = sinon.spy();
+	const spy = jest.fn();
 
-	beforeEach( () => {
-		spy.resetHistory();
+	afterEach( () => {
+		spy.mockClear();
 	} );
 
 	describe( '#receiveThumbnail', () => {
@@ -33,7 +32,7 @@ describe( 'actions', () => {
 			const thumbnailUrl = 'thumbnailUrl';
 			const action = receiveThumbnail( embedUrl, thumbnailUrl );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: READER_THUMBNAIL_RECEIVE,
 				embedUrl,
 				thumbnailUrl,
@@ -49,7 +48,7 @@ describe( 'actions', () => {
 		const youtubeEmbedUrl = 'https://youtube.com/?v=UoOCrbV3ZQ';
 		const youtubeThumbnailUrl = 'https://img.youtube.com/vi/UoOCrbV3ZQ/mqdefault.jpg';
 
-		useNock( ( nock ) => {
+		beforeAll( () => {
 			nock( 'https://vimeo.com' )
 				.get( '/api/v2/video/6999927.json' )
 				.reply( 200, deepFreeze( sampleVimeoResponse ) );
@@ -58,81 +57,79 @@ describe( 'actions', () => {
 				.reply( 500, deepFreeze( {} ) );
 		} );
 
-		test( 'vimeo: should dispatch properly when receiving a valid response', () => {
-			const dispatchSpy = sinon.spy();
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
+		test( 'vimeo: should dispatch properly when receiving a valid response', async () => {
+			const dispatchSpy = jest.fn();
 			const request = requestThumbnail( successfulEmbedUrl )( dispatchSpy );
 
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
 				type: READER_THUMBNAIL_REQUEST,
 				embedUrl: successfulEmbedUrl,
 			} );
 
-			return request
-				.then( () => {
-					expect( dispatchSpy ).to.have.been.calledWith( {
-						type: READER_THUMBNAIL_REQUEST_SUCCESS,
-						embedUrl: successfulEmbedUrl,
-					} );
+			await request;
 
-					expect( dispatchSpy ).to.have.been.calledWith( {
-						type: READER_THUMBNAIL_RECEIVE,
-						embedUrl: successfulEmbedUrl,
-						thumbnailUrl,
-					} );
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
+				type: READER_THUMBNAIL_REQUEST_SUCCESS,
+				embedUrl: successfulEmbedUrl,
+			} );
 
-					expect( dispatchSpy ).to.have.been.calledThrice;
-				} )
-				.catch( ( err ) => {
-					assert.fail( err, undefined, 'errback should not have been called' );
-				} );
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
+				type: READER_THUMBNAIL_RECEIVE,
+				embedUrl: successfulEmbedUrl,
+				thumbnailUrl,
+			} );
+
+			expect( dispatchSpy ).toHaveBeenCalledTimes( 3 );
 		} );
 
 		test( 'youtube: should dispatch action with thumbnail instantly', () => {
-			const dispatchSpy = sinon.spy();
+			const dispatchSpy = jest.fn();
 			requestThumbnail( youtubeEmbedUrl )( dispatchSpy );
 
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
 				type: READER_THUMBNAIL_RECEIVE,
 				embedUrl: youtubeEmbedUrl,
 				thumbnailUrl: youtubeThumbnailUrl,
 			} );
-			expect( dispatchSpy ).to.have.been.calledOnce;
+			expect( dispatchSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		test( 'should dispatch the right actions if network request fails', () => {
-			const dispatchSpy = sinon.spy();
+		test( 'should dispatch the right actions if network request fails', async () => {
+			const dispatchSpy = jest.fn();
 			const request = requestThumbnail( failureEmbedUrl )( dispatchSpy );
 
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
 				type: READER_THUMBNAIL_REQUEST,
 				embedUrl: failureEmbedUrl,
 			} );
 
-			return request
-				.then( () => {
-					expect( dispatchSpy ).to.have.been.calledWithMatch( {
-						type: READER_THUMBNAIL_REQUEST_FAILURE,
-						embedUrl: failureEmbedUrl,
-					} );
+			await request;
 
-					expect( dispatchSpy ).to.have.been.calledTwice;
+			expect( dispatchSpy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: READER_THUMBNAIL_REQUEST_FAILURE,
+					embedUrl: failureEmbedUrl,
 				} )
-				.catch( ( err ) => {
-					assert.fail( err, undefined, 'errback should not have been called' );
-				} );
+			);
+
+			expect( dispatchSpy ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		test( 'should dispatch a failure action instantly if unsupported', () => {
-			const dispatchSpy = sinon.spy();
+			const dispatchSpy = jest.fn();
 			requestThumbnail( unsupportedEmbedUrl )( dispatchSpy );
 
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( dispatchSpy ).toHaveBeenCalledWith( {
 				type: READER_THUMBNAIL_REQUEST_FAILURE,
 				embedUrl: unsupportedEmbedUrl,
 				error: { type: 'UNSUPPORTED_EMBED' },
 			} );
 
-			expect( dispatchSpy ).to.have.been.calledOnce;
+			expect( dispatchSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import nock from 'nock';
+
+/**
  * Internal dependencies
  */
 import {
@@ -21,7 +26,6 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	TERMS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
-import useNock from 'calypso/test-helpers/use-nock';
 
 /**
  * Module Variables
@@ -50,7 +54,7 @@ const categoryTaxonomyName = 'category';
 
 describe( 'actions', () => {
 	describe( 'addTerm()', () => {
-		useNock( ( nock ) => {
+		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( `/rest/v1.1/sites/${ siteId }/taxonomies/${ taxonomyName }/terms/new` )
@@ -64,6 +68,10 @@ describe( 'actions', () => {
 					message: 'The taxonomy does not exist',
 					error: 'invalid_taxonomy',
 				} );
+		} );
+
+		afterAll( () => {
+			nock.cleanAll();
 		} );
 
 		test( 'should dispatch a TERMS_RECEIVE', () => {
@@ -85,47 +93,44 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch a TERMS_RECEIVE event on success', () => {
+		test( 'should dispatch a TERMS_RECEIVE event on success', async () => {
 			const spy = jest.fn();
-			return addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					terms: [
-						{
-							ID: 123,
-							name: 'ribs',
-							description: '',
-						},
-					],
-					query: undefined,
-					found: undefined,
-				} );
+			await addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				terms: [
+					{
+						ID: 123,
+						name: 'ribs',
+						description: '',
+					},
+				],
+				query: undefined,
+				found: undefined,
 			} );
 		} );
 
-		test( 'should dispatch a TERM_REMOVE event on success', () => {
+		test( 'should dispatch a TERM_REMOVE event on success', async () => {
 			const spy = jest.fn();
-			return addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERM_REMOVE,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					termId: expect.stringMatching( /^temporary/ ),
-				} );
+			await addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERM_REMOVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				termId: expect.stringMatching( /^temporary/ ),
 			} );
 		} );
 
-		test( 'should dispatch a TERM_REMOVE event on failure', () => {
+		test( 'should dispatch a TERM_REMOVE event on failure', async () => {
 			const spy = jest.fn();
-			return addTerm( siteId, 'chicken-and-ribs', { name: 'new term' } )( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERM_REMOVE,
-					siteId: siteId,
-					taxonomy: 'chicken-and-ribs',
-					termId: expect.stringMatching( /^temporary/ ),
-				} );
+			await addTerm( siteId, 'chicken-and-ribs', { name: 'new term' } )( spy );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERM_REMOVE,
+				siteId: siteId,
+				taxonomy: 'chicken-and-ribs',
+				termId: expect.stringMatching( /^temporary/ ),
 			} );
 		} );
 	} );
@@ -187,7 +192,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSiteTerms()', () => {
-		useNock( ( nock ) => {
+		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/rest/v1.1/sites/${ siteId }/taxonomies/${ taxonomyName }/terms` )
@@ -202,6 +207,10 @@ describe( 'actions', () => {
 				} );
 		} );
 
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
 		test( 'should dispatch a TERMS_REQUEST', () => {
 			const spy = jest.fn();
 			requestSiteTerms( siteId, taxonomyName )( spy );
@@ -214,57 +223,45 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch a TERMS_RECEIVE event on success', () => {
+		test( 'should dispatch a TERMS_RECEIVE event on success', async () => {
 			const spy = jest.fn();
-			return requestSiteTerms(
-				siteId,
-				taxonomyName
-			)( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					terms: testTerms,
-					query: {},
-					found: 2,
-				} );
+			await requestSiteTerms( siteId, taxonomyName )( spy );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				terms: testTerms,
+				query: {},
+				found: 2,
 			} );
 		} );
 
-		test( 'should dispatch TERMS_REQUEST_SUCCESS action when request succeeds', () => {
+		test( 'should dispatch TERMS_REQUEST_SUCCESS action when request succeeds', async () => {
 			const spy = jest.fn();
-			return requestSiteTerms(
-				siteId,
-				taxonomyName
-			)( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_REQUEST_SUCCESS,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					query: {},
-				} );
+			await requestSiteTerms( siteId, taxonomyName )( spy );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_REQUEST_SUCCESS,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				query: {},
 			} );
 		} );
 
-		test( 'should dispatch TERMS_REQUEST_FAILURE action when request fails', () => {
+		test( 'should dispatch TERMS_REQUEST_FAILURE action when request fails', async () => {
 			const spy = jest.fn();
-			return requestSiteTerms(
-				12345,
-				'chicken-and-ribs'
-			)( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_REQUEST_FAILURE,
-					siteId: 12345,
-					taxonomy: 'chicken-and-ribs',
-					query: {},
-					error: expect.objectContaining( { error: 'invalid_taxonomy' } ),
-				} );
+			await requestSiteTerms( 12345, 'chicken-and-ribs' )( spy );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_REQUEST_FAILURE,
+				siteId: 12345,
+				taxonomy: 'chicken-and-ribs',
+				query: {},
+				error: expect.objectContaining( { error: 'invalid_taxonomy' } ),
 			} );
 		} );
 	} );
 
 	describe( 'updateTerm()', () => {
-		useNock( ( nock ) => {
+		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( `/rest/v1.1/sites/${ siteId }/taxonomies/${ taxonomyName }/terms/slug:rib` )
@@ -286,7 +283,11 @@ describe( 'actions', () => {
 				} );
 		} );
 
-		test( 'should dispatch a TERMS_RECEIVE, TERM_REMOVE POST_EDIT and SITE_SETTINGS_UPDATE on Success', () => {
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
+		test( 'should dispatch a TERMS_RECEIVE, TERM_REMOVE POST_EDIT and SITE_SETTINGS_UPDATE on Success', async () => {
 			const postObjects = {
 				[ siteId ]: {
 					'0fcb4eb16f493c19b627438fdc18d57c': {
@@ -331,48 +332,48 @@ describe( 'actions', () => {
 			const getState = () => state;
 
 			const spy = jest.fn();
-			return updateTerm( siteId, categoryTaxonomyName, 10, 'rib', { name: 'ribs' } )(
+			await updateTerm( siteId, categoryTaxonomyName, 10, 'rib', { name: 'ribs' } )(
 				spy,
 				getState
-			).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERM_REMOVE,
-					siteId: siteId,
-					taxonomy: categoryTaxonomyName,
-					termId: 10,
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: categoryTaxonomyName,
-					terms: [
-						{ ID: 11, name: 'chicken', slug: 'chicken', parent: 123 },
-						{ ID: 123, name: 'ribs', description: '' },
-					],
-					query: undefined,
-					found: undefined,
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: POST_EDIT,
-					siteId: siteId,
-					postId: 120,
-					post: {
-						terms: {
-							[ categoryTaxonomyName ]: [ { ID: 123, name: 'ribs', description: '' } ],
-						},
+			);
+
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERM_REMOVE,
+				siteId: siteId,
+				taxonomy: categoryTaxonomyName,
+				termId: 10,
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: categoryTaxonomyName,
+				terms: [
+					{ ID: 11, name: 'chicken', slug: 'chicken', parent: 123 },
+					{ ID: 123, name: 'ribs', description: '' },
+				],
+				query: undefined,
+				found: undefined,
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: POST_EDIT,
+				siteId: siteId,
+				postId: 120,
+				post: {
+					terms: {
+						[ categoryTaxonomyName ]: [ { ID: 123, name: 'ribs', description: '' } ],
 					},
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: SITE_SETTINGS_UPDATE,
-					siteId: siteId,
-					settings: {
-						default_category: 123,
-					},
-				} );
+				},
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: SITE_SETTINGS_UPDATE,
+				siteId: siteId,
+				settings: {
+					default_category: 123,
+				},
 			} );
 		} );
 
-		test( 'should not dispatch SITE_SETTINGS_UPDATE on Success if the taxonomy is not equal to "category"', () => {
+		test( 'should not dispatch SITE_SETTINGS_UPDATE on Success if the taxonomy is not equal to "category"', async () => {
 			const state = {
 				posts: { queries: {} },
 				siteSettings: {
@@ -398,22 +399,19 @@ describe( 'actions', () => {
 			const getState = () => state;
 
 			const spy = jest.fn();
-			return updateTerm( siteId, taxonomyName, 10, 'rib', { name: 'ribs' } )( spy, getState ).then(
-				() => {
-					expect( spy ).not.toHaveBeenCalledWith( {
-						type: SITE_SETTINGS_UPDATE,
-						siteId: siteId,
-						settings: {
-							default_category: 123,
-						},
-					} );
-				}
-			);
+			await updateTerm( siteId, taxonomyName, 10, 'rib', { name: 'ribs' } )( spy, getState );
+			expect( spy ).not.toHaveBeenCalledWith( {
+				type: SITE_SETTINGS_UPDATE,
+				siteId: siteId,
+				settings: {
+					default_category: 123,
+				},
+			} );
 		} );
 	} );
 
 	describe( 'deleteTerm()', () => {
-		useNock( ( nock ) => {
+		beforeAll( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/wp/v2/sites/${ siteId }/taxonomies/${ taxonomyName }/` )
@@ -424,7 +422,11 @@ describe( 'actions', () => {
 				.reply( 200, { status: 'ok' } );
 		} );
 
-		test( 'should dispatch a TERMS_RECEIVE, TERM_REMOVE and POST_EDIT on Success', () => {
+		afterAll( () => {
+			nock.cleanAll();
+		} );
+
+		test( 'should dispatch a TERMS_RECEIVE, TERM_REMOVE and POST_EDIT on Success', async () => {
 			const postObjects = {
 				[ siteId ]: {
 					'0fcb4eb16f493c19b627438fdc18d57c': {
@@ -464,46 +466,41 @@ describe( 'actions', () => {
 			const getState = () => state;
 
 			const spy = jest.fn();
-			return deleteTerm(
-				siteId,
-				taxonomyName,
-				10,
-				'ribs'
-			)( spy, getState ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					terms: [ { ID: 15, name: 'chicken ribs', slug: 'chicken-ribs', parent: 5 } ],
-					query: undefined,
-					found: undefined,
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: POST_EDIT,
-					siteId: siteId,
-					postId: 120,
-					post: {
-						terms: {
-							[ taxonomyName ]: [],
-						},
+			await deleteTerm( siteId, taxonomyName, 10, 'ribs' )( spy, getState );
+
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				terms: [ { ID: 15, name: 'chicken ribs', slug: 'chicken-ribs', parent: 5 } ],
+				query: undefined,
+				found: undefined,
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: POST_EDIT,
+				siteId: siteId,
+				postId: 120,
+				post: {
+					terms: {
+						[ taxonomyName ]: [],
 					},
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERM_REMOVE,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					termId: 10,
-				} );
-				expect( spy ).not.toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: taxonomyName,
-					terms: [],
-				} );
+				},
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERM_REMOVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				termId: 10,
+			} );
+			expect( spy ).not.toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				terms: [],
 			} );
 		} );
 
-		test( 'should dispatch a TERMS_RECEIVE for default category on Success', () => {
+		test( 'should dispatch a TERMS_RECEIVE for default category on Success', async () => {
 			const state = {
 				posts: {
 					queries: {
@@ -534,30 +531,25 @@ describe( 'actions', () => {
 			const getState = () => state;
 
 			const spy = jest.fn();
-			return deleteTerm(
-				siteId,
-				categoryTaxonomyName,
-				10,
-				'ribs'
-			)( spy, getState ).then( () => {
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: categoryTaxonomyName,
-					terms: [ { ID: 5, name: 'chicken', slug: 'chicken', parent: 0, post_count: 12 } ],
-					query: undefined,
-					found: undefined,
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERM_REMOVE,
-					siteId: siteId,
-					taxonomy: categoryTaxonomyName,
-					termId: 10,
-				} );
+			await deleteTerm( siteId, categoryTaxonomyName, 10, 'ribs' )( spy, getState );
+
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: categoryTaxonomyName,
+				terms: [ { ID: 5, name: 'chicken', slug: 'chicken', parent: 0, post_count: 12 } ],
+				query: undefined,
+				found: undefined,
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERM_REMOVE,
+				siteId: siteId,
+				taxonomy: categoryTaxonomyName,
+				termId: 10,
 			} );
 		} );
 
-		test( 'should not dispatch a TERMS_RECEIVE for default category when prior category had no post_count', () => {
+		test( 'should not dispatch a TERMS_RECEIVE for default category when prior category had no post_count', async () => {
 			const state = {
 				posts: {
 					queries: {
@@ -588,34 +580,32 @@ describe( 'actions', () => {
 			const getState = () => state;
 
 			const spy = jest.fn();
-			return deleteTerm(
-				siteId,
-				categoryTaxonomyName,
-				10,
-				'ribs'
-			)( spy, getState ).then( () => {
-				expect( spy ).not.toHaveBeenCalledWith( {
-					type: TERMS_RECEIVE,
-					siteId: siteId,
-					taxonomy: categoryTaxonomyName,
-					terms: [ { ID: 5, name: 'chicken', slug: 'chicken', parent: 0, post_count: 10 } ],
-					query: undefined,
-					found: undefined,
-				} );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: TERM_REMOVE,
-					siteId: siteId,
-					taxonomy: categoryTaxonomyName,
-					termId: 10,
-				} );
+			await deleteTerm( siteId, categoryTaxonomyName, 10, 'ribs' )( spy, getState );
+
+			expect( spy ).not.toHaveBeenCalledWith( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: categoryTaxonomyName,
+				terms: [ { ID: 5, name: 'chicken', slug: 'chicken', parent: 0, post_count: 10 } ],
+				query: undefined,
+				found: undefined,
+			} );
+			expect( spy ).toHaveBeenCalledWith( {
+				type: TERM_REMOVE,
+				siteId: siteId,
+				taxonomy: categoryTaxonomyName,
+				termId: 10,
 			} );
 		} );
 
-		test( 'should not dispatch any action on Failure', () => {
+		test( 'should not dispatch any action on Failure', async () => {
 			const spy = jest.fn();
-			return updateTerm( siteId, taxonomyName, 10, 'toto', { name: 'ribs' } )( spy ).catch( () => {
-				expect( spy ).not.toHaveBeenCalled();
-			} );
+
+			await expect(
+				updateTerm( siteId, taxonomyName, 10, 'toto', { name: 'ribs' } )( spy )
+			).rejects.toThrow();
+
+			expect( spy ).not.toHaveBeenCalled();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactors unit tests to avoid using conditional expects, as detected by the eslint rule `jest/no-conditional-expects`

* In the same tests, refactor away `chai`, `sinon` and `useNock`, and refactor them to use `async/await` instead of `.then/catch` promise handling.



#### Testing instructions

N/A