### PR TITLE
Login: Add send me a login link to the password validation message

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -47,7 +47,7 @@ import {
 	isFormDisabled as isFormDisabledSelector,
 } from 'calypso/state/login/selectors';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { getSignupUrl } from 'calypso/lib/login';
+import { canDoMagicLogin, getSignupUrl, getLoginLinkPageUrl } from 'calypso/lib/login';
 import { isRegularAccount } from 'calypso/state/login/utils';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -448,6 +448,36 @@ export class LoginForm extends Component {
 		);
 	}
 
+	renderMagicLoginLink() {
+		if (
+			! canDoMagicLogin(
+				this.props.twoFactorAuthType,
+				this.props.oauth2Client,
+				this.props.wccomFrom,
+				this.props.isJetpackWooCommerceFlow
+			)
+		) {
+			return null;
+		}
+
+		return this.props.translate(
+			' Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
+			{
+				components: {
+					magicLoginLink: (
+						<a
+							href={ getLoginLinkPageUrl(
+								this.props.locale,
+								this.props.currentRoute,
+								this.props.isGutenboarding
+							) }
+						/>
+					),
+				},
+			}
+		);
+	}
+
 	render() {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 
@@ -578,7 +608,6 @@ export class LoginForm extends Component {
 							} ) }
 						>
 							<FormLabel htmlFor="password">{ this.props.translate( 'Password' ) }</FormLabel>
-
 							<FormPasswordInput
 								autoCapitalize="off"
 								autoComplete="current-password"
@@ -593,9 +622,10 @@ export class LoginForm extends Component {
 								disabled={ isFormDisabled }
 								tabIndex={ isPasswordHidden ? -1 : undefined /* not tabbable when hidden */ }
 							/>
-
 							{ requestError && requestError.field === 'password' && (
-								<FormInputValidation isError text={ requestError.message } />
+								<FormInputValidation isError text={ requestError.message }>
+									{ this.renderMagicLoginLink() }
+								</FormInputValidation>
 							) }
 						</div>
 					</div>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -461,7 +461,7 @@ export class LoginForm extends Component {
 		}
 
 		return this.props.translate(
-			' Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
+			'Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
 			{
 				components: {
 					magicLoginLink: (

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -460,8 +460,9 @@ export class LoginForm extends Component {
 			return null;
 		}
 
+		// The leading space is NO typo! It's added since the first part of the validation message (originating from the BE) contains no trailing space.
 		return this.props.translate(
-			'Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
+			' Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
 			{
 				components: {
 					magicLoginLink: (

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -14,6 +14,7 @@ import {
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import { login } from 'calypso/lib/paths';
 
 export function getSocialServiceFromClientId( clientId ) {
 	if ( ! clientId ) {
@@ -123,3 +124,44 @@ export function getSignupUrl(
 
 	return signupUrl;
 }
+
+export const getLoginLinkPageUrl = ( locale, currentRoute, isGutenboarding ) => {
+	const loginParameters = {
+		locale,
+		twoFactorAuthType: 'link',
+	};
+
+	if ( currentRoute === '/login-in/jetpack' ) {
+		loginParameters.twoFactorAuthType = 'jetpack/link';
+	} else if ( isGutenboarding ) {
+		loginParameters.twoFactorAuthType = 'new/link';
+	}
+
+	return login( loginParameters );
+};
+
+export const canDoMagicLogin = (
+	twoFactorAuthType,
+	oauth2Client,
+	wccomFrom,
+	isJetpackWooCommerceFlow
+) => {
+	if ( ! config.isEnabled( `login/magic-login` ) || twoFactorAuthType ) {
+		return false;
+	}
+
+	// jetpack cloud cannot have users being sent to WordPress.com
+	if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+		return false;
+	}
+
+	if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+		return false;
+	}
+
+	if ( isJetpackWooCommerceFlow ) {
+		return false;
+	}
+
+	return true;
+};

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -125,13 +125,13 @@ export function getSignupUrl(
 	return signupUrl;
 }
 
-export const getLoginLinkPageUrl = ( locale, currentRoute, isGutenboarding ) => {
+export const getLoginLinkPageUrl = ( locale = 'en', currentRoute, isGutenboarding ) => {
 	const loginParameters = {
 		locale,
 		twoFactorAuthType: 'link',
 	};
 
-	if ( currentRoute === '/login-in/jetpack' ) {
+	if ( currentRoute === '/log-in/jetpack' ) {
 		loginParameters.twoFactorAuthType = 'jetpack/link';
 	} else if ( isGutenboarding ) {
 		loginParameters.twoFactorAuthType = 'new/link';

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -1,0 +1,171 @@
+/**
+ * Internal dependencies
+ */
+import {
+	canDoMagicLogin,
+	getLoginLinkPageUrl,
+	getSignupUrl,
+	getSocialServiceFromClientId,
+} from '..';
+import { login } from 'calypso/lib/paths';
+import config from '@automattic/calypso-config';
+
+jest.mock( 'calypso/lib/paths' );
+jest.mock( '@automattic/calypso-config', () => {
+	const defaultExport = jest.fn();
+	defaultExport.isEnabled = jest.fn();
+	defaultExport.default = jest.fn();
+	return defaultExport;
+} );
+
+const MOCK_LOCALE = 'en';
+const MOCK_TWO_FACTOR_AUTH_TYPE = {
+	default: 'link',
+	jetpack: 'jetpack/link',
+	gutenboarding: 'new/link',
+};
+const MOCK_CURRENT_ROUTES = { jetpack: '/log-in/jetpack', start: '/log-in' };
+const MOCK_OAUTH_CLIENT = { default: { id: 12345 }, jetpack: { id: 68663 }, woo: { id: 50019 } };
+const MOCK_WCCOM_FROM = 'testing';
+
+const MOCK_CALYPSO_CONFIGS = {
+	default: 99999,
+	google_oauth_client_id: 11111,
+	facebook_app_id: 22222,
+	apple_oauth_client_id: 33333,
+	signup_url: '/start',
+};
+
+const MOCK_CURRENT_QUERY = {
+	redirect_to: '/start/domains',
+};
+
+describe( 'login', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'getSignupUrl', () => {
+		beforeEach( () => {
+			config.mockImplementation( ( key ) => MOCK_CALYPSO_CONFIGS[ key ] );
+		} );
+
+		it( 'should return the proper signup url with /start', () => {
+			const expected = getSignupUrl(
+				MOCK_CURRENT_QUERY,
+				MOCK_CURRENT_ROUTES.start,
+				null,
+				MOCK_LOCALE,
+				undefined,
+				false
+			);
+			expect( expected ).toBe( '/start' );
+		} );
+	} );
+
+	describe( 'getSocialServiceFromClientId', () => {
+		beforeEach( () => {
+			config.mockImplementation( ( key ) => MOCK_CALYPSO_CONFIGS[ key ] );
+		} );
+
+		it( 'should return null when no client id is provided', () => {
+			expect( getSocialServiceFromClientId( undefined ) ).toBeNull();
+		} );
+
+		it( 'should return null when no client id matches', () => {
+			expect( getSocialServiceFromClientId( MOCK_CALYPSO_CONFIGS.default ) ).toBeNull();
+		} );
+
+		it( 'should return google when client id matches', () => {
+			expect( getSocialServiceFromClientId( MOCK_CALYPSO_CONFIGS.google_oauth_client_id ) ).toBe(
+				'google'
+			);
+		} );
+
+		it( 'should return facebook when client id matches', () => {
+			expect( getSocialServiceFromClientId( MOCK_CALYPSO_CONFIGS.facebook_app_id ) ).toBe(
+				'facebook'
+			);
+		} );
+
+		it( 'should return apple when client id matches', () => {
+			expect( getSocialServiceFromClientId( MOCK_CALYPSO_CONFIGS.apple_oauth_client_id ) ).toBe(
+				'apple'
+			);
+		} );
+	} );
+
+	describe( 'getLoginLinkPageUrl', () => {
+		it( 'should fallback to default when no locale is provided', () => {
+			getLoginLinkPageUrl();
+
+			expect( login ).toHaveBeenCalledWith( {
+				locale: MOCK_LOCALE,
+				twoFactorAuthType: MOCK_TWO_FACTOR_AUTH_TYPE.default,
+			} );
+		} );
+
+		it( 'should set the right locale', () => {
+			const expected = {
+				locale: MOCK_LOCALE,
+				twoFactorAuthType: MOCK_TWO_FACTOR_AUTH_TYPE.default,
+			};
+			getLoginLinkPageUrl( MOCK_LOCALE );
+			expect( login ).toHaveBeenCalledWith( expected );
+		} );
+
+		it( 'should set the correct 2fa type for Jetpack', () => {
+			const expected = {
+				locale: MOCK_LOCALE,
+				twoFactorAuthType: MOCK_TWO_FACTOR_AUTH_TYPE.jetpack,
+			};
+
+			getLoginLinkPageUrl( MOCK_LOCALE, MOCK_CURRENT_ROUTES.jetpack );
+			expect( login ).toHaveBeenCalledWith( expected );
+		} );
+
+		it( 'should set the correct 2fa type for Gutenboarding', () => {
+			const expected = {
+				locale: MOCK_LOCALE,
+				twoFactorAuthType: MOCK_TWO_FACTOR_AUTH_TYPE.gutenboarding,
+			};
+
+			getLoginLinkPageUrl( MOCK_LOCALE, undefined, true );
+			expect( login ).toHaveBeenCalledWith( expected );
+		} );
+	} );
+
+	describe( 'canDoMagicLogin', () => {
+		beforeEach( () => {
+			config.isEnabled.mockImplementation( () => true );
+		} );
+
+		it( 'should do magic login', () => {
+			expect( canDoMagicLogin( undefined, undefined, false, false ) ).toBeTruthy();
+		} );
+
+		it( 'should not do magic login when disabled or when a 2fa type is defined', () => {
+			config.isEnabled.mockImplementation( () => false );
+
+			expect( canDoMagicLogin( undefined, undefined, false, false ) ).toBeFalsy();
+
+			expect(
+				canDoMagicLogin( MOCK_TWO_FACTOR_AUTH_TYPE.default, undefined, false, false )
+			).toBeFalsy();
+		} );
+
+		it( 'should not do magic login while on Jetpack Cloud', () => {
+			expect( canDoMagicLogin( undefined, MOCK_OAUTH_CLIENT.jetpack, false, false ) ).toBeFalsy();
+		} );
+
+		it( 'should not do magic login while Woo 2fa is enabled', () => {
+			expect(
+				canDoMagicLogin( undefined, MOCK_OAUTH_CLIENT.woo, MOCK_WCCOM_FROM, false )
+			).toBeFalsy();
+		} );
+
+		it( 'should not do magic login if Jetpack WooCommerce Flow', () => {
+			expect( canDoMagicLogin( undefined, undefined, undefined, true ) ).toBeFalsy();
+		} );
+	} );
+} );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -6,7 +6,7 @@ import {
 	getLoginLinkPageUrl,
 	getSignupUrl,
 	getSocialServiceFromClientId,
-} from '..';
+} from 'calypso/lib/login';
 import { login } from 'calypso/lib/paths';
 import config from '@automattic/calypso-config';
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -9,20 +9,10 @@ import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
-<<<<<<< HEAD
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
-import { getSignupUrl, getLoginLinkPageUrl } from 'calypso/lib/login';
-import {
-	isCrowdsignalOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isWooOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
-import { login, lostPassword } from 'calypso/lib/paths';
-=======
 import { getSignupUrl, getLoginLinkPageUrl, canDoMagicLogin } from 'calypso/lib/login';
 import { isCrowdsignalOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { getUrlParts } from '@automattic/calypso-url';
->>>>>>> 00d97f7d99 (Update rendering logic for magic login link)
+import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -214,7 +214,7 @@ export class LoginLinks extends React.Component {
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 			>
-				{ this.props.translate( 'Email me a login link, Stefan' ) }
+				{ this.props.translate( 'Email me a login link' ) }
 			</a>
 		);
 	}

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
+<<<<<<< HEAD
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 import { getSignupUrl, getLoginLinkPageUrl } from 'calypso/lib/login';
 import {
@@ -17,6 +18,11 @@ import {
 	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
+=======
+import { getSignupUrl, getLoginLinkPageUrl, canDoMagicLogin } from 'calypso/lib/login';
+import { isCrowdsignalOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { getUrlParts } from '@automattic/calypso-url';
+>>>>>>> 00d97f7d99 (Update rendering logic for magic login link)
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -180,24 +186,18 @@ export class LoginLinks extends React.Component {
 	}
 
 	renderMagicLoginLink() {
-		if ( ! config.isEnabled( 'login/magic-login' ) || this.props.twoFactorAuthType ) {
+		if (
+			! canDoMagicLogin(
+				this.props.twoFactorAuthType,
+				this.props.oauth2Client,
+				this.props.wccomFrom,
+				this.props.isJetpackWooCommerceFlow
+			)
+		) {
 			return null;
 		}
 
 		if ( this.props.isLoggedIn ) {
-			return null;
-		}
-
-		// jetpack cloud cannot have users being sent to WordPress.com
-		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
-			return null;
-		}
-
-		// @todo Implement a muriel version of the email login links for the WooCommerce onboarding flows
-		if ( isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom ) {
-			return null;
-		}
-		if ( this.props.isJetpackWooCommerceFlow ) {
 			return null;
 		}
 
@@ -214,7 +214,7 @@ export class LoginLinks extends React.Component {
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 			>
-				{ this.props.translate( 'Email me a login link' ) }
+				{ this.props.translate( 'Email me a login link, Stefan' ) }
 			</a>
 		);
 	}

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -10,7 +10,7 @@ import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
-import { getSignupUrl } from 'calypso/lib/login';
+import { getSignupUrl, getLoginLinkPageUrl } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
@@ -92,25 +92,6 @@ export class LoginLinks extends React.Component {
 
 	recordSignUpLinkClick = () => {
 		this.props.recordTracksEvent( 'calypso_login_sign_up_link_click' );
-	};
-
-	getLoginLinkPageUrl = () => {
-		// The email address from the URL (if present) is added to the login
-		// parameters in this.handleMagicLoginLinkClick(). But it's left out
-		// here deliberately, to ensure that if someone copies this link to
-		// paste somewhere else, their email address isn't included in it.
-		const loginParameters = {
-			locale: this.props.locale,
-			twoFactorAuthType: 'link',
-		};
-
-		if ( this.props.currentRoute === '/log-in/jetpack' ) {
-			loginParameters.twoFactorAuthType = 'jetpack/link';
-		} else if ( this.props.isGutenboarding ) {
-			loginParameters.twoFactorAuthType = 'new/link';
-		}
-
-		return login( loginParameters );
 	};
 
 	renderBackLink() {
@@ -229,7 +210,7 @@ export class LoginLinks extends React.Component {
 				// A simpler solution would have been to add rel=external or
 				// rel=download, but it would have been semantically wrong.
 				ref={ this.loginLinkRef }
-				href={ this.getLoginLinkPageUrl() }
+				href={ getLoginLinkPageUrl() }
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 			>


### PR DESCRIPTION
Note from @escapemanuele on 2023-10-19: We will work on this PR to get it up to date, and check if it is still useful.


### Changes proposed in this Pull Request

Adding a login link to the password validation message to improve the user experience for the login page.

#### Translator notes
> Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?

When a user provides the wrong password, a validation message is shown. The to-be-translated copy is part of it (see screenshot).

<img width="547" alt="Screenshot 2021-07-13 at 11 05 05" src="https://user-images.githubusercontent.com/12104589/125424423-798ce33d-8dbe-44bd-80f2-1ed5b552fbca.png">


#### Technical changes
* `canDoMagicLogin`: Util to validate if the magic login link is allowed to be sent.
* `getLoginLinkPageUrl`: Util to generate a magic login link.
* `renderMagicLoginLink`: Method to render the magic login link in the validation message.

### Testing instructions
1. Check out this branch and `yarn && yarn start`.
2. Apply D62486-code to your sandbox.
3. Make sure that public-api.wordpress.com is proxied.
4. Go to `/log-in`
5. Enter an existing username/email address and click on "continue".
6. Enter a wrong password deliberately.
7. Confirm that:
    * [ ] The validation message copy is updated to _"Oops, that's not the right password. Would you like to receive a login link?"_
    * [ ] Clicking on the link redirects to the _email-me-a-login-link_ view.

Related to #53379