### PR TITLE
Happy Chat: Show in-chat unread messages indicator 

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -10,7 +10,9 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { useAutoscroll } from './autoscroll';
+import { Button } from '@automattic/components';
 import Emojify from 'calypso/components/emojify';
+import Gridicon from 'calypso/components/gridicon';
 import { useScrollbleed } from './scrollbleed';
 import { addSchemeIfMissing, setUrlScheme } from './url';
 
@@ -179,27 +181,45 @@ function Timeline( props ) {
 
 	const { timeline, isCurrentUser, isExternalUrl = () => true, twemojiUrl } = props;
 
+	const unreadMessages = autoscroll.disabledAt
+		? timeline.filter( ( { timestamp } ) => timestamp >= autoscroll.disabledAt )
+		: [];
+
 	return (
-		<div
-			className="happychat__conversation"
-			ref={ onScrollContainer }
-			onMouseEnter={ scrollbleed.lock }
-			onMouseLeave={ scrollbleed.unlock }
-		>
-			{ groupMessages( timeline ).map( ( item ) => {
-				const firstItem = item[ 0 ];
-				if ( firstItem.type !== 'message' ) {
-					debug( 'no handler for message type', firstItem.type, firstItem );
-					return null;
-				}
-				return renderGroupedMessages( {
-					item,
-					isCurrentUser: isCurrentUser( firstItem ),
-					isExternalUrl,
-					twemojiUrl,
-				} );
-			} ) }
-		</div>
+		<>
+			<div
+				className="happychat__conversation"
+				ref={ onScrollContainer }
+				onMouseEnter={ scrollbleed.lock }
+				onMouseLeave={ scrollbleed.unlock }
+			>
+				{ groupMessages( timeline ).map( ( item ) => {
+					const firstItem = item[ 0 ];
+					if ( firstItem.type !== 'message' ) {
+						debug( 'no handler for message type', firstItem.type, firstItem );
+						return null;
+					}
+					return renderGroupedMessages( {
+						item,
+						isCurrentUser: isCurrentUser( firstItem ),
+						isExternalUrl,
+						twemojiUrl,
+					} );
+				} ) }
+			</div>
+			{ unreadMessages.length > 0 && (
+				<div className="happychat__unread-messages-container">
+					<Button
+						primary
+						className="happychat__unread-messages-button"
+						onClick={ autoscroll.enableAutoscroll }
+					>
+						{ unreadMessages.length } new message{ unreadMessages.length > 1 ? 's' : '' }
+						<Gridicon icon="arrow-down" />
+					</Button>
+				</div>
+			) }
+		</>
 	);
 }
 

--- a/client/components/happychat/timeline.scss
+++ b/client/components/happychat/timeline.scss
@@ -111,6 +111,24 @@
 		a {
 			color: var( --color-accent );
 		}
+	}
+}
 
+.happychat__unread-messages-container {
+	position: relative;
+	height: 0;
+	margin: 0 30px 0 20px;
+}
+
+.happychat__unread-messages-button {
+	position: absolute;
+	bottom: 10px;
+	left: 50%;
+	transform: translateX( -50% );
+	border-radius: 8px;
+	padding-left: 2em;
+	padding-right: 2em;
+	> .gridicon {
+		margin-left: 0.5em;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses 1518-gh-Automattic/happychat

When a Happy Chat session is open and the user scrolls up, an audible notice plays when new messages arrive. But often users still miss that, don't realize they're scrolled up, and think the chat has frozen or the HE just isn't responding. This leads to delayed response times, and in some cases users abandon the chat.

This PR adds a visual indicator if the user is scrolled up and there are new messages they haven't seen yet:

https://user-images.githubusercontent.com/518059/120566630-464f8900-c3d5-11eb-9658-ec21c73d3928.mov

Clicking the button will return you to the bottom of the chat and hide the button. Scrolling to the bottom of the chat will do the same.

#### Testing instructions

* Open a Happy Chat session
* Try lots of scenarios with scrolling to different positions, navigating to different pages, minimizing and re-opening chat, all the while sending messages from both sides — the chat button should only appear when there are new messages you haven't seen yet.
* Check that the three Tracks events are firing correctly:
  * `calypso_happychat_unread_messages_button_show` when the button appears
  * `calypso_happychat_unread_messages_button_hide` when the button disappears (including when the button is clicked)
  * `calypso_happychat_unread_messages_button_click` when the button is clicked