### PR TITLE
Remove always-on manage/* feature flags

### DIFF
--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -3,35 +3,24 @@
  */
 
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import PurchaseDetail from 'calypso/components/purchase-detail';
-import { isEnabled } from '@automattic/calypso-config';
 
 /**
  * Image dependencies
  */
 import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
 
-function isCustomizeEnabled() {
-	return isEnabled( 'manage/customize' );
-}
-
 function getEditCSSLink( selectedSite ) {
-	const adminUrl = selectedSite.URL + '/wp-admin/';
-	const customizerInAdmin =
-		adminUrl +
-		'customize.php?return=' +
-		encodeURIComponent( window.location.href ) +
-		'&section=jetpack_custom_css';
-
-	return isCustomizeEnabled() ? '/customize/custom-css/' + selectedSite.slug : customizerInAdmin;
+	return '/customize/custom-css/' + selectedSite.slug;
 }
 
-export default localize( ( { selectedSite, translate } ) => {
+export default function CustomCSS( { selectedSite } ) {
+	const translate = useTranslate();
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -42,8 +31,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				) }
 				buttonText={ translate( 'Edit CSS' ) }
 				href={ getEditCSSLink( selectedSite ) }
-				target={ isCustomizeEnabled() ? undefined : '_blank' }
 			/>
 		</div>
 	);
-} );
+}

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -9,23 +9,14 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'calypso/components/purchase-detail';
-import { isEnabled } from '@automattic/calypso-config';
 
 /**
  * Image dependencies
  */
 import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
 
-function isCustomizeEnabled() {
-	return isEnabled( 'manage/customize' );
-}
-
 function getCustomizeLink( selectedSite ) {
-	const adminUrl = selectedSite.URL + '/wp-admin/';
-	const customizerInAdmin =
-		adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href );
-
-	return isCustomizeEnabled() ? '/customize/' + selectedSite.slug : customizerInAdmin;
+	return '/customize/' + selectedSite.slug;
 }
 
 export default localize( ( { selectedSite, translate } ) => {
@@ -40,7 +31,6 @@ export default localize( ( { selectedSite, translate } ) => {
 				) }
 				buttonText={ translate( 'Start customizing' ) }
 				href={ getCustomizeLink( selectedSite ) }
-				target={ isCustomizeEnabled() ? undefined : '_blank' }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -96,7 +96,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
-				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
+				<UploadPlugins selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
 			</Fragment>
@@ -161,7 +161,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomCSS selectedSite={ selectedSite } />
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
-				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
+				<UploadPlugins selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
 				<SellOnlinePaypal isJetpack={ false } />

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,6 @@ import page from 'page';
  */
 import { siteSelection, sites } from 'calypso/my-sites/controller';
 import { authenticate, post, redirect, siteEditor, exitPost } from './controller';
-import config from '@automattic/calypso-config';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
@@ -50,19 +49,17 @@ export default function () {
 	page.exit( '/page/:site?/:post?', exitPost );
 	page( '/page/:site?', siteSelection, redirect, makeLayout, clientRender );
 
-	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-		page( '/edit/:customPostType', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/edit/:customPostType/:site/:post?',
-			siteSelection,
-			redirect,
-			authenticate,
-			post,
-			makeLayout,
-			clientRender
-		);
-		page( '/edit/:customPostType/:site?', siteSelection, redirect, makeLayout, clientRender );
-	}
+	page( '/edit/:customPostType', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/edit/:customPostType/:site/:post?',
+		siteSelection,
+		redirect,
+		authenticate,
+		post,
+		makeLayout,
+		clientRender
+	);
+	page( '/edit/:customPostType/:site?', siteSelection, redirect, makeLayout, clientRender );
 
 	/*
 	 * Redirecto the old `/block-editor` routes to the default routes.
@@ -86,14 +83,12 @@ export default function () {
 		page.redirect( `/page/${ site }/` );
 	} );
 
-	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-		page( '/block-editor/edit/:customPostType/:site/:post?', ( { params = {} } ) => {
-			const { customPostType, site, post: postId } = params;
-			if ( postId ) {
-				return page.redirect( `/edit/${ customPostType }/${ site }/${ postId }` );
-			}
+	page( '/block-editor/edit/:customPostType/:site/:post?', ( { params = {} } ) => {
+		const { customPostType, site, post: postId } = params;
+		if ( postId ) {
+			return page.redirect( `/edit/${ customPostType }/${ site }/${ postId }` );
+		}
 
-			page.redirect( `/edit/${ customPostType }/${ site }` );
-		} );
-	}
+		page.redirect( `/edit/${ customPostType }/${ site }` );
+	} );
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -18,36 +18,28 @@ import { sidebar } from 'calypso/me/controller';
 import { siteSelection } from 'calypso/my-sites/controller';
 
 export default ( router ) => {
-	if ( config.isEnabled( 'manage/payment-methods' ) ) {
-		router(
-			paths.paymentMethods,
-			sidebar,
-			paymentMethodsController.paymentMethods,
-			makeLayout,
-			clientRender
-		);
+	router(
+		paths.paymentMethods,
+		sidebar,
+		paymentMethodsController.paymentMethods,
+		makeLayout,
+		clientRender
+	);
 
-		router(
-			paths.addNewPaymentMethod,
-			sidebar,
-			controller.addNewPaymentMethod,
-			makeLayout,
-			clientRender
-		);
+	router(
+		paths.addNewPaymentMethod,
+		sidebar,
+		controller.addNewPaymentMethod,
+		makeLayout,
+		clientRender
+	);
 
-		router(
-			paths.addCreditCard,
-			sidebar,
-			controller.addNewPaymentMethod,
-			makeLayout,
-			clientRender
-		);
+	router( paths.addCreditCard, sidebar, controller.addNewPaymentMethod, makeLayout, clientRender );
 
-		// redirect legacy urls
-		router( '/payment-methods/add-credit-card', () => {
-			page.redirect( paths.addCreditCard );
-		} );
-	}
+	// redirect legacy urls
+	router( '/payment-methods/add-credit-card', () => {
+		page.redirect( paths.addCreditCard );
+	} );
 
 	router(
 		paths.billingHistory,

--- a/client/me/purchases/payment-methods/payment-method-list.jsx
+++ b/client/me/purchases/payment-methods/payment-method-list.jsx
@@ -12,7 +12,6 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Button, CompactCard } from '@automattic/components';
-import config from '@automattic/calypso-config';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import PaymentMethodDelete from 'calypso/me/purchases/payment-methods/payment-method-delete';
 import {
@@ -62,10 +61,6 @@ class PaymentMethodList extends Component {
 	};
 
 	renderAddPaymentMethodButton() {
-		if ( ! config.isEnabled( 'manage/payment-methods' ) ) {
-			return null;
-		}
-
 		return (
 			<Button primary compact onClick={ this.goToAddPaymentMethod }>
 				{ this.props.translate( 'Add payment method' ) }

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -14,7 +14,6 @@ import i18n from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
-import { isEnabled } from '@automattic/calypso-config';
 import { isBusiness, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
@@ -121,7 +120,7 @@ const BusinessPlanDetails = ( {
 				/>
 			) }
 
-			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) && (
+			{ ! selectedFeature && (
 				<PurchaseDetail
 					icon={ <img alt="" src={ updatesImage } /> }
 					title={ i18n.translate( 'Add a Plugin' ) }

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -13,7 +13,6 @@ import i18n from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
-import { isEnabled } from '@automattic/calypso-config';
 import { isEcommerce, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
@@ -53,7 +52,7 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 				onClick={ trackOnboardingButtonClick }
 			/>
 
-			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) && (
+			{ ! selectedFeature && (
 				<PurchaseDetail
 					icon={ <img alt="" src={ updatesImage } /> }
 					title={ i18n.translate( 'Add a Plugin' ) }

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,24 +11,7 @@ import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { getSiteFileModDisableReason } from 'calypso/lib/site/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import config from '@automattic/calypso-config';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
-
-const BasicDetails = ( { translate } ) => {
-	const email = useSelector( getCurrentUserEmail );
-	return (
-		<PurchaseDetail
-			icon="cog"
-			title={ translate( 'Set up your VaultPress and Akismet accounts' ) }
-			description={ translate(
-				'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. ' +
-					'Follow the instructions in the email to get started.',
-				{ args: { email } }
-			) }
-		/>
-	);
-};
 
 class EnhancedDetails extends Component {
 	componentDidMount() {
@@ -125,8 +108,4 @@ const mapDispatchToProps = ( dispatch, { selectedSite } ) => ( {
 	},
 } );
 
-const JetpackPlanDetails = config.isEnabled( 'manage/plugins/setup' )
-	? connect( null, mapDispatchToProps )( EnhancedDetails )
-	: BasicDetails;
-
-export default localize( JetpackPlanDetails );
+export default localize( connect( null, mapDispatchToProps )( EnhancedDetails ) );

--- a/client/my-sites/customize/index.js
+++ b/client/my-sites/customize/index.js
@@ -9,19 +9,16 @@ import page from 'page';
  */
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { customize } from './controller';
-import config from '@automattic/calypso-config';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
-	if ( config.isEnabled( 'manage/customize' ) ) {
-		page( '/customize/:panel([^.]+)?', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/customize/:panel?/:domain',
-			siteSelection,
-			navigation,
-			customize,
-			makeLayout,
-			clientRender
-		);
-	}
+	page( '/customize/:panel([^.]+)?', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/customize/:panel?/:domain',
+		siteSelection,
+		navigation,
+		customize,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -14,7 +14,6 @@ import { get } from 'lodash';
  */
 import { Button, CompactCard } from '@automattic/components';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
-import config from '@automattic/calypso-config';
 import {
 	isRequestingInviteResend,
 	didInviteResendSucceed,
@@ -50,7 +49,6 @@ class PeopleListItem extends React.PureComponent {
 		const site = this.props.site;
 		const user = this.props.user;
 		return (
-			config.isEnabled( 'manage/edit-user' ) &&
 			user &&
 			user.roles &&
 			site &&

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -7,7 +7,6 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import config from '@automattic/calypso-config';
 import {
 	browsePlugins,
 	browsePluginsOrPlugin,
@@ -41,100 +40,98 @@ export default function () {
 		clientRender
 	);
 
-	if ( config.isEnabled( 'manage/plugins' ) ) {
-		page( '/plugins/wpcom-masterbar-redirect/:site', ( context ) => {
-			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
-			page.redirect( `/plugins/${ context.params.site }` );
-		} );
+	page( '/plugins/wpcom-masterbar-redirect/:site', ( context ) => {
+		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
+		page.redirect( `/plugins/${ context.params.site }` );
+	} );
 
-		page( '/plugins/browse/wpcom-masterbar-redirect/:site', ( context ) => {
-			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_add_click' ) );
-			page.redirect( `/plugins/browse/${ context.params.site }` );
-		} );
+	page( '/plugins/browse/wpcom-masterbar-redirect/:site', ( context ) => {
+		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_add_click' ) );
+		page.redirect( `/plugins/browse/${ context.params.site }` );
+	} );
 
-		page( '/plugins/manage/wpcom-masterbar-redirect/:site', ( context ) => {
-			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_manage_click' ) );
-			page.redirect( `/plugins/manage/${ context.params.site }` );
-		} );
+	page( '/plugins/manage/wpcom-masterbar-redirect/:site', ( context ) => {
+		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_manage_click' ) );
+		page.redirect( `/plugins/manage/${ context.params.site }` );
+	} );
 
-		page( '/plugins/browse/:category/:site', ( context ) => {
-			const { category, site } = context.params;
-			page.redirect( `/plugins/${ category }/${ site }` );
-		} );
+	page( '/plugins/browse/:category/:site', ( context ) => {
+		const { category, site } = context.params;
+		page.redirect( `/plugins/${ category }/${ site }` );
+	} );
 
-		page( '/plugins/browse/:siteOrCategory?', ( context ) => {
-			const { siteOrCategory } = context.params;
-			page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
-		} );
+	page( '/plugins/browse/:siteOrCategory?', ( context ) => {
+		const { siteOrCategory } = context.params;
+		page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
+	} );
 
-		page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/plugins/upload/:site_id',
-			scrollTopIfNoHash,
-			siteSelection,
-			navigation,
-			upload,
-			makeLayout,
-			clientRender
-		);
+	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/plugins/upload/:site_id',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		upload,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/plugins',
-			scrollTopIfNoHash,
-			siteSelection,
-			navigation,
-			browsePlugins,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/plugins',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		browsePlugins,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/plugins/manage/:site?',
-			scrollTopIfNoHash,
-			siteSelection,
-			navigation,
-			plugins,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/plugins/manage/:site?',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		plugins,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
-			scrollTopIfNoHash,
-			siteSelection,
-			navigation,
-			jetpackCanUpdate,
-			plugins,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		jetpackCanUpdate,
+		plugins,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/plugins/:plugin/:site_id?',
-			scrollTopIfNoHash,
-			siteSelection,
-			navigation,
-			browsePluginsOrPlugin,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/plugins/:plugin/:site_id?',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		browsePluginsOrPlugin,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/plugins/:plugin/eligibility/:site_id',
-			scrollTopIfNoHash,
-			siteSelection,
-			navigation,
-			eligibility,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/plugins/:plugin/eligibility/:site_id',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		eligibility,
+		makeLayout,
+		clientRender
+	);
 
-		page.exit( '/plugins/*', ( context, next ) => {
-			if ( 0 !== page.current.indexOf( '/plugins/' ) ) {
-				resetHistory();
-			}
+	page.exit( '/plugins/*', ( context, next ) => {
+		if ( 0 !== page.current.indexOf( '/plugins/' ) ) {
+			resetHistory();
+		}
 
-			next();
-		} );
-	}
+		next();
+	} );
 }

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -69,18 +69,16 @@ export default function () {
 			page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
 		} );
 
-		if ( config.isEnabled( 'manage/plugins/upload' ) ) {
-			page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
-			page(
-				'/plugins/upload/:site_id',
-				scrollTopIfNoHash,
-				siteSelection,
-				navigation,
-				upload,
-				makeLayout,
-				clientRender
-			);
-		}
+		page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
+		page(
+			'/plugins/upload/:site_id',
+			scrollTopIfNoHash,
+			siteSelection,
+			navigation,
+			upload,
+			makeLayout,
+			clientRender
+		);
 
 		page(
 			'/plugins',

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -23,25 +23,23 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
-	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
-		page(
-			'/plugins/setup',
-			scrollTopIfNoHash,
-			siteSelection,
-			setupPlugins,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/plugins/setup',
+		scrollTopIfNoHash,
+		siteSelection,
+		setupPlugins,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/plugins/setup/:site',
-			scrollTopIfNoHash,
-			siteSelection,
-			setupPlugins,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/plugins/setup/:site',
+		scrollTopIfNoHash,
+		siteSelection,
+		setupPlugins,
+		makeLayout,
+		clientRender
+	);
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
 		page( '/plugins/wpcom-masterbar-redirect/:site', ( context ) => {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -45,7 +45,6 @@ import {
 } from 'calypso/state/ui/selectors';
 import { getPlugins, isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { Button } from '@automattic/components';
-import { isEnabled } from '@automattic/calypso-config';
 import { getVisibleSites, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 
 /**
@@ -367,10 +366,6 @@ export class PluginsMain extends Component {
 	};
 
 	renderUploadPluginButton() {
-		if ( ! isEnabled( 'manage/plugins/upload' ) ) {
-			return null;
-		}
-
 		const { selectedSiteSlug, translate } = this.props;
 		const uploadUrl = '/plugins/upload' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -388,10 +388,6 @@ export class PluginsBrowser extends Component {
 	};
 
 	renderUploadPluginButton() {
-		if ( ! isEnabled( 'manage/plugins/upload' ) ) {
-			return null;
-		}
-
 		const { siteSlug, translate } = this.props;
 		const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
 

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -90,7 +90,6 @@ class SiteMenu extends PureComponent {
 				name: 'post',
 				label: translate( 'Posts' ),
 				capability: 'edit_posts',
-				config: 'manage/posts',
 				queryable: true,
 				link: '/posts' + this.getMyParameter(),
 				paths: [ '/posts', '/posts/my' ],

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -112,7 +112,6 @@ class SiteMenu extends PureComponent {
 				count: get( this.props.commentCounts, 'pending' ),
 				capability: 'edit_posts',
 				queryable: true,
-				config: 'manage/comments',
 				link: '/comments',
 				paths: [ '/comment', '/comments' ],
 				wpAdminLink: 'edit-comments.php',

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -218,7 +218,6 @@ class SiteMenu extends PureComponent {
 					return memo.concat( {
 						name: postType.name,
 						label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
-						config: 'manage/custom-post-types',
 						//controls if we show the wp-admin link. It feels like this is coupling two different meanings (api_queryable)
 						queryable: false,
 
@@ -241,7 +240,6 @@ class SiteMenu extends PureComponent {
 				return memo.concat( {
 					name: postType.name,
 					label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
-					config: 'manage/custom-post-types',
 					queryable: postType.api_queryable,
 
 					//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -49,7 +49,6 @@ class ToolsMenu extends PureComponent {
 			label: translate( 'Plugins' ),
 			capability: 'manage_options',
 			queryable: ! config.isEnabled( 'calypsoify/plugins' ) || ! isAtomicSite,
-			config: 'manage/plugins',
 			link: '/plugins',
 			paths: [ '/extensions', '/plugins' ],
 			wpAdminLink: 'plugin-install.php?calypsoify=1',

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -68,7 +68,7 @@ class SiteSettingsFormWriting extends Component {
 			>
 				{
 					// Only show taxonomy management for non-advanced dashboard user setting
-					config.isEnabled( 'manage/site-settings/categories' ) && ! showAdvancedDashboard && (
+					! showAdvancedDashboard && (
 						<div className="site-settings__taxonomies">
 							<QueryTaxonomies siteId={ siteId } postType="post" />
 							<TaxonomyCard taxonomy="category" postType="post" />

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import SectionNav from 'calypso/components/section-nav';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
@@ -60,7 +59,7 @@ export class SiteSettingsNavigation extends Component {
 						{ strings.general }
 					</NavItem>
 
-					{ config.isEnabled( 'manage/security' ) && site.jetpack && (
+					{ site.jetpack && (
 						<NavItem
 							path={ `/settings/security/${ site.slug }` }
 							preloadSectionName="settings-security"

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -6,7 +6,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { podcasting, taxonomies, writing } from './controller';
@@ -23,19 +22,17 @@ export default function () {
 		clientRender
 	);
 
-	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
-		page( '/settings/taxonomies/:taxonomy', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/taxonomies/:taxonomy', siteSelection, sites, makeLayout, clientRender );
 
-		page(
-			'/settings/taxonomies/:taxonomy/:site_id',
-			siteSelection,
-			navigation,
-			setScroll,
-			taxonomies,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/settings/taxonomies/:taxonomy/:site_id',
+		siteSelection,
+		navigation,
+		setScroll,
+		taxonomies,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/settings/podcasting', siteSelection, sites, makeLayout, clientRender );
 

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 
 /**
  * Internal Dependencies
@@ -10,10 +9,6 @@ import page from 'page';
 import Types from './main';
 import { mapPostStatus } from 'calypso/lib/route';
 import { POST_STATUSES } from 'calypso/state/posts/constants';
-
-export function redirect() {
-	page.redirect( '/posts' );
-}
 
 export function list( context, next ) {
 	const search = context.query.s;

--- a/client/my-sites/types/index.js
+++ b/client/my-sites/types/index.js
@@ -4,15 +4,10 @@
 
 import { makeLayout } from 'calypso/controller';
 import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
-import { list, redirect } from './controller';
-import config from '@automattic/calypso-config';
+import { list } from './controller';
 
 export default function ( router ) {
-	if ( ! config.isEnabled( 'manage/custom-post-types' ) ) {
-		return;
-	}
-
 	router( '/types/:type/:status?/:site', siteSelection, navigation, list, makeLayout );
 	router( '/types/:type', siteSelection, sites, makeLayout );
-	router( '/types', redirect );
+	router( '/types', '/posts' );
 }

--- a/config/README.md
+++ b/config/README.md
@@ -18,7 +18,6 @@ The config files contain a features object that can be used to determine whether
 ```json
 {
 	"features": {
-		"manage/posts": true,
 		"reader": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -115,7 +115,6 @@
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,
-		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/development.json
+++ b/config/development.json
@@ -109,7 +109,6 @@
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/site-importer-endpoints": true,
-		"manage/payment-methods": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/development.json
+++ b/config/development.json
@@ -111,7 +111,6 @@
 		"manage/import/site-importer-endpoints": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/site-settings/analytics": true,
-		"manage/site-settings/categories": true,
 		"marketplace-yoast": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/development.json
+++ b/config/development.json
@@ -113,7 +113,6 @@
 		"manage/payment-methods": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
-		"manage/plugins/setup": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/development.json
+++ b/config/development.json
@@ -111,7 +111,6 @@
 		"manage/import/site-importer-endpoints": true,
 		"manage/payment-methods": true,
 		"manage/plugins/compatibility-warning": false,
-		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": true,

--- a/config/development.json
+++ b/config/development.json
@@ -111,7 +111,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/site-importer-endpoints": true,
 		"manage/payment-methods": true,
-		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/development.json
+++ b/config/development.json
@@ -107,7 +107,6 @@
 		"login/magic-login": true,
 		"happychat": true,
 		"mailchimp": true,
-		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,

--- a/config/development.json
+++ b/config/development.json
@@ -114,7 +114,6 @@
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,
-		"manage/plugins/upload": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/development.json
+++ b/config/development.json
@@ -107,7 +107,6 @@
 		"login/magic-login": true,
 		"happychat": true,
 		"mailchimp": true,
-		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/site-importer-endpoints": true,

--- a/config/development.json
+++ b/config/development.json
@@ -107,7 +107,6 @@
 		"login/magic-login": true,
 		"happychat": true,
 		"mailchimp": true,
-		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/site-importer-endpoints": true,
 		"manage/payment-methods": true,

--- a/config/development.json
+++ b/config/development.json
@@ -107,7 +107,6 @@
 		"login/magic-login": true,
 		"happychat": true,
 		"mailchimp": true,
-		"manage/comments": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,

--- a/config/development.json
+++ b/config/development.json
@@ -110,7 +110,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/site-importer-endpoints": true,
 		"manage/plugins/compatibility-warning": false,
-		"manage/site-settings/analytics": true,
 		"marketplace-yoast": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -80,7 +80,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,
-		"manage/plugins/setup": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"mailchimp": false,
 		"manage/export/guided-transfer": true,
-		"manage/payment-methods": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"mailchimp": false,
 		"manage/custom-post-types": true,
-		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"mailchimp": false,
 		"manage/export/guided-transfer": true,
-		"manage/site-settings/analytics": true,
 		"marketplace-yoast": false,
 		"me/account/color-scheme-picker": true,
 		"network-connection": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -82,7 +82,6 @@
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,
-		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"mailchimp": false,
-		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,7 +78,6 @@
 		"mailchimp": false,
 		"manage/export/guided-transfer": true,
 		"manage/site-settings/analytics": true,
-		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,
 		"me/account/color-scheme-picker": true,
 		"network-connection": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -79,7 +79,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
-		"manage/plugins": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,7 +78,6 @@
 		"mailchimp": false,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
-		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,7 +81,6 @@
 		"manage/payment-methods": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
-		"manage/plugins/upload": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"mailchimp": false,
-		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"layout/query-selected-editor": true,
 		"legal-updates-banner": false,
 		"mailchimp": false,
-		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
 		"manage/security": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/plugins/browser": true,
 		"manage/security": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"manage/custom-post-types": true,
-		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,

--- a/config/production.json
+++ b/config/production.json
@@ -78,7 +78,6 @@
 		"mailchimp": true,
 		"manage/payment-methods": true,
 		"manage/plugins/browser": true,
-		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/payment-methods": true,
 		"manage/plugins/browser": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/production.json
+++ b/config/production.json
@@ -81,7 +81,6 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/setup": true,
-		"manage/plugins/upload": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"manage/site-settings/analytics": true,
-		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,6 @@
 		"manage/plugins/browser": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,
-		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/production.json
+++ b/config/production.json
@@ -80,7 +80,6 @@
 		"manage/payment-methods": true,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
-		"manage/plugins/setup": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/plugins/browser": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/production.json
+++ b/config/production.json
@@ -76,7 +76,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/site-settings/analytics": true,
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -78,7 +78,6 @@
 		"mailchimp": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
-		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,6 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"manage/site-settings/analytics": true,
-		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/site-settings/analytics": true,
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,6 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"manage/payment-methods": true,
-		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -82,7 +82,6 @@
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,
-		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -79,7 +79,6 @@
 		"mailchimp": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
-		"manage/plugins": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -80,7 +80,6 @@
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,
-		"manage/plugins/setup": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"manage/payment-methods": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
-		"manage/plugins/upload": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -77,7 +77,6 @@
 		"legal-updates-banner": false,
 		"login/magic-login": true,
 		"mailchimp": true,
-		"manage/payment-methods": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,6 @@
 		"login/magic-login": true,
 		"mailchimp": true,
 		"manage/custom-post-types": true,
-		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,

--- a/config/test.json
+++ b/config/test.json
@@ -66,7 +66,6 @@
 		"legal-updates-banner": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/edit-user": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/test.json
+++ b/config/test.json
@@ -70,7 +70,6 @@
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,
-		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,6 @@
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/plugins/compatibility-warning": false,
-		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"me/account-close": true,

--- a/config/test.json
+++ b/config/test.json
@@ -66,7 +66,6 @@
 		"legal-updates-banner": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,6 @@
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/edit-user": true,
-		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/test.json
+++ b/config/test.json
@@ -69,7 +69,6 @@
 		"manage/edit-user": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
-		"manage/plugins/setup": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/test.json
+++ b/config/test.json
@@ -68,7 +68,6 @@
 		"mailchimp": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/site-settings/analytics": true,
-		"manage/site-settings/categories": true,
 		"me/account-close": true,
 		"memberships": true,
 		"network-connection": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,6 @@
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/plugins/compatibility-warning": false,
-		"manage/site-settings/analytics": true,
 		"me/account-close": true,
 		"memberships": true,
 		"network-connection": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -87,7 +87,6 @@
 		"manage/payment-methods": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
-		"manage/plugins/upload": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"login/magic-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
 		"manage/security": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,7 +83,6 @@
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
-		"manage/payment-methods": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"login/magic-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/comments": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,7 +85,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
-		"manage/plugins": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -84,7 +84,6 @@
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
-		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"login/magic-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -86,7 +86,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,
-		"manage/plugins/setup": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -88,7 +88,6 @@
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,
-		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,7 +83,6 @@
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
-		"manage/site-settings/analytics": true,
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -84,7 +84,6 @@
 		"mailchimp": true,
 		"manage/export/guided-transfer": true,
 		"manage/site-settings/analytics": true,
-		"manage/site-settings/categories": true,
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"login/magic-login": true,
 		"keyboard-shortcuts": true,
 		"mailchimp": true,
-		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,


### PR DESCRIPTION
This PR removes several `manage/*` feature flags that are either always-on in all environments or that are not used in code. Most of them have been dormant for years.

**How to test/review:**
Best reviewed commit by commit.
