### PR TITLE
Media: Speficically pass post ID when uploading media

### DIFF
--- a/client/lib/media/utils/get-file-uploader.js
+++ b/client/lib/media/utils/get-file-uploader.js
@@ -8,14 +8,11 @@ const debug = debugFactory( 'calypso:media' );
  * Internal dependencies
  */
 import wpcom from 'calypso/lib/wp';
-import { getEditorPostId } from 'calypso/state/editor/selectors';
 
-export const getFileUploader = ( getState ) => ( file, siteId ) => {
+export const getFileUploader = ( file, siteId, postId ) => {
 	// Determine upload mechanism by object type
 	const isUrl = 'string' === typeof file;
 
-	// Assign parent ID if currently editing post
-	const postId = getEditorPostId( getState() );
 	const title = file.title;
 	if ( postId ) {
 		file = {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -164,30 +164,6 @@ UndocumentedSite.prototype.getConnection = function ( connectionId ) {
 };
 
 /**
- * Upload an external media item to the WordPress media library
- *
- * @param {string} service - external media service name (i.e 'google_photos')
- * @param {Array} files - array of external media file IDs
- * @param {number} postId - ID of the post to attach the media item to
- *
- * @returns {object} promise - resolves on completion of the GET request
- */
-UndocumentedSite.prototype.uploadExternalMedia = function ( service, files, postId = 0 ) {
-	debug( '/sites/:site_id:/external-media-upload query' );
-
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/external-media-upload',
-		},
-		{
-			external_ids: files,
-			service,
-			post_id: postId,
-		}
-	);
-};
-
-/**
  * Runs Theme Setup (Headstart).
  *
  * @returns {Promise} A Promise to resolve when complete.

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -168,10 +168,11 @@ UndocumentedSite.prototype.getConnection = function ( connectionId ) {
  *
  * @param {string} service - external media service name (i.e 'google_photos')
  * @param {Array} files - array of external media file IDs
+ * @param {number} postId - ID of the post to attach the media item to
  *
  * @returns {object} promise - resolves on completion of the GET request
  */
-UndocumentedSite.prototype.uploadExternalMedia = function ( service, files ) {
+UndocumentedSite.prototype.uploadExternalMedia = function ( service, files, postId = 0 ) {
 	debug( '/sites/:site_id:/external-media-upload query' );
 
 	return this.wpcom.req.post(
@@ -181,6 +182,7 @@ UndocumentedSite.prototype.uploadExternalMedia = function ( service, files ) {
 		{
 			external_ids: files,
 			service,
+			post_id: postId,
 		}
 	);
 };

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -415,6 +415,7 @@ export class MediaLibraryContent extends React.Component {
 					site={ this.props.site }
 					visible={ ! this.props.isRequesting }
 					canCopy={ this.props.postId === undefined }
+					postId={ this.props.postId }
 					source={ this.props.source }
 					onSourceChange={ this.props.onSourceChange }
 					selectedItems={ this.props.selectedItems }

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -15,6 +15,7 @@ import DropZone from 'calypso/components/drop-zone';
 import { userCan } from 'calypso/lib/site/utils';
 import { clearMediaItemErrors } from 'calypso/state/media/actions';
 import { addMedia } from 'calypso/state/media/thunks';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
 
 const noop = () => {};
 
@@ -41,7 +42,7 @@ class MediaLibraryDropZone extends React.Component {
 		}
 
 		this.props.clearMediaItemErrors( this.props.site.ID );
-		this.props.addMedia( files, this.props.site );
+		this.props.addMedia( files, this.props.site, this.props.postId );
 		this.props.onAddMedia();
 
 		if ( this.props.trackStats ) {
@@ -95,6 +96,9 @@ class MediaLibraryDropZone extends React.Component {
 	}
 }
 
-export default connect( null, { addMedia, clearMediaItemErrors } )(
-	localize( MediaLibraryDropZone )
-);
+export default connect(
+	( state ) => ( {
+		postId: getEditorPostId( state ),
+	} ),
+	{ addMedia, clearMediaItemErrors }
+)( localize( MediaLibraryDropZone ) );

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -26,6 +26,7 @@ class MediaLibraryExternalHeader extends React.Component {
 		site: PropTypes.object.isRequired,
 		visible: PropTypes.bool.isRequired,
 		canCopy: PropTypes.bool,
+		postId: PropTypes.number,
 		selectedItems: PropTypes.array,
 		onSourceChange: PropTypes.func,
 		sticky: PropTypes.bool,
@@ -88,10 +89,10 @@ class MediaLibraryExternalHeader extends React.Component {
 	}
 
 	onCopy = () => {
-		const { site, selectedItems, source, onSourceChange } = this.props;
+		const { postId, site, selectedItems, source, onSourceChange } = this.props;
 
 		onSourceChange( '', () => {
-			this.props.addExternalMedia( selectedItems, site, source );
+			this.props.addExternalMedia( selectedItems, site, postId, source );
 		} );
 	};
 

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -19,6 +19,7 @@ import { VideoPressFileTypes } from 'calypso/lib/media/constants';
 import { clearMediaItemErrors } from 'calypso/state/media/actions';
 import { addMedia } from 'calypso/state/media/thunks';
 import { getSectionName } from 'calypso/state/ui/selectors';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
 
 /**
  * Style dependencies
@@ -55,7 +56,7 @@ class MediaLibraryUploadButton extends React.Component {
 	uploadFiles = ( event ) => {
 		if ( event.target.files && this.props.site ) {
 			this.props.clearMediaItemErrors( this.props.site.ID );
-			this.props.addMedia( event.target.files, this.props.site );
+			this.props.addMedia( event.target.files, this.props.site, this.props.postId );
 		}
 
 		this.formRef.current.reset();
@@ -106,6 +107,7 @@ class MediaLibraryUploadButton extends React.Component {
 
 const mapStateToProps = ( state ) => {
 	return {
+		postId: getEditorPostId( state ),
 		sectionName: getSectionName( state ),
 	};
 };

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -16,6 +16,7 @@ import { bumpStat } from 'calypso/lib/analytics/mc';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { ScreenReaderText } from '@automattic/components';
 import { clearMediaItemErrors } from 'calypso/state/media/actions';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
 import { addMedia } from 'calypso/state/media/thunks';
 
 /**
@@ -55,7 +56,7 @@ class MediaLibraryUploadUrl extends Component {
 		}
 
 		this.props.clearMediaItemErrors( this.props.site.ID );
-		this.props.addMedia( this.state.value, this.props.site );
+		this.props.addMedia( this.state.value, this.props.site, this.props.postId );
 
 		this.setState( { value: '', isError: false } );
 		this.props.onAddMedia();
@@ -116,6 +117,9 @@ class MediaLibraryUploadUrl extends Component {
 	}
 }
 
-export default connect( null, { addMedia, clearMediaItemErrors } )(
-	localize( MediaLibraryUploadUrl )
-);
+export default connect(
+	( state ) => ( {
+		postId: getEditorPostId( state ),
+	} ),
+	{ addMedia, clearMediaItemErrors }
+)( localize( MediaLibraryUploadUrl ) );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -149,7 +149,7 @@ export class EditorMediaModal extends Component {
 	}
 
 	copyExternalAfterLoadingWordPressLibrary( selectedMedia, originalSource ) {
-		const { site } = this.props;
+		const { postId, site } = this.props;
 
 		// Trigger the action to clear pointers/selected items
 		this.props.changeMediaSource( site.ID );
@@ -164,7 +164,7 @@ export class EditorMediaModal extends Component {
 				// Reset the query so that we're adding the new media items to the correct
 				// list, with no external source.
 				this.props.setQuery( site.ID, {} );
-				this.props.addExternalMedia( selectedMedia, site, originalSource );
+				this.props.addExternalMedia( selectedMedia, site, postId, originalSource );
 			}
 		);
 	}

--- a/client/state/media/thunks/add-external-media.js
+++ b/client/state/media/thunks/add-external-media.js
@@ -4,8 +4,8 @@
 import { uploadMedia } from './upload-media';
 import wpcom from 'calypso/lib/wp';
 
-const getExternalUploader = ( service ) => ( file, siteId ) => {
-	return wpcom.undocumented().site( siteId ).uploadExternalMedia( service, [ file.guid ] );
+const getExternalUploader = ( service ) => ( file, siteId, postId ) => {
+	return wpcom.undocumented().site( siteId ).uploadExternalMedia( service, [ file.guid ], postId );
 };
 
 /**
@@ -13,9 +13,10 @@ const getExternalUploader = ( service ) => ( file, siteId ) => {
  *
  * @param {object|object[]} file The media file or files to upload
  * @param {object} site The site for which to upload the file(s)
+ * @param {number} postId - ID of the post to attach the media item to
  * @param {object} service The external media service used
  */
-export const addExternalMedia = ( file, site, service ) => ( dispatch ) => {
+export const addExternalMedia = ( file, site, postId, service ) => ( dispatch ) => {
 	const uploader = getExternalUploader( service );
-	return dispatch( uploadMedia( file, site, uploader ) );
+	return dispatch( uploadMedia( file, site, postId, uploader ) );
 };

--- a/client/state/media/thunks/add-external-media.js
+++ b/client/state/media/thunks/add-external-media.js
@@ -4,9 +4,12 @@
 import { uploadMedia } from './upload-media';
 import wpcom from 'calypso/lib/wp';
 
-const getExternalUploader = ( service ) => ( file, siteId, postId ) => {
-	return wpcom.undocumented().site( siteId ).uploadExternalMedia( service, [ file.guid ], postId );
-};
+const getExternalUploader = ( service ) => ( file, siteId, postId = 0 ) =>
+	wpcom.req.post( `/sites/${ siteId }/external-media-upload`, {
+		external_ids: [ file.guid ],
+		service,
+		post_id: postId,
+	} );
 
 /**
  * Add a single external media file.

--- a/client/state/media/thunks/add-media.js
+++ b/client/state/media/thunks/add-media.js
@@ -9,8 +9,8 @@ import { getFileUploader } from 'calypso/lib/media/utils';
  *
  * @param {object|object[]} file The file or files to upload
  * @param {object} site The site for which to upload the file(s)
+ * @param {number} postId - ID of the post to attach the media item to
  */
-export const addMedia = ( file, site ) => ( dispatch, getState ) => {
-	const uploader = getFileUploader( getState );
-	return dispatch( uploadMedia( file, site, uploader ) );
+export const addMedia = ( file, site, postId = 0 ) => ( dispatch ) => {
+	return dispatch( uploadMedia( file, site, postId, getFileUploader ) );
 };

--- a/client/state/media/thunks/test/add-external-media.js
+++ b/client/state/media/thunks/test/add-external-media.js
@@ -10,6 +10,7 @@ jest.mock( 'calypso/state/media/thunks/upload-media', () => ( {
 } ) );
 
 describe( 'media - thunks - addExternalMedia', () => {
+	const postId = 0;
 	const site = Symbol( 'site' );
 	const file = Symbol( 'file' );
 	const service = Symbol( 'service' );
@@ -20,17 +21,22 @@ describe( 'media - thunks - addExternalMedia', () => {
 
 	describe( 'single file', () => {
 		it( 'should dispatch to uploadMedia with the file uploader', async () => {
-			await addExternalMedia( file, site, service );
+			await addExternalMedia( file, site, postId, service );
 
-			expect( uploadMedia ).toHaveBeenCalledWith( file, site, expect.any( Function ) );
+			expect( uploadMedia ).toHaveBeenCalledWith( file, site, postId, expect.any( Function ) );
 		} );
 	} );
 
 	describe( 'multiple files', () => {
 		it( 'should dispatch to uploadMedia with the file uploader', async () => {
-			await addExternalMedia( [ file, file ], site, service );
+			await addExternalMedia( [ file, file ], site, postId, service );
 
-			expect( uploadMedia ).toHaveBeenCalledWith( [ file, file ], site, expect.any( Function ) );
+			expect( uploadMedia ).toHaveBeenCalledWith(
+				[ file, file ],
+				site,
+				postId,
+				expect.any( Function )
+			);
 		} );
 	} );
 } );

--- a/client/state/media/thunks/test/add-media.js
+++ b/client/state/media/thunks/test/add-media.js
@@ -12,6 +12,7 @@ jest.mock( 'calypso/state/media/thunks/upload-media', () => ( {
 } ) );
 
 describe( 'media - thunks - addMedia', () => {
+	const postId = 0;
 	const site = Symbol( 'site' );
 	const file = Symbol( 'file' );
 	const dispatch = jest.fn();
@@ -21,21 +22,17 @@ describe( 'media - thunks - addMedia', () => {
 
 	describe( 'single file', () => {
 		it( 'should dispatch to uploadMedia with the file uploader', async () => {
-			const uploader = jest.fn();
-			getFileUploader.mockReturnValueOnce( uploader );
-			await addMedia( file, site );
+			await addMedia( file, site, postId );
 
-			expect( uploadMedia ).toHaveBeenCalledWith( file, site, uploader );
+			expect( uploadMedia ).toHaveBeenCalledWith( file, site, postId, getFileUploader );
 		} );
 	} );
 
 	describe( 'multiple files', () => {
 		it( 'should dispatch to uploadMedia with the file uploader', async () => {
-			const uploader = jest.fn();
-			getFileUploader.mockReturnValueOnce( uploader );
-			await addMedia( [ file, file ], site );
+			await addMedia( [ file, file ], site, postId );
 
-			expect( uploadMedia ).toHaveBeenCalledWith( [ file, file ], site, uploader );
+			expect( uploadMedia ).toHaveBeenCalledWith( [ file, file ], site, postId, getFileUploader );
 		} );
 	} );
 } );

--- a/client/state/media/thunks/test/upload-media.js
+++ b/client/state/media/thunks/test/upload-media.js
@@ -22,6 +22,7 @@ describe( 'media - thunks - uploadMedia', () => {
 	let fileUploader;
 
 	const siteId = 1343323;
+	const postId = 0;
 	const site = { ID: siteId };
 	const file = Object.freeze( {
 		fileContents: Symbol( 'file contents' ),
@@ -57,7 +58,7 @@ describe( 'media - thunks - uploadMedia', () => {
 			const receiveMedia = jest.spyOn( syncActions, 'receiveMedia' );
 			const failMediaItemRequest = jest.spyOn( syncActions, 'failMediaItemRequest' );
 
-			await expect( uploadMedia( file, site, fileUploader ) ).resolves.toEqual( [
+			await expect( uploadMedia( file, site, postId, fileUploader ) ).resolves.toEqual( [
 				{
 					...file,
 					ID: savedId,
@@ -81,7 +82,7 @@ describe( 'media - thunks - uploadMedia', () => {
 
 		it( 'should call the onItemSuccess callback', async () => {
 			const onItemUploaded = jest.fn();
-			await uploadMedia( file, site, fileUploader, onItemUploaded );
+			await uploadMedia( file, site, postId, fileUploader, onItemUploaded );
 
 			expect( onItemUploaded ).toHaveBeenCalledWith(
 				{
@@ -106,7 +107,7 @@ describe( 'media - thunks - uploadMedia', () => {
 			const receiveMedia = jest.spyOn( syncActions, 'receiveMedia' );
 			const failMediaItemRequest = jest.spyOn( syncActions, 'failMediaItemRequest' );
 
-			await expect( uploadMedia( file, site, fileUploader ) ).resolves.toEqual( [] );
+			await expect( uploadMedia( file, site, postId, fileUploader ) ).resolves.toEqual( [] );
 
 			expect( successMediaItemRequest ).not.toHaveBeenCalled();
 			expect( receiveMedia ).not.toHaveBeenCalled();
@@ -115,7 +116,7 @@ describe( 'media - thunks - uploadMedia', () => {
 
 		it( 'should call the onItemFailure callback', async () => {
 			const onItemFailure = jest.fn();
-			await uploadMedia( file, site, fileUploader, jest.fn(), onItemFailure );
+			await uploadMedia( file, site, postId, fileUploader, jest.fn(), onItemFailure );
 
 			expect( onItemFailure ).toHaveBeenCalledWith( { ...file } );
 		} );

--- a/client/state/media/thunks/upload-media.js
+++ b/client/state/media/thunks/upload-media.js
@@ -29,6 +29,7 @@ const noop = () => {};
  *
  * @param {object|object[]} files The file to upload
  * @param {object} site The site to add the media to
+ * @param {number} postId - ID of the post to attach the media item to
  * @param {Function} uploader The file uploader to use
  * @param {Function?} onItemUploaded Optional function to call when upload for an individual item succeeds
  * @param {Function?} onItemFailure Optional function to be called when upload for an individual item fails
@@ -38,6 +39,7 @@ const noop = () => {};
 export const uploadMedia = (
 	files,
 	site,
+	postId = 0,
 	uploader,
 	onItemUploaded = noop,
 	onItemFailure = noop
@@ -65,7 +67,7 @@ export const uploadMedia = (
 			const {
 				media: [ uploadedMedia ],
 				found,
-			} = await uploader( file, siteId );
+			} = await uploader( file, siteId, postId );
 			const uploadedMediaWithTransientId = {
 				...uploadedMedia,
 				transientId: transientMedia.ID,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In media, we currently rely on the uploader (external or not) to provide the post ID that serves as a parent when uploading a media file. However, that's not always accurate, as @jsnajdr described in https://github.com/Automattic/wp-calypso/pull/53279#discussion_r643694616

This PR updates `addMedia` and `uploadMedia` so they specifically accept `postId` to attach the media file to (if any).

#### Testing instructions

* Go to `/media/:site`
* Upload files in different ways and verify that they end up without a `postId` (`post_parent`):
  * Drag and drop
  * Via URL
  * Via an external source
* Go to edit a post.
* Insert an image block.
* Click the button to upload a new file.
* Upload files in different ways and verify that they end up with the `postId` (`post_parent`) of the current post:
  * Drag and drop
  * Via URL
  * Via an external source
* Verify test pass.