### PR TITLE
Site Editor Tracking: Fix insert_method property value

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -65,7 +65,10 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// If it is then the block was inserted using this menu. This inserter closes
 	// automatically when the user tries to use another form of block insertion
 	// (at least at the time of writing), which is why we can rely on this method.
-	if ( select( 'core/edit-post' ).isInserterOpened() ) {
+	if (
+		select( 'core/edit-post' )?.isInserterOpened() ||
+		select( 'core/edit-site' )?.isInserterOpened()
+	) {
 		return 'header-inserter';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure `header-inserter` inserter method is recognized in the site editor too

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Open Site Editor, open the inserter sidebar and insert a block. Make sure `insert_method` is set `header-inserter`.
* Open Post Editor, open the inserter sidebar and insert a block. Make sure `insert_method` is set `header-inserter`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/53414
