### PR TITLE
Checkout: Remove unnecessary `lib/user` mock from `getThankYouPageUrl`

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -16,13 +16,6 @@ import {
 } from '@automattic/calypso-products';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
-let mockGSuiteCountryIsValid = true;
-jest.mock( 'calypso/lib/user', () =>
-	jest.fn( () => ( {
-		get: () => ( { is_valid_google_apps_country: mockGSuiteCountryIsValid } ),
-	} ) )
-);
-
 jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud', () => jest.fn() );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),
@@ -662,7 +655,6 @@ describe( 'getThankYouPageUrl', () => {
 				},
 			],
 		};
-		mockGSuiteCountryIsValid = true;
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -685,7 +677,6 @@ describe( 'getThankYouPageUrl', () => {
 				},
 			],
 		};
-		mockGSuiteCountryIsValid = false;
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -708,7 +699,6 @@ describe( 'getThankYouPageUrl', () => {
 				},
 			],
 		};
-		mockGSuiteCountryIsValid = false;
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
@@ -730,7 +720,6 @@ describe( 'getThankYouPageUrl', () => {
 				},
 			],
 		};
-		mockGSuiteCountryIsValid = false;
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the tests of `getThankYouPageUrl` we're currently mocking `lib/user` but that doesn't seem to be necessary. This PR removes that mock.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify unit tests pass: 

```
yarn run test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
```