### PR TITLE
wpcom-undocumented: Remove unused site methods

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -90,35 +90,6 @@ UndocumentedSite.prototype.domains = function () {
 	return this.wpcom.req.get( `/sites/${ this._id }/domains`, { apiVersion: '1.2' } );
 };
 
-UndocumentedSite.prototype.postAutosave = function ( postId, attributes, callback ) {
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/posts/' + postId + '/autosave',
-			body: attributes,
-		},
-		callback
-	);
-};
-
-UndocumentedSite.prototype.embeds = function ( attributes, callback ) {
-	let url = '/sites/' + this._id + '/embeds';
-	if ( attributes && attributes.embed_url ) {
-		url += '/render';
-	}
-
-	return this.wpcom.req.get( url, attributes, callback );
-};
-
-UndocumentedSite.prototype.embedReversal = function ( markup, callback ) {
-	return this.wpcom.req.post(
-		`/sites/${ this._id }/embeds/reversal`,
-		{
-			maybe_embed: markup,
-		},
-		callback
-	);
-};
-
 UndocumentedSite.prototype.shortcodes = function ( attributes, callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/shortcodes/render', attributes, callback );
 };
@@ -134,30 +105,6 @@ UndocumentedSite.prototype.removeViewer = function ( viewerId, callback ) {
 		},
 		callback
 	);
-};
-
-UndocumentedSite.prototype.deleteUser = function ( userId, attributes, callback ) {
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/users/' + userId + '/delete',
-			body: attributes,
-		},
-		callback
-	);
-};
-
-UndocumentedSite.prototype.updateUser = function ( userId, attributes, callback ) {
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/users/' + userId,
-			body: attributes,
-		},
-		callback
-	);
-};
-
-UndocumentedSite.prototype.getUser = function ( login, callback ) {
-	return this.wpcom.req.get( '/sites/' + this._id + '/users/login:' + login, callback );
 };
 
 UndocumentedSite.prototype.setOption = function ( query, callback ) {
@@ -186,17 +133,6 @@ UndocumentedSite.prototype.postCounts = function ( options, callback ) {
 	delete query.type;
 
 	return this.wpcom.req.get( '/sites/' + this._id + '/post-counts/' + type, query, callback );
-};
-
-/**
- * Returns media storage limits and space used for a given site. If site has
- * unlimited storage or is a jetpack site, values returned will be -1.
- *
- * @param {Function} callback - called on completion of the GET request
- * @returns {object} promise - resolves on completion of the GET request
- */
-UndocumentedSite.prototype.mediaStorage = function ( callback ) {
-	return this.wpcom.req.get( '/sites/' + this._id + '/media-storage', callback );
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes some unused `wpcom-undocumented` site methods.

#### Testing instructions

Verify that none of the removed methods are in use.