### PR TITLE
Playwright: additional unit tests for calypso-e2e module.

### DIFF
--- a/packages/calypso-e2e/__mocks__/config.js
+++ b/packages/calypso-e2e/__mocks__/config.js
@@ -28,6 +28,10 @@ const values = {
 			height: 790,
 		},
 	},
+	calypsoBaseURL: 'https://wordpress.com',
+	testAccounts: {
+		basicUser: [ 'wpcomuser', 'hunter2', 'wpcomuser.wordpress.com' ],
+	},
 };
 
 /**

--- a/packages/calypso-e2e/__mocks__/config.js
+++ b/packages/calypso-e2e/__mocks__/config.js
@@ -31,6 +31,8 @@ const values = {
 	calypsoBaseURL: 'https://wordpress.com',
 	testAccounts: {
 		basicUser: [ 'wpcomuser', 'hunter2', 'wpcomuser.wordpress.com' ],
+		advancedUser: [ 'advancedwpcomuser', 'azurediamond', 'advancedwpcomuser.wordpress.com' ],
+		noURLUser: [ 'nourluser', 'password1234' ],
 	},
 };
 

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -23,7 +23,8 @@
 		"@types/config": "^0.0.38",
 		"@types/jest": "^25.2.3",
 		"@types/node": "^15.0.2",
-		"asana-phrase": "^0.0.8"
+		"asana-phrase": "^0.0.8",
+		"mockdate": "^3.0.5"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -93,7 +93,7 @@ export function toTitleCase( words: string[] | string ): string {
 	}
 
 	const result = words.map( function ( word ) {
-		return word.charAt( 0 ).toUpperCase() + word.slice( 1 ).toLowerCase();
+		return word.charAt( 0 ).toUpperCase() + word.slice( 1 );
 	} );
 
 	return result.join( ' ' );

--- a/packages/calypso-e2e/src/hooks/recording.ts
+++ b/packages/calypso-e2e/src/hooks/recording.ts
@@ -7,7 +7,7 @@ import { Context } from 'mocha';
 /**
  * Internal dependencies
  */
-import { getVideoName } from '../media-helper';
+import { getFileName } from '../media-helper';
 
 /**
  * Clears the list of failed tests for a suite.
@@ -63,7 +63,7 @@ export async function saveVideo( this: Context ): Promise< void > {
 		await this.page.video().delete();
 	} else {
 		const original = await this.page.video().path();
-		const custom = getVideoName( this.failedTest[ 0 ] );
+		const custom = getFileName( { name: this.failedTest[ 0 ], type: 'video' } );
 		try {
 			await fs.rename( original, custom );
 		} catch ( err ) {

--- a/packages/calypso-e2e/src/hooks/screenshot.ts
+++ b/packages/calypso-e2e/src/hooks/screenshot.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getScreenshotName } from '../media-helper';
+import { getFileName } from '../media-helper';
 
 /**
  * Type dependencies
@@ -33,5 +33,6 @@ export async function saveScreenshot( this: Context ): Promise< void > {
 		return;
 	}
 
-	await page.screenshot( { path: getScreenshotName( test.title ) } );
+	const path = getFileName( { name: test.title, type: 'screenshot' } );
+	await page.screenshot( { path: path } );
 }

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -48,35 +48,40 @@ export function getVideoDir(): string {
 }
 
 /**
- * Returns a descriptive file name for the screenshot file.
+ * Returns a descriptive file name for the requested artifact type.
  *
- * @param {string} name Name of the test case that failed.
+ * @param {{[key: string]: string}} param0 Object assembled by the caller.
+ * @param {string} param0.name Name of the test suite or step that failed.
+ * @param {string} param0.type Target type of the file name.
  * @returns {string} A Path-like string.
+ * @throws {Error} If target type is not one of supported types.
  */
-export function getScreenshotName( name: string ): string {
-	const shortTestFileName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	const screenSize = getViewportName().toUpperCase();
-	const locale = getLocale().toUpperCase();
-	const date = getDateString();
-	const fileName = `FAILED-${ locale }-${ screenSize }-${ shortTestFileName }-${ date }`;
-	const screenshotDir = getScreenshotDir();
-	return `${ screenshotDir }/${ fileName }.png`;
-}
-
-/**
- * Returns a descriptive file name for video recording file.
- *
- * @param {string} name Name of the suite and test case that failed.
- * @returns {string} A Path-like string.
- */
-export function getVideoName( name: string ): string {
+export function getFileName( {
+	name,
+	type,
+}: {
+	name: string;
+	type: 'video' | 'screenshot';
+} ): string {
 	const suiteName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
+	const viewportName = getViewportName().toUpperCase();
 	const locale = getLocale().toUpperCase();
-	const screenSize = getViewportName().toUpperCase();
 	const date = getDateString();
-	const fileName = `FAILED-${ locale }-${ screenSize }-${ suiteName }-${ date }`;
-	const videoDir = getVideoDir();
-	return `${ videoDir }/${ fileName }.webm`;
+	const fileName = `FAILED-${ locale }-${ viewportName }-${ suiteName }-${ date }`;
+
+	let dir;
+	let extension;
+
+	if ( type.toLowerCase() === 'screenshot' ) {
+		dir = getScreenshotDir();
+		extension = 'png';
+	} else if ( type.toLowerCase() === 'video' ) {
+		dir = getVideoDir();
+		extension = 'webm';
+	} else {
+		throw new Error( `Unsupported type specified, received ${ type }` );
+	}
+	return `${ dir }/${ fileName }.${ extension }`;
 }
 
 /**

--- a/packages/calypso-e2e/test/browser-helper.test.ts
+++ b/packages/calypso-e2e/test/browser-helper.test.ts
@@ -27,6 +27,7 @@ describe( 'BrowserHelper Tests', function () {
 			${ 'dEsKtoP' }               | ${ 'desktop' }
 			${ 'non_existent_viewport' } | ${ 'non_existent_viewport' }
 			${ 'TEST_ENV' }              | ${ 'test_env' }
+			${ '"mobile"' }              | ${ '"mobile"' }
 		`(
 			'Returns $expected when environment variable is set to $env_var',
 			function ( { env_var, expected } ) {
@@ -85,6 +86,7 @@ describe( 'BrowserHelper Tests', function () {
 			${ 'unsupported_viewport' }
 			${ 'desktop_variant' }
 			${ 'm0bile' }
+			${ '"desktop"' }
 		`( 'Throws error when environment variable is set to $env_var', function ( { env_var } ) {
 			process.env.VIEWPORT_NAME = env_var;
 			expect( () => getViewportSize() ).toThrow();

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -69,7 +69,7 @@ describe( 'DataHelper Tests', function () {
 		test.each`
 			accountType             | expected
 			${ 'nonexistent_user' } | ${ Error }
-			${ 'noURLUser' }        | ${ TypeError }
+			${ 'noURLUser' }        | ${ ReferenceError }
 		`(
 			'Throws error if getAccountSiteURL is called with $accountType',
 			function ( { accountType, expected } ) {

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, test } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import { getAccountCredential, getCalypsoURL } from '../src/data-helper';
+
+describe( 'DataHelper Tests', function () {
+	describe( `Test: getCalypsoURL`, function () {
+		test.each`
+			route           | queryStrings                               | expected
+			${ '/' }        | ${ undefined }                             | ${ 'https://wordpress.com/' }
+			${ 'log-in' }   | ${ undefined }                             | ${ 'https://wordpress.com/log-in' }
+			${ 'post/new' } | ${ { param: 'test' } }                     | ${ 'https://wordpress.com/post/new?param=test' }
+			${ 'post/new' } | ${ { param: 'test', query: 'jest-test' } } | ${ 'https://wordpress.com/post/new?param=test&query=jest-test' }
+			${ 'post/new' } | ${ { param: 'ASCIIではありません' } }      | ${ 'https://wordpress.com/post/new?param=ASCII%E3%81%A7%E3%81%AF%E3%81%82%E3%82%8A%E3%81%BE%E3%81%9B%E3%82%93' }
+		`(
+			'Returns $expected if getCalypsoURL is called with $route and $queryStrings',
+			function ( { route, queryStrings, expected } ) {
+				expect( getCalypsoURL( route, queryStrings ) ).toBe( expected );
+			}
+		);
+	} );
+
+	describe( `Test: getAccountCredential`, function () {
+		test.each`
+			username         | expected
+			${ 'basicUser' } | ${ [ 'wpcomuser', 'hunter2' ] }
+		`(
+			'Returns $expected if getAccountCredentials is called with $username',
+			function ( { username, expected } ) {
+				expect( getAccountCredential( username ) ).toBe( expected );
+			}
+		);
+	} );
+} );

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -6,7 +6,13 @@ import { describe, expect, test } from '@jest/globals';
 /**
  * Internal dependencies
  */
-import { getAccountCredential, getCalypsoURL, getAccountSiteURL } from '../src/data-helper';
+import {
+	getAccountCredential,
+	getCalypsoURL,
+	getAccountSiteURL,
+	toTitleCase,
+	createSuiteTitle,
+} from '../src/data-helper';
 
 describe( 'DataHelper Tests', function () {
 	describe( `Test: getCalypsoURL`, function () {
@@ -49,25 +55,53 @@ describe( 'DataHelper Tests', function () {
 	} );
 
 	describe( `Test: getAccountSiteURL`, function () {
-		// test.each`
-		// 	accountType      | expected
-		// 	${ 'basicUser' } | ${ 'https://wpcomuser.wordpress.com/' }
-		// 	${ 'advancedUser' } | ${ 'https://advancedwpcomuser.wordpress.com/' }
-		// `(
-		// 	'Returns $expected if getAccountSiteURL is called with $accountType',
-		// 	function ( { accountType, expected } ) {
-		// 		expect( getAccountSiteURL( accountType ) ).toStrictEqual( expected );
-		// 	}
-		// );
+		test.each`
+			accountType         | expected
+			${ 'basicUser' }    | ${ 'https://wpcomuser.wordpress.com/' }
+			${ 'advancedUser' } | ${ 'https://advancedwpcomuser.wordpress.com/' }
+		`(
+			'Returns $expected if getAccountSiteURL is called with $accountType',
+			function ( { accountType, expected } ) {
+				expect( getAccountSiteURL( accountType ) ).toStrictEqual( expected );
+			}
+		);
 
 		test.each`
 			accountType             | expected
 			${ 'nonexistent_user' } | ${ Error }
-			${ 'noURLUser' }        | ${ Error }
+			${ 'noURLUser' }        | ${ TypeError }
 		`(
 			'Throws error if getAccountCredentials is called with $accountType',
 			function ( { accountType, expected } ) {
 				expect( () => getAccountSiteURL( accountType ) ).toThrow( expected );
+			}
+		);
+	} );
+
+	describe( `Test: toTitleCase`, function () {
+		test.each`
+			words                        | expected
+			${ 'test' }                  | ${ 'Test' }
+			${ 'test words' }            | ${ 'Test Words' }
+			${ [ 'test', 'words' ] }     | ${ 'Test Words' }
+			${ 'Test Words Third' }      | ${ 'Test Words Third' }
+			${ '11 Words Third' }        | ${ '11 Words Third' }
+			${ [ '12', '33', 'ABCDE' ] } | ${ '12 33 ABCDE' }
+		`( 'Returns $expected if toTitleCase is called with $words', function ( { words, expected } ) {
+			expect( toTitleCase( words ) ).toStrictEqual( expected );
+		} );
+	} );
+
+	describe( `Test: createSuiteTitle`, function () {
+		test.each`
+			suite                       | viewport       | expected
+			${ 'Feature (Click: Tap)' } | ${ 'desktop' } | ${ '[WPCOM] Feature (Click: Tap): (desktop) @parallel' }
+			${ 'Manage' }               | ${ 'mobile' }  | ${ '[WPCOM] Manage: (mobile) @parallel' }
+		`(
+			'Returns $expected if toTitleCase is called with $words',
+			function ( { suite, viewport, expected } ) {
+				process.env.VIEWPORT_NAME = viewport;
+				expect( createSuiteTitle( suite ) ).toStrictEqual( expected );
 			}
 		);
 	} );

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -37,7 +37,7 @@ describe( 'DataHelper Tests', function () {
 			${ 'basicUser' } | ${ [ 'wpcomuser', 'hunter2' ] }
 			${ 'noURLUser' } | ${ [ 'nourluser', 'password1234' ] }
 		`(
-			'Returns $expected if getAccountCredentials is called with $accountType',
+			'Returns $expected if getAccountCredential is called with $accountType',
 			function ( { accountType, expected } ) {
 				expect( getAccountCredential( accountType ) ).toStrictEqual( expected );
 			}
@@ -47,7 +47,7 @@ describe( 'DataHelper Tests', function () {
 			accountType
 			${ 'nonexistent_user' }
 		`(
-			'Throws error if getAccountCredentials is called with $accountType',
+			'Throws error if getAccountCredential is called with $accountType',
 			function ( { accountType } ) {
 				expect( () => getAccountCredential( accountType ) ).toThrow();
 			}
@@ -71,7 +71,7 @@ describe( 'DataHelper Tests', function () {
 			${ 'nonexistent_user' } | ${ Error }
 			${ 'noURLUser' }        | ${ TypeError }
 		`(
-			'Throws error if getAccountCredentials is called with $accountType',
+			'Throws error if getAccountSiteURL is called with $accountType',
 			function ( { accountType, expected } ) {
 				expect( () => getAccountSiteURL( accountType ) ).toThrow( expected );
 			}

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from '@jest/globals';
 /**
  * Internal dependencies
  */
-import { getAccountCredential, getCalypsoURL } from '../src/data-helper';
+import { getAccountCredential, getCalypsoURL, getAccountSiteURL } from '../src/data-helper';
 
 describe( 'DataHelper Tests', function () {
 	describe( `Test: getCalypsoURL`, function () {
@@ -27,12 +27,47 @@ describe( 'DataHelper Tests', function () {
 
 	describe( `Test: getAccountCredential`, function () {
 		test.each`
-			username         | expected
+			accountType      | expected
 			${ 'basicUser' } | ${ [ 'wpcomuser', 'hunter2' ] }
+			${ 'noURLUser' } | ${ [ 'nourluser', 'password1234' ] }
 		`(
-			'Returns $expected if getAccountCredentials is called with $username',
-			function ( { username, expected } ) {
-				expect( getAccountCredential( username ) ).toBe( expected );
+			'Returns $expected if getAccountCredentials is called with $accountType',
+			function ( { accountType, expected } ) {
+				expect( getAccountCredential( accountType ) ).toStrictEqual( expected );
+			}
+		);
+
+		test.each`
+			accountType
+			${ 'nonexistent_user' }
+		`(
+			'Throws error if getAccountCredentials is called with $accountType',
+			function ( { accountType } ) {
+				expect( () => getAccountCredential( accountType ) ).toThrow();
+			}
+		);
+	} );
+
+	describe( `Test: getAccountSiteURL`, function () {
+		// test.each`
+		// 	accountType      | expected
+		// 	${ 'basicUser' } | ${ 'https://wpcomuser.wordpress.com/' }
+		// 	${ 'advancedUser' } | ${ 'https://advancedwpcomuser.wordpress.com/' }
+		// `(
+		// 	'Returns $expected if getAccountSiteURL is called with $accountType',
+		// 	function ( { accountType, expected } ) {
+		// 		expect( getAccountSiteURL( accountType ) ).toStrictEqual( expected );
+		// 	}
+		// );
+
+		test.each`
+			accountType             | expected
+			${ 'nonexistent_user' } | ${ Error }
+			${ 'noURLUser' }        | ${ Error }
+		`(
+			'Throws error if getAccountCredentials is called with $accountType',
+			function ( { accountType, expected } ) {
+				expect( () => getAccountSiteURL( accountType ) ).toThrow( expected );
 			}
 		);
 	} );

--- a/packages/calypso-e2e/test/media-helper.test.ts
+++ b/packages/calypso-e2e/test/media-helper.test.ts
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import path from 'path';
+import mockdate from 'mockdate';
 import { describe, expect, test, beforeAll, afterAll } from '@jest/globals';
 
 /**
  * Internal dependencies
  */
-import { getAssetDir, getScreenshotDir, getVideoDir } from '../src/media-helper';
+import { getAssetDir, getScreenshotDir, getVideoDir, getFileName } from '../src/media-helper';
 
 let env: NodeJS.ProcessEnv;
 
@@ -90,6 +91,45 @@ describe( 'MediaHelper Tests', function () {
 			const expected = path.resolve( __dirname, '..', 'screenshots/videos' );
 			expect( getVideoDir() ).toBe( expected );
 		} );
+	} );
+
+	describe( `Test: getFileName`, function () {
+		let timestamp: number;
+
+		beforeAll( function () {
+			process.env.TEMP_ASSET_PATH = '/tmp';
+			process.env.VIDEODIR = 'recording';
+			process.env.SCREENSHOTDIR = 'screenshots';
+			process.env.LOCALE = 'en';
+			process.env.VIEWPORT_NAME = 'desktop';
+			timestamp = 1500000000;
+			mockdate.set( timestamp );
+		} );
+
+		test.each`
+			name                            | type              | expected
+			${ 'Log in' }                   | ${ 'screenshot' } | ${ path.resolve( '/tmp/screenshots', `FAILED-EN-DESKTOP-log-in-1500000000.png` ) }
+			${ 'Check for likes (manage)' } | ${ 'video' }      | ${ path.resolve( '/tmp/recording', `FAILED-EN-DESKTOP-check-for-likes--manage--1500000000.webm` ) }
+			${ '何でしょう' }               | ${ 'screenshot' } | ${ path.resolve( '/tmp/screenshots', `FAILED-EN-DESKTOP-------1500000000.png` ) }
+		`(
+			'Returns $expected when test name and artifact type is specified.',
+			function ( { name, type, expected } ) {
+				expect( getFileName( { name: name, type: type } ) ).toBe( expected );
+			}
+		);
+
+		test.each`
+			type               | expected
+			${ 'invalid' }     | ${ Error }
+			${ '' }            | ${ Error }
+			${ 'screenshots' } | ${ Error }
+			${ 'recordings' }  | ${ Error }
+		`(
+			'Throws $expected when unsupported artifact type is specified.',
+			function ( { type, expected } ) {
+				expect( () => getFileName( { name: 'test', type: type } ) ).toThrow( expected );
+			}
+		);
 	} );
 } );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18884,6 +18884,11 @@ mockdate@^2.0.5:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
   integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements additional unit tests for code I have written in `calypso-e2e` module.

Furthermore, there have been some refactoring of the helper files:
- `DataHelper.toTitleCase`, to no longer lowercase characters from 2nd char onwards.
- `getScreenshotName` and `getVideoName` have been refactored into one function.

#### Testing instructions

Local
- run `yarn jest` and ensure all tests pass.

TeamCity
- ensure all tests pass for both `Unit Tests` and `Playwright E2E`.
*note*: E2E failure are due to this being based on old trunk.
