### PR TITLE
Remove lodash from my-sites/plans

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -47,8 +47,7 @@ export function plans( context, next ) {
 }
 
 export function features( context ) {
-	const domain = context.params.domain;
-	const feature = context?.params?.feature;
+	const { feature, domain } = context.params;
 	let comparePath = domain ? `/plans/${ domain }` : '/plans/';
 
 	if ( isValidFeatureKey( feature ) ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -3,7 +3,6 @@
  */
 import page from 'page';
 import React from 'react';
-import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -49,7 +48,7 @@ export function plans( context, next ) {
 
 export function features( context ) {
 	const domain = context.params.domain;
-	const feature = get( context, 'params.feature' );
+	const feature = context?.params?.feature;
 	let comparePath = domain ? `/plans/${ domain }` : '/plans/';
 
 	if ( isValidFeatureKey( feature ) ) {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.tsx
@@ -5,7 +5,6 @@ import React, { FC, ReactElement, useCallback, useMemo } from 'react';
 import { connect, DefaultRootState } from 'react-redux';
 import { isDesktop } from '@automattic/viewport';
 import { localize, LocalizeProps, TranslateResult } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -105,7 +104,7 @@ export const ThankYouCard: FC< Props > = ( {
 		[ dispatchRecordTracksEvent ]
 	);
 
-	const jetpackVersion = useMemo( () => get( selectedSite, 'options.jetpack_version', 0 ), [
+	const jetpackVersion = useMemo( () => selectedSite?.options?.jetpack_version ?? 0, [
 		selectedSite,
 	] );
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component, Fragment } from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -130,7 +129,7 @@ class CurrentPlan extends Component {
 		}
 
 		if ( JETPACK_SEARCH_PRODUCTS.includes( product ) ) {
-			const jetpackVersion = get( selectedSite, 'options.jetpack_version', 0 );
+			const jetpackVersion = selectedSite?.options?.jetpack_version ?? 0;
 			return <SearchProductThankYou { ...{ jetpackVersion } } />;
 		}
 

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -4,7 +4,7 @@
 import { isDesktop } from '@automattic/viewport';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { get, includes, minBy } from 'lodash';
+import { includes, minBy } from 'lodash';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import moment from 'moment';
 
@@ -398,7 +398,7 @@ function mapStateToProps( state ) {
 
 	const siteId = getSelectedSiteId( state );
 	const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
-	const rewindState = get( getRewindState( state, siteId ), 'state', 'uninitialized' );
+	const rewindState = getRewindState( state, siteId )?.state ?? 'uninitialized';
 	const isMinimumVersion =
 		siteId && isJetpackMinimumVersion( state, siteId, OFFER_RESET_VIDEO_MINIMUM_JETPACK_VERSION );
 
@@ -426,7 +426,7 @@ function mapStateToProps( state ) {
 		productInstallStatus,
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-		taskStatuses: get( getSiteChecklist( state, siteId ), 'tasks' ),
+		taskStatuses: getSiteChecklist( state, siteId )?.tasks,
 		wpAdminUrl,
 		hasVideoHosting:
 			siteId &&

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -4,7 +4,7 @@
 import { isDesktop } from '@automattic/viewport';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { includes, minBy } from 'lodash';
+import { minBy } from 'lodash';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import moment from 'moment';
 
@@ -418,7 +418,7 @@ function mapStateToProps( state ) {
 		akismetFinished: productInstallStatus && productInstallStatus.akismet_status === 'installed',
 		vaultpressFinished:
 			productInstallStatus &&
-			includes( [ 'installed', 'skipped' ], productInstallStatus.vaultpress_status ),
+			[ 'installed', 'skipped' ].includes( productInstallStatus.vaultpress_status ),
 		widgetCustomizerPaneUrl: siteId ? getCustomizerUrl( state, siteId, 'widgets' ) : null,
 		isPaidPlan,
 		hasAntiSpam,

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -4,7 +4,6 @@
 import { isDesktop } from '@automattic/viewport';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { minBy } from 'lodash';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import moment from 'moment';
 
@@ -97,16 +96,15 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 			includesJetpackBackup( sitePurchase.productSlug )
 		);
 
-		const earliestPurchaseWithJetpackBackup = minBy( purchasesWithJetpackBackup, ( purchase ) =>
-			moment( purchase.subscribedDate )
-		);
+		const earliestJetpackBackupSubscribeDate = purchasesWithJetpackBackup
+			.map( ( purchase ) => moment( purchase.subscribedDate ) )
+			.sort( ( a, b ) => a.valueOf() - b.valueOf() )?.[ 0 ];
 
-		return (
-			!! earliestPurchaseWithJetpackBackup &&
-			moment( earliestPurchaseWithJetpackBackup.subscribedDate ).isAfter(
-				moment().subtract( 5, 'minutes' )
-			)
-		);
+		if ( ! earliestJetpackBackupSubscribeDate ) {
+			return false;
+		}
+
+		return earliestJetpackBackupSubscribeDate.isAfter( moment().subtract( 5, 'minutes' ) );
 	}
 
 	isComplete( taskId: string ): boolean {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -396,7 +396,7 @@ function mapStateToProps( state ) {
 
 	const siteId = getSelectedSiteId( state );
 	const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
-	const rewindState = getRewindState( state, siteId )?.state ?? 'uninitialized';
+	const rewindState = getRewindState( state, siteId ).state;
 	const isMinimumVersion =
 		siteId && isJetpackMinimumVersion( state, siteId, OFFER_RESET_VIDEO_MINIMUM_JETPACK_VERSION );
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { sortBy } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
 import React, { useMemo, useRef, useState, useEffect, useCallback, RefObject } from 'react';
 import { useSelector } from 'react-redux';
@@ -40,6 +39,15 @@ import type { JetpackProductSlug, JetpackPlanSlug } from '@automattic/calypso-pr
  */
 import './style.scss';
 
+const sortByGridPosition = ( items: SelectorProduct[] ) =>
+	items
+		.map( ( i ): [ number, SelectorProduct ] => [
+			getProductPosition( i.productSlug as JetpackPlanSlug | JetpackProductSlug ),
+			i,
+		] )
+		.sort( ( [ aPosition ], [ bPosition ] ) => aPosition - bPosition )
+		.map( ( [ , item ] ) => item );
+
 const ProductGrid: React.FC< ProductsGridProps > = ( {
 	duration,
 	urlQueryArgs,
@@ -70,10 +78,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const isInJetpackCloud = useMemo( isJetpackCloud, [] );
 	// Retrieve and cache the plans array, which might be already translated.
 	const untranslatedSortedPlans = useMemo(
-		() =>
-			sortBy( getPlansToDisplay( { duration, currentPlanSlug } ), ( item ) =>
-				getProductPosition( item.productSlug as JetpackPlanSlug )
-			),
+		() => sortByGridPosition( getPlansToDisplay( { duration, currentPlanSlug } ) ),
 		[ duration, currentPlanSlug ]
 	);
 	// Get the first plan description and pass it through `translate` so that
@@ -91,22 +96,18 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		: null;
 
 	const sortedPlans = useMemo(
-		() =>
-			sortBy( getPlansToDisplay( { duration, currentPlanSlug } ), ( item ) =>
-				getProductPosition( item.productSlug as JetpackPlanSlug )
-			),
+		() => sortByGridPosition( getPlansToDisplay( { duration, currentPlanSlug } ) ),
 		[ duration, currentPlanSlug, translatedFirstPlanDescription, translatedFirstPlanFirstFeature ]
 	);
 	const sortedProducts = useMemo(
 		() =>
-			sortBy(
+			sortByGridPosition(
 				getProductsToDisplay( {
 					duration,
 					availableProducts,
 					purchasedProducts,
 					includedInPlanProducts,
-				} ),
-				( item ) => getProductPosition( item.productSlug as JetpackProductSlug )
+				} )
 			),
 		[ duration, availableProducts, includedInPlanProducts, purchasedProducts ]
 	);
@@ -114,9 +115,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	let popularProducts = [] as SelectorProduct[];
 	let otherProducts = [] as SelectorProduct[];
 
-	const allProducts = sortBy( [ ...sortedPlans, ...sortedProducts ], ( item ) =>
-		getProductPosition( item.productSlug as JetpackPlanSlug | JetpackProductSlug )
-	);
+	const allProducts = sortByGridPosition( [ ...sortedPlans, ...sortedProducts ] );
 	popularProducts = allProducts.slice( 0, 3 );
 	otherProducts = allProducts.slice( 3 );
 

--- a/client/my-sites/plans/jetpack-plans/use-detect-window-boundary.ts
+++ b/client/my-sites/plans/jetpack-plans/use-detect-window-boundary.ts
@@ -2,9 +2,23 @@
  * External dependencies
  */
 import { useEffect, useRef, useState } from 'react';
-import { throttle } from 'lodash';
 
-export const THROTTLE_RATE = 50;
+const THROTTLE_RATE_MS = 50;
+
+const throttle = ( func, waitForMilliseconds ) => {
+	let timeout = undefined;
+
+	return ( ...args ) => {
+		if ( timeout ) {
+			return;
+		}
+
+		func( ...args );
+		timeout = setTimeout( () => {
+			timeout = null;
+		}, waitForMilliseconds );
+	};
+};
 
 /**
  * Returns whether an element has touched/crossed the upper Window's boundary.
@@ -34,12 +48,12 @@ const useDetectWindowBoundary = ( offsetY = 0 ) => {
 			}
 
 			setBorderCrossed( window.pageYOffset + offsetY > initialTopPos.current );
-		}, THROTTLE_RATE );
+		}, THROTTLE_RATE_MS );
 
 		window.addEventListener( 'scroll', addStickyClass );
 
 		return () => window.removeEventListener( 'scroll', addStickyClass );
-	}, [ elementRef.current, offsetY ] );
+	}, [ offsetY ] );
 
 	return [ elementRef, borderCrossed ];
 };

--- a/client/my-sites/plans/jetpack-plans/use-detect-window-boundary.ts
+++ b/client/my-sites/plans/jetpack-plans/use-detect-window-boundary.ts
@@ -1,24 +1,10 @@
 /**
  * External dependencies
  */
+import { throttle } from 'lodash';
 import { useEffect, useRef, useState } from 'react';
 
 const THROTTLE_RATE_MS = 50;
-
-const throttle = ( func, waitForMilliseconds ) => {
-	let timeout = undefined;
-
-	return ( ...args ) => {
-		if ( timeout ) {
-			return;
-		}
-
-		func( ...args );
-		timeout = setTimeout( () => {
-			timeout = null;
-		}, waitForMilliseconds );
-	};
-};
 
 /**
  * Returns whether an element has touched/crossed the upper Window's boundary.

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { translate, TranslateResult, numberFormat } from 'i18n-calypso';
-import { compact } from 'lodash';
 import page from 'page';
 import { createElement, Fragment } from 'react';
 import { createSelector } from '@automattic/state-utils';
@@ -517,11 +516,9 @@ export function buildCardFeatureItemFromFeatureKey(
 			text: feature.getTitle( variation ),
 			description: options?.withoutDescription ? undefined : feature.getDescription?.(),
 			subitems: subFeaturesKeys
-				? compact(
-						subFeaturesKeys.map( ( f ) =>
-							buildCardFeatureItemFromFeatureKey( f, options, variation )
-						)
-				  )
+				? subFeaturesKeys
+						.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
+						.filter( ( f ): f is SelectorProductFeaturesItem => !! f )
 				: undefined,
 			isHighlighted: feature.isProduct?.( variation ) || feature.isPlan,
 		};
@@ -534,16 +531,16 @@ export function buildCardFeatureItemFromFeatureKey(
  * @param {string[]} features Feature keys
  * @param {object?} options Options
  * @param {string?} variation Experiment variation
- * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
+ * @returns {SelectorProductFeaturesItem[]} Features
  */
 export function buildCardFeaturesFromFeatureKeys(
 	features: string[],
 	options?: Record< string, unknown >,
 	variation?: Iterations
-): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
-	return compact(
-		features.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
-	);
+): SelectorProductFeaturesItem[] {
+	return features
+		.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
+		.filter( ( f ): f is SelectorProductFeaturesItem => !! f );
 }
 
 /**

--- a/client/my-sites/plans/jetpack-plans/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/utils.ts
@@ -518,7 +518,7 @@ export function buildCardFeatureItemFromFeatureKey(
 			subitems: subFeaturesKeys
 				? subFeaturesKeys
 						.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
-						.filter( ( f ): f is SelectorProductFeaturesItem => !! f )
+						.filter( Boolean )
 				: undefined,
 			isHighlighted: feature.isProduct?.( variation ) || feature.isPlan,
 		};
@@ -540,7 +540,7 @@ export function buildCardFeaturesFromFeatureKeys(
 ): SelectorProductFeaturesItem[] {
 	return features
 		.map( ( f ) => buildCardFeatureItemFromFeatureKey( f, options, variation ) )
-		.filter( ( f ): f is SelectorProductFeaturesItem => !! f );
+		.filter( Boolean );
 }
 
 /**

--- a/client/my-sites/plans/p2-plans-main.jsx
+++ b/client/my-sites/plans/p2-plans-main.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -39,10 +38,6 @@ export class P2PlansMain extends Component {
 	}
 }
 
-export default connect( ( state, props ) => {
-	const siteId = get( props.site, [ 'ID' ] );
-
-	return {
-		siteId,
-	};
-} )( localize( P2PlansMain ) );
+export default connect( ( state, props ) => ( {
+	siteId: props.site?.ID,
+} ) )( localize( P2PlansMain ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR continues the effort to deprecate lodash as a dependency in wp-calypso _(see: p4TIVU-9Bf-p2)_.

* Replace references to `_.get` with ES6's safe navigation operator (`?.`) and the coalesce operator (`??`).
* Replace `_.includes` with ES6's `Array.includes`.
* Replace `_.minBy` with ES6 `Array` operations.
* Replace `_.sortBy` with ES6 `Array` operations and a custom sort function.
* Replace `_.compact` with `Array.filter`.
* Replace `_.throttle` with a custom throttle function.

#### Testing instructions

##### Plan features comparison

1. For a WordPress.com site, visit `/plans/features/<feature>/<domain>` where `domain` is your site's domain and `feature` is a slug representing a feature visible on the page, like `live-chat-support-business-days` or `free-custom-domain`.
2. Verify that the Plans page loads and the corresponding feature is highlighted for all plan tiers it applies to.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/670067/120854445-ccd5a900-c542-11eb-886c-8828bddc8d55.png">

##### Jetpack Search version check

1. Create and connect a Jetpack site with a version of Jetpack _prior to_ v8.4.
2. Visit `/plans/my-plan/<site>?thank-you=true&product=jetpack_search`, where `<site>` is your site's slug.
3. Verify that you see a thank you page that says the following:

> Welcome to Jetpack Search!
> We are currently indexing your site.
> In the meantime you'll need to update Jetpack to version 8.4 or higher in order to ... [snipped for brevity]

4. Substituting a version of Jetpack _no earlier than_ v8.4, repeat steps 1 and 2.
5. Verify that the message in step 3 has changed:

> Welcome to Jetpack Search!
> We are currently indexing your site.
> In the meantime, we have configured Jetpack Search on your site ... [snipped for brevity]

<img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/120855630-589c0500-c544-11eb-9e3b-7da671c94ffd.png"> <img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/120856297-3fe01f00-c545-11eb-847c-876694870429.png">

##### My Plan page: My Checklist

* Select a Jetpack site and visit the My Plan page.
* Verify that the My Checklist section shows a placeholder only until all its task items are loaded.
* Verify that checklist steps for Backup and Scan show appropriately (i.e., correct copy and completion status).
* Verify that checklist steps for VaultPress sites also show appropriately (i.e., correct copy and completion status).

<img height="200" alt="image" src="https://user-images.githubusercontent.com/670067/120858934-20e38c00-c549-11eb-9b3a-3caedb906fd2.png">

* Shows loading placeholder only until checklist data is loaded
* Rewind steps reflected accurately (copy, status, for new purchase of Backup)
* VaultPress steps reflected accurately (copy, status)

##### Plans page: features list

1. Select a Jetpack site and visit the Plans page.
2. Verify that all product features are displayed exactly as in production, in the same order, with the same copy, and with no blank entries.

<img width="291" alt="image" src="https://user-images.githubusercontent.com/670067/120857817-79b22500-c547-11eb-9b2d-35c7ee2c9338.png">

##### Plans page: product grid ordering

1. Select a Jetpack site and visit the Plans page.
2. Verify that products in the grid are ordered exactly as they are in production, including any already-owned products.

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/670067/120857767-63a46480-c547-11eb-8f9f-f85f8153df02.png">

##### Plans page: monthly/yearly toggle

1. Select a Jetpack site and visit the Plans page.
2. Verify that the monthly/yearly billing term toggle "sticks" to the top of the page as you scroll down and returns to its original page position as you scroll back up. You should notice no dips in performance as a result of this behavior.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/670067/120857645-2d66e500-c547-11eb-97d9-7dea0564315c.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/670067/120857665-36f04d00-c547-11eb-9708-49d93b656759.png">

##### Plans page: P2 sites

1. Select a P2 site and visit the Plans page.
2. Verify that the page loads correctly for the selected site.

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/670067/120858006-c269de00-c547-11eb-9c3e-26684bc56859.png">