### PR TITLE
Design Picker - Blank Canvas: Flip is_alpha switch

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -433,7 +433,6 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": false,
-			"is_alpha": false,
 			"features": []
 		},
 		{

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -433,7 +433,7 @@
 			"categories": [ "featured" ],
 			"is_premium": false,
 			"is_fse": false,
-			"is_alpha": true,
+			"is_alpha": false,
 			"features": []
 		},
 		{


### PR DESCRIPTION
### Changes proposed in this Pull Request
In order to release the blank canvas design in production, we have to remove its alpha status. In this PR, we do exactly that.

### Technical changes
* switch `is_alpha` prop in `available-designs-config.json` from `false` to `true`.

### Testing instructions
Video: https://www.loom.com/share/c823cd6243c14beab8266bd28f2ddbaa

#### Old
* Navigate to https://wordpress.com/new/design 
* [x] The blank canvas design shouldn't be available/visible in the list of designs.

#### New
* Navigate to https://hash-1bdebf29d25f0ee733cab308be60f2bbe383b3cf.calypso.live/new/design
* [x] Validate that the blank canvas design is available in the list of designs


Fixes #53217
