### PR TITLE
Checkout: Improve types of Giropay and Bancontact

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -155,39 +155,29 @@ function useCreateP24( {
 function useCreateBancontact( {
 	isStripeLoading,
 	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	stripeConfiguration: StripeConfiguration | null;
-	stripe: Stripe | null;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createBancontactPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
-			shouldLoad && stripe && stripeConfiguration
+			shouldLoad
 				? createBancontactMethod( {
 						store: paymentMethodStore,
-						stripe,
-						stripeConfiguration,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+		[ shouldLoad, paymentMethodStore ]
 	);
 }
 
 function useCreateGiropay( {
 	isStripeLoading,
 	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	stripeConfiguration: StripeConfiguration | null;
-	stripe: Stripe | null;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createGiropayPaymentMethodStore(), [] );
@@ -196,11 +186,9 @@ function useCreateGiropay( {
 			shouldLoad
 				? createGiropayMethod( {
 						store: paymentMethodStore,
-						stripe,
-						stripeConfiguration,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+		[ shouldLoad, paymentMethodStore ]
 	);
 }
 
@@ -458,15 +446,11 @@ export default function useCreatePaymentMethods( {
 	const bancontactMethod = useCreateBancontact( {
 		isStripeLoading,
 		stripeLoadingError,
-		stripeConfiguration,
-		stripe,
 	} );
 
 	const giropayMethod = useCreateGiropay( {
 		isStripeLoading,
 		stripeLoadingError,
-		stripeConfiguration,
-		stripe,
 	} );
 
 	const epsMethod = useCreateEps( {

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -45,20 +45,20 @@ declare module '@wordpress/data' {
 	function dispatch( key: StoreKey ): StoreActions< NounsInStore >;
 }
 
+const actions: StoreActions< NounsInStore > = {
+	changeCustomerName( payload ) {
+		return { type: 'CUSTOMER_NAME_SET', payload };
+	},
+};
+
+const selectors: StoreSelectorsWithState< NounsInStore > = {
+	getCustomerName( state ) {
+		return state.customerName;
+	},
+};
+
 export function createBancontactPaymentMethodStore(): BancontactStore {
 	debug( 'creating a new bancontact payment method store' );
-	const actions: StoreActions< NounsInStore > = {
-		changeCustomerName( payload ) {
-			return { type: 'CUSTOMER_NAME_SET', payload };
-		},
-	};
-
-	const selectors: StoreSelectorsWithState< NounsInStore > = {
-		getCustomerName( state ) {
-			return state.customerName;
-		},
-	};
-
 	const store = registerStore( 'bancontact', {
 		reducer(
 			state: StoreState< NounsInStore > = {
@@ -76,7 +76,7 @@ export function createBancontactPaymentMethodStore(): BancontactStore {
 		selectors,
 	} );
 
-	return { ...store, actions, selectors };
+	return store;
 }
 
 export function createBancontactMethod( { store }: { store: BancontactStore } ): PaymentMethod {

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -195,11 +195,11 @@ function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total:
 }
 
 function isFormValid( store: BancontactStore ) {
-	const customerName = store.selectors.getCustomerName( store.getState() );
+	const customerName = selectors.getCustomerName( store.getState() );
 
 	if ( ! customerName.value.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( store.actions.changeCustomerName( '' ) );
+		store.dispatch( actions.changeCustomerName( '' ) );
 		return false;
 	}
 	return true;

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -14,7 +14,6 @@ import {
 	useSelect,
 	useDispatch,
 } from '@automattic/composite-checkout';
-import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
 import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
 /**
@@ -24,57 +23,49 @@ import styled from '../styled';
 import Field from '../field';
 import { SummaryLine, SummaryDetails } from '../summary-details';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import type {
+	PaymentMethodStore,
+	StoreSelectors,
+	StoreSelectorsWithState,
+	StoreActions,
+	StoreState,
+} from '../payment-method-store';
 
-const debug = debugFactory( 'composite-checkout:bancontact-payment-method' );
+const debug = debugFactory( 'wpcom-checkout:bancontact-payment-method' );
 
 // Disabling this to make migration easier
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-interface StoreStateValue {
-	value: string;
-	isTouched: boolean;
-}
+type StoreKey = 'bancontact';
+type NounsInStore = 'customerName';
+type BancontactStore = PaymentMethodStore< NounsInStore >;
 
-interface StoreState {
-	customerName: StoreStateValue;
-}
-
-type StoreAction = { type: string; payload: string };
-
-interface StoreActions {
-	changeCustomerName: ( payload: string ) => StoreAction;
-}
-
-interface StoreSelectors {
-	getCustomerName: ( state: StoreState ) => StoreStateValue;
-}
-
-interface BancontactStore extends ReturnType< typeof registerStore > {
-	actions: StoreActions;
-	selectors: StoreSelectors;
+declare module '@wordpress/data' {
+	function select( key: StoreKey ): StoreSelectors< NounsInStore >;
+	function dispatch( key: StoreKey ): StoreActions< NounsInStore >;
 }
 
 export function createBancontactPaymentMethodStore(): BancontactStore {
 	debug( 'creating a new bancontact payment method store' );
-	const actions = {
-		changeCustomerName( payload: string ) {
+	const actions: StoreActions< NounsInStore > = {
+		changeCustomerName( payload ) {
 			return { type: 'CUSTOMER_NAME_SET', payload };
 		},
 	};
 
-	const selectors = {
-		getCustomerName( state: StoreState ) {
-			return state.customerName || '';
+	const selectors: StoreSelectorsWithState< NounsInStore > = {
+		getCustomerName( state ) {
+			return state.customerName;
 		},
 	};
 
 	const store = registerStore( 'bancontact', {
 		reducer(
-			state = {
+			state: StoreState< NounsInStore > = {
 				customerName: { value: '', isTouched: false },
 			},
 			action
-		) {
+		): StoreState< NounsInStore > {
 			switch ( action.type ) {
 				case 'CUSTOMER_NAME_SET':
 					return { ...state, customerName: { value: action.payload, isTouched: true } };
@@ -88,37 +79,21 @@ export function createBancontactPaymentMethodStore(): BancontactStore {
 	return { ...store, actions, selectors };
 }
 
-export function createBancontactMethod( {
-	store,
-	stripe,
-	stripeConfiguration,
-}: {
-	store: BancontactStore;
-	stripe: Stripe;
-	stripeConfiguration: StripeConfiguration;
-} ): PaymentMethod {
+export function createBancontactMethod( { store }: { store: BancontactStore } ): PaymentMethod {
 	return {
 		id: 'bancontact',
 		label: <BancontactLabel />,
 		activeContent: <BancontactFields />,
 		inactiveContent: <BancontactSummary />,
-		submitButton: (
-			<BancontactPayButton
-				store={ store }
-				stripe={ stripe }
-				stripeConfiguration={ stripeConfiguration }
-			/>
-		),
-		getAriaLabel: ( __ ) => __( 'Bancontact' ),
+		submitButton: <BancontactPayButton store={ store } />,
+		getAriaLabel: () => 'Bancontact',
 	};
 }
 
 function BancontactFields() {
 	const { __ } = useI18n();
 
-	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() ) as
-		| StoreStateValue
-		| undefined;
+	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'bancontact' );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
@@ -130,9 +105,9 @@ function BancontactFields() {
 				type="Text"
 				autoComplete="cc-name"
 				label={ __( 'Your name' ) }
-				value={ customerName?.value ?? '' }
+				value={ customerName.value }
 				onChange={ changeCustomerName }
-				isError={ customerName?.isTouched && customerName?.value.length === 0 }
+				isError={ customerName.isTouched && customerName.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
 			/>
@@ -173,20 +148,14 @@ function BancontactPayButton( {
 	disabled,
 	onClick,
 	store,
-	stripe,
-	stripeConfiguration,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: BancontactStore;
-	stripe: Stripe;
-	stripeConfiguration: StripeConfiguration;
 } ) {
-	const [ items, total ] = useLineItems();
+	const [ , total ] = useLineItems();
 	const { formStatus } = useFormStatus();
-	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() ) as
-		| StoreStateValue
-		| undefined;
+	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 	if ( ! onClick ) {
 		throw new Error(
 			'Missing onClick prop; BancontactPayButton must be used as a payment button in CheckoutSubmitButton'
@@ -200,11 +169,7 @@ function BancontactPayButton( {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting bancontact payment' );
 					onClick( 'bancontact', {
-						stripe,
-						name: customerName?.value,
-						items,
-						total,
-						stripeConfiguration,
+						name: customerName.value,
 					} );
 				}
 			} }
@@ -230,9 +195,9 @@ function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total:
 }
 
 function isFormValid( store: BancontactStore ) {
-	const customerName = store.selectors.getCustomerName( store.getState() as StoreState );
+	const customerName = store.selectors.getCustomerName( store.getState() );
 
-	if ( ! customerName?.value.length ) {
+	if ( ! customerName.value.length ) {
 		// Touch the field so it displays a validation error
 		store.dispatch( store.actions.changeCustomerName( '' ) );
 		return false;
@@ -271,13 +236,11 @@ function BancontactLogo() {
 }
 
 function BancontactSummary() {
-	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() ) as
-		| StoreStateValue
-		| undefined;
+	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 
 	return (
 		<SummaryDetails>
-			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ customerName.value }</SummaryLine>
 		</SummaryDetails>
 	);
 }

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -45,19 +45,20 @@ declare module '@wordpress/data' {
 	function dispatch( key: StoreKey ): StoreActions< NounsInStore >;
 }
 
+const actions: StoreActions< NounsInStore > = {
+	changeCustomerName( payload ) {
+		return { type: 'CUSTOMER_NAME_SET', payload };
+	},
+};
+
+const selectors: StoreSelectorsWithState< NounsInStore > = {
+	getCustomerName( state ) {
+		return state.customerName;
+	},
+};
+
 export function createGiropayPaymentMethodStore(): GiropayStore {
 	debug( 'creating a new giropay payment method store' );
-	const actions: StoreActions< NounsInStore > = {
-		changeCustomerName( payload ) {
-			return { type: 'CUSTOMER_NAME_SET', payload };
-		},
-	};
-
-	const selectors: StoreSelectorsWithState< NounsInStore > = {
-		getCustomerName( state ) {
-			return state.customerName;
-		},
-	};
 
 	const store = registerStore( 'giropay', {
 		reducer(
@@ -76,7 +77,7 @@ export function createGiropayPaymentMethodStore(): GiropayStore {
 		selectors,
 	} );
 
-	return { ...store, actions, selectors };
+	return store;
 }
 
 export function createGiropayMethod( { store }: { store: GiropayStore } ): PaymentMethod {
@@ -199,11 +200,11 @@ function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total:
 }
 
 function isFormValid( store: GiropayStore ): boolean {
-	const customerName = store.selectors.getCustomerName( store.getState() );
+	const customerName = selectors.getCustomerName( store.getState() );
 
 	if ( ! customerName.value.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( store.actions.changeCustomerName( '' ) );
+		store.dispatch( actions.changeCustomerName( '' ) );
 		return false;
 	}
 	return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up some of the types and unnecessary arguments introduced in #53346 and #51690 which converted the Giropay and Bancontact payment methods to TypeScript, respectively. Since nearly all the Stripe redirect payment methods use the same sort of data store for their forms, we were able to generalize that store in https://github.com/Automattic/wp-calypso/pull/53510 and we can apply those types to the previously-migrated stores here.

#### Testing instructions

- Set your user currency to EUR.
- Apply D45443-code to your sandbox to force Bancontact to be available.
- Make a new purchase in checkout and select Bancontact as the payment method, entering any string in the "name" field.
- Verify that you are redirected to the Stripe test page, and that it reads "Bancontact" (no need to complete the purchase).
- Apply D45434-code to your sandbox to force Giropay to be available.
- Go back to checkout and repeat the above process with Giropay instead (still no need to complete the purchase).