### PR TITLE
E2E: Remove deprecated inserted block item CSS query

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -385,10 +385,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			title
 		);
 
-		// @todo Remove the deprecated query once GB v10.7+ is up on prod. This is needed for now to make sure all tests (more specifically upgrade tests that use non-edge sites) pass.
-		const insertedBlockItemDeprecatedQuery = `.edit-post-layout__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }`;
 		const inserterBlockItemLocator = By.css(
-			`.edit-post-editor__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }, ${ insertedBlockItemDeprecatedQuery }`
+			`.edit-post-editor__inserter-panel .block-editor-block-types-list button.editor-block-list-item-${ prefix }${ blockClass }`
 		);
 
 		const insertedBlockLocator = By.css(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove a deprecated CSS locator in E2E that's no longer needed (nor valid) for Gutenberg v10.7.x+, the version we have in WPCOM production at the time of this writing. 

#### Testing instructions

* E2E tests should pass (use teamcity to triggger the GB Desktop and Mobile tests in this branch)

Related to https://github.com/Automattic/wp-calypso/pull/52832.
