### PR TITLE
Allow turning off each web payment method for specific currencies

### DIFF
--- a/packages/wpcom-checkout/src/use-is-web-payment-available.ts
+++ b/packages/wpcom-checkout/src/use-is-web-payment-available.ts
@@ -74,13 +74,31 @@ export function useIsWebPayAvailable(
 			}
 		}
 
+		const normalizedCurrency: string = currency ? currency.toLowerCase() : 'usd';
+		// These arrays let us easily turn off web payments for particular currencies.
+		// Other payment methods handle this on the backend in a similar way.
+		const applePayDisabledCurrencies: string[] = [];
+		const googlePayDisabledCurrencies: string[] = [ 'inr', 'idr', 'huf', 'twd' ];
+		const isApplePayAllowedForCurrency = ! applePayDisabledCurrencies.includes(
+			normalizedCurrency
+		);
+		if ( ! isApplePayAllowedForCurrency ) {
+			debug( 'Apple Pay disabled by currency check.' );
+		}
+		const isGooglePayAllowedForCurrency = ! googlePayDisabledCurrencies.includes(
+			normalizedCurrency
+		);
+		if ( ! isGooglePayAllowedForCurrency ) {
+			debug( 'Google Pay disabled by currency check.' );
+		}
+
 		const paymentRequestOptions = {
 			requestPayerName: true,
 			requestPayerPhone: false,
 			requestPayerEmail: false,
 			requestShipping: false,
 			country: countryCode,
-			currency: currency ? currency.toLowerCase() : 'usd',
+			currency: normalizedCurrency,
 			// This is just used here to determine if web pay is available, not for
 			// the actual payment, so we leave most of the purchase details blank
 			displayItems: [],
@@ -98,8 +116,8 @@ export function useIsWebPayAvailable(
 			debug( 'stripe paymentRequest.canMakePayment returned', result );
 			setCanMakePayment( {
 				isLoading: false,
-				isApplePayAvailable: !! result?.applePay,
-				isGooglePayAvailable: !! result?.googlePay,
+				isApplePayAvailable: isApplePayAllowedForCurrency && !! result?.applePay,
+				isGooglePayAvailable: isGooglePayAllowedForCurrency && !! result?.googlePay,
 			} );
 		} );
 


### PR DESCRIPTION
From time to time (for instance, right now) a bug arises with a payment method that only affects specific currencies. It's handy to be able to turn off the method for only those currencies. The other payment methods handle this on the backend using a similar mechanism.

#### Changes proposed in this Pull Request

* Adds a mechanism for turning off Apple Pay and Google Pay (independently) for specific currencies.

#### Testing instructions

- Verify that Google Pay is not available in the IDR, INR, HUF, and TWD currencies when it otherwise would be.
- Verify that Google Pay is available in any other supported currency (e.g. USD, CAD, EUR, HKD).
- Verify that Apple Pay is available in any supported currency.
