### PR TITLE
Storefront: Add unique theme demo URL for Storefront as a temporary workaround

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -847,7 +847,7 @@ export default connect(
 			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// No siteId specified since we want the *canonical* URL :-)
 			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),
-			demoUrl: getThemeDemoUrl( state, id ),
+			demoUrl: getThemeDemoUrl( state, id, siteId ),
 			previousRoute: getPreviousRoute( state ),
 		};
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -245,7 +245,7 @@ class ThemeSheet extends React.Component {
 		return (
 			<div className="theme__sheet-preview-link">
 				<span className="theme__sheet-preview-link-text">
-					{ i18n.translate( 'Open Live Demo', {
+					{ i18n.translate( 'Open live demo', {
 						context: 'Individual theme live preview button',
 					} ) }
 				</span>
@@ -254,7 +254,7 @@ class ThemeSheet extends React.Component {
 	}
 
 	renderScreenshot() {
-		const { isWpcomTheme, name: themeName } = this.props;
+		const { isWpcomTheme, name: themeName, demo_uri } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
@@ -277,7 +277,7 @@ class ThemeSheet extends React.Component {
 			return (
 				<a
 					className="theme__sheet-screenshot is-active"
-					href={ this.props.demo_uri }
+					href={ demo_uri }
 					onClick={ ( e ) => {
 						this.previewAction( e, 'screenshot' );
 					} }
@@ -299,7 +299,7 @@ class ThemeSheet extends React.Component {
 			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
 		};
 
-		const { siteSlug, id } = this.props;
+		const { siteSlug, id, demo_uri } = this.props;
 		const sitePart = siteSlug ? `/${ siteSlug }` : '';
 
 		const nav = (
@@ -315,13 +315,13 @@ class ThemeSheet extends React.Component {
 				) ) }
 				{ this.shouldRenderPreviewButton() ? (
 					<NavItem
-						path={ this.props.demo_uri }
+						path={ demo_uri }
 						onClick={ ( e ) => {
 							this.previewAction( e, 'link' );
 						} }
 						className="theme__sheet-preview-nav-item"
 					>
-						{ i18n.translate( 'Open Live Demo', {
+						{ i18n.translate( 'Open live demo', {
 							context: 'Individual theme live preview button',
 						} ) }
 					</NavItem>
@@ -561,7 +561,7 @@ class ThemeSheet extends React.Component {
 						</div>
 					</div>
 					<Button primary={ true } href={ '/themes/' }>
-						{ i18n.translate( 'See All Themes' ) }
+						{ i18n.translate( 'See all themes' ) }
 					</Button>
 				</Card>
 
@@ -777,7 +777,17 @@ class ThemeSheet extends React.Component {
 const ConnectedThemeSheet = connectOptions( ThemeSheet );
 
 const ThemeSheetWithOptions = ( props ) => {
-	const { siteId, isActive, isLoggedIn, isPremium, isPurchased, isJetpack } = props;
+	const {
+		siteId,
+		isActive,
+		isLoggedIn,
+		isPremium,
+		isPurchased,
+		isJetpack,
+		demo_uri,
+		name: themeName,
+	} = props;
+	const storefrontDemoUri = 'https://themes.woocommerce.com/storefront/';
 
 	let defaultOption;
 	let secondaryOption = 'tryandcustomize';
@@ -803,6 +813,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	return (
 		<ConnectedThemeSheet
 			{ ...props }
+			demo_uri={ 'Storefront' === themeName ? storefrontDemoUri : demo_uri }
 			siteId={ siteId }
 			defaultOption={ defaultOption }
 			secondaryOption={ secondaryOption }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -50,6 +50,7 @@ import {
 	getThemeDetailsUrl,
 	getThemeRequestErrors,
 	getThemeForumUrl,
+	getThemeDemoUrl,
 } from 'calypso/state/themes/selectors';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -234,8 +235,8 @@ class ThemeSheet extends React.Component {
 	}
 
 	isThemeAvailable() {
-		const { demo_uri, retired } = this.props;
-		return demo_uri && ! retired;
+		const { demoUrl, retired } = this.props;
+		return demoUrl && ! retired;
 	}
 
 	// Render "Open Live Demo" pseudo-button for mobiles.
@@ -254,7 +255,7 @@ class ThemeSheet extends React.Component {
 	}
 
 	renderScreenshot() {
-		const { isWpcomTheme, name: themeName, demo_uri } = this.props;
+		const { isWpcomTheme, name: themeName, demoUrl } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
@@ -277,7 +278,7 @@ class ThemeSheet extends React.Component {
 			return (
 				<a
 					className="theme__sheet-screenshot is-active"
-					href={ demo_uri }
+					href={ demoUrl }
 					onClick={ ( e ) => {
 						this.previewAction( e, 'screenshot' );
 					} }
@@ -299,7 +300,7 @@ class ThemeSheet extends React.Component {
 			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
 		};
 
-		const { siteSlug, id, demo_uri } = this.props;
+		const { siteSlug, id, demoUrl } = this.props;
 		const sitePart = siteSlug ? `/${ siteSlug }` : '';
 
 		const nav = (
@@ -315,7 +316,7 @@ class ThemeSheet extends React.Component {
 				) ) }
 				{ this.shouldRenderPreviewButton() ? (
 					<NavItem
-						path={ demo_uri }
+						path={ demoUrl }
 						onClick={ ( e ) => {
 							this.previewAction( e, 'link' );
 						} }
@@ -777,17 +778,7 @@ class ThemeSheet extends React.Component {
 const ConnectedThemeSheet = connectOptions( ThemeSheet );
 
 const ThemeSheetWithOptions = ( props ) => {
-	const {
-		siteId,
-		isActive,
-		isLoggedIn,
-		isPremium,
-		isPurchased,
-		isJetpack,
-		demo_uri,
-		name: themeName,
-	} = props;
-	const storefrontDemoUri = 'https://themes.woocommerce.com/storefront/';
+	const { siteId, isActive, isLoggedIn, isPremium, isPurchased, isJetpack, demoUrl } = props;
 
 	let defaultOption;
 	let secondaryOption = 'tryandcustomize';
@@ -813,7 +804,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	return (
 		<ConnectedThemeSheet
 			{ ...props }
-			demo_uri={ 'Storefront' === themeName ? storefrontDemoUri : demo_uri }
+			demo_uri={ demoUrl }
 			siteId={ siteId }
 			defaultOption={ defaultOption }
 			secondaryOption={ secondaryOption }
@@ -856,6 +847,7 @@ export default connect(
 			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// No siteId specified since we want the *canonical* URL :-)
 			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),
+			demoUrl: getThemeDemoUrl( state, id ),
 			previousRoute: getPreviousRoute( state ),
 		};
 	},

--- a/client/state/themes/selectors/get-theme-demo-url.js
+++ b/client/state/themes/selectors/get-theme-demo-url.js
@@ -15,5 +15,12 @@ import 'calypso/state/themes/init';
  */
 export function getThemeDemoUrl( state, themeId, siteId ) {
 	const theme = getCanonicalTheme( state, siteId, themeId );
+	//Temp. workaround to show an accurate theme demo site for Storefront
+	const storefrontDemoUri = 'https://themes.woocommerce.com/storefront/';
+
+	if ( 'Storefront' === theme?.name ) {
+		return storefrontDemoUri;
+	}
+
 	return theme?.demo_uri;
 }

--- a/client/state/themes/selectors/get-theme-demo-url.js
+++ b/client/state/themes/selectors/get-theme-demo-url.js
@@ -15,7 +15,8 @@ import 'calypso/state/themes/init';
  */
 export function getThemeDemoUrl( state, themeId, siteId ) {
 	const theme = getCanonicalTheme( state, siteId, themeId );
-	//Temp. workaround to show an accurate theme demo site for Storefront
+	// Temp. workaround to show an accurate theme demo site for Storefront
+	// See https://github.com/Automattic/wp-calypso/issues/37658#issuecomment-843273411 for discussion
 	const storefrontDemoUri = 'https://themes.woocommerce.com/storefront/';
 
 	if ( 'Storefront' === theme?.name ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Temporarily update the `getThemeDemoUrl` selector to point to a special demo site for Storefront rather than the automatically generated one at wp-themes.com
* Update direct references to the demo site on the theme sheet to the unique demo site for Storefront
* Also updates button copy for "Open Live Demo" to use Title case

Fixes #37658

[We talked about whether we should do a "hacky" fix like this and decided it's probably worth it](https://github.com/Automattic/wp-calypso/issues/37658#issuecomment-843426848), since it does not look like we'll be adding Storefront to WP.com soon.

**Before**

<img width="1665" alt="Screen Shot 2021-06-01 at 1 13 02 PM" src="https://user-images.githubusercontent.com/2124984/120365040-f8a32580-c2db-11eb-8ad6-3ba45aa141c3.png">

**After**

<img width="1663" alt="Screen Shot 2021-06-01 at 1 15 13 PM" src="https://user-images.githubusercontent.com/2124984/120365055-fccf4300-c2db-11eb-8633-3ecd18ef5466.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/themes` for an Atomic site
* Search for Storefront under "Show all themes"
* Click the "Live demo" link under the theme's ellipsis menu; it should first open an iFrame preview, which then redirects you to `https://themes.woocommerce.com/storefront/` in a new tab (this is the known behavior for all themes uploaded by a user ie. not native to WP.com)
* View the theme sheet for Storefront (click on the screenshot); you should see `https://themes.woocommerce.com/storefront/`as the URL when you hover over the "Open live demo" button or the theme screenshot on the right
* Clicking on either the screenshot or the "Open live demo" button should open the iFrame preview, which then redirects you to `https://themes.woocommerce.com/storefront/` in a new tab
* Make sure other themes' demo links work as expected; themes native to WP.com will open demo sites in the iFrame preview, themes that have been installed by the user will open in a new tab 