### PR TITLE
Analytics: Fix recordTracksEvent import in analytics library docs

### DIFF
--- a/packages/calypso-analytics/README.md
+++ b/packages/calypso-analytics/README.md
@@ -19,7 +19,7 @@ recordTracksEvent( 'calypso_signup_step_start', { step: 'a_nice_step' } );
 _Note: Unless you have a strong reason to call `recordTracksEvent` directly, you should use the Analytics Middleware instead:_
 
 ```js
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 dispatch( recordTracksEvent( 'calypso_checkout_coupon_apply', { coupon_code: 'abc123' } ) );
 ```


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are two ways to call `recordTracksEvent()`; one is by using the function directly from the `@automattic/calypso-analytics` package, and the other is to use the calypso data-layer middleware by dispatching an action to redux. This is a little confusing because both the raw function and the redux action creator are called `recordTracksEvents`, but they are defined in two different places.

In https://github.com/Automattic/wp-calypso/pull/41125, an example was added to the README of the `@automattic/calypso-analytics` package to explain how to use the redux action creator rather than the raw function, but https://github.com/Automattic/wp-calypso/pull/47453 (accidentally, I think) broke that example. Using the code in the example will in fact throw an error since the exported `recordTracksEvents` function has no return value and cannot be used as an action creator. This PR restores the correct example, which is not ideal because it references an import path in a separate npm package, but it is better than providing an example that is totally wrong.

#### Testing instructions

None needed. Just verify that places that use `recordTracksEvents` inside a redux dispatch call are importing from the location in the corrected example. 

Eg: https://github.com/Automattic/wp-calypso/blob/76f435dff2a9e25aab2b2219f249ad4ab12b4f60/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L40