### PR TITLE
Signup: Hide username input and use the email identifier for the hint

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -458,11 +458,8 @@ class SignupForm extends Component {
 
 	getUserNameHint() {
 		const email = formState.getFieldValue( this.state.form, 'email' );
-		const firstName = formState.getFieldValue( this.state.form, 'firstName' );
-		const lastName = formState.getFieldValue( this.state.form, 'lastName' );
-
 		const emailIdentifier = email.match( /^(.*?)@/ );
-		return ( emailIdentifier && emailIdentifier[ 1 ] ) || `${ firstName }.${ lastName }`;
+		return emailIdentifier && emailIdentifier[ 1 ];
 	}
 
 	getUserData() {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -113,7 +113,7 @@ class SignupForm extends Component {
 
 	static defaultProps = {
 		displayNameInput: false,
-		displayUsernameInput: true,
+		displayUsernameInput: false,
 		flowName: '',
 		isSocialSignupEnabled: false,
 		showRecaptchaToS: false,
@@ -456,20 +456,38 @@ class SignupForm extends Component {
 		);
 	}
 
-	getUserData() {
-		const extraFields = {
-			extra: {
-				first_name: formState.getFieldValue( this.state.form, 'firstName' ),
-				last_name: formState.getFieldValue( this.state.form, 'lastName' ),
-			},
-		};
+	getUserNameHint() {
+		const email = formState.getFieldValue( this.state.form, 'email' );
+		const firstName = formState.getFieldValue( this.state.form, 'firstName' );
+		const lastName = formState.getFieldValue( this.state.form, 'lastName' );
 
-		return {
-			username: formState.getFieldValue( this.state.form, 'username' ),
+		const emailIdentifier = email.match( /^(.*?)@/ );
+		return ( emailIdentifier && emailIdentifier[ 1 ] ) || `${ firstName }.${ lastName }`;
+	}
+
+	getUserData() {
+		const userData = {
 			password: formState.getFieldValue( this.state.form, 'password' ),
 			email: formState.getFieldValue( this.state.form, 'email' ),
-			...( this.props.displayNameInput && extraFields ),
 		};
+
+		if ( this.props.displayNameInput ) {
+			userData.extra = {
+				first_name: formState.getFieldValue( this.state.form, 'firstName' ),
+				last_name: formState.getFieldValue( this.state.form, 'lastName' ),
+			};
+		}
+
+		if ( this.props.displayUsernameInput ) {
+			userData.username = formState.getFieldValue( this.state.form, 'username' );
+		} else {
+			userData.extra = {
+				...userData.extra,
+				username_hint: this.getUserNameHint(),
+			};
+		}
+
+		return userData;
 	}
 
 	getErrorMessagesWithLogin( fieldName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the username field and uses the email identifier (the part before @) as a hint.

#### Testing instructions

1. In incognito, go to https://calypso.live/start/user?branch=update/hide-username-input
2. Enable 3rd party cookies.
3. Sign up using some email and password (you can use your personal email suffixed by `+something`).
4. The account should be created and your username should be inspired by your email address. You can see your username here: https://calypso.live/me?branch=update/hide-username-input. 

#### Screenshots

- **Before**
<img width="418" alt="Screenshot 1" src="https://user-images.githubusercontent.com/14192054/121898206-d245a700-cd2b-11eb-9fd5-3e3e2191a876.png">

- **After**
<img width="418" alt="Screenshot 2" src="https://user-images.githubusercontent.com/14192054/121898043-a62a2600-cd2b-11eb-81e7-39764ba0272a.png">


Implements the first A/C from https://github.com/Automattic/wp-calypso/issues/52852.
Closes https://github.com/Automattic/wp-calypso/issues/22419