### PR TITLE
Jetpack Search: handle disconnected sites

### DIFF
--- a/client/my-sites/jetpack-search/controller.js
+++ b/client/my-sites/jetpack-search/controller.js
@@ -7,6 +7,18 @@ import React from 'react';
  * Internal dependencies
  */
 import JetpackSearchMain from './main';
+import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-disconnected-switch';
+import JetpackSearchDisconnected from './disconnected';
+
+export function showJetpackIsDisconnected( context, next ) {
+	context.primary = (
+		<IsJetpackDisconnectedSwitch
+			trueComponent={ <JetpackSearchDisconnected /> }
+			falseComponent={ context.primary }
+		/>
+	);
+	next();
+}
 
 /* handles /jetpack-search/:site, see `jetpackSearchMainPath` */
 export function jetpackSearchMain( context, next ) {

--- a/client/my-sites/jetpack-search/disconnected.tsx
+++ b/client/my-sites/jetpack-search/disconnected.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import JetpackDisconnected from 'calypso/components/jetpack/jetpack-disconnected';
+import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+
+export default function JetpackSearchDisconnected(): ReactElement {
+	const isCloud = isJetpackCloud();
+	return (
+		<Main className="jetpack-search">
+			<DocumentHead title="Jetpack Search" />
+			<SidebarNavigation />
+			<PageViewTracker path="/jetpack-search/:site" title="Jetpack Search" />
+			<div className="jetpack-search__disconnected">
+				{ isCloud ? <JetpackDisconnected /> : <JetpackDisconnectedWPCOM /> }
+			</div>
+		</Main>
+	);
+}

--- a/client/my-sites/jetpack-search/index.js
+++ b/client/my-sites/jetpack-search/index.js
@@ -6,7 +6,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetpackSearchMain } from 'calypso/my-sites/jetpack-search/controller';
+import {
+	jetpackSearchMain,
+	showJetpackIsDisconnected,
+} from 'calypso/my-sites/jetpack-search/controller';
 import { jetpackSearchMainPath } from './paths';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -18,6 +21,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		jetpackSearchMain,
+		showJetpackIsDisconnected,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/jetpack-search/style.scss
+++ b/client/my-sites/jetpack-search/style.scss
@@ -3,3 +3,7 @@
 		@include placeholder( --color-neutral-10 );
 	}
 }
+
+.theme-jetpack-cloud .jetpack-search__disconnected {
+	padding-top: 40px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle disconnected Jetpack sites in `/jetpack-search`.

#### Testing instructions

1. Run locally with CALYPSO_ENV=jetpack-cloud-development yarn start and map jetpack.cloud.localhost to 127.0.0.1 in your “hosts” file.
2. Visit http://jetpack.cloud.localhost:3000/ and choose the 'Search' item in the sidebar.
3. Try to access a site that is disconnected from Jetpack (like an old jurassic.ninja site). It should look like this:

<img width="769" alt="119295009-e278e200-bca9-11eb-9b72-84e125fdf2d8" src="https://user-images.githubusercontent.com/17325/120137747-12cffb80-c229-11eb-96cb-2579e85ae2af.png">

4. Stop Calypso and restart with the regular environment (yarn start) and access via http://calypso.localhost:3000.
5. Try to access the same disconnected site via URL - like `/jetpack-search/my-disconnected-site.example.com`. Ensure you're shown a Calypso blue version of the screen as shown below:

<img width="776" alt="Screen Shot 2021-05-31 at 15 55 46" src="https://user-images.githubusercontent.com/17325/120137742-0f3c7480-c229-11eb-925e-962bd3b2d6e4.png">

