### PR TITLE
Purchase Product: Refactor to use Redux user

### DIFF
--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import Debug from 'debug';
+import page from 'page';
 import { get, some } from 'lodash';
 
 /**
@@ -13,6 +14,8 @@ import config from '@automattic/calypso-config';
 import SearchPurchase from './search';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { ALLOWED_MOBILE_APP_REDIRECT_URL_LIST } from '../../jetpack-connect/constants';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { login } from 'calypso/lib/paths';
 import {
 	persistMobileRedirect,
 	retrieveMobileRedirect,
@@ -48,6 +51,17 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 
 	return get( planSlugs, [ interval, type ], '' );
 };
+
+export function redirectToLogin( context, next ) {
+	const loggedIn = isUserLoggedIn( context.store.getState() );
+
+	if ( ! loggedIn ) {
+		page( login( { isJetpack: true, redirectTo: context.path } ) );
+		return;
+	}
+
+	next();
+}
 
 export function persistMobileAppFlow( context, next ) {
 	const { query } = context;

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -6,9 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import userFactory from 'calypso/lib/user';
 import * as controller from './controller';
-import { login } from 'calypso/lib/paths';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 
 /**
@@ -17,22 +15,13 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import '../../jetpack-connect/style.scss';
 
 export default function () {
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
-
-	if ( isLoggedOut ) {
-		page(
-			'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
-			( { path } ) => page( login( { isJetpack: true, redirectTo: path } ) )
-		);
-	} else {
-		page(
-			'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
-			controller.persistMobileAppFlow,
-			controller.setMasterbar,
-			controller.purchase,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
+		controller.redirectToLogin,
+		controller.persistMobileAppFlow,
+		controller.setMasterbar,
+		controller.purchase,
+		makeLayout,
+		clientRender
+	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `purchase-product` section to use Redux for current user instead of `lib/user`.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Make sure you're logged out of WP.com
* Go to `/purchase-product/jetpack_search`
* Verify you're redirected to the Jetpack login page and the `redirect_to` query arg is preserved: `/log-in/jetpack?redirect_to=%2Fpurchase-product%2Fjetpack_search`
* Log into WP.com.
* Go to `/purchase-product/jetpack_search`
* Verify you're presented with the Jetpack Connect flow to input the site URL to install Jetpack Search.