### PR TITLE
Rename `calypso_jetpack_product_click` tracking event

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -127,9 +127,9 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		if ( purchase && isUpgradeableToYearly ) {
 			// Name of `calypso_product_checkout_click` is misleading, since it's only triggered
 			// for Jetpack products. Leaving it here to not break current analysis, but please
-			// use `calypso_jetpack_product_click` instead when using tracking tools.
+			// use `calypso_jetpack_pricing_page_product_click` instead when using tracking tools.
 			dispatch( recordTracksEvent( 'calypso_product_checkout_click', trackingProps ) );
-			dispatch( recordTracksEvent( 'calypso_jetpack_product_click', trackingProps ) );
+			dispatch( recordTracksEvent( 'calypso_jetpack_pricing_page_product_click', trackingProps ) );
 
 			const { productSlug: slug } = product;
 			const yearlySlug = getYearlySlugFromMonthly( slug );
@@ -148,9 +148,9 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 
 		// Name of `calypso_product_checkout_click` is misleading, since it's only triggered
 		// for Jetpack products. Leaving it here to not break current analysis, but please
-		// use `calypso_jetpack_product_click` instead when using tracking tools.
+		// use `calypso_jetpack_pricing_page_product_click` instead when using tracking tools.
 		dispatch( recordTracksEvent( 'calypso_product_checkout_click', trackingProps ) );
-		dispatch( recordTracksEvent( 'calypso_jetpack_product_click', trackingProps ) );
+		dispatch( recordTracksEvent( 'calypso_jetpack_pricing_page_product_click', trackingProps ) );
 		checkout( siteSlug, product.productSlug, urlQueryArgs );
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR renames the tracking event `calypso_jetpack_product_click` to `calypso_jetpack_pricing_page_product_click`, which provides better context (that's important for the registration process).

Original event was introduced in #53193.

### Implementation notes

`calypso_jetpack_product_click` was introduced a couple of days ago and never publicized. It's safe to replace it altogether.

### Testing instructions

- Download the PR and run Calypso or cloud
- Make sure you can see tracking events in the dev tools

#### Cloud

- Visit `/pricing` and click on any product card
- Check that `calypso_jetpack_pricing_page_product_click` was dispatched

#### Calypso

- Visit `/plans/:site` and click on any product card
- Check that `calypso_jetpack_pricing_page_product_click` was dispatched

