### PR TITLE
Handle the case when useDispatch returns null in Block Editor NUX

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -35,7 +35,7 @@ registerPlugin( 'wpcom-block-editor-nux', {
 			[]
 		);
 
-		const { setOpenState } = useDispatch( 'automattic/starter-page-layouts' );
+		const setOpenState = useDispatch( 'automattic/starter-page-layouts' )?.setOpenState;
 
 		const { fetchWelcomeGuideStatus } = useDispatch( 'automattic/wpcom-welcome-guide' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sometimes, for reasons I can't understand, `useDispatch` returns null for unregistered stores. It should return an empty object. This handles that case. 

This is a harmless quick fix, but it bothers me to say that I can't yet figure out the underlying issue.

