### PR TITLE
Don't show 'Add' button for email when user can't add email for a domain

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -43,7 +43,7 @@ import Spinner from 'calypso/components/spinner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -295,6 +295,7 @@ class DomainItem extends PureComponent {
 
 		if ( hasGSuiteWithUs( domainDetails ) ) {
 			const gSuiteMailboxCount = getGSuiteMailboxCount( domainDetails );
+
 			return translate( '%(gSuiteMailboxCount)d mailbox', '%(gSuiteMailboxCount)d mailboxes', {
 				count: gSuiteMailboxCount,
 				args: {
@@ -306,6 +307,7 @@ class DomainItem extends PureComponent {
 
 		if ( hasTitanMailWithUs( domainDetails ) ) {
 			const titanMailboxCount = getMaxTitanMailboxCount( domainDetails );
+
 			return translate( '%(titanMailboxCount)d mailbox', '%(titanMailboxCount)d mailboxes', {
 				args: {
 					titanMailboxCount,
@@ -316,10 +318,12 @@ class DomainItem extends PureComponent {
 		}
 
 		if ( hasEmailForwards( domainDetails ) ) {
+			const emailForwardsCount = getEmailForwardsCount( domainDetails );
+
 			return translate( '%(emailForwardsCount)d forward', '%(emailForwardsCount)d forwards', {
-				count: domainDetails.emailForwardsCount,
+				count: emailForwardsCount,
 				args: {
-					emailForwardsCount: domainDetails.emailForwardsCount,
+					emailForwardsCount,
 				},
 				comment: 'The number of email forwards active for the current domain',
 			} );

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -23,10 +23,11 @@ import { withoutHttp } from 'calypso/lib/url';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { handleRenewNowClick } from 'calypso/lib/purchases';
 import {
-	resolveDomainStatus,
+	canCurrentUserAddEmail,
 	isDomainInGracePeriod,
 	isDomainUpdateable,
 	getDomainTypeText,
+	resolveDomainStatus,
 } from 'calypso/lib/domains';
 import InfoPopover from 'calypso/components/info-popover';
 import { emailManagement } from 'calypso/my-sites/email/paths';
@@ -42,6 +43,7 @@ import Spinner from 'calypso/components/spinner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -313,7 +315,7 @@ class DomainItem extends PureComponent {
 			} );
 		}
 
-		if ( domainDetails?.emailForwardsCount > 0 ) {
+		if ( hasEmailForwards( domainDetails ) ) {
 			return translate( '%(emailForwardsCount)d forward', '%(emailForwardsCount)d forwards', {
 				count: domainDetails.emailForwardsCount,
 				args: {
@@ -321,6 +323,10 @@ class DomainItem extends PureComponent {
 				},
 				comment: 'The number of email forwards active for the current domain',
 			} );
+		}
+
+		if ( ! canCurrentUserAddEmail( domainDetails ) ) {
+			return this.renderMinus();
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a check to the domain listing page to prevent us showing the "Add" button in the email column of the domain listing page when the user isn't allowed to add email for that domain 

#### Testing instructions

* Run this branch locally or access it via the [live branch](https://calypso.live/?branch=fix/email-permission-check-in-domain-list-page)
* For a site with one or more domains that don't have email, navigate to Upgrades -> Domains
* Verify that you don't see the "Add" button in the email column for any domains you're not allowed to add email for
   -  The easiest way to do this is by enabling store sandbox mode, as we show many of the domains, but don't permit adding email for them

#### Screenshot

<img width="1053" alt="Screenshot 2021-06-02 at 09 49 46" src="https://user-images.githubusercontent.com/3376401/120444534-feeedb80-c387-11eb-873b-1fbeea0243c0.png">
