### PR TITLE
Settings: Move Search card above Cloudflare card

### DIFF
--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -71,8 +71,6 @@ class SiteSettingsPerformance extends Component {
 				/>
 				<SiteSettingsNavigation site={ site } section="performance" />
 
-				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }
-
 				<Search
 					handleAutosavingToggle={ handleAutosavingToggle }
 					updateFields={ updateFields }
@@ -83,6 +81,8 @@ class SiteSettingsPerformance extends Component {
 					fields={ fields }
 					trackEvent={ trackEvent }
 				/>
+
+				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }
 
 				{ siteIsJetpack && (
 					<Fragment>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reorders the Performance settings page so that the Jetpack Search card is above the CDN card.

<table>
<tr>
	<td>Before</td>
	<td>After</td>
<tr>
	<td>
<img width="740" alt="Screen Shot 2021-05-25 at 2 06 48 PM" src="https://user-images.githubusercontent.com/4044428/119566704-ac4e6780-bd68-11eb-9071-4c355232824b.png">
</td>
	<td>
<img width="740" alt="Screen Shot 2021-05-25 at 2 06 58 PM" src="https://user-images.githubusercontent.com/4044428/119566719-b1131b80-bd68-11eb-9d6a-d628f6153231.png">
</td>

</table>

#### Testing instructions
* Spin up this branch and ensure that the Jetpack Search card renders above the CDN card in Performance settings.

See pbxNRc-PI-p2#comment-2117