### PR TITLE
Reader: Fix "List Not Found" Error

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -140,6 +140,11 @@ function ReaderListEdit( props ) {
 		);
 	}
 
+	// The list does not exist
+	if ( isMissing ) {
+		return <Missing />;
+	}
+
 	return (
 		<>
 			{ ! list && <QueryReaderList owner={ props.owner } slug={ props.slug } /> }
@@ -150,8 +155,7 @@ function ReaderListEdit( props ) {
 						args: { listName: list?.title || decodeURIComponent( props.slug ) },
 					} ) }
 				/>
-				{ ! list && ! isMissing && <Card>{ translate( 'Loading…' ) }</Card> }
-				{ isMissing && <Missing /> }
+				{ ! list && <Card>{ translate( 'Loading…' ) }</Card> }
 				{ list && (
 					<>
 						<SectionNav>

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import QueryReaderList from 'calypso/components/data/query-reader-list';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
@@ -40,6 +41,7 @@ class ListMissing extends React.Component {
 
 		return (
 			<div>
+				<DocumentHead title={ this.props.translate( 'List not found' ) } />
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<EmptyContent
 					title={ this.props.translate( 'List not found' ) }

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -11,16 +10,11 @@ import { connect } from 'react-redux';
  */
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
-import QueryReaderList from 'calypso/components/data/query-reader-list';
+import ReaderMain from 'calypso/reader/components/reader-main';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class ListMissing extends React.Component {
-	static propTypes = {
-		owner: PropTypes.string.isRequired,
-		slug: PropTypes.string.isRequired,
-	};
-
 	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
@@ -28,31 +22,20 @@ class ListMissing extends React.Component {
 	};
 
 	render() {
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		const action = (
-			<a
-				className="empty-content__action button is-primary"
-				onClick={ this.recordAction }
-				href="/read"
-			>
-				{ this.props.translate( 'Back to Followed Sites' ) }
-			</a>
-		);
-
 		return (
-			<div>
+			<ReaderMain>
 				<DocumentHead title={ this.props.translate( 'List not found' ) } />
-				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<EmptyContent
 					title={ this.props.translate( 'List not found' ) }
 					line={ this.props.translate( "Sorry, we couldn't find that list." ) }
-					action={ action }
+					action={ this.props.translate( 'Back to Followed Sites' ) }
+					actionURL="/read"
+					actionCallback={ this.recordAction }
 					illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
 					illustrationWidth={ 500 }
 				/>
-			</div>
+			</ReaderMain>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -249,36 +249,6 @@ export const errors = withSchemaValidation( errorsSchema, ( state = {}, action )
 	return state;
 } );
 
-/**
- * A missing list is one that's been requested, but we couldn't find (API response 404-ed).
- *
- * @param  {object} state  Current state
- * @param  {object} action Action payload
- * @returns {object}        Updated state
- */
-export function missingLists( state = [], action ) {
-	switch ( action.type ) {
-		case READER_LISTS_RECEIVE:
-			// Remove any valid lists from missingLists
-			return filter( state, ( list ) => {
-				return ! find( action.lists, { owner: list.owner, slug: list.slug } );
-			} );
-		case READER_LIST_REQUEST_SUCCESS:
-			// Remove any valid lists from missingLists
-			return filter( state, ( list ) => {
-				return action.data.list.owner !== list.owner && action.data.list.slug !== list.slug;
-			} );
-		case READER_LIST_REQUEST_FAILURE:
-			// Add lists that have failed with a 403 or 404 to missingLists
-			if ( ! action.error || ! includes( [ 403, 404 ], action.error.statusCode ) ) {
-				return state;
-			}
-			return union( state, [ { owner: action.owner, slug: action.slug } ] );
-	}
-
-	return state;
-}
-
 export default combineReducers( {
 	items,
 	listItems,
@@ -289,5 +259,4 @@ export default combineReducers( {
 	isRequestingLists,
 	isUpdatingList,
 	errors,
-	missingLists,
 } );

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -182,8 +182,5 @@ export function isSubscribedByOwnerAndSlug( state, owner, slug ) {
  * @returns {boolean} Is the list missing?
  */
 export function isMissingByOwnerAndSlug( state, owner, slug ) {
-	const preparedOwner = owner.toLowerCase();
-	const preparedSlug = slug.toLowerCase();
-
 	return ! state.reader?.lists?.isRequestingLists && ! getListByOwnerAndSlug( state, owner, slug );
 }

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -185,7 +185,5 @@ export function isMissingByOwnerAndSlug( state, owner, slug ) {
 	const preparedOwner = owner.toLowerCase();
 	const preparedSlug = slug.toLowerCase();
 
-	return !! find( state.reader.lists.missingLists, ( list ) => {
-		return list.owner === preparedOwner && list.slug === preparedSlug;
-	} );
+	return ! state.reader?.lists?.isRequestingLists && ! getListByOwnerAndSlug( state, owner, slug );
 }

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { items, listItems, updatedLists, missingLists, subscribedLists } from '../reducer';
+import { items, listItems, updatedLists, subscribedLists } from '../reducer';
 import {
 	READER_LIST_DELETE,
 	READER_LIST_FOLLOW_RECEIVE,
@@ -115,84 +115,6 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).toEqual( [ 841 ] );
-		} );
-	} );
-
-	describe( '#missingLists()', () => {
-		test( 'should default to an empty array', () => {
-			const state = missingLists( undefined, {} );
-			expect( state ).toEqual( [] );
-		} );
-
-		test( 'should store new missing lists in the case of a 404', () => {
-			const state = missingLists( undefined, {
-				type: READER_LIST_REQUEST_FAILURE,
-				error: {
-					statusCode: 404,
-				},
-				owner: 'lister',
-				slug: 'banana',
-			} );
-
-			expect( state ).toEqual( [ { owner: 'lister', slug: 'banana' } ] );
-		} );
-
-		test( 'should not store new missing lists in the case of a different error', () => {
-			const state = missingLists( undefined, {
-				type: READER_LIST_REQUEST_FAILURE,
-				error: {
-					statusCode: 400,
-				},
-				owner: 'lister',
-				slug: 'banana',
-			} );
-
-			expect( state ).toEqual( [] );
-		} );
-
-		test( 'should remove a missing list if a successful lists response is received', () => {
-			const initialState = missingLists( undefined, {
-				type: READER_LIST_REQUEST_FAILURE,
-				error: {
-					statusCode: 404,
-				},
-				owner: 'lister',
-				slug: 'banana',
-			} );
-
-			expect( initialState ).toEqual( [ { owner: 'lister', slug: 'banana' } ] );
-
-			const state = missingLists( initialState, {
-				type: READER_LISTS_RECEIVE,
-				lists: [
-					{ ID: 841, title: 'Hello World', owner: 'lister', slug: 'banana' },
-					{ ID: 413, title: 'Mangos and feijoas', owner: 'lister', slug: 'mango' },
-				],
-			} );
-
-			expect( state ).toEqual( [] );
-		} );
-
-		test( 'should remove a missing list if a successful single list response is received', () => {
-			const initialState = missingLists( undefined, {
-				type: READER_LIST_REQUEST_FAILURE,
-				error: {
-					statusCode: 404,
-				},
-				owner: 'lister',
-				slug: 'banana',
-			} );
-
-			expect( initialState ).toEqual( [ { owner: 'lister', slug: 'banana' } ] );
-
-			const state = missingLists( initialState, {
-				type: READER_LIST_REQUEST_SUCCESS,
-				data: {
-					list: { ID: 841, title: 'Hello World', owner: 'lister', slug: 'banana' },
-				},
-			} );
-
-			expect( state ).toEqual( [] );
 		} );
 	} );
 

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -338,7 +338,19 @@ describe( 'selectors', () => {
 				{
 					reader: {
 						lists: {
-							missingLists: [],
+							items: {
+								123: {
+									ID: 123,
+									owner: 'lister',
+									slug: 'bananas',
+								},
+								456: {
+									ID: 456,
+									owner: 'lister',
+									slug: 'ants',
+								},
+							},
+							isRequestingLists: false,
 						},
 					},
 				},
@@ -349,17 +361,57 @@ describe( 'selectors', () => {
 			expect( isMissing ).toEqual( false );
 		} );
 
+		test( 'should return false if lists are still being requested', () => {
+			const isMissing = isMissingByOwnerAndSlug(
+				{
+					reader: {
+						lists: {
+							items: {
+								123: {
+									ID: 123,
+									owner: 'lister',
+									slug: 'bananas',
+								},
+								456: {
+									ID: 456,
+									owner: 'lister',
+									slug: 'ants',
+								},
+							},
+							isRequestingLists: true,
+						},
+					},
+				},
+				'lister',
+				'kittens'
+			);
+
+			expect( isMissing ).toEqual( false );
+		} );
+
 		test( 'should return true if the owner and slug match a missing list', () => {
 			const isMissing = isMissingByOwnerAndSlug(
 				{
 					reader: {
 						lists: {
-							missingLists: [ { owner: 'lister', slug: 'bananas' } ],
+							items: {
+								123: {
+									ID: 123,
+									owner: 'lister',
+									slug: 'bananas',
+								},
+								456: {
+									ID: 456,
+									owner: 'lister',
+									slug: 'ants',
+								},
+							},
+							isRequestingLists: false,
 						},
 					},
 				},
 				'lister',
-				'bananas'
+				'kittens'
 			);
 
 			expect( isMissing ).toEqual( true );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is only my second time looking at Lists, so forgive me if I'm completely missing something, but I've been exploring this in depth and I can't understand why `missingLists` is needed. It's currently broken, but it seems the intention was to add missing lists to an array. Given that we're already aware of the owner and slug, it feels like it makes more sense to replace all this with a more simple one-liner: `! state.reader?.lists?.isRequestingLists && ! getListByOwnerAndSlug( state, owner, slug )`.

But I realise this does delete a lot of code, and although I'm pretty confident there's no downside to this, please let me know if I'm missing something obvious!

#### Testing instructions

Visit something like `/read/list/not/there` and verify that the appropriate error appears. A real list shouldn't prompt this error.

<img width="1845" alt="Screenshot 2021-05-28 at 16 53 54" src="https://user-images.githubusercontent.com/43215253/120012231-2552f680-bfd7-11eb-9652-e6fa36be976d.png">

cc @bluefuton 

Fixes #48702
