### PR TITLE
Allow only non WPCOM accounts to be edited.

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -77,22 +77,29 @@ class EditUserForm extends React.Component {
 	}
 
 	getAllowedSettingsToChange() {
-		const { currentUser, user, isJetpack } = this.props;
+		const { currentUser, user, isJetpack, hasWPCOMAccountLinked } = this.props;
 		const allowedSettings = [];
 
 		if ( ! user.ID ) {
 			return allowedSettings;
 		}
 
-		// On WP.com sites, a user should only be able to update role.
-		// A user should not be able to update own role.
+		// On any site, admins should be able to change only other
+		// user's role or isExternalContributor.
 		if ( isJetpack ) {
+			// Jetpack self hosted or Atomic.
 			if ( ! user.linked_user_ID || user.linked_user_ID !== currentUser.ID ) {
 				allowedSettings.push( 'roles', 'isExternalContributor' );
 			}
-			allowedSettings.push( 'first_name', 'last_name', 'name' );
 		} else if ( user.ID !== currentUser.ID ) {
+			// WP.com Simple sites.
 			allowedSettings.push( 'roles', 'isExternalContributor' );
+		}
+
+		// On any site, allow editing 'first_name', 'last_name', 'name'
+		// only for users without WP.com account.
+		if ( ! hasWPCOMAccountLinked ) {
+			allowedSettings.push( 'first_name', 'last_name', 'name' );
 		}
 
 		return allowedSettings;
@@ -249,16 +256,27 @@ class EditUserForm extends React.Component {
 			return null;
 		}
 
+		const { translate, hasWPCOMAccountLinked, disabled, markChanged, isUpdating } = this.props;
+
 		return (
 			<form
 				className="edit-team-member-form__form" // eslint-disable-line
-				disabled={ this.props.disabled }
+				disabled={ disabled }
 				onSubmit={ this.updateUser }
-				onChange={ this.props.markChanged }
+				onChange={ markChanged }
 			>
-				{ editableFields.map( ( fieldId ) => this.renderField( fieldId, this.props.isUpdating ) ) }
+				{ editableFields.map( ( fieldId ) => this.renderField( fieldId, isUpdating ) ) }
+				{ hasWPCOMAccountLinked && (
+					<p className="edit-team-member-form__explanation">
+						{ translate(
+							'This user has a WordPress.com account, ' +
+								'they can change their First Name, Last Name, Display Name that ' +
+								'is also shown in your site through their WordPress.com profile settings.'
+						) }
+					</p>
+				) }
 				<FormButtonsBar>
-					<FormButton disabled={ ! this.hasUnsavedSettings() || this.props.isUpdating }>
+					<FormButton disabled={ ! this.hasUnsavedSettings() || isUpdating }>
 						{ this.props.translate( 'Save changes', {
 							context: 'Button label that prompts user to save form',
 						} ) }
@@ -280,6 +298,7 @@ export default localize(
 				isExternalContributor: userId && externalContributors.includes( userId ),
 				isVip: isVipSite( state, siteId ),
 				isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
+				hasWPCOMAccountLinked: user?.linked_user_ID !== false,
 			};
 		},
 		{

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -269,9 +269,7 @@ class EditUserForm extends React.Component {
 				{ hasWPCOMAccountLinked && (
 					<p className="edit-team-member-form__explanation">
 						{ translate(
-							'This user has a WordPress.com account, ' +
-								'they can change their First Name, Last Name, Display Name that ' +
-								'is also shown in your site through their WordPress.com profile settings.'
+							'This user has a WordPress.com account, only they are allowed to update their personal information through their WordPress.com profile settings.'
 						) }
 					</p>
 				) }

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -9,3 +9,7 @@
 		margin-bottom: 0;
 	}
 }
+
+.edit-team-member-form__explanation {
+	color: var( --color-neutral-light );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
As discussed here, WordPress.com account data (**First Name**, **Last Name**, **Display Name**) should not be editable from admins in Calypso. They should be editable only from each WordPress.com user respective [https://wordpress.com/me](https://wordpress.com/me) - this path will be fixed here D61970-code for Atomic. This is already happening for Simple sites, with this diff we bring parity for Atomic (& Jetpack) sites too.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to [https://wordpress.com/people/team/](https://wordpress.com/people/team/) for each of the following scenarios and try to edit **First Name**, **Last Name**, **Display Name** for the current and another user. 

**Simple Sites**
- The fields shouldn't appear for any user 
- Nothing should have changed, check for regressions

**Atomic Sites**
- The fields shouldn't appear for WordPress.com linked users
- The fields **should** appear for local created users through `/wp-admin/user-new.php`

**Jetpack Sites**
- Same as atomic 
- Be ware that even a user may have been invited through WordPress.com to that site their info won't be editable if they don't explicit connect their account to WordPress.com
![](https://cln.sh/ag8Xnq+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Before | After
-------|------
![](https://cln.sh/qKJTgW+) | ![](https://cln.sh/TI1s7J+)

Related to https://github.com/Automattic/wp-calypso/issues/46077