### PR TITLE
Fix JavaScript syntax highlighting on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 package-lock.json merge=npm-merge-driver
-*.js linguist-language=JSX


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* JavaScript file syntax highlighting is broken (example https://github.com/Automattic/wp-calypso/blob/trunk/client/devdocs/index.js) on GitHub because we are trying to force them to use JSX language. This has been removed from Linguist (used by GitHub). Now it's merged into JavaScript so we don't need to specify this anymore. 

Related Linguist PR: https://github.com/github/linguist/pull/5133

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open https://github.com/Automattic/wp-calypso/blob/fix/github-javascript-syntax-highlighting/client/devdocs/index.js
* Force reload the page (SHIFT + CMD + R on Mac)
