### PR TITLE
Jetpack Connect: Remove version checks from install step

### DIFF
--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 
@@ -12,14 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) => {
-	const contentClassName = classNames(
-		'example-components__content',
-		'example-components__connect-jetpack',
-		{
-			'is-legacy': isLegacy,
-		}
-	);
+const JetpackConnectExampleConnect = ( { url, translate, onClick } ) => {
 	return (
 		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
@@ -37,16 +29,14 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 					/>
 				</div>
 			</div>
-			<div className={ contentClassName }>
+			<div className="example-components__content example-components__connect-jetpack">
 				<div className="example-components__content-wp-admin-masterbar" />
 				<div className="example-components__content-wp-admin-sidebar" />
 				<div className="example-components__content-wp-admin-main">
 					<div className="example-components__content-wp-admin-connect-banner">
-						{ ! isLegacy ? (
-							<div className="example-components__content-wp-admin-plugin-name" aria-hidden>
-								{ translate( 'Connect Jetpack to WordPress.com' ) }
-							</div>
-						) : null }
+						<div className="example-components__content-wp-admin-plugin-name" aria-hidden>
+							{ translate( 'Connect Jetpack to WordPress.com' ) }
+						</div>
 						<div className="example-components__content-wp-admin-connect-button" aria-hidden>
 							{ translate( 'Set up Jetpack' ) }
 						</div>
@@ -58,13 +48,11 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 };
 
 JetpackConnectExampleConnect.propTypes = {
-	isLegacy: PropTypes.bool,
 	onClick: PropTypes.func,
 	url: PropTypes.string,
 };
 
 JetpackConnectExampleConnect.defaultProps = {
-	isLegacy: false,
 	onClick: () => {},
 	url: '',
 };

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -76,7 +76,7 @@ class InstallInstructions extends Component {
 	}
 
 	render() {
-		const { jetpackVersion, remoteSiteUrl } = this.props;
+		const { remoteSiteUrl } = this.props;
 		const instructionsData = this.getInstructionsData();
 
 		return (
@@ -93,7 +93,6 @@ class InstallInstructions extends Component {
 								<JetpackInstallStep
 									key={ 'instructions-step-' + key }
 									stepName={ stepName }
-									jetpackVersion={ jetpackVersion }
 									currentUrl={ remoteSiteUrl }
 									confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
 									onClick={ instructionsData.buttonOnClick }
@@ -128,7 +127,6 @@ const connectComponent = connect(
 		}
 
 		return {
-			jetpackVersion: remoteSiteData.jetpackVersion || false,
 			notJetpack,
 		};
 	},

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -10,19 +10,16 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import { preventWidows } from 'calypso/lib/formatting';
-import versionCompare from 'calypso/lib/version-compare';
 import JetpackExampleInstall from './example-components/jetpack-install';
 import JetpackExampleActivate from './example-components/jetpack-activate';
 import JetpackExampleConnect from './example-components/jetpack-connect';
 
-const NEW_INSTRUCTIONS_JETPACK_VERSION = '4.2.0';
 const noop = () => {};
 
 class JetpackInstallStep extends Component {
 	static propTypes = {
 		confirmJetpackInstallStatus: PropTypes.func.isRequired,
 		currentUrl: PropTypes.string,
-		jetpackVersion: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		onClick: PropTypes.func,
 	};
 
@@ -66,14 +63,9 @@ class JetpackInstallStep extends Component {
 	}
 
 	getStep( stepName ) {
-		const { currentUrl, jetpackVersion, onClick, translate } = this.props;
+		const { currentUrl, onClick, translate } = this.props;
 
-		const isLegacyVersion =
-			jetpackVersion && versionCompare( jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' );
-
-		const jetpackConnectExample = (
-			<JetpackExampleConnect url={ currentUrl } isLegacy={ isLegacyVersion } onClick={ onClick } />
-		);
+		const jetpackConnectExample = <JetpackExampleConnect url={ currentUrl } onClick={ onClick } />;
 
 		const steps = {
 			installJetpack: {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -412,29 +412,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 }
 
-.example-components__connect-jetpack.is-legacy {
-	.example-components__content-wp-admin-connect-banner {
-		margin: 10px;
-		padding: 12px 10px 16px;
-		text-align: right;
-		background-color: var( --studio-jetpack-green-20 );
-		border-left: 0;
-	}
-
-	.example-components__content-wp-admin-connect-button {
-		display: inline-block;
-		font-size: $font-body-extra-small;
-		line-height: 1;
-		padding: 11px 10px;
-		color: var( --color-text-inverted );
-		background-color: var( --studio-jetpack-green-40 );
-		border-color: var( --studio-jetpack-green-40 );
-		border-radius: 2px;
-		box-shadow: 0 2px 3px 0 rgba( var( --color-neutral-100 ), 0.2 ),
-			0 4px 0 0 var( --studio-jetpack-green-60 );
-	}
-}
-
 .example-components__content-wp-admin-plugin-card {
 	margin: 10px;
 	padding: 12px 10px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack's support policy is the current version - 1. With regards to that, every once in a while we've been removing obsolete version checks for older, no longer supported versions of Jetpack. 

This PR addresses that for some remaining older version checks in the Jetpack installation steps. #46067 and #52827 were similar PRs a while ago.

#### Testing instructions

* Go to https://jurassic.ninja/specialops/
* Create a site **without Jetpack**
* Go to `http://calypso.localhost:3000/jetpack/connect/`
* Input the site URL and proceed.
* Verify the installation form screen looks the same as before.
* Click the "Install Jetpack manually" link at the bottom.
* Verify the steps screen looks and works the same as before.