### PR TITLE
i18n-utils: Add localize url mappings for `/theme` and `/themes`

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -109,6 +109,12 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 		}
 		return prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
+	'wordpress.com/theme/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
+	'wordpress.com/themes/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : prefixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
 };
 
 export function localizeUrl( fullUrl: string, locale: Locale, isLoggedIn = true ): string {

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -292,6 +292,66 @@ describe( '#localizeUrl', () => {
 		);
 	} );
 
+	test( 'theme', () => {
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/', 'en', true ) ).toEqual(
+			'https://wordpress.com/theme/maywood/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/', 'de', true ) ).toEqual(
+			'https://wordpress.com/theme/maywood/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/', 'pl', true ) ).toEqual(
+			'https://wordpress.com/theme/maywood/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/', 'en', false ) ).toEqual(
+			'https://wordpress.com/theme/maywood/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/', 'de', false ) ).toEqual(
+			'https://wordpress.com/de/theme/maywood/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/', 'pl', false ) ).toEqual(
+			'https://wordpress.com/theme/maywood/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/theme/maywood/setup/99999/', 'de', true ) ).toEqual(
+			'https://wordpress.com/theme/maywood/setup/99999/'
+		);
+		expect(
+			localizeUrl( 'https://wordpress.com/theme/maywood/setup/99999/', 'de', false )
+		).toEqual( 'https://wordpress.com/de/theme/maywood/setup/99999/' );
+	} );
+
+	test( 'themes', () => {
+		expect( localizeUrl( 'https://wordpress.com/themes/', 'en', true ) ).toEqual(
+			'https://wordpress.com/themes/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/', 'de', true ) ).toEqual(
+			'https://wordpress.com/themes/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/', 'pl', true ) ).toEqual(
+			'https://wordpress.com/themes/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/', 'en', false ) ).toEqual(
+			'https://wordpress.com/themes/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/', 'de', false ) ).toEqual(
+			'https://wordpress.com/de/themes/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/', 'pl', false ) ).toEqual(
+			'https://wordpress.com/themes/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/free/', 'de', true ) ).toEqual(
+			'https://wordpress.com/themes/free/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/themes/free/', 'de', false ) ).toEqual(
+			'https://wordpress.com/de/themes/free/'
+		);
+		expect(
+			localizeUrl( 'https://wordpress.com/themes/free/filter/example-filter/', 'de', true )
+		).toEqual( 'https://wordpress.com/themes/free/filter/example-filter/' );
+		expect(
+			localizeUrl( 'https://wordpress.com/themes/free/filter/example-filter/', 'de', false )
+		).toEqual( 'https://wordpress.com/de/themes/free/filter/example-filter/' );
+	} );
+
 	test( 'tos', () => {
 		expect( localizeUrl( 'https://wordpress.com/tos/', 'en' ) ).toEqual(
 			'https://wordpress.com/tos/'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `wordpress.com/theme/` and `wordpress.com/themes/` mappings for `localizeUrl`.

#### Testing instructions

* Review code changes
* Run package unit tests with `cd packages/i18n-utils && yarn test`

Related to https://github.com/Automattic/wp-calypso/pull/41410
