### PR TITLE
Checkout: Display tax breakdown when available

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -6,7 +6,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
 import {
 	getTotalLineItemFromCart,
-	getTaxLineItemFromCart,
+	getTaxBreakdownLineItemsFromCart,
 	getCreditsLineItemFromCart,
 	getSubtotalLineItemFromCart,
 } from '@automattic/wpcom-checkout';
@@ -72,7 +72,7 @@ export default function PaymentMethodStep( {
 	activeStepContent: React.ReactNode;
 } ): JSX.Element {
 	const { responseCart } = useShoppingCart();
-	const taxLineItem = getTaxLineItemFromCart( responseCart );
+	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	return (
 		<>
@@ -84,7 +84,9 @@ export default function PaymentMethodStep( {
 
 			<WPOrderReviewSection>
 				<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
-				{ taxLineItem && <NonProductLineItem tax lineItem={ taxLineItem } /> }
+				{ taxLineItems.map( ( taxLineItem ) => (
+					<NonProductLineItem tax lineItem={ taxLineItem } />
+				) ) }
 				{ creditsLineItem && responseCart.sub_total_integer > 0 && (
 					<NonProductLineItem subtotal lineItem={ creditsLineItem } />
 				) }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -15,7 +15,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
-	getTaxLineItemFromCart,
+	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
 } from '@automattic/wpcom-checkout';
 
@@ -38,7 +38,7 @@ export default function WPCheckoutOrderSummary( {
 	const { formStatus } = useFormStatus();
 	const { responseCart } = useShoppingCart();
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
-	const taxLineItem = getTaxLineItemFromCart( responseCart );
+	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 
 	const hasRenewalInCart = responseCart.products.some(
@@ -79,12 +79,12 @@ export default function WPCheckoutOrderSummary( {
 						<span>{ couponLineItem.amount.displayValue }</span>
 					</CheckoutSummaryLineItem>
 				) }
-				{ taxLineItem && (
+				{ taxLineItems.map( ( taxLineItem ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + taxLineItem.id }>
 						<span>{ taxLineItem.label }</span>
 						<span>{ taxLineItem.amount.displayValue }</span>
 					</CheckoutSummaryLineItem>
-				) }
+				) ) }
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -22,7 +22,6 @@ import type {
 } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
-	getTaxLineItemFromCart,
 	getCreditsLineItemFromCart,
 	isWpComProductRenewal,
 } from '@automattic/wpcom-checkout';
@@ -322,7 +321,6 @@ export function WPOrderReviewLineItems( {
 	createUserAndSiteBeforeTransaction?: boolean;
 } ): JSX.Element {
 	const { responseCart } = useShoppingCart();
-	const taxLineItem = getTaxLineItemFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 
@@ -343,11 +341,6 @@ export function WPOrderReviewLineItems( {
 					</WPOrderReviewListItem>
 				);
 			} ) }
-			{ taxLineItem && ! isSummary && (
-				<WPOrderReviewListItem key={ taxLineItem.id }>
-					<NonProductLineItem tax lineItem={ taxLineItem } isSummary={ isSummary } />
-				</WPOrderReviewListItem>
-			) }
 			{ couponLineItem && (
 				<WPOrderReviewListItem key={ couponLineItem.id }>
 					<NonProductLineItem

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -13,6 +13,7 @@ export function getEmptyResponseCart(): ResponseCart {
 		total_tax: '0',
 		total_tax_integer: 0,
 		total_tax_display: '0',
+		total_tax_breakdown: [],
 		total_cost: 0,
 		total_cost_integer: 0,
 		total_cost_display: '0',

--- a/packages/shopping-cart/src/shopping-cart-endpoint.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint.ts
@@ -66,6 +66,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	total_tax: string; // Please try not to use this
 	total_tax_integer: number;
 	total_tax_display: string;
+	total_tax_breakdown: TaxBreakdownItem[];
 	total_cost: number; // Please try not to use this
 	total_cost_integer: number;
 	total_cost_display: string;
@@ -100,6 +101,15 @@ export interface ResponseCartTaxData {
 		subdivision_code?: string;
 	};
 	display_taxes: boolean;
+}
+
+export interface TaxBreakdownItem {
+	tax_collected: number;
+	tax_collected_integer: number;
+	tax_collected_display: string;
+	label?: string;
+	rate: number;
+	rate_display: string;
 }
 
 /**

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -3,7 +3,7 @@
  */
 import { translate } from 'i18n-calypso';
 import type { LineItem } from '@automattic/composite-checkout';
-import type { ResponseCart } from '@automattic/shopping-cart';
+import type { ResponseCart, TaxBreakdownItem } from '@automattic/shopping-cart';
 
 export function getLineItemsFromCart( cart: ResponseCart ): LineItem[] {
 	return cart.products.map( ( product ) => ( {
@@ -85,6 +85,37 @@ export function getTaxLineItemFromCart( responseCart: ResponseCart ): LineItem |
 			displayValue: responseCart.total_tax_display,
 		},
 	};
+}
+
+export function getTaxBreakdownLineItemsFromCart( responseCart: ResponseCart ): LineItem[] {
+	if ( ! responseCart.tax.display_taxes ) {
+		return [];
+	}
+	if (
+		! Array.isArray( responseCart.total_tax_breakdown ) ||
+		responseCart.total_tax_breakdown.length === 0
+	) {
+		const lineItem = getTaxLineItemFromCart( responseCart );
+		return lineItem ? [ lineItem ] : [];
+	}
+	return responseCart.total_tax_breakdown.map(
+		( taxBreakdownItem: TaxBreakdownItem, index: number ): LineItem => {
+			const id = `tax-line-item-${ index }`;
+			const label = taxBreakdownItem.label
+				? `${ taxBreakdownItem.label } (${ taxBreakdownItem.rate_display })`
+				: String( translate( 'Tax' ) );
+			return {
+				id,
+				label,
+				type: 'tax',
+				amount: {
+					currency: responseCart.currency,
+					value: taxBreakdownItem.tax_collected_integer,
+					displayValue: taxBreakdownItem.tax_collected_display,
+				},
+			};
+		}
+	);
 }
 
 export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineItem | null {

--- a/packages/wpcom-checkout/test/transformations.js
+++ b/packages/wpcom-checkout/test/transformations.js
@@ -5,6 +5,7 @@ import {
 	getLineItemsFromCart,
 	getCreditsLineItemFromCart,
 	getTaxLineItemFromCart,
+	getTaxBreakdownLineItemsFromCart,
 	getSubtotalLineItemFromCart,
 	getCouponLineItemFromCart,
 	getTotalLineItemFromCart,
@@ -149,6 +150,79 @@ describe( 'getTaxLineItemFromCart', function () {
 		};
 
 		expect( getTaxLineItemFromCart( cartWithTaxes ) ).toStrictEqual( expected );
+	} );
+} );
+
+describe( 'getTaxBreakdownLineItemsFromCart', function () {
+	it( 'returns empty array if taxes are not displayed', () => {
+		expect( getTaxBreakdownLineItemsFromCart( cart ) ).toEqual( [] );
+	} );
+
+	it( 'returns line item for taxes if displayed', () => {
+		const cartWithTaxes = {
+			...cart,
+			tax: { ...cart.tax, display_taxes: true },
+			total_tax_breakdown: [
+				{
+					label: 'GST',
+					rate_display: '5%',
+					tax_collected_integer: 100,
+					tax_collected_display: 'JPY 100',
+				},
+				{
+					label: 'PST',
+					rate_display: '10%',
+					tax_collected_integer: 200,
+					tax_collected_display: 'JPY 200',
+				},
+			],
+		};
+		const expected = [
+			{
+				id: 'tax-line-item-0',
+				type: 'tax',
+				label: 'GST (5%)',
+				amount: {
+					currency: 'JPY',
+					value: 100,
+					displayValue: 'JPY 100',
+				},
+			},
+			{
+				id: 'tax-line-item-1',
+				type: 'tax',
+				label: 'PST (10%)',
+				amount: {
+					currency: 'JPY',
+					value: 200,
+					displayValue: 'JPY 200',
+				},
+			},
+		];
+
+		expect( getTaxBreakdownLineItemsFromCart( cartWithTaxes ) ).toStrictEqual( expected );
+	} );
+
+	it( 'returns the total_tax root values if the breakdown array is empty', () => {
+		const cartWithTaxes = {
+			...cart,
+			tax: { ...cart.tax, display_taxes: true },
+			total_tax_breakdown: [],
+		};
+		const expected = [
+			{
+				id: 'tax-line-item',
+				type: 'tax',
+				label: 'Tax',
+				amount: {
+					currency: 'JPY',
+					value: 100,
+					displayValue: 'JPY 100',
+				},
+			},
+		];
+
+		expect( getTaxBreakdownLineItemsFromCart( cartWithTaxes ) ).toStrictEqual( expected );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display the breakdown of the individual applicable taxes when available in the shopping cart response.

![image](https://user-images.githubusercontent.com/15204776/120828318-01853880-c522-11eb-9af5-0b77f8bc697e.png)


#### Testing instructions
 * Apply D62284-code
 * While Sandboxed, add any product to the cart and use the following billing information: Country: Canada, Postal Code: G0T 9Z9
 * Verify that the taxes are rendered properly, as in the image above.
