### PR TITLE
Checkout: Use Redux to check for logged in user

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -29,7 +29,10 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
-import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserVisibleSiteCount,
+	isUserLoggedIn,
+} from 'calypso/state/current-user/selectors';
 import {
 	retrieveSignupDestination,
 	setSignupCheckoutPageUnloaded,
@@ -47,11 +50,10 @@ const debug = debugFactory( 'calypso:checkout-controller' );
 export function checkout( context, next ) {
 	const { feature, plan, purchaseId } = context.params;
 
-	const isLoggedOut = ! isUserLoggedIn( context.store.getState() );
 	const state = context.store.getState();
+	const isLoggedOut = ! isUserLoggedIn( state );
 	const selectedSite = getSelectedSite( state );
-	const currentUser = getCurrentUser( state );
-	const hasSite = currentUser && currentUser.visible_site_count >= 1;
+	const hasSite = getCurrentUserVisibleSiteCount( state ) >= 1;
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 	const isDisallowedForSitePicker =
 		context.pathname.includes( '/checkout/no-site' ) &&

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -29,8 +29,7 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
-import userFactory from 'calypso/lib/user';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	retrieveSignupDestination,
 	setSignupCheckoutPageUnloaded,
@@ -48,8 +47,7 @@ const debug = debugFactory( 'calypso:checkout-controller' );
 export function checkout( context, next ) {
 	const { feature, plan, purchaseId } = context.params;
 
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
+	const isLoggedOut = ! isUserLoggedIn( context.store.getState() );
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 	const currentUser = getCurrentUser( state );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the checkout controller to use Redux for checking whether the user is logged out. The change is pretty straightforward, as the Redux store is already available in that context.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify that checkout still works the same way when tested as a logged-out user and logged-in user.