### PR TITLE
Jetpack Thank you: include paragraph for users going through the logged-out checkout flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
@@ -22,6 +22,7 @@ import Main from 'calypso/components/main';
 interface Props {
 	site: number | string;
 	productSlug: string | 'no_product';
+	isUserlessCheckoutFlow: boolean;
 }
 
 const getRequestUnauthorizedSiteId = ( siteId: string | number ): string =>
@@ -49,6 +50,7 @@ const requestUnauthorizedSite = ( siteId: string | number ) =>
 const JetpackCheckoutThankYou: FunctionComponent< Props > = ( {
 	site: siteFragment,
 	productSlug,
+	isUserlessCheckoutFlow = false,
 } ) => {
 	const translate = useTranslate();
 
@@ -101,6 +103,19 @@ const JetpackCheckoutThankYou: FunctionComponent< Props > = ( {
 						} ) }
 					</p>
 				) }
+
+				{ isUserlessCheckoutFlow && (
+					<p
+						className={
+							isLoading
+								? 'jetpack-checkout-thank-you__email-message-loading'
+								: 'jetpack-checkout-thank-you__email-message'
+						}
+					>
+						{ translate( 'We sent you an email with your receipt and further instructions.' ) }
+					</p>
+				) }
+
 				{ ( isLoading || ( siteName && siteUrl ) ) && (
 					<Button
 						className="jetpack-checkout-thank-you__button"

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -705,6 +705,12 @@
 			margin-bottom: 64px;
 		}
 
+		.jetpack-checkout-thank-you__email-message-loading,
+		.jetpack-checkout-thank-you__email-message {
+			margin-top: -32px;
+			margin-bottom: 64px;
+		}
+
 		.jetpack-checkout-thank-you__button,
 		.jetpack-checkout-thank-you__button:visited {
 			border-radius: 4px;
@@ -730,7 +736,8 @@
 		}
 	}
 
-	.jetpack-checkout-thank-you__sub-message-loading {
+	.jetpack-checkout-thank-you__sub-message-loading,
+	.jetpack-checkout-thank-you__email-message-loading {
 		@include placeholder( --color-neutral-30 );
 	}
 }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -282,8 +282,14 @@ export function redirectToSupportSession( context ) {
 }
 
 export function jetpackCheckoutThankYou( context, next ) {
+	const isUserlessCheckoutFlow = context.path.includes( '/checkout/jetpack' );
+
 	context.primary = (
-		<JetpackCheckoutThankYou site={ context.params.site } productSlug={ context.params.product } />
+		<JetpackCheckoutThankYou
+			site={ context.params.site }
+			productSlug={ context.params.product }
+			isUserlessCheckoutFlow={ isUserlessCheckoutFlow }
+		/>
 	);
 
 	next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to 1200152453830945-as-1200386304452705

* Users going through the new logged-out checkout flow should be explained that they need to go to their inbox in order to complete the account creation process.

#### Implementation notes

Instead of directly adding the new paragraph in the component, I decided to add the `isUserlessCheckoutFlow` prop to decide whether the message should be displayed. I did this because I anticipate that we are going to use the same Thank you page in the future for all Jetpack purchase flow, and not just this one. The rest of the flows don't need this message since those flows don't consider the creation of an account.

#### Testing instructions

* Download this PR and start Calypso Blue with `yarn start`.
* Visit `http://calypso.localhost:3000/checkout/jetpack/thank-you/[site]/jetpack_complete` replacing `[site]` with a site slug of a site you own.

#### Demo – before
![image](https://user-images.githubusercontent.com/3418513/119879568-5fe66180-bef9-11eb-8d81-999f289feb6e.png)

#### Demo – after
![image](https://user-images.githubusercontent.com/3418513/119879122-ddf63880-bef8-11eb-94d6-ac4c2a574273.png)