### PR TITLE
Domains: Add support for optional postal code when country does not support it

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -6,6 +6,7 @@ import { useSelect, useDispatch } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { ContactDetailsType, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
 import { Field, styled } from '@automattic/wpcom-checkout';
 import {
 	isDomainProduct,
@@ -25,6 +26,8 @@ import {
 import type { CountryListItem } from '../types/country-list-item';
 import TaxFields from './tax-fields';
 import DomainContactDetails from './domain-contact-details';
+import getCountries from 'calypso/state/selectors/get-countries';
+import { useSelector } from 'react-redux';
 
 const ContactDetailsFormDescription = styled.p`
 	font-size: 14px;
@@ -57,11 +60,13 @@ export default function ContactDetailsContainer( {
 		updateDomainContactFields,
 		updateCountryCode,
 		updatePostalCode,
+		updateRequiredDomainFields,
 		updateEmail,
 	} = useDispatch( 'wpcom' );
 	const contactDetails = prepareDomainContactDetails( contactInfo );
 	const contactDetailsErrors = prepareDomainContactDetailsErrors( contactInfo );
 	const { email } = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
+	const countries = useSelector( ( state ) => getCountries( state, 'domains' ) );
 
 	switch ( contactDetailsType ) {
 		case 'domain':
@@ -76,7 +81,14 @@ export default function ContactDetailsContainer( {
 						domainNames={ domainNames }
 						contactDetails={ contactDetails }
 						contactDetailsErrors={ contactDetailsErrors }
-						updateDomainContactFields={ updateDomainContactFields }
+						updateDomainContactFields={ ( details: DomainContactDetailsData ) => {
+							updateDomainContactFields( details );
+							updateRequiredDomainFields( {
+								postalCode:
+									countries?.find( ( country ) => country.code === details.countryCode )
+										?.has_postal_codes ?? true,
+							} );
+						} }
 						shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 						isDisabled={ isDisabled }
 						isLoggedOutCart={ isLoggedOutCart }

--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -68,6 +68,15 @@ export default function ContactDetailsContainer( {
 	const { email } = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
 	const countries = useSelector( ( state ) => getCountries( state, 'domains' ) );
 
+	const updateDomainContactRelatedData = ( details: DomainContactDetailsData ) => {
+		updateDomainContactFields( details );
+		updateRequiredDomainFields( {
+			postalCode:
+				countries?.find( ( country ) => country.code === details.countryCode )?.has_postal_codes ??
+				true,
+		} );
+	};
+
 	switch ( contactDetailsType ) {
 		case 'domain':
 			return (
@@ -81,14 +90,7 @@ export default function ContactDetailsContainer( {
 						domainNames={ domainNames }
 						contactDetails={ contactDetails }
 						contactDetailsErrors={ contactDetailsErrors }
-						updateDomainContactFields={ ( details: DomainContactDetailsData ) => {
-							updateDomainContactFields( details );
-							updateRequiredDomainFields( {
-								postalCode:
-									countries?.find( ( country ) => country.code === details.countryCode )
-										?.has_postal_codes ?? true,
-							} );
-						} }
+						updateDomainContactFields={ updateDomainContactRelatedData }
 						shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 						isDisabled={ isDisabled }
 						isLoggedOutCart={ isLoggedOutCart }

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -9,6 +9,7 @@ import type {
 	WpcomStoreState,
 	ManagedContactDetails,
 	ManagedContactDetailsErrors,
+	ManagedContactDetailsRequiredMask,
 } from '@automattic/wpcom-checkout';
 
 /**
@@ -33,6 +34,7 @@ type WpcomStoreAction =
 	| { type: 'UPDATE_PHONE'; payload: string }
 	| { type: 'UPDATE_PHONE_NUMBER_COUNTRY'; payload: string }
 	| { type: 'UPDATE_POSTAL_CODE'; payload: string }
+	| { type: 'UPDATE_REQUIRED_DOMAIN_FIELDS'; payload: ManagedContactDetailsRequiredMask }
 	| { type: 'TOUCH_CONTACT_DETAILS' }
 	| { type: 'UPDATE_COUNTRY_CODE'; payload: string }
 	| { type: 'LOAD_COUNTRY_CODE_FROM_GEOIP'; payload: string }
@@ -70,6 +72,8 @@ export function useWpcomStore(
 				return updaters.updatePhoneNumberCountry( state, action.payload );
 			case 'UPDATE_POSTAL_CODE':
 				return updaters.updatePostalCode( state, action.payload );
+			case 'UPDATE_REQUIRED_DOMAIN_FIELDS':
+				return updaters.updateRequiredDomainFields( state, action.payload );
 			case 'UPDATE_EMAIL':
 				return updaters.updateEmail( state, action.payload );
 			case 'UPDATE_COUNTRY_CODE':
@@ -159,6 +163,10 @@ export function useWpcomStore(
 
 			updatePostalCode( payload: string ): WpcomStoreAction {
 				return { type: 'UPDATE_POSTAL_CODE', payload };
+			},
+
+			updateRequiredDomainFields( payload: ManagedContactDetailsRequiredMask ): WpcomStoreAction {
+				return { type: 'UPDATE_REQUIRED_DOMAIN_FIELDS', payload };
 			},
 
 			updateEmail( payload: string ): WpcomStoreAction {

--- a/client/my-sites/checkout/composite-checkout/types/country-list-item.ts
+++ b/client/my-sites/checkout/composite-checkout/types/country-list-item.ts
@@ -1,4 +1,5 @@
 export interface CountryListItem {
 	code: string;
 	name: string;
+	has_postal_codes: boolean;
 }

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -718,6 +718,13 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		};
 	},
 
+	updateRequiredDomainFields: (
+		details: ManagedContactDetails,
+		requiredMask: ManagedContactDetailsRequiredMask
+	): ManagedContactDetails => {
+		return applyContactDetailsRequiredMask( details, requiredMask );
+	},
+
 	updateEmail: ( oldDetails: ManagedContactDetails, newEmail: string ): ManagedContactDetails => {
 		return {
 			...oldDetails,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -355,6 +355,10 @@ export type ManagedContactDetailsUpdaters = {
 		arg0: ManagedContactDetails,
 		arg1: DomainContactDetails
 	) => ManagedContactDetails;
+	updateRequiredDomainFields: (
+		arg0: ManagedContactDetails,
+		arg1: ManagedContactDetailsRequiredMask
+	) => ManagedContactDetails;
 	touchContactFields: ( arg0: ManagedContactDetails ) => ManagedContactDetails;
 	updateVatId: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
 	setErrorMessages: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For some countries, the postal code is not supported. In these cases, the postal code field should be optional. 

---

This PR adds the new action `updateRequiredDomainFields` to the `wpcom` store, enabling the toggle capability of a field's requirement. 

#### Preview

- If the country **supports** postal codes, then the postal code field is **required**:

https://user-images.githubusercontent.com/18705930/123697987-f75e0d80-d833-11eb-8c21-cfe4ba6883e8.mov

- If the country **doesn’t support** postal codes, then the postal code field is **optional**:

https://user-images.githubusercontent.com/18705930/123698036-06dd5680-d834-11eb-8aed-1f536438971c.mov


---


#### Testing instructions

* Verify all tests pass.
* Verify we the postal code field is optional for countries without support for it (e.g. Curacao)