### PR TITLE
Jetpack Logged-out Checkout: Auto-connect user after checkout.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -229,7 +229,8 @@ export class JetpackAuthorize extends Component {
 			getRoleFromScope( scope ) === 'subscriber' ||
 			this.isJetpackUpgradeFlow() ||
 			this.isFromJetpackConnectionManager() ||
-			this.isFromJetpackBackupPlugin()
+			this.isFromJetpackBackupPlugin() ||
+			this.isJetpackSiteOnlyCheckout()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -258,6 +259,7 @@ export class JetpackAuthorize extends Component {
 		const { alreadyAuthorized, authApproved, from } = this.props.authQuery;
 		return (
 			this.isSso() ||
+			this.isJetpackSiteOnlyCheckout() ||
 			includes( [ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ], from ) || // Auto authorize the old WooCommerce setup wizard only.
 			( ! this.props.isAlreadyOnSitesList &&
 				! alreadyAuthorized &&
@@ -294,6 +296,22 @@ export class JetpackAuthorize extends Component {
 	}
 
 	/**
+	 * Check if the user is coming from the Jetpack site-only checkout flow.
+	 *
+	 * @param  {object}  props           Props to test
+	 * @param  {?string} props.authQuery.redirectAfterAuth Where were we redirected after auth.
+	 * @returns {boolean}                True if the user is coming Jetpack site-only checkout flow, false otherwise.
+	 */
+	isJetpackSiteOnlyCheckout( props = this.props ) {
+		const { redirectAfterAuth } = props.authQuery;
+		return (
+			redirectAfterAuth &&
+			redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' ) &&
+			redirectAfterAuth.includes( 'from=jetpack_site_only_checkout' )
+		);
+	}
+
+	/**
 	 * Check if the user is coming from the Jetpack upgrade flow.
 	 *
 	 * @param  {object}  props           Props to test
@@ -303,7 +321,9 @@ export class JetpackAuthorize extends Component {
 	isJetpackUpgradeFlow( props = this.props ) {
 		const { redirectAfterAuth } = props.authQuery;
 		return (
-			redirectAfterAuth && redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' )
+			redirectAfterAuth &&
+			redirectAfterAuth.includes( 'page=jetpack&action=authorize_redirect' ) &&
+			! redirectAfterAuth.includes( 'from=jetpack_site_only_checkout' )
 		);
 	}
 
@@ -417,7 +437,7 @@ export class JetpackAuthorize extends Component {
 			recordTracksEvent( 'calypso_jpc_try_again_click' );
 			return this.handleResolve();
 		}
-		if ( this.props.isAlreadyOnSitesList ) {
+		if ( this.props.isAlreadyOnSitesList && ! this.isJetpackSiteOnlyCheckout() ) {
 			recordTracksEvent( 'calypso_jpc_return_site_click' );
 			return this.redirect();
 		}
@@ -617,7 +637,7 @@ export class JetpackAuthorize extends Component {
 			return translate( 'Authorizing your connection' );
 		}
 
-		if ( this.props.isAlreadyOnSitesList ) {
+		if ( this.props.isAlreadyOnSitesList && ! this.isJetpackSiteOnlyCheckout() ) {
 			return translate( 'Return to your site' );
 		}
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -933,7 +933,29 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( redirectTo );
 	} );
 
-	it( 'redirects to the jetpack checkout thank you when jetpack checkout arg is set', () => {
+	it( 'redirects to the redirects to the user connection/authorization page when jetpack checkout arg is set and the adminUrl is set', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: 'jetpack_backup_daily',
+				},
+			],
+		};
+		const siteSlug = 'foo.bar';
+		const adminUrl = `https://${ siteSlug }/wp-admin/`;
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			adminUrl,
+			siteSlug,
+			cart,
+			isJetpackCheckout: true,
+		} );
+		expect( url ).toBe(
+			`${ adminUrl }admin.php?page=jetpack&action=authorize_redirect&from=jetpack_site_only_checkout&dest_url=http://wordpress.com/checkout/jetpack/thank-you/${ siteSlug }/${ cart?.products[ 0 ]?.product_slug }`
+		);
+	} );
+
+	it( 'redirects to the jetpack checkout thank you when jetpack checkout arg is set but no adminUrl is defined', () => {
 		const cart = {
 			products: [
 				{

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -933,7 +933,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( redirectTo );
 	} );
 
-	it( 'redirects to the redirects to the user connection/authorization page when jetpack checkout arg is set and the adminUrl is set', () => {
+	it( 'redirects to the user connection/authorization page when jetpack checkout arg is set and the adminUrl is set', () => {
 		const cart = {
 			products: [
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Logged-out Visitor Checkout flow, after the user account is created and the purchase transaction is completed, this PR redirects to the user authorization page (`/jetpack/connect/authorize?client_id=...`) and auto-authorizes the user connection. Once authorization is complete it redirects to the logged-out checkout thank you page (`/checkout/jetpack/thank-you/:site/:product_slug`).

Related to #1200152453830945-as-1200329115728364
Requires Jetpack plugin PR: https://github.com/Automattic/jetpack/pull/20034

Example video:

https://user-images.githubusercontent.com/11078128/121076999-11f91580-c7a5-11eb-9846-057018f88751.mp4



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before testing this PR you'll need to add, `define( 'USE_STORE_SANDBOX', true );` into `/wp-content/mu-plugins/0-sandbox.php` in your sandbox.  And point `public-api.wordpress.com` to your sandbox IP (in your hosts file). This is so we can use checkout with a test credit card. See p1HpG7-c5P-p2 for instructions checking out with a test credit card.

1. Checkout this PR and run in Calypso blue (`yarn start`).
2. Create a Jurassic.ninja site (with options)
    - Include Jetpack Beta plugin
    - Jetpack Branch: `add/site-only-checkout-flag`
3. SSH into the JN site using the `SSH command`, `SSH User`, and `SSH password` listed in the wp-admin dashboard.
4. Navigate to the WordPress root directory (`/apps/user<some user id>/public/`).
5. Edit `wp-config.php` with vim (or whatever your preferred command-line editor is), Add the line: `define( 'CALYPSO_ENV', 'development' );`.
6. Now make sure you are **logged-out** of wordpress.com.
7. Now in the site wp-admin dashboard, click the "Set up Jetpack" button.
8. Next, make sure to click, "Continue without signing in" to initiate Logged out visitor checkout flow.
9. On Jetpack’s Pricing page, click on any Jetpack product.
10. You should now be on the `/checkout/jetpack/...` page.  In the url, change `https://wordpress.com` to `http://calypso.localhost:3000` and press enter.
11. Complete your billing information **entering an email address that is not linked to a WordPress.com account**.
12. Enter the following test credit card data:
    Cardholder name: Test
    Card number: 4242 4242 4242 4242
    Expiry date: 12 / 23
    Security code: 123
13. Click on the Pay $ button to confirm the purchase.
14. Verify that after purchase is completed you are redirected to the user authorization page, auto-authorization takes place, and then you are redirected to the thank-you page. (just like in the video above).

