### PR TITLE
Add button to open webmail for Professional Email purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -42,6 +42,12 @@ import { Button } from '@automattic/components';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { downloadTrafficGuide } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import { emailManagementEdit } from 'calypso/my-sites/email/paths';
+import { getTitanEmailUrl } from 'calypso/lib/titan';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -368,6 +374,10 @@ export class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = '/me/concierge/' + selectedSite.slug + '/book';
 	};
 
+	trackTitanWebmailClick = () => {
+		this.props.recordTracksEvent( 'calypso_thank_you_titan_webmail_click' );
+	};
+
 	downloadTrafficGuideHandler = ( event ) => {
 		event.preventDefault();
 
@@ -459,12 +469,25 @@ export class CheckoutThankYouHeader extends PureComponent {
 	};
 
 	maybeGetSecondaryButton() {
-		const { upgradeIntent, translate } = this.props;
+		const { primaryPurchase, upgradeIntent, translate } = this.props;
 
 		if ( upgradeIntent === 'hosting' ) {
 			return (
 				<Button onClick={ this.visitSiteHostingSettings }>
 					{ translate( 'Return to Hosting' ) }
+				</Button>
+			);
+		}
+
+		if ( isTitanMail( primaryPurchase ) ) {
+			return (
+				<Button
+					href={ getTitanEmailUrl( '' ) }
+					onClick={ this.trackTitanWebmailClick }
+					target="_blank"
+				>
+					{ translate( 'Log in to my email' ) }
+					<Gridicon icon="external" />
 				</Button>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -349,12 +349,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = selectedSite.URL;
 	};
 
-	visitEmailManagement = ( event ) => {
-		event.preventDefault();
-		const { primaryPurchase, selectedSite } = this.props;
-		page( emailManagementEdit( selectedSite.slug, primaryPurchase.meta ) );
-	};
-
 	visitSiteHostingSettings = ( event ) => {
 		event.preventDefault();
 
@@ -374,8 +368,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = '/me/concierge/' + selectedSite.slug + '/book';
 	};
 
-	trackTitanWebmailClick = () => {
+	visitTitanWebmail = ( event ) => {
+		event.preventDefault();
+
 		this.props.recordTracksEvent( 'calypso_thank_you_titan_webmail_click' );
+
+		window.open( getTitanEmailUrl( '' ) );
 	};
 
 	downloadTrafficGuideHandler = ( event ) => {
@@ -458,10 +456,16 @@ export class CheckoutThankYouHeader extends PureComponent {
 				: translate( 'Manage domains' );
 		}
 
-		if (
-			isGSuiteOrExtraLicenseOrGoogleWorkspace( primaryPurchase ) ||
-			isTitanMail( primaryPurchase )
-		) {
+		if ( isTitanMail( primaryPurchase ) ) {
+			return (
+				<>
+					{ translate( 'Log in to my email' ) }
+					<Gridicon icon="external" />
+				</>
+			);
+		}
+
+		if ( isGSuiteOrExtraLicenseOrGoogleWorkspace( primaryPurchase ) ) {
 			return translate( 'Manage email' );
 		}
 
@@ -469,7 +473,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 	};
 
 	maybeGetSecondaryButton() {
-		const { primaryPurchase, upgradeIntent, translate } = this.props;
+		const { primaryPurchase, selectedSite, translate, upgradeIntent } = this.props;
 
 		if ( upgradeIntent === 'hosting' ) {
 			return (
@@ -481,13 +485,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if ( isTitanMail( primaryPurchase ) ) {
 			return (
-				<Button
-					href={ getTitanEmailUrl( '' ) }
-					onClick={ this.trackTitanWebmailClick }
-					target="_blank"
-				>
-					{ translate( 'Log in to my email' ) }
-					<Gridicon icon="external" />
+				<Button href={ emailManagementEdit( selectedSite.slug, primaryPurchase.meta ) }>
+					{ translate( 'Manage email' ) }
 				</Button>
 			);
 		}
@@ -560,7 +559,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		} else if ( isTrafficGuidePurchase ) {
 			clickHandler = this.downloadTrafficGuideHandler;
 		} else if ( isTitanMail( primaryPurchase ) ) {
-			clickHandler = this.visitEmailManagement;
+			clickHandler = this.visitTitanWebmail;
 		}
 
 		return (

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -189,6 +189,10 @@
 	button:nth-child( 2 ) {
 		margin-left: 10px;
 	}
+
+	.button > .gridicon.gridicons-external {
+		margin-left: 6px;
+	}
 }
 
 .checkout-thank-you__header-heading {
@@ -674,7 +678,7 @@
 .jetpack-checkout-thank-you {
 	.jetpack-checkout-thank-you__card,
 	.jetpack-checkout-thank-you__card-loading {
-		box-shadow: 0px 0px 40px 0px #00000014;
+		box-shadow: 0 0 40px 0 #00000014;
 
 		width: 100%;
 		max-width: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the buttons in the post-checkout Thank You page for Professional Email.
* The primary button now launches the Titan webmail application in a new window/tab.
* The secondary button navigates to the email management page in the current window.

#### Testing instructions

* Load this branch locally or via [the live branch](https://calypso.live/?branch=add/titan-webmail-link-to-thank-you-page)
* You can then test this via one of two approaches:
  1. Test using an existing Professional Email receipt
    - Find an emailed receipt for a previous Professional Email purchase - the subject should include "WordPress.com Receipt #(receiptId)", or find the receipt from your billing history in Calypso
    - Navigate to `/checkout/thank-you/:siteSlug/:receiptId`
  2. Purchase a new Professional Email subscription for a domain you own
* Via either path, you should see a "Congratulations on your purchase!" header, some further text about getting an email, and then see a secondary "Manage email" button next to a "Log in to my email" button (which should be primary).

#### Screenshot

<img width="978" alt="Screenshot 2021-06-07 at 22 03 18" src="https://user-images.githubusercontent.com/3376401/121081144-9a46dd00-c7dc-11eb-8200-81d554ea83df.png">
