### PR TITLE
Fix Professional Email mailbox validation

### DIFF
--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -14,13 +14,13 @@ import { validatePasswordField } from 'calypso/lib/gsuite/new-users';
 import wp from 'calypso/lib/wp';
 
 /**
- * A Titan mailbox error value.
+ * A Titan mailbox error, which is null or a translation result.
  *
  * @typedef {null|import('i18n-calypso').TranslateResult} TitanMailboxValueError
  */
 
 /**
- * A Titan mailbox with a boolean value
+ * A Titan mailbox value object with a boolean value.
  *
  * @typedef {Object} TitanMailboxBooleanValue
  * @property {boolean} value
@@ -28,7 +28,7 @@ import wp from 'calypso/lib/wp';
  */
 
 /**
- * A Titan mailbox with a string value
+ * A Titan mailbox value object with a string value.
  *
  * @typedef {Object} TitanMailboxStringValue
  * @property {string} value
@@ -36,7 +36,7 @@ import wp from 'calypso/lib/wp';
  */
 
 /**
- * A Titan mailbox with a string value
+ * A Titan mailbox value object, which may contain a string or boolean value.
  *
  * @typedef {TitanMailboxBooleanValue|TitanMailboxStringValue} TitanMailboxValue
  */

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -15,6 +15,7 @@ import {
 	areAllMailboxesValid,
 	buildNewTitanMailbox,
 	transformMailboxForCart,
+	validateMailboxes as validateTitanMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'calypso/lib/gsuite/new-users';
 import { Button } from '@automattic/components';
@@ -87,6 +88,7 @@ class EmailProvidersComparison extends React.Component {
 				titan: isDomainEligibleForEmail,
 			},
 			addingToCart: false,
+			validatedTitanMailboxUuids: [],
 		};
 	}
 
@@ -138,14 +140,23 @@ class EmailProvidersComparison extends React.Component {
 		const { domain } = this.props;
 		const { titanMailboxes } = this.state;
 
-		const mailboxesAreValid = areAllMailboxesValid( titanMailboxes, [ 'alternativeEmail' ] );
+		const validatedTitanMailboxes = validateTitanMailboxes( titanMailboxes );
+
+		const mailboxesAreValid = areAllMailboxesValid( validatedTitanMailboxes );
 		const userCanAddEmail = canCurrentUserAddEmail( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
-			mailbox_count: titanMailboxes.length,
+			mailbox_count: validatedTitanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: 'titan',
 			user_can_add_email: userCanAddEmail,
+		} );
+
+		const validatedTitanMailboxUuids = validatedTitanMailboxes.map( ( mailbox ) => mailbox.uuid );
+
+		this.setState( {
+			titanMailboxes: validatedTitanMailboxes,
+			validatedTitanMailboxUuids,
 		} );
 
 		if ( ! mailboxesAreValid || ! userCanAddEmail ) {
@@ -156,14 +167,15 @@ class EmailProvidersComparison extends React.Component {
 
 		const cartItem = titanMailMonthly( {
 			domain: domain.name,
-			quantity: titanMailboxes.length,
+			quantity: validatedTitanMailboxes.length,
 			extra: {
-				email_users: titanMailboxes.map( transformMailboxForCart ),
-				new_quantity: titanMailboxes.length,
+				email_users: validatedTitanMailboxes.map( transformMailboxForCart ),
+				new_quantity: validatedTitanMailboxes.length,
 			},
 		} );
 
 		this.setState( { addingToCart: true } );
+
 		shoppingCartManager
 			.addProductsToCart( [ fillInSingleCartItemAttributes( cartItem, productsList ) ] )
 			.then( () => {
@@ -386,6 +398,7 @@ class EmailProvidersComparison extends React.Component {
 				domain={ domain.name }
 				onReturnKeyPress={ this.onTitanFormReturnKeyPress }
 				showLabels={ true }
+				validatedMailboxUuids={ this.state.validatedTitanMailboxUuids }
 			>
 				<Button
 					className="email-providers-comparison__titan-mailbox-action-continue"

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -17,6 +17,7 @@ import {
 	areAllMailboxesAvailable,
 	buildNewTitanMailbox,
 	transformMailboxForCart,
+	validateMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
 import { Button, Card } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -71,6 +72,7 @@ class TitanAddMailboxes extends React.Component {
 		mailboxes: [ buildNewTitanMailbox( this.props.selectedDomainName, false ) ],
 		isAddingToCart: false,
 		isCheckingAvailability: false,
+		validatedMailboxUuids: [],
 	};
 
 	isMounted = false;
@@ -133,13 +135,16 @@ class TitanAddMailboxes extends React.Component {
 	handleContinue = async () => {
 		const { selectedSite } = this.props;
 		const { mailboxes } = this.state;
-		const allMailboxesAreValid = areAllMailboxesValid( mailboxes, [ 'alternativeEmail' ] );
+
+		const validatedMailboxes = validateMailboxes( mailboxes );
+
+		const allMailboxesAreValid = areAllMailboxesValid( validatedMailboxes );
 
 		let allMailboxesAreAvailable = false;
 		if ( allMailboxesAreValid ) {
 			this.setState( { isCheckingAvailability: true } );
 			allMailboxesAreAvailable = await areAllMailboxesAvailable(
-				mailboxes,
+				validatedMailboxes,
 				this.onMailboxesChange
 			);
 			if ( this.isMounted ) {
@@ -149,6 +154,13 @@ class TitanAddMailboxes extends React.Component {
 
 		const canContinue = allMailboxesAreValid && allMailboxesAreAvailable;
 
+		const validatedMailboxUuids = validatedMailboxes.map( ( mailbox ) => mailbox.uuid );
+
+		this.setState( {
+			mailboxes: validatedMailboxes,
+			validatedMailboxUuids,
+		} );
+
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
 			can_continue: canContinue,
 			mailbox_count: mailboxes.length,
@@ -156,6 +168,7 @@ class TitanAddMailboxes extends React.Component {
 
 		if ( canContinue ) {
 			this.setState( { isAddingToCart: true } );
+
 			this.props.shoppingCartManager
 				.addProductsToCart( [
 					fillInSingleCartItemAttributes( this.getCartItem(), this.props.productsList ),
@@ -203,10 +216,6 @@ class TitanAddMailboxes extends React.Component {
 		);
 	};
 
-	onButtonClick = () => {
-		this.setState( { quantity: this.state.quantity + 1 } );
-	};
-
 	onMailboxesChange = ( updatedMailboxes ) => {
 		this.setState( { mailboxes: updatedMailboxes, quantity: updatedMailboxes.length } );
 	};
@@ -227,6 +236,7 @@ class TitanAddMailboxes extends React.Component {
 						domain={ selectedDomainName }
 						mailboxes={ this.state.mailboxes }
 						onMailboxesChange={ this.onMailboxesChange }
+						validatedMailboxUuids={ this.state.validatedMailboxUuids }
 					>
 						<Button className="titan-add-mailboxes__action-cancel" onClick={ this.handleCancel }>
 							{ translate( 'Cancel' ) }

--- a/client/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list.jsx
@@ -27,6 +27,7 @@ const TitanNewMailboxList = ( {
 	onMailboxesChange,
 	onReturnKeyPress = noop,
 	showLabels = true,
+	validatedMailboxUuids = [],
 } ) => {
 	const translate = useTranslate();
 
@@ -75,6 +76,7 @@ const TitanNewMailboxList = ( {
 					onMailboxValueChange={ onMailboxValueChange( mailbox.uuid ) }
 					mailbox={ mailbox }
 					onReturnKeyPress={ onReturnKeyPress }
+					showAllErrors={ validatedMailboxUuids.includes( mailbox.uuid ) }
 					showLabels={ showLabels }
 					showTrashButton={ index > 0 }
 				/>

--- a/client/my-sites/email/titan-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-new-mailbox.jsx
@@ -34,6 +34,7 @@ const TitanNewMailbox = ( {
 		name: { value: name, error: nameError },
 		password: { value: password, error: passwordError },
 	},
+	showAllErrors = false,
 	showLabels = true,
 	showTrashButton = true,
 } ) => {
@@ -55,10 +56,11 @@ const TitanNewMailbox = ( {
 	const [ nameFieldTouched, setNameFieldTouched ] = useState( false );
 	const [ passwordFieldTouched, setPasswordFieldTouched ] = useState( false );
 
-	const hasAlternativeEmailError = alternativeEmailFieldTouched && null !== alternativeEmailError;
-	const hasMailboxError = mailboxFieldTouched && null !== mailboxError;
-	const hasNameError = nameFieldTouched && null !== nameError;
-	const hasPasswordError = passwordFieldTouched && null !== passwordError;
+	const hasAlternativeEmailError =
+		( alternativeEmailFieldTouched || showAllErrors ) && null !== alternativeEmailError;
+	const hasMailboxError = ( mailboxFieldTouched || showAllErrors ) && null !== mailboxError;
+	const hasNameError = ( nameFieldTouched || showAllErrors ) && null !== nameError;
+	const hasPasswordError = ( passwordFieldTouched || showAllErrors ) && null !== passwordError;
 
 	const showIsAdminToggle = false;
 
@@ -200,7 +202,9 @@ TitanNewMailbox.propTypes = {
 	onMailboxValueChange: PropTypes.func.isRequired,
 	onReturnKeyPress: PropTypes.func.isRequired,
 	mailbox: getMailboxPropTypeShape(),
+	showAllErrors: PropTypes.bool,
 	showLabels: PropTypes.bool.isRequired,
+	showTrashButton: PropTypes.bool,
 };
 
 export default TitanNewMailbox;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR improves the logic for the Professional Email pages that display mailbox creation fields so they show all errors after the user tries to add the mailbox(es) to their cart.
* The PR also adds JSDoc annotations to `client/lib/titan/new-mailbox.js`

From a technical perspective, this PR has three core pieces:
* The `TitanNewMailbox` component has a new `showAllErrors` prop that overrides the existing interaction-based logic when it is true.
* The wrapping page logic re-validates all the mailboxes before adding them to the cart, as the validation is currently interaction-driven and wouldn't occur for new mailboxes that had no interactions yet. After this validation step, we recall the uuids for the validated mailboxes.
* The wrapping page supplies the fully validated mailbox uuids to the `TitanNewMailboxList` component, which then uses the uuids to control which mailboxes should show all errors.

_I've kept the changes to Professional Email for now, as I was more familiar with that code, and wanted to get feedback before porting. The work for Google can happen in a follow-on PR._

#### Testing instructions

* Run this branch locally or via [the live branch](https://calypso.live/?branch=fix/email-account-validation-display).
* Run through the following tests when creating Professional Email mailboxes via `/email/:domain/manage/:siteSlug` for a domain with and without an existing Professional Email subscription (for the first case, you'll need to click on "Add new mailboxes")
  - Enter only some of the fields in the first mailbox _without_ interacting with the other fields (we've received issues with the password field and the name field, but you should also test with leaving the "Password reset email address" field empty)
  - Click on "Continue" or "Add Professional Email" to submit the form (or try hitting Enter/Return with a field focused)
  - Verify that errors are displayed for all invalid fields, especially the ones you didn't interact with
  - Click on the "Add another mailbox" button
  - Verify that no errors are displayed for the newly created mailbox
  - Click on the "Continue"/"Add Professional Email" button (or hit Enter/Return)
  - Verify that all the empty fields in the newly created mailbox are highlighted
  - Throw more test cases and interactions at the form and make sure you see all validation issues whenever you try to submit the data.

Fixes #53308