### PR TITLE
Plans: Use IntersectionObserver to control PlansFilterBar stickiness

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
@@ -43,10 +43,6 @@ type DiscountMessageProps = {
 	toggleChecked?: boolean;
 };
 
-const CLOUD_MASTERBAR_STICKY = false;
-const CALYPSO_MASTERBAR_HEIGHT = 47;
-const CLOUD_MASTERBAR_HEIGHT = CLOUD_MASTERBAR_STICKY ? 94 : 0;
-
 const DiscountMessage: React.FC< DiscountMessageProps > = ( { toggleChecked } ) => {
 	const translate = useTranslate();
 	const isMobile: boolean = useMobileBreakpoint();
@@ -94,16 +90,20 @@ const PlansFilterBar: React.FC< FilterBarProps > = ( {
 	onDurationChange,
 } ) => {
 	const translate = useTranslate();
-	const isInConnectStore = useMemo( isConnectStore, [] );
-	const isInJetpackCloud = useMemo( isJetpackCloud, [] );
-	const windowBoundaryOffset =
-		isInJetpackCloud || isInConnectStore ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
+
+	const CALYPSO_MASTERBAR_HEIGHT = 47;
+	const CLOUD_MASTERBAR_HEIGHT = 0;
+
+	const windowBoundaryOffset = useMemo( () => {
+		if ( isJetpackCloud() || isConnectStore() ) {
+			return CLOUD_MASTERBAR_HEIGHT;
+		}
+
+		return CALYPSO_MASTERBAR_HEIGHT;
+	}, [] );
 	const [ barRef, hasCrossed ] = useDetectWindowBoundary( windowBoundaryOffset );
 
-	const [ durationChecked, setDurationChecked ] = useState(
-		duration === TERM_ANNUALLY ? true : false
-	);
-
+	const [ durationChecked, setDurationChecked ] = useState( duration === TERM_ANNUALLY );
 	useEffect( () => {
 		const selectedDuration = durationChecked ? TERM_ANNUALLY : TERM_MONTHLY;
 		onDurationChange?.( selectedDuration );

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/index.tsx
@@ -110,26 +110,35 @@ const PlansFilterBar: React.FC< FilterBarProps > = ( {
 	}, [ onDurationChange, durationChecked ] );
 
 	return (
-		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>
-			<div className="plans-filter-bar__duration-toggle-wrapper">
-				<div
-					className={ classNames( 'plans-filter-bar__duration-toggle', {
-						checked: durationChecked,
-					} ) }
-				>
-					<span className="plans-filter-bar__toggle-off-label">
-						{ translate( 'Bill monthly' ) }
-					</span>
-					<ToggleControl
-						className="plans-filter-bar__toggle-control"
-						checked={ durationChecked }
-						onChange={ () => setDurationChecked( ( prevState ) => ! prevState ) }
-					/>
-					<span className="plans-filter-bar__toggle-on-label">{ translate( 'Bill yearly' ) }</span>
+		<>
+			<div className="plans-filter-bar__viewport-sentinel" ref={ barRef }></div>
+			<div
+				className={ classNames( 'plans-filter-bar', {
+					sticky: hasCrossed,
+				} ) }
+			>
+				<div className="plans-filter-bar__duration-toggle-wrapper">
+					<div
+						className={ classNames( 'plans-filter-bar__duration-toggle', {
+							checked: durationChecked,
+						} ) }
+					>
+						<span className="plans-filter-bar__toggle-off-label">
+							{ translate( 'Bill monthly' ) }
+						</span>
+						<ToggleControl
+							className="plans-filter-bar__toggle-control"
+							checked={ durationChecked }
+							onChange={ () => setDurationChecked( ( prevState ) => ! prevState ) }
+						/>
+						<span className="plans-filter-bar__toggle-on-label">
+							{ translate( 'Bill yearly' ) }
+						</span>
+					</div>
+					{ showDiscountMessage && <DiscountMessage toggleChecked={ durationChecked } /> }
 				</div>
-				{ showDiscountMessage && <DiscountMessage toggleChecked={ durationChecked } /> }
 			</div>
-		</div>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/use-detect-window-boundary.ts
+++ b/client/my-sites/plans/jetpack-plans/use-detect-window-boundary.ts
@@ -48,7 +48,7 @@ const useDetectWindowBoundary = (
 		// intersection ratio becomes 1.0 (fully visible), or
 		// when it becomes less than 1.0 (not fully visible)
 		observerRef.current = new IntersectionObserver( handler, {
-			rootMargin: `-${ offsetY }px 0px 0px 0px`,
+			rootMargin: `${ -1 * offsetY }px 0px 0px 0px`,
 			threshold: [ 1 ],
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `useDetectWindowBoundary` to use `IntersectionObserver` instead of `onscroll`, to minimize CPU usage on less performant devices.
* Add more documentation to more thoroughly explain what `useDetectWindowBoundary` does.
* Combine logic to determine the height of the masterbar into one self-contained `useMemo` call.

#### Testing instructions

**NOTE:** Please test the following in all combinations, to account for changes to masterbar behavior at the top of the page:

* Calypso Blue and Calypso Green
* Mobile and desktop screens
* Logged in and not logged in

1. Visit the Plans/Pricing page.
2. Scroll up and down the page, verifying that the monthly/yearly billing toggle "sticks" to the top of the page as it scrolls out of view. Once fully in view, it should return to being a static element on the page. For more, see the attached animation or try out these test instructions in production (behavior should be identical).

#### Reference screenshot

![Kapture 2021-06-08 at 12 13 59](https://user-images.githubusercontent.com/670067/121228994-0b28dc00-c853-11eb-9cf4-55758b0bf039.gif)