### PR TITLE
Add new eslint rule for calypos-e2e package: require-jsdoc.

### DIFF
--- a/packages/calypso-e2e/.eslintrc.js
+++ b/packages/calypso-e2e/.eslintrc.js
@@ -6,5 +6,17 @@ module.exports = {
 		// This is a node.js project, it is ok to import node modules
 		'import/no-nodejs-modules': 'off',
 		'no-console': 'off',
+		'require-jsdoc': [
+			'error',
+			{
+				require: {
+					FunctionDeclaration: true,
+					MethodDefinition: true,
+					ClassDeclaration: true,
+					ArrowFunctionExpression: false,
+					FunctionExpression: false,
+				},
+			},
+		],
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a new rule for `@automattic/calypso-e2e` to enforce the use of JSDoc for:
- classes
- functions
- class methods

This aligns with what I believe are the minimum JSDoc requirements for a well-documented codebase.

#### Testing instructions

Try making a function within `calypso-e2e` without a JSDoc and see if it catches.

Related to #51082
