### PR TITLE
SiteNotice: add missing translate() call and improve moment.js date comparison

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -249,9 +249,7 @@ export class SiteNotice extends React.Component {
 	}
 
 	promotionEndsToday( { endsAt } ) {
-		const now = new Date();
-		const format = 'YYYYMMDD';
-		return moment( now ).format( format ) === moment( endsAt ).format( format );
+		return moment().isSame( endsAt, 'day' );
 	}
 
 	render() {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -220,7 +220,7 @@ export class SiteNotice extends React.Component {
 			return null;
 		}
 
-		const { site, activeDiscount } = this.props;
+		const { translate, site, activeDiscount } = this.props;
 		const { nudgeText, nudgeEndsTodayText, ctaText, name } = activeDiscount;
 
 		const bannerText =
@@ -236,12 +236,12 @@ export class SiteNotice extends React.Component {
 		return (
 			<UpsellNudge
 				event="calypso_upgrade_nudge_impression"
-				forceDisplay={ true }
+				forceDisplay
 				tracksClickName="calypso_upgrade_nudge_cta_click"
 				tracksClickProperties={ eventProperties }
 				tracksImpressionName="calypso_upgrade_nudge_impression"
 				tracksImpressionProperties={ eventProperties }
-				callToAction={ ctaText || 'Upgrade' }
+				callToAction={ ctaText || translate( 'Upgrade' ) }
 				href={ `/plans/${ site.slug }?discount=${ name }` }
 				title={ bannerText }
 			/>


### PR DESCRIPTION
I did two drive-by fixes in `SiteNotice` that is the only consumer of `getActiveDiscount`:
- add a missing `translate()` around an "Upgrade" label
- improve a moment.js "are both times the same day" comparison: there is a convenient API for that

None of these two fixes can be currently tested in real life, because no discounts define the `nudgeText` fields.

Found when working on the `lib/abtest` removal.

**How to test:**
Verify that unit tests pass.