### PR TITLE
Desktop: Add ability to doubleclick title bar on mac to maximize or unmaximize window

### DIFF
--- a/desktop/app/window-handlers/navigation/index.js
+++ b/desktop/app/window-handlers/navigation/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { ipcMain } = require( 'electron' );
+const { ipcMain, systemPreferences } = require( 'electron' );
 const Config = require( '../../lib/config' );
 const isCalypso = require( '../../lib/is-calypso' );
 const ipc = require( '../../lib/calypso-commands' );
@@ -13,7 +13,7 @@ const webBase = Config.baseURL();
  */
 const log = require( '../../lib/logger' )( 'desktop:navigation' );
 
-module.exports = function ( { view } ) {
+module.exports = function ( { view, window } ) {
 	ipcMain.on( 'back-button-clicked', () => {
 		log.info( `User clicked 'go back'...` );
 		view.webContents.goBack();
@@ -31,5 +31,15 @@ module.exports = function ( { view } ) {
 		} else {
 			view.webContents.loadURL( webBase + 'stats/day' );
 		}
+	} );
+
+	ipcMain.on( 'title-bar-double-click', () => {
+		if ( process.platform === 'darwin' ) {
+			const action = systemPreferences.getUserDefault( 'AppleActionOnDoubleClick', 'string' );
+			if ( action === 'None' ) return;
+			if ( action === 'Minimize' ) return window.minimize();
+		}
+		if ( window.isMaximized() ) return window.unmaximize();
+		return window.maximize();
 	} );
 };

--- a/desktop/app/window-handlers/navigation/index.js
+++ b/desktop/app/window-handlers/navigation/index.js
@@ -33,13 +33,13 @@ module.exports = function ( { view, window } ) {
 		}
 	} );
 
-	ipcMain.on( 'title-bar-double-click', () => {
-		if ( process.platform === 'darwin' ) {
+	if ( process.platform === 'darwin' ) {
+		ipcMain.on( 'title-bar-double-click', () => {
 			const action = systemPreferences.getUserDefault( 'AppleActionOnDoubleClick', 'string' );
 			if ( action === 'None' ) return;
 			if ( action === 'Minimize' ) return window.minimize();
-		}
-		if ( window.isMaximized() ) return window.unmaximize();
-		return window.maximize();
-	} );
+			if ( window.isMaximized() ) return window.unmaximize();
+			return window.maximize();
+		} );
+	}
 };

--- a/desktop/public_desktop/index.html
+++ b/desktop/public_desktop/index.html
@@ -53,6 +53,13 @@
 			</div>
 		</div>
 		<script>
+      function handleDoubleClick() {
+        const titleBar = document.getElementById('title-bar');
+        titleBar.addEventListener('dblclick', function () {
+          window.electron.send('title-bar-double-click');
+        });
+      }
+      handleDoubleClick();
 			function Navigate() {
 				const titleBarButtons = document.getElementById( 'title-bar-buttons' );
 				// Override title bar button padding on window load (Linux, Windows)

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -17,6 +17,7 @@ const sendChannels = [
 	'print',
 	'secrets',
 	'toggle-dev-tools',
+	'title-bar-double-click',
 ];
 
 // Incoming IPC message channels from Main process to Renderer.


### PR DESCRIPTION
### Description

With most apps on Mac if you double click the title bar the window maximizes or unmaximizes. This wasn't happening with the app with the custom titlebar. 
This adds that functionality back so this action works.

### Testing

- Run `yarn run dev` from the desktop folder. 
- Doubleclick the title bar 
- Ensure the window maximizes or unmaximizes as expected.