### PR TITLE
Block patterns: reregister remote core and Gutenberg patterns using site locale

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -37,6 +37,7 @@ class Block_Patterns_From_API {
 	 * @var array
 	 */
 	private $core_to_wpcom_categories_dictionary;
+
 	/**
 	 * @var string
 	 */
@@ -45,7 +46,7 @@ class Block_Patterns_From_API {
 	/**
 	 * Block_Patterns constructor.
 	 *
-	 * @param string $editor_type The current editor. One of `block_editor` (default), `site_editor`.
+	 * @param string               $editor_type The current editor. One of `block_editor` (default), `site_editor`.
 	 * @param Block_Patterns_Utils $utils       A class dependency containing utils methods.
 	 */
 	public function __construct( string $editor_type = 'block_editor', Block_Patterns_Utils $utils = null ) {
@@ -73,7 +74,7 @@ class Block_Patterns_From_API {
 	 *
 	 * @return array Results of pattern registration.
 	 */
-	public function register_patterns() {
+	public function register_patterns(): array {
 		$this->reregister_core_and_gutenberg_patterns();
 
 		// Used to track which patterns we successfully register.
@@ -86,7 +87,7 @@ class Block_Patterns_From_API {
 			$pattern_categories = array();
 			$block_patterns     = $this->get_patterns( $patterns_cache_key, $patterns_source );
 
-			foreach ( (array) $block_patterns as $pattern ) {
+			foreach ( $block_patterns as $pattern ) {
 				foreach ( (array) $pattern['categories'] as $slug => $category ) {
 					$pattern_categories[ $slug ] = array( 'label' => $category['title'] );
 				}
@@ -116,11 +117,11 @@ class Block_Patterns_From_API {
 			}
 
 			// Register categories (and re-register existing categories).
-			foreach ( (array) $pattern_categories as $slug => $category_properties ) {
+			foreach ( $pattern_categories as $slug => $category_properties ) {
 				register_block_pattern_category( $slug, $category_properties );
 			}
 
-			foreach ( (array) $block_patterns as $pattern ) {
+			foreach ( $block_patterns as $pattern ) {
 				if ( $this->can_register_pattern( $pattern ) ) {
 					$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
 
@@ -161,7 +162,7 @@ class Block_Patterns_From_API {
 	 * @param string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`.
 	 * @return array                      The list of translated patterns.
 	 */
-	private function get_patterns( $patterns_cache_key, $patterns_source ) {
+	private function get_patterns( $patterns_cache_key, $patterns_source ): array {
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 		if ( $override_source_site ) {
 			// Skip caching and request all patterns from a specified source site.
@@ -220,7 +221,7 @@ class Block_Patterns_From_API {
 	 *
 	 * @return bool
 	 */
-	private function can_register_pattern( $pattern ) {
+	private function can_register_pattern( $pattern ): bool {
 		if ( empty( $pattern['pattern_meta'] ) ) {
 			// Default to allowing patterns without metadata to be registered.
 			return true;
@@ -271,7 +272,7 @@ class Block_Patterns_From_API {
 
 	/**
 	 * Update categories for core patterns if a records exists in $this->core_to_wpcom_categories_dictionary
-	 * and reregister them.
+	 * and re-register them.
 	 */
 	private function update_core_patterns_with_wpcom_categories() {
 		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -244,7 +244,7 @@ class Block_Patterns_From_API {
 	}
 
 	/**
-	 * Because we prevent core pattern registation in full-site-editing-plugin.php in `remove_theme_support_for_core_block_patterns()`
+	 * Because we prevent core pattern registration in full-site-editing-plugin.php in `remove_theme_support_for_core_block_patterns()`
 	 * we have to reregister core WordPress patterns,
 	 * that is, those in wp-includes/block-patterns.php
 	 * Gutenberg adds new and overrides existing core patterns. We don't want these for now.

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -243,19 +243,22 @@ class Block_Patterns_From_API {
 	}
 
 	/**
-	 * Because we prevent core pattern registration in full-site-editing-plugin.php in `remove_theme_support_for_core_block_patterns()`
+	 * Because we prevent core pattern registration in full-site-editing-plugin.php in
+	 * `remove_theme_support_for_core_block_patterns()`
 	 * we have to "manually" register core WordPress and Gutenberg patterns,
-	 * that is, those in wp-includes/block-patterns.php (Core) and lib/block-patterns.php (Gutenberg)
-	 * Gutenberg overrides existing core patterns and loads remote patterns.
-	 * We also have to manually register core WordPress and Gutenberg patterns in order to make them use the site locale, not the account locale.
+	 * that is, those in lib/block-patterns.php (Gutenberg)
+	 * Herem we're duplicating Gutenberg's functions in lib/block-patterns.php, that is,
+	 * overriding existing core patterns and loading remote patterns.
+	 * We duplicate because we have to manually register core WordPress and Gutenberg patterns
+	 * in order to make them use the site locale, not the account locale.
 	 */
 	private function reregister_core_and_gutenberg_patterns() {
 		$did_switch_locale = switch_to_locale( $this->utils->get_block_patterns_locale() );
 		add_theme_support( 'core-block-patterns' );
 
-		// WordPress Core patterns. See: WordPress wp-includes/block-patterns.php.
-		if ( function_exists( '_register_core_block_patterns_and_categories' ) ) {
-			_register_core_block_patterns_and_categories();
+		// Do this just in case.  See Gutenberg lib/block-patterns.php.
+		if ( function_exists( 'remove_core_patterns' ) ) {
+			remove_core_patterns();
 		}
 
 		// Gutenberg patterns. See Gutenberg lib/block-patterns.php.

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -39,6 +39,8 @@ class Block_Patterns_From_API {
 	private $core_to_wpcom_categories_dictionary;
 
 	/**
+	 * This is the current editor type. One of `block_editor` (default), `site_editor`.
+	 *
 	 * @var string
 	 */
 	private $editor_type;
@@ -54,7 +56,7 @@ class Block_Patterns_From_API {
 		$this->patterns_sources = array( 'block_patterns' );
 
 		// While we're still testing the FSE patterns, limit activation via a filter.
-		if ( $this->editor_type === 'site_editor' && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
+		if ( 'site_editor' === $this->editor_type && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
 			$this->patterns_sources[] = 'fse_block_patterns';
 		}
 
@@ -246,24 +248,24 @@ class Block_Patterns_From_API {
 	 * that is, those in wp-includes/block-patterns.php (Core) and lib/block-patterns.php (Gutenberg)
 	 * Gutenberg overrides existing core patterns and loads remote patterns.
 	 * We also have to manually register core WordPress and Gutenberg patterns in order to make them use the site locale, not the account locale.
-	 * @TODO WordPress 5.8 has a `_load_remote_block_patterns()` method which we should call instead of `load_remote_patterns()`.
 	 */
 	private function reregister_core_and_gutenberg_patterns() {
 		$did_switch_locale = switch_to_locale( $this->utils->get_block_patterns_locale() );
 		add_theme_support( 'core-block-patterns' );
 
-		// WordPress Core patterns. See: WordPress wp-includes/block-patterns.php
+		// WordPress Core patterns. See: WordPress wp-includes/block-patterns.php.
 		if ( function_exists( '_register_core_block_patterns_and_categories' ) ) {
 			_register_core_block_patterns_and_categories();
 		}
 
-		// Gutenberg patterns. See Gutenberg lib/block-patterns.php
+		// Gutenberg patterns. See Gutenberg lib/block-patterns.php.
 		if ( function_exists( 'register_gutenberg_patterns' ) ) {
 			register_gutenberg_patterns();
 		}
 
-		// Load core pattern directory from the public API. See Gutenberg lib/block-patterns.php
-		if ( $this->editor_type === 'site_editor' && function_exists( 'load_remote_patterns' ) ) {
+		// Load core pattern directory from the public API. See Gutenberg lib/block-patterns.php.
+		// @TODO WordPress 5.8 has a `_load_remote_block_patterns()` method which we should call instead of `load_remote_patterns()`.
+		if ( 'site_editor' === $this->editor_type && function_exists( 'load_remote_patterns' ) ) {
 			load_remote_patterns();
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -246,25 +246,28 @@ class Block_Patterns_From_API {
 	 * that is, those in wp-includes/block-patterns.php (Core) and lib/block-patterns.php (Gutenberg)
 	 * Gutenberg overrides existing core patterns and loads remote patterns.
 	 * We also have to manually register core WordPress and Gutenberg patterns in order to make them use the site locale, not the account locale.
+	 * @TODO WordPress 5.8 has a `_load_remote_block_patterns()` method which we should call instead of `load_remote_patterns()`.
 	 */
 	private function reregister_core_and_gutenberg_patterns() {
 		$did_switch_locale = switch_to_locale( $this->utils->get_block_patterns_locale() );
 		add_theme_support( 'core-block-patterns' );
 
+		// WordPress Core patterns. See: WordPress wp-includes/block-patterns.php
 		if ( function_exists( '_register_core_block_patterns_and_categories' ) ) {
 			_register_core_block_patterns_and_categories();
-			// The site locale might be the same as the current locale so switching could have failed in such instances.
 		}
 
+		// Gutenberg patterns. See Gutenberg lib/block-patterns.php
 		if ( function_exists( 'register_gutenberg_patterns' ) ) {
 			register_gutenberg_patterns();
 		}
 
-		//
+		// Load core pattern directory from the public API. See Gutenberg lib/block-patterns.php
 		if ( $this->editor_type === 'site_editor' && function_exists( 'load_remote_patterns' ) ) {
 			load_remote_patterns();
 		}
 
+		// The site locale might be the same as the current locale so switching could have failed in such instances.
 		if ( false !== $did_switch_locale ) {
 			restore_previous_locale();
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -107,15 +107,16 @@ class Block_Patterns_From_Api_Test extends TestCase {
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
 
-		/**
-	 *  Tests that we're making a request where there are no cached patterns.
+	/**
+	 *  Tests that we're making two requests when we specify that we're on the site editor.
 	 */
 	public function test_patterns_site_editor_source_site() {
 		/**
 		 * A callback for the `a8c_enable_fse_block_patterns_api` filter.
+		 *
 		 * @return bool
 		 */
-		$should_enable_fse_block_patterns_api = function() {
+		$should_enable_fse_block_patterns_api = function () {
 			return true;
 		};
 
@@ -127,8 +128,8 @@ class Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->exactly( 2 ) )
 			->method( 'remote_get' )
 			->withConsecutive(
-				[ 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' ],
-				[ 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=fse_block_patterns' ]
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' ),
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=fse_block_patterns' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -90,7 +90,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	 */
 	public function test_patterns_request_succeeds_with_empty_cache() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
-		$block_patterns_from_api = new Block_Patterns_From_API( array(), $utils_mock );
+		$block_patterns_from_api = new Block_Patterns_From_API( '', $utils_mock );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_get' )
@@ -107,12 +107,41 @@ class Block_Patterns_From_Api_Test extends TestCase {
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
 
+		/**
+	 *  Tests that we're making a request where there are no cached patterns.
+	 */
+	public function test_patterns_site_editor_source_site() {
+		/**
+		 * A callback for the `a8c_enable_fse_block_patterns_api` filter.
+		 * @return bool
+		 */
+		$should_enable_fse_block_patterns_api = function() {
+			return true;
+		};
+
+		add_filter( 'a8c_enable_fse_block_patterns_api', $should_enable_fse_block_patterns_api );
+
+		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
+		$block_patterns_from_api = new Block_Patterns_From_API( 'site_editor', $utils_mock );
+
+		$utils_mock->expects( $this->exactly( 2 ) )
+			->method( 'remote_get' )
+			->withConsecutive(
+				[ 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' ],
+				[ 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=fse_block_patterns' ]
+			);
+
+		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
+
+		remove_filter( 'a8c_enable_fse_block_patterns_api', $should_enable_fse_block_patterns_api );
+	}
+
 	/**
 	 *  Tests that we're NOT making a request where there ARE cached patterns.
 	 */
 	public function test_patterns_request_succeeds_with_set_cache() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ), array( $this->pattern_mock_object ) );
-		$block_patterns_from_api = new Block_Patterns_From_API( array(), $utils_mock );
+		$block_patterns_from_api = new Block_Patterns_From_API( '', $utils_mock );
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_get' )
@@ -137,7 +166,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 
 		add_filter( 'a8c_override_patterns_source_site', $example_site );
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
-		$block_patterns_from_api = new Block_Patterns_From_API( array(), $utils_mock );
+		$block_patterns_from_api = new Block_Patterns_From_API( '', $utils_mock );
 
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_get' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -259,7 +259,7 @@ function load_block_patterns_from_api( $current_screen ) {
 
 	// While we're still testing the FSE patterns, limit activation via a filter.
 	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
-		$editor_type        = 'site_editor';
+		$editor_type = 'site_editor';
 	}
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -269,20 +269,6 @@ function load_block_patterns_from_api( $current_screen ) {
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 
 /**
- * Removes the core patterns that we can prevent Gutenberg patterns from loading.
- *
- * @return void
- */
-function remove_theme_support_for_core_block_patterns() {
-	/*
-		Gutenberg performs a check of `get_theme_support( 'core-block-patterns' )`
-		before loading its own patterns, overriding core patterns, and loading remote patterns.
-	*/
-	remove_theme_support( 'core-block-patterns' );
-}
-add_action( 'after_setup_theme', __NAMESPACE__ . '\remove_theme_support_for_core_block_patterns' );
-
-/**
  * Load WPCOM Block Patterns Modifications.
  *
  * This is responsible for modifying how block patterns behave in the editor,
@@ -296,6 +282,12 @@ function load_wpcom_block_patterns_modifications() {
 	// 	require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
 	// }
 	// phpcs:enable
+	/*
+		Removes the core patterns that we can prevent Gutenberg patterns from loading.
+		Gutenberg performs a check of `get_theme_support( 'core-block-patterns' )`
+		before loading its own patterns, overriding core patterns, and loading remote patterns.
+	*/
+	remove_theme_support( 'core-block-patterns' );
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_patterns_modifications' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -255,15 +255,15 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	$patterns_sources = array( 'block_patterns' );
+	$editor_type = 'block_editor';
 
 	// While we're still testing the FSE patterns, limit activation via a filter.
 	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
-		$patterns_sources[] = 'fse_block_patterns';
+		$editor_type        = 'site_editor';
 	}
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	$block_patterns_from_api = new Block_Patterns_From_API( $patterns_sources );
+	$block_patterns_from_api = new Block_Patterns_From_API( $editor_type );
 	$block_patterns_from_api->register_patterns();
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -269,6 +269,20 @@ function load_block_patterns_from_api( $current_screen ) {
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );
 
 /**
+ * Removes the core patterns that we can prevent Gutenberg patterns from loading.
+ *
+ * @return void
+ */
+function remove_theme_support_for_core_block_patterns() {
+	/*
+		Gutenberg performs a check of `get_theme_support( 'core-block-patterns' )`
+		before loading its own patterns, overriding core patterns, and loading remote patterns.
+	*/
+	remove_theme_support( 'core-block-patterns' );
+}
+add_action( 'after_setup_theme', __NAMESPACE__ . '\remove_theme_support_for_core_block_patterns' );
+
+/**
  * Load WPCOM Block Patterns Modifications.
  *
  * This is responsible for modifying how block patterns behave in the editor,

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -282,6 +282,7 @@ function load_wpcom_block_patterns_modifications() {
 	// 	require_once __DIR__ . '/block-patterns/class-block-patterns-modifications.php';
 	// }
 	// phpcs:enable
+
 	/*
 		Removes the core patterns that we can prevent Gutenberg patterns from loading.
 		Gutenberg performs a check of `get_theme_support( 'core-block-patterns' )`


### PR DESCRIPTION
## Changes proposed in this Pull Request

Core [WordPress](https://github.com/WordPress/WordPress/blob/master/wp-includes/block-patterns.php) and [Gutenberg](https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php#L245
) register patterns behind a `get_theme_support( 'core-block-patterns' )` check.


This PR:

1. deactivates `'core-block-patterns'` theme support to prevent Gutenberg registering its patterns and fudging around with core patterns. This method replaces the string check of pattern names, thereby simplifying the additions we made in https://github.com/Automattic/wp-calypso/pull/52656, and should be more reliable as a result.
2. Loads WordPress core patterns, Gutenberg and remote core patterns manually so we can switch to the site locale first


## Testing instructions

Apply this ETK patch to your sandbox

`install-plugin.sh etk update/remove-core-block-patterns-theme-support`

and open up block editor in a sandboxed site.

Check that we're loading WPCOM patterns and Gutenberg patterns from https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php.

In the Site Editor, check that we're loading remote core patterns. See equivalent: https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php#L248

Switch your site language and make sure that you see evidence that the patterns/pattern categories are at least trying to be translated :)

<img width="316" alt="Screen Shot 2021-06-21 at 12 53 05 pm" src="https://user-images.githubusercontent.com/6458278/122700974-a37d8280-d28f-11eb-9701-359207784c05.png">



```
cd apps/editing-toolkit
yarn run test:php --testsuite block-patterns

```

