### PR TITLE
Jetpack Connect: Refactor away from `lib/user` in route definitions

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -20,7 +20,7 @@ import NoDirectAccessError from './no-direct-access-error';
 import OrgCredentialsForm from './remote-credentials';
 import SearchPurchase from './search';
 import StoreHeader from './store-header';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath } from 'calypso/lib/i18n-utils';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
@@ -357,5 +357,27 @@ export function sso( context, next ) {
 			ssoNonce={ context.params.ssoNonce }
 		/>
 	);
+	next();
+}
+
+export function authorizeOrSignup( context, next ) {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
+	if ( isLoggedIn ) {
+		authorizeForm( context, next );
+		return;
+	}
+
+	signupForm( context, next );
+}
+
+export function redirectToLoginIfLoggedOut( context, next ) {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
+	if ( ! isLoggedIn ) {
+		page( login( { isNative: true, isJetpack: true, redirectTo: context.path } ) );
+		return;
+	}
+
 	next();
 }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -375,7 +375,7 @@ export function redirectToLoginIfLoggedOut( context, next ) {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 
 	if ( ! isLoggedIn ) {
-		page( login( { isNative: true, isJetpack: true, redirectTo: context.path } ) );
+		page( login( { isJetpack: true, redirectTo: context.path } ) );
 		return;
 	}
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -88,13 +88,9 @@ export default function () {
 			page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
 
-	page(
-		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
-		controller.redirectToLoginIfLoggedOut
-	);
-
 	jetpackPlans(
 		`/jetpack/connect/plans`,
+		controller.redirectToLoginIfLoggedOut,
 		siteSelection,
 		controller.offerResetRedirects,
 		controller.offerResetContext

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -7,9 +7,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import userFactory from 'calypso/lib/user';
 import * as controller from './controller';
-import { login } from 'calypso/lib/paths';
 import { siteSelection } from 'calypso/my-sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
@@ -23,8 +21,6 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import './style.scss';
 
 export default function () {
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
 	const locale = getLanguageRouteParam( 'locale' );
 
 	const planTypeString = [
@@ -67,24 +63,14 @@ export default function () {
 		clientRender
 	);
 
-	if ( isLoggedOut ) {
-		page(
-			`/jetpack/connect/authorize/${ locale }`,
-			controller.setMasterbar,
-			controller.signupForm,
-			makeLayout,
-			clientRender
-		);
-	} else {
-		page(
-			`/jetpack/connect/authorize/${ locale }`,
-			controller.redirectWithoutLocaleIfLoggedIn,
-			controller.setMasterbar,
-			controller.authorizeForm,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		`/jetpack/connect/authorize/${ locale }`,
+		controller.redirectWithoutLocaleIfLoggedIn,
+		controller.setMasterbar,
+		controller.authorizeOrSignup,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/jetpack/connect/instructions',
@@ -102,11 +88,10 @@ export default function () {
 			page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
 
-	if ( isLoggedOut ) {
-		page( '/jetpack/connect/plans/:interval(yearly|monthly)?/:site', ( { path } ) =>
-			page( login( { isJetpack: true, redirectTo: path } ) )
-		);
-	}
+	page(
+		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
+		controller.redirectToLoginIfLoggedOut
+	);
 
 	jetpackPlans(
 		`/jetpack/connect/plans`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In Jetpack Connect, we rely on `lib/user` to declare a couple of routes conditionally, based on whether the user is logged in or  not:
  * Authorization - whether to show the authorization form or the signup form
  * Plans - whether to redirect to the login page

This PR removes the logic from the route definition part and moves it to the actual controllers. On one side, this makes it more reliable because at that later point we can determine with a greater chance whether the user is logged in if the request was loading. On the other hand, this reduces unnecessary indirection and ambiguity when declaring the routes. 

This PR is part of #24004 where we aim to reduxify `lib/user`.

I'd love some help from @Automattic/jetpack-voyager to test this and make sure we're not breaking anything in the Jetpack flows 😅 

#### Testing instructions

* As a logged-in user, go to `/jetpack/connect/plans/:site` where `:site` is a connected site. Verify you're seeing the plans page.
* As a logged-out user, go to `/jetpack/connect/plans/:site`. Verify you are redirected to the Jetpack login page.
* Verify that going to `/jetpack/connect/plans` or `/jetpack/connect/plans/yearly` or `/jetpack/connect/plans/monthly`, regardless of being logged in or out, redirects you to `/jetpack/connect/store` and preserves the billing interval, if any.
* Go to `/jetpack/connect/authorize/es` and verify it works the same as before (displaying an error message)
* Go to `/jetpack/connect/authorize/es?client_id=123123&site=example.com&nonce=nonce&secret=1&_wp_nonce=something&blogname=something&home_url=something&redirect_uri=something&scope=something&secret=something&site=something&site_url=something&state=something&debug` and verify it still renders the signup form.
* Try the last 2 steps without a locale (the `/es` part)
* Verify the connection flow through Jetpack Connect , particularly the authorization step still works. To test that, you can spawn a new JN site (https://jurassic.ninja/create) and input it at `/jetpack/connect` to begin with. Verify you can finish authorization without errors and you're led to the plans page after that.