### PR TITLE
Remove feature flags for Woo-styling login and signup

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -133,7 +133,7 @@ class Login extends Component {
 			! socialConnect &&
 			! privateSite &&
 			! oauth2Client &&
-			! ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) &&
+			! isJetpackWooCommerceFlow &&
 			! isJetpack &&
 			! fromSite &&
 			! twoFactorEnabled &&
@@ -271,11 +271,7 @@ class Login extends Component {
 				);
 			}
 
-			if (
-				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-				isWooOAuth2Client( oauth2Client ) &&
-				wccomFrom
-			) {
+			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 				preHeader = (
 					<Fragment>
 						{ 'cart' === wccomFrom ? (
@@ -333,7 +329,7 @@ class Login extends Component {
 					},
 				} );
 			}
-		} else if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+		} else if ( isJetpackWooCommerceFlow ) {
 			headerText = translate( 'Log in to your WordPress.com account' );
 			preHeader = (
 				<div className="login__jetpack-logo">

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -302,15 +302,11 @@ export class LoginForm extends Component {
 
 	recordWooCommerceLoginTracks( method ) {
 		const { isJetpackWooCommerceFlow, oauth2Client, wccomFrom } = this.props;
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+		if ( isJetpackWooCommerceFlow ) {
 			this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
 				login_method: method,
 			} );
-		} else if (
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( oauth2Client ) &&
-			'cart' === wccomFrom
-		) {
+		} else if ( isWooOAuth2Client( oauth2Client ) && 'cart' === wccomFrom ) {
 			this.props.recordTracksEvent( 'wcadmin_storeprofiler_payment_login', {
 				login_method: method,
 			} );
@@ -481,7 +477,7 @@ export class LoginForm extends Component {
 			isGutenboarding
 		);
 
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+		if ( isJetpackWooCommerceFlow ) {
 			return this.renderWooCommerce();
 		}
 
@@ -489,11 +485,7 @@ export class LoginForm extends Component {
 			return this.renderWooCommerce( !! accountType ); // Only show the social buttons after the user entered an email.
 		}
 
-		if (
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( oauth2Client ) &&
-			wccomFrom
-		) {
+		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			return this.renderWooCommerce();
 		}
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -30,7 +30,6 @@ import PropTypes from 'prop-types';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import wpcom from 'calypso/lib/wp';
-import config from '@automattic/calypso-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Button } from '@automattic/components';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
@@ -630,15 +629,11 @@ class SignupForm extends Component {
 
 	recordWooCommerceSignupTracks( method ) {
 		const { isJetpackWooCommerceFlow, oauth2Client, wccomFrom } = this.props;
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+		if ( isJetpackWooCommerceFlow ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
 				signup_method: method,
 			} );
-		} else if (
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( oauth2Client ) &&
-			'cart' === wccomFrom
-		) {
+		} else if ( isWooOAuth2Client( oauth2Client ) && 'cart' === wccomFrom ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_payment_create_account', {
 				signup_method: method,
 			} );
@@ -930,12 +925,9 @@ class SignupForm extends Component {
 		}
 
 		if (
-			( config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-				this.props.isJetpackWooCommerceFlow ) ||
+			this.props.isJetpackWooCommerceFlow ||
 			this.props.isJetpackWooDnaFlow ||
-			( config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-				isWooOAuth2Client( this.props.oauth2Client ) &&
-				this.props.wccomFrom )
+			( isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom )
 		) {
 			return (
 				<div className={ classNames( 'signup-form__woocommerce', this.props.className ) }>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -82,9 +82,7 @@ class Document extends React.Component {
 			`var installedChunks = ${ jsonStringifyForHtml( installedChunks ) };\n`;
 
 		const isJetpackWooCommerceFlow =
-			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-			'jetpack-connect' === sectionName &&
-			'woocommerce-onboarding' === requestFrom;
+			'jetpack-connect' === sectionName && 'woocommerce-onboarding' === requestFrom;
 
 		const isJetpackWooDnaFlow = 'jetpack-connect' === sectionName && isWooDna;
 

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import config from '@automattic/calypso-config';
 import FormattedHeader from 'calypso/components/formatted-header';
 import safeImageUrl from 'calypso/lib/safe-image-url';
 import Site from 'calypso/blocks/site';
@@ -89,7 +88,7 @@ export class AuthFormHeader extends Component {
 
 		const currentState = this.getState();
 
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isWoo ) {
+		if ( isWoo ) {
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate( 'Create a Jetpack account' );
@@ -113,7 +112,7 @@ export class AuthFormHeader extends Component {
 		const { translate, isWoo, wooDnaConfig } = this.props;
 		const currentState = this.getState();
 
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isWoo ) {
+		if ( isWoo ) {
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate(

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -368,7 +368,7 @@ export class JetpackAuthorize extends Component {
 	handleSignIn = () => {
 		const { recordTracksEvent } = this.props;
 		const { from } = this.props.authQuery;
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && 'woocommerce-onboarding' === from ) {
+		if ( 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { different_account: true } );
 		}
 	};
@@ -378,7 +378,7 @@ export class JetpackAuthorize extends Component {
 		const { from } = this.props.authQuery;
 		recordTracksEvent( 'calypso_jpc_signout_click' );
 
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && 'woocommerce-onboarding' === from ) {
+		if ( 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { create_jetpack: true } );
 		}
 
@@ -432,7 +432,7 @@ export class JetpackAuthorize extends Component {
 
 		recordTracksEvent( 'calypso_jpc_approve_click' );
 
-		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && 'woocommerce-onboarding' === from ) {
+		if ( 'woocommerce-onboarding' === from ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
 		}
 

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 import JetpackHeader from 'calypso/components/jetpack-header';
 import Main from 'calypso/components/main';
@@ -36,6 +35,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	render() {
 		const {
 			isWide,
+			isWoo,
 			className,
 			children,
 			partnerSlug,
@@ -44,7 +44,6 @@ export class JetpackConnectMainWrapper extends PureComponent {
 			pageTitle,
 		} = this.props;
 
-		const isWoo = config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isWoo;
 		const isWooDna = wooDnaConfig && wooDnaConfig.isWooDnaFlow();
 
 		const wrapperClassName = classNames( 'jetpack-connect__main', {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -247,13 +247,9 @@ class Layout extends Component {
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
-			'is-jetpack-woocommerce-flow':
-				config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isJetpackWooCommerceFlow,
+			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
-			'is-wccom-oauth-flow':
-				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-				isWooOAuth2Client( this.props.oauth2Client ) &&
-				this.props.wccomFrom,
+			'is-wccom-oauth-flow': isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom,
 		} );
 
 		const optionalBodyProps = () => {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -74,24 +74,16 @@ const LayoutLoggedOut = ( {
 		'is-jetpack-site': isJetpackCheckout,
 		'is-gutenboarding-login': isGutenboardingLogin,
 		'is-popup': isPopup,
-		'is-jetpack-woocommerce-flow':
-			config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow,
+		'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
-		'is-wccom-oauth-flow':
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( oauth2Client ) &&
-			wccomFrom,
+		'is-wccom-oauth-flow': isWooOAuth2Client( oauth2Client ) && wccomFrom,
 	};
 
 	let masterbar = null;
 
 	// Uses custom styles for DOPS clients and WooCommerce - which are the only ones with a name property defined
 	if ( useOAuth2Layout && oauth2Client && oauth2Client.name ) {
-		if (
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( oauth2Client ) &&
-			wccomFrom
-		) {
+		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			masterbar = null;
 		} else {
 			classes.dops = true;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -80,11 +80,7 @@ export function getSignupUrl(
 		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
 	}
 
-	if (
-		config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-		oauth2Client &&
-		isWooOAuth2Client( oauth2Client )
-	) {
+	if ( oauth2Client && isWooOAuth2Client( oauth2Client ) ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
@@ -206,7 +206,7 @@ export class LoginLinks extends React.Component {
 	}
 
 	renderMagicLoginLink() {
-		if ( ! isEnabled( 'login/magic-login' ) || this.props.twoFactorAuthType ) {
+		if ( ! config.isEnabled( 'login/magic-login' ) || this.props.twoFactorAuthType ) {
 			return null;
 		}
 
@@ -220,17 +220,10 @@ export class LoginLinks extends React.Component {
 		}
 
 		// @todo Implement a muriel version of the email login links for the WooCommerce onboarding flows
-		if (
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( this.props.oauth2Client ) &&
-			this.props.wccomFrom
-		) {
+		if ( isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom ) {
 			return null;
 		}
-		if (
-			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-			this.props.isJetpackWooCommerceFlow
-		) {
+		if ( this.props.isJetpackWooCommerceFlow ) {
 			return null;
 		}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -124,7 +124,6 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 
 	const oauthClientId = request.query.oauth2_client_id || request.query.client_id;
 	const isWCComConnect =
-		config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 		( 'login' === request.context.sectionName || 'signup' === request.context.sectionName ) &&
 		request.query[ 'wccom-from' ] &&
 		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -128,11 +128,7 @@ export class UserStep extends Component {
 		let subHeaderText = props.subHeaderText;
 
 		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
-			if (
-				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-				isWooOAuth2Client( oauth2Client ) &&
-				wccomFrom
-			) {
+			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 				subHeaderText =
 					'cart' === wccomFrom
 						? translate(
@@ -444,11 +440,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		if (
-			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			isWooOAuth2Client( oauth2Client ) &&
-			wccomFrom
-		) {
+		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			isSocialSignupEnabled = true;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -86,7 +86,6 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
@@ -186,7 +185,6 @@
 		"upsell/nudge-component": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-referrers": true,
-		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false

--- a/config/production.json
+++ b/config/production.json
@@ -58,7 +58,6 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/woocommerce": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
@@ -144,7 +143,6 @@
 		"use-translation-chunks": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-referrers": false,
-		"woocommerce/onboarding-oauth": true,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false
 	},

--- a/config/stage.json
+++ b/config/stage.json
@@ -59,7 +59,6 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/woocommerce": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
@@ -147,7 +146,6 @@
 		"use-translation-chunks": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-referrers": false,
-		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -66,7 +66,6 @@
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,
@@ -152,7 +151,6 @@
 		"upsell/nudge-component": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-referrers": false,
-		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,
 		"wordpress-action-search": false


### PR DESCRIPTION
There are two feature flags that are (practically) always `true` and that are used to enable custom styling of Calypso Login, Signup and Jetpack Connect sections when they are part of Woo-related flows (determined from query args like OAuth client ID etc):
- `jetpack/connect/woocommerce`
- `woocommerce/onboarding-oauth`

In this PR I'm removing them and simplifying the conditions that use them. Jetpack Cloud doesn't enable these flags, but Login and Signup are not active there, so it's OK.

**How to test:**
I'm not really sure: @justinshreve could you help with that?
