### PR TITLE
Remove removeFollowers helpers from wpcom.undocumented

### DIFF
--- a/client/data/followers/use-remove-follower-mutation.js
+++ b/client/data/followers/use-remove-follower-mutation.js
@@ -13,8 +13,8 @@ function useRemoveFollowerMutation() {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
 		( { siteId, type, followerId } ) => {
-			const method = type === 'email' ? 'removeEmailFollower' : 'removeFollower';
-			return wp.undocumented().site( siteId )[ method ]( followerId );
+			const typeSlug = type === 'email' ? 'email-followers' : 'followers';
+			return wp.req.post( `/sites/${ siteId }/${ typeSlug }/${ followerId }/delete` );
 		},
 		{
 			onSuccess( data, variables ) {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -160,24 +160,6 @@ UndocumentedSite.prototype.getUser = function ( login, callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/users/login:' + login, callback );
 };
 
-UndocumentedSite.prototype.removeFollower = function ( followerId, callback ) {
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/followers/' + followerId + '/delete',
-		},
-		callback
-	);
-};
-
-UndocumentedSite.prototype.removeEmailFollower = function ( followerId, callback ) {
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/email-followers/' + followerId + '/delete',
-		},
-		callback
-	);
-};
-
 UndocumentedSite.prototype.setOption = function ( query, callback ) {
 	return this.wpcom.req.post(
 		'/sites/' + this._id + '/option',


### PR DESCRIPTION
In the recently created `useRemoveFollowerMutation` hook, call the REST methods with direct `wpcom.req.post` calls and remove the helpers from `wpcom.undocumented()`.
