### PR TITLE
desktop: deploy to wp-desktop repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
       - image: circleci/golang:1.12-node
     working_directory: /home/circleci/wp-calypso
     environment:
-      VERSION: "desktop-v0.0.5"
+      VERSION: << pipeline.git.tag >>
     steps:
       - checkout
       - attach_workspace:
@@ -654,75 +654,75 @@ workflows:
       - translate:
           requires:
             - setup
-  # wp-desktop:
-  #   jobs:
-  #     - wp-desktop-assets:
-  #         filters:
-  #           branches:
-  #             only:
-  #             - trunk
-  #             - /release\/.*/
-  #             - /desktop\/.*/
-  #     - wp-desktop-mac:
-  #         requires:
-  #           - wp-desktop-assets
-  #         filters:
-  #           branches:
-  #             only:
-  #               - trunk
-  #               - /release\/.*/
-  #               - /desktop\/.*/
-  #     - wp-desktop-linux:
-  #         requires:
-  #           - wp-desktop-assets
-  #         filters:
-  #           branches:
-  #             only:
-  #               - trunk
-  #               - /release\/.*/
-  #               - /desktop\/.*/
-  #     - wp-desktop-windows:
-  #         requires:
-  #           - wp-desktop-assets
-  #         filters:
-  #           branches:
-  #             only:
-  #               - trunk
-  #               - /release\/.*/
-  #               - /desktop\/.*/
-  wp-desktop-release:
-    # when: << pipeline.git.tag >>
+  wp-desktop:
     jobs:
-      - wp-desktop-assets
-          # filters:
-          #   tags:
-          #     only: /v.*/
+      - wp-desktop-assets:
+          filters:
+            branches:
+              only:
+              - trunk
+              - /release\/.*/
+              - /desktop\/.*/
       - wp-desktop-mac:
           requires:
             - wp-desktop-assets
-          # filters:
-          #   tags:
-          #     only: /v.*/
+          filters:
+            branches:
+              only:
+                - trunk
+                - /release\/.*/
+                - /desktop\/.*/
       - wp-desktop-linux:
           requires:
             - wp-desktop-assets
-          # filters:
-          #   tags:
-          #     only: /v.*/
+          filters:
+            branches:
+              only:
+                - trunk
+                - /release\/.*/
+                - /desktop\/.*/
       - wp-desktop-windows:
           requires:
             - wp-desktop-assets
-          # filters:
-          #   tags:
-          #     only: /v.*/
+          filters:
+            branches:
+              only:
+                - trunk
+                - /release\/.*/
+                - /desktop\/.*/
+  wp-desktop-release:
+    when: << pipeline.git.tag >>
+    jobs:
+      - wp-desktop-assets:
+          filters:
+            tags:
+              only: /v.*/
+      - wp-desktop-mac:
+          requires:
+            - wp-desktop-assets
+          filters:
+            tags:
+              only: /v.*/
+      - wp-desktop-linux:
+          requires:
+            - wp-desktop-assets
+          filters:
+            tags:
+              only: /v.*/
+      - wp-desktop-windows:
+          requires:
+            - wp-desktop-assets
+          filters:
+            tags:
+              only: /v.*/
       - wp-desktop-publish:
           requires:
             - wp-desktop-mac
             - wp-desktop-linux
             - wp-desktop-windows
-          # filters:
-          #   tags:
-          #     only: /v.*/
+          filters:
+            tags:
+              only: /v.*/
 
   e2e-jetpack-be-scheduled:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,18 +359,19 @@ jobs:
       - slack/status:
           webhook: << parameters.slack-webhook >>
 
-  # TODO: Make this local to the Win, Linux and Mac jobs
   wp-desktop-assets:
-    machine:
-      image: ubuntu-1604:202004-01
-    resource_class: medium
+    docker:
+      - image: circleci/node:12.16.2-browsers
     <<: *desktop_defaults
     environment:
-      NVM_DIR: '/opt/circleci/.nvm'
       VERSION: << pipeline.git.tag >>
       CONFIG_ENV: release
+    working_directory: ~/wp-calypso
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/wp-calypso
+      - run: *update-node
       - when:
           condition: << pipeline.git.tag >>
           steps:
@@ -379,7 +380,7 @@ jobs:
                 command: cd desktop/bin && node validate_tag.js $VERSION
       - run: *desktop-decrypt-assets
       - persist_to_workspace:
-          root: /home/circleci/wp-calypso
+          root: ~/wp-calypso
           paths: *desktop-cache-paths
       - run: *desktop-notify-github-failure
       - slack/status: *desktop-notify-slack-failure
@@ -607,7 +608,7 @@ jobs:
   # GitHub release and generate the release notes using the Git commits history
   wp-desktop-publish:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-node
     working_directory: /home/circleci/wp-calypso
     environment:
       VERSION: << pipeline.git.tag >>
@@ -619,8 +620,13 @@ jobs:
           name: Install Dependencies
           command: go get github.com/tcnksm/ghr
       - run:
+          name: Update wp-desktop repo README
+          command: |
+            node desktop/bin/github/update-desktop-repo-readme.js
+      - run:
           name: Publish Github Release
           command: |
+            VERSION="${VERSION#desktop-}"
             echo "Publishing draft release for wp-desktop $VERSION..."
             NAME="WP-Desktop ${VERSION#?}"
 
@@ -628,10 +634,10 @@ jobs:
             ./desktop/bin/make-changelog.sh > desktop/CHANGELOG.md
 
             ghr \
-              --token "${GH_TOKEN}" \
+              --token "${WP_DESKTOP_SECRET}" \
               --username "${CIRCLE_PROJECT_USERNAME}" \
-              --repository "${CIRCLE_PROJECT_REPONAME}" \
-              --commitish "${CIRCLE_SHA1}" \
+              --repository "wp-desktop" \
+              --commitish "trunk" \
               --name "${NAME}" \
               --body "$(cat desktop/CHANGELOG.md)" \
               --delete \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
       - image: circleci/golang:1.12-node
     working_directory: /home/circleci/wp-calypso
     environment:
-      VERSION: << pipeline.git.tag >>
+      VERSION: "desktop-v0.0.5"
     steps:
       - checkout
       - attach_workspace:
@@ -654,75 +654,75 @@ workflows:
       - translate:
           requires:
             - setup
-  wp-desktop:
-    jobs:
-      - wp-desktop-assets:
-          filters:
-            branches:
-              only:
-              - trunk
-              - /release\/.*/
-              - /desktop\/.*/
-      - wp-desktop-mac:
-          requires:
-            - wp-desktop-assets
-          filters:
-            branches:
-              only:
-                - trunk
-                - /release\/.*/
-                - /desktop\/.*/
-      - wp-desktop-linux:
-          requires:
-            - wp-desktop-assets
-          filters:
-            branches:
-              only:
-                - trunk
-                - /release\/.*/
-                - /desktop\/.*/
-      - wp-desktop-windows:
-          requires:
-            - wp-desktop-assets
-          filters:
-            branches:
-              only:
-                - trunk
-                - /release\/.*/
-                - /desktop\/.*/
+  # wp-desktop:
+  #   jobs:
+  #     - wp-desktop-assets:
+  #         filters:
+  #           branches:
+  #             only:
+  #             - trunk
+  #             - /release\/.*/
+  #             - /desktop\/.*/
+  #     - wp-desktop-mac:
+  #         requires:
+  #           - wp-desktop-assets
+  #         filters:
+  #           branches:
+  #             only:
+  #               - trunk
+  #               - /release\/.*/
+  #               - /desktop\/.*/
+  #     - wp-desktop-linux:
+  #         requires:
+  #           - wp-desktop-assets
+  #         filters:
+  #           branches:
+  #             only:
+  #               - trunk
+  #               - /release\/.*/
+  #               - /desktop\/.*/
+  #     - wp-desktop-windows:
+  #         requires:
+  #           - wp-desktop-assets
+  #         filters:
+  #           branches:
+  #             only:
+  #               - trunk
+  #               - /release\/.*/
+  #               - /desktop\/.*/
   wp-desktop-release:
-    when: << pipeline.git.tag >>
+    # when: << pipeline.git.tag >>
     jobs:
-      - wp-desktop-assets:
-          filters:
-            tags:
-              only: /v.*/
+      - wp-desktop-assets
+          # filters:
+          #   tags:
+          #     only: /v.*/
       - wp-desktop-mac:
           requires:
             - wp-desktop-assets
-          filters:
-            tags:
-              only: /v.*/
+          # filters:
+          #   tags:
+          #     only: /v.*/
       - wp-desktop-linux:
           requires:
             - wp-desktop-assets
-          filters:
-            tags:
-              only: /v.*/
+          # filters:
+          #   tags:
+          #     only: /v.*/
       - wp-desktop-windows:
           requires:
             - wp-desktop-assets
-          filters:
-            tags:
-              only: /v.*/
+          # filters:
+          #   tags:
+          #     only: /v.*/
       - wp-desktop-publish:
           requires:
             - wp-desktop-mac
             - wp-desktop-linux
             - wp-desktop-windows
-          filters:
-            tags:
-              only: /v.*/
+          # filters:
+          #   tags:
+          #     only: /v.*/
 
   e2e-jetpack-be-scheduled:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,25 +696,25 @@ workflows:
       - wp-desktop-assets:
           filters:
             tags:
-              only: /v.*/
+              only: /desktop-v.*/
       - wp-desktop-mac:
           requires:
             - wp-desktop-assets
           filters:
             tags:
-              only: /v.*/
+              only: /desktop-v.*/
       - wp-desktop-linux:
           requires:
             - wp-desktop-assets
           filters:
             tags:
-              only: /v.*/
+              only: /desktop-v.*/
       - wp-desktop-windows:
           requires:
             - wp-desktop-assets
           filters:
             tags:
-              only: /v.*/
+              only: /desktop-v.*/
       - wp-desktop-publish:
           requires:
             - wp-desktop-mac
@@ -722,7 +722,7 @@ workflows:
             - wp-desktop-windows
           filters:
             tags:
-              only: /v.*/
+              only: /desktop-v.*/
 
   e2e-jetpack-be-scheduled:
     jobs:

--- a/desktop/bin/github/update-desktop-repo-readme.js
+++ b/desktop/bin/github/update-desktop-repo-readme.js
@@ -58,7 +58,6 @@ async function request( method = 'GET', postData ) {
 async function updateWpDesktopREADME() {
 	// Get blob sha for resource
 	const { sha } = JSON.parse( await request( 'GET' ) );
-	console.log( 'Got sha: ', sha );
 
 	// Make changelog
 	const { stdout: changelog } = await exec(

--- a/desktop/bin/github/update-desktop-repo-readme.js
+++ b/desktop/bin/github/update-desktop-repo-readme.js
@@ -1,0 +1,86 @@
+/* eslint-disable import/no-nodejs-modules */
+/* eslint-disable no-console */
+
+/* Used to update wp-desktop repository README prior to application deployments */
+
+// External Dependencies
+const path = require( 'path' );
+const https = require( 'https' );
+const { promisify } = require( 'util' );
+const exec = promisify( require( 'child_process' ).exec );
+
+// Module Constants
+
+const VERSION = process.env.VERSION
+	? process.env.VERSION.replace( 'desktop-', '' )
+	: ( function () {
+			throw new Error( 'Error: no version' );
+	  } )();
+
+async function request( method = 'GET', postData ) {
+	const params = {
+		method,
+		port: 443,
+		hostname: 'api.github.com',
+		path: `/repos/Automattic/wp-desktop/contents/README.md`,
+		headers: {
+			'User-Agent': 'wp-desktop',
+			Accept: 'application/json',
+			Authorization: 'token ' + process.env.WP_DESKTOP_SECRET,
+		},
+	};
+
+	return new Promise( ( resolve, reject ) => {
+		const req = https.request( params, ( res ) => {
+			if ( res.statusCode < 200 || res.statusCode >= 300 ) {
+				return reject( new Error( `Status Code ${ res.statusCode }: ${ res.statusMessage }` ) );
+			}
+
+			const data = [];
+
+			res.on( 'data', ( chunk ) => {
+				data.push( chunk );
+			} );
+
+			res.on( 'end', () => resolve( Buffer.concat( data ).toString() ) );
+		} );
+
+		req.on( 'error', reject );
+
+		if ( postData ) {
+			req.write( postData );
+		}
+
+		req.end();
+	} );
+}
+
+async function updateWpDesktopREADME() {
+	// Get blob sha for resource
+	const { sha } = JSON.parse( await request( 'GET' ) );
+	console.log( 'Got sha: ', sha );
+
+	// Make changelog
+	const { stdout: changelog } = await exec(
+		`cd "${ path.resolve( __dirname, '..' ) }" && ./make-changelog.sh`
+	);
+	const content = Buffer.from(
+		`## WordPress Desktop "${ VERSION }"` +
+			`\n\nNote: The source code for this project is now maintained at https://www.github.com/Automattic/wp-calypso/desktop.` +
+			` This repository is used for deployment and issue-reporting purposes only.` +
+			`\n\n` +
+			changelog
+	).toString( 'base64' ); // Github API: patch needs to be base-64 encoded
+
+	const params = {
+		message: `Bump version to ${ VERSION } `,
+		content,
+		sha,
+	};
+
+	const body = JSON.stringify( params );
+
+	await request( 'PUT', body );
+}
+
+updateWpDesktopREADME();

--- a/desktop/bin/github/update-desktop-repo-readme.js
+++ b/desktop/bin/github/update-desktop-repo-readme.js
@@ -65,8 +65,8 @@ async function updateWpDesktopREADME() {
 		`cd "${ path.resolve( __dirname, '..' ) }" && ./make-changelog.sh`
 	);
 	const content = Buffer.from(
-		`## WordPress Desktop "${ VERSION }"` +
-			`\n\nNote: The source code for this project is now maintained at https://www.github.com/Automattic/wp-calypso/desktop.` +
+		`## WP-Desktop ${ VERSION }` +
+			`\n\nNote: The source code for this project is now maintained at https://github.com/Automattic/wp-calypso/tree/trunk/desktop.` +
 			` This repository is used for deployment and issue-reporting purposes only.` +
 			`\n\n` +
 			changelog

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 CALYPSO_DIR=$(cd $(dirname $0)/../../ && pwd)
 
@@ -60,6 +60,5 @@ if [ ! -z "$git_log" ]; then
 else
   echo "No changes"
 fi
-
 
 printf "\n"

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -50,8 +50,7 @@ echo "## Latest Changes"
 echo ""
 
 # Fill and sort changelog (final sort in commit-date order)
-# git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop-listeners" "$CALYPSO_DIR/client/desktop")
-git_log=""
+git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop-listeners" "$CALYPSO_DIR/client/desktop")
 
 if [ ! -z "$git_log" ]; then
   echo "$git_log" | while IFS=$'\r' read change; do

--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -50,7 +50,8 @@ echo "## Latest Changes"
 echo ""
 
 # Fill and sort changelog (final sort in commit-date order)
-git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop-listeners" "$CALYPSO_DIR/client/desktop")
+# git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag -- "$CALYPSO_DIR/desktop/" "$CALYPSO_DIR/client/lib/desktop-listeners" "$CALYPSO_DIR/client/desktop")
+git_log=""
 
 if [ ! -z "$git_log" ]; then
   echo "$git_log" | while IFS=$'\r' read change; do

--- a/desktop/bin/validate_tag.js
+++ b/desktop/bin/validate_tag.js
@@ -7,6 +7,8 @@
 // given input.
 //
 
+const path = require( 'path' );
+
 if ( process.argv.length === 2 ) {
 	const msg =
 		`Usage: ${ process.argv[ 1 ] } 1.2.3-beta4` + '\nExpected version parameter to check.';
@@ -16,12 +18,14 @@ if ( process.argv.length === 2 ) {
 const version = process.argv[ 2 ];
 // Remove the leading v that a tag from version control may have.
 // This regex means "a letter v at the start of the string"
-const sanitizedVersion = version.replace( /^v/, '' );
+const sanitizedVersion = version.replace( /^desktop-v/, '' );
 
 console.log( `Validating package.json version matches ${ version }...` );
 
 const fs = require( 'fs' );
-const config = JSON.parse( fs.readFileSync( '../package.json', 'utf8' ) );
+const config = JSON.parse(
+	fs.readFileSync( path.resolve( __dirname, '..', 'package.json' ), 'utf8' )
+);
 const packageVersion = config.version;
 
 if ( packageVersion !== sanitizedVersion ) {

--- a/desktop/electron-builder.json
+++ b/desktop/electron-builder.json
@@ -6,6 +6,13 @@
 		"buildResources": "./resource/icons",
 		"output": "./release"
 	},
+	"publish": [
+		{
+			"provider": "github",
+			"owner": "Automattic",
+			"repo": "wp-desktop"
+		}
+	],
 	"files": [ "dist", "package.json", "config/*.json" ],
 	"mac": {
 		"category": "public.app-category.social-networking",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "7.0.0",
+	"version": "0.0.5",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "0.0.5",
+	"version": "7.0.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
### Description

Deploy wp-desktop to wp-desktop repository.

After this change lands, deployments will be triggered in Calypso via tagging with `desktop-v1.2.3`, and desktop draft releases will be published to the wp-desktop repository. The `ghr` utility will take care of deleting and re-creating a release/tag in the destination repository automatically in case a build for a particular tag needs to be re-created, which is nice. 

cc: @mokagio 

### Testing

I verified that this change appears to be working as expected with the temporary commit ed904cb9dcc433259ff91956a9b3b872ff493971, which pushed a new draft release to the wp-desktop repository [here](https://github.com/Automattic/wp-desktop/releases/tag/untagged-ff0061ec2ee0be5ffb7d), as well as updated the repository README.