### PR TITLE
User: Move `sendVerificationEmail` out of `lib/user`

### DIFF
--- a/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Spinner from 'calypso/components/spinner';
-import user from 'calypso/lib/user';
+import wpcom from 'calypso/lib/wp';
 
 class EmailUnverifiedNotice extends React.Component {
 	state = {
@@ -48,13 +48,16 @@ class EmailUnverifiedNotice extends React.Component {
 			pendingRequest: true,
 		} );
 
-		user().sendVerificationEmail( ( error, response ) => {
-			this.setState( {
-				emailSent: response && response.success,
-				error: error,
-				pendingRequest: false,
+		wpcom
+			.undocumented()
+			.me()
+			.sendVerificationEmail( ( error, response ) => {
+				this.setState( {
+					emailSent: response && response.success,
+					error: error,
+					pendingRequest: false,
+				} );
 			} );
-		} );
 	};
 
 	renderEmailSendPending() {

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -32,8 +32,6 @@ export interface User extends EventEmitter {
 	handleFetchSuccess: ( userdata: UserData ) => void;
 	getLanguage: () => Language | undefined;
 	clear: () => Promise< void > | void;
-	sendVerificationEmail< Callback extends WPCOMCallback >( callback: Callback ): XMLHttpRequest;
-	sendVerificationEmail(): Promise< void >;
 	set: ( attributes: UserData ) => boolean;
 	decrementSiteCount: () => void;
 	incrementSiteCount: () => void;

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -210,19 +210,6 @@ User.prototype.clear = async function () {
 	await clearStorage();
 };
 
-/**
- * Sends the user an email with a link to verify their account if they
- * are unverified.
- *
- * @param {Function} [fn] A callback to receive the HTTP response from the send-verification-email endpoint.
- *
- * @returns {(Promise|object)} If a callback is provided, this is an object representing an XMLHttpRequest.
- *                             If no callback is provided, this is a Promise.
- */
-User.prototype.sendVerificationEmail = function ( fn ) {
-	return wpcom.undocumented().me().sendVerificationEmail( fn );
-};
-
 User.prototype.set = function ( attributes ) {
 	let changed = false;
 

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -4,13 +4,13 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import user from 'calypso/lib/user';
 
 /**
  * Internal dependencies
  */
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import wpcom from 'calypso/lib/wp';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 /**
@@ -58,7 +58,9 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			user()
+			wpcom
+				.undocumented()
+				.me()
 				.sendVerificationEmail()
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -21,6 +21,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import user from 'calypso/lib/user';
+import wpcom from 'calypso/lib/wp';
 
 const VERIFY_EMAIL_ERROR_NOTICE = 'ecommerce-verify-email-error';
 const RESEND_ERROR = 'RESEND_ERROR';
@@ -55,21 +56,24 @@ class AtomicStoreThankYouCard extends Component {
 
 		this.setState( { resendStatus: RESEND_PENDING } );
 
-		user().sendVerificationEmail( ( error ) => {
-			if ( error ) {
-				this.props.errorNotice(
-					translate( "Couldn't resend verification email. Please try again." ),
-					{
-						id: VERIFY_EMAIL_ERROR_NOTICE,
-					}
-				);
+		wpcom
+			.undocumented()
+			.me()
+			.sendVerificationEmail( ( error ) => {
+				if ( error ) {
+					this.props.errorNotice(
+						translate( "Couldn't resend verification email. Please try again." ),
+						{
+							id: VERIFY_EMAIL_ERROR_NOTICE,
+						}
+					);
 
-				this.setState( { resendStatus: RESEND_ERROR } );
-				return;
-			}
+					this.setState( { resendStatus: RESEND_ERROR } );
+					return;
+				}
 
-			this.setState( { resendStatus: RESEND_SUCCESS } );
-		} );
+				this.setState( { resendStatus: RESEND_SUCCESS } );
+			} );
 	};
 
 	resendButtonText = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, `sendVerificationEmail` is unnecessarily being proxied by the `lib/user` library - it only sends a WP.com request and does nothing more than that. If we call `wpcom` directly, we don't need to rely on the `lib/user` instance. 

This PR refactors those 3 instances that use `sendVerificationEmail` to use `wpcom` directly, rather than doing it through a proxy method of `lib/user`. We also remove the unused method from the library.

This PR is part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Create a WP.com account using any flow, but don't verify the email.
* Go to `/help`
* Click the "Resend Email" button on the notice.
* Verify it still works well, sending an email and hiding the notice (or displaying an error upon failure).