### PR TITLE
Jetpack Checkout: Set post purchase destination to wp-admin recommendations page.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -33,7 +33,7 @@ import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_RESET_PLANS,
 	JETPACK_REDIRECT_URL,
-	redirectCloudCheckoutToWpAdmin,
+	redirectCheckoutToWpAdmin,
 } from '@automattic/calypso-products';
 import { persistSignupDestination, retrieveSignupDestination } from 'calypso/signup/storageUtils';
 import { badNaiveClientSideRollout } from 'calypso/lib/naive-client-side-rollout';
@@ -290,10 +290,10 @@ function getFallbackDestination( {
 		if ( isJetpackNotAtomic && purchasedProduct ) {
 			debug( 'the site is jetpack and bought a jetpack product', siteSlug, purchasedProduct );
 
-			// Jetpack Cloud will either redirect to wp-admin (if JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN
+			// Jetpack Cloud will either redirect to wp-admin (if JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN
 			// flag is set), or otherwise will redirect to a Jetpack Redirect API url (source=jetpack-checkout-thankyou)
 			if ( isJetpackCloud() ) {
-				if ( redirectCloudCheckoutToWpAdmin() && adminUrl ) {
+				if ( redirectCheckoutToWpAdmin() && adminUrl ) {
 					debug( 'checkout is Jetpack Cloud, returning wp-admin url' );
 					return `${ adminUrl }admin.php?page=jetpack#/recommendations`;
 				}
@@ -303,7 +303,9 @@ function getFallbackDestination( {
 				) }`;
 			}
 			// Otherwise if not Jetpack Cloud:
-			return `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;
+			return redirectCheckoutToWpAdmin() && adminUrl
+				? `${ adminUrl }admin.php?page=jetpack#/recommendations`
+				: `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;
 		}
 
 		// If we just purchased a legacy Jetpack plan, redirect to the Jetpack onboarding plugin install flow.

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -12,7 +12,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_ECOMMERCE,
 	JETPACK_REDIRECT_URL,
-	redirectCloudCheckoutToWpAdmin,
+	redirectCheckoutToWpAdmin,
 } from '@automattic/calypso-products';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
@@ -26,7 +26,7 @@ jest.mock( 'calypso/lib/user', () =>
 jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud', () => jest.fn() );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),
-	redirectCloudCheckoutToWpAdmin: jest.fn(),
+	redirectCheckoutToWpAdmin: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/calypso-config', () => {
@@ -48,7 +48,7 @@ const defaultArgs = {
 describe( 'getThankYouPageUrl', () => {
 	beforeEach( () => {
 		isJetpackCloud.mockImplementation( () => false );
-		redirectCloudCheckoutToWpAdmin.mockImplementation( () => false );
+		redirectCheckoutToWpAdmin.mockImplementation( () => false );
 	} );
 
 	it( 'redirects to the root page when no site is set', () => {
@@ -269,9 +269,9 @@ describe( 'getThankYouPageUrl', () => {
 		);
 	} );
 
-	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCloudCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product', () => {
+	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product', () => {
 		isJetpackCloud.mockImplementation( () => true );
-		redirectCloudCheckoutToWpAdmin.mockImplementation( () => true );
+		redirectCheckoutToWpAdmin.mockImplementation( () => true );
 		const adminUrl = 'https://my.site/wp-admin/';
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -223,6 +223,6 @@ export const JETPACK_ANTI_SPAM_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/u
 // If JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN is true, checkout will redirect to the site's wp-admin,
 // otherwise it will redirect to the JETPACK_REDIRECT_URL. Checkout references these constants in:
 // client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
-export const JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN = true;
+export const JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN = true;
 export const JETPACK_REDIRECT_URL =
 	'https://jetpack.com/redirect/?source=jetpack-checkout-thankyou';

--- a/packages/calypso-products/src/plans-utilities.js
+++ b/packages/calypso-products/src/plans-utilities.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import {
-	JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN,
+	JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN,
 	BEST_VALUE_PLANS,
 	TERM_MONTHLY,
 	PLAN_MONTHLY_PERIOD,
@@ -39,4 +39,4 @@ export function getTermDuration( term ) {
 	}
 }
 
-export const redirectCloudCheckoutToWpAdmin = () => !! JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN;
+export const redirectCheckoutToWpAdmin = () => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;


### PR DESCRIPTION
This PR updates the post-purchase destination (for non-atomic Jetpack purchases) to the site's wp-admin Jetpack dashboard recommendations assistant.

Previously these purchases were being redirected to the Calypso blue product checklist (guided tour).


Related to: 1164141197617539-as-1200403218057318

#### Changes proposed in this Pull Request

* Renamed the flag `redirectCloudCheckoutToWpAdmin` to `redirectCheckoutToWpAdmin`
* And now use this flag for both Cloud and non-Cloud (Calypso) checkout to determine the post-checkout destination.
* As of this PR, `redirectCheckoutToWpAdmin` is `true` and set to `/wp-admin/admin.php?page=jetpack#/recommendations` for all non-atomic Jetpack purchases originating from **_both_** Calypso checkout and Cloud checkout. (however Cloud checkout is not currently in use at this time anyway, but if/when it is enabled someday, it is also set to the Recommendations assistant page.)

#### Testing instructions

1. Checkout this PR & run `yarn start`
2. Create a JN site and connect it (Or use any self-hosted Jetpack site already connected to your account)
3. Select the site and go to the /plans page: `http://calypso.localhost:3000/plans/:site`
4. Select and purchase any product or plan.
5. Verify that after purchase completed, you are redirected to the site's recommendation assistant.
    ( `/wp-admin/admin.php?page=jetpack#/recommendations` )


**Verify all unit tests pass:**
Run: `yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->