### PR TITLE
Fix the "Switch Site" arrow direction for RTL

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
@@ -39,6 +39,7 @@ class CurrentSite extends Component {
 		anySiteSelected: PropTypes.array,
 		forceAllSitesView: PropTypes.bool,
 		isNavUnificationEnabled: PropTypes.bool.isRequired,
+		isRtl: PropTypes.bool,
 	};
 
 	switchSites = ( event ) => {
@@ -68,6 +69,8 @@ class CurrentSite extends Component {
 			/* eslint-enable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 		}
 
+		const arrowDirection = this.props.isRtl ? 'right' : 'left';
+
 		return (
 			<Card className="current-site">
 				<div role="button" tabIndex="0" aria-hidden="true" onClick={ this.expandUnifiedNavSidebar }>
@@ -76,9 +79,11 @@ class CurrentSite extends Component {
 							<Button borderless onClick={ this.switchSites }>
 								{ this.props.isNavUnificationEnabled ? (
 									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-									<span className="gridicon dashicons-before dashicons-arrow-left-alt2"></span>
+									<span
+										className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
+									></span>
 								) : (
-									<Gridicon icon="chevron-left" />
+									<Gridicon icon={ `chevron-${ arrowDirection }` } />
 								) }
 								<span className="current-site__switch-sites-label">
 									{ translate( 'Switch Site' ) }
@@ -134,4 +139,4 @@ export default connect(
 		setLayoutFocus,
 		savePreference,
 	}
-)( localize( CurrentSite ) );
+)( withRtl( localize( CurrentSite ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The "Switch Site" back-arrow icon did not take RTL into account and was always pointing to the left.
* This PR fixes this by making the arrow point to the right for RTL.

##### Before
The arrow icon was pointing left for both LTR and RTL:

![image](https://user-images.githubusercontent.com/75777864/120981742-44404e00-c778-11eb-8d27-350025a0c470.png) ![image](https://user-images.githubusercontent.com/75777864/120981619-21ae3500-c778-11eb-9ddb-4945256182ca.png)

##### After
The arrow icon is now pointing to the right for RTL, and still to the left for LTR:

![image](https://user-images.githubusercontent.com/75777864/120981684-34c10500-c778-11eb-9759-d3d93f4c4559.png) ![image](https://user-images.githubusercontent.com/75777864/120981661-2c68ca00-c778-11eb-9997-21003e485bc4.png)


#### Testing instructions

* Review the code changes.
* Verify that the arrow is pointing to the right for RTL and to the left for LTR, as per the screenshots.


Related to 263-gh-Automattic/i18n-issues
