### PR TITLE
Comments: use Calypso comment links even for Jetpack sites

### DIFF
--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -19,7 +19,6 @@ import Emojify from 'calypso/components/emojify';
 import QueryComment from 'calypso/components/data/query-comment';
 import { stripHTML, decodeEntities } from 'calypso/lib/formatting';
 import { getParentComment, getSiteComment } from 'calypso/state/comments/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export class CommentContent extends Component {
@@ -118,7 +117,6 @@ export class CommentContent extends Component {
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
-	const isJetpack = isJetpackSite( state, siteId );
 
 	const comment = getSiteComment( state, siteId, commentId );
 	const postId = get( comment, 'post.ID' );
@@ -127,14 +125,11 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const parentCommentId = get( comment, 'parent.ID', 0 );
 	const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );
 
-	const parentCommentUrl = isJetpack
-		? get( parentComment, 'URL' )
-		: `/comment/${ siteSlug }/${ parentCommentId }`;
+	const parentCommentUrl = `/comment/${ siteSlug }/${ parentCommentId }`;
 
 	return {
 		commentContent: get( comment, 'content' ),
 		commentStatus: get( comment, 'status' ),
-		isJetpack,
 		isParentCommentLoaded: ! parentCommentId || !! parentCommentContent,
 		parentCommentContent,
 		parentCommentId,


### PR DESCRIPTION
Fixes a regression introduced a long time in this commit that removes the `comments/management/comment-view feature` feature flag:

https://github.com/Automattic/wp-calypso/commit/3d085b0bb000a066ae0ffe7b3df3a966411918fb#diff-1d6d1a285110a4bfa3111ed34eb5c1966cd7905b18a4311d5e04da5c6c8714b0L132

Note that the `comments/management/comment-view` feature flag is always true, so the `else` branches, including the isJetpack one, should be removed. But the `isJetpack` one wasn't removed. Removing it now. The `parentCommentUrl` value has only one version.

Spinoff from #53042.