### PR TITLE
Emails: Invite users to upgrade to Titan or Google Workspace on Email Plan page for email forwards

### DIFF
--- a/client/my-sites/email/email-existing-forwards-notice/index.jsx
+++ b/client/my-sites/email/email-existing-forwards-notice/index.jsx
@@ -20,8 +20,7 @@ const EmailExistingForwardsNotice = ( { domainsWithForwards, selectedDomainName 
 	return (
 		<Notice showDismiss={ false } status="is-warning">
 			{ translate(
-				"Existing email forwards for '%(domainName)s' will be removed once you upgrade. " +
-					'Use the form below to set up the email addresses you want to continue using.',
+				'Existing email forwards will be removed once you upgrade. Set up the email addresses you want to continue using below.',
 				{
 					args: {
 						domainName: selectedDomainName,

--- a/client/my-sites/email/email-existing-forwards-notice/index.jsx
+++ b/client/my-sites/email/email-existing-forwards-notice/index.jsx
@@ -20,7 +20,7 @@ const EmailExistingForwardsNotice = ( { domainsWithForwards, selectedDomainName 
 	return (
 		<Notice showDismiss={ false } status="is-warning">
 			{ translate(
-				"Please note that your existing email forwards for '%(domainName)s' will be removed if you upgrade to a hosted email solution. " +
+				"Existing email forwards for '%(domainName)s' will be removed once you upgrade. " +
 					'Use the form below to set up the email addresses you want to continue using.',
 				{
 					args: {

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import titleCase from 'to-title-case';
 
 /**
  * Internal dependencies
@@ -149,7 +150,7 @@ class EmailManagementHome extends React.Component {
 			<Main wideLayout>
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				<DocumentHead title={ translate( 'Emails' ) } />
+				<DocumentHead title={ titleCase( translate( 'Emails' ) ) } />
 
 				<SidebarNavigation />
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { isEnabled } from '@automattic/calypso-config';
-import { localize } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -20,6 +20,7 @@ import {
 	emailManagementManageTitanAccount,
 	emailManagementManageTitanMailboxes,
 	emailManagementNewTitanAccount,
+	emailManagementPurchaseNewEmailAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
@@ -39,6 +40,7 @@ import {
 } from 'calypso/lib/gsuite';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
@@ -50,6 +52,28 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+
+const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
+	const translate = useTranslate();
+
+	if ( ! hasEmailForwards( domain ) ) {
+		return null;
+	}
+
+	return (
+		<VerticalNavItem
+			path={ emailManagementPurchaseNewEmailAccount( selectedSiteSlug, domain.name, currentRoute ) }
+		>
+			{ translate( 'Upgrade to unlock email features' ) }
+		</VerticalNavItem>
+	);
+};
+
+UpgradeNavItem.propTypes = {
+	currentRoute: PropTypes.string,
+	domain: PropTypes.object.isRequired,
+	selectedSiteSlug: PropTypes.string.isRequired,
+};
 
 class EmailPlan extends React.Component {
 	static propTypes = {
@@ -332,7 +356,7 @@ class EmailPlan extends React.Component {
 	}
 
 	render() {
-		const { domain, selectedSite, hasSubscription, purchase, isLoadingPurchase } = this.props;
+		const { currentRoute, domain, selectedSite, hasSubscription, purchase, isLoadingPurchase } = this.props;
 
 		const { isLoadingEmailAccounts } = this.state;
 
@@ -366,6 +390,12 @@ class EmailPlan extends React.Component {
 				<div className="email-plan__actions">
 					<VerticalNav>
 						{ this.renderAddNewMailboxesOrRenewNavItem() }
+
+						<UpgradeNavItem
+							currentRoute={ currentRoute }
+							domain={ domain }
+							selectedSiteSlug={ selectedSite.slug }
+						/>
 
 						{ this.renderManageAllMailboxesNavItem() }
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -8,11 +8,13 @@ import { localize, useTranslate } from 'i18n-calypso';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
 import page from 'page';
 import PropTypes from 'prop-types';
+import titleCase from 'to-title-case';
 
 /**
  * Internal dependencies
  */
 import wp from 'calypso/lib/wp';
+import DocumentHead from 'calypso/components/data/document-head';
 import {
 	emailManagement,
 	emailManagementAddGSuiteUsers,
@@ -356,7 +358,14 @@ class EmailPlan extends React.Component {
 	}
 
 	render() {
-		const { currentRoute, domain, selectedSite, hasSubscription, purchase, isLoadingPurchase } = this.props;
+		const {
+			currentRoute,
+			domain,
+			selectedSite,
+			hasSubscription,
+			purchase,
+			isLoadingPurchase,
+		} = this.props;
 
 		const { isLoadingEmailAccounts } = this.state;
 
@@ -367,6 +376,8 @@ class EmailPlan extends React.Component {
 			<>
 				{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				{ queryForEmailForwards && <QueryEmailForwards domainName={ domain.name } /> }
+
+				<DocumentHead title={ titleCase( this.getHeaderText() ) } />
 
 				<HeaderCake onClick={ this.handleBack }>{ this.getHeaderText() }</HeaderCake>
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -42,7 +42,6 @@ import {
 } from 'calypso/lib/gsuite';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
@@ -58,7 +57,7 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
 
-	if ( ! hasEmailForwards( domain ) ) {
+	if ( hasGSuiteWithUs( domain ) || hasTitanMailWithUs( domain ) ) {
 		return null;
 	}
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -66,7 +66,7 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 		<VerticalNavItem
 			path={ emailManagementPurchaseNewEmailAccount( selectedSiteSlug, domain.name, currentRoute ) }
 		>
-			{ translate( 'Upgrade to unlock email features' ) }
+			{ translate( 'Upgrade to a hosted email' ) }
 		</VerticalNavItem>
 	);
 };

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -6,6 +6,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
+import titleCase from 'to-title-case';
 
 /**
  * Internal dependencies
@@ -103,7 +104,7 @@ class TitanManageMailboxes extends Component {
 				{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 
 				<Main wideLayout={ true }>
-					<DocumentHead title={ translate( 'Manage All Mailboxes' ) } />
+					<DocumentHead title={ titleCase( translate( 'Manage all mailboxes' ) ) } />
 
 					<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -5,6 +5,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import titleCase from 'to-title-case';
 
 /**
  * Internal dependencies
@@ -85,7 +86,7 @@ class TitanManagementIframe extends React.Component {
 					<QueryEmailAccounts siteId={ selectedSiteId } />
 				) }
 				<QuerySiteDomains siteId={ selectedSiteId } />
-				<DocumentHead title={ pageTitle } />
+				<DocumentHead title={ titleCase( pageTitle ) } />
 				<SidebarNavigation />
 
 				<Header backHref={ emailManagementPath } selectedDomainName={ domainName }>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -149,6 +149,12 @@ class EmailProvidersComparison extends React.Component {
 		page( emailManagementForwarding( selectedSite.slug, selectedDomainName, currentRoute ) );
 	};
 
+	isUpgrading = () => {
+		const { domain } = this.props;
+
+		return hasEmailForwards( domain );
+	};
+
 	onTitanMailboxesChange = ( updatedMailboxes ) =>
 		this.setState( { titanMailboxes: updatedMailboxes } );
 
@@ -277,7 +283,7 @@ class EmailProvidersComparison extends React.Component {
 	renderEmailForwardingCard() {
 		const { domain, translate } = this.props;
 
-		if ( hasEmailForwards( domain ) ) {
+		if ( this.isUpgrading( domain ) ) {
 			return null;
 		}
 
@@ -344,6 +350,20 @@ class EmailProvidersComparison extends React.Component {
 				? newUsers( selectedDomainName )
 				: this.state.googleUsers;
 
+		const buttonLabel = this.isUpgrading( domain )
+			? translate( 'Upgrade to %(googleMailService)s', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily(),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+			  } )
+			: translate( 'Add %(googleMailService)s', {
+					args: {
+						googleMailService: getGoogleMailServiceFamily(),
+					},
+					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+			  } );
+
 		const formFields = domain ? (
 			<FormFieldset>
 				<GSuiteNewUserList
@@ -361,12 +381,7 @@ class EmailProvidersComparison extends React.Component {
 						busy={ this.state.addingToCart }
 						onClick={ this.onGoogleConfirmNewUsers }
 					>
-						{ translate( 'Add %(googleMailService)s', {
-							args: {
-								googleMailService: getGoogleMailServiceFamily(),
-							},
-							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-						} ) }
+						{ buttonLabel }
 					</Button>
 				</GSuiteNewUserList>
 			</FormFieldset>
@@ -388,12 +403,7 @@ class EmailProvidersComparison extends React.Component {
 				onExpandedChange={ this.onExpandedStateChange }
 				onButtonClick={ this.onGoogleConfirmNewUsers }
 				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
-				expandButtonLabel={ translate( 'Add %(googleMailService)s', {
-					args: {
-						googleMailService: getGoogleMailServiceFamily(),
-					},
-					comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-				} ) }
+				expandButtonLabel={ buttonLabel }
 				features={ getGoogleFeatures() }
 			/>
 		);
@@ -418,9 +428,26 @@ class EmailProvidersComparison extends React.Component {
 				icon="my-sites"
 			/>
 		);
+
 		const poweredByTitan = (
 			<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />
 		);
+
+		const buttonLabel = this.isUpgrading( domain )
+			? translate( 'Upgrade to %(titanProductName)s', {
+					args: {
+						titanProductName: getTitanProductName(),
+					},
+					comment:
+						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+			  } )
+			: translate( 'Add %(titanProductName)s', {
+					args: {
+						titanProductName: getTitanProductName(),
+					},
+					comment:
+						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+			  } );
 
 		const formFields = (
 			<TitanNewMailboxList
@@ -437,13 +464,7 @@ class EmailProvidersComparison extends React.Component {
 					busy={ this.state.addingToCart }
 					onClick={ this.onTitanConfirmNewMailboxes }
 				>
-					{ translate( 'Add %(titanProductName)s', {
-						args: {
-							titanProductName: getTitanProductName(),
-						},
-						comment:
-							'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
-					} ) }
+					{ buttonLabel }
 				</Button>
 			</TitanNewMailboxList>
 		);
@@ -463,13 +484,7 @@ class EmailProvidersComparison extends React.Component {
 				discount={ discount }
 				formFields={ formFields }
 				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
-				expandButtonLabel={ translate( 'Add %(titanProductName)s', {
-					args: {
-						titanProductName: getTitanProductName(),
-					},
-					comment:
-						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
-				} ) }
+				expandButtonLabel={ buttonLabel }
 				features={ getTitanFeatures() }
 			/>
 		);
@@ -496,7 +511,7 @@ class EmailProvidersComparison extends React.Component {
 			comment: '%(domainName)s is the domain name, e.g example.com',
 		};
 
-		const title = hasEmailForwards( domain )
+		const title = this.isUpgrading( domain )
 			? translate( 'Upgrade to a hosted email' )
 			: translate( 'Add email' );
 
@@ -511,7 +526,7 @@ class EmailProvidersComparison extends React.Component {
 				<PromoCard
 					isPrimary
 					title={
-						hasEmailForwards( domain )
+						this.isUpgrading( domain )
 							? translate( 'Upgrade to start sending emails from %(domainName)s', translateArgs )
 							: translate( 'Get your own @%(domainName)s email address', translateArgs )
 					}
@@ -519,7 +534,7 @@ class EmailProvidersComparison extends React.Component {
 					className="email-providers-comparison__action-panel"
 				>
 					<p>
-						{ hasEmailForwards( domain )
+						{ this.isUpgrading( domain )
 							? translate( 'Pick from one of our flexible options to unlock full email features.' )
 							: translate(
 									'Pick one of our flexible options to connect your domain with email ' +

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -497,7 +497,7 @@ class EmailProvidersComparison extends React.Component {
 		};
 
 		const title = hasEmailForwards( domain )
-			? translate( 'Upgrade email' )
+			? translate( 'Upgrade to a hosted email' )
 			: translate( 'Add email' );
 
 		return (
@@ -510,16 +510,22 @@ class EmailProvidersComparison extends React.Component {
 
 				<PromoCard
 					isPrimary
-					title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }
+					title={
+						hasEmailForwards( domain )
+							? translate( 'Upgrade to start sending emails from %(domainName)s', translateArgs )
+							: translate( 'Get your own @%(domainName)s email address', translateArgs )
+					}
 					image={ image }
 					className="email-providers-comparison__action-panel"
 				>
 					<p>
-						{ translate(
-							'Pick one of our flexible options to connect your domain with email ' +
-								'and start getting emails @%(domainName)s today.',
-							translateArgs
-						) }
+						{ hasEmailForwards( domain )
+							? translate( 'Pick from one of our flexible options to unlock full email features.' )
+							: translate(
+									'Pick one of our flexible options to connect your domain with email ' +
+										'and start getting emails @%(domainName)s today.',
+									translateArgs
+							  ) }
 					</p>
 				</PromoCard>
 			</>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -283,7 +283,7 @@ class EmailProvidersComparison extends React.Component {
 	renderEmailForwardingCard() {
 		const { domain, translate } = this.props;
 
-		if ( this.isUpgrading( domain ) ) {
+		if ( this.isUpgrading() ) {
 			return null;
 		}
 
@@ -350,7 +350,7 @@ class EmailProvidersComparison extends React.Component {
 				? newUsers( selectedDomainName )
 				: this.state.googleUsers;
 
-		const buttonLabel = this.isUpgrading( domain )
+		const buttonLabel = this.isUpgrading()
 			? translate( 'Upgrade to %(googleMailService)s', {
 					args: {
 						googleMailService: getGoogleMailServiceFamily(),
@@ -433,7 +433,7 @@ class EmailProvidersComparison extends React.Component {
 			<img src={ poweredByTitanLogo } alt={ translate( 'Powered by Titan' ) } />
 		);
 
-		const buttonLabel = this.isUpgrading( domain )
+		const buttonLabel = this.isUpgrading()
 			? translate( 'Upgrade to %(titanProductName)s', {
 					args: {
 						titanProductName: getTitanProductName(),
@@ -497,7 +497,7 @@ class EmailProvidersComparison extends React.Component {
 	};
 
 	renderHeader() {
-		const { currentRoute, domain, selectedDomainName, selectedSite, translate } = this.props;
+		const { currentRoute, selectedDomainName, selectedSite, translate } = this.props;
 
 		const image = {
 			path: emailIllustration,
@@ -511,7 +511,7 @@ class EmailProvidersComparison extends React.Component {
 			comment: '%(domainName)s is the domain name, e.g example.com',
 		};
 
-		const title = this.isUpgrading( domain )
+		const title = this.isUpgrading()
 			? translate( 'Upgrade to a hosted email' )
 			: translate( 'Add email' );
 
@@ -526,7 +526,7 @@ class EmailProvidersComparison extends React.Component {
 				<PromoCard
 					isPrimary
 					title={
-						this.isUpgrading( domain )
+						this.isUpgrading()
 							? translate( 'Upgrade to start sending emails from %(domainName)s', translateArgs )
 							: translate( 'Get your own @%(domainName)s email address', translateArgs )
 					}
@@ -534,7 +534,7 @@ class EmailProvidersComparison extends React.Component {
 					className="email-providers-comparison__action-panel"
 				>
 					<p>
-						{ this.isUpgrading( domain )
+						{ this.isUpgrading()
 							? translate( 'Pick from one of our flexible options to unlock full email features.' )
 							: translate(
 									'Pick one of our flexible options to connect your domain with email ' +


### PR DESCRIPTION
This pull request adds a new option at the bottom of the `Email Plan` page for email forwards in order to allow users to upgrade to a more powerful email solution such as Google Workspace or Titan:

<img width="623" alt="01" src="https://user-images.githubusercontent.com/594356/122964248-554baa80-d387-11eb-9576-bfda45eeea47.png">

This new link redirects to the `Email Comparison` page with a slightly different copy:

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/123263090-e2624100-d4f8-11eb-9fef-ef28d10edd91.png">


Note this pull request also adds a missing page title to the `Email Plan` page, and makes sure that page titles from all email pages are correctly capitalized.

#### Testing instructions

1. Run `git checkout update/email-forwards-email-plan-page` and start your server, or open a [live branch](https://calypso.live/?branch=update/email-forwards-email-plan-page)
2. Log into a WordPress.com account that has a domain with email forwards
3. Open the [`Emails` page](http://calypso.localhost:3000/emails)
4. Click that domain to access the `Email forwarding settings` page
5. Click on the `Upgrade to a hosted email` navigation link
6. Assert that you are presented with the `Email Comparison` page
7. Assert that the title of the page is `Upgrade To A Hosted Email`
8. Assert that the title in the header is `Upgrade to a hosted email`
9. Assert that the `Email Forwarding` section is not displayed
10. Assert that you can purchase either a Titan or a Google Workspace account
11. Log into a WordPress.com account that has a domain with no emails this time
12. Navigate back to the `Emails` page
13. Click the `Add Email` button to access the `Email Comparison` page
14. Assert that the title of the page is `Add Email`
15. Assert that the title in the header is `Add email`
16. Assert that the `Email Forwarding` section is displayed