### PR TITLE
Themes Sheet: Add site selection and appropriate padding

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -36,7 +36,7 @@
 	// Themes sets it own padding/margin
 	.is-section-theme &,
 	.is-section-themes.has-no-sidebar & {
-		padding: 0;
+		padding: 0 0 0 calc( var( --sidebar-width-max ) );
 		margin: 0;
 	}
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -34,8 +34,12 @@
 	}
 
 	// Themes sets it own padding/margin
-	.is-section-theme &,
-	.is-section-themes.has-no-sidebar & {
+	.is-section-themes.has-no-sidebar &,
+	.is-section-theme.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+	.is-section-theme & {
 		padding: 0 0 0 calc( var( --sidebar-width-max ) );
 		margin: 0;
 	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -34,11 +34,12 @@
 	}
 
 	// Themes sets it own padding/margin
-	.is-section-themes.has-no-sidebar &,
-	.is-section-theme.has-no-sidebar & {
+	.is-section-theme.has-no-sidebar &,
+	.is-section-themes.has-no-sidebar & {
 		padding: 0;
 		margin: 0;
 	}
+	
 	.is-section-theme & {
 		padding: 0 0 0 calc( var( --sidebar-width-max ) );
 		margin: 0;

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -3,7 +3,7 @@
  */
 import { makeLayout, redirectLoggedOut } from 'calypso/controller';
 import { details, fetchThemeDetailsData } from './controller';
-import { siteSelection } from 'calypso/my-sites/controller';
+import { navigation, siteSelection } from 'calypso/my-sites/controller';
 
 function redirectToLoginIfSiteRequested( context, next ) {
 	if ( context.params.site_id ) {
@@ -21,6 +21,7 @@ export default function ( router ) {
 		siteSelection,
 		fetchThemeDetailsData,
 		details,
+		navigation,
 		makeLayout
 	);
 }


### PR DESCRIPTION
Page: http://calypso.localhost:3000/theme/ANY_THEME/SITE_SLUG

![image](https://user-images.githubusercontent.com/10274366/121265417-c0c15280-c886-11eb-91e0-48a6407b6bed.png)


The "My Sites" button doesn't work on the Theme page. It wasn't originally a part of the layout, along with the entire sidebar. This pull request adds the sidebar to the Theme page along with appropriate padding so that the Theme page doesn't sit behind the sidebar.

#### Testing instructions

1. Go to the themes page for one of your sites.
2. Then select a theme, to go to the Theme page.
3. Click the "My Sites" button. [(Mobile)](https://user-images.githubusercontent.com/10274366/121264853-d4b88480-c885-11eb-9ad4-7d0567da3541.png)  [(Desktop)](https://user-images.githubusercontent.com/10274366/121264914-eef26280-c885-11eb-8464-46ae5cb2884b.png)
4. Our site's navigation should slide out. This didn't used to exist for the Theme page. Try different functionality from this navigation. Try selecting a different site. Try navigating to a different page. Try collapsing the sidebar by clicking the same button.
5. Repeat the above steps for different devices, such as different browsers, desktop, mobile or tablet. Try server side rendering.
6. Try selecting a different site, then applying a theme you selected in step 2 to that new site.

