### PR TITLE
Reader: Remove unused abtest framework

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -8,7 +8,6 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'calypso/lib/abtest';
 import { sectionify } from 'calypso/lib/route';
 import {
 	trackPageLoad,
@@ -32,10 +31,6 @@ import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 
 const analyticsPageTitle = 'Reader';
-
-const activeAbTests = [
-	// active tests would go here
-];
 let lastRoute = null;
 
 function userHasHistory( context ) {
@@ -48,12 +43,6 @@ function renderFeedError( context, next ) {
 }
 
 const exported = {
-	initAbTests( context, next ) {
-		// spin up the ab tests that are currently active for the reader
-		activeAbTests.forEach( ( test ) => abtest( test ) );
-		next();
-	},
-
 	prettyRedirects( context, next ) {
 		// Do we have a 'pretty' site or feed URL? We only use this for /discover.
 		let redirect;
@@ -335,7 +324,6 @@ const exported = {
 };
 
 export const {
-	initAbTests,
 	prettyRedirects,
 	legacyRedirects,
 	updateLastRoute,

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -42,298 +42,281 @@ function renderFeedError( context, next ) {
 	next();
 }
 
-const exported = {
-	prettyRedirects( context, next ) {
-		// Do we have a 'pretty' site or feed URL? We only use this for /discover.
-		let redirect;
-		if ( context.params.blog_id ) {
-			redirect = getPrettySiteUrl( context.params.blog_id );
-		} else if ( context.params.feed_id ) {
-			redirect = getPrettyFeedUrl( context.params.feed_id );
+export function prettyRedirects( context, next ) {
+	// Do we have a 'pretty' site or feed URL? We only use this for /discover.
+	let redirect;
+	if ( context.params.blog_id ) {
+		redirect = getPrettySiteUrl( context.params.blog_id );
+	} else if ( context.params.feed_id ) {
+		redirect = getPrettyFeedUrl( context.params.feed_id );
+	}
+
+	if ( redirect ) {
+		return page.redirect( redirect );
+	}
+
+	next();
+}
+
+export function legacyRedirects( context, next ) {
+	const legacyPathRegexes = {
+		feedStream: /^\/read\/blog\/feed\/([0-9]+)$/i,
+		feedFullPost: /^\/read\/post\/feed\/([0-9]+)\/([0-9]+)$/i,
+		blogStream: /^\/read\/blog\/id\/([0-9]+)$/i,
+		blogFullPost: /^\/read\/post\/id\/([0-9]+)\/([0-9]+)$/i,
+	};
+
+	if ( context.path.match( legacyPathRegexes.feedStream ) ) {
+		page.redirect( `/read/feeds/${ context.params.feed_id }` );
+	} else if ( context.path.match( legacyPathRegexes.feedFullPost ) ) {
+		page.redirect( `/read/feeds/${ context.params.feed_id }/posts/${ context.params.post_id }` );
+	} else if ( context.path.match( legacyPathRegexes.blogStream ) ) {
+		page.redirect( `/read/blogs/${ context.params.blog_id }` );
+	} else if ( context.path.match( legacyPathRegexes.blogFullPost ) ) {
+		page.redirect( `/read/blogs/${ context.params.blog_id }/posts/${ context.params.post_id }` );
+	}
+
+	next();
+}
+
+export function updateLastRoute( context, next ) {
+	if ( lastRoute ) {
+		context.lastRoute = lastRoute;
+	}
+	lastRoute = context.path;
+	next();
+}
+
+export function incompleteUrlRedirects( context, next ) {
+	let redirect;
+	// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
+	if ( context.path.match( /^\/read\/feeds\/([0-9]+)\/posts$/i ) ) {
+		redirect = `/read/feeds/${ context.params.feed_id }`;
+	} else if ( context.path.match( /^\/read\/blogs\/([0-9]+)\/posts$/i ) ) {
+		redirect = `/read/blogs/${ context.params.blog_id }`;
+	}
+
+	if ( redirect ) {
+		return page.redirect( redirect );
+	}
+
+	next();
+}
+
+export function sidebar( context, next ) {
+	context.secondary = (
+		<AsyncLoad require="calypso/reader/sidebar" path={ context.path } placeholder={ null } />
+	);
+
+	next();
+}
+
+export function unmountSidebar( context, next ) {
+	next();
+}
+
+export function following( context, next ) {
+	const basePath = sectionify( context.path );
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Following';
+	const mcKey = 'following';
+	const startDate = getStartDate( context );
+
+	const state = context.store.getState();
+	// only for a8c for now
+	if ( isAutomatticTeamMember( getReaderTeams( state ) ) ) {
+		// select last reader path if available, otherwise just open following
+		const currentSection = getSection( state );
+		const lastPath = getLastPath( state );
+
+		if ( lastPath && lastPath !== '/read' && currentSection.name !== 'reader' ) {
+			return page.redirect( lastPath );
 		}
 
-		if ( redirect ) {
-			return page.redirect( redirect );
+		// if we have no last path, default to Following/All and expand following
+		const isOpen = isFollowingOpen( state );
+		if ( ! isOpen ) {
+			context.store.dispatch( toggleReaderSidebarFollowing() );
 		}
+	}
 
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_following_loaded' );
+
+	setPageTitle( context, i18n.translate( 'Following' ) );
+
+	// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
+	context.primary = React.createElement( StreamComponent, {
+		key: 'following',
+		listName: i18n.translate( 'Followed Sites' ),
+		streamKey: 'following',
+		startDate,
+		recsStreamKey: 'custom_recs_posts_with_images',
+		showPrimaryFollowButtonOnCards: false,
+		trackScrollPage: trackScrollPage.bind(
+			null,
+			basePath,
+			fullAnalyticsPageTitle,
+			analyticsPageTitle,
+			mcKey
+		),
+		onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+	} );
+	next();
+}
+
+export function feedDiscovery( context, next ) {
+	if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
+		waitForHttpData( () => ( { feedId: requestFeedDiscovery( context.params.feed_id ) } ) )
+			.then( ( { feedId } ) => {
+				page.redirect( `/read/feeds/${ feedId.data }` );
+			} )
+			.catch( () => {
+				renderFeedError( context, next );
+			} );
+	} else {
 		next();
-	},
+	}
+}
 
-	legacyRedirects( context, next ) {
-		const legacyPathRegexes = {
-			feedStream: /^\/read\/blog\/feed\/([0-9]+)$/i,
-			feedFullPost: /^\/read\/post\/feed\/([0-9]+)\/([0-9]+)$/i,
-			blogStream: /^\/read\/blog\/id\/([0-9]+)$/i,
-			blogFullPost: /^\/read\/post\/id\/([0-9]+)\/([0-9]+)$/i,
-		};
-
-		if ( context.path.match( legacyPathRegexes.feedStream ) ) {
-			page.redirect( `/read/feeds/${ context.params.feed_id }` );
-		} else if ( context.path.match( legacyPathRegexes.feedFullPost ) ) {
-			page.redirect( `/read/feeds/${ context.params.feed_id }/posts/${ context.params.post_id }` );
-		} else if ( context.path.match( legacyPathRegexes.blogStream ) ) {
-			page.redirect( `/read/blogs/${ context.params.blog_id }` );
-		} else if ( context.path.match( legacyPathRegexes.blogFullPost ) ) {
-			page.redirect( `/read/blogs/${ context.params.blog_id }/posts/${ context.params.post_id }` );
-		}
-
+export function feedListing( context, next ) {
+	const feedId = context.params.feed_id;
+	if ( ! parseInt( feedId, 10 ) ) {
 		next();
-	},
+		return;
+	}
 
-	updateLastRoute( context, next ) {
-		if ( lastRoute ) {
-			context.lastRoute = lastRoute;
-		}
-		lastRoute = context.path;
-		next();
-	},
+	const basePath = '/read/feeds/:feed_id';
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + feedId;
+	const mcKey = 'blog';
 
-	incompleteUrlRedirects( context, next ) {
-		let redirect;
-		// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
-		if ( context.path.match( /^\/read\/feeds\/([0-9]+)\/posts$/i ) ) {
-			redirect = `/read/feeds/${ context.params.feed_id }`;
-		} else if ( context.path.match( /^\/read\/blogs\/([0-9]+)\/posts$/i ) ) {
-			redirect = `/read/blogs/${ context.params.blog_id }`;
-		}
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_blog_preview', { feed_id: feedId } );
 
-		if ( redirect ) {
-			return page.redirect( redirect );
-		}
-
-		next();
-	},
-
-	sidebar( context, next ) {
-		context.secondary = (
-			<AsyncLoad require="calypso/reader/sidebar" path={ context.path } placeholder={ null } />
-		);
-
-		next();
-	},
-
-	unmountSidebar( context, next ) {
-		next();
-	},
-
-	following( context, next ) {
-		const basePath = sectionify( context.path );
-		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Following';
-		const mcKey = 'following';
-		const startDate = getStartDate( context );
-
-		const state = context.store.getState();
-		// only for a8c for now
-		if ( isAutomatticTeamMember( getReaderTeams( state ) ) ) {
-			// select last reader path if available, otherwise just open following
-			const currentSection = getSection( state );
-			const lastPath = getLastPath( state );
-
-			if ( lastPath && lastPath !== '/read' && currentSection.name !== 'reader' ) {
-				return page.redirect( lastPath );
-			}
-
-			// if we have no last path, default to Following/All and expand following
-			const isOpen = isFollowingOpen( state );
-			if ( ! isOpen ) {
-				context.store.dispatch( toggleReaderSidebarFollowing() );
-			}
-		}
-
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		recordTrack( 'calypso_reader_following_loaded' );
-
-		setPageTitle( context, i18n.translate( 'Following' ) );
-
-		// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
-		context.primary = React.createElement( StreamComponent, {
-			key: 'following',
-			listName: i18n.translate( 'Followed Sites' ),
-			streamKey: 'following',
-			startDate,
-			recsStreamKey: 'custom_recs_posts_with_images',
-			showPrimaryFollowButtonOnCards: false,
-			trackScrollPage: trackScrollPage.bind(
+	context.primary = (
+		<AsyncLoad
+			require="calypso/reader/feed-stream"
+			key={ 'feed-' + feedId }
+			streamKey={ 'feed:' + feedId }
+			feedId={ +feedId }
+			trackScrollPage={ trackScrollPage.bind(
 				null,
 				basePath,
 				fullAnalyticsPageTitle,
 				analyticsPageTitle,
 				mcKey
-			),
-			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-		} );
-		next();
-	},
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showPrimaryFollowButtonOnCards={ false }
+			suppressSiteNameLink={ true }
+			showBack={ userHasHistory( context ) }
+			placeholder={ null }
+		/>
+	);
+	next();
+}
 
-	feedDiscovery( context, next ) {
-		if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
-			waitForHttpData( () => ( { feedId: requestFeedDiscovery( context.params.feed_id ) } ) )
-				.then( ( { feedId } ) => {
-					page.redirect( `/read/feeds/${ feedId.data }` );
-				} )
-				.catch( () => {
-					renderFeedError( context, next );
-				} );
-		} else {
-			next();
-		}
-	},
+export function blogListing( context, next ) {
+	const basePath = '/read/blogs/:blog_id';
+	const blogId = context.params.blog_id;
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + blogId;
+	const streamKey = 'site:' + blogId;
+	const mcKey = 'blog';
 
-	feedListing( context, next ) {
-		const feedId = context.params.feed_id;
-		if ( ! parseInt( feedId, 10 ) ) {
-			next();
-			return;
-		}
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_blog_preview', {
+		blog_id: context.params.blog_id,
+	} );
 
-		const basePath = '/read/feeds/:feed_id';
-		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + feedId;
-		const mcKey = 'blog';
+	context.primary = (
+		<AsyncLoad
+			require="calypso/reader/site-stream"
+			key={ 'site-' + blogId }
+			streamKey={ streamKey }
+			siteId={ +blogId }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showPrimaryFollowButtonOnCards={ false }
+			suppressSiteNameLink={ true }
+			showBack={ userHasHistory( context ) }
+			placeholder={ null }
+		/>
+	);
+	next();
+}
 
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		recordTrack( 'calypso_reader_blog_preview', { feed_id: feedId } );
+export function readA8C( context, next ) {
+	const basePath = sectionify( context.path );
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > A8C';
+	const mcKey = 'a8c';
+	const streamKey = 'a8c';
+	const startDate = getStartDate( context );
 
-		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/feed-stream"
-				key={ 'feed-' + feedId }
-				streamKey={ 'feed:' + feedId }
-				feedId={ +feedId }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showPrimaryFollowButtonOnCards={ false }
-				suppressSiteNameLink={ true }
-				showBack={ userHasHistory( context ) }
-				placeholder={ null }
-			/>
-		);
-		next();
-	},
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	blogListing( context, next ) {
-		const basePath = '/read/blogs/:blog_id';
-		const blogId = context.params.blog_id;
-		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + blogId;
-		const streamKey = 'site:' + blogId;
-		const mcKey = 'blog';
+	setPageTitle( context, 'Automattic' );
 
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		recordTrack( 'calypso_reader_blog_preview', {
-			blog_id: context.params.blog_id,
-		} );
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	context.primary = (
+		<AsyncLoad
+			require="calypso/reader/a8c/main"
+			key="read-a8c"
+			className="is-a8c"
+			listName="Automattic"
+			streamKey={ streamKey }
+			startDate={ startDate }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			showPrimaryFollowButtonOnCards={ false }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			placeholder={ null }
+		/>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+	next();
+}
 
-		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/site-stream"
-				key={ 'site-' + blogId }
-				streamKey={ streamKey }
-				siteId={ +blogId }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showPrimaryFollowButtonOnCards={ false }
-				suppressSiteNameLink={ true }
-				showBack={ userHasHistory( context ) }
-				placeholder={ null }
-			/>
-		);
-		next();
-	},
+export function readFollowingP2( context, next ) {
+	const basePath = sectionify( context.path );
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > P2';
+	const mcKey = 'p2';
+	const streamKey = 'p2';
+	const startDate = getStartDate( context );
 
-	readA8C( context, next ) {
-		const basePath = sectionify( context.path );
-		const fullAnalyticsPageTitle = analyticsPageTitle + ' > A8C';
-		const mcKey = 'a8c';
-		const streamKey = 'a8c';
-		const startDate = getStartDate( context );
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	setPageTitle( context, 'P2' );
 
-		setPageTitle( context, 'Automattic' );
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/a8c/main"
-				key="read-a8c"
-				className="is-a8c"
-				listName="Automattic"
-				streamKey={ streamKey }
-				startDate={ startDate }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				showPrimaryFollowButtonOnCards={ false }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				placeholder={ null }
-			/>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-		next();
-	},
-
-	readFollowingP2( context, next ) {
-		const basePath = sectionify( context.path );
-		const fullAnalyticsPageTitle = analyticsPageTitle + ' > P2';
-		const mcKey = 'p2';
-		const streamKey = 'p2';
-		const startDate = getStartDate( context );
-
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-
-		setPageTitle( context, 'P2' );
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/p2/main"
-				key="read-p2"
-				listName="P2"
-				streamKey={ streamKey }
-				startDate={ startDate }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				showPrimaryFollowButtonOnCards={ false }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				placeholder={ null }
-			/>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-		next();
-	},
-};
-
-export const {
-	prettyRedirects,
-	legacyRedirects,
-	updateLastRoute,
-	incompleteUrlRedirects,
-	sidebar,
-	unmountSidebar,
-	following,
-	feedDiscovery,
-	feedListing,
-	blogListing,
-	readA8C,
-	readFollowingP2,
-} = exported;
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	context.primary = (
+		<AsyncLoad
+			require="calypso/reader/p2/main"
+			key="read-p2"
+			listName="P2"
+			streamKey={ streamKey }
+			startDate={ startDate }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			showPrimaryFollowButtonOnCards={ false }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			placeholder={ null }
+		/>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+	next();
+}

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -7,24 +7,15 @@ import page from 'page';
  * Internal dependencies
  */
 import { conversations, conversationsA8c } from './controller';
-import { initAbTests, sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
-	page(
-		'/read/conversations',
-		updateLastRoute,
-		initAbTests,
-		sidebar,
-		conversations,
-		makeLayout,
-		clientRender
-	);
+	page( '/read/conversations', updateLastRoute, sidebar, conversations, makeLayout, clientRender );
 
 	page(
 		'/read/conversations/a8c',
 		updateLastRoute,
-		initAbTests,
 		sidebar,
 		conversationsA8c,
 		makeLayout,

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -7,9 +7,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { discover } from './controller';
-import { initAbTests, sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
-	page( '/discover', updateLastRoute, initAbTests, sidebar, discover, makeLayout, clientRender );
+	page( '/discover', updateLastRoute, sidebar, discover, makeLayout, clientRender );
 }

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -7,11 +7,10 @@ import page from 'page';
  * Internal dependencies
  */
 import { followingManage } from './controller';
-import { initAbTests, updateLastRoute, sidebar } from 'calypso/reader/controller';
+import { updateLastRoute, sidebar } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
-	page( '/following/*', initAbTests );
 	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
 	page( '/following/edit*', '/following/manage' );
 

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -12,7 +12,6 @@ import {
 	feedListing,
 	following,
 	incompleteUrlRedirects,
-	initAbTests,
 	legacyRedirects,
 	prettyRedirects,
 	readA8C,
@@ -48,7 +47,7 @@ export default async function () {
 	await lazyLoadDependencies();
 
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/read', initAbTests, updateLastRoute, sidebar, following, makeLayout, clientRender );
+		page( '/read', updateLastRoute, sidebar, following, makeLayout, clientRender );
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/read' );
@@ -59,7 +58,6 @@ export default async function () {
 		page( '/read/feed', '/read' );
 
 		// Feed stream
-		page( '/read/*', initAbTests );
 		page( '/read/blog/feed/:feed_id', legacyRedirects );
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -7,17 +7,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { likes } from './controller';
-import { initAbTests, updateLastRoute, sidebar } from 'calypso/reader/controller';
+import { updateLastRoute, sidebar } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
-	page(
-		'/activities/likes',
-		initAbTests,
-		updateLastRoute,
-		sidebar,
-		likes,
-		makeLayout,
-		clientRender
-	);
+	page( '/activities/likes', updateLastRoute, sidebar, likes, makeLayout, clientRender );
 }

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -8,7 +8,7 @@ import { startsWith } from 'lodash';
  * Internal dependencies
  */
 import { tagListing } from './controller';
-import { initAbTests, sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
@@ -19,6 +19,6 @@ const redirectHashtaggedTags = ( context, next ) => {
 };
 
 export default function () {
-	page( '/tag/*', redirectHashtaggedTags, initAbTests );
+	page( '/tag/*', redirectHashtaggedTags );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we're migrating `lib/user` to use Redux, we're hitting some instances where we need to migrate usages for the `abtest` library. However, since that one is deprecated and no longer practically used, it doesn't seem like it's worth the effort.

This PR removes the framework that was put in place to allow A/B tests to run in the reader. It hasn't been used for the past 5 years, see https://github.com/Automattic/wp-calypso/blame/cdf82ed416c9359d6b18d362d26c12375d795ab9/client/reader/controller.js#L36. So it can be removed already.

This PR is remotely related to #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Verify there are no currently running A/B tests, related to the reader
* Smoke test the reader