### PR TITLE
Temporary fix for editor crash when getLocaleData is undefined. 

### DIFF
--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -19,7 +19,7 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
  * Get the current locale slug from the @wordpress/i18n locale data
  */
 function getWpI18nLocaleSlug(): string | undefined {
-	return i18n.getLocaleData()?.[ '' ]?.language;
+	return i18n.getLocaleData && i18n.getLocaleData()?.[ '' ]?.language;
 }
 
 /**


### PR DESCRIPTION
fixes #53324 by temporarily adding a check for getLocaleData being undefined.
I dug into the root cause of the issue here, but it is related to the version of the `wordpress/i18n` library being loaded at runtime. For now, let's just do a check. The type signature of this method allows returning `undefined` in which case the default locale 'en' will be used

### Testing instructions 

On an atomic site with the ETK installed
Deactivate the gutenberg plugin
In the editor, open the welcome tour ( welcome tour may automatically open for new sites/users )
Note editor crash
