### PR TITLE
Theme Showcase - Live Demos: Record Tracks Events

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -218,7 +218,7 @@ class ThemeSheet extends React.Component {
 		}
 		event.preventDefault();
 
-		this.props.recordTracksEvent( `calypso_theme_live_demo_${ type }_preview` );
+		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview', { type } );
 
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions( this.props.defaultOption, this.props.secondaryOption );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -218,7 +218,7 @@ class ThemeSheet extends React.Component {
 		}
 		event.preventDefault();
 
-		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview', { type } );
+		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview_click', { type } );
 
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions( this.props.defaultOption, this.props.secondaryOption );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -212,11 +212,13 @@ class ThemeSheet extends React.Component {
 		return null;
 	}
 
-	previewAction = ( event ) => {
+	previewAction = ( event, type ) => {
 		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
 			return;
 		}
 		event.preventDefault();
+
+		this.props.recordTracksEvent( `calypso_theme_live_demo_${ type }_preview` );
 
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions( this.props.defaultOption, this.props.secondaryOption );
@@ -276,7 +278,9 @@ class ThemeSheet extends React.Component {
 				<a
 					className="theme__sheet-screenshot is-active"
 					href={ this.props.demo_uri }
-					onClick={ this.previewAction }
+					onClick={ ( e ) => {
+						this.previewAction( e, 'screenshot' );
+					} }
 					rel="noopener noreferrer"
 				>
 					{ this.shouldRenderPreviewButton() && this.renderPreviewButton() }
@@ -312,7 +316,9 @@ class ThemeSheet extends React.Component {
 				{ this.shouldRenderPreviewButton() ? (
 					<NavItem
 						path={ this.props.demo_uri }
-						onClick={ this.previewAction }
+						onClick={ ( e ) => {
+							this.previewAction( e, 'link' );
+						} }
 						className="theme__sheet-preview-nav-item"
 					>
 						{ i18n.translate( 'Open Live Demo', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds Tracks Events for when the "Live Demo" link is pressed on the Theme Showcase:

- `calypso_theme_live_demo_screenshot_preview` for the screenshot
- `calypso_theme_live_demo_link_preview` for the link

#### Testing instructions

You can make these events appear by running `localStorage.debug = 'calypso:analytics*';` in console. Once doing that, visit `/theme/hever/` and verify that the events are appropriately fired when clicking the screenshot and the link.

<img width="1098" alt="Screenshot 2021-06-02 at 08 30 56" src="https://user-images.githubusercontent.com/43215253/120441916-fcd34f80-c37c-11eb-871c-f3d48ab2e513.png">

cc @sixhours

Fixes #53312
