### PR TITLE
Sections: Re-order `/me/*` section definitions

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -78,6 +78,8 @@ const sections = [
 		module: 'calypso/me/site-blocks',
 		group: 'me',
 	},
+	// This should be the last section for `/me` paths as it would otherwise have precedence over
+	// the other sub `/me/*` sections when resolving the requested path
 	{
 		name: 'me',
 		paths: [ '/me' ],

--- a/client/sections.js
+++ b/client/sections.js
@@ -25,12 +25,6 @@ const sections = [
 		group: 'sites',
 	},
 	{
-		name: 'me',
-		paths: [ '/me' ],
-		module: 'calypso/me',
-		group: 'me',
-	},
-	{
 		name: 'account',
 		paths: [ '/me/account' ],
 		module: 'calypso/me/account',
@@ -43,15 +37,21 @@ const sections = [
 		group: 'me',
 	},
 	{
-		name: 'activity',
-		paths: [ '/activity-log' ],
-		module: 'calypso/my-sites/activity',
-		group: 'sites',
+		name: 'concierge',
+		paths: [ '/me/concierge' ],
+		module: 'calypso/me/concierge',
+		group: 'me',
 	},
 	{
-		name: 'security',
-		paths: [ '/me/security' ],
-		module: 'calypso/me/security',
+		name: 'happychat',
+		paths: [ '/me/chat' ],
+		module: 'calypso/me/happychat',
+		group: 'me',
+	},
+	{
+		name: 'notification-settings',
+		paths: [ '/me/notifications' ],
+		module: 'calypso/me/notification-settings',
 		group: 'me',
 	},
 	{
@@ -67,15 +67,9 @@ const sections = [
 		group: 'me',
 	},
 	{
-		name: 'site-purchases',
-		paths: [ '/purchases' ],
-		module: 'calypso/my-sites/purchases',
-		group: 'sites',
-	},
-	{
-		name: 'notification-settings',
-		paths: [ '/me/notifications' ],
-		module: 'calypso/me/notification-settings',
+		name: 'security',
+		paths: [ '/me/security' ],
+		module: 'calypso/me/security',
 		group: 'me',
 	},
 	{
@@ -85,10 +79,22 @@ const sections = [
 		group: 'me',
 	},
 	{
-		name: 'concierge',
-		paths: [ '/me/concierge' ],
-		module: 'calypso/me/concierge',
+		name: 'me',
+		paths: [ '/me' ],
+		module: 'calypso/me',
 		group: 'me',
+	},
+	{
+		name: 'activity',
+		paths: [ '/activity-log' ],
+		module: 'calypso/my-sites/activity',
+		group: 'sites',
+	},
+	{
+		name: 'site-purchases',
+		paths: [ '/purchases' ],
+		module: 'calypso/my-sites/purchases',
+		group: 'sites',
 	},
 	{
 		name: 'media',
@@ -365,12 +371,6 @@ const sections = [
 		paths: [ '/types' ],
 		module: 'calypso/my-sites/types',
 		group: 'sites',
-	},
-	{
-		name: 'happychat',
-		paths: [ '/me/chat' ],
-		module: 'calypso/me/happychat',
-		group: 'me',
 	},
 	{
 		name: 'comments',


### PR DESCRIPTION
Since we're comparing whether any of the paths for a given section definition matches the beginning of the requested path ([#1](https://github.com/Automattic/wp-calypso/blob/676374718c6fd416b720b17afab929255fbfea07/client/server/pages/index.js#L676-L678) [#2](https://github.com/Automattic/wp-calypso/blob/676374718c6fd416b720b17afab929255fbfea07/client/utils.js#L8)), having the main `/me` defined before its sub sections results in all `/me/*` routes being resolved with the handler for the main `/me` section.

One problem that can be observed currently is with `context.chunkFiles` not having the correct set of files required for the initial page load.

#### Changes proposed in this Pull Request

* Move `/me` section definition after the other sub `/me/*` section.
* Sort `/me/*` section definitions alphabetically by their paths.

#### Testing instructions

* Confirm all `/me/*` are still loading properly.
* Go to a sub-section, e.g. `/me/account` and confirm it has been resolved with the correct set of `chunkFiles` by inspecting the source code and validating that the assets are being bootstrapped as `<link />` and `<script />` tags. For example, `/me/account` should have script/link for `account.{hash}.min.js` and `account.{hash}.min.css`.
