### PR TITLE
Playwright: migrate domain management for existing site spec.

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -100,3 +100,60 @@ export function createSuiteTitle( title: string ): string {
 
 	return parts.join( ' ' );
 }
+
+/**
+ * Returns a test email address resolving to a real Mailosaur address.
+ *
+ * @param {[key: string]: string} options Object to control the generated email address.
+ * @param {string} options.prefix String prefix to be prepended prior to the global email prefix.
+ * @param {string} options.inboxId String identifier of the Mailosaur inbox.
+ * @returns {string} Email address.
+ */
+export function getTestEmailAddress( options: { prefix: string; inboxId: string } ): string {
+	const domain = 'mailosaur.io';
+	const globalEmailPrefix = config.has( 'emailPrefix' ) ? config.get( 'emailPrefix' ) : '';
+	return `${ globalEmailPrefix }${ options.prefix }.${ options.inboxId }@${ domain }`;
+}
+
+/**
+ * Generate and return a test domain registrar contact information.
+ *
+ * @param {[key: string]: string} options Object to control the generated registrar details.options.
+ * @param {string} options.email Email address to be used for the test domain registrar details.
+ * @returns {[key: string]: string} Object containing generated domain registrar details.
+ */
+export function getTestDomainRegistrarDetails( options: {
+	email: string;
+} ): { [ key: string ]: string } {
+	return {
+		firstName: 'End to End',
+		lastName: 'Testing',
+		emailAddress: options.email,
+		phoneNumber: '0422 888 888',
+		countryCode: 'AU',
+		address: '888 Queen Street',
+		city: 'Brisbane',
+		stateCode: 'QLD',
+		postalCode: '4000',
+	};
+}
+
+/**
+ * Generate and return a test blog name.
+ *
+ * @returns {string} Test blog name.
+ */
+export function getNewBlogName(): string {
+	return `e2eflowtesting${ new Date().getTime().toString() }${ getRandomInt( 100, 999 ) }`;
+}
+
+/**
+ * Returns a pseudo-random integer between the min and max values.
+ *
+ * @param {number} min Minimum value of the bound.
+ * @param {number} max Maximum value of the bound.
+ * @returns {number} Generated pseudo-random number.
+ */
+export function getRandomInt( min: number, max: number ): number {
+	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;
+}

--- a/packages/calypso-e2e/src/lib/components/cart-component.ts
+++ b/packages/calypso-e2e/src/lib/components/cart-component.ts
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+// import assert from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	showCartButton: '.popover-cart',
+	popOver: '.popover',
+	cartItems: '.cart-item',
+	moreItems: '.cart-items__expander',
+};
+
+/**
+ * Component for the Upgrade Shopping Cart.
+ *
+ * @augments {BaseContainer}
+ */
+export class CartComponent extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.showCartButton );
+	}
+
+	async viewCart(): Promise< void > {
+		await this.page.click( selectors.showCartButton );
+		const popOver = await this.page.waitForSelector( selectors.popOver );
+		await popOver.waitForElementState( 'stable' );
+	}
+
+	async removeDomain( name: string ): Promise< void > {
+		const expander = await this.page.$( selectors.moreItems );
+		if ( expander ) {
+			await expander.click();
+		}
+
+		const popOver = await this.page.waitForSelector( selectors.popOver );
+		const items = await popOver.$$( selectors.cartItems );
+		const numItems = items.length;
+
+		for ( const item of items ) {
+			const match = await item.$( `text=${ name }` );
+
+			if ( match ) {
+				console.log( 'match!' );
+				const removeButton = await item.waitForSelector( '.cart__remove-item' );
+				console.log( removeButton );
+
+				await removeButton.click();
+				await popOver.waitForElementState( 'stable' );
+			}
+		}
+
+		if ( numItems === 1 ) {
+			await this.page.waitForSelector( selectors.showCartButton, { state: 'hidden' } );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/domains-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domains-search-component.ts
@@ -1,0 +1,67 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	main: '.domain-search__content',
+	busy: '.is-busy',
+	searchBox: '.register-domain-step__search-card input',
+	suggestionList: '.domain-search-results__domain-suggestions',
+	suggestionPlaceholder: '.is-placeholder',
+	moreResultsButton: '.register-domain-step__next-page-button',
+
+	// G Suite upsell
+	gSuiteCard: '.gsuite-upsell-card__form',
+	gSuiteSkipButton: '.gsuite-upsell-card__skip-button',
+};
+
+/**
+ * Component for domain search and selection.
+ *
+ * @augments {BaseContainer}
+ */
+export class DomainsSearchComponent extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.main );
+	}
+
+	async _postInit(): Promise< void > {
+		await this.page.waitForSelector( selectors.moreResultsButton );
+	}
+
+	async search( name: string ): Promise< void > {
+		await this.page.fill( selectors.searchBox, name );
+		await this.page.waitForSelector( selectors.suggestionPlaceholder, { state: 'detached' } );
+		const element = await this.page.waitForSelector( selectors.moreResultsButton );
+		await element.waitForElementState( 'stable' );
+	}
+
+	async selectByName( name: string ): Promise< void > {
+		await this.page.click( `text=${ name }` );
+	}
+
+	async selectByTld( tld: string ): Promise< void > {
+		if ( tld.charAt( 0 ) !== '.' ) {
+			tld = '.' + tld;
+		}
+
+		const element = await this.page.waitForSelector(
+			`${ selectors.suggestionList }:has-text("${ tld }")`
+		);
+		console.log( await element.innerHTML() );
+		await element.waitForElementState( 'stable' );
+		await element.click();
+		await this.page.waitForSelector( selectors.busy, { state: 'hidden' } );
+	}
+
+	async declineGSuite(): Promise< void > {
+		await this.page.waitForSelector( selectors.gSuiteCard );
+		await this.page.click( selectors.gSuiteSkipButton );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -4,3 +4,5 @@
 export * from './navbar-component';
 export * from './likes-component';
 export * from './sidebar-component';
+export * from './domains-search-component';
+export * from './cart-component';

--- a/packages/calypso-e2e/src/lib/pages/checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/checkout-page.ts
@@ -1,0 +1,114 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	// Page-wide selectors
+	main: '.composite-checkout',
+	loadingIndicator: 'text=Loading checkout',
+	checkoutSteps: '.checkout__step-wrapper',
+	closeButton: '.masterbar__secure-checkout .masterbar__close-button',
+
+	// Contact Information
+	editContactInformationButton: 'button[aria-label="Edit the contact details"]',
+	contactInformationFields: '.contact-details-form-fields',
+	firstName: '#first-name',
+	lastName: '#last-name',
+	email: '#email',
+	phoneCountryOption: '.phone-input__country-select',
+	phoneNumber: 'input[name="phone"]',
+	countryOption: 'select[name=country-code]',
+	addressPrimary: '#address-1',
+	city: '#city',
+	state: 'select[name=state]',
+	postalCode: '#postal-code',
+
+	// Payment
+	paymentMethodsList: '.checkout-payment-methods',
+};
+
+/**
+ * Page representing the Checkout page and its various sections.
+ *
+ * @augments {BaseContainer}
+ */
+export class CheckoutPage extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.main );
+	}
+
+	async _postInit(): Promise< void > {
+		await this.page.waitForSelector( selectors.loadingIndicator, { state: 'hidden' } );
+		await this.page.waitForSelector( selectors.checkoutSteps );
+		await this.page.waitForLoadState( 'networkidle' );
+	}
+
+	async close(): Promise< void > {
+		await this.page.click( selectors.closeButton );
+		await this.page.waitForNavigation();
+	}
+
+	async enterRegistrarDetails( details: {
+		firstName: string;
+		lastName: string;
+		emailAddress: string;
+		phoneNumber: string;
+		countryCode: string;
+		address: string;
+		city: string;
+		stateCode: string;
+		postalCode: string;
+	} ): Promise< void > {
+		await this.page.click( selectors.editContactInformationButton );
+
+		const fields = await this.page.waitForSelector( selectors.contactInformationFields, {
+			state: 'visible',
+		} );
+		await fields.waitForElementState( 'stable' );
+
+		await this.populateContactInformationFields( details );
+
+		await this.page.click( 'text=Continue' );
+		await this.page.waitForSelector( selectors.contactInformationFields, { state: 'hidden' } );
+	}
+
+	async populateContactInformationFields( details: {
+		firstName: string;
+		lastName: string;
+		emailAddress: string;
+		phoneNumber: string;
+		countryCode: string;
+		address: string;
+		city: string;
+		stateCode: string;
+		postalCode: string;
+	} ): Promise< void > {
+		await this.fillField( selectors.firstName, details.firstName );
+		await this.fillField( selectors.lastName, details.lastName );
+		await this.fillField( selectors.email, details.emailAddress );
+		await this.page.selectOption( selectors.phoneCountryOption, details.countryCode );
+		await this.page.selectOption( selectors.countryOption, details.countryCode );
+		await this.fillField( selectors.phoneNumber, details.phoneNumber );
+		await this.fillField( selectors.addressPrimary, details.address );
+		await this.fillField( selectors.city, details.city );
+		await this.page.selectOption( selectors.state, details.stateCode );
+		await this.fillField( selectors.postalCode, details.postalCode );
+	}
+
+	async fillField( selector: string, text: string ): Promise< void > {
+		const field = await this.page.waitForSelector( selector, { state: 'attached' } );
+		await field.waitForElementState( 'stable' );
+		await this.page.fill( selector, '' );
+		await this.page.fill( selector, text );
+	}
+
+	async viewPaymentMethods(): Promise< void > {
+		await this.page.waitForSelector( selectors.paymentMethodsList );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/domains-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/domains-page.ts
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	main: '.main',
+	addDomainButton: '.add-domain-button',
+	targetPopover: '.popover__menu',
+};
+
+/**
+ * Page representing the Upgrades > Domains page.
+ *
+ * @augments {BaseContainer}
+ */
+export class DomainsPage extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.main );
+	}
+
+	async addDomain(
+		options: { target?: 'this site' | 'new site' | 'different site' | 'without a site' } = {}
+	): Promise< void > {
+		await this.page.click( selectors.addDomainButton );
+		await this.page.waitForSelector( selectors.targetPopover );
+		const target = options.target;
+		await this.page.click( `text=${ target }` );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -5,3 +5,5 @@ export * from './login-page';
 export * from './gutenberg-editor-page';
 export * from './my-home-page';
 export * from './marketing-page';
+export * from './domains-page';
+export * from './checkout-page';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -4,6 +4,5 @@
 export * from './login-page';
 export * from './gutenberg-editor-page';
 export * from './my-home-page';
-export * from './marketing-page';
 export * from './domains-page';
 export * from './checkout-page';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -4,5 +4,6 @@
 export * from './login-page';
 export * from './gutenberg-editor-page';
 export * from './my-home-page';
-export * from './domains-page';
+export * from './marketing-page';
 export * from './checkout-page';
+export * from './domains-page';

--- a/test/e2e/specs/specs-playwright/wp-domains__manage-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-domains__manage-spec.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import {
+	DataHelper,
+	BrowserHelper,
+	LoginFlow,
+	SidebarComponent,
+	DomainsPage,
+	DomainsSearchComponent,
+	CheckoutPage,
+	CartComponent,
+} from '@automattic/calypso-e2e';
+
+/**
+ * Constants
+ */
+const host = DataHelper.getJetpackHost();
+const viewportName = BrowserHelper.getViewportName();
+
+describe( `[${ host }] Domains (Manage): (${ viewportName }) @parallel`, function () {
+	describe( 'Add domain to existing site', function () {
+		let domainsSearchComponent;
+		let sidebarComponent;
+		let checkoutPage;
+
+		const siteName = DataHelper.getNewBlogName();
+
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( this.page, 'gutenbergSimpleSiteUser' );
+			await loginFlow.login();
+		} );
+
+		it( 'View domain management', async function () {
+			sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.clickMenuItem( 'Upgrades' );
+			await sidebarComponent.clickMenuItem( 'Domains' );
+		} );
+
+		it( 'Click on add domain to this site', async function () {
+			const domainsPage = await DomainsPage.Expect( this.page );
+			await domainsPage.addDomain( { target: 'this site' } );
+		} );
+
+		it( 'Search for a domain name', async function () {
+			domainsSearchComponent = await DomainsSearchComponent.Expect( this.page );
+			await domainsSearchComponent.search( siteName );
+		} );
+
+		it( 'Choose the .com TLD', async function () {
+			await domainsSearchComponent.selectByTld( '.com' );
+		} );
+
+		it( 'Decline G Suite upsell', async function () {
+			await domainsSearchComponent.declineGSuite();
+		} );
+
+		it( 'Enter domain registration details', async function () {
+			checkoutPage = await CheckoutPage.Expect( this.page );
+			const inboxId = config.get( 'domainsInboxId' );
+			const emailAddress = DataHelper.getTestEmailAddress( { prefix: siteName, inboxId: inboxId } );
+			const registrarDetails = DataHelper.getTestDomainRegistrarDetails( { email: emailAddress } );
+			await checkoutPage.enterRegistrarDetails( registrarDetails );
+		} );
+
+		it( 'See secure payment', async function () {
+			await checkoutPage.viewPaymentMethods();
+		} );
+
+		it( 'Return to domain management', async function () {
+			await checkoutPage.close();
+			await sidebarComponent.clickMenuItem( 'Domains' );
+		} );
+
+		it( 'Remove domain from cart', async function () {
+			await sidebarComponent.clickMenuItem( 'Domains' );
+			const cartComponent = await CartComponent.Expect( this.page );
+			await cartComponent.viewCart();
+			await cartComponent.removeDomain( siteName );
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-domains__manage-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-domains__manage-spec.js
@@ -4,7 +4,6 @@
 import config from 'config';
 import {
 	DataHelper,
-	BrowserHelper,
 	LoginFlow,
 	SidebarComponent,
 	DomainsPage,
@@ -13,13 +12,7 @@ import {
 	CartComponent,
 } from '@automattic/calypso-e2e';
 
-/**
- * Constants
- */
-const host = DataHelper.getJetpackHost();
-const viewportName = BrowserHelper.getViewportName();
-
-describe( `[${ host }] Domains (Manage): (${ viewportName }) @parallel`, function () {
+describe( DataHelper.createSuiteTitle( 'Domains (Management) ' ), function () {
 	describe( 'Add domain to existing site', function () {
 		let domainsSearchComponent;
 		let sidebarComponent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to migrate a subset of the `Domain Management` test to run under Playwright.

To do this, the following necessary components and pages have been implemented:
- cart
- domain search
- checkout page
- domains page

Additional utility functions have been implemented in DataHelper that are mostly carried over from the Selenium counterparts.

#### Testing instructions

CI
- ensure tests pass.

Local
- pull branch
- transpile to JS
- run `mocha --config .mocharc_playwright.yml`

Related to #52849
