### PR TITLE
Remove the jetpack/connect/remote-install feature flag

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -50,25 +50,13 @@ export default function () {
 		clientRender
 	);
 
-	if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
-		page(
-			'/jetpack/connect/install',
-			controller.setMasterbar,
-			controller.credsForm,
-			makeLayout,
-			clientRender
-		);
-	} else {
-		page(
-			`/jetpack/connect/:type(install)/${ locale }`,
-			controller.redirectWithoutLocaleIfLoggedIn,
-			controller.persistMobileAppFlow,
-			controller.setMasterbar,
-			controller.connect,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/jetpack/connect/install',
+		controller.setMasterbar,
+		controller.credsForm,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/jetpack/connect',

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import { JETPACK_ADMIN_PATH } from 'calypso/jetpack-connect/constants';
@@ -118,11 +117,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], status ) ||
 				( status === NOT_CONNECTED_JETPACK && forceRemoteInstall )
 			) {
-				if (
-					config.isEnabled( 'jetpack/connect/remote-install' ) &&
-					! isMobileAppFlow &&
-					! skipRemoteInstall
-				) {
+				if ( ! isMobileAppFlow && ! skipRemoteInstall ) {
 					debug( 'Redirecting to remote_install' );
 					this.redirect( 'remote_install' );
 				} else {

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import React, { Component, Fragment } from 'react';
-import config from '@automattic/calypso-config';
 import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, includes } from 'lodash';
@@ -81,10 +80,8 @@ export class OrgCredentialsForm extends Component {
 	UNSAFE_componentWillMount() {
 		const { siteToConnect } = this.props;
 
-		if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
-			if ( ! siteToConnect ) {
-				page.redirect( '/jetpack/connect' );
-			}
+		if ( ! siteToConnect ) {
+			page.redirect( '/jetpack/connect' );
 		}
 
 		this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_view', {

--- a/config/development.json
+++ b/config/development.json
@@ -86,7 +86,6 @@
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
-		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -41,7 +41,6 @@
 		"jetpack-cloud/search": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/search-product": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -36,7 +36,6 @@
 		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/search-product": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -37,7 +37,6 @@
 		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/search-product": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/redirect-legacy-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -58,7 +58,6 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -60,7 +60,6 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,

--- a/config/test.json
+++ b/config/test.json
@@ -52,7 +52,6 @@
 		"inline-help": true,
 		"ive/use-external-assignment": true,
 		"jetpack/concierge-sessions": false,
-		"jetpack/connect/remote-install": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,7 +67,6 @@
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jetpack/features-section/simple": true,


### PR DESCRIPTION
Removes the `jetpack/connect/remote-install` feature flag that is true in absolutely all environments, even Jetpack Cloud.