### PR TITLE
Add error_code to Email Comparison clicks for diagnostics

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -144,12 +144,16 @@ class EmailProvidersComparison extends React.Component {
 
 		const mailboxesAreValid = areAllMailboxesValid( validatedTitanMailboxes );
 		const userCanAddEmail = canCurrentUserAddEmail( domain );
+		const userCannotAddEmailReason = userCanAddEmail
+			? null
+			: getCurrentUserCannotAddEmailReason( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
 			mailbox_count: validatedTitanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: 'titan',
 			user_can_add_email: userCanAddEmail,
+			user_cannot_add_email_code: userCannotAddEmailReason ? userCannotAddEmailReason.code : '',
 		} );
 
 		const validatedTitanMailboxUuids = validatedTitanMailboxes.map( ( mailbox ) => mailbox.uuid );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We've seen situations where users have failed to add email to a domain because they are not permitted to do so, but we're not showing them an error message. This PR adds some diagnostics to understand what error code(s) may be involved in these particular cases.

#### Testing instructions

This one is somewhat tricky to test, because we're not sure how this problem is being triggered. So the tests below mostly confirm that the expected code path is working.

* Run this branch locally or via the [live branch](https://calypso.live/?branch=add/email-comparison-add-diagnostics).
* For a domain you own that doesn't have any email service, navigate to the Email Comparison page via Upgrades -> Emails -> Add Email for that domain
* Open your browser network tab
* Fill out the form for Professional Email and click on "Add Professional Email"
* Verify that we send a `calypso_email_providers_add_click` Tracks event that includes a `user_cannot_add_email_code` field.