### PR TITLE
desktop: fix window and view references

### DIFF
--- a/desktop/app/lib/platform/linux/index.js
+++ b/desktop/app/lib/platform/linux/index.js
@@ -8,8 +8,14 @@ const { app } = require( 'electron' );
  */
 const log = require( '../../../lib/logger' )( 'platform:linux' );
 
-function LinuxPlatform( { window } ) {
-	this.window = window;
+/**
+ *
+ * Module variables
+ */
+let window;
+
+function LinuxPlatform( appWindow ) {
+	window = appWindow.window;
 
 	app.on( 'activate', function () {
 		log.info( 'Window activated' );
@@ -28,11 +34,11 @@ function LinuxPlatform( { window } ) {
 }
 
 LinuxPlatform.prototype.restore = function () {
-	if ( this.window.isMinimized() ) {
-		this.window.restore();
+	if ( window.isMinimized() ) {
+		window.restore();
 	}
 
-	this.window.show();
+	window.show();
 };
 
 LinuxPlatform.prototype.showNotificationsBadge = function ( count ) {

--- a/desktop/app/lib/platform/mac/index.js
+++ b/desktop/app/lib/platform/mac/index.js
@@ -10,19 +10,18 @@ const appQuit = require( '../../../lib/app-quit' );
 const menuSetter = require( '../../../lib/menu-setter' );
 const log = require( '../../../lib/logger' )( 'platform:mac' );
 
-function MacPlatform( appWindow ) {
-	this.window = appWindow.window;
-	this.dockMenu = Menu.buildFromTemplate( require( './dock-menu' )( app, appWindow ) );
+let window;
+let dockMenu;
 
-	app.dock.setMenu( this.dockMenu );
+function MacPlatform( appWindow ) {
+	window = appWindow.window;
+	dockMenu = Menu.buildFromTemplate( require( './dock-menu' )( app, appWindow ) );
+
+	app.dock.setMenu( dockMenu );
 
 	app.on( 'activate', function () {
-		log.info( 'Window activated' );
-
-		if ( this.window ) {
-			this.window.show();
-			this.window.focus();
-		}
+		window.show();
+		window.focus();
 	} );
 
 	app.on( 'window-all-closed', function () {
@@ -36,22 +35,22 @@ function MacPlatform( appWindow ) {
 		appQuit.allowQuit();
 	} );
 
-	this.window.on( 'close', function ( ev ) {
+	window.on( 'close', function ( ev ) {
 		if ( appQuit.shouldQuitToBackground() ) {
 			log.info( `User clicked 'close': hiding main window...` );
 			ev.preventDefault();
-			this.window.hide();
+			window.hide();
 			appWindow.view.webContents.send( 'notifications-panel-show', false );
 		}
 	} );
 }
 
 MacPlatform.prototype.restore = function () {
-	if ( this.window.isMinimized() ) {
-		this.window.restore();
+	if ( window.isMinimized() ) {
+		window.restore();
 	}
 
-	this.window.show();
+	window.show();
 };
 
 MacPlatform.prototype.showNotificationsBadge = function ( count, bounce ) {
@@ -73,7 +72,7 @@ MacPlatform.prototype.clearNotificationsBadge = function () {
 };
 
 MacPlatform.prototype.setDockMenu = function ( enabled ) {
-	menuSetter.setRequiresUser( this.dockMenu, enabled );
+	menuSetter.setRequiresUser( dockMenu, enabled );
 };
 
 module.exports = MacPlatform;

--- a/desktop/app/lib/platform/windows/index.js
+++ b/desktop/app/lib/platform/windows/index.js
@@ -21,22 +21,27 @@ const TRAY_SETTING = 'win_tray';
 const TRAY_NO_NOTIFICATION = '-tray-icon.ico';
 const TRAY_NOTIFICATION = '-tray-icon-notification.ico';
 
-function WindowsPlatform( { view, window } ) {
-	this.window = window;
-	this.view = view;
-	this.trayMenu = Menu.buildFromTemplate( windowsTrayMenu( this.restore.bind( this ) ) );
-	this.tray = new Tray( this.getIcon( TRAY_NO_NOTIFICATION ) );
+let window;
+let view;
+let trayMenu;
+let tray;
 
-	this.tray.setToolTip( 'WordPress.com' );
-	this.tray.setContextMenu( this.trayMenu );
-	this.tray.on( 'click', this.restore.bind( this ) );
+function WindowsPlatform( appWindow ) {
+	window = appWindow.window;
+	view = appWindow.view;
+	trayMenu = Menu.buildFromTemplate( windowsTrayMenu( this.restore.bind( this ) ) );
+	tray = new Tray( this.getIcon( TRAY_NO_NOTIFICATION ) );
+
+	tray.setToolTip( 'WordPress.com' );
+	tray.setContextMenu( trayMenu );
+	tray.on( 'click', this.restore.bind( this ) );
 
 	window.on( 'close', this.onClosed.bind( this ) );
 
 	app.on( 'before-quit', function () {
 		log.info( "Responding to app event 'before-quit', destroying tray" );
-		if ( this.tray ) {
-			this.tray.destroy();
+		if ( tray ) {
+			tray.destroy();
 		}
 	} );
 }
@@ -47,8 +52,8 @@ WindowsPlatform.prototype.onClosed = function ( ev ) {
 
 		ev.preventDefault();
 
-		this.window.hide();
-		this.view.webContents.send( 'notifications-panel-show', false );
+		window.hide();
+		view.webContents.send( 'notifications-panel-show', false );
 		this.showBackgroundBubble();
 
 		return;
@@ -64,7 +69,7 @@ WindowsPlatform.prototype.showBackgroundBubble = function () {
 
 		Settings.saveSetting( TRAY_SETTING, true );
 
-		this.tray.displayBalloon( {
+		tray.displayBalloon( {
 			icon: assets.getPath( 'windows-tray-bubble.png' ),
 			title: 'WordPress.com',
 			content: "We've minimized WordPress.com to your tray. Click on the icon to restore it.",
@@ -73,7 +78,7 @@ WindowsPlatform.prototype.showBackgroundBubble = function () {
 };
 
 WindowsPlatform.prototype.restore = function () {
-	this.window.show();
+	window.show();
 };
 
 WindowsPlatform.prototype.getIcon = function ( filename ) {
@@ -81,15 +86,15 @@ WindowsPlatform.prototype.getIcon = function ( filename ) {
 };
 
 WindowsPlatform.prototype.showNotificationsBadge = function () {
-	this.tray.setImage( this.getIcon( TRAY_NOTIFICATION ) );
+	tray.setImage( this.getIcon( TRAY_NOTIFICATION ) );
 };
 
 WindowsPlatform.prototype.clearNotificationsBadge = function () {
-	this.tray.setImage( this.getIcon( TRAY_NO_NOTIFICATION ) );
+	tray.setImage( this.getIcon( TRAY_NO_NOTIFICATION ) );
 };
 
 WindowsPlatform.prototype.setDockMenu = function ( enabled ) {
-	menuSetter.setRequiresUser( this.trayMenu, enabled );
+	menuSetter.setRequiresUser( trayMenu, enabled );
 };
 
 module.exports = WindowsPlatform;


### PR DESCRIPTION
### Description

References to `this.window.<FUNCTION>` would cause a crash for some reason as `this.window` would resolve as `undefined`. This PR movies `window` and other app component references within the `Platform` functions to module-level variables.