### PR TITLE
New Onboarding: Update tracks events for design selection

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -30,29 +30,34 @@ const Designs: React.FunctionComponent = () => {
 	const { goBack, goNext } = useStepNavigation();
 
 	const { setSelectedDesign, setFonts, resetFonts } = useDispatch( ONBOARD_STORE );
-	const { getSelectedDesign, hasPaidDesign, getRandomizedDesigns } = useSelect( ( select ) =>
-		select( ONBOARD_STORE )
-	);
+
+	const { getSelectedDesign, hasPaidDesign, getRandomizedDesigns } = useSelect( ( select ) => {
+		const onboardStore = select( ONBOARD_STORE );
+
+		return {
+			getSelectedDesign: onboardStore.getSelectedDesign(),
+			hasPaidDesign: onboardStore.hasPaidDesign(),
+			getRandomizedDesigns: onboardStore.getRandomizedDesigns(),
+		};
+	} );
 	const isAnchorFmSignup = useIsAnchorFm();
 
-	const selectedDesign = getSelectedDesign();
-
 	useTrackStep( 'DesignSelection', () => ( {
-		selected_design: selectedDesign?.slug,
-		is_selected_design_premium: hasPaidDesign(),
+		selected_design: getSelectedDesign?.slug,
+		is_selected_design_premium: hasPaidDesign,
 	} ) );
 
 	const [ userHasSelectedDesign, setUserHasSelectedDesign ] = React.useState( false );
 
 	React.useEffect( () => {
-		if ( selectedDesign && userHasSelectedDesign ) {
+		if ( getSelectedDesign && userHasSelectedDesign ) {
 			// The `userHasSelectedDesign` local state variable is used to delay
 			// the call to `goNext()` by at least 1 re-render. This is to allow
 			// time for the `goNext()` function to update and correctly skip the
 			// `style` step when necessary
 			goNext();
 		}
-	}, [ goNext, userHasSelectedDesign, selectedDesign ] );
+	}, [ goNext, userHasSelectedDesign, getSelectedDesign ] );
 
 	return (
 		<div className="gutenboarding-page designs">
@@ -72,7 +77,7 @@ const Designs: React.FunctionComponent = () => {
 				</ActionButtons>
 			</div>
 			<DesignPicker
-				designs={ getRandomizedDesigns().featured.filter(
+				designs={ getRandomizedDesigns?.featured.filter(
 					( design ) =>
 						// TODO Add finalized design templates to available designs config
 						// along with `is_anchorfm` prop (config is stored in the


### PR DESCRIPTION
### Changes proposed in this Pull Request
Use the `getSelectedDesign` selector directly in the `<Design/>` component to get the proper values for the selected design.

### Testing instructions
1. Check out this branch and `yarn && yarn start`.
2. Open a browser and go to `/new?fresh`.
3. Open the network tab in DevTools and make sure to preserve the log.
4. Create a new site with an empty page (blank canvas design).
5. After selecting a design, go to the next step
6. Filter the network tab with `selected_design` and inspect the query params
7. Ensure that:
    * [ ] `selected_design` is equal to the selected design.

<img width="679" alt="Screenshot 2021-06-04 at 17 23 35" src="https://user-images.githubusercontent.com/12104589/120825485-ba1a9e80-c559-11eb-83f6-14b4b3cadce3.png">


fixes #52667