### PR TITLE
Move getSiteId to state/sites/selectors

### DIFF
--- a/client/components/site-offset/context.tsx
+++ b/client/components/site-offset/context.tsx
@@ -10,7 +10,7 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -18,9 +18,8 @@ import {
 } from 'calypso/my-sites/controller';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import getSiteId from 'calypso/state/selectors/get-site-id';
 import { requestSite } from 'calypso/state/sites/actions';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteId, getSiteSlug } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 
 /**

--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 import user from 'calypso/lib/user';
 
 // State actions and selectors
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import { requestSites } from 'calypso/state/sites/actions';
 import { promisify } from 'calypso/utils';
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -40,7 +40,7 @@ import {
 	getSelectedImportEngine,
 	getNuxUrlInputValue,
 } from 'calypso/state/importer-nux/temp-selectors';
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import { Site } from '@automattic/data-stores';
 const Visibility = Site.Visibility;
 

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -23,7 +23,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { getSiteComment } from 'calypso/state/comments/selectors';
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 
 /**
  * Style dependencies

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import EmptyContent from 'calypso/components/empty-content';
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -15,6 +15,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
 	getSite,
+	getSiteId,
 	getSiteAdminUrl,
 	getSiteSlug,
 	isJetpackModuleActive,
@@ -38,7 +39,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import getSiteId from 'calypso/state/selectors/get-site-id';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';

--- a/client/my-sites/migrate/controller.js
+++ b/client/my-sites/migrate/controller.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import SectionMigrate from 'calypso/my-sites/migrate/section-migrate';
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import { isEnabled } from '@automattic/calypso-config';
 
 export function ensureFeatureFlag( context, next ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -40,7 +40,7 @@ import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { setSiteType } from 'calypso/state/signup/steps/site-type/actions';
 import { login } from 'calypso/lib/paths';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
 import { loadExperimentAssignment } from 'calypso/lib/explat';

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -58,8 +58,7 @@ import { submitSignupStep, removeStep, addStep } from 'calypso/state/signup/prog
 import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
 import { submitSiteType } from 'calypso/state/signup/steps/site-type/actions';
 import { submitSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
-import getSiteId from 'calypso/state/selectors/get-site-id';
-import { isCurrentPlanPaid, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { getSiteId, isCurrentPlanPaid, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -4,14 +4,13 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
-import { filter } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import getSiteId from 'calypso/state/selectors/get-site-id';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -100,16 +99,13 @@ export class PlansAtomicStoreStep extends Component {
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
-		let plans = filter(
-			[
-				hideFreePlan ? null : PLAN_FREE,
-				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-				PLAN_PREMIUM,
-				PLAN_BUSINESS,
-				PLAN_ECOMMERCE,
-			],
-			( value ) => !! value
-		);
+		let plans = [
+			hideFreePlan ? null : PLAN_FREE,
+			isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+			PLAN_PREMIUM,
+			PLAN_BUSINESS,
+			PLAN_ECOMMERCE,
+		].filter( Boolean );
 
 		if ( designType === DESIGN_TYPE_STORE ) {
 			plans = [ PLAN_BUSINESS ];

--- a/client/state/sites/selectors/get-site-id.js
+++ b/client/state/sites/selectors/get-site-id.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import { getSite } from 'calypso/state/sites/selectors';
+import getSite from './get-site';
 
 /**
  * Returns a normalized site ID from any key accepted by `getSite`. Intends to

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -25,6 +25,7 @@ export { default as getSiteDomain } from './get-site-domain';
 export { default as getSiteFrontPage } from './get-site-front-page';
 export { default as getSiteFrontPageType } from './get-site-front-page-type';
 export { default as getSiteHomeUrl } from './get-site-home-url';
+export { default as getSiteId } from './get-site-id';
 export { default as getSiteOption } from './get-site-option';
 export { default as getSitePlan } from './get-site-plan';
 export { default as getSitePlanSlug } from './get-site-plan-slug';


### PR DESCRIPTION
Moves the `getSiteId` selector to `state/sites/selectors` so that closely related selectors that use each other are not at distant places in the source tree.

**How to test:**
Verify that Calypso compiles and that unit tests pass. We're just moving code around without any changes.