### PR TITLE
Framework: Remove `userUtils.getLocaleSlug()`

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -56,10 +56,6 @@ const userUtils = {
 			} );
 	},
 
-	getLocaleSlug() {
-		return user().get().localeSlug;
-	},
-
 	isLoggedIn() {
 		return Boolean( user().data );
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes `userUtils.getLocaleSlug()` from `lib/user` as it's unused. This is not a huge win, but since we have other ways of retrieving the current user locale, removing this will ensure that we're using them instead of this legacy one.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify the removed function is not in use.