### PR TITLE
Signup: Use Redux logged in user logic in utils

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -104,7 +104,8 @@ export default class SignupFlowController {
 	_unsubscribeStore?: ReduxUnsubscribe;
 
 	constructor( options: SignupFlowControllerOptions ) {
-		this._flow = flows.getFlow( options.flowName );
+		const userLoggedIn = isUserLoggedIn( options.reduxStore.getState() );
+		this._flow = flows.getFlow( options.flowName, userLoggedIn );
 		this._flowName = options.flowName;
 		this._onComplete = options.onComplete;
 		this._reduxStore = options.reduxStore;
@@ -175,7 +176,8 @@ export default class SignupFlowController {
 
 		const hasStepThatProvidesSiteSlug = ( flowName: string ) => {
 			let foundStepThatProvidesSiteSlug = false;
-			forEach( pick( steps, flows.getFlow( flowName ).steps ), ( step ) => {
+			const userLoggedIn = isUserLoggedIn( this._reduxStore.getState() );
+			forEach( pick( steps, flows.getFlow( flowName, userLoggedIn ).steps ), ( step ) => {
 				if ( ( step.providesDependencies || [] ).indexOf( 'siteSlug' ) > -1 ) {
 					foundStepThatProvidesSiteSlug = true;
 					return false;
@@ -414,8 +416,9 @@ export default class SignupFlowController {
 	}
 
 	changeFlowName( flowName: string ) {
+		const userLoggedIn = isUserLoggedIn( this._reduxStore.getState() );
 		flows.resetExcludedSteps();
 		this._flowName = flowName;
-		this._flow = flows.getFlow( flowName );
+		this._flow = flows.getFlow( flowName, userLoggedIn );
 	}
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -817,7 +817,7 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 		flowName,
 	} = nextProps;
 
-	const flowSteps = flows.getFlow( flowName ).steps;
+	const flowSteps = flows.getFlow( flowName, nextProps.isLoggedIn ).steps;
 	let fulfilledDependencies = [];
 
 	if ( vertical && -1 === flowSteps.indexOf( 'survey' ) ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -8,7 +8,6 @@ import { get, includes, reject } from 'lodash';
  */
 import config from '@automattic/calypso-config';
 import stepConfig from './steps';
-import user from 'calypso/lib/user';
 import { isEcommercePlan } from '@automattic/calypso-products';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -152,9 +151,10 @@ const Flows = {
 	 * The returned flow is modified according to several filters.
 	 *
 	 * @param {string} flowName The name of the flow to return
+	 * @param {boolean} isUserLoggedIn Whether the user is logged in
 	 * @returns {object} A flow object
 	 */
-	getFlow( flowName ) {
+	getFlow( flowName, isUserLoggedIn ) {
 		let flow = Flows.getFlows()[ flowName ];
 
 		// if the flow couldn't be found, return early
@@ -162,11 +162,11 @@ const Flows = {
 			return flow;
 		}
 
-		if ( user() && user().get() ) {
+		if ( isUserLoggedIn ) {
 			flow = removeUserStepFromFlow( flow );
 		}
 
-		if ( flowName === 'p2' && user() && user().get() ) {
+		if ( flowName === 'p2' && isUserLoggedIn ) {
 			flow = removeP2DetailsStepFromFlow( flow );
 		}
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -218,7 +218,7 @@ export default {
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const flowName = getFlowName( context.params, userLoggedIn );
 		const localeFromParams = context.params.lang;
-		const localeFromStore = store.get( 'signup-locale' );
+		const localeFromStore = ! userLoggedIn ? store.get( 'signup-locale' ) : '';
 		const signupProgress = getSignupProgress( context.store.getState() );
 
 		// Special case for the user step which may use oauth2 redirect flow

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -99,7 +99,8 @@ export const removeP2SignupClassName = function () {
 
 export default {
 	redirectTests( context, next ) {
-		const currentFlowName = getFlowName( context.params );
+		const isLoggedIn = isUserLoggedIn( context.store.getState() );
+		const currentFlowName = getFlowName( context.params, isLoggedIn );
 		currentFlowName === 'onboarding' && loadExperimentAssignment( 'refined_reskin_v2' );
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();
@@ -139,7 +140,7 @@ export default {
 			// Planned to be rerun see pbxNRc-xd-p2#comment-1949
 			// Commented out for eslint, to rerun next() has to be placed below this.
 			// const localeFromParams = context.params.lang;
-			// const flowName = getFlowName( context.params );
+			// const flowName = getFlowName( context.params, isLoggedIn );
 			// if (
 			// 	flowName === 'free' &&
 			//  	// Checking for treatment variation previously happened here:
@@ -181,7 +182,7 @@ export default {
 	redirectWithoutLocaleIfLoggedIn( context, next ) {
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		if ( userLoggedIn && context.params.lang ) {
-			const flowName = getFlowName( context.params );
+			const flowName = getFlowName( context.params, userLoggedIn );
 			const stepName = getStepName( context.params );
 			const stepSectionName = getStepSectionName( context.params );
 			let urlWithoutLocale = getStepUrl( flowName, stepName, stepSectionName );
@@ -214,10 +215,10 @@ export default {
 	},
 
 	redirectToFlow( context, next ) {
-		const flowName = getFlowName( context.params );
+		const userLoggedIn = isUserLoggedIn( context.store.getState() );
+		const flowName = getFlowName( context.params, userLoggedIn );
 		const localeFromParams = context.params.lang;
 		const localeFromStore = store.get( 'signup-locale' );
-		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const signupProgress = getSignupProgress( context.store.getState() );
 
 		// Special case for the user step which may use oauth2 redirect flow
@@ -228,7 +229,7 @@ export default {
 			if (
 				alternativeFlowName &&
 				alternativeFlowName !== flowName &&
-				canResumeFlow( alternativeFlowName, signupProgress )
+				canResumeFlow( alternativeFlowName, signupProgress, userLoggedIn )
 			) {
 				window.location =
 					getStepUrl(
@@ -254,7 +255,7 @@ export default {
 
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
-		if ( ! userLoggedIn && shouldForceLogin( flowName ) ) {
+		if ( ! userLoggedIn && shouldForceLogin( flowName, userLoggedIn ) ) {
 			return page.redirect( login( { redirectTo: context.path } ) );
 		}
 
@@ -263,7 +264,7 @@ export default {
 			! userLoggedIn &&
 			! localeFromParams &&
 			localeFromStore &&
-			canResumeFlow( flowName, signupProgress )
+			canResumeFlow( flowName, signupProgress, userLoggedIn )
 		) {
 			window.location =
 				getStepUrl(
@@ -289,8 +290,9 @@ export default {
 	},
 
 	async start( context, next ) {
+		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const basePath = sectionify( context.path );
-		const flowName = getFlowName( context.params );
+		const flowName = getFlowName( context.params, userLoggedIn );
 		const stepName = getStepName( context.params );
 		const stepSectionName = getStepSectionName( context.params );
 
@@ -334,7 +336,7 @@ export default {
 			stepName,
 			stepSectionName,
 			stepComponent,
-			pageTitle: getFlowPageTitle( actualFlowName ),
+			pageTitle: getFlowPageTitle( actualFlowName, userLoggedIn ),
 		} );
 
 		next();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -278,9 +278,10 @@ export default {
 			return;
 		}
 
-		if ( context.pathname !== getValidPath( context.params ) ) {
+		if ( context.pathname !== getValidPath( context.params, userLoggedIn ) ) {
 			return page.redirect(
-				getValidPath( context.params ) + ( context.querystring ? '?' + context.querystring : '' )
+				getValidPath( context.params, userLoggedIn ) +
+					( context.querystring ? '?' + context.querystring : '' )
 			);
 		}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -155,7 +155,7 @@ class Signup extends React.Component {
 	};
 
 	UNSAFE_componentWillMount() {
-		const flow = flows.getFlow( this.props.flowName );
+		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
 		const queryObject = ( this.props.initialContext && this.props.initialContext.query ) || {};
 
 		let providedDependencies;
@@ -192,7 +192,7 @@ class Signup extends React.Component {
 		// a WP.com account during the signup flow.
 		this.completeP2FlowAfterLoggingIn();
 
-		if ( canResumeFlow( this.props.flowName, this.props.progress ) ) {
+		if ( canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) ) {
 			// Resume from the current window location
 			return;
 		}
@@ -200,7 +200,8 @@ class Signup extends React.Component {
 		if ( this.getPositionInFlow() !== 0 ) {
 			// Flow is not resumable; redirect to the beginning of the flow.
 			// Set `resumingStep` to prevent flash of incorrect step before the redirect.
-			const destinationStep = flows.getFlow( this.props.flowName ).steps[ 0 ];
+			const destinationStep = flows.getFlow( this.props.flowName, this.props.isLoggedIn )
+				.steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, this.props.locale ) );
 		}
@@ -337,7 +338,11 @@ class Signup extends React.Component {
 	}
 
 	updateShouldShowLoadingScreen = ( progress = this.props.progress ) => {
-		const hasInvalidSteps = !! getFirstInvalidStep( this.props.flowName, progress );
+		const hasInvalidSteps = !! getFirstInvalidStep(
+			this.props.flowName,
+			progress,
+			this.props.isLoggedIn
+		);
 		const waitingForServer = ! hasInvalidSteps && this.isEveryStepSubmitted( progress );
 		const startLoadingScreen = waitingForServer && ! this.state.shouldShowLoadingScreen;
 
@@ -378,8 +383,8 @@ class Signup extends React.Component {
 	};
 
 	removeFulfilledSteps = ( nextProps ) => {
-		const { flowName, stepName } = nextProps;
-		const flowSteps = flows.getFlow( flowName ).steps;
+		const { flowName, isLoggedIn, stepName } = nextProps;
+		const flowSteps = flows.getFlow( flowName, isLoggedIn ).steps;
 		const excludedSteps = clone( flows.excludedSteps );
 		map( excludedSteps, ( flowStepName ) => this.processFulfilledSteps( flowStepName, nextProps ) );
 		map( flowSteps, ( flowStepName ) => this.processFulfilledSteps( flowStepName, nextProps ) );
@@ -537,7 +542,7 @@ class Signup extends React.Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName ).steps;
+		const flowSteps = flows.getFlow( nextFlowName, this.props.isLoggedIn ).steps;
 		const currentStepIndex = flowSteps.indexOf( this.props.stepName );
 		const nextStepName = flowSteps[ currentStepIndex + 1 ];
 		const nextProgressItem = get( this.props.progress, nextStepName );
@@ -551,7 +556,11 @@ class Signup extends React.Component {
 	};
 
 	goToFirstInvalidStep = ( progress = this.props.progress ) => {
-		const firstInvalidStep = getFirstInvalidStep( this.props.flowName, progress );
+		const firstInvalidStep = getFirstInvalidStep(
+			this.props.flowName,
+			progress,
+			this.props.isLoggedIn
+		);
 
 		if ( firstInvalidStep ) {
 			recordSignupInvalidStep( this.props.flowName, this.props.stepName );
@@ -568,18 +577,22 @@ class Signup extends React.Component {
 	};
 
 	isEveryStepSubmitted = ( progress = this.props.progress ) => {
-		const flowSteps = flows.getFlow( this.props.flowName ).steps;
-		const completedSteps = getCompletedSteps( this.props.flowName, progress );
+		const flowSteps = flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps;
+		const completedSteps = getCompletedSteps(
+			this.props.flowName,
+			progress,
+			this.props.isLoggedIn
+		);
 		return flowSteps.length === completedSteps.length;
 	};
 
 	getPositionInFlow() {
 		const { flowName, stepName } = this.props;
-		return flows.getFlow( flowName ).steps.indexOf( stepName );
+		return flows.getFlow( flowName, this.props.isLoggedIn ).steps.indexOf( stepName );
 	}
 
 	getFlowLength() {
-		return flows.getFlow( this.props.flowName ).steps.length;
+		return flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps.length;
 	}
 
 	renderProcessingScreen( isReskinned ) {
@@ -611,7 +624,7 @@ class Signup extends React.Component {
 			...steps[ this.props.stepName ].props,
 		};
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
-		const flow = flows.getFlow( this.props.flowName );
+		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
 		const planWithDomain =
 			this.props.domainsWithPlansOnly &&
 			domainItem &&
@@ -669,7 +682,7 @@ class Signup extends React.Component {
 
 	shouldWaitToRender() {
 		const isStepRemovedFromFlow = ! includes(
-			flows.getFlow( this.props.flowName ).steps,
+			flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps,
 			this.props.stepName
 		);
 		const isDomainsForSiteEmpty =

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -203,7 +203,8 @@ class Signup extends React.Component {
 			const destinationStep = flows.getFlow( this.props.flowName, this.props.isLoggedIn )
 				.steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
-			return page.redirect( getStepUrl( this.props.flowName, destinationStep, this.props.locale ) );
+			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
+			return page.redirect( getStepUrl( this.props.flowName, destinationStep, undefined, locale ) );
 		}
 
 		this.isReskinned = false;
@@ -532,7 +533,8 @@ class Signup extends React.Component {
 		// redirect the user to the next step
 		scrollPromise.then( () => {
 			if ( ! this.isEveryStepSubmitted() ) {
-				page( getStepUrl( flowName, stepName, stepSectionName, this.props.locale ) );
+				const locale = ! this.props.isLoggedIn ? this.props.locale : '';
+				page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
 			} else if ( this.isEveryStepSubmitted() ) {
 				this.goToFirstInvalidStep();
 			}
@@ -571,8 +573,9 @@ class Signup extends React.Component {
 				return;
 			}
 
+			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			debug( `Navigating to the first invalid step: ${ firstInvalidStep.stepName }` );
-			page( getStepUrl( this.props.flowName, firstInvalidStep.stepName, this.props.locale ) );
+			page( getStepUrl( this.props.flowName, firstInvalidStep.stepName, locale ) );
 		}
 	};
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -86,7 +86,7 @@ export class NavigationLink extends Component {
 			return this.props.backUrl;
 		}
 
-		const { flowName, signupProgress, stepName } = this.props;
+		const { flowName, signupProgress, stepName, userLoggedIn } = this.props;
 		const previousStep = this.getPreviousStep( flowName, signupProgress, stepName );
 
 		const stepSectionName = get(
@@ -95,11 +95,13 @@ export class NavigationLink extends Component {
 			''
 		);
 
+		const locale = ! userLoggedIn ? getLocaleSlug() : '';
+
 		return getStepUrl(
 			previousStep.lastKnownFlow || this.props.flowName,
 			previousStep.stepName,
 			stepSectionName,
-			getLocaleSlug()
+			locale
 		);
 	}
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { getFilteredSteps } from '../utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -48,15 +49,17 @@ export class NavigationLink extends Component {
 	getPreviousStep( flowName, signupProgress, currentStepName ) {
 		const previousStep = { stepName: null };
 
-		if ( isFirstStepInFlow( flowName, currentStepName ) ) {
+		if ( isFirstStepInFlow( flowName, currentStepName, this.props.userLoggedIn ) ) {
 			return previousStep;
 		}
 
 		//Progressed steps will be filtered and sorted in relation to the steps definition of the current flow
 		//Skipped steps are also filtered out
-		const filteredProgressedSteps = getFilteredSteps( flowName, signupProgress ).filter(
-			( step ) => ! step.wasSkipped
-		);
+		const filteredProgressedSteps = getFilteredSteps(
+			flowName,
+			signupProgress,
+			this.props.userLoggedIn
+		).filter( ( step ) => ! step.wasSkipped );
 		if ( filteredProgressedSteps.length === 0 ) {
 			return previousStep;
 		}
@@ -182,6 +185,7 @@ export class NavigationLink extends Component {
 
 export default connect(
 	( state ) => ( {
+		userLoggedIn: isUserLoggedIn( state ),
 		signupProgress: getSignupProgress( state ),
 	} ),
 	{ recordTracksEvent, submitSignupStep }

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -86,7 +86,10 @@ describe( 'NavigationLink', () => {
 	test( 'should set a proper url as href prop when the direction is "back".', () => {
 		expect( getStepUrl ).not.toHaveBeenCalled();
 
-		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
+		const wrapper = shallow(
+			// We're mocking a logged-out user to ensure locale is being considered
+			<NavigationLink { ...props } userLoggedIn={ false } direction="back" />
+		);
 
 		// It should call getStepUrl()
 		expect( getStepUrl ).toHaveBeenCalled();

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -36,6 +36,7 @@ describe( 'NavigationLink', () => {
 		submitSignupStep: noop,
 		goToNextStep: jest.fn(),
 		translate: ( str ) => `translated:${ str }`,
+		userLoggedIn: true,
 	};
 
 	beforeEach( () => {
@@ -124,7 +125,7 @@ describe( 'NavigationLink', () => {
 	} );
 
 	test( 'getPreviousStep() When in 2nd step should return 1st step', () => {
-		const navigationLink = new NavigationLink();
+		const navigationLink = new NavigationLink( props );
 		const { flowName, signupProgress, stepName } = props;
 		getPreviousStepName.mockReturnValue( 'test:step1' );
 		const previousStep = navigationLink.getPreviousStep( flowName, signupProgress, stepName );
@@ -132,7 +133,7 @@ describe( 'NavigationLink', () => {
 	} );
 
 	test( 'getPreviousStep() When in 1st step should return nullish step', () => {
-		const navigationLink = new NavigationLink();
+		const navigationLink = new NavigationLink( props );
 		const { flowName, signupProgress } = props;
 		isFirstStepInFlow.mockReturnValue( true );
 		const previousStep = navigationLink.getPreviousStep( flowName, signupProgress, 'test:step1' );
@@ -140,7 +141,7 @@ describe( 'NavigationLink', () => {
 	} );
 
 	test( 'getPreviousStep() When in 3rd step should return 2nd step', () => {
-		const navigationLink = new NavigationLink();
+		const navigationLink = new NavigationLink( props );
 		const { flowName, signupProgress } = props;
 		getPreviousStepName.mockReturnValue( 'test:step2' );
 		isFirstStepInFlow.mockReturnValue( false );
@@ -149,7 +150,7 @@ describe( 'NavigationLink', () => {
 	} );
 
 	test( 'getPreviousStep() When current steps is unknown, step should return last step in progress which belong to the current flow', () => {
-		const navigationLink = new NavigationLink();
+		const navigationLink = new NavigationLink( props );
 		const { flowName, signupProgress } = props;
 
 		const singupProgressWithSomeStepsThatDoNotBelongToThisFlow = {
@@ -175,7 +176,7 @@ describe( 'NavigationLink', () => {
 	} );
 
 	test( 'getPreviousStep() When current progress does not contain any step of the current flow return nullish step', () => {
-		const navigationLink = new NavigationLink();
+		const navigationLink = new NavigationLink( props );
 		const { flowName } = props;
 
 		const singupProgressWithOnlyStepsThatDoNotBelongToThisFlow = {
@@ -206,7 +207,7 @@ describe( 'NavigationLink', () => {
 
 	test( 'getPreviousStep() When there are skipped steps they should be ignored', () => {
 		const { flowName, signupProgress } = props;
-		const navigationLink = new NavigationLink();
+		const navigationLink = new NavigationLink( props );
 		const stepsWithSkippedSteps = {
 			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
 			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: true },

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -59,6 +59,7 @@ import { getStepModuleName } from 'calypso/signup/config/step-components';
 import { getExternalBackUrl } from './utils';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -174,12 +175,16 @@ class DomainsStep extends React.Component {
 		return this.showTestCopy;
 	}
 
+	getLocale() {
+		return ! this.props.userLoggedIn ? this.props.locale : '';
+	}
+
 	getMapDomainUrl = () => {
-		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
+		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.getLocale() );
 	};
 
 	getTransferDomainUrl = () => {
-		return getStepUrl( this.props.flowName, this.props.stepName, 'transfer', this.props.locale );
+		return getStepUrl( this.props.flowName, this.props.stepName, 'transfer', this.getLocale() );
 	};
 
 	getUseYourDomainUrl = () => {
@@ -187,7 +192,7 @@ class DomainsStep extends React.Component {
 			this.props.flowName,
 			this.props.stepName,
 			'use-your-domain',
-			this.props.locale
+			this.getLocale()
 		);
 	};
 
@@ -748,22 +753,18 @@ class DomainsStep extends React.Component {
 			return null;
 		}
 
-		const { flowName, isAllDomains, translate, sites, isReskinned } = this.props;
+		const { flowName, isAllDomains, translate, sites, isReskinned, userLoggedIn } = this.props;
 		const source = get( this.props, 'queryObject.source' );
 		const hasSite = Object.keys( sites ).length > 0;
 		let backUrl;
 		let backLabelText;
 		let isExternalBackUrl;
+		const locale = ! userLoggedIn ? getLocaleSlug() : '';
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
-			backUrl = getStepUrl(
-				this.props.flowName,
-				this.props.stepName,
-				'use-your-domain',
-				getLocaleSlug()
-			);
+			backUrl = getStepUrl( this.props.flowName, this.props.stepName, 'use-your-domain', locale );
 		} else if ( this.props.stepSectionName ) {
-			backUrl = getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() );
+			backUrl = getStepUrl( this.props.flowName, this.props.stepName, undefined, locale );
 		} else if ( 0 === this.props.positionInFlow && hasSite ) {
 			backUrl = '/sites/';
 			backLabelText = translate( 'Back to My Sites' );
@@ -866,6 +867,7 @@ export default connect(
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			sites: getSitesItems( state ),
 			isPlanStepSkipped: isPlanStepExistsAndSkipped( state ),
+			userLoggedIn: isUserLoggedIn( state ),
 		};
 	},
 	{

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -21,6 +21,7 @@ import FormTextInputWithAction from 'calypso/components/forms/form-text-input-wi
 import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -114,8 +115,9 @@ class SurveyStep extends React.Component {
 			'To get started, tell us what your blog or website is about.'
 		);
 
+		const locale = ! this.props.userLoggedIn ? this.props.locale : '';
 		const backUrl = this.props.stepSectionName
-			? getStepUrl( this.props.flowName, this.props.stepName, undefined, this.props.locale )
+			? getStepUrl( this.props.flowName, this.props.stepName, undefined, locale )
 			: undefined;
 
 		return (
@@ -142,7 +144,8 @@ class SurveyStep extends React.Component {
 	};
 
 	handleOther = () => {
-		page( getStepUrl( this.props.flowName, this.props.stepName, 'other', this.props.locale ) );
+		const locale = ! this.props.userLoggedIn ? this.props.locale : '';
+		page( getStepUrl( this.props.flowName, this.props.stepName, 'other', locale ) );
 	};
 
 	handleVerticalOther = ( otherTextValue ) => {
@@ -188,6 +191,7 @@ class SurveyStep extends React.Component {
 
 export default connect(
 	( state ) => ( {
+		userLoggedIn: isUserLoggedIn( state ),
 		signupProgress: getSignupProgress( state ),
 	} ),
 	{ setSurvey, submitSignupStep }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -40,6 +40,7 @@ import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/compone
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { login } from 'calypso/lib/paths';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -92,7 +93,7 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
+		if ( flows.getFlow( this.props.flowName, this.props.userLoggedIn )?.showRecaptcha ) {
 			this.initGoogleRecaptcha();
 		}
 
@@ -123,7 +124,7 @@ export class UserStep extends Component {
 	}
 
 	setSubHeaderText( props ) {
-		const { flowName, oauth2Client, positionInFlow, translate, wccomFrom } = props;
+		const { flowName, oauth2Client, positionInFlow, translate, userLoggedIn, wccomFrom } = props;
 
 		let subHeaderText = props.subHeaderText;
 
@@ -173,7 +174,7 @@ export class UserStep extends Component {
 					}
 				);
 			}
-		} else if ( 1 === getFlowSteps( flowName ).length ) {
+		} else if ( 1 === getFlowSteps( flowName, userLoggedIn ).length ) {
 			// Displays specific sub header if users only want to create an account, without a site
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
 		}
@@ -271,7 +272,7 @@ export class UserStep extends Component {
 		let recaptchaDidntLoad = false;
 		let recaptchaFailed = false;
 
-		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
+		if ( flows.getFlow( this.props.flowName, this.props.userLoggedIn )?.showRecaptcha ) {
 			if ( isRecaptchaLoaded ) {
 				recaptchaToken = await recordGoogleRecaptchaAction(
 					this.state.recaptchaClientId,
@@ -399,8 +400,8 @@ export class UserStep extends Component {
 		}
 
 		const stepAfterRedirect =
-			getNextStepName( this.props.flowName, this.props.stepName ) ||
-			getPreviousStepName( this.props.flowName, this.props.stepName );
+			getNextStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn ) ||
+			getPreviousStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn );
 		const queryArgs = new URLSearchParams( this.props?.initialContext?.query );
 		const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
 
@@ -460,7 +461,9 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					showRecaptchaToS={ flows.getFlow( this.props.flowName )?.showRecaptcha }
+					showRecaptchaToS={
+						flows.getFlow( this.props.flowName, this.props.userLoggedIn )?.showRecaptcha
+					}
 					horizontal={ isReskinned }
 					isReskinned={ isReskinned }
 				/>
@@ -490,6 +493,7 @@ export default connect(
 		suggestedUsername: getSuggestedUsername( state ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		from: get( getCurrentQueryArguments( state ), 'from' ),
+		userLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{
 		errorNotice,

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -13,17 +13,10 @@ import sinon from 'sinon';
  */
 import mockedFlows from './fixtures/flows';
 import flows from 'calypso/signup/config/flows';
-import userFactory from 'calypso/lib/user';
-
-jest.mock( 'calypso/lib/user', () => require( './mocks/lib/user' ) );
 
 describe( 'Signup Flows Configuration', () => {
 	describe( 'getFlow', () => {
-		let user;
-
 		beforeAll( () => {
-			user = userFactory();
-
 			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
 		} );
 
@@ -32,13 +25,11 @@ describe( 'Signup Flows Configuration', () => {
 		} );
 
 		test( 'should return the full flow when the user is not logged in', () => {
-			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user', 'site' ] );
+			assert.deepEqual( flows.getFlow( 'main', false ).steps, [ 'user', 'site' ] );
 		} );
 
 		test( 'should remove the user step from the flow when the user is logged in', () => {
-			user.setLoggedIn( true );
-			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'site' ] );
-			user.setLoggedIn( false );
+			assert.deepEqual( flows.getFlow( 'main', true ).steps, [ 'site' ] );
 		} );
 	} );
 
@@ -54,7 +45,7 @@ describe( 'Signup Flows Configuration', () => {
 
 		test( 'should exclude site step from getFlow', () => {
 			flows.excludeStep( 'site' );
-			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user' ] );
+			assert.deepEqual( flows.getFlow( 'main', false ).steps, [ 'user' ] );
 		} );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -17,22 +17,22 @@ function getDefaultFlowName() {
 	return defaultFlowName;
 }
 
-export function getFlowName( parameters ) {
-	return parameters.flowName && isFlowName( parameters.flowName )
+export function getFlowName( parameters, isUserLoggedIn ) {
+	return parameters.flowName && isFlowName( parameters.flowName, isUserLoggedIn )
 		? parameters.flowName
 		: getDefaultFlowName();
 }
 
-function isFlowName( pathFragment ) {
-	return ! isEmpty( flows.getFlow( pathFragment ) );
+function isFlowName( pathFragment, isUserLoggedIn ) {
+	return ! isEmpty( flows.getFlow( pathFragment, isUserLoggedIn ) );
 }
 
 export function getStepName( parameters ) {
 	return find( pick( parameters, [ 'flowName', 'stepName' ] ), isStepName );
 }
 
-export function isFirstStepInFlow( flowName, stepName ) {
-	const { steps: stepsBelongingToFlow } = flows.getFlow( flowName );
+export function isFirstStepInFlow( flowName, stepName, isUserLoggedIn ) {
+	const { steps: stepsBelongingToFlow } = flows.getFlow( flowName, isUserLoggedIn );
 	return stepsBelongingToFlow.indexOf( stepName ) === 0;
 }
 
@@ -65,10 +65,10 @@ export function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 	return '/start' + flow + step + section + locale;
 }
 
-export function getValidPath( parameters ) {
+export function getValidPath( parameters, isUserLoggedIn ) {
 	const locale = parameters.lang;
-	const flowName = getFlowName( parameters );
-	const currentFlowSteps = flows.getFlow( flowName ).steps;
+	const flowName = getFlowName( parameters, isUserLoggedIn );
+	const currentFlowSteps = flows.getFlow( flowName, isUserLoggedIn ).steps;
 	const stepName = getStepName( parameters ) || currentFlowSteps[ 0 ];
 	const stepSectionName = getStepSectionName( parameters );
 
@@ -79,23 +79,23 @@ export function getValidPath( parameters ) {
 	return getStepUrl( flowName, stepName, stepSectionName, locale );
 }
 
-export function getPreviousStepName( flowName, currentStepName ) {
-	const flow = flows.getFlow( flowName );
+export function getPreviousStepName( flowName, currentStepName, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
 	return flow.steps[ flow.steps.indexOf( currentStepName ) - 1 ];
 }
 
-export function getNextStepName( flowName, currentStepName ) {
-	const flow = flows.getFlow( flowName );
+export function getNextStepName( flowName, currentStepName, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
 	return flow.steps[ flow.steps.indexOf( currentStepName ) + 1 ];
 }
 
-export function getFlowSteps( flowName ) {
-	const flow = flows.getFlow( flowName );
+export function getFlowSteps( flowName, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
 	return flow.steps;
 }
 
-export function getFlowPageTitle( flowName ) {
-	const flow = flows.getFlow( flowName );
+export function getFlowPageTitle( flowName, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
 	return flow.pageTitle || translate( 'Create a site' );
 }
 
@@ -168,8 +168,8 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 	return 'blog';
 }
 
-export function getFilteredSteps( flowName, progress ) {
-	const flow = flows.getFlow( flowName );
+export function getFilteredSteps( flowName, progress, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
 
 	if ( ! flow ) {
 		return [];
@@ -183,35 +183,40 @@ export function getFilteredSteps( flowName, progress ) {
 	);
 }
 
-export function getFirstInvalidStep( flowName, progress ) {
-	return find( getFilteredSteps( flowName, progress ), { status: 'invalid' } );
+export function getFirstInvalidStep( flowName, progress, isUserLoggedIn ) {
+	return find( getFilteredSteps( flowName, progress, isUserLoggedIn ), { status: 'invalid' } );
 }
 
-export function getCompletedSteps( flowName, progress, options = {} ) {
+export function getCompletedSteps( flowName, progress, options = {}, isUserLoggedIn ) {
 	// Option to check that the current `flowName` matches the `lastKnownFlow`.
 	// This is to ensure that when resuming progress, we only do so if
 	// the last known flow matches the one that the user is returning to.
 	if ( options.shouldMatchFlowName ) {
 		return filter(
-			getFilteredSteps( flowName, progress ),
+			getFilteredSteps( flowName, progress, isUserLoggedIn ),
 			( step ) => 'in-progress' !== step.status && step.lastKnownFlow === flowName
 		);
 	}
 	return filter(
-		getFilteredSteps( flowName, progress ),
+		getFilteredSteps( flowName, progress, isUserLoggedIn ),
 		( step ) => 'in-progress' !== step.status
 	);
 }
 
-export function canResumeFlow( flowName, progress ) {
-	const flow = flows.getFlow( flowName );
-	const flowStepsInProgressStore = getCompletedSteps( flowName, progress, {
-		shouldMatchFlowName: true,
-	} );
+export function canResumeFlow( flowName, progress, isUserLoggedIn ) {
+	const flow = flows.getFlow( flowName, isUserLoggedIn );
+	const flowStepsInProgressStore = getCompletedSteps(
+		flowName,
+		progress,
+		{
+			shouldMatchFlowName: true,
+		},
+		isUserLoggedIn
+	);
 	return flowStepsInProgressStore.length > 0 && ! flow.disallowResume;
 }
 
-export const shouldForceLogin = ( flowName ) => {
-	const flow = flows.getFlow( flowName );
+export const shouldForceLogin = ( flowName, userLoggedIn ) => {
+	const flow = flows.getFlow( flowName, userLoggedIn );
 	return !! flow && flow.forceLogin;
 };

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -9,7 +9,6 @@ import { translate } from 'i18n-calypso';
  */
 import steps from 'calypso/signup/config/steps-pure';
 import flows from 'calypso/signup/config/flows';
-import user from 'calypso/lib/user';
 
 const { defaultFlowName } = flows;
 
@@ -52,10 +51,7 @@ export function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 	const flow = flowName ? `/${ flowName }` : '';
 	const step = stepName ? `/${ stepName }` : '';
 	const section = stepSectionName ? `/${ stepSectionName }` : '';
-	// when the user is logged in, the locale slug is meaningless in a
-	// signup URL, as the page will be translated in the language the user
-	// has in their settings.
-	const locale = localeSlug && ! user().get() ? `/${ localeSlug }` : '';
+	const locale = localeSlug ? `/${ localeSlug }` : '';
 
 	if ( flowName === defaultFlowName ) {
 		// we don't include the default flow name in the route


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, some of the signup utils require knowing whether the user is logged in or not, and are using `lib/user` for that. However, since we're reduxifying `lib/user`, we have to pass down that information (whether the user is logged in) as an extra argument to all those functions. That also helps to keep those utility functions pure.

Note: we're treating `getStepUrl` separately - it doesn't really need to contain the user locale logic inside it (locale should also be considered if the user is logged out), so we're moving out that logic and keeping the method simpler and independent from any current user information.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Ensure that any of those utility functions that rely on the user is properly passing that as an argument everywhere.
* Besides that, I don't have a specific list of testing instructions, due to the fact that there are multiple chains of steps where these functions are used in. I was hoping folks from @Automattic/martech-decepticons could assist with reviewing and testing it. Essentially, doing some smoke testing in various flows of the signup steps and ensuring everything still works well should be enough. Thanks a bunch 🙇‍♂️ 