### PR TITLE
Restructure routes

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import page from 'page';
 import { includes, some } from 'lodash';
-import config from '@automattic/calypso-config';
 
 /**
  * Internal Dependencies
@@ -20,7 +19,6 @@ import PluginUpload from './plugin-upload';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import AsyncLoad from 'calypso/components/async-load';
-import { isMarketplaceProduct } from 'calypso/my-sites/plugins/marketplace/constants';
 import MarketplacePluginDetails from 'calypso/my-sites/plugins/marketplace/marketplace-plugin-details';
 
 /**
@@ -41,27 +39,39 @@ function renderSinglePlugin( context, siteUrl ) {
 		prevPath = sectionify( context.prevPath );
 	}
 
-	//Add condition to check if business/ecommerce plan before committing
-	if ( config.isEnabled( 'marketplace-yoast' ) && isMarketplaceProduct( pluginSlug ) ) {
-		context.primary = (
-			<MarketplacePluginDetails
-				path={ context.path }
-				prevQuerystring={ lastPluginsQuerystring }
-				prevPath={ prevPath }
-				marketplacePluginSlug={ pluginSlug }
-				siteUrl={ siteUrl }
-			/>
-		);
-	} else {
-		// Render single plugin component
-		context.primary = React.createElement( PluginComponent, {
-			path: context.path,
-			prevQuerystring: lastPluginsQuerystring,
-			prevPath,
-			pluginSlug,
-			siteUrl,
-		} );
+	// Render single plugin component
+	context.primary = React.createElement( PluginComponent, {
+		path: context.path,
+		prevQuerystring: lastPluginsQuerystring,
+		prevPath,
+		pluginSlug,
+		siteUrl,
+	} );
+}
+
+export function renderMarketplacePlugin( context, next ) {
+	const siteUrl = getSiteFragment( context.path );
+
+	const pluginSlug = decodeURIComponent( context.params.plugin );
+
+	let prevPath;
+	if ( lastPluginsListVisited ) {
+		prevPath = lastPluginsListVisited;
+	} else if ( context.prevPath ) {
+		prevPath = sectionify( context.prevPath );
 	}
+
+	context.primary = (
+		<MarketplacePluginDetails
+			path={ context.path }
+			prevQuerystring={ lastPluginsQuerystring }
+			prevPath={ prevPath }
+			marketplacePluginSlug={ pluginSlug }
+			siteUrl={ siteUrl }
+		/>
+	);
+
+	next();
 }
 
 function getPathWithoutSiteSlug( context, site ) {

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -15,6 +15,7 @@ import {
 	jetpackCanUpdate,
 	plugins,
 	renderDomainsPage,
+	renderMarketplacePlugin,
 	renderPluginsSetupStatusPage,
 	resetHistory,
 	scrollTopIfNoHash,
@@ -105,11 +106,17 @@ export default function () {
 		);
 
 		if ( config.isEnabled( 'marketplace-yoast' ) ) {
-			page( '/plugins/domain/:site', siteSelection, renderDomainsPage, makeLayout, clientRender );
+			page( '/plugins/marketplace/domain/:site', renderDomainsPage, makeLayout, clientRender );
 			page(
-				'/plugins/marketplace/setup/:site',
-				siteSelection,
+				'/plugins/marketplace/product/setup/:site',
 				renderPluginsSetupStatusPage,
+				makeLayout,
+				clientRender
+			);
+			page(
+				'/plugins/marketplace/product/details/:plugin/:site',
+				navigation,
+				renderMarketplacePlugin,
 				makeLayout,
 				clientRender
 			);

--- a/client/my-sites/plugins/marketplace/marketplace-domain-upsell/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-domain-upsell/index.tsx
@@ -156,7 +156,9 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 						previousPath
 							? page( previousPath )
 							: page(
-									`/plugins/wordpress-seo${ selectedSite?.slug ? `/${ selectedSite.slug }` : '' }`
+									`/plugins/marketplace/product/details/wordpress-seo${
+										selectedSite?.slug ? `/${ selectedSite.slug }` : ''
+									}`
 							  )
 					}
 					tooltip={ translate( 'Close Domain Selection' ) }

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
@@ -29,6 +29,8 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import PurchaseArea from './purchase-area';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import MainComponent from 'calypso/components/main';
 
 interface MarketplacePluginDetailsInterface {
 	marketplacePluginSlug: keyof PluginProductMappingInterface;
@@ -64,7 +66,8 @@ function MarketplacePluginDetails( {
 	};
 
 	return (
-		<div>
+		<MainComponent>
+			<SidebarNavigation />
 			{ ! wporgFetching ? (
 				<PurchaseArea
 					siteDomains={ siteDomains }
@@ -86,7 +89,7 @@ function MarketplacePluginDetails( {
 			) : (
 				'Loading...'
 			) }
-		</div>
+		</MainComponent>
 	);
 }
 

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
@@ -80,7 +80,7 @@ function MarketplacePluginDetails( {
 					}
 					onNavigateToDomainsSelection={ () =>
 						page(
-							`/plugins/domain${
+							`/plugins/marketplace/domain${
 								selectedSite?.slug ? `/${ selectedSite?.slug }?flags=marketplace-yoast` : ''
 							}`
 						)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restructures routes to be outside the plugin system completely.

#### Testing instructions

Create a new site with a business plan or ecom plan and visit the following routes with the feature flag enabled

`/plugins/marketplace/product/details/wordpress-seo/:site?flags=marketplace-yoast`
- http://calypso.localhost:3000/plugins/marketplace/product/details/wordpress-seo/awesome.com?flags=marketplace-yoast

`/plugins/marketplace/product/setup/:site?flags=marketplace-yoast`
- http://calypso.localhost:3000/plugins/marketplace/product/setup/awesome.com?flags=marketplace-yoast

`/plugins/marketplace/domain/:site?flags=marketplace-yoast`
- http://calypso.localhost:3000/plugins/marketplace/domain/awesome.com?flags=marketplace-yoast

Make sure the routes work and display the correct relevant page. Also visit the calypso yeost-seo plugins page and make sure everything works and remains unchanged.