### PR TITLE
Emails: Fix Add new mailboxes link not shown for email forwards on Email Plan page

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-subscription.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-subscription.jsx
@@ -28,11 +28,7 @@ class EmailPlanSubscription extends React.Component {
 	}
 
 	renderRenewButton() {
-		const { domain, purchase, selectedSite, isLoadingPurchase, translate } = this.props;
-
-		if ( ! domain.currentUserCanManage ) {
-			return null;
-		}
+		const { purchase, selectedSite, isLoadingPurchase, translate } = this.props;
 
 		if ( ! purchase && ! isLoadingPurchase ) {
 			return null;

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -38,7 +38,6 @@ import {
 } from 'calypso/lib/gsuite';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
@@ -178,6 +177,7 @@ class EmailPlan extends React.Component {
 
 		if ( hasGSuiteWithUs( domain ) ) {
 			const googleMailService = getGoogleMailServiceFamily( getGSuiteProductSlug( domain ) );
+
 			return translate( '%(googleMailService)s settings', {
 				args: {
 					googleMailService,
@@ -266,31 +266,39 @@ class EmailPlan extends React.Component {
 	}
 
 	renderAddNewMailboxesOrRenewNavItem() {
-		const { domain, purchase, translate } = this.props;
+		const { domain, hasSubscription, purchase, translate } = this.props;
 
-		if ( hasEmailForwards( domain ) ) {
+		if ( hasTitanMailWithUs( domain ) && ! hasSubscription ) {
 			return (
 				<VerticalNavItem { ...this.getAddMailboxProps() }>
-					{ translate( 'Add new email forwards' ) }
+					{ translate( 'Add new mailboxes' ) }
 				</VerticalNavItem>
 			);
 		}
 
-		if ( ! purchase ) {
-			return <VerticalNavItem isPlaceholder />;
-		}
+		if ( hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) ) {
+			if ( ! purchase ) {
+				return <VerticalNavItem isPlaceholder />;
+			}
 
-		if ( isExpired( purchase ) ) {
+			if ( isExpired( purchase ) ) {
+				return (
+					<VerticalNavItem onClick={ this.handleRenew } path="#">
+						{ translate( 'Renew to add new mailboxes' ) }
+					</VerticalNavItem>
+				);
+			}
+
 			return (
-				<VerticalNavItem onClick={ this.handleRenew } path="#">
-					{ translate( 'Renew to add new mailboxes' ) }
+				<VerticalNavItem { ...this.getAddMailboxProps() }>
+					{ translate( 'Add new mailboxes' ) }
 				</VerticalNavItem>
 			);
 		}
 
 		return (
 			<VerticalNavItem { ...this.getAddMailboxProps() }>
-				{ translate( 'Add new mailboxes' ) }
+				{ translate( 'Add new email forwards' ) }
 			</VerticalNavItem>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -38,6 +38,7 @@ import {
 } from 'calypso/lib/gsuite';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
@@ -111,11 +112,13 @@ class EmailPlan extends React.Component {
 
 	getMailboxes() {
 		const account = this.getAccount();
+
 		return account?.emails ?? [];
 	}
 
 	handleBack = () => {
 		const { selectedSite } = this.props;
+
 		page( emailManagement( selectedSite.slug ) );
 	};
 
@@ -246,10 +249,6 @@ class EmailPlan extends React.Component {
 	renderManageAllMailboxesNavItem() {
 		const { domain, translate } = this.props;
 
-		if ( ! domain ) {
-			return null;
-		}
-
 		if ( ! hasGSuiteWithUs( domain ) && ! hasTitanMailWithUs( domain ) ) {
 			return null;
 		}
@@ -267,14 +266,22 @@ class EmailPlan extends React.Component {
 	}
 
 	renderAddNewMailboxesOrRenewNavItem() {
-		const { domain, hasSubscription, purchase, selectedSite, translate } = this.props;
+		const { domain, hasSubscription, purchase, translate } = this.props;
 
-		if ( ! domain.currentUserCanManage || ! hasSubscription ) {
-			return null;
+		if ( hasEmailForwards( domain ) ) {
+			return (
+				<VerticalNavItem { ...this.getAddMailboxProps() }>
+					{ translate( 'Add new email forwards' ) }
+				</VerticalNavItem>
+			);
 		}
 
-		if ( ! selectedSite || ! purchase ) {
+		if ( ! purchase ) {
 			return <VerticalNavItem isPlaceholder />;
+		}
+
+		if ( ! hasSubscription ) {
+			return null;
 		}
 
 		if ( isExpired( purchase ) ) {

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -266,7 +266,7 @@ class EmailPlan extends React.Component {
 	}
 
 	renderAddNewMailboxesOrRenewNavItem() {
-		const { domain, hasSubscription, purchase, translate } = this.props;
+		const { domain, purchase, translate } = this.props;
 
 		if ( hasEmailForwards( domain ) ) {
 			return (
@@ -278,10 +278,6 @@ class EmailPlan extends React.Component {
 
 		if ( ! purchase ) {
 			return <VerticalNavItem isPlaceholder />;
-		}
-
-		if ( ! hasSubscription ) {
-			return null;
 		}
 
 		if ( isExpired( purchase ) ) {


### PR DESCRIPTION
This pull request fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/53189, which would prevent the `Add new mailboxes` option from being displayed for email forwards on the `Email Plan` page. This patch fixes that issue, and also:

* Renames `Add new mailboxes` to `Add new email forwards`
* Removes `domain.currentUserCanManage` checks which are specific to domains (and not emails)
* Removes some unnecessary checks on `domain` and `selectedSite`

Before | After
------ | -----
<img width="624" alt="02" src="https://user-images.githubusercontent.com/594356/120495547-18f6e100-c3bd-11eb-9d8f-7158909c527b.png"> |<img width="624" alt="01" src="https://user-images.githubusercontent.com/594356/120495561-1c8a6800-c3bd-11eb-9a81-a38f29322d26.png">

#### Testing instructions

1. Run `git checkout fix/adding-email-forwards` and start your server, or open a [live branch](https://calypso.live/?branch=fix/adding-email-forwards)
2. Log into a WordPress.com account that has a domain with email forwards
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the domain with email forwards
5. Assert that a `Add new email forwards` link is displayed
6. Click that link
7. Assert that you are presented with the `Email Forwarding` page