### PR TITLE
Shopping Cart: Re-fetch cart whenever window is focused

### DIFF
--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ShoppingCartProvider, useShoppingCart } from '@automattic/shopping-cart';
 import type { RequestCart, ResponseCart } from '@automattic/shopping-cart';
@@ -32,15 +32,24 @@ export default function CalypsoShoppingCartProvider( {
 	getCart?: ( cartKey: string ) => Promise< ResponseCart >;
 } ): JSX.Element {
 	const selectedSite = useSelector( getSelectedSite );
+	const finalCartKey = cartKey === undefined ? getCartKey( { selectedSite } ) : cartKey;
+
+	const options = useMemo(
+		() => ( {
+			refetchOnWindowFocus: !! finalCartKey,
+		} ),
+		[ finalCartKey ]
+	);
 
 	// If cartKey is null, we pass that to ShoppingCartProvider because it is
 	// probably intentional to delay loading. If cartKey is undefined, we try to
 	// get our own.
 	return (
 		<ShoppingCartProvider
-			cartKey={ cartKey === undefined ? getCartKey( { selectedSite } ) : cartKey }
+			cartKey={ finalCartKey }
 			getCart={ getCart || wpcomGetCart }
 			setCart={ wpcomSetCart }
+			options={ options }
 		>
 			<CalypsoShoppingCartMessages />
 			{ children }

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -15,6 +15,7 @@ It requires three props:
 - `cartKey: string | number | undefined | null`. Every cart is keyed by a cart key; usually this is the WordPress.com site ID (preferred, because it is always unique) or site slug. It can also be `'no-site'` or `'no-user'`. If `undefined` or `null`, the cart will not be loaded and the `isLoading` value will be `true`; this can be used to temporarily disable the cart.
 - `getCart: ( cartKey: string ) => Promise< ResponseCart >`. This is an async function that will fetch the cart from the server.
 - `setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >`. This is an async function that will send an updated cart to the server.
+- `options?: { refetchOnWindowFocus?: boolean }`. Optional. Can be used to trigger `getCart` when the window or tab is hidden and then refocused.
 
 ## useShoppingCart
 

--- a/packages/shopping-cart/src/shopping-cart-provider.tsx
+++ b/packages/shopping-cart/src/shopping-cart-provider.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import type { RequestCart, ResponseCart } from './types';
+import type { RequestCart, ResponseCart, ShoppingCartManagerOptions } from './types';
 import useShoppingCartManager from './use-shopping-cart-manager';
 import ShoppingCartContext from './shopping-cart-context';
 
@@ -14,17 +14,20 @@ export default function ShoppingCartProvider( {
 	cartKey,
 	setCart,
 	getCart,
+	options,
 	children,
 }: {
 	cartKey: string | number | null | undefined;
 	setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
+	options?: ShoppingCartManagerOptions;
 	children: React.ReactNode;
 } ): JSX.Element {
 	const shoppingCartManager = useShoppingCartManager( {
 		cartKey,
 		setCart,
 		getCart,
+		options,
 	} );
 
 	return (

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -16,6 +16,11 @@ export interface ShoppingCartManagerArguments {
 	cartKey: string | number | null | undefined;
 	setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
+	options?: ShoppingCartManagerOptions;
+}
+
+export interface ShoppingCartManagerOptions {
+	refetchOnWindowFocus?: boolean;
 }
 
 export interface ShoppingCartManager {

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import type { CacheStatus, ShoppingCartManagerOptions } from './types';
+
+const debug = debugFactory( 'shopping-cart:use-refetch-on-focus' );
+
+export default function useRefetchOnFocus(
+	options: ShoppingCartManagerOptions,
+	cacheStatus: CacheStatus,
+	refetch: () => void
+): void {
+	useEffect( () => {
+		if ( ! options.refetchOnWindowFocus || cacheStatus !== 'valid' ) {
+			return;
+		}
+
+		function isFocused(): boolean {
+			return [ undefined, 'visible', 'prerender' ].includes( document.visibilityState );
+		}
+
+		function handleFocusChange(): void {
+			if ( ! isFocused() ) {
+				debug( 'window was made invisible; ignoring' );
+				return;
+			}
+
+			debug( 'window was refocused; refetching' );
+			refetch();
+		}
+
+		window.addEventListener( 'visibilitychange', handleFocusChange );
+		window.addEventListener( 'focus', handleFocusChange );
+
+		return () => {
+			window.removeEventListener( 'visibilitychange', handleFocusChange );
+			window.removeEventListener( 'focus', handleFocusChange );
+		};
+	}, [ options.refetchOnWindowFocus, refetch, cacheStatus ] );
+}

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import debugFactory from 'debug';
 
 /**
@@ -25,8 +25,6 @@ export default function useRefetchOnFocus(
 	lastCart: ResponseCart,
 	refetch: () => void
 ): void {
-	const lastRefreshTime = useRef< number >( convertMsToSecs( Date.now() ) );
-
 	useEffect( () => {
 		if ( ! options.refetchOnWindowFocus || cacheStatus !== 'valid' ) {
 			return;
@@ -38,7 +36,8 @@ export default function useRefetchOnFocus(
 
 		function wasLastFetchRecent(): boolean {
 			const nowInSeconds = convertMsToSecs( Date.now() );
-			const secondsSinceLastFetch = nowInSeconds - lastRefreshTime.current;
+			const lastRefreshTime = lastCart.cart_generated_at_timestamp;
+			const secondsSinceLastFetch = nowInSeconds - lastRefreshTime;
 			debug( 'last fetch was', secondsSinceLastFetch, 'seconds ago' );
 			return secondsSinceLastFetch < minimumFetchInterval;
 		}

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -146,9 +146,6 @@ export default function useShoppingCartManager( {
 		[ dispatchAndWaitForValid ]
 	);
 
-	// Refetch when the window is refocused
-	useRefetchOnFocus( options ?? {}, cacheStatus, reloadFromServer );
-
 	const isLoading = cacheStatus === 'fresh' || cacheStatus === 'fresh-pending' || ! cartKey;
 	const loadingErrorForManager = cacheStatus === 'error' ? loadingError : null;
 	const isPendingUpdate =
@@ -162,6 +159,14 @@ export default function useShoppingCartManager( {
 	if ( cacheStatus === 'valid' ) {
 		lastValidResponseCart.current = responseCartWithoutTempProducts;
 	}
+
+	// Refetch when the window is refocused
+	useRefetchOnFocus(
+		options ?? {},
+		cacheStatus,
+		responseCartWithoutTempProducts,
+		reloadFromServer
+	);
 
 	useEffect( () => {
 		if ( cartValidCallbacks.current.length === 0 ) {

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -31,6 +31,7 @@ import useShoppingCartReducer from './use-shopping-cart-reducer';
 import useInitializeCartFromServer from './use-initialize-cart-from-server';
 import useCartUpdateAndRevalidate from './use-cart-update-and-revalidate';
 import { createRequestCartProducts } from './create-request-cart-product';
+import useRefetchOnFocus from './use-refetch-on-focus';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-manager' );
 
@@ -38,6 +39,7 @@ export default function useShoppingCartManager( {
 	cartKey,
 	setCart,
 	getCart,
+	options,
 }: ShoppingCartManagerArguments ): ShoppingCartManager {
 	const setServerCart = useCallback( ( cartParam ) => setCart( String( cartKey ), cartParam ), [
 		cartKey,
@@ -143,6 +145,9 @@ export default function useShoppingCartManager( {
 		() => dispatchAndWaitForValid( { type: 'CART_RELOAD' } ),
 		[ dispatchAndWaitForValid ]
 	);
+
+	// Refetch when the window is refocused
+	useRefetchOnFocus( options ?? {}, cacheStatus, reloadFromServer );
 
 	const isLoading = cacheStatus === 'fresh' || cacheStatus === 'fresh-pending' || ! cartKey;
 	const loadingErrorForManager = cacheStatus === 'error' ? loadingError : null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an experiment based inspired by the [react-query window focus refetch](https://react-query.tanstack.com/guides/window-focus-refetching) feature. This modifies the calypso shopping cart so that it will refetch the cart whenever the window (or tab) is unfocused and then refocused.

The refetch behavior will not trigger if the last fetch was less than 1 minute ago.

#### Testing instructions

- Add a product to your cart and visit checkout in a window or tab; let's call it "tab A".
- Open a second window or tab and load checkout there also; let's call this "tab B".
- In tab B, click to modify the cart in some way. The simplest option is to delete the item in the cart, but you could also change the tax location, change the product variant, or click an upsell.
- Return to tab A and verify that the cart now looks identical to tab B, with the change complete. (You may see the form briefly disable while it is updating, but it can be quite fast.)

NOTE: while you can use devtools to verify that the cart has reloaded, having (at least Chrome) devtools open interferes with the window focus event; changing _tabs_ will still trigger the refetch in this case, but not changing windows.