### PR TITLE
Adding Fullstory exclude class to checkout pages

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -226,9 +226,9 @@ export function Checkout( {
 
 	const getDefaultCheckoutSteps = () => <DefaultCheckoutSteps />;
 
+	// the `composite-checkout` class name is used by FullStory to avoid recording WordPress.com checkout session activity
 	const classNames = joinClasses( [
 		'composite-checkout',
-		'fs-exclude', // this class is used by FullStory to exclude recording session activity
 		...( className ? [ className ] : [] ),
 		...( isRTL() ? [ 'rtl' ] : [] ),
 	] );

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -228,7 +228,7 @@ export function Checkout( {
 
 	const classNames = joinClasses( [
 		'composite-checkout',
-		'fs-exclude',
+		'fs-exclude', // this class is used by FullStory to exclude recording session activity
 		...( className ? [ className ] : [] ),
 		...( isRTL() ? [ 'rtl' ] : [] ),
 	] );

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -226,7 +226,9 @@ export function Checkout( {
 
 	const getDefaultCheckoutSteps = () => <DefaultCheckoutSteps />;
 
-	// the `composite-checkout` class name is used by FullStory to avoid recording WordPress.com checkout session activity
+	// Note: the composite-checkout class name is also used by FullStory to avoid recording
+	// WordPress.com checkout session activity. If this class name is changed or removed, we
+	// will also need to adjust this FullStory configuration.
 	const classNames = joinClasses( [
 		'composite-checkout',
 		...( className ? [ className ] : [] ),

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -228,6 +228,7 @@ export function Checkout( {
 
 	const classNames = joinClasses( [
 		'composite-checkout',
+		'fs-exclude',
 		...( className ? [ className ] : [] ),
 		...( isRTL() ? [ 'rtl' ] : [] ),
 	] );


### PR DESCRIPTION
This PR adds the `fs-exclude` CSS class to the Calypso checkout pages, which causes FullStory to exclude checkout sessions from session recordings. This is in addition to the current check which looks for `composite-checkout`.

#### Testing instructions
* Checkout this PR and start Calypso.
* Load the admin section of a test site.
* Add an upgrade to your cart and start the checkout process.
* View the page source and confirm that the `fs-exclude` class has been added to the page.

Related to #52768 
