### PR TITLE
WIP: Initial approach to mailbox list refactor

### DIFF
--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import page from 'page';
@@ -12,14 +13,6 @@ import { withShoppingCart } from '@automattic/shopping-cart';
  * Internal dependencies
  */
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
-import {
-	areAllMailboxesValid,
-	areAllMailboxesAvailable,
-	buildNewTitanMailbox,
-	transformMailboxForCart,
-	validateMailboxes,
-} from 'calypso/lib/titan/new-mailbox';
-import { Button, Card } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
@@ -28,12 +21,6 @@ import {
 	emailManagementNewTitanAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
-import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
-import {
-	getMaxTitanMailboxCount,
-	getTitanProductName,
-	hasTitanMailWithUs,
-} from 'calypso/lib/titan';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
 	getDomainsBySiteId,
@@ -41,7 +28,12 @@ import {
 	isRequestingSiteDomains,
 } from 'calypso/state/sites/domains/selectors';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
-import { getProductBySlug, getProductsList } from 'calypso/state/products-list/selectors';
+import {
+	getMaxTitanMailboxCount,
+	getTitanProductName,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import HeaderCake from 'calypso/components/header-cake';
@@ -50,14 +42,13 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import SectionHeader from 'calypso/components/section-header';
 import {
 	TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
 	TITAN_MAIL_MONTHLY_SLUG,
 } from 'calypso/lib/titan/constants';
-import SectionHeader from 'calypso/components/section-header';
 import TitanExistingForwardsNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-existing-forwards-notice';
 import TitanMailboxPricingNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice';
-import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -68,23 +59,6 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import './style.scss';
 
 class TitanAddMailboxes extends React.Component {
-	state = {
-		mailboxes: [ buildNewTitanMailbox( this.props.selectedDomainName, false ) ],
-		isAddingToCart: false,
-		isCheckingAvailability: false,
-		validatedMailboxUuids: [],
-	};
-
-	isMounted = false;
-
-	componentDidMount() {
-		this.isMounted = true;
-	}
-
-	componentWillUnmount() {
-		this.isMounted = false;
-	}
-
 	recordClickEvent = ( eventName, eventProps ) => {
 		const { recordTracksEvent, selectedDomainName } = this.props;
 		recordTracksEvent( eventName, {
@@ -115,76 +89,11 @@ class TitanAddMailboxes extends React.Component {
 		this.goToEmail();
 	};
 
-	getCartItem = () => {
-		const { maxTitanMailboxCount, selectedDomainName } = this.props;
-		const mailboxes = this.state.mailboxes;
-		const quantity = mailboxes.length + maxTitanMailboxCount;
-		const new_quantity = mailboxes.length;
-		const email_users = mailboxes.map( transformMailboxForCart );
-
-		return titanMailMonthly( {
-			domain: selectedDomainName,
-			quantity,
-			extra: {
-				email_users,
-				new_quantity,
-			},
-		} );
-	};
-
-	handleContinue = async () => {
-		const { selectedSite } = this.props;
-		const { mailboxes } = this.state;
-
-		const validatedMailboxes = validateMailboxes( mailboxes );
-
-		const allMailboxesAreValid = areAllMailboxesValid( validatedMailboxes );
-
-		let allMailboxesAreAvailable = false;
-		if ( allMailboxesAreValid ) {
-			this.setState( { isCheckingAvailability: true } );
-			allMailboxesAreAvailable = await areAllMailboxesAvailable(
-				validatedMailboxes,
-				this.onMailboxesChange
-			);
-			if ( this.isMounted ) {
-				this.setState( { isCheckingAvailability: false } );
-			}
-		}
-
-		const canContinue = allMailboxesAreValid && allMailboxesAreAvailable;
-
-		const validatedMailboxUuids = validatedMailboxes.map( ( mailbox ) => mailbox.uuid );
-
-		this.setState( {
-			mailboxes: validatedMailboxes,
-			validatedMailboxUuids,
-		} );
-
+	trackMailboxSubmission = ( { mailboxCount, mailboxesAreValid } ) => {
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_continue_button_click', {
-			can_continue: canContinue,
-			mailbox_count: mailboxes.length,
+			can_continue: mailboxesAreValid,
+			mailbox_count: mailboxCount,
 		} );
-
-		if ( canContinue ) {
-			this.setState( { isAddingToCart: true } );
-
-			this.props.shoppingCartManager
-				.addProductsToCart( [
-					fillInSingleCartItemAttributes( this.getCartItem(), this.props.productsList ),
-				] )
-				.then( () => {
-					if ( this.isMounted ) {
-						this.setState( { isAddingToCart: false } );
-					}
-					const { errors } = this.props?.cart?.messages;
-					if ( errors && errors.length ) {
-						// Stay on the page to show the relevant error
-						return;
-					}
-					return this.isMounted && page( '/checkout/' + selectedSite.slug );
-				} );
-		}
 	};
 
 	handleUnusedMailboxFinishSetupClick = () => {
@@ -216,12 +125,14 @@ class TitanAddMailboxes extends React.Component {
 		);
 	};
 
-	onMailboxesChange = ( updatedMailboxes ) => {
-		this.setState( { mailboxes: updatedMailboxes, quantity: updatedMailboxes.length } );
-	};
-
 	renderForm() {
-		const { isLoadingDomains, selectedDomainName, titanMonthlyProduct, translate } = this.props;
+		const {
+			isLoadingDomains,
+			selectedDomain,
+			selectedDomainName,
+			titanMonthlyProduct,
+			translate,
+		} = this.props;
 
 		if ( isLoadingDomains || ! titanMonthlyProduct ) {
 			return <AddEmailAddressesCardPlaceholder />;
@@ -233,23 +144,17 @@ class TitanAddMailboxes extends React.Component {
 
 				<Card>
 					<TitanNewMailboxList
-						domain={ selectedDomainName }
-						mailboxes={ this.state.mailboxes }
-						onMailboxesChange={ this.onMailboxesChange }
-						validatedMailboxUuids={ this.state.validatedMailboxUuids }
-					>
-						<Button className="titan-add-mailboxes__action-cancel" onClick={ this.handleCancel }>
-							{ translate( 'Cancel' ) }
-						</Button>
-						<Button
-							className="titan-add-mailboxes__action-continue"
-							primary
-							busy={ this.state.isAddingToCart || this.state.isCheckingAvailability }
-							onClick={ this.handleContinue }
-						>
-							{ translate( 'Continue' ) }
-						</Button>
-					</TitanNewMailboxList>
+						cancelButtonClassName="titan-add-mailboxes__action-cancel"
+						cancelButtonText={ translate( 'Cancel' ) }
+						domainName={ selectedDomainName }
+						existingDomainObject={ selectedDomain }
+						onCancel={ this.handleCancel }
+						onSubmitMailboxList={ this.trackMailboxSubmission }
+						shouldCheckAvailability={ true }
+						showCancelButton={ true }
+						submitButtonClassName="titan-add-mailboxes__action-continue"
+						submitButtonText={ translate( 'Continue' ) }
+					/>
 				</Card>
 			</>
 		);
@@ -333,7 +238,6 @@ export default connect(
 			isLoadingDomains,
 			currentRoute: getCurrentRoute( state ),
 			domainsWithForwards: getDomainsWithForwards( state, domains ),
-			productsList: getProductsList( state ),
 			maxTitanMailboxCount: hasTitanMailWithUs( selectedDomain )
 				? getMaxTitanMailboxCount( selectedDomain )
 				: 0,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

_Note: This PR is intended to get feedback from the team about the approach. I haven't been testing it extensively yet._

This PR restructures the data flow for the `TitanNewMailboxList` component and its current consumers. The major changes involved are as follows:
 * The component now manages all state for the list of mailboxes it is working with, instead of getting that handling passed in, as we had a lot of duplication in the consumers.
 * The validation and submission of mailboxes is handled by the component itself (though it does provide notification of submission attempts to consumers via a callback prop)
 * The consumers no longer supply any buttons as children, but can only specify some props of those buttons
 * Shifts some of the possibly-async logic into effect-driven code -- this may or may not be valid, but was mostly to try and handle the relevant pieces using a functional component.

The PR does not do the following, but we could take them on at some point:
 * The class names for some items are currently passed in to keep existing styles in place - we should eventually refactor those styles into the mailbox list component.
 * The component will only work for Titan at present, but we could pass in the validation functions and possibly the cart item creation logic as props, and then move to consolidate some aspects of the existing Titan and Google code for new mailbox creation and validation.

#### Testing instructions

TBD, but will likely involve regression testing of the email comparison page and add mailbox page for Professional Email.