### PR TITLE
Domains: Ensure consistent type for selectedDomainName prop in DomainManagementHeader component

### DIFF
--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -52,7 +52,7 @@ class ChangeSiteAddress extends React.Component {
 
 		return (
 			<Main className="change-site-address">
-				<Header onClick={ this.goBack } selectedDomainName={ domain }>
+				<Header onClick={ this.goBack } selectedDomainName={ domain.name }>
 					{ translate( 'Change Site Address' ) }
 				</Header>
 

--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
@@ -50,9 +51,15 @@ const DomainManagementHeader = ( props ) => {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
-export default connect( ( state ) => {
+const connectComponent = connect( ( state ) => {
 	const path = getCurrentRoute( state );
 	return {
 		isManagingAllDomains: isUnderDomainManagementAll( path ),
 	};
 } )( DomainManagementHeader );
+
+connectComponent.propTypes = {
+	selectedDomainName: PropTypes.string,
+};
+
+export default connectComponent;

--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -23,9 +23,7 @@ import './style.scss';
 const DomainManagementHeader = ( props ) => {
 	const { selectedDomainName, isManagingAllDomains, onClick, backHref, children } = props;
 	const translate = useTranslate();
-	let formattedHeaderText = selectedDomainName?.domain
-		? selectedDomainName.domain
-		: selectedDomainName;
+	let formattedHeaderText = selectedDomainName;
 	if ( ! selectedDomainName ) {
 		formattedHeaderText = isManagingAllDomains
 			? translate( 'All Domains' )

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import React from 'react';
-
+import PropTypes from 'prop-types';
 /**
  * Internal Dependencies
  */
@@ -85,6 +85,10 @@ function Transfer( props ) {
 		</Main>
 	);
 }
+
+Transfer.propTypes = {
+	selectedDomainName: PropTypes.string.isRequired,
+};
 
 export default connect( ( state, ownProps ) => {
 	const domain = getSelectedDomain( ownProps );

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -86,11 +86,7 @@ function Transfer( props ) {
 	);
 }
 
-Transfer.propTypes = {
-	selectedDomainName: PropTypes.string.isRequired,
-};
-
-export default connect( ( state, ownProps ) => {
+const connectComponent = connect( ( state, ownProps ) => {
 	const domain = getSelectedDomain( ownProps );
 	const siteId = getSelectedSiteId( state );
 	return {
@@ -103,3 +99,9 @@ export default connect( ( state, ownProps ) => {
 		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
 	};
 } )( localize( Transfer ) );
+
+connectComponent.propTypes = {
+	selectedDomainName: PropTypes.string.isRequired,
+};
+
+export default connectComponent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #53259, a validation to check whether an object or a string was being passed to the `selectedDomainName` prop on the `DomainManagementHeader` component was added. 

This validation could be reverted in favor of replacing all `selectedDomainName` prop references with the actual domain name - and restricting only strings to be passed to it, which would increase the component's consistency.

---

This PR changes all references to the `selectedDomainName` prop on the `DomainManagementHeader` component, replacing them with the domain name, and adds `propTypes` on components where it's referenced and to itself, to make sure only a string can be passed to it.

#### Testing instructions

* Verify all tests pass.
* Verify we correctly replace all `DomainManagementHeader` `selectedDomainName` props with the specified domain name. 