### PR TITLE
Fix: Reader not showing protocol-relative images

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -55,18 +55,19 @@ const imageShouldBeRemovedFromContent = ( imageUrl ) => {
 	return some( bannedUrlParts, ( part ) => includes( imageUrl.toLowerCase(), part ) );
 };
 
-function forceToHaveProtocol( post, url ) {
+function provideProtocol( post, url ) {
 	const postUrlParts = getUrlParts( post.URL );
 
 	// The image on the relative-protocol URL will have the same protocol with the post
 	if ( url.startsWith( '//' ) ) {
 		return `${ postUrlParts.protocol || 'https:' }${ url }`;
 	}
+
 	return url;
 }
 
 function makeImageSafe( post, image, maxWidth ) {
-	let imgSource = forceToHaveProtocol( post, image.getAttribute( 'src' ) );
+	let imgSource = image.getAttribute( 'src' );
 	const imgSourceParts = getUrlParts( imgSource );
 	const hostName = imgSourceParts.hostname;
 
@@ -83,6 +84,11 @@ function makeImageSafe( post, image, maxWidth ) {
 	let safeSource = maxWidth
 		? maxWidthPhotonishURL( safeImageURL( imgSource ), maxWidth )
 		: safeImageURL( imgSource );
+
+	// When the image URL is not photoned, try providing protocol
+	if ( ! safeSource ) {
+		imgSource = provideProtocol( post, imgSource );
+	}
 
 	// allow https sources through even if we can't make them 'safe'
 	// helps images that use querystring params and are from secure sources

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -55,8 +55,18 @@ const imageShouldBeRemovedFromContent = ( imageUrl ) => {
 	return some( bannedUrlParts, ( part ) => includes( imageUrl.toLowerCase(), part ) );
 };
 
+function forceToHaveProtocol( post, url ) {
+	const postUrlParts = getUrlParts( post.URL );
+
+	// The image on the relative-protocol URL will have the same protocol with the post
+	if ( url.startsWith( '//' ) ) {
+		return `${ postUrlParts.protocol || 'https:' }${ url }`;
+	}
+	return url;
+}
+
 function makeImageSafe( post, image, maxWidth ) {
-	let imgSource = image.getAttribute( 'src' );
+	let imgSource = forceToHaveProtocol( post, image.getAttribute( 'src' ) );
 	const imgSourceParts = getUrlParts( imgSource );
 	const hostName = imgSourceParts.hostname;
 

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -436,6 +436,18 @@ describe( 'index', () => {
 			expect( normalized.content ).toBe( '<img src="//example.wordpress/example.jpg-SAFE">' );
 		} );
 
+		test( 'handles external scheme-relative images with query params', () => {
+			const post = {
+				URL: 'https://example.wordpress.com/2015/01/my-post/',
+				content:
+					'<img src="//example.wp/example.jpg?ad=1&amp;auto=compress&amp;cs=tinysrgb&amp;dpr=2&amp;h=640&amp;w=426">',
+			};
+			const normalized = withContentDOM( [ makeImagesSafe() ] )( post );
+			expect( normalized.content ).toBe(
+				'<img src="https://example.wp/example.jpg?ad=1&amp;auto=compress&amp;cs=tinysrgb&amp;dpr=2&amp;h=640&amp;w=426">'
+			);
+		} );
+
 		test( 'can route all images through photon if a size is specified', () => {
 			const post = {
 				content:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the bug that Reader doesn't display the images with relative protocol URLs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new post.
* Switch to the code editor and paste the following code that contains a protocol relative image.
  ```html
  <!-- wp:image {"sizeSlug":"large"} -->
  <figure class="wp-block-image size-large"><img src="//images.pexels.com/photos/346529/pexels-photo-346529.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=2&amp;h=640&amp;w=426" alt=""/></figure>
  <!-- /wp:image -->
  ```
* Publish it and make sure the image is displayed on the website.
* Check the post in Reader.
* The image should be displayed here too.
  <img width="960" alt="Relative_protocol_image_‹_Taggon_on_wordpress_‹_Reader_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/121042089-4fce5c00-c7ee-11eb-8e80-e098b584a9c3.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #38442
