### PR TITLE
Checkout: remove coupon notices before displaying new ones

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -11,11 +11,11 @@ import type { ResponseCart, ResponseCartMessage } from '@automattic/shopping-car
 /**
  * Internal dependencies
  */
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
 
-function WrappedCartMessage( { message }: { message: ResponseCartMessage } ): JSX.Element {
+function CartMessage( { message }: { message: ResponseCartMessage } ): JSX.Element {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
@@ -23,7 +23,7 @@ function WrappedCartMessage( { message }: { message: ResponseCartMessage } ): JS
 		translate,
 		selectedSiteSlug,
 	] );
-	return <p key={ `${ message.code }-${ message.message }` }>{ getPrettyMessage( message ) }</p>;
+	return <>{ getPrettyMessage( message ) }</>;
 }
 
 export default function CartMessages( {
@@ -153,10 +153,17 @@ function showMessages(
 	messageType: 'error' | 'success'
 ): void {
 	const messageActionCreator = messageType === 'error' ? errorNotice : successNotice;
-	reduxDispatch(
-		messageActionCreator(
-			messages.map( ( message ): React.ReactNode => <WrappedCartMessage message={ message } /> ),
-			{ isPersistent: true }
-		)
-	);
+	// Remove previous messages that match the codes we are about to display
+	messages.map( ( message ) => {
+		reduxDispatch( removeNotice( message.code ) );
+	} );
+
+	messages.map( ( message ) => {
+		reduxDispatch(
+			messageActionCreator( <CartMessage message={ message } />, {
+				isPersistent: true,
+				id: message.code,
+			} )
+		);
+	} );
 }

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -175,7 +175,7 @@ function showMessages(
 	messages.map( ( message ) => {
 		reduxDispatch(
 			messageActionCreator( <CartMessage message={ message } />, {
-				isPersistent: true,
+				isPersistent: messageType === 'error',
 				id: getNoticeIdForMessage( message ),
 			} )
 		);

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -126,6 +126,7 @@ function getInvalidMultisitePurchaseErrorMessage( {
 	);
 }
 
+// Use this to transform message strings into React components
 function getMessagePrettifier(
 	translate: ReturnType< typeof useTranslate >,
 	selectedSiteSlug: string | null | undefined
@@ -147,6 +148,19 @@ function getMessagePrettifier(
 	};
 }
 
+// Use this to group messages so that they will replace existing messages with the same id
+function getNoticeIdForMessage( message: ResponseCartMessage ): string {
+	switch ( message.code ) {
+		case 'coupon-not-found':
+		case 'coupon-removed':
+		case 'coupon-removed-invalid':
+		case 'coupon-applied':
+			return 'coupon-message';
+		default:
+			return message.code;
+	}
+}
+
 function showMessages(
 	messages: ResponseCartMessage[],
 	reduxDispatch: ReturnType< typeof useDispatch >,
@@ -155,14 +169,14 @@ function showMessages(
 	const messageActionCreator = messageType === 'error' ? errorNotice : successNotice;
 	// Remove previous messages that match the codes we are about to display
 	messages.map( ( message ) => {
-		reduxDispatch( removeNotice( message.code ) );
+		reduxDispatch( removeNotice( getNoticeIdForMessage( message ) ) );
 	} );
 
 	messages.map( ( message ) => {
 		reduxDispatch(
 			messageActionCreator( <CartMessage message={ message } />, {
 				isPersistent: true,
-				id: message.code,
+				id: getNoticeIdForMessage( message ),
 			} )
 		);
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies how cart messages are displayed so that any currently displayed notice will be removed if we are about to display that message again. It also includes a translation function `getNoticeIdForMessage` that allows this behavior to extend across different messages that share the same context. The function currently only groups coupon message types so that any new coupon message will remove any existing coupon message.

One side effect of this new functionality is that cart messages are now displayed one-at-a-time instead of being grouped together. Previously if the cart response returned multiple error messages (or multiple success messages), those messages would be wrapped in paragraph tags and displayed as a single notice. However, I think that in practice this is extremely rare.

Fixes 360-gh-Automattic/payments-shilling

#### Testing instructions

- Visit checkout with a product in the cart.
- Add an invalid coupon code and press Apply.
- Verify that you see an error notification, but do not dismiss it.
- Add another invalid coupon code and press Apply.
- Verify that you still see a single error notification, but do not dismiss it.
- Add a valid coupon code and press Apply.
- Verify that the error notification disappears and a success notification is displayed.