### PR TITLE
Playwright: reduce boilerplate in test file

### DIFF
--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -22,11 +22,6 @@ import { getViewportSize } from './browser-helper';
  */
 import { viewportSize } from './types';
 
-/**
- * Constants
- */
-const playwrightTimeoutMS: number = config.get( 'playwrightTimeoutMS' );
-
 export let browser: Browser;
 
 /**
@@ -49,7 +44,6 @@ export async function start(): Promise< Page > {
  */
 export async function launchPage(): Promise< Page > {
 	const browserContext = await launchBrowserContext();
-	browserContext.setDefaultTimeout( playwrightTimeoutMS );
 	return await browserContext.newPage();
 }
 
@@ -105,7 +99,6 @@ export async function launchBrowser(): Promise< Browser > {
 	return await chromium.launch( {
 		headless: isHeadless,
 		args: [ '--window-position=0,0', `--window-size=${ dimension.width },${ dimension.height }` ],
-		timeout: playwrightTimeoutMS,
 	} );
 }
 

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -5,6 +5,11 @@ import phrase from 'asana-phrase';
 import config from 'config';
 
 /**
+ * Internal dependencies
+ */
+import { getViewportName } from './browser-helper';
+
+/**
  * Assembles and returns the URL to a specific route/asset/query in Calypso.
  *
  * @param {string} route Additional state or page to build into the returned URL.
@@ -84,7 +89,7 @@ export function randomPhrase(): string {
 export function createSuiteTitle( title: string ): string {
 	const parts = [
 		`[${ getJetpackHost() }]`,
-		`${ title.toProperCase() }:`,
+		`${ toTitleCase( [ title ] ) }:`,
 		`(${ getViewportName() })`,
 		'@parallel',
 	];

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -74,3 +74,20 @@ export function randomPhrase(): string {
 	const generated: Array< string > = phrase.default32BitFactory().randomPhrase();
 	return toTitleCase( generated );
 }
+
+/**
+ * Generates a structured test suite name from environmental and user-provided parameters.
+ *
+ * @param {string} title Title of the test.
+ * @returns {string} Test suite name.
+ */
+export function createSuiteTitle( title: string ): string {
+	const parts = [
+		`[${ getJetpackHost() }]`,
+		`${ title.toProperCase() }:`,
+		`(${ getViewportName() })`,
+		'@parallel',
+	];
+
+	return parts.join( ' ' );
+}

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -57,12 +57,16 @@ export function getJetpackHost(): string {
 }
 
 /**
- * Given an array of strings, returns a single string with each word in TitleCase.
+ * Given either a string or array of strings, returns a single string with each word in TitleCase.
  *
- * @param {string[]} words Array of strings to be converted to TitleCase.
- * @returns {string} Array of strings converted to TitleCase.
+ * @param {string[]|string} words Either string or array of strings to be converted to TitleCase.
+ * @returns {string} String with each distinct word converted to TitleCase.
  */
-export function toTitleCase( words: string[] ): string {
+export function toTitleCase( words: string[] | string ): string {
+	if ( typeof words === 'string' ) {
+		words = words.trim().split( ' ' );
+	}
+
 	const result = words.map( function ( word ) {
 		return word.charAt( 0 ).toUpperCase() + word.slice( 1 ).toLowerCase();
 	} );
@@ -89,7 +93,7 @@ export function randomPhrase(): string {
 export function createSuiteTitle( title: string ): string {
 	const parts = [
 		`[${ getJetpackHost() }]`,
-		`${ toTitleCase( [ title ] ) }:`,
+		`${ toTitleCase( title ) }:`,
 		`(${ getViewportName() })`,
 		'@parallel',
 	];

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -6,3 +6,5 @@ file:
   - 'lib/before.js'
 reporter:
   - 'spec-junit-reporter'
+# If not defined, in slower environment the default 2000ms timeout is exhausted before browser launches.
+timeout: 30000

--- a/test/e2e/.mocharc_playwright.yml
+++ b/test/e2e/.mocharc_playwright.yml
@@ -6,5 +6,3 @@ file:
   - 'lib/before.js'
 reporter:
   - 'spec-junit-reporter'
-# Timeout for mocha when starting up only.
-timeout: 15000

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -7,7 +7,7 @@
 	"startBrowserTimeoutMS": 60000,
 	"startAppTimeoutMS": 240000,
 	"afterHookTimeoutMS": 60000,
-	"playwrightTimeoutMS": 15000,
+	"playwrightTimeoutMS": 30000,
 	"browser": "chrome",
 	"proxy": "direct",
 	"saveAllScreenshots": false,

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -7,7 +7,6 @@
 	"startBrowserTimeoutMS": 60000,
 	"startAppTimeoutMS": 240000,
 	"afterHookTimeoutMS": 60000,
-	"playwrightTimeoutMS": 30000,
 	"browser": "chrome",
 	"proxy": "direct",
 	"saveAllScreenshots": false,

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import config from 'config';
+import assert from 'assert';
 import {
-	BrowserHelper,
 	DataHelper,
 	LoginFlow,
 	NewPostFlow,
@@ -14,15 +13,10 @@ import {
 /**
  * Constants
  */
-const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const host = DataHelper.getJetpackHost();
-const viewportName = BrowserHelper.getViewportName();
 const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 
-describe( `[${ host }] Likes: (${ viewportName }) @parallel`, function () {
-	this.timeout( mochaTimeOut );
-
+describe( DataHelper.createSuiteTitle( 'Like' ), function () {
 	describe( 'New post', function () {
 		let gutenbergEditorPage;
 		let likesComponent;

--- a/test/e2e/specs/specs-playwright/wp-likes-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes-spec.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import assert from 'assert';
 import {
 	DataHelper,
 	LoginFlow,
@@ -16,7 +15,7 @@ import {
 const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 
-describe( DataHelper.createSuiteTitle( 'Like' ), function () {
+describe( DataHelper.createSuiteTitle( 'Likes' ), function () {
 	describe( 'New post', function () {
 		let gutenbergEditorPage;
 		let likesComponent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements some boilerplate reduction changes for Playwright.

- use a new helper function `DataHelper.createSuiteTitle` to generate a nicely formatted name for the suite.

Additionally, the default timeout for the entire Playwright-based framework has been updated to `30000ms`. This is the default value used internally by Playwright.
Therefore test developers no longer need to manually set the mocha timeout value in the test.

#### Testing instructions

CI
- ensure that tests have proper names when run locally and on TeamCity.

Local
1. pull the branch.
2. open a test under `test/e2e/specs/specs-playwright`.
3. add in a line like  `this.page.click('random-element-does-not-exist')`.
4. execute `mocha --config .mocharc_playwright.yml specs/specs-playwright/<spec-file>`
5. ensure the timeout occurs at 30000ms.

Parent: #53169

