### PR TITLE
Jetpack Plans: update Priority Support copy

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -216,7 +216,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 						{ translate( 'Monthly plans are 7-day money back guarantee.' ) }
 					</li>
 					<li className="product-grid__asterisk-item">
-						{ translate( 'All plans include priority support' ) }
+						{ translate( 'All paid products and plans include priority support.' ) }
 					</li>
 				</ul>
 			</ProductGridSection>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to 1164141197617539-as-1200409295622579

* Replace `All plans include priority support` with `All paid products and plans include priority support.` to clearly state that Jetpack Free does not include Priority Support.

#### Testing instructions

* Download this PR and run Calypso Green with `yarn start-jetpack-cloud`.
* Go to `http://jetpack.cloud.localhost:3000/pricing`.
* Scroll down to the middle of the page.
* Make sure you observe the `All paid products and plans include priority support.` message (see capture below).

#### Demo – before

![image](https://user-images.githubusercontent.com/3418513/120494955-41b1b300-c38a-11eb-9fd8-2d882ff9e281.png)

#### Demo – after

![image](https://user-images.githubusercontent.com/3418513/120494261-addfe700-c389-11eb-943d-be2e25500a5d.png)






