### PR TITLE
Fix addSubscriber/deleteSubscriber REST methods

### DIFF
--- a/client/mailing-lists/utils.js
+++ b/client/mailing-lists/utils.js
@@ -15,14 +15,14 @@ function createSubscriberResourceUrl( category, emailAddress, method ) {
 }
 
 export function deleteSubscriber( category, emailAddress, hmac, context ) {
-	return wpcom.req.post( createSubscriberResourceUrl( category, emailAddress, 'new' ), {
+	return wpcom.req.post( createSubscriberResourceUrl( category, emailAddress, 'delete' ), {
 		hmac,
 		context,
 	} );
 }
 
 export function addSubscriber( category, emailAddress, hmac, context ) {
-	return wpcom.req.post( createSubscriberResourceUrl( category, emailAddress, 'delete' ), {
+	return wpcom.req.post( createSubscriberResourceUrl( category, emailAddress, 'new' ), {
 		hmac,
 		context,
 	} );


### PR DESCRIPTION
Fixes a regression I introduced in #53406: `addSubscriber` called the `/delete` endpoint and `deleteSubscriber` called the `/new` endpoint 🤦 