### PR TITLE
Allow `./bin/add-pr-comment.sh` to fail (happens if there is no PR, for example)

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -367,6 +367,7 @@ object BuildDockerImage : BuildType({
 				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
+				chmod +x ./bin/add-pr-comment.sh
 				./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
 				Link to live branch is being generated...
 				Please wait a few minutes and refresh this page.
@@ -415,6 +416,7 @@ object BuildDockerImage : BuildType({
 				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
+				chmod +x ./bin/add-pr-comment.sh
 				./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
 				Link to Calypso live: https://calypso.live?image=registry.a8c.com/calypso/app:build-%build.number%
 				Link to Jetpack Cloud live: https://calypso.live?image=registry.a8c.com/calypso/app:build-%build.number%&env=jetpack

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -367,7 +367,7 @@ object BuildDockerImage : BuildType({
 				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
-				. ./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF
+				. ./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
 				Link to live branch is being generated...
 				Please wait a few minutes and refresh this page.
 				EOF
@@ -415,7 +415,7 @@ object BuildDockerImage : BuildType({
 				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
-				. ./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF
+				. ./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
 				Link to Calypso live: https://calypso.live?image=registry.a8c.com/calypso/app:build-%build.number%
 				Link to Jetpack Cloud live: https://calypso.live?image=registry.a8c.com/calypso/app:build-%build.number%&env=jetpack
 				EOF

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -367,7 +367,7 @@ object BuildDockerImage : BuildType({
 				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
-				. ./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
+				./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
 				Link to live branch is being generated...
 				Please wait a few minutes and refresh this page.
 				EOF
@@ -415,7 +415,7 @@ object BuildDockerImage : BuildType({
 				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
-				. ./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
+				./bin/add-pr-comment.sh "%teamcity.build.branch%" "calypso-live" <<- EOF || true
 				Link to Calypso live: https://calypso.live?image=registry.a8c.com/calypso/app:build-%build.number%
 				Link to Jetpack Cloud live: https://calypso.live?image=registry.a8c.com/calypso/app:build-%build.number%&env=jetpack
 				EOF

--- a/bin/add-pr-comment.sh
+++ b/bin/add-pr-comment.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-#set -x
+set -x
 
 ### Expected binaries
 # - jq


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sometimes we run tests for branches that don't have a PR open yet. `./bin/add-pr-comment.sh` exits with `1` if there is no PR open (which I think is ok), but we are not using it for anything critical here, so no reason to stop the build in that case.

#### Testing instructions

N/A