### PR TITLE
selectors: add getProductByType() selector

### DIFF
--- a/client/state/products-list/selectors/get-product-by-type.js
+++ b/client/state/products-list/selectors/get-product-by-type.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { get, filter } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/products-list/init';
+
+/**
+ * Retrieves the product with the specified slug.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productType - internal product type, eg 'marketplace'
+ * @returns {?object} the products list, or null if not found
+ */
+export function getProductByType( state, productType ) {
+	return filter(
+		get( state, [ 'productsList', 'items' ], [] ),
+		{ product_type: productType },
+		null
+	);
+}

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -3,6 +3,7 @@ export { computeProductsWithPrices } from './compute-products-with-prices';
 export { getAvailableProductsList } from './get-available-products-list';
 export { getPlanPrice } from './get-plan-price';
 export { getProductBySlug } from './get-product-by-slug';
+export { getProductByType } from './get-product-by-type';
 export { getProductCost } from './get-product-cost';
 export { getProductName } from './get-product-name';
 export { getProductDisplayCost } from './get-product-display-cost';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the `getProductByType()` selector that provides a way to get all productions associated with a site, by type.

```es6
import { getProductByType } from 'calypso/state/products-list/selectors';

function MyComponent( { marketplaceProducts } ) {
  return (
    <div>
      { `This site has ${ marketplaceProducts.length } types of marketplace products }
    </div>
  );
}

export default connect(
  ( state ) => {
    return {
      marketplaceProducts: getProductByType( state, 'marketplace' ),
    };
  }
)( MyComponent );
```

#### Testing instructions

* TBD

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
