### PR TITLE
Signup: Update email validation message

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -503,7 +503,7 @@ class SignupForm extends Component {
 						<p>
 							{ message }
 							&nbsp;
-							{ this.props.translate( 'If this is you {{a}}log in now{{/a}}.', {
+							{ this.props.translate( 'Go to the {{a}}login page{{/a}}.', {
 								components: {
 									a: (
 										<a

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -41,7 +41,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import Notice from 'calypso/components/notice';
 import LoggedOutForm from 'calypso/components/logged-out-form';
-import { login } from 'calypso/lib/paths';
+import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import formState from 'calypso/lib/form-state';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
@@ -503,16 +503,20 @@ class SignupForm extends Component {
 						<p>
 							{ message }
 							&nbsp;
-							{ this.props.translate( 'Go to the {{a}}login page{{/a}}.', {
-								components: {
-									a: (
-										<a
-											href={ link }
-											onClick={ ( event ) => this.handleLoginClick( event, fieldValue ) }
-										/>
-									),
-								},
-							} ) }
+							{ this.props.translate(
+								'{{loginLink}}Log in{{/loginLink}} or {{pwdResetLink}}reset your password{{/pwdResetLink}}.',
+								{
+									components: {
+										loginLink: (
+											<a
+												href={ link }
+												onClick={ ( event ) => this.handleLoginClick( event, fieldValue ) }
+											/>
+										),
+										pwdResetLink: <a href={ lostPassword( this.props.locale ) } />,
+									},
+								}
+							) }
 						</p>
 					</span>
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Changing the email address validation message to a more user-friendly alternative.

### Technical changes
* Copy is updated to _"An account with this email already exists. **Log in** or **reset your password**."_

#### Testing instructions
1. Check out this branch and `yarn && yarn start`
2. Apply D62261-code to your sandbox
3. Make sure that `public-api.wordpress.com` is proxied.
4. Go to `/start/user` create a new user with **an email address that's already registered**
5. Confirm that:
   * [ ] The validation message copy is updated to _"An account with this email already exists. **Log in** or **reset your password**."_
   * [ ] The "log in" link redirects to the existing 'login' page.
   * [ ] The "reset your password" link redirects to the existing 'reset your password' page.

#### Translation screenshot
![image](https://user-images.githubusercontent.com/17054134/121889510-9e618600-cd19-11eb-9393-86f46caeeeb9.png)

Fixes #53378