### PR TITLE
Remove unneeded mocking of lib/abtest and i18n-calypso

### DIFF
--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -1,20 +1,4 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 const translate = ( x ) => x;
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
 
 /**
  * External dependencies

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 /**
  * External dependencies
  */

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -1,24 +1,7 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
 
 /**
  * External dependencies

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/blocks/dismissible-card', () => {
 	const React = require( 'react' );
 	return class DismissibleCard extends React.Component {};
@@ -11,19 +7,6 @@ jest.mock( 'calypso/lib/analytics/track-component-view', () => {
 	const React = require( 'react' );
 	return class TrackComponentView extends React.Component {};
 } );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
 
 /**
  * External dependencies

--- a/client/components/seo/preview-upgrade-nudge/test/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/test/index.jsx
@@ -1,25 +1,8 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'calypso/lib/analytics/track-component-view', () => 'TrackComponentView' );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
 
 /**
  * External dependencies

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -10,9 +10,6 @@ import { renderToString } from 'react-dom/server';
  */
 import LayoutLoggedOut from '../logged-out';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
 jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );
 
 describe( 'index', () => {

--- a/client/lib/automated-transfer/test/index.js
+++ b/client/lib/automated-transfer/test/index.js
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( '@automattic/calypso-config', () => {
 	const defaultExport = jest.fn();
 	defaultExport.isEnabled = jest.fn();

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -16,8 +16,6 @@ import flows from 'calypso/signup/config/flows';
 import { isDomainStepSkippable } from 'calypso/signup/config/steps';
 import user from 'calypso/lib/user';
 
-jest.mock( 'calypso/lib/abtest', () => ( { abtest: () => '' } ) );
-
 jest.mock( 'calypso/lib/user', () => {
 	const getStub = jest.fn();
 

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( '../shared/upsell', () => 'Upsell' );
 jest.mock( '../shared/no-available-times', () => 'NoAvailableTimes' );
 

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -9,10 +9,6 @@ import React from 'react';
  */
 import { CheckoutThankYouHeader } from '../header';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.unmock( '@automattic/calypso-products' );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -30,10 +30,6 @@ import {
 import { CheckoutThankYou } from '../index';
 import { isRebrandCitiesSiteUrl } from 'calypso/lib/rebrand-cities';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.unmock( '@automattic/calypso-products' );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/test/index.jsx
@@ -1,28 +1,10 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
-
 /**
  * External dependencies
  */
-import React from 'react';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS_MONTHLY,

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -2,26 +2,9 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: ( Comp ) => ( props ) => (
-		<Comp
-			{ ...props }
-			translate={ function ( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: ( x ) => x,
-	translate: ( x ) => x,
-} ) );
 
 /**
  * External dependencies

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/ad-tracking', () => ( {} ) );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'react-redux', () => ( {
 	connect: () => ( component ) => component,
 } ) );

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -26,10 +26,6 @@ import {
 	PLAN_BLOGGER_2_YEARS,
 } from '@automattic/calypso-products';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,9 +1,5 @@
 /** @jest-environment jsdom */
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -13,15 +13,9 @@ import { shallow } from 'enzyme';
  */
 import { MySitesSidebar } from '..';
 import config from '@automattic/calypso-config';
-import { abtest } from 'calypso/lib/abtest';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: jest.fn( () => {
-		return 'sidebarUpsells';
-	} ),
-} ) );
 jest.mock( 'calypso/lib/analytics/track-component-view', () => 'TrackComponentView' );
 jest.mock( 'calypso/my-sites/sidebar/utils', () => ( {
 	itemLinkMatches: jest.fn( () => true ),
@@ -43,7 +37,6 @@ describe( 'MySitesSidebar', () => {
 
 		beforeEach( () => {
 			config.isEnabled.mockImplementation( () => true );
-			abtest.mockImplementation( () => 'sidebarUpsells' );
 		} );
 
 		test( 'Should return null item if woocommerce/extension-dashboard is disabled', () => {
@@ -108,8 +101,7 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper ).toEqual( {} );
 		} );
 
-		test( 'Should return null item if user who can upgrade can not use store on this site (control a/b group)', () => {
-			abtest.mockImplementation( () => 'control' );
+		test( 'Should return null item if user who can upgrade can not use store on this site', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: false,
 				canUserUpgradeSite: true,
@@ -126,11 +118,10 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 
-		test( "Should return null if user who can't upgrade user can not use store on this site (control a/b group)", () => {
-			abtest.mockImplementation( () => 'control' );
+		test( "Should return null if user who can't upgrade user can not use store on this site", () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseCalypsoStore: false,
-				canUserUpgradeSite: true,
+				canUserUpgradeSite: false,
 				...defaultProps,
 				site: {
 					plan: {

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -2,10 +2,6 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'store', () => ( {
 	get: () => {},
 	User: () => {},

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -15,7 +15,6 @@ import { THEMES_REQUEST_FAILURE } from 'calypso/state/themes/action-types';
 import { receiveThemes } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 
-jest.mock( 'calypso/lib/abtest', () => ( { abtest: () => {} } ) );
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () =>
 	require( 'calypso/components/empty-component' )

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -9,9 +9,6 @@ import { intersection, isEmpty, keys } from 'lodash';
 import flows from '../flows';
 import steps from '../steps';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
 jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );
 
 describe( 'index', () => {

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -1,7 +1,3 @@
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
@@ -11,10 +7,6 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-
-jest.mock( 'i18n-calypso', () => ( {
-	translate: ( str ) => str,
-} ) );
 
 /**
  * Internal dependencies

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -20,10 +20,6 @@ const noop = () => {};
 const translate = ( string ) => string;
 
 jest.mock( 'calypso/blocks/signup-form', () => require( 'calypso/components/empty-component' ) );
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-	getABTestVariation: () => null,
-} ) );
 jest.mock( 'calypso/signup/step-wrapper', () => require( 'calypso/components/empty-component' ) );
 jest.mock( 'calypso/signup/utils', () => ( {
 	getFlowSteps: ( flow ) => {

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -19,10 +19,6 @@ import {
 } from '../utils';
 import flows from 'calypso/signup/config/flows';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/signup/config/flows-pure', () => ( {
 	generateFlows: () => require( './fixtures/flows' ).default,
 } ) );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -19,10 +19,6 @@ import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import { getPlan, TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 
-jest.mock( 'calypso/lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
 } ) );


### PR DESCRIPTION
Removes unneeded mocking of the `lib/abtest` modules, and a few cases of `i18n-calypso`, too.

`lib/abtest` is no longer used in the tested code, and `i18n-calypso` has been refactored to be side-effect free a long time ago.