### PR TITLE
Jetpack Logged Out Checkout: fix usage of `checkoutBackUrl`

### DIFF
--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -605,6 +605,21 @@ export function checkout(
 	const productsArray = Array.isArray( products ) ? products : [ products ];
 	const productsString = productsArray.join( ',' );
 
+	if ( isJetpackCloud() ) {
+		// Unauthenticated users will be presented with a Jetpack branded version of the login form
+		// if the URL has the query parameter `source=jetpack-plans`. We only want to do this if the
+		// user is in Jetpack Cloud.
+		if ( ! urlQueryArgs.source ) {
+			urlQueryArgs.source = 'jetpack-plans';
+		}
+
+		// This URL is used when clicking the back button in the checkout screen to redirect users
+		// back to cloud instead of wordpress.com
+		if ( ! urlQueryArgs.checkoutBackUrl ) {
+			urlQueryArgs.checkoutBackUrl = window.location.href;
+		}
+	}
+
 	if ( config.isEnabled( 'jetpack/userless-checkout' ) ) {
 		const { unlinked, purchasetoken, purchaseNonce, site } = urlQueryArgs;
 		const canDoUnlinkedCheckout = unlinked && !! site && ( !! purchasetoken || purchaseNonce );
@@ -630,21 +645,6 @@ export function checkout(
 	const path = siteSlug
 		? `/checkout/${ siteSlug }/${ productsString }`
 		: `/jetpack/connect/${ productsString }`;
-
-	if ( isJetpackCloud() ) {
-		// Unauthenticated users will be presented with a Jetpack branded version of the login form
-		// if the URL has the query parameter `source=jetpack-plans`. We only want to do this if the
-		// user is in Jetpack Cloud.
-		if ( ! urlQueryArgs.source ) {
-			urlQueryArgs.source = 'jetpack-plans';
-		}
-
-		// This URL is used when clicking the back button in the checkout screen to redirect users
-		// back to cloud instead of wordpress.com
-		if ( ! urlQueryArgs.checkoutBackUrl ) {
-			urlQueryArgs.checkoutBackUrl = window.location.href;
-		}
-	}
 
 	if ( isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
 		window.location.href = addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,6 +45,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/redirect-legacy-plans": true,
+		"jetpack/userless-checkout": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -40,6 +40,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/redirect-legacy-plans": true,
+		"jetpack/userless-checkout": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to 1200152453830945-as-1200396910417985

The close button on the Jetpack logged-out checkout page leads users to `wordpress.com/start`. This breaks the UX since the button should lead users back to where they came from (the pricing page).

* Run the logic that computes the `checkoutBackUrl` before the one that creates the checkout URL for the logged-out checkout flow.
* Add the `jetpack/userless-checkout` feature flag to Jetpack's env config files that don't have it (production stays disabled).

#### Testing instructions

* Download this PR.
* Run Calypso Green with `yarn start-jetpack-cloud`.
* Create Jurassic Ninja site.
* Connect the site at the site-level (no user connection).
* Once you are on the pricing page, replace the domain `https://cloud.jetpack.com` with `jetpack.cloud.localhost:3000` and keep the rest of the URL intact.
* Click on any Jetpack product.
* Once you are on the checkout page, click on the close X button located at the top-left corner of the screen.
* Make sure you are back on the pricing page.

#### Demo – before

https://user-images.githubusercontent.com/3418513/120046495-453ae800-bfe0-11eb-8604-8474f9eda892.mp4

#### Demo – after

https://user-images.githubusercontent.com/3418513/120046314-e37a7e00-bfdf-11eb-8019-0d493673cd32.mp4