### PR TITLE
Import: Use Redux current user for mapping authors

### DIFF
--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -9,7 +9,6 @@ import { get } from 'lodash';
  */
 import { toApi, fromApi } from 'calypso/state/imports/api';
 import wpcom from 'calypso/lib/wp';
-import user from 'calypso/lib/user';
 import {
 	mapAuthor,
 	startMappingAuthors,
@@ -29,6 +28,7 @@ import {
 } from 'calypso/state/action-types';
 import { getImporterStatus } from 'calypso/state/imports/selectors';
 import { prefetchmShotsPreview } from 'calypso/lib/mshots';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 /**
  * Redux dependencies
@@ -80,7 +80,7 @@ export const startMappingSiteImporterAuthors = ( { importerStatus, site, targetS
 
 	// WXR was uploaded, map the authors
 	if ( singleAuthorSite ) {
-		const currentUserData = user().get();
+		const currentUserData = getCurrentUser( getState() );
 		const currentUser = {
 			...currentUserData,
 			name: currentUserData.display_name,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR replaces the `lib/user` usage in the imports actions to use Redux current user. It's a straightforward use - 

This PR is part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go to `/import/:site` where `:site` is a WP.com simple site where you're the sole admin.
* Click "WordPress".
* Click "upload it to import content.".
* Upload a WP export file. If you don't have any, you can use the one from [here](https://codex.wordpress.org/Theme_Unit_Test).
* You will be presented with a screen to map original export authors to the ones on the site.
* Verify that the suggested mapped user still appears well and there are no errors in the console.