### PR TITLE
Fix: incorrect description of the Live Chat feature

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -42,7 +42,7 @@ import {
 	FEATURE_BLANK,
 	FEATURE_BLOG_DOMAIN,
 	FEATURE_BUSINESS_ONBOARDING,
-  FEATURE_CLOUDFLARE_ANALYTICS,
+	FEATURE_CLOUDFLARE_ANALYTICS,
 	FEATURE_COLLECT_PAYMENTS_V2,
 	FEATURE_COMMUNITY_SUPPORT,
 	FEATURE_CRM_LEADS_AND_FUNNEL,
@@ -1338,13 +1338,14 @@ export const FEATURES_LIST = {
 	[ FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS ]: {
 		getSlug: () => FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 		getTitle: () => i18n.translate( 'Live chat support 24X5' ),
-		getDescription: () => {},
+		getDescription: () =>
+			i18n.translate( 'Live chat is available 24 hours a day from Monday through Friday.' ),
 	},
 
 	[ FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS ]: {
 		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 		getTitle: () => i18n.translate( 'Live chat support 24X7' ),
-		getDescription: () => {},
+		getDescription: () => i18n.translate( 'Live chat is available 24/7.' ),
 	},
 };
 

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -364,7 +364,7 @@ const getPlanEcommerceDetails = () => ( {
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
-			isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT,
+			isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			isLoggedInMonthlyPricing && FEATURE_EMAIL_SUPPORT,
 			FEATURE_HOSTING,
 			FEATURE_JETPACK_ADVANCED,
@@ -470,7 +470,7 @@ const getPlanPremiumDetails = () => ( {
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
-			isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT,
+			isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 			isLoggedInMonthlyPricing && FEATURE_EMAIL_SUPPORT,
 			FEATURE_HOSTING,
 			FEATURE_JETPACK_ESSENTIAL,
@@ -494,7 +494,7 @@ const getPlanPremiumDetails = () => ( {
 		FEATURE_13GB_STORAGE,
 	],
 	getSignupFeatures: () => [
-		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_LIVE_CHAT_SUPPORT_BUSINESS_DAYS,
 		FEATURE_ADVANCED_CUSTOMIZATION,
 		FEATURE_ALL_PERSONAL_FEATURES,
 	],
@@ -553,7 +553,7 @@ const getPlanBusinessDetails = () => ( {
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
-			isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT,
+			isLoggedInMonthlyPricing && FEATURE_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			isLoggedInMonthlyPricing && FEATURE_EMAIL_SUPPORT,
 			FEATURE_HOSTING,
 			FEATURE_JETPACK_ADVANCED,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the description of the Live Chat feature on the plans page of My Home to sync up with the plans signup step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit My Home Plans page of your free plan site.
* Select the _Pay annually_ tab.
* Make sure Live Chat feature varies as follows:
  * Premium plan: _Live Chat 24X5_ - Live chat is available 24 hours a day from Monday through Friday.
  * Business and E-commerce plans: _Live Chat 24X7_ - Live chat is available 24/7.
    ![Plans_‹_FreePlan_—_WordPress_com](https://user-images.githubusercontent.com/212034/119929807-2bd27580-bfb9-11eb-978a-90f208577748.jpg)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #53238
