### PR TITLE
Remove pricing page A/A experiment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -7,7 +7,6 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { useExperiment } from 'calypso/lib/explat';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import {
@@ -39,9 +38,6 @@ import type {
 
 import './style.scss';
 
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:plans:abtesting' );
-
 const SelectorPage: React.FC< SelectorPageProps > = ( {
 	defaultDuration = TERM_ANNUALLY,
 	siteSlug: siteSlugProp,
@@ -53,23 +49,6 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	highlightedProducts = [],
 }: SelectorPageProps ) => {
 	const dispatch = useDispatch();
-
-	const [ loadingExperiment, experiment ] = useExperiment( 'jetpack_explat_testing_20210510' );
-	useEffect( () => {
-		if ( loadingExperiment ) {
-			debug( 'Loading experiment ...' );
-			return;
-		}
-
-		if ( ! experiment ) {
-			debug( 'ERROR CONDITION: Experiment not loading, but no information found.' );
-			return;
-		}
-
-		debug( 'Experiment loaded!' );
-		debug( 'Experiment name:', experiment.experimentName );
-		debug( 'Assigned variation:', experiment.variationName );
-	}, [ loadingExperiment, experiment ] );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the A/A experiment implemented in #51522.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the pricing page, and check that it looks and behaves as expected, without any errors in the console