### PR TITLE
Search: always hide footer in Jetpack Cloud

### DIFF
--- a/client/my-sites/jetpack-search/footer.tsx
+++ b/client/my-sites/jetpack-search/footer.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, Fragment } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+
+export default function JetpackSearchFooter(): ReactElement {
+	const siteId = useSelector( getSelectedSiteId );
+	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+	const isCloud = isJetpackCloud();
+
+	// Don't display this footer in Jetpack Cloud or for non-WordPress.com sites
+	if ( isCloud || ! isWPCOM ) {
+		return null;
+	}
+
+	return (
+		<Fragment>
+			<WhatIsJetpack />
+		</Fragment>
+	);
+}

--- a/client/my-sites/jetpack-search/footer.tsx
+++ b/client/my-sites/jetpack-search/footer.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -23,7 +23,6 @@ import {
 } from 'calypso/state/ui/selectors';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import JetpackSearchUpsell from './upsell';
 import JetpackSearchPlaceholder from './placeholder';
 import { isJetpackSearch, planHasJetpackSearch } from '@automattic/calypso-products';
@@ -31,7 +30,7 @@ import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import JetpackSearchFooter from './footer';
 
 /**
  * Asset dependencies
@@ -51,7 +50,6 @@ export default function JetpackSearchMain(): ReactElement {
 		sitePurchases.find( checkForSearchProduct ) || planHasJetpackSearch( site?.plan?.product_slug );
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	const onSettingsClick = useTrackCallback( undefined, 'calypso_jetpack_search_settings' );
-	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 
 	if ( ! hasLoadedSitePurchases ) {
 		return <JetpackSearchPlaceholder siteId={ siteId } />;
@@ -102,7 +100,7 @@ export default function JetpackSearchMain(): ReactElement {
 				/>
 			</PromoCard>
 
-			{ isWPCOM && <WhatIsJetpack /> }
+			<JetpackSearchFooter />
 		</Main>
 	);
 }

--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -17,7 +17,7 @@ import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackSearchFooter from './footer';
 
 /**
  * Asset dependencies
@@ -68,7 +68,7 @@ export default function JetpackSearchUpsell(): ReactElement {
 				/>
 			</PromoCard>
 
-			<WhatIsJetpack />
+			<JetpackSearchFooter />
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On WordPress.com, we show a 'What is Jetpack?' footer in the Jetpack Search section. We never want to show this in Jetpack Cloud. This PR refactors the footer and ensures it is hidden for Cloud.

 No footer in Cloud:
<img width="738" alt="Screen Shot 2021-05-28 at 14 36 43" src="https://user-images.githubusercontent.com/17325/119921689-8de3a880-bfc2-11eb-9870-2df11c654936.png">

Footer shown in Calypso blue for WP.com sites:
<img width="792" alt="Screen Shot 2021-05-28 at 14 38 56" src="https://user-images.githubusercontent.com/17325/119921694-8f14d580-bfc2-11eb-9c40-af65812ce9a9.png">

#### Testing instructions

1. Run locally with CALYPSO_ENV=jetpack-cloud-development yarn start and map jetpack.cloud.localhost to 127.0.0.1 in your “hosts” file.
2. Visit http://jetpack.cloud.localhost:3000/ and ensure the 'Search' item is in the sidebar. Check that the Search page loads. Ensure there is no 'What is Jetpack?' footer shown for any site you select.
3. Stop Calypso and restart with the regular environment (yarn start) and access via http://calypso.localhost:3000.
4. Visit the same section in Calypso blue via Jetpack > Search and ensure there _is_ a 'What is Jetpack?' footer for any wpcom site.
