### PR TITLE
Jetpack Partner portal (Billing): support no invoice available response

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -80,31 +80,19 @@ export default function BillingDetails(): ReactElement {
 				<Card compact>
 					<div className="billing-details__row">
 						<div className="billing-details__product">
-							<TextPlaceholder />
-							<span className="billing-details__line-item-meta">
-								<TextPlaceholder />
-							</span>
+							{ billing.isLoading ? <TextPlaceholder /> : '-' }
 						</div>
 
 						<div className="billing-details__assigned">
-							<TextPlaceholder />
-							<span className="billing-details__line-item-meta billing-details__line-item-meta--is-mobile">
-								<TextPlaceholder />
-							</span>
+							{ billing.isLoading ? <TextPlaceholder /> : '-' }
 						</div>
 
 						<div className="billing-details__unassigned">
-							<TextPlaceholder />
-							<span className="billing-details__line-item-meta billing-details__line-item-meta--is-mobile">
-								<TextPlaceholder />
-							</span>
+							{ billing.isLoading ? <TextPlaceholder /> : '-' }
 						</div>
 
 						<div className="billing-details__subtotal">
-							<TextPlaceholder />
-							<span className="billing-details__line-item-meta">
-								<TextPlaceholder />
-							</span>
+							{ billing.isLoading ? <TextPlaceholder /> : '-' }
 						</div>
 					</div>
 				</Card>
@@ -119,12 +107,12 @@ export default function BillingDetails(): ReactElement {
 								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
 							} ) }
 
-						{ ! billing.isSuccess && <TextPlaceholder /> }
+						{ ! billing.isSuccess && billing.isLoading && <TextPlaceholder /> }
 					</span>
 					<strong className="billing-details__cost-amount">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
 
-						{ ! billing.isSuccess && <TextPlaceholder /> }
+						{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 					</strong>
 
 					<span className="billing-details__total-label billing-details__line-item-meta">
@@ -133,7 +121,7 @@ export default function BillingDetails(): ReactElement {
 					<span className="billing-details__line-item-meta">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.assigned, 'USD' ) }
 
-						{ ! billing.isSuccess && <TextPlaceholder /> }
+						{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 					</span>
 
 					<span className="billing-details__total-label billing-details__line-item-meta">
@@ -142,7 +130,7 @@ export default function BillingDetails(): ReactElement {
 					<span className="billing-details__line-item-meta">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.unassigned, 'USD' ) }
 
-						{ ! billing.isSuccess && <TextPlaceholder /> }
+						{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 					</span>
 				</div>
 			</Card>

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -4,6 +4,7 @@
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
@@ -80,19 +81,19 @@ export default function BillingDetails(): ReactElement {
 				<Card compact>
 					<div className="billing-details__row">
 						<div className="billing-details__product">
-							{ billing.isLoading ? <TextPlaceholder /> : '-' }
+							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
 						</div>
 
 						<div className="billing-details__assigned">
-							{ billing.isLoading ? <TextPlaceholder /> : '-' }
+							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
 						</div>
 
 						<div className="billing-details__unassigned">
-							{ billing.isLoading ? <TextPlaceholder /> : '-' }
+							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
 						</div>
 
 						<div className="billing-details__subtotal">
-							{ billing.isLoading ? <TextPlaceholder /> : '-' }
+							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
 						</div>
 					</div>
 				</Card>
@@ -112,7 +113,8 @@ export default function BillingDetails(): ReactElement {
 					<strong className="billing-details__cost-amount">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
 
-						{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+						{ ! billing.isSuccess &&
+							( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 					</strong>
 
 					<span className="billing-details__total-label billing-details__line-item-meta">
@@ -121,7 +123,8 @@ export default function BillingDetails(): ReactElement {
 					<span className="billing-details__line-item-meta">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.assigned, 'USD' ) }
 
-						{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+						{ ! billing.isSuccess &&
+							( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 					</span>
 
 					<span className="billing-details__total-label billing-details__line-item-meta">
@@ -130,7 +133,8 @@ export default function BillingDetails(): ReactElement {
 					<span className="billing-details__line-item-meta">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.unassigned, 'USD' ) }
 
-						{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+						{ ! billing.isSuccess &&
+							( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 					</span>
 				</div>
 			</Card>

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -81,19 +81,27 @@ export default function BillingDetails(): ReactElement {
 				<Card compact>
 					<div className="billing-details__row">
 						<div className="billing-details__product">
-							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
+							{ billing.isLoading && <TextPlaceholder /> }
+
+							{ billing.isError && <Gridicon icon="minus" /> }
 						</div>
 
 						<div className="billing-details__assigned">
-							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
+							{ billing.isLoading && <TextPlaceholder /> }
+
+							{ billing.isError && <Gridicon icon="minus" /> }
 						</div>
 
 						<div className="billing-details__unassigned">
-							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
+							{ billing.isLoading && <TextPlaceholder /> }
+
+							{ billing.isError && <Gridicon icon="minus" /> }
 						</div>
 
 						<div className="billing-details__subtotal">
-							{ billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> }
+							{ billing.isLoading && <TextPlaceholder /> }
+
+							{ billing.isError && <Gridicon icon="minus" /> }
 						</div>
 					</div>
 				</Card>
@@ -113,8 +121,9 @@ export default function BillingDetails(): ReactElement {
 					<strong className="billing-details__cost-amount">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
 
-						{ ! billing.isSuccess &&
-							( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+						{ billing.isLoading && <TextPlaceholder /> }
+
+						{ billing.isError && <Gridicon icon="minus" /> }
 					</strong>
 
 					<span className="billing-details__total-label billing-details__line-item-meta">
@@ -123,8 +132,9 @@ export default function BillingDetails(): ReactElement {
 					<span className="billing-details__line-item-meta">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.assigned, 'USD' ) }
 
-						{ ! billing.isSuccess &&
-							( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+						{ billing.isLoading && <TextPlaceholder /> }
+
+						{ billing.isError && <Gridicon icon="minus" /> }
 					</span>
 
 					<span className="billing-details__total-label billing-details__line-item-meta">
@@ -133,8 +143,9 @@ export default function BillingDetails(): ReactElement {
 					<span className="billing-details__line-item-meta">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.unassigned, 'USD' ) }
 
-						{ ! billing.isSuccess &&
-							( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+						{ billing.isLoading && <TextPlaceholder /> }
+
+						{ billing.isError && <Gridicon icon="minus" /> }
 					</span>
 				</div>
 			</Card>

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -116,7 +116,7 @@ export default function BillingDetails(): ReactElement {
 								args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
 							} ) }
 
-						{ ! billing.isSuccess && billing.isLoading && <TextPlaceholder /> }
+						{ billing.isLoading && <TextPlaceholder /> }
 					</span>
 					<strong className="billing-details__cost-amount">
 						{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -84,7 +84,8 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.total, 0 ) }
 
-					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+					{ ! billing.isSuccess &&
+						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 				</strong>
 			</div>
 
@@ -93,7 +94,8 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned, 0 ) }
 
-					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+					{ ! billing.isSuccess &&
+						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 				</strong>
 			</div>
 
@@ -102,7 +104,8 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned, 0 ) }
 
-					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+					{ ! billing.isSuccess &&
+						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 				</strong>
 			</div>
 
@@ -119,7 +122,8 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
 
-					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
+					{ ! billing.isSuccess &&
+						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
 				</strong>
 			</div>
 		</Card>

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -84,7 +84,7 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.total, 0 ) }
 
-					{ ! billing.isSuccess && <TextPlaceholder /> }
+					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 				</strong>
 			</div>
 
@@ -93,7 +93,7 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned, 0 ) }
 
-					{ ! billing.isSuccess && <TextPlaceholder /> }
+					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 				</strong>
 			</div>
 
@@ -102,7 +102,7 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned, 0 ) }
 
-					{ ! billing.isSuccess && <TextPlaceholder /> }
+					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 				</strong>
 			</div>
 
@@ -119,7 +119,7 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
 
-					{ ! billing.isSuccess && <TextPlaceholder /> }
+					{ ! billing.isSuccess && ( billing.isLoading ? <TextPlaceholder /> : '-' ) }
 				</strong>
 			</div>
 		</Card>

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -84,8 +84,9 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.total, 0 ) }
 
-					{ ! billing.isSuccess &&
-						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+					{ billing.isLoading && <TextPlaceholder /> }
+
+					{ billing.isError && <Gridicon icon="minus" /> }
 				</strong>
 			</div>
 

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -94,8 +94,9 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned, 0 ) }
 
-					{ ! billing.isSuccess &&
-						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+					{ billing.isLoading && <TextPlaceholder /> }
+
+					{ billing.isError && <Gridicon icon="minus" /> }
 				</strong>
 			</div>
 
@@ -104,8 +105,9 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned, 0 ) }
 
-					{ ! billing.isSuccess &&
-						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+					{ billing.isLoading && <TextPlaceholder /> }
+
+					{ billing.isError && <Gridicon icon="minus" /> }
 				</strong>
 			</div>
 
@@ -122,8 +124,9 @@ export default function BillingSummary(): ReactElement {
 				<strong className="billing-summary__value">
 					{ billing.isSuccess && formatCurrency( billing.data.costs.total, 'USD' ) }
 
-					{ ! billing.isSuccess &&
-						( billing.isLoading ? <TextPlaceholder /> : <Gridicon icon="minus" /> ) }
+					{ billing.isLoading && <TextPlaceholder /> }
+
+					{ billing.isError && <Gridicon icon="minus" /> }
 				</strong>
 			</div>
 		</Card>

--- a/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
@@ -111,9 +111,7 @@ export default function useBillingDashboardQuery< TError = unknown >(
 				if ( error.hasOwnProperty( 'code' ) && 'no_billing_invoice_available' === error.code ) {
 					dispatch(
 						plainNotice(
-							translate(
-								'We have not started calculating your upcoming invoice yet. The statistics might not be correct.'
-							),
+							translate( 'Your upcoming invoice is being prepared and will be available soon.' ),
 							{
 								id: 'partner-portal-billing-dashboard-no-billing-invoice-available',
 							}
@@ -132,35 +130,6 @@ export default function useBillingDashboardQuery< TError = unknown >(
 			...options,
 		}
 	);
-
-	// Convert the "No billing invoice available" response to a success response with
-	// default values since the should not care about the difference anyways and we
-	// can still maintain "isError" checks for hard errors.
-	// A notice has also been shipped with the default values to indicate potential
-	// the current status of the billing dashboard.
-	if (
-		response.isError &&
-		response.error.hasOwnProperty( 'code' ) &&
-		'no_billing_invoice_available' === response.error.code
-	) {
-		response.isSuccess = true;
-		response.isError = false;
-		response.status = 'success';
-		response.data = {
-			date: '',
-			products: [],
-			costs: {
-				total: 0,
-				assigned: 0,
-				unassigned: 0,
-			},
-			licenses: {
-				total: 0,
-				assigned: 0,
-				unassigned: 0,
-			},
-		};
-	}
 
 	return response;
 }

--- a/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
@@ -127,6 +127,23 @@ export default function useBillingDashboardQuery< TError = unknown >(
 					} )
 				);
 			},
+			retry: ( failureCount, error ) => {
+				// There is no reason for us to try and re-fetch on the "no billing
+				// invoice available" error because it is an expected behaviour which
+				// is only going to change when Jetpack prepares an invoice and is
+				// therefore not necessarily a temporary error and might take hours
+				// or even days before changing to either success or another error.
+				if ( error.hasOwnProperty( 'code' ) && 'no_billing_invoice_available' === error.code ) {
+					return false;
+				}
+
+				// We have to define a fallback amount of failures because we
+				// override the retry option with a function.
+				// We use 3 as the failureCount since its the default value for
+				// react-query that we used before.
+				// @link https://react-query.tanstack.com/guides/query-retries
+				return 3 > failureCount;
+			},
 			...options,
 		}
 	);

--- a/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
@@ -99,7 +99,7 @@ export default function useBillingDashboardQuery< TError = unknown >(
 	const dispatch = useDispatch();
 	const activeKeyId = useSelector( getActivePartnerKeyId );
 
-	const response = useQuery< APIBilling, TError, Billing >(
+	return useQuery< APIBilling, TError, Billing >(
 		[ 'partner-portal', 'billing-dashboard', activeKeyId ],
 		queryBillingDashboard,
 		{
@@ -130,6 +130,4 @@ export default function useBillingDashboardQuery< TError = unknown >(
 			...options,
 		}
 	);
-
-	return response;
 }

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -345,9 +345,9 @@ describe( 'useBillingDashboardQuery', () => {
 			wrapper,
 		} );
 
-		// Test that the response has been converted to "Success".
-		await waitFor( () => result.current.isSuccess );
-		expect( result.current.isError ).toBe( false );
+		// Wait for the response.
+		await waitFor( () => result.current.isError );
+		expect( result.current.isError ).toBe( true );
 
 		// Test that the correct notification is being triggered.
 		expect( dispatch.mock.calls[ 0 ][ 0 ].type ).toBe( 'NOTICE_CREATE' );

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -321,13 +321,7 @@ describe( 'useBillingDashboardQuery', () => {
 	} );
 
 	it( 'dispatches notification on no invoice available', async () => {
-		const queryClient = new QueryClient( {
-			defaultOptions: {
-				queries: {
-					retry: false,
-				},
-			},
-		} );
+		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
@@ -341,7 +335,7 @@ describe( 'useBillingDashboardQuery', () => {
 		const dispatch = jest.fn();
 		useDispatch.mockReturnValue( dispatch );
 
-		const { result, waitFor } = renderHook( () => useBillingDashboardQuery(), {
+		const { result, waitFor } = renderHook( () => useBillingDashboardQuery( { retry: false } ), {
 			wrapper,
 		} );
 
@@ -358,13 +352,7 @@ describe( 'useBillingDashboardQuery', () => {
 	} );
 
 	it( 'dispatches notice on error', async () => {
-		const queryClient = new QueryClient( {
-			defaultOptions: {
-				queries: {
-					retry: false,
-				},
-			},
-		} );
+		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
@@ -376,7 +364,7 @@ describe( 'useBillingDashboardQuery', () => {
 		const dispatch = jest.fn();
 		useDispatch.mockReturnValue( dispatch );
 
-		const { result, waitFor } = renderHook( () => useBillingDashboardQuery(), {
+		const { result, waitFor } = renderHook( () => useBillingDashboardQuery( { retry: false } ), {
 			wrapper,
 		} );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR aims to add support for the `no_billing_invoice_available` error code in the billing dashboard added by D62037-code.

We wish to support this error in the front-end because everything has actually worked up until this point and is not a direct error (they're not missing any settings or any connections went wrong) but we - Automattic - have not started creating their invoice yet.

The current implementation just displays loading indicators with a red notification which communicates that something went wrong and could potentially lead the guest to be confused about what to do to fix this error.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Easy way

* Add `return new WP_Error( 'no_billing_invoice_available', 'Unable to retrieve upcoming invoice', '' );` to the beginning of `Jetpack_Licensing\Repository\License::get_billing_details()` to imitate the response without creating a new partner without an upcoming invoice.
* Start the `cloud.jetpack.com` site locally (`npm start start-jetpack-cloud`)
* Go to the Partner Portal (http://jetpack.cloud.localhost:3000/partner-portal)
* Select any of your keys (Testing or Production)
* Go to the Billing page and wait for the page to load

You should now see a grey notification saying that _we have not started calculating the upcoming invoice yet and the statistics might be wrong._ and the billing page itself should show zeros as default value.

### 1:1 Test

This requires some Jetpack partnership knowledge to be able to test since you have to create a new partner.

* Create a new partner (the partner has to be new since they should not have an upcoming invoice)
* Start the `cloud.jetpack.com` site locally (`npm start start-jetpack-cloud`)
* Go to the Partner Portal (http://jetpack.cloud.localhost:3000/partner-portal)
* Select any of your keys (Testing or Production)
* Go to the Billing page and wait for the page to load

You should now see a grey notification saying that _we have not started calculating the upcoming invoice yet and the statistics might be wrong._ and the billing page itself should show zeros as default value.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Screenshots

**Before:**
The old way we handled the "no upcoming invoice" response.

![Screenshot 2021-06-07 at 14 03 50](https://user-images.githubusercontent.com/3846700/121013536-3a7b1280-c799-11eb-8e4b-3aa292d501d0.png)

**After:**
The suggested way we should handle the "no upcoming invoice" response.

![Screenshot 2021-06-07 at 19 39 45](https://user-images.githubusercontent.com/3846700/121066034-c016b680-c7c9-11eb-93ce-dcd55e94dfa6.png)

---


**Loading:**
Some places had double `<TextPlaceholder>` indicators which has been simplified during our refactor to display a `-` default value when the page is done loading.
We do this because it would have made the code unnecessarily more difficult to read/maintain and it didn't make a uniform loading experience to begin with. 

![Screenshot 2021-06-07 at 19 41 02](https://user-images.githubusercontent.com/3846700/121066091-cefd6900-c7c9-11eb-84ad-5086ee5ab70a.png)

## Related

1187494150150258-as-1200408426367592
1187494150150258-as-1200359063069386
D62037-code