### PR TITLE
Reader: Remove unnecessary user utils mocks

### DIFF
--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -16,7 +16,6 @@ import * as fixtures from './fixtures';
 jest.mock( '@automattic/calypso-config', () => {
 	return () => require( './fixtures' ).discoverSiteId;
 } );
-jest.mock( 'calypso/lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
 
 describe( 'helper', () => {
 	const { discoverPost } = fixtures;

--- a/client/state/selectors/test/get-reader-stream-offset-item.js
+++ b/client/state/selectors/test/get-reader-stream-offset-item.js
@@ -8,7 +8,6 @@ import deepFreeze from 'deep-freeze';
  */
 import { getOffsetItem } from 'calypso/state/reader/streams/selectors';
 
-jest.mock( 'calypso/lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
 jest.mock( 'calypso/reader/stream/utils' );
 jest.mock( 'calypso/state/reader/follows/selectors/get-reader-follows' );
 

--- a/client/state/selectors/test/get-reader-stream-should-request-recommendations.js
+++ b/client/state/selectors/test/get-reader-stream-should-request-recommendations.js
@@ -1,16 +1,10 @@
 /**
- * External Dependencies
- */
-import _ from 'lodash';
-
-/**
  * Internal Dependencies
  */
 import { getDistanceBetweenRecs } from 'calypso/reader/stream/utils';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import { shouldRequestRecs } from 'calypso/state/reader/streams/selectors';
 
-jest.mock( 'calypso/lib/user/utils', () => ( { getLocaleSlug: () => 'en' } ) );
 jest.mock( 'calypso/reader/stream/utils' );
 jest.mock( 'calypso/state/reader/follows/selectors/get-reader-follows' );
 
@@ -18,8 +12,8 @@ describe( 'shouldRequestRecs', () => {
 	const generateState = ( { following, recs } ) => ( {
 		reader: {
 			streams: {
-				following: { items: _.fill( Array( following ), {} ) },
-				recs: { items: _.fill( Array( recs ), {} ) },
+				following: { items: Array( following ).fill( {} ) },
+				recs: { items: Array( recs ).fill( {} ) },
 			},
 		},
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes several unnecessary mocks of the user utils in Reader tests.

We also use the advantage to refactor a couple `_.fill()` instances we missed in #50763 to use `Array.prototype.fill()` instead.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify all tests are still passing.