### PR TITLE
i18n: Add hreflang links for themes section

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -58,6 +58,12 @@ export const ssrSetupLocale = ssrSetupLocaleMiddleware();
 
 export const setHrefLangLinks = ( context, next ) => {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
+	if ( isLoggedIn ) {
+		next();
+		return;
+	}
+
 	const langCodes = [ 'x-default', 'en', ...config( 'magnificent_non_en_locales' ) ];
 	const hrefLangBlock = langCodes.map( ( hrefLang ) => {
 		let localeSlug = hrefLang;

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -3,15 +3,20 @@
  */
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
+import config from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
 
 /**
  * Internal dependencies
  */
 import { makeLayoutMiddleware } from './shared.js';
 import { ssrSetupLocaleMiddleware } from './ssr-setup-locale.js';
+import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 
 /**
  * Re-export
@@ -50,6 +55,37 @@ const ProviderWrappedLoggedOutLayout = ( {
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLoggedOutLayout );
 
 export const ssrSetupLocale = ssrSetupLocaleMiddleware();
+
+export const setHrefLangLinks = ( context, next ) => {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+	const hrefLangBlock = []
+		.concat( 'x-default', 'en', config( 'magnificent_non_en_locales' ) )
+		.map( ( hrefLang ) => {
+			let localeSlug = hrefLang;
+
+			if ( localeSlug === 'x-default' ) {
+				localeSlug = config( 'i18n_default_locale_slug' );
+			}
+
+			const baseUrl = `${ context.res.req.protocol }://${ context.res.req.get( 'host' ) }${
+				context.res.req.originalUrl
+			}`;
+			const baseUrlWithoutLang = baseUrl.replace(
+				new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
+				'$2'
+			);
+			const href = localizeUrl( baseUrlWithoutLang, localeSlug, isLoggedIn );
+
+			return {
+				rel: 'alternate',
+				hrefLang,
+				href,
+			};
+		} );
+
+	context.store.dispatch( setDocumentHeadLink( hrefLangBlock ) );
+	next();
+};
 
 /**
  * These functions are not used by Node. It is here to provide an APi compatible with `./index.web.js`

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -58,30 +58,29 @@ export const ssrSetupLocale = ssrSetupLocaleMiddleware();
 
 export const setHrefLangLinks = ( context, next ) => {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
-	const hrefLangBlock = []
-		.concat( 'x-default', 'en', config( 'magnificent_non_en_locales' ) )
-		.map( ( hrefLang ) => {
-			let localeSlug = hrefLang;
+	const langCodes = [ 'x-default', 'en', ...config( 'magnificent_non_en_locales' ) ];
+	const hrefLangBlock = langCodes.map( ( hrefLang ) => {
+		let localeSlug = hrefLang;
 
-			if ( localeSlug === 'x-default' ) {
-				localeSlug = config( 'i18n_default_locale_slug' );
-			}
+		if ( localeSlug === 'x-default' ) {
+			localeSlug = config( 'i18n_default_locale_slug' );
+		}
 
-			const baseUrl = `${ context.res.req.protocol }://${ context.res.req.get( 'host' ) }${
-				context.res.req.originalUrl
-			}`;
-			const baseUrlWithoutLang = baseUrl.replace(
-				new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
-				'$2'
-			);
-			const href = localizeUrl( baseUrlWithoutLang, localeSlug, isLoggedIn );
+		const baseUrl = `${ context.res.req.protocol }://${ context.res.req.get( 'host' ) }${
+			context.res.req.originalUrl
+		}`;
+		const baseUrlWithoutLang = baseUrl.replace(
+			new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
+			'$2'
+		);
+		const href = localizeUrl( baseUrlWithoutLang, localeSlug, isLoggedIn );
 
-			return {
-				rel: 'alternate',
-				hrefLang,
-				href,
-			};
-		} );
+		return {
+			rel: 'alternate',
+			hrefLang,
+			href,
+		};
+	} );
 
 	context.store.dispatch( setDocumentHeadLink( hrefLangBlock ) );
 	next();

--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { makeLayout, ssrSetupLocale, setHrefLangLinks } from 'calypso/controller';
 import { details, fetchThemeDetailsData, notFoundError } from './controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 
@@ -14,6 +14,7 @@ export default function ( router ) {
 		ssrSetupLocale,
 		fetchThemeDetailsData,
 		details,
+		setHrefLangLinks,
 		makeLayout,
 
 		// Error handlers

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { makeLayout, ssrSetupLocale, setHrefLangLinks } from 'calypso/controller';
 import {
 	fetchThemeData,
 	fetchThemeFilters,
@@ -29,6 +29,7 @@ export default function ( router ) {
 	];
 	router(
 		showcaseRoutes,
+		setHrefLangLinks,
 		ssrSetupLocale,
 		fetchThemeFilters,
 		validateVertical,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add hreflang links for themes section.

#### Testing instructions

* Boot Calypso locally with `yarn install && BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`.
* Inspect the source code of **not logged-in** `calypso.localhost:3000/themes` and `calypso.localhost:3000/theme/{themeSlug}`.
* Confirm `<link rel="alternate" langhref="..." href="..." />` tags are present and point to the correct URLs. Note that it's expected that the URLs will [only be localized when Calypso is loaded from `wordpress.com` and `calypso.localhost:3000` hostnames](https://github.com/Automattic/wp-calypso/blob/f55548a3cd91ce93ec4583d55c8d0ee930389f4e/packages/i18n-utils/src/localize-url.tsx#L112-L124).
* Re-boot Calypso with `wpcom-user-bootstrap` enabled (i.e. `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-user-bootstrap yarn start`) to emulate having logged-in state on the server side and confirm the hreflang links are not being printed for the same URLs.

#### Merge instructions

* Drop https://github.com/Automattic/wp-calypso/pull/53449/commits/f55548a3cd91ce93ec4583d55c8d0ee930389f4e
* Merge after https://github.com/Automattic/wp-calypso/pull/41410

Related to https://github.com/Automattic/wp-calypso/pull/41410#discussion_r635092751
