### PR TITLE
My Home: Update 'Site Title' task action URL to point to Customizer

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -136,7 +136,7 @@ export const getTask = (
 					'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
 				),
 				actionText: translate( 'Name your site' ),
-				actionUrl: `/settings/general/${ siteSlug }`,
+				actionUrl: `https://${ siteSlug }/wp-admin/customize.php?autofocus[section]=title_tagline`,
 				tour: 'checklistSiteTitle',
 			};
 			break;


### PR DESCRIPTION
This addresses #53434 by changing the link on the 'Site Title' item to link directly to the Site Identity section of the Customizer instead of the Calypso settings pages.

it does not address the question of the Onboarding/checklist tour though...