### PR TITLE
Happy Chat: Fix floating bubble's "unread" visual indication

### DIFF
--- a/client/state/happychat/selectors/has-unread-messages.js
+++ b/client/state/happychat/selectors/has-unread-messages.js
@@ -18,9 +18,7 @@ export default createSelector(
 		return (
 			typeof lastMessageTimestamp === 'number' &&
 			typeof lostFocusAt === 'number' &&
-			// Message timestamps are reported in seconds. We need to multiply by 1000 to convert
-			// to milliseconds, so we can compare it to other JS-generated timestamps
-			lastMessageTimestamp * 1000 >= lostFocusAt
+			lastMessageTimestamp >= lostFocusAt
 		);
 	},
 	[ getHappychatTimeline, getLostFocusTimestamp ]

--- a/client/state/happychat/selectors/test/has-unread-messages.js
+++ b/client/state/happychat/selectors/test/has-unread-messages.js
@@ -19,9 +19,9 @@ describe( 'selectors', () => {
 		// Need to convert timestamps to seconds, instead of milliseconds, because
 		// that's what the Happychat service provides
 		const timeline = [
-			{ timestamp: ( NOW - FIVE_MINUTES ) / 1000 },
-			{ timestamp: ( NOW - ONE_MINUTE ) / 1000 },
-			{ timestamp: NOW / 1000 },
+			{ timestamp: NOW - FIVE_MINUTES },
+			{ timestamp: NOW - ONE_MINUTE },
+			{ timestamp: NOW },
 		];
 
 		test( 'returns false if Happychat is focused', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses 1518-gh-Automattic/happychat

It looks like for just over two years the "unread messages" indication on the floating Happy Chat bubble has been broken, _always_ showing in the "unread" state. The only indication that an HE had sent a message when Happy Chat was minimized is an audible "ping," which isn't actually very effective without an accompanying visual change (for many reasons).

This PR fixes that, making the bubble default "blue" when it's minimized, changing to the accent "pink" when there's a new message. It may make sense to experiment with making the visual indicator here even stronger (a pulsing color or similar?) since this is such a high-value indicator, but for now I just want to fix the long-standing bug:

https://user-images.githubusercontent.com/518059/120568471-89abf680-c3d9-11eb-97eb-6fe474f2ca74.mov

For posterity, it broke as part of our work on 607-gh-Automattic/happychat where we updated Happy Chat messages from a seconds-based timestamp to a ms-based timestamp. This selector had not been updated so it was comparing "Time HC was minimized in ms" to "Time of latest message in ms times 1000" which would _always_ be bigger.

#### Testing instructions

* Open a chat session
* Minimize Happy Chat — the bubble should be blue
* Send a couple messages from the HUD
* The bubble should turn pink
* Opening and minimizing Happy Chat again should make the bubble turn blue again
