### PR TITLE
Adds product_id to the ticket meta

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -193,7 +193,7 @@ class HelpContact extends React.Component {
 		const { currentUserLocale, supportVariation } = this.props;
 		let plan = 'N/A';
 		if ( site ) {
-			plan = `${ site.plan.product_name_short } (${ getPlanTermLabel(
+			plan = `${ site.plan.product_id } - ${ site.plan.product_name_short } (${ getPlanTermLabel(
 				site.plan.product_slug,
 				( val ) => val // Passing an identity function instead of `translate` to always return the English string
 			) })`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Context pcbrnV-wF-p2#comment-3746
* Adds the `product_id` to the ticket meta to help with tagging.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Login as a user with a valid plan.
- Change the interface language to any language except English. This can be done by navigating to /me/account and changing the language from there.
- Create a ticket by clicking on the "?" icon in the bottom right and select "Contact Us".
- Inspect the network response for the request sent to create the ticket.
- The product ID of the plan should be present in the message body. For example, for the annual Personal plan, the text would be:
```
...
Plan: 1009 - Personal (Annual subscription)
...
``` 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->