### PR TITLE
Search: enable Jetpack Search section in Jetpack Cloud dev

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -23,6 +23,7 @@ import ScanBadge from 'calypso/components/jetpack/scan-badge';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { isEnabled } from '@automattic/calypso-config';
 
 export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
@@ -90,7 +91,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
 				</SidebarItem>
 			) }
-			{ ! isJetpackCloud() && (
+			{ ( ! isJetpackCloud() || isEnabled( 'jetpack-cloud/search' ) ) && (
 				<SidebarItem
 					tipTarget="jetpack-search"
 					icon={ showIcons ? 'search' : undefined }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -38,6 +38,7 @@
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": false,
+		"jetpack-cloud/search": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/search-product": true,
 		"jetpack/connect/remote-install": true,
@@ -67,8 +68,9 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"scan": true,
-		"jetpack-connect": true
+		"jetpack-connect": true,
+		"jetpack-search": true,
+		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enable the 'Search' menu item in Jetpack Cloud (development environment only).

There's still a fair bit of work to prepare the section for production. This PR adds a feature flag and enables it in the dev environment as a basis for further improvements.

![image](https://user-images.githubusercontent.com/17325/119769120-fde42700-bf0d-11eb-91ec-70e2f5e15c1f.png)

#### Testing instructions
1. Run locally with `CALYPSO_ENV=jetpack-cloud-development yarn start` and map `jetpack.cloud.localhost` to 127.0.0.1 in your “hosts” file.
2. Visit http://jetpack.cloud.localhost:3000/ and ensure the 'Search' item is in the sidebar. Check that the Search page loads. There may be issues (button goes to wrong place, look and feel is wrong) but we'll sort these out in followup PRs.
3. Stop Calypso and restart with the regular environment (`yarn start`) and access via http://calypso.localhost:3000.
4. Visit the same section in Calypso blue via Jetpack > Search and ensure the experience is consistent.
