### PR TITLE
My Home: Remove code that handles the start_site_setup checklist task

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -54,7 +54,6 @@ export const getTask = (
 		emailVerificationStatus,
 		isDomainUnverified,
 		isEmailUnverified,
-		isPodcastingSite,
 		menusUrl,
 		siteId,
 		siteSlug,
@@ -64,29 +63,6 @@ export const getTask = (
 ) => {
 	let taskData = {};
 	switch ( task.id ) {
-		case CHECKLIST_KNOWN_TASKS.START_SITE_SETUP:
-			taskData = {
-				timing: 1,
-				label: translate( 'Site created' ),
-				title: translate( 'Your site has been created!' ),
-				description: translate(
-					"Next, we'll guide you through setting up and launching your site."
-				),
-				actionText: translate( 'Get started' ),
-				...( ! task.isCompleted && {
-					actionDispatch: requestSiteChecklistTaskUpdate,
-					actionDispatchArgs: [ siteId, task.id ],
-				} ),
-				actionAdvanceToNext: true,
-				completeOnView: true,
-			};
-
-			// Change the task title for podcasting sites.
-			if ( isPodcastingSite ) {
-				taskData.title = translate( 'Welcome to your podcast site!' );
-				taskData.hideLabel = true;
-			}
-			break;
 		case CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED:
 			taskData = {
 				timing: 2,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -175,7 +175,6 @@ const SiteSetupList = ( {
 				emailVerificationStatus,
 				isDomainUnverified,
 				isEmailUnverified,
-				isPodcastingSite,
 				menusUrl,
 				siteId,
 				siteSlug,

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -16,7 +16,6 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 const noop = () => {};
 
 export const CHECKLIST_KNOWN_TASKS = {
-	START_SITE_SETUP: 'start_site_setup',
 	DOMAIN_VERIFIED: 'domain_verified',
 	EMAIL_VERIFIED: 'email_verified',
 	BLOGNAME_SET: 'blogname_set',

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -35,8 +35,7 @@ export default function isSiteChecklistComplete( state, siteId ) {
 	 *	This is because updating the front page doesn't apply when the site doesn't have a page set as the front page.
 	 *	Any other case leads to a pending task.
 	 *	C) the mobile_app_installed task, because it shouldn't affect the site setup status.
-	 *	D) the start_site_setup task, because it autocompletes on view as a way of starting the checklist.
-	 *	E) the site_menu_updated task, because it shouldn't affect the site setup status.
+	 *	D) the site_menu_updated task, because it shouldn't affect the site setup status.
 	 *
 	 *		@param   {object}  task The task that we'll check to see if it's completed.
 	 *		@returns {boolean}      Whether the task is considered to be completed or not.
@@ -52,11 +51,6 @@ export default function isSiteChecklistComplete( state, siteId ) {
 
 		// The mobile app setup task shouldn't affect the site setup status.
 		if ( CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED === task.id ) {
-			return true;
-		}
-
-		// Starting site setup autocompletes, so it shouldn't cause an incomplete checklist.
-		if ( CHECKLIST_KNOWN_TASKS.START_SITE_SETUP === task.id ) {
 			return true;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

D62160-code removes start_site_setup from the tasks returned by the backend.
This change removes the client-side handling for that task which is no
longer needed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D62160-code to sandbox if it hasn't shipped yet
* Smoke test the checklist on My Home to make sure it's still working

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53138
