### PR TITLE
VAT: add tracks events to details form

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -5,7 +5,6 @@ import React, { useState, useEffect } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { CompactCard, Button, Card } from '@automattic/components';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**
  * Internal dependencies
@@ -22,6 +21,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import type { VatDetails, UpdateError } from './use-vat-details';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 


### PR DESCRIPTION
This adds Tracks events to the VAT details form submission, submission result, and Happiness link click.

Includes #53133, will need to be rebased after it merges.

**To test:**
- Apply D61272-code and sandbox Store and public-api.wordpress.com
- Visit http://calypso.localhost:3000/me/purchases/vat-details
- Run the following in your browser console and refresh the page: `localStorage.setItem('debug', 'calypso:analytics*');`
- Enter the County code UK and the VAT number 1234.
- Submit the form.
- Verify that the `calypso_vat_details_update` event is recorded when the form is submitted 
- Verify that you receive a validation error and that the `calypso_vat_details_validation_failure` event is recorded.
- Enter the County code `UK` and the VAT number `553557881`. (Note: this is a test number that will only work when viewing the form sandboxed).
- Submit the form.
- Verify that the `calypso_vat_details_update` event is recorded when the form is submitted 
- Verify that the validation is successful and that the `calypso_vat_details_validation_success` event is recorded.
- Click the "Contact support" link under the VAT ID field
- Verify that the `calypso_vat_details_support_click` event is recorded