### PR TITLE
Purchases: Use Redux locale when downgrading

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import userUtils from 'calypso/lib/user/utils';
 
 const noop = () => {};
 
@@ -35,10 +35,10 @@ export class DowngradeStep extends Component {
 	};
 
 	render() {
-		const { translate, refundAmount, planCost, currencySymbol } = this.props;
+		const { locale, translate, refundAmount, planCost, currencySymbol } = this.props;
 		const canRefund = !! parseFloat( refundAmount );
 		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
-		const isEnglishLocale = [ 'en', 'en-gb' ].indexOf( userUtils.getLocaleSlug() ) >= 0;
+		const isEnglishLocale = [ 'en', 'en-gb' ].indexOf( locale ) >= 0;
 		const downgradeWarning = translate(
 			'If you choose to downgrade, your plan will be downgraded immediately.'
 		);
@@ -91,6 +91,7 @@ export class DowngradeStep extends Component {
 }
 
 const mapStateToProps = ( state ) => ( {
+	locale: getCurrentLocaleSlug( state ),
 	selectedSite: getSelectedSite( state ),
 } );
 const mapDispatchToProps = { recordTracksEvent };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the locale in the downgrade step of the purchase cancellation form to use Redux instead of `lib/user`. 

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Checkout this branch locally.
* Buy a Personal plan.
* After that, upgrade to Premium plan.
* Remove `downgradePossible` from [this line](https://github.com/Automattic/wp-calypso/blob/3ad54614a4022826034ef4312e82b1df2d014c06/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js#L46).
* Go to `/me/purchases` and pick the purchase that you just made.
* Click the "Remove WordPress.com Premium" button at the bottom.
* From the survey, select "The plan was too expensive." and "I'm staying here and using the free plan.".
* On the next step you should see a downgrade screen. Verify it still works the same way as before:
  * For English locales, title should say "Would you rather switch to a more affordable plan?" at the top.
  * For non-English locales, title should say "Would you rather switch to a lower-tier plan?" at the top.
* Keep an eye in the console for new errors, make sure there are none. 
