### PR TITLE
Reader: Fix Users Being Unable to Add Site to a List

### DIFF
--- a/client/reader/list-manage/feed-url-adder.jsx
+++ b/client/reader/list-manage/feed-url-adder.jsx
@@ -43,7 +43,7 @@ export default function FeedUrlAdder( { list, query } ) {
 									list.ID,
 									list.owner,
 									list.slug,
-									addSchemeIfMissing( query, 'https' )
+									addSchemeIfMissing( queryWithoutProtocol, 'http' )
 							  )
 							: deleteReaderListFeed(
 									list.ID,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes users being unable to add a site to a list.

The basic problem is that the API doesn't accept a `https://...` URL, but expects a `http://...` URL instead. I did wonder if this should be the case, but looking at #47127, I think that it's intentional and this was probably caused by a typo. Because of this, it's also failing when just the slug is provided. `queryWithoutProtocol` should also be used instead of `query` in case the user enters a full URL with `https://`.

#### Testing instructions

Visit `/read/list/new` and verify it's possible to add a site with these formats:

- example.com
- https://example.com
- http://example.com

<img width="1222" alt="Screenshot 2021-05-27 at 22 21 24" src="https://user-images.githubusercontent.com/43215253/119899154-ac05c600-bf3a-11eb-93c1-dabd7b456153.png">

cc @jsnmoon, @bluefuton 

Fixes #52444
May be related to #47830