### PR TITLE
Desktop: Use current user from Redux

### DIFF
--- a/client/lib/desktop-listeners/index.js
+++ b/client/lib/desktop-listeners/index.js
@@ -7,7 +7,6 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { newPost } from 'calypso/lib/paths';
-import user from 'calypso/lib/user';
 import userUtilities from 'calypso/lib/user/utils';
 import * as oAuthToken from 'calypso/lib/oauth-token';
 import { getStatsPathForTab } from 'calypso/lib/route';
@@ -17,6 +16,7 @@ import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/anal
 import { NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET } from 'calypso/state/desktop/window-events';
 import { setForceRefresh as forceNotificationsRefresh } from 'calypso/state/notifications-panel/actions';
 import { navigate } from 'calypso/lib/navigate';
+import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 /**
  * Module variables
@@ -102,7 +102,7 @@ const DesktopListeners = {
 	sendUserLoginStatus: function () {
 		let status = true;
 
-		if ( user().get() === false ) {
+		if ( ! isUserLoggedIn( this.store.getState() ) ) {
 			status = false;
 		}
 
@@ -111,7 +111,7 @@ const DesktopListeners = {
 		window.electron.send(
 			'user-login-status',
 			status,
-			{ id: user().data.ID },
+			{ id: getCurrentUserId( this.store.getState() ) },
 			oAuthToken.getToken()
 		);
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the desktop app to use Redux instead of `lib/user` for retrieving the user. There are a couple of instances that we're essentially touching:

* Checking if the user is logged in
* Retrieving the user ID

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go through #49614 for setting up to test the desktop app dev version
* Verify the app still works the same way for logged out and logged in users.