### PR TITLE
 Stats: Include URL in CSV Export Data

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -180,19 +180,31 @@ describe( 'utils', () => {
 		test( 'should parse simple object to csv', () => {
 			expect(
 				buildExportArray( {
+					actions: [
+						{
+							type: 'link',
+							data: 'https://example.com/chicken',
+						},
+					],
 					label: 'Chicken',
 					value: 10,
 				} )
-			).toEqual( [ [ '"Chicken"', 10 ] ] );
+			).toEqual( [ [ '"Chicken"', 10, 'https://example.com/chicken' ] ] );
 		} );
 
 		test( 'should escape simple object to csv', () => {
 			expect(
 				buildExportArray( {
+					actions: [
+						{
+							type: 'link',
+							data: 'https://example.com/chicken',
+						},
+					],
 					label: 'Chicken and "Ribs"',
 					value: 10,
 				} )
-			).toEqual( [ [ '"Chicken and ""Ribs""', 10 ] ] );
+			).toEqual( [ [ '"Chicken and ""Ribs""', 10, 'https://example.com/chicken' ] ] );
 		} );
 
 		test( 'should recurse child data', () => {
@@ -200,16 +212,40 @@ describe( 'utils', () => {
 				buildExportArray( {
 					label: 'BBQ',
 					value: 10,
+					actions: [
+						{
+							type: 'link',
+							data: 'https://example.com/bbq',
+						},
+					],
 					children: [
 						{
+							actions: [
+								{
+									type: 'link',
+									data: 'https://example.com/bbq/chicken',
+								},
+							],
 							label: 'Chicken',
 							value: 5,
 						},
 						{
+							actions: [
+								{
+									type: 'link',
+									data: 'https://example.com/bbq/ribs',
+								},
+							],
 							label: 'Ribs',
 							value: 2,
 							children: [
 								{
+									actions: [
+										{
+											type: 'link',
+											data: 'https://example.com/bbq/ribs/babyback',
+										},
+									],
 									label: 'Babyback',
 									value: 1,
 								},
@@ -218,10 +254,10 @@ describe( 'utils', () => {
 					],
 				} )
 			).toEqual( [
-				[ '"BBQ"', 10 ],
-				[ '"BBQ > Chicken"', 5 ],
-				[ '"BBQ > Ribs"', 2 ],
-				[ '"BBQ > Ribs > Babyback"', 1 ],
+				[ '"BBQ"', 10, 'https://example.com/bbq' ],
+				[ '"BBQ > Chicken"', 5, 'https://example.com/bbq/chicken' ],
+				[ '"BBQ > Ribs"', 2, 'https://example.com/bbq/ribs' ],
+				[ '"BBQ > Ribs > Babyback"', 1, 'https://example.com/bbq/ribs/babyback' ],
 			] );
 		} );
 	} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -101,12 +101,12 @@ function parseAvatar( avatarUrl ) {
  * @returns {Array}         CSV Row
  */
 export function buildExportArray( data, parent = null ) {
-	if ( ! data || ! data.label || ! data.value ) {
+	if ( ! data || ! data.label || ! data.value || ! data.actions ) {
 		return [];
 	}
 	const label = parent ? parent + ' > ' + data.label : data.label;
 	const escapedLabel = label.replace( /\"/, '""' ); // eslint-disable-line no-useless-escape
-	let exportData = [ [ '"' + escapedLabel + '"', data.value ] ];
+	let exportData = [ [ '"' + escapedLabel + '"', data.value, data.actions[ 0 ].data ] ];
 
 	if ( data.children ) {
 		const childData = map( data.children, ( child ) => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -101,12 +101,17 @@ function parseAvatar( avatarUrl ) {
  * @returns {Array}         CSV Row
  */
 export function buildExportArray( data, parent = null ) {
-	if ( ! data || ! data.label || ! data.value || ! data.actions || ! data.actions.length ) {
+	if ( ! data || ! data.label || ! data.value ) {
 		return [];
 	}
 	const label = parent ? parent + ' > ' + data.label : data.label;
 	const escapedLabel = label.replace( /\"/, '""' ); // eslint-disable-line no-useless-escape
-	let exportData = [ [ '"' + escapedLabel + '"', data.value, data.actions[ 0 ].data ] ];
+	let exportData = [ [ '"' + escapedLabel + '"', data.value ] ];
+
+	// Includes the URL for content data, but not for "Countries" data where it doesn't exist.
+	if ( data.actions && data.actions.length ) {
+		exportData = [ [ '"' + escapedLabel + '"', data.value, data.actions[ 0 ].data ] ];
+	}
 
 	if ( data.children ) {
 		const childData = map( data.children, ( child ) => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -101,7 +101,7 @@ function parseAvatar( avatarUrl ) {
  * @returns {Array}         CSV Row
  */
 export function buildExportArray( data, parent = null ) {
-	if ( ! data || ! data.label || ! data.value || ! data.actions ) {
+	if ( ! data || ! data.label || ! data.value || ! data.actions || ! data.actions.length ) {
 		return [];
 	}
 	const label = parent ? parent + ' > ' + data.label : data.label;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the URL of the content to CSV exports in Stats

#### Testing instructions

Visit `/stats/day/posts/SITEURL` and click the " Download data as CSV" button at the bottom of the table. You may need to upload the file to something like Google Sheets in order to analyse it, but it should now include the content's URL.

| Before                                                                                                                                                                | After                                                                                                                                                                 |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="683" alt="Screenshot 2021-05-30 at 11 19 20" src="https://user-images.githubusercontent.com/43215253/120100711-015bf600-c13a-11eb-8092-b90125cabc58.png"> | <<img width="1105" alt="Screenshot 2021-05-30 at 11 19 12" src="https://user-images.githubusercontent.com/43215253/120100707-fbfeab80-c139-11eb-9c2d-4c89636ab4a5.png"> |

cc @sixhours 

Fixes #39912
