### PR TITLE
desktop: fix window/title bar resize

### DIFF
--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -61,7 +61,12 @@ function showAppWindow() {
 	mainWindow.webContents.loadURL( `file://${ getPath( 'index.html' ) }` );
 
 	mainWindow.setBrowserView( mainView );
-	mainView.setBounds( { ...bounds, ...{ x: 0, y: TITLE_BAR_HEIGHT } } );
+	mainView.setBounds( {
+		x: 0,
+		y: TITLE_BAR_HEIGHT,
+		width: bounds.width,
+		height: bounds.height - TITLE_BAR_HEIGHT,
+	} );
 	mainWindow.on( 'will-resize', ( _, newBounds ) => {
 		mainView.setBounds( {
 			x: 0,

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -20,6 +20,8 @@ const { getPath } = require( '../lib/assets' );
  * Module variables
  */
 const USE_LOCALHOST = process.env.WP_DESKTOP_DEBUG_LOCALHOST !== undefined;
+const TITLE_BAR_HEIGHT = 38;
+
 let mainWindow = null;
 
 function showAppWindow() {
@@ -59,8 +61,15 @@ function showAppWindow() {
 	mainWindow.webContents.loadURL( `file://${ getPath( 'index.html' ) }` );
 
 	mainWindow.setBrowserView( mainView );
-	mainView.setBounds( { ...bounds, ...{ x: 0, y: 38 } } );
-	mainView.setAutoResize( { horizontal: true, vertical: true } );
+	mainView.setBounds( { ...bounds, ...{ x: 0, y: TITLE_BAR_HEIGHT } } );
+	mainWindow.on( 'will-resize', ( _, newBounds ) => {
+		mainView.setBounds( {
+			x: 0,
+			y: TITLE_BAR_HEIGHT,
+			width: newBounds.width,
+			height: newBounds.height - TITLE_BAR_HEIGHT,
+		} );
+	} );
 
 	SessionManager.init( mainWindow );
 

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -67,12 +67,20 @@ function showAppWindow() {
 		width: bounds.width,
 		height: bounds.height - TITLE_BAR_HEIGHT,
 	} );
-	mainWindow.on( 'will-resize', ( _, newBounds ) => {
+	mainWindow.on( 'resize', function () {
+		const newBounds = mainWindow.getBounds();
+
+		// Windows doesn't resize properly and requires extra space added to fit properly after resize.
+		const boundsPadding =
+			process.platform === 'win32'
+				? { width: 20, height: TITLE_BAR_HEIGHT + 55 }
+				: { width: 0, height: TITLE_BAR_HEIGHT };
+
 		mainView.setBounds( {
 			x: 0,
 			y: TITLE_BAR_HEIGHT,
-			width: newBounds.width,
-			height: newBounds.height - TITLE_BAR_HEIGHT,
+			width: newBounds.width - boundsPadding.width,
+			height: newBounds.height - boundsPadding.height,
 		} );
 	} );
 


### PR DESCRIPTION
### Description

This PR fixes the window/browser view resizing such that the title bar remains a fixed size and is not relative to the window size. I believe this also fixes some quirks observed when resizing content more generally.

### To Test

Build/run the app from the desktop folder with `yarn run dev` and play around with resizing the window!