### PR TITLE
Fix headerText value provided to FormattedHeader

### DIFF
--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -23,7 +23,9 @@ import './style.scss';
 const DomainManagementHeader = ( props ) => {
 	const { selectedDomainName, isManagingAllDomains, onClick, backHref, children } = props;
 	const translate = useTranslate();
-	let formattedHeaderText = selectedDomainName;
+	let formattedHeaderText = selectedDomainName?.domain
+		? selectedDomainName.domain
+		: selectedDomainName;
 	if ( ! selectedDomainName ) {
 		formattedHeaderText = isManagingAllDomains
 			? translate( 'All Domains' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In Automattic/wp-calypso/pull/53119 the `headerText` value passed to a `<FormattedHeader>` was changed, but the `selectedDomainName` prop can be either a string OR an object so a crash was occuring:

![error](https://user-images.githubusercontent.com/15803018/120027157-43593080-bfb0-11eb-9434-b20f5a665347.png)

Checking `selectedDomainName?.domain` to see if it's an object first and picking off the `domain` property to assign to `formattedHeaderText` if it is.

#### Testing instructions

* After pulling down changes, in Calypso navigate to the Domains page for a WPcom simple site: `/domains/manage/example.wordpress.com`
* Click on the WordPress.com (Free site address) provided domain name.
* Click on `Change site address`, and make sure that page doesn't crash and you are able to change the free site address.

Additional Testing:

* Make sure that the domain management screens work for sites with free & custom domain names.
* Make sure that the "All Domains" management screen functions as expected: `/domains/manage`

#### Context

* Internal: p1622223238051200-slack-C02DQP0FP
* CC: @katiebethbrown 