### PR TITLE
Checkout: Remove success notice from one-click upsell modal

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -4,7 +4,6 @@
 import React, { useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Dialog } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { useStripe } from '@automattic/calypso-stripe';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -48,7 +47,6 @@ export function PurchaseModal( {
 	siteSlug,
 	siteId,
 }: PurchaseModalProps ): JSX.Element {
-	const translate = useTranslate();
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
 		cart,
@@ -56,7 +54,6 @@ export function PurchaseModal( {
 		setStep,
 		storedCard: cards?.[ 0 ],
 		onClose,
-		successMessage: translate( 'Your purchase has been completed!' ),
 	} );
 	const contentProps = {
 		cards,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -9,7 +9,7 @@ import type { ResponseCart } from '@automattic/shopping-cart';
 /**
  * Internal dependencies
  */
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { translateResponseCartToWPCOMCart } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
@@ -28,14 +28,12 @@ export function useSubmitTransaction( {
 	storedCard,
 	setStep,
 	onClose,
-	successMessage,
 }: {
 	cart: ResponseCart;
 	siteId: string | number;
 	storedCard: StoredCard;
 	setStep: SetStep;
 	onClose: OnClose;
-	successMessage: string;
 } ): SubmitTransactionFunction {
 	const callPaymentProcessor = useProcessPayment();
 	const reduxDispatch = useDispatch();
@@ -56,11 +54,6 @@ export function useSubmitTransaction( {
 			siteId: siteId ? String( siteId ) : undefined,
 		} )
 			.then( () => {
-				reduxDispatch(
-					successNotice( successMessage, {
-						displayOnNextPage: true,
-					} )
-				);
 				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
 			} )
 			.catch( ( error ) => {
@@ -71,16 +64,7 @@ export function useSubmitTransaction( {
 				reduxDispatch( errorNotice( error.message ) );
 				onClose();
 			} );
-	}, [
-		siteId,
-		callPaymentProcessor,
-		cart,
-		storedCard,
-		setStep,
-		onClose,
-		reduxDispatch,
-		successMessage,
-	] );
+	}, [ siteId, callPaymentProcessor, cart, storedCard, setStep, onClose, reduxDispatch ] );
 }
 
 export function formatDate( cardExpiry: string ): string {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -4,6 +4,7 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useProcessPayment } from '@automattic/composite-checkout';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -11,10 +12,15 @@ import { useProcessPayment } from '@automattic/composite-checkout';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { translateResponseCartToWPCOMCart } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
+import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
-export function extractStoredCardMetaValue( card, key ) {
+export function extractStoredCardMetaValue( card: StoredCard, key: string ): string | undefined {
 	return card.meta?.find( ( meta ) => meta.meta_key === key )?.meta_value;
 }
+
+type SetStep = ( step: string ) => void;
+type OnClose = () => void;
+type SubmitTransactionFunction = () => void;
 
 export function useSubmitTransaction( {
 	cart,
@@ -23,7 +29,14 @@ export function useSubmitTransaction( {
 	setStep,
 	onClose,
 	successMessage,
-} ) {
+}: {
+	cart: ResponseCart;
+	siteId: string | number;
+	storedCard: StoredCard;
+	setStep: SetStep;
+	onClose: OnClose;
+	successMessage: string;
+} ): SubmitTransactionFunction {
 	const callPaymentProcessor = useProcessPayment();
 	const reduxDispatch = useDispatch();
 
@@ -70,7 +83,7 @@ export function useSubmitTransaction( {
 	] );
 }
 
-export function formatDate( cardExpiry ) {
+export function formatDate( cardExpiry: string ): string {
 	const expiryDate = new Date( cardExpiry );
 	const formattedDate = expiryDate.toLocaleDateString( 'en-US', {
 		month: '2-digit',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checkout completes, the [payment complete callback](https://github.com/Automattic/wp-calypso/blob/9d1101b4de22db02ad2ca52528aecde05998481b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L53) generates [a thank-you URL](https://github.com/Automattic/wp-calypso/blob/9d1101b4de22db02ad2ca52528aecde05998481b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts#L44) and redirects there. If the thank-you URL is customer home, it [includes a query string](https://github.com/Automattic/wp-calypso/blob/f9def4bfd3958309062af5d9aa136242205a8616/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts#L435) that causes [the customer home page to display a purchase success notice](https://github.com/Automattic/wp-calypso/blob/f9def4bfd3958309062af5d9aa136242205a8616/client/my-sites/customer-home/main.jsx#L62).

This is fine, but there's a second version of checkout: the one-click upsell modal. In this version of checkout, when the transaction completes, [a separate success message is displayed](https://github.com/Automattic/wp-calypso/blob/f9def4bfd3958309062af5d9aa136242205a8616/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js#L46-L50) regardless of the thank-you URL.

Therefore, if the upsell modal ends up redirecting to the customer home page, you get _two_ success messages rather than one. 

In this PR, we remove the success notice from the upsell modal, so that it will behave like the main checkout. This does mean that some thank-you URLs may not include a separate success notice (although the pages themselves typically say something like "Congratulations on your purchase!"), but it means that this problem can be resolved for both checkouts rather than giving them different behaviors.

Fixes https://github.com/Automattic/wp-calypso/issues/52611

Additionally, this converts the utils file of the upsell modal to TypeScript.

<img width="572" alt="Screen Shot 2021-06-03 at 7 37 41 PM" src="https://user-images.githubusercontent.com/2036909/120725256-8c731e00-c4a3-11eb-8942-c8ad416bb747.png">


#### Testing instructions

- Go to https://wordpress.com/start and signup as a new user.
- Purchase a Personal plan in the signup flow, and after successful completion of the purchase, you should then be shown the Quick Start upsell.
- Purchase a Quick Start session from the upsell page.
- After successful completion of the purchase, you will be taken to Customer Home.
- Verify that you see a single success message.