### PR TITLE
ci(e2e): Skip flaky test

### DIFF
--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -60,12 +60,13 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 	// Skipped because it depends on the existing state. If the user does not have a pending purchase
 	// it may show only 5 results, but this test doesn't try to create a purchase.
 	it.skip( 'Displays Default Results initially', async function () {
-		supportSearchComponent = await SupportSearchComponent.Expect( this.driver );
+		// supportSearchComponent = await SupportSearchComponent.Expect( this.driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 		assert.equal( resultsCount, 6, 'There are not 6 Default Results displayed.' );
 	} );
 
 	it( 'Returns API Search Results for valid search query', async function () {
+		supportSearchComponent = await SupportSearchComponent.Expect( this.driver );
 		await supportSearchComponent.searchFor( 'Domain' );
 
 		const searchResultsCount = await supportSearchComponent.getSearchResultsCount();

--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -57,7 +57,9 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		);
 	} );
 
-	it( 'Displays Default Results initially', async function () {
+	// Skipped because it depends on exissting state. If the user does not have a pending purchase
+	// it may show only 5 results, but this test doesn't try to create a purchase.
+	it.skip( 'Displays Default Results initially', async function () {
 		supportSearchComponent = await SupportSearchComponent.Expect( this.driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 		assert.equal( resultsCount, 6, 'There are not 6 Default Results displayed.' );

--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -57,7 +57,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		);
 	} );
 
-	// Skipped because it depends on exissting state. If the user does not have a pending purchase
+	// Skipped because it depends on the existing state. If the user does not have a pending purchase
 	// it may show only 5 results, but this test doesn't try to create a purchase.
 	it.skip( 'Displays Default Results initially', async function () {
 		supportSearchComponent = await SupportSearchComponent.Expect( this.driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable test that relies on existing state:

It checks for the presence of 6 help items, but one of those items is displayed only if the user has a pending purchase (#45408). However, the test doesn't try to create that purchase, and ends up being flaky.

#### Testing instructions

N/A