### PR TITLE
Remove the promisify helper from client/utils

### DIFF
--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import debugFactory from 'debug';
-
-/**
  * Internal dependencies
  */
 import user from 'calypso/lib/user';
@@ -11,31 +6,15 @@ import user from 'calypso/lib/user';
 // State actions and selectors
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { requestSites } from 'calypso/state/sites/actions';
-import { promisify } from 'calypso/utils';
 
-/**
- * Constants
- */
-const debug = debugFactory( 'calypso:signup:step-actions:fetch-sites-and-user' );
-
-function fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) {
-	if ( getSiteId( reduxStore.getState(), siteSlug ) ) {
-		debug( 'fetchReduxSite: found new site' );
-		callback();
-		return;
+async function fetchSitesUntilSiteAppears( siteSlug, reduxStore ) {
+	while ( ! getSiteId( reduxStore.getState(), siteSlug ) ) {
+		await reduxStore.dispatch( requestSites() );
 	}
-
-	// Have to manually call the thunk in order to access the promise on which
-	// to call `then`.
-	debug( 'fetchReduxSite: requesting all sites', siteSlug );
-	reduxStore
-		.dispatch( requestSites() )
-		.then( () => fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) );
 }
 
 export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
-	Promise.all( [
-		promisify( fetchSitesUntilSiteAppears )( siteSlug, reduxStore ),
-		user().fetch(),
-	] ).then( onComplete );
+	Promise.all( [ fetchSitesUntilSiteAppears( siteSlug, reduxStore ), user().fetch() ] ).then(
+		onComplete
+	);
 }

--- a/client/utils.js
+++ b/client/utils.js
@@ -7,16 +7,3 @@ export function pathToRegExp( path ) {
 	}
 	return new RegExp( '^' + path + '(/.*)?$' );
 }
-
-// takes in a fn where its last arg is a node-style callback
-// outputs a promise
-export const promisify = ( fn ) => ( ...args ) =>
-	new Promise( ( resolve, reject ) => {
-		fn( ...args, ( err, data ) => {
-			if ( err ) {
-				reject( err );
-			} else {
-				resolve( data );
-			}
-		} );
-	} );


### PR DESCRIPTION
Removes the `promisify` helper from `client/utils`. It has only one usage that can be easily transformed into an async function with a `while` loop.

**How to test:**
The affected code runs at the end of a Signup flow, when a site is being created. Verify that Signup that creates a new session proceeds smoothly.