### PR TITLE
Remove lodash references from client/boot

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -3,7 +3,6 @@
  */
 import debugFactory from 'debug';
 import page from 'page';
-import { startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
 import Modal from 'react-modal';
@@ -175,7 +174,7 @@ const oauthTokenMiddleware = () => {
 
 		// Forces OAuth users to the /login page if no token is present
 		page( '*', function ( context, next ) {
-			const isValidSection = loggedOutRoutes.some( ( route ) => startsWith( context.path, route ) );
+			const isValidSection = loggedOutRoutes.some( ( route ) => context.path.startsWith( route ) );
 
 			// Check we have an OAuth token, otherwise redirect to auth/login page
 			if (
@@ -350,7 +349,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	page( '*', emailVerification );
 
 	// delete any lingering local storage data from signup
-	if ( ! startsWith( window.location.pathname, '/start' ) ) {
+	if ( ! window.location.pathname.startsWith( '/start' ) ) {
 		[ 'signupProgress', 'signupDependencies' ].forEach( ( item ) => store.remove( item ) );
 	}
 

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -41,8 +41,8 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 
 		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
 
-		// This looks weird, but we really _do_ have an object with an empty string as its key
-		// (see: generate_translated_json in WPCOM)
+		// The empty string key [ '' ] where metadata about the translation file
+		// (e.g., the locale name, plurals definitions, etc.) are stored.
 		const languageSlug = i18nLocaleStringsObject?.[ '' ]?.localeSlug;
 		if ( languageSlug ) {
 			loadUserUndeployedTranslations( languageSlug );

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
@@ -45,7 +40,10 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
 
 		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
-		const languageSlug = get( i18nLocaleStringsObject, [ '', 'localeSlug' ] );
+
+		// This looks weird, but we really _do_ have an object with an empty string as its key
+		// (see: generate_translated_json in WPCOM)
+		const languageSlug = i18nLocaleStringsObject?.[ '' ]?.localeSlug;
 		if ( languageSlug ) {
 			loadUserUndeployedTranslations( languageSlug );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace one reference to `_.get` with safe navigation (`?.`), adding a comment to clarify an unorthodox object path.
* Replace two references to `_.startsWith` with the standard `String.startsWith` method.

#### Testing instructions

* Run Calypso in your testing environment.
* Verify that redirects to login with OAuth still work as intended.
* Verify that local storage for the keys `signupProgress` and `signupDependencies` are properly cleared when the browser window visits a path that doesn't begin with `/start`.