### PR TITLE
Block Editor Tracking: Make sure undo and redo is tracked in all cases

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -324,7 +324,7 @@ const REDUX_TRACKING = {
 		updateOptions: trackGlobalStyles( 'wpcom_global_styles_update' ),
 		publishOptions: trackGlobalStyles( 'wpcom_global_styles_publish' ),
 	},
-	// Post Editor i using the undo/redo from the 'core/editor' store
+	// Post Editor is using the undo/redo from the 'core/editor' store
 	'core/editor': {
 		undo: 'wpcom_block_editor_undo_performed',
 		redo: 'wpcom_block_editor_redo_performed',

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -324,7 +324,13 @@ const REDUX_TRACKING = {
 		updateOptions: trackGlobalStyles( 'wpcom_global_styles_update' ),
 		publishOptions: trackGlobalStyles( 'wpcom_global_styles_publish' ),
 	},
+	// Post Editor i using the undo/redo from the 'core/editor' store
 	'core/editor': {
+		undo: 'wpcom_block_editor_undo_performed',
+		redo: 'wpcom_block_editor_redo_performed',
+	},
+	// Site Editor is using the undo/redo from the 'core' store
+	core: {
 		undo: 'wpcom_block_editor_undo_performed',
 		redo: 'wpcom_block_editor_redo_performed',
 	},


### PR DESCRIPTION
Once https://github.com/Automattic/wp-calypso/pull/53384 merged, I'll add E2E tests for these events

#### Changes proposed in this Pull Request

* Track  `undo` and `redo` action of `core` store.

`undo` and `redo` was moved from `core/editor` to `core` store 2 years ago in Gutenberg. The Post Editor is still using the `core/editor` one, but the Site Editor is using the actions from the `core` store.

This change makes sure `undo` and `redo` are always tracked.

#### Testing instructions

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Open Post Editor, make sure undo and redo are tracked
* Open Page Editor, make sure undo and redo are tracked
* Open Site Editor, make sure undo and redo are tracked

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53412
Fixes https://github.com/Automattic/wp-calypso/issues/53412
