### PR TITLE
Remove wpcom.undocumented() payment config methods

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -25,10 +25,8 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
  */
 import './style.scss';
 
-const wpcom = wp.undocumented();
-
 function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {
-	return fetchStripeConfiguration( args, wpcom );
+	return fetchStripeConfiguration( args, wp );
 }
 
 function removeHashFromUrl(): void {

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -11,18 +11,6 @@ import wp from 'calypso/lib/wp';
 import { translatedEbanxError } from 'calypso/lib/checkout/processor-specific';
 
 const debug = debugFactory( 'calypso:store-transactions' );
-const wpcom = wp.undocumented();
-
-const promisifiedEbanxConfiguration = ( data ) => {
-	return new Promise( ( resolve, reject ) => {
-		wpcom.ebanxConfiguration( data, ( configError, configuration ) => {
-			if ( configError ) {
-				return reject( configError );
-			}
-			resolve( configuration );
-		} );
-	} );
-};
 
 const promisifiedCreateEbanxToken = ( ebanx, parameters ) => {
 	return new Promise( ( resolve ) => {
@@ -43,7 +31,9 @@ const promisifiedEbanxDeviceFingerprint = ( ebanx ) => {
 export async function createEbanxToken( requestType, cardDetails ) {
 	debug( 'creating token with ebanx' );
 
-	const configuration = await promisifiedEbanxConfiguration( { request_type: requestType } );
+	const configuration = await wp.req.get( '/me/ebanx-configuration', {
+		request_type: requestType,
+	} );
 	const ebanx = await paymentGatewayLoader.ready( configuration.js_url, 'EBANX', false );
 
 	ebanx.config.setMode( configuration.environment );
@@ -81,7 +71,7 @@ function getEbanxParameters( cardDetails ) {
 }
 
 export async function getStripeConfiguration( requestArgs ) {
-	const config = await wpcom.stripeConfiguration( requestArgs );
+	const config = await wp.req.get( '/me/stripe-configuration', requestArgs );
 	debug( 'Stripe configuration', config );
 	return config;
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1348,44 +1348,6 @@ Undocumented.prototype.updateCreditCard = function ( params, fn ) {
 };
 
 /**
- * GET paygate configuration
- *
- * @param {object} query - query parameters
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.paygateConfiguration = function ( query, fn ) {
-	debug( '/me/paygate-configuration query' );
-
-	return this.wpcom.req.get( '/me/paygate-configuration', query, fn );
-};
-
-/**
- * GET stripe configuration
- *
- * @param {object} query - query parameters
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.stripeConfiguration = function ( query, fn ) {
-	debug( '/me/stripe-configuration query' );
-
-	return this.wpcom.req.get( '/me/stripe-configuration', query, fn );
-};
-
-/**
- * GET ebanx js configuration
- *
- * @param {object} query - query parameters
- * @param {Function} fn The callback function
- *
- * @returns {Promise} promise
- */
-Undocumented.prototype.ebanxConfiguration = function ( query, fn ) {
-	debug( '/me/ebanx-configuration query' );
-
-	return this.wpcom.req.get( '/me/ebanx-configuration', query, fn );
-};
-
-/**
  * GET paypal_express_url
  *
  * @param {object} [data] The GET data

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -23,10 +23,6 @@ import getCartKey from './get-cart-key';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 
-// Aliasing wpcom functions explicitly bound to wpcom is required here;
-// otherwise we get `this is not defined` errors.
-const wpcom = wp.undocumented();
-
 const emptyCart = getEmptyResponseCart();
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
@@ -147,5 +143,5 @@ export default function CheckoutSystemDecider( {
 }
 
 function fetchStripeConfigurationWpcom( args ) {
-	return fetchStripeConfiguration( args, wpcom );
+	return fetchStripeConfiguration( args, wp );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -14,7 +14,7 @@ import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 const { select } = defaultRegistry;
 
 export async function fetchStripeConfiguration( requestArgs, wpcom ) {
-	return wpcom.stripeConfiguration( requestArgs );
+	return wpcom.req.get( '/me/stripe-configuration', requestArgs );
 }
 
 async function createAccountCallback( response ) {


### PR DESCRIPTION
Removes the following methods from `wpcom.undocumented()`:
- `stripeConfiguration()`
- `ebanxConfiguration()`
- `paygateConfiguration()` (never used)

and replaces their invocation with direct calls like `wp.req.get( '/me/stripe-configuration' )`.

There is a `fetchStripeConfiguration` helper that used to accept `wp.undocumented()` object as parameter and called the configuration methods on it. We now pass the base `wp` object instead, so that `wp.req.get` can be called on it. All usages were updated accordingly.

The `promisifiedEbanxConfiguration` helper is redundant: all `wpcom` functions already support returning a promise when the callback arg is omitted. Just use it.

**How to test:**
I have very little idea how to test this: asking @sirbrillig for help.