### PR TITLE
Block Editor Tracking: Fix innerBlocksReplace tracking

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -289,14 +289,14 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 	// because the template part or reusable block just loaded.
 	const parentBlock = select( 'core/block-editor' ).getBlocksByClientId( rootClientId )?.[ 0 ];
 	if ( parentBlock ) {
-		const { name, innerBlocks } = parentBlock;
+		const { name } = parentBlock;
 		const isAsyncLoadedEntityBlock =
 			// Template Part
 			name === 'core/template-part' ||
 			// Reusable Block
 			name === 'core/block';
+		const innerBlocks = select( 'core/block-editor' ).getBlocks( rootClientId );
 		const hasInnerBlocks = innerBlocks.length > 0;
-
 		if ( isAsyncLoadedEntityBlock && ! hasInnerBlocks ) {
 			return;
 		}

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -293,7 +293,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		const isAsyncLoadedEntityBlock =
 			// Template Part
 			name === 'core/template-part' ||
-			// Reusable BLock
+			// Reusable Block
 			name === 'core/block';
 		const hasInnerBlocks = innerBlocks.length > 0;
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -286,17 +286,17 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		reusable blocks for the following reasons:
 
 		1. Template Parts and Reusable Blocks are asynchronously loaded blocks.
-		Content is fetched from the REST API so the inner blocks are
-		populated when the response is received. We want to ignore
-		`replaceInnerBlocks` action calls when the `innerBlocks` are replaced
-		because the template part or reusable block just loaded.
+		   Content is fetched from the REST API so the inner blocks are
+		   populated when the response is received. We want to ignore
+		   `replaceInnerBlocks` action calls when the `innerBlocks` are replaced
+		   because the template part or reusable block just loaded.
 
-		2. Having multiple instances of the same template part or resuable block
-		and making edits to a single instance will cause all the other instances
-		to update via `replaceInnerBlocks`.
+		2. Having multiple instances of the same template part or reusable block
+		   and making edits to a single instance will cause all the other instances
+		   to update via `replaceInnerBlocks`.
 
-		3. Perfoming and undo or redo related to template parts or reusable blocks
-		will update the instances via `replaceInnerBlocks`. 
+		3. Performing undo or redo related to template parts and reusable blocks
+		   will update the instances via `replaceInnerBlocks`. 
 	*/
 	const parentBlock = select( 'core/block-editor' ).getBlocksByClientId( rootClientId )?.[ 0 ];
 	if ( parentBlock ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reusable Block and Template Parts are loaded asynchronously from the REST API. When they are loaded, then all the blocks from the API response are inserted by using `replaceInnerBlocks`. This causes the `trackInnerBlockReplacement` to track all these block replacements. Which is giving us totally false tracking 😄  

Any changes made to the underlying template part or reusable block entity will result in a `replaceInnerBlocks`.
These changes will result in a `replaceInnerBlocksCall`:
* any undo or redo related to template parts and reusable blocks
* having multiple instances of a template part or reusable block and making an edit to a single instance
* template part and reusable block loading for the first time

We want to ignore all of these and as far as we know, there are no other use-case that's relying on `replaceInnerBlocks`. So we are safe to ingore them.

Related code for template part inner blocks syncing: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js

Related code for reusable block inner blocks syncing: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/provider/use-block-sync.js

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2

**Reusable Block**

* Create a new Post
* Add any block
* Convert it to a reusable block
* Save and Refresh page
* Make sure `replaceInnerBlocks` is called (you will see that in the console), but no events are recorded
  * `trunk` branch:
![image](https://user-images.githubusercontent.com/2256104/121326735-1cd1b880-c913-11eb-894c-07242b071454.png)

  * this branch:
![image](https://user-images.githubusercontent.com/2256104/121326851-383cc380-c913-11eb-92a6-1b9626dbb45b.png)


**Template Part**
* Open site editor
* Insert template parts if you don't have any
* Make sure you have blocks inside the template parts
* Save and Refresh page
* Make sure `replaceInnerBlocks` is called for each template part (you will see that in the console), but no events are recorded


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes  #53413 
