### PR TITLE
Calypso Config: Disable gutenboarding/alpha-templates feature flag 

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"gutenboarding/alpha-templates": true,
+		"gutenboarding/alpha-templates": false,
 		"gutenboarding/show-vertical-input": false,
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -54,7 +54,7 @@
 		"gutenboarding/mshot-preview": true,
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/long-previews": true,
-		"gutenboarding/alpha-templates": true,
+		"gutenboarding/alpha-templates": false,
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request
Disable the `gutenboarding/alpha-templates` feature flag from development environments and leave Horizon for beta testing.
 
### Technical changes
* switch `gutenboarding/alpha-templates` feature flag prop in `development.json` and `wpcalypso.json` from _true_ to _false_.

### Testing instructions

#### Control
1. Navigate to https://hash-8beec845a383ec962050e4b9d1adaa9bd164040b.calypso.live/new/design?flags=gutenboarding/alpha-templates
2. Confirm that:
     * [ ] Coutoire design is available in the list of designs.
3. Navigate to https://hash-8beec845a383ec962050e4b9d1adaa9bd164040b.calypso.live/new/design
4. Confirm that:
     * [ ] Coutoire design is **NOT** available in the list of designs.

Fixes #53226 