### PR TITLE
User: Remove unused `getLanguage()` method

### DIFF
--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -19,7 +19,6 @@ import wpcom from 'calypso/lib/wp';
 import Emitter from 'calypso/lib/mixins/emitter';
 import { isE2ETest } from 'calypso/lib/e2e';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
-import { getLanguage } from 'calypso/lib/i18n-utils/utils';
 import { clearStorage } from 'calypso/lib/browser-storage';
 import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'calypso/lib/abtest/utility';
 
@@ -191,10 +190,6 @@ User.prototype.handleFetchSuccess = function ( userData ) {
 	}
 	this.data = userData;
 	this.emit( 'change' );
-};
-
-User.prototype.getLanguage = function () {
-	return getLanguage( this.data.localeSlug );
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It seems like the `getLanguage()` method from `lib/user` is not used. This PR removes it. We tend to use the same method from the `i18n-utils` instead FWIW.

This PR is part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Not needed, just verify that the removed method is not in use.