### PR TITLE
ci(e2e): Disable tests that don't work well in parallel

### DIFF
--- a/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
@@ -30,7 +30,12 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 const emailClient = new EmailClient( inviteInboxId );
 
-describe( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel`, function () {
+/**
+ * This test creates new invtites and try to clean them up. The problem is the invites are per-site,
+ * so all test runs will share the same list of invites. It causes this test to be flaky when run in
+ * parallel.
+ */
+describe.skip( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 	const newUserName = 'e2eflowtestingviewer' + new Date().getTime().toString();
 	const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );

--- a/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains-spec.js
@@ -30,7 +30,12 @@ const screenSize = driverManager.currentScreenSize();
 const domainsInboxId = config.get( 'domainsInboxId' );
 const host = dataHelper.getJetpackHost();
 
-describe( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function () {
+/**
+ * This test adds domains to the shopping cart, assert their status and try to clean them up. The problem is
+ * the shopping carg is per-site, so all test runs will share the same shopping cart. It causes
+ * this test to be flaky when run in parallel.
+ */
+describe.skip( `[${ host }] Managing Domains: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Adding a domain to an existing site', function () {


### PR DESCRIPTION
#### Background

There are a few tests that don't work well when run in parallel: they create some state (shopping cart, list of user invites...) associated with the site. As the tests always use the same user and site they may fail when run in parallel.

Parallezation occurs in two different ways:
- Inside the same run, we spin up 16 chrome instances, each running a test in parallel.
- In TeamCity, we may start two runs in parallel, each for a different branch.

#### Changes proposed in this Pull Request

* Disable those tests until we have a strategy for running them.

#### Testing instructions

N/A