### PR TITLE
User Edit Form: strongly types field keys.

### DIFF
--- a/client/my-sites/people/contractor-select/index.tsx
+++ b/client/my-sites/people/contractor-select/index.tsx
@@ -13,6 +13,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import SupportInfo from 'calypso/components/support-info';
 
 interface Props {
+	key: string;
 	checked: boolean;
 	onChange: ( event ) => void;
 	disabled: boolean;
@@ -23,11 +24,11 @@ interface Props {
  */
 import './style.scss';
 
-const ContractorSelect: FunctionComponent< Props > = ( { checked, onChange, disabled } ) => {
+const ContractorSelect: FunctionComponent< Props > = ( { key, checked, onChange, disabled } ) => {
 	const translate = useTranslate();
 
 	return (
-		<FormFieldset className="contractor-select">
+		<FormFieldset key={ key } className="contractor-select">
 			<FormLabel>
 				<FormCheckbox
 					className="contractor-select__checkbox"

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -37,6 +37,13 @@ import './style.scss';
  */
 const debug = debugModule( 'calypso:my-sites:people:edit-team-member-form' );
 
+const fieldKeys = {
+	firstName: 'first_name',
+	lastName: 'last_name',
+	name: 'name',
+	roles: 'roles',
+};
+
 class EditUserForm extends React.Component {
 	state = this.getStateObject( this.props );
 
@@ -89,17 +96,17 @@ class EditUserForm extends React.Component {
 		if ( isJetpack ) {
 			// Jetpack self hosted or Atomic.
 			if ( ! user.linked_user_ID || user.linked_user_ID !== currentUser.ID ) {
-				allowedSettings.push( 'roles', 'isExternalContributor' );
+				allowedSettings.push( fieldKeys.roles, 'isExternalContributor' );
 			}
 		} else if ( user.ID !== currentUser.ID ) {
 			// WP.com Simple sites.
-			allowedSettings.push( 'roles', 'isExternalContributor' );
+			allowedSettings.push( fieldKeys.roles, 'isExternalContributor' );
 		}
 
 		// On any site, allow editing 'first_name', 'last_name', 'name'
 		// only for users without WP.com account.
 		if ( ! hasWPCOMAccountLinked ) {
-			allowedSettings.push( 'first_name', 'last_name', 'name' );
+			allowedSettings.push( fieldKeys.firstName, fieldKeys.lastName, fieldKeys.name );
 		}
 
 		return allowedSettings;
@@ -159,16 +166,16 @@ class EditUserForm extends React.Component {
 	renderField = ( fieldId, isDisabled ) => {
 		let returnField = null;
 		switch ( fieldId ) {
-			case 'roles':
+			case fieldKeys.roles:
 				returnField = (
-					<Fragment key="roles">
+					<Fragment key={ fieldKeys.roles }>
 						<RoleSelect
-							id="roles"
-							name="roles"
+							id={ fieldKeys.roles }
+							name={ fieldKeys.roles }
 							siteId={ this.props.siteId }
 							value={ this.state.roles }
 							onChange={ this.handleChange }
-							onFocus={ this.recordFieldFocus( 'roles' ) }
+							onFocus={ this.recordFieldFocus( fieldKeys.roles ) }
 							disabled={ isDisabled }
 						/>
 						{ ! this.props.isVip &&
@@ -183,58 +190,58 @@ class EditUserForm extends React.Component {
 					</Fragment>
 				);
 				break;
-			case 'first_name':
+			case fieldKeys.firstName:
 				returnField = (
-					<FormFieldset key="first_name">
-						<FormLabel htmlFor="first_name">
+					<FormFieldset key={ fieldKeys.firstName }>
+						<FormLabel htmlFor={ fieldKeys.firstName }>
 							{ this.props.translate( 'First Name', {
 								context: 'Text that is displayed in a label of a form.',
 							} ) }
 						</FormLabel>
 						<FormTextInput
-							id="first_name"
-							name="first_name"
+							id={ fieldKeys.firstName }
+							name={ fieldKeys.firstName }
 							value={ this.state.first_name }
 							onChange={ this.handleChange }
-							onFocus={ this.recordFieldFocus( 'first_name' ) }
+							onFocus={ this.recordFieldFocus( fieldKeys.firstName ) }
 							disabled={ isDisabled }
 						/>
 					</FormFieldset>
 				);
 				break;
-			case 'last_name':
+			case fieldKeys.lastName:
 				returnField = (
-					<FormFieldset key="last_name">
-						<FormLabel htmlFor="last_name">
+					<FormFieldset key={ fieldKeys.lastName }>
+						<FormLabel htmlFor={ fieldKeys.lastName }>
 							{ this.props.translate( 'Last Name', {
 								context: 'Text that is displayed in a label of a form.',
 							} ) }
 						</FormLabel>
 						<FormTextInput
-							id="last_name"
-							name="last_name"
+							id={ fieldKeys.lastName }
+							name={ fieldKeys.lastName }
 							value={ this.state.last_name }
 							onChange={ this.handleChange }
-							onFocus={ this.recordFieldFocus( 'last_name' ) }
+							onFocus={ this.recordFieldFocus( fieldKeys.lastName ) }
 							disabled={ isDisabled }
 						/>
 					</FormFieldset>
 				);
 				break;
-			case 'name':
+			case fieldKeys.name:
 				returnField = (
-					<FormFieldset key="name">
-						<FormLabel htmlFor="name">
+					<FormFieldset key={ fieldKeys.name }>
+						<FormLabel htmlFor={ fieldKeys.name }>
 							{ this.props.translate( 'Public Display Name', {
 								context: 'Text that is displayed in a label of a form.',
 							} ) }
 						</FormLabel>
 						<FormTextInput
-							id="name"
-							name="name"
+							id={ fieldKeys.name }
+							name={ fieldKeys.name }
 							value={ this.state.name }
 							onChange={ this.handleChange }
-							onFocus={ this.recordFieldFocus( 'name' ) }
+							onFocus={ this.recordFieldFocus( fieldKeys.name ) }
 							disabled={ isDisabled }
 						/>
 					</FormFieldset>

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -89,7 +89,7 @@ class EditUserForm extends React.Component {
 		const allowedSettings = new Set();
 
 		if ( ! user.ID ) {
-			return allowedSettings;
+			return [];
 		}
 
 		// On any site, admins should be able to change only other

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -42,6 +42,7 @@ const fieldKeys = {
 	lastName: 'last_name',
 	name: 'name',
 	roles: 'roles',
+	isExternalContributor: 'isExternalContributor',
 };
 
 class EditUserForm extends React.Component {
@@ -85,7 +86,7 @@ class EditUserForm extends React.Component {
 
 	getAllowedSettingsToChange() {
 		const { currentUser, user, isJetpack, hasWPCOMAccountLinked } = this.props;
-		const allowedSettings = [];
+		const allowedSettings = new Set();
 
 		if ( ! user.ID ) {
 			return allowedSettings;
@@ -96,20 +97,24 @@ class EditUserForm extends React.Component {
 		if ( isJetpack ) {
 			// Jetpack self hosted or Atomic.
 			if ( ! user.linked_user_ID || user.linked_user_ID !== currentUser.ID ) {
-				allowedSettings.push( fieldKeys.roles, 'isExternalContributor' );
+				allowedSettings.add( fieldKeys.roles );
+				allowedSettings.add( fieldKeys.isExternalContributor );
 			}
 		} else if ( user.ID !== currentUser.ID ) {
 			// WP.com Simple sites.
-			allowedSettings.push( fieldKeys.roles, 'isExternalContributor' );
+			allowedSettings.add( fieldKeys.roles );
+			allowedSettings.add( fieldKeys.isExternalContributor );
 		}
 
 		// On any site, allow editing 'first_name', 'last_name', 'name'
 		// only for users without WP.com account.
 		if ( ! hasWPCOMAccountLinked ) {
-			allowedSettings.push( fieldKeys.firstName, fieldKeys.lastName, fieldKeys.name );
+			allowedSettings.add( fieldKeys.firstName );
+			allowedSettings.add( fieldKeys.lastName );
+			allowedSettings.add( fieldKeys.name );
 		}
 
-		return allowedSettings;
+		return Array.from( allowedSettings );
 	}
 
 	hasUnsavedSettings() {

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -141,7 +141,7 @@ class EditUserForm extends React.Component {
 	updateUser = ( event ) => {
 		event.preventDefault();
 
-		const { siteId, user, markSaved, hasWPCOMAccountLinked } = this.props;
+		const { siteId, user, markSaved } = this.props;
 		const changedSettings = this.getChangedSettings();
 		debug( 'Changed settings: ' + JSON.stringify( changedSettings ) );
 
@@ -159,12 +159,12 @@ class EditUserForm extends React.Component {
 		if ( true === changedSettings.isExternalContributor ) {
 			requestExternalContributorsAddition(
 				siteId,
-				hasWPCOMAccountLinked ? user?.linked_user_ID || user.ID : user.ID // On simple sites linked_user_ID is undefined for connected users.
+				user?.linked_user_ID ?? user?.ID // On simple sites linked_user_ID is undefined for connected users.
 			);
 		} else if ( false === changedSettings.isExternalContributor ) {
 			requestExternalContributorsRemoval(
 				siteId,
-				hasWPCOMAccountLinked ? user?.linked_user_ID || user.ID : user.ID // On simple sites linked_user_ID is undefined for connected users.
+				user?.linked_user_ID ?? user?.ID // On simple sites linked_user_ID is undefined for connected users.
 			);
 		}
 

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -275,12 +275,11 @@ class PeopleProfile extends Component {
 }
 
 export default connect( ( _state, { siteId, user } ) => {
-	const userId = user && user.ID;
-	const linkedUserId = user && user.linked_user_ID;
+	const hasWPCOMAccountLinked = false !== user?.linked_user_ID;
 	const externalContributors = ( siteId && requestExternalContributors( siteId ).data ) || [];
 	return {
 		isExternalContributor: externalContributors.includes(
-			undefined !== linkedUserId ? linkedUserId : userId
+			hasWPCOMAccountLinked ? user?.linked_user_ID || user?.ID : user?.ID
 		),
 	};
 } )( localize( withLocalizedMoment( PeopleProfile ) ) );

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -275,11 +275,8 @@ class PeopleProfile extends Component {
 }
 
 export default connect( ( _state, { siteId, user } ) => {
-	const hasWPCOMAccountLinked = false !== user?.linked_user_ID;
 	const externalContributors = ( siteId && requestExternalContributors( siteId ).data ) || [];
 	return {
-		isExternalContributor: externalContributors.includes(
-			hasWPCOMAccountLinked ? user?.linked_user_ID || user?.ID : user?.ID
-		),
+		isExternalContributor: externalContributors.includes( user?.linked_user_ID ?? user?.ID ),
 	};
 } )( localize( withLocalizedMoment( PeopleProfile ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* introduces and uses a typed `fieldKeys` object .
* replaces allowedSettings array with Set to avoid duplicates.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/edit` of an Atomic site
* select a local user
* make sure that there are no regressions, you should be able to edit:
- role
- is External contributor
- First Name
- Last Name
- Display Name

![](https://cln.sh/s97fuz+)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #53252
