### PR TITLE
desktop: disable back to wordpress btn on login

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -338,7 +338,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-				{ this.renderBackLink() }
+				{ ! config.isEnabled( 'desktop' ) && this.renderBackLink() }
 			</div>
 		);
 	}


### PR DESCRIPTION
### Description

This PR disables the "Back to Wordpress" link on the login page, as this is not necessary/may potentially be confusing for users (excuse the different heights for the before/after screenshots!).

<p align="center">
<img width="400" alt="before-back-to-wordpress-enabled" src="https://user-images.githubusercontent.com/8979548/120695439-9fb4c800-c468-11eb-9c0d-09b7068d961b.png">
<img width="400" alt="after-back-to-wordpress-disabled" src="https://user-images.githubusercontent.com/8979548/120695450-a2afb880-c468-11eb-9b7a-dad368e1e355.png">
</p>

### To Test

1. Start local Calypso server with `yarn start`
2. Start desktop app and point to localhost by running `yarn run dev:localhost` from desktop folder