### PR TITLE
Playwright: migrate the SEO Preview test spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -12,6 +12,7 @@ import { Page } from 'playwright';
 const selectors = {
 	sidebar: '.sidebar',
 };
+
 /**
  * Component representing the sidebar on the dashboard of WPCOM.
  *
@@ -27,6 +28,11 @@ export class SidebarComponent extends BaseContainer {
 		super( page, selectors.sidebar );
 	}
 
+	/**
+	 * Post-initialization steps of this object.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async _postInit(): Promise< void > {
 		await this.page.waitForLoadState( 'networkidle' );
 	}
@@ -36,8 +42,12 @@ export class SidebarComponent extends BaseContainer {
 	 * Note that the menu item must be visible in some shape or form.
 	 * If there are multiple elements that match the selector, the first
 	 * matching element will be clicked (as per Playwright documentation).
+	 * Waits and assertions should be placed on the page/component that this
+	 * method will cause a navigation to, to ensure readiness before the script
+	 * continues.
 	 *
 	 * @param {string} name Plaintext name of the menu item in the sidebar.
+	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMenuItem( name: string ): Promise< void > {
 		await this.page.click( `text=${ toTitleCase( name ) }` );
@@ -47,6 +57,7 @@ export class SidebarComponent extends BaseContainer {
 	 * Hovers over the sidebar menu item matching the name.
 	 *
 	 * @param {string} name Plaintext name of the menu item in the sidebar.
+	 * @returns {Promise<void>} No return value.
 	 */
 	async hoverMenuItem( name: string ): Promise< void > {
 		const element = await this.page.waitForSelector( `text=${ toTitleCase( name ) }` );

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -6,13 +6,13 @@ import { BaseContainer } from '../base-container';
 /**
  * Type dependencies
  */
-import { Page } from 'playwright';
+import { ElementHandle, Page } from 'playwright';
 
 const selectors = {
-	sidebar: '#secondary',
+	sidebar: '.sidebar',
 };
 /**
- * Component representing the navbar/masterbar at top of WPCOM.
+ * Component representing the sidebar on the dashboard of WPCOM.
  *
  * @augments {BaseContainer}
  */
@@ -24,5 +24,48 @@ export class SidebarComponent extends BaseContainer {
 	 */
 	constructor( page: Page ) {
 		super( page, selectors.sidebar );
+	}
+
+	async _postInit(): Promise< void > {
+		await this.page.waitForLoadState( 'networkidle' );
+	}
+
+	/**
+	 * Locates and returns the ElementHandle matching the given string identifier.
+	 *
+	 * @param {string} name Plaintext name of the menu item in the sidebar.
+	 * @returns {Promise<ElementHandle>} ElementHandle matching the name.
+	 * @throws {Error} If name did not match any visible sidebar menu item.
+	 */
+	async _getMenuItemHandle( name: string ): Promise< ElementHandle > {
+		const sanitizedName = name.toProperCase();
+		const handle = await this.page.$( `text=${ sanitizedName }` );
+		if ( ! handle ) {
+			throw new Error( `Menu item ${ sanitizedName } not found in the sidebar.` );
+		}
+		return handle;
+	}
+
+	/**
+	 * Clicks on the sidebar menu item matching the name.
+	 * Note that the menu item must be visible in some shape or form.
+	 *
+	 * @param {string} name Plaintext name of the menu item in the sidebar.
+	 */
+	async clickMenuItem( name: string ): Promise< void > {
+		const handle = await this._getMenuItemHandle( name );
+
+		await handle.click();
+	}
+
+	/**
+	 * Hovers over the sidebar menu item matching the name.
+	 *
+	 * @param {string} name Plaintext name of the menu item in the sidebar.
+	 */
+	async hoverMenuItem( name: string ): Promise< void > {
+		const handle = await this._getMenuItemHandle( name );
+
+		await handle.hover();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -6,7 +6,7 @@ import { BaseContainer } from '../base-container';
 /**
  * Type dependencies
  */
-import { ElementHandle, Page } from 'playwright';
+import { Page } from 'playwright';
 
 const selectors = {
 	sidebar: '.sidebar',
@@ -31,31 +31,15 @@ export class SidebarComponent extends BaseContainer {
 	}
 
 	/**
-	 * Locates and returns the ElementHandle matching the given string identifier.
-	 *
-	 * @param {string} name Plaintext name of the menu item in the sidebar.
-	 * @returns {Promise<ElementHandle>} ElementHandle matching the name.
-	 * @throws {Error} If name did not match any visible sidebar menu item.
-	 */
-	async _getMenuItemHandle( name: string ): Promise< ElementHandle > {
-		const sanitizedName = name.toProperCase();
-		const handle = await this.page.$( `text=${ sanitizedName }` );
-		if ( ! handle ) {
-			throw new Error( `Menu item ${ sanitizedName } not found in the sidebar.` );
-		}
-		return handle;
-	}
-
-	/**
 	 * Clicks on the sidebar menu item matching the name.
 	 * Note that the menu item must be visible in some shape or form.
+	 * If there are multiple elements that match the selector, the first
+	 * matching element will be clicked (as per Playwright documentation).
 	 *
 	 * @param {string} name Plaintext name of the menu item in the sidebar.
 	 */
 	async clickMenuItem( name: string ): Promise< void > {
-		const handle = await this._getMenuItemHandle( name );
-
-		await handle.click();
+		await this.page.click( `text=${ name.toProperCase() }` );
 	}
 
 	/**
@@ -64,8 +48,7 @@ export class SidebarComponent extends BaseContainer {
 	 * @param {string} name Plaintext name of the menu item in the sidebar.
 	 */
 	async hoverMenuItem( name: string ): Promise< void > {
-		const handle = await this._getMenuItemHandle( name );
-
-		await handle.hover();
+		const element = await this.page.waitForSelector( `text=${ name.toProperCase() }` );
+		await element.hover();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
+import { toTitleCase } from '../../data-helper';
 
 /**
  * Type dependencies
@@ -39,7 +40,7 @@ export class SidebarComponent extends BaseContainer {
 	 * @param {string} name Plaintext name of the menu item in the sidebar.
 	 */
 	async clickMenuItem( name: string ): Promise< void > {
-		await this.page.click( `text=${ name.toProperCase() }` );
+		await this.page.click( `text=${ toTitleCase( name ) }` );
 	}
 
 	/**
@@ -48,7 +49,7 @@ export class SidebarComponent extends BaseContainer {
 	 * @param {string} name Plaintext name of the menu item in the sidebar.
 	 */
 	async hoverMenuItem( name: string ): Promise< void > {
-		const element = await this.page.waitForSelector( `text=${ name.toProperCase() }` );
+		const element = await this.page.waitForSelector( `text=${ toTitleCase( name ) }` );
 		await element.hover();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -4,3 +4,4 @@
 export * from './login-page';
 export * from './gutenberg-editor-page';
 export * from './my-home-page';
+export * from './marketing-page';

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
+import { toTitleCase } from '../../data-helper';
 
 /**
  * Type dependencies
@@ -34,7 +35,7 @@ export class MarketingPage extends BaseContainer {
 	}
 
 	async clickTabItem( name: string ): Promise< void > {
-		const sanitizedName = name.toProperCase();
+		const sanitizedName = toTitleCase( [ name ] );
 
 		await this.page.click( `text=${ sanitizedName }` );
 	}

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -30,10 +30,21 @@ export class MarketingPage extends BaseContainer {
 		super( page, selectors.content );
 	}
 
+	/**
+	 * Post-initialization steps when creating an instance of this object.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async _postInit(): Promise< void > {
 		await this.page.waitForSelector( selectors.navtabsList );
 	}
 
+	/**
+	 * Given a string, clicks on the tab matching the string at top of the page.
+	 *
+	 * @param {string} name Name of the tab to click on the top of the page.
+	 * @returns {Promise<void>} No return value.
+	 */
 	async clickTabItem( name: string ): Promise< void > {
 		const sanitizedName = toTitleCase( [ name ] );
 
@@ -41,16 +52,34 @@ export class MarketingPage extends BaseContainer {
 	}
 
 	/* SEO Preview Methods */
+
+	/**
+	 * Enters text into the Website Meta Information field.
+	 *
+	 * @param {string} [text] String to be used as the description of the web site in SEO.
+	 * @returns {Promise<void>} No return value.
+	 */
 	async enterWebsiteMetaInformation( text = 'test text' ): Promise< void > {
 		await this.page.fill( selectors.websiteMetaTextArea, text );
-		await this.page.click( selectors.seoPreviewButton );
 	}
 
+	/**
+	 * Open the preview of SEO changes.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async openSEOPreview(): Promise< void > {
+		await this.page.click( selectors.seoPreviewButton );
 		await this.page.waitForSelector( selectors.seoPreviewPane );
 	}
 
+	/**
+	 * Close the preview of SEO changes.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async closeSEOPreview(): Promise< void > {
 		await this.page.click( selectors.seoPreviewPaneCloseButton );
+		await this.page.waitForSelector( selectors.content );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	content: '#primary',
+	navtabsList: '.section-nav-tabs__list',
+
+	// Traffic tab
+	websiteMetaTextArea: '#advanced_seo_front_page_description',
+	seoPreviewButton: '.seo-settings__preview-button',
+	seoPreviewPane: '.web-preview.is-seo',
+	seoPreviewPaneCloseButton: '.web-preview .web-preview__close',
+};
+
+/**
+ * Page representing the Tools > Marketing page.
+ *
+ * @augments {BaseContainer}
+ */
+export class MarketingPage extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.content );
+	}
+
+	async _postInit(): Promise< void > {
+		await this.page.waitForSelector( selectors.navtabsList );
+	}
+
+	async clickTabItem( name: string ): Promise< void > {
+		const sanitizedName = name.toProperCase();
+
+		await this.page.click( `text=${ sanitizedName }` );
+	}
+
+	/* SEO Preview Methods */
+	async enterWebsiteMetaInformation( text = 'test text' ): Promise< void > {
+		await this.page.fill( selectors.websiteMetaTextArea, text );
+		await this.page.click( selectors.seoPreviewButton );
+	}
+
+	async openSEOPreview(): Promise< void > {
+		await this.page.waitForSelector( selectors.seoPreviewPane );
+	}
+
+	async closeSEOPreview(): Promise< void > {
+		await this.page.click( selectors.seoPreviewPaneCloseButton );
+	}
+}

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import {
+	DataHelper,
+	BrowserHelper,
+	LoginFlow,
+	SidebarComponent,
+	MarketingPage,
+} from '@automattic/calypso-e2e';
+
+/**
+ * Constants
+ */
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const host = DataHelper.getJetpackHost();
+const viewportName = BrowserHelper.getViewportName();
+
+describe( `[${ host }] SEO Preview Page: (${ viewportName }) @canary @parallel @safaricanary`, function () {
+	this.timeout( mochaTimeOut );
+	let marketingPage;
+
+	it( 'Log in', async function () {
+		const loginFlow = new LoginFlow( this.page, 'wooCommerceUser' );
+		await loginFlow.login();
+	} );
+
+	it( 'Navigate to Tools > Marketing page', async function () {
+		const sidebarComponent = await SidebarComponent.Expect( this.page );
+		await sidebarComponent.clickMenuItem( 'Tools' );
+	} );
+
+	it( 'Click on Traffic tab', async function () {
+		marketingPage = await MarketingPage.Expect( this.page );
+		await marketingPage.clickTabItem( 'Traffic' );
+	} );
+
+	it( 'Enter SEO meta description', async function () {
+		await marketingPage.enterWebsiteMetaInformation();
+	} );
+
+	it( 'Open and close SEO preview', async function () {
+		await marketingPage.openSEOPreview();
+		await this.page.waitForTimeout( 2000 );
+		await marketingPage.closeSEOPreview();
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -1,24 +1,9 @@
 /**
  * External dependencies
  */
-import config from 'config';
-import {
-	DataHelper,
-	BrowserHelper,
-	LoginFlow,
-	SidebarComponent,
-	MarketingPage,
-} from '@automattic/calypso-e2e';
+import { DataHelper, LoginFlow, SidebarComponent, MarketingPage } from '@automattic/calypso-e2e';
 
-/**
- * Constants
- */
-const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-const host = DataHelper.getJetpackHost();
-const viewportName = BrowserHelper.getViewportName();
-
-describe( `[${ host }] SEO Preview Page: (${ viewportName }) @canary @parallel @safaricanary`, function () {
-	this.timeout( mochaTimeOut );
+describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
 	let marketingPage;
 
 	it( 'Log in', async function () {
@@ -42,7 +27,6 @@ describe( `[${ host }] SEO Preview Page: (${ viewportName }) @canary @parallel @
 
 	it( 'Open and close SEO preview', async function () {
 		await marketingPage.openSEOPreview();
-		await this.page.waitForTimeout( 2000 );
 		await marketingPage.closeSEOPreview();
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR migrates the `wp-calypso-seo-preview.js` test to Playwright.

- `MarketingPage` page object created to represent the page under `Tools > Marketing`.
- `SidebarComponent` fleshed out with methods to interact with the menu items.

#### Testing instructions

CI
- trigger runs on add/playwright-seo-preview-spec branch in TeamCity.

Local
- pull the changes then run with:
```
mocha --config .mocharc_playwright.yml specs/specs-playwright/wp-seo__preview-spec.js
```

Related to #52849
Parent: #53291 