### PR TITLE
My Home: Play Store button shouldn't on the Go Mobile card on iPad

### DIFF
--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -29,8 +29,8 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 	const isDesktopView = isDesktop();
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
 	const isIos = isiPad || isiPod || isiPhone;
-	const showIosBadge = isDesktopView || isIos || ! isAndroid;
-	const showAndroidBadge = isDesktopView || isAndroid || ! isIos;
+	const showIosBadge = ! isAndroid;
+	const showAndroidBadge = ! isIos;
 	const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
 	const isDesktopApp = config.isEnabled( 'desktop' );
 

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isDesktop } from '@automattic/viewport';
 import React from 'react';
 import classnames from 'classnames';
 import { Card, Button } from '@automattic/components';
@@ -26,7 +25,6 @@ import './style.scss';
 
 export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 	const translate = useTranslate();
-	const isDesktopView = isDesktop();
 	const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
 	const isIos = isiPad || isiPod || isiPhone;
 	const showIosBadge = ! isAndroid;
@@ -56,7 +54,7 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 					) }
 				</div>
 			</div>
-			{ isDesktopView && ! isDesktopApp && (
+			{ ! isDesktopApp && (
 				<div className="go-mobile__email-link">
 					{ translate( 'Get a download link via email — click it on your phone to get the app.' ) }
 					<Button className="go-mobile__email-link-button is-link" onClick={ emailLogin }>

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .customer-home__layout-col-right {
 	@include breakpoint-deprecated( '<480px' ) {
 		.go-mobile__subheader.customer-home__card-subheader {
@@ -23,6 +26,11 @@
 	padding-top: 20px;
 	border-top: 1px solid var( --color-neutral-5 );
 	color: var( --color-text-subtle );
+	display: none;
+
+	@include break-large() {
+		display: block;
+	}
 }
 
 .go-mobile__email-link-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't use viewport size to determine whether to show app store icons
* Switch to CSS only solution for showing/hiding the "send me an email link" text

<img width="1023" alt="Screenshot 2021-06-03 at 9 42 53 PM" src="https://user-images.githubusercontent.com/1500769/120624302-ad903a80-c4b4-11eb-9a47-b0bf8282d8ca.png">


The `isDesktop` viewport function was being used to decide what sort of device the user was using, when really it's just a screensize function. An iPad in landscape orientation is wide enough for `isDesktop` to return true, which meant the desktop device logic was firing.

Changed logic so the Play Store button appears on anything but iOS, and the App Store button appears on anything but Android. That way on desktop browsers both buttons will still appear.

For the CSS change, the `isDesktop()` function and `break-large()` mixin both use the same breakpoint of 960px so there should be no change there.

#### Testing instructions

To get the Go Mobile card to appear on all device types use this diff D62243-code

Use devtools to emulate an iPad in landscape orientation. The Go Mobile card in the bottom right should only include the Apple App Store

Test that other device types work as expected too.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52995