### PR TITLE
Hosting Configuration: redirect to hosting configuration page after Checkout

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -84,7 +84,7 @@ class Hosting extends Component {
 			<UpsellNudge
 				title={ translate( 'Upgrade to the Business plan to access all hosting features' ) }
 				event="calypso_hosting_configuration_upgrade_click"
-				href={ `/checkout/${ siteId }/business` }
+				href={ `/checkout/${ siteId }/business?redirect_to=/hosting-config/${ siteId }` }
 				plan={ PLAN_BUSINESS }
 				feature={ FEATURE_SFTP }
 				showIcon={ true }


### PR DESCRIPTION
When clicking the upsell nudge from the Hosting Configuration page and completing Checkout, we leave the user on a meaningless thank you page. This returns the user to the Hosting Configuration page, where the activation banner will help them go Atomic.

**To test:**
- on a simple site without a business or ecommerce plan
- visit Settings > Hosting Configuration
- verify that you see the Upsell (and the page is faded-out)
- click the upsell and complete Checkout
- verify that you are returned to the Hosting Configuration page and the upsell is now the Atomic activation notice