### PR TITLE
ETK: Show editing sidebar by default

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
@@ -26,13 +26,7 @@ function WpcomNux() {
 		isManuallyOpened: select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideManuallyOpened(),
 	} ) );
 
-	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
-
-	// Hide editor sidebar first time users sees the editor
-	useEffect( () => {
-		show && closeGeneralSidebar();
-	}, [ closeGeneralSidebar, show ] );
 
 	// Track opening of the welcome guide
 	useEffect( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -28,16 +28,10 @@ function LaunchWpcomWelcomeTour() {
 		isManuallyOpened: select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideManuallyOpened(),
 	} ) );
 
-	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const localeSlug = useLocale();
 
 	// Preload first card image (others preloaded after open state confirmed)
 	new window.Image().src = getTourContent( localeSlug )[ 0 ].imgSrc;
-
-	// Hide editor sidebar first time user sees the editor
-	useEffect( () => {
-		show && closeGeneralSidebar();
-	}, [ closeGeneralSidebar, show ] );
 
 	useEffect( () => {
 		if ( ! show && ! isNewPageLayoutModalOpen ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts #43716 and falls back to core behavior, which is to show the editing sidebar by default when a user first opens the editor
* More discussion in pd2qbF-5L-p2

**Before**

https://user-images.githubusercontent.com/2124984/120687307-e35f0000-c46f-11eb-942c-7fae9587bb74.mov

**After**

To see these changes working on a sandbox, you have to open the URL in a new window and clear cookies/cache. The Before/After will be much more impressive when this is merged @ianstewart  ;)

https://user-images.githubusercontent.com/2124984/120815221-9c2f4880-c51d-11eb-8ebf-d0d255ce8576.mov

Fixes #53383

#### Testing instructions

* Switch to this PR and `yarn dev --sync` to your sandbox
* Create a new site from `/new` and sandbox the site's address
* You'll be brought to the editor with the sidebar closed by default. Copy the site's editor URL, close the window/tab, and clear cache/cookies
* Paste the site's editor URL into a new tab or browser window; when the editor loads, you should see the sidebar is open and stays open.
