### PR TITLE
SiftScience: Use Redux for current user

### DIFF
--- a/client/lib/siftscience/README.md
+++ b/client/lib/siftscience/README.md
@@ -2,4 +2,4 @@
 
 `SiftScience` is a 3rd party service we're using to help flag purchase fraud. On the client side, it sends some data about the user's environment to help determine whether or not they're fraud.
 
-On any page we'd like to collect user data for sift, simply call `SiftScience.recordUser();`. This fills out the window.\_sift object as required, and loads the external sift script. Nothing needs to be done beyond calling `recordUser()`. At this point, we're not tracking pageviews with sift, we're only sending data about user environments - so we don't need to call `recordUser()` on each pageload, only once before they checkout.
+For any route we'd like to collect user data for sift, simply include `recordSiftScienceUser();` as an Express.js route handler. This fills out the window.\_sift object as required, and loads the external sift script. Nothing needs to be done beyond that. At this point, we're not tracking pageviews with sift, we're only sending data about user environments - so we don't need to call `recordSiftScienceUser()` on each pageload, only once before they checkout.

--- a/client/lib/siftscience/index.js
+++ b/client/lib/siftscience/index.js
@@ -10,8 +10,8 @@ const debug = debugFactory( 'calypso:siftscience' );
  * Internal dependencies
  */
 import { loadScript } from '@automattic/load-script';
-import user from 'calypso/lib/user';
 import config from '@automattic/calypso-config';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 const SIFTSCIENCE_URL = 'https://cdn.siftscience.com/s.js';
 let hasLoaded = false;
@@ -20,24 +20,23 @@ if ( ! window._sift ) {
 	window._sift = [];
 }
 
-/**
- * Expose `SiftScience`
- */
-export default {
-	recordUser: function () {
-		if ( ! hasLoaded ) {
-			window._sift.push( [ '_setAccount', config( 'siftscience_key' ) ] );
-			window._sift.push( [ '_setUserId', user().get().ID ] );
-			window._sift.push( [ '_trackPageview' ] );
+export function recordSiftScienceUser( context, next ) {
+	if ( ! hasLoaded ) {
+		const userId = getCurrentUserId( context.store.getState() );
 
-			hasLoaded = true;
-			loadScript( SIFTSCIENCE_URL, function ( error ) {
-				if ( error ) {
-					debug( 'Error loading siftscience' );
-				} else {
-					debug( 'siftscience loaded successfully' );
-				}
-			} );
-		}
-	},
-};
+		window._sift.push( [ '_setAccount', config( 'siftscience_key' ) ] );
+		window._sift.push( [ '_setUserId', userId ] );
+		window._sift.push( [ '_trackPageview' ] );
+
+		hasLoaded = true;
+		loadScript( SIFTSCIENCE_URL, function ( error ) {
+			if ( error ) {
+				debug( 'Error loading siftscience' );
+			} else {
+				debug( 'siftscience loaded successfully' );
+			}
+		} );
+	}
+
+	next();
+}

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -17,14 +17,14 @@ import {
 	jetpackCheckoutThankYou,
 } from './controller';
 import { noop } from './utils';
-import SiftScience from 'calypso/lib/siftscience';
+import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
 import { noSite, siteSelection } from 'calypso/my-sites/controller';
 import { isEnabled } from '@automattic/calypso-config';
 import userFactory from 'calypso/lib/user';
 
 export default function () {
-	SiftScience.recordUser();
+	page( '/checkout*', recordSiftScienceUser );
 
 	const user = userFactory();
 	const isLoggedOut = ! user.get();

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -14,7 +14,7 @@ import {
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
-import SiftScience from 'calypso/lib/siftscience';
+import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import config from '@automattic/calypso-config';
 import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -51,7 +51,7 @@ function getCommonHandlers( {
 }
 
 export default function () {
-	SiftScience.recordUser();
+	page( '/domains*', recordSiftScienceUser );
 
 	// These redirects are work-around in response to an issue where navigating back after a
 	// successful site address change shows a continuous placeholder state... #23929 for details.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the SiftScience library to use Redux instead of `lib/user` for retrieving the user. We currently load it when we declare the client-side routes, but don't need to load it that early, so we can include the loader as an Express.js middleware instead.

FWIW I'm happy to move this to any controller file in `client/my-sites` if y'all think it makes more sense than in `client/lib`. 

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go to any route in `/checkout/` or `/domains`
* Verify the SiftScience file is loaded.
* Verify the SiftScience file is not loaded on any other routes.