### PR TITLE
Add @Automattic/quality-squad as one of the co-owners of test/e2e/.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,5 +126,5 @@
 /packages/languages @Automattic/i18n
 
 # E2E specs
-/test/e2e @WunderBart @scinos
+/test/e2e @WunderBart @scinos @Automattic/quality-squad
 /packages/calypso-e2e @worldomonation


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As discussed in the Quality Squad team meeting on June 2, the Quality Squad should be the co-owners of the test/e2e code.

#### Testing instructions
