### PR TITLE
User: Remove optimistic site count `(in|de)`crement methods

### DIFF
--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -33,8 +33,6 @@ export interface User extends EventEmitter {
 	getLanguage: () => Language | undefined;
 	clear: () => Promise< void > | void;
 	set: ( attributes: UserData ) => boolean;
-	decrementSiteCount: () => void;
-	incrementSiteCount: () => void;
 	verificationPollerCallback: ( signal?: true ) => void;
 	checkVerification: () => void;
 	signalVerification: () => void;

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -211,28 +211,6 @@ User.prototype.set = function ( attributes ) {
 	return changed;
 };
 
-User.prototype.decrementSiteCount = function () {
-	const user = this.get();
-	if ( user ) {
-		this.set( {
-			visible_site_count: user.visible_site_count - 1,
-			site_count: user.site_count - 1,
-		} );
-	}
-	this.fetch();
-};
-
-User.prototype.incrementSiteCount = function () {
-	const user = this.get();
-	if ( user ) {
-		return this.set( {
-			visible_site_count: user.visible_site_count + 1,
-			site_count: user.site_count + 1,
-		} );
-	}
-	this.fetch();
-};
-
 /**
  * Called every VERIFICATION_POLL_INTERVAL milliseconds
  * if the email is not verified.

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -146,13 +146,13 @@ const handler = ( dispatch, action, getState ) => {
 
 		case INVITE_ACCEPTED:
 			if ( ! [ 'follower', 'viewer' ].includes( action.invite.role ) ) {
-				user().incrementSiteCount();
+				user().fetch();
 			}
 			return;
 
 		case SITE_DELETE_RECEIVE:
 		case JETPACK_DISCONNECT_RECEIVE:
-			user().decrementSiteCount();
+			user().fetch();
 			return;
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we'll optimistically change the current user site count as follows:
* Increment when an invite has been accepted
* Decrement when a site has been deleted or a Jetpack site has been disconnected

However, after doing that change, we'll re-fetch the user data. Considering that it's usually a fast request, there's no need to do that optimistic update.

This PR gets rid of those increment and decrement methods and their usages, replacing them with simple user re-fetching.

This PR is part of #24004 where we aim to reduxify `lib/user`. It simplifies the library to remove unnecessary code, thus making it easier to reduxify.

#### Testing instructions

* Send an invite for a user to join a site you own with another user.
* Check the site count in the sidebar site selector.
* After accepting the invite, verify the count increases as it did before.
* Check the site count in the sidebar site selector.
* Delete a WP.com site.
* You'll be redirected to `/stats/day`
* Verify the site count decreased.
* Check the site count in the sidebar site selector.
* Disconnect a Jetpack site.
* After the redirect, verify the site count decreased.