### PR TITLE
Plans: Ensure that the interval layout is used for all

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -29,8 +29,6 @@ import {
 	isPremiumPlan,
 	isBusinessPlan,
 	isEcommercePlan,
-	isWpComFreePlan,
-	isWpComMonthlyPlan,
 	planMatches,
 	TYPE_FREE,
 	TYPE_BLOGGER,
@@ -61,7 +59,7 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getTld } from 'calypso/lib/domains';
 import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/actions';
@@ -518,10 +516,7 @@ export default connect(
 		const siteId = get( props.site, [ 'ID' ] );
 		const currentPlan = getSitePlan( state, siteId );
 		const sitePlanSlug = currentPlan?.product_slug;
-		const eligibleForWpcomMonthlyPlans =
-			( isAtomicSite( state, siteId ) && sitePlanSlug === 'jetpack_free' ) ||
-			isWpComFreePlan( sitePlanSlug ) ||
-			isWpComMonthlyPlan( sitePlanSlug );
+		const eligibleForWpcomMonthlyPlans = isEligibleForWpComMonthlyPlan( state, siteId );
 
 		let customerType = chooseDefaultCustomerType( {
 			currentCustomerType: props.customerType,

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -100,17 +100,24 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	);
 };
 
-type IntervalTypeProps = Pick< Props, 'intervalType' | 'plans' | 'isInSignup' >;
+type IntervalTypeProps = Pick<
+	Props,
+	'intervalType' | 'plans' | 'isInSignup' | 'eligibleForWpcomMonthlyPlans'
+>;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const translate = useTranslate();
-	const { intervalType, isInSignup } = props;
+	const { intervalType, isInSignup, eligibleForWpcomMonthlyPlans } = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = intervalType === 'monthly' && isInSignup;
 	const maxDiscount = useMaxDiscount( props.plans );
+
+	if ( ! eligibleForWpcomMonthlyPlans ) {
+		return null;
+	}
 
 	return (
 		<IntervalTypeToggleWrapper

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -29,6 +29,7 @@ import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import {
 	getPlan,
@@ -176,6 +177,7 @@ export default connect( ( state ) => {
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
 	);
+	const sitePlanSlug = currentPlan?.productSlug;
 
 	return {
 		currentPlanIntervalType,
@@ -184,7 +186,9 @@ export default connect( ( state ) => {
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 		isEligibleForWpComMonthlyPlan:
-			isWpComMonthlyPlan( currentPlan?.productSlug ) || isWpComFreePlan( currentPlan?.productSlug ),
+			( isAtomicSite( state, selectedSiteId ) && sitePlanSlug === 'jetpack_free' ) ||
+			isWpComMonthlyPlan( sitePlanSlug ) ||
+			isWpComFreePlan( sitePlanSlug ),
 		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -29,14 +29,9 @@ import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import {
-	getPlan,
-	getIntervalTypeForTerm,
-	isWpComMonthlyPlan,
-	isWpComFreePlan,
-} from '@automattic/calypso-products';
+import { getPlan, getIntervalTypeForTerm } from '@automattic/calypso-products';
 import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 
 class Plans extends React.Component {
@@ -68,10 +63,10 @@ class Plans extends React.Component {
 	}
 
 	isInvalidPlanInterval() {
-		const { isEligibleForWpComMonthlyPlan, intervalType, selectedSite } = this.props;
+		const { isSiteEligibleForMonthlyPlan, intervalType, selectedSite } = this.props;
 		const isWpcomMonthly = intervalType === 'monthly';
 
-		return selectedSite && isWpcomMonthly && ! isEligibleForWpComMonthlyPlan;
+		return selectedSite && isWpcomMonthly && ! isSiteEligibleForMonthlyPlan;
 	}
 
 	redirectIfInvalidPlanInterval() {
@@ -177,7 +172,6 @@ export default connect( ( state ) => {
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
 	);
-	const sitePlanSlug = currentPlan?.productSlug;
 
 	return {
 		currentPlanIntervalType,
@@ -185,10 +179,7 @@ export default connect( ( state ) => {
 		selectedSite: getSelectedSite( state ),
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
-		isEligibleForWpComMonthlyPlan:
-			( isAtomicSite( state, selectedSiteId ) && sitePlanSlug === 'jetpack_free' ) ||
-			isWpComMonthlyPlan( sitePlanSlug ) ||
-			isWpComFreePlan( sitePlanSlug ),
+		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -19,6 +19,7 @@ import PopoverCart from 'calypso/my-sites/checkout/cart/popover-cart';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 class PlansNavigation extends React.Component {
@@ -133,9 +134,10 @@ export default connect( ( state ) => {
 	const site = getSite( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isOnFreePlan = isSiteOnFreePlan( state, siteId );
+	const isAtomic = isAtomicSite( state, siteId );
 	return {
 		isJetpack,
-		shouldShowMyPlan: ! isOnFreePlan || isJetpack,
+		shouldShowMyPlan: ! isOnFreePlan || ( isJetpack && ! isAtomic ),
 		site,
 	};
 } )( localize( PlansNavigation ) );

--- a/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
+++ b/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import { createSelector } from '@automattic/state-utils';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { isWpComMonthlyPlan, isWpComFreePlan } from '@automattic/calypso-products';
+/**
+ * Return true if the site is eligible for a monthly plan on WPCOM.
+ *
+ * @param {object} state the global state tree
+ * @param {number} siteId the ID of the site to check.
+ * @returns {boolean} Whether the site is eligible for a monthly plan.
+ */
+export default createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		const currentPlanSlug = getCurrentPlan( state, siteId )?.productSlug;
+
+		return (
+			( isAtomicSite( state, siteId ) && currentPlanSlug === 'jetpack_free' ) ||
+			isWpComMonthlyPlan( currentPlanSlug ) ||
+			isWpComFreePlan( currentPlanSlug )
+		);
+	},
+	( state, siteId = getSelectedSiteId( state ) ) => [
+		isAtomicSite( state, siteId ),
+		getCurrentPlan( state, siteId ),
+	]
+);

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -28,13 +28,6 @@ export default class PlansPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, locator );
 	}
 
-	async openAdvancedPlansSegment() {
-		const locator = By.css(
-			'.plans-features-main ul.segmented-control.is-primary.plan-features__interval-type.is-customer-type-toggle li:nth-child(2)'
-		);
-		return await driverHelper.clickWhenClickable( this.driver, locator );
-	}
-
 	async waitForComparison() {
 		const plansPageMainCssClass =
 			host === 'WPCOM' ? '.plans-features-main__group' : '.selector__main';

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
@@ -41,9 +41,6 @@ describe( `[${ host }] Plans - Viewing: (${ screenSize }) @parallel @jetpack`, f
 	it( 'Compare plans', async function () {
 		const plansPage = await PlansPage.Expect( this.driver );
 		await plansPage.openPlansTab();
-		if ( host === 'WPCOM' ) {
-			await plansPage.openAdvancedPlansSegment();
-		}
 		return await plansPage.waitForComparison();
 	} );
 


### PR DESCRIPTION
We have been using two layouts for the plans page, the 'interval' layout
allowing people to view plans by month or year, and a 'customer' layout,
which displayed plans according to customer type.

When monthly plans were not available, we were defaulting to the
customer view. This would be all sites that are currently on an annual
plan, and also Atomic lapsed sites, because of the way they report
themselves as being on a `jetpack_free` plan.

#### Changes proposed in this Pull Request

This change still allows for the 'customer' layout to be used, but
defaults to using the 'interval' view for all sites. As monthly plans
aren't available to people currently on an annual plan, that option is
hidden for those sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With a free site, goto `/plans`
* You should see all plans with the option to buy monthly or annually
* Buy an annual plan
* Go back to the plans screen. With this change, you will be shown the annual plans but no monthly option, without this change you will be shown the 'customer' view with plans split by customer type
* With an Atomic site without a plan, and using this branch, this should function the same as for simple sites
* Jetpack sites should continue to function as before.

New view after purchasing a plan

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/96462/119790383-c9e81200-becb-11eb-9d00-5f8151e77a2b.png">

An Atomic site without a plan, but with this change:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/96462/119790588-f7cd5680-becb-11eb-93fa-6bf43c8ed06a.png">

How an Atomic site without a plan looks currently:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/96462/119790745-14698e80-becc-11eb-84ae-8ed32da09888.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #51823
