### PR TITLE
Design Picker: Hide Coutoire design

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -274,6 +274,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
+			"is_alpha": true,
 			"features": []
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Coutoire design by using the `is_alpha` flag

#### Testing instructions

- Go to `/new/design`. Coutoire design shouldn't be there.
- For debugging, the design will still be available by visiting `/new/design?flags=gutenboarding/alpha-templates`

Related to p1622823277037500-slack-C0202PMUXLJ