### PR TITLE
Support removing email forwards from the email plan page

### DIFF
--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -121,6 +121,14 @@ in a popover. It is fully keyboard accessible.
 If set, `PopoverMenuItem` will be rendered as a link; otherwise, it will be
 rendered as a button.
 
+#### `isExternalLink { bool } - default: false`
+
+If set to `true`, renders the component using the `ExternalLink` component, which includes an external indicator. Note that `href` **must** be specified to ensure the component remains keyboard accessible.
+
+#### `onClick { func } - optional`
+
+If set, this function will be called when the item is clicked.
+
 #### `className { string } - optional`
 
 Sets a custom className on the button or link.

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -46,7 +46,7 @@ export default class PopoverMenuItem extends Component {
 	};
 
 	render() {
-		const { children, className, href, icon, isExternalLink, isSelected, onClick } = this.props;
+		const { children, className, href, icon, isExternalLink, isSelected } = this.props;
 		const itemProps = omit(
 			this.props,
 			'icon',
@@ -61,10 +61,10 @@ export default class PopoverMenuItem extends Component {
 		} );
 
 		let ItemComponent = this.props.itemComponent;
-		if ( isExternalLink && ( href || onClick ) ) {
+		if ( isExternalLink && href ) {
 			ItemComponent = ExternalLink;
 			itemProps.icon = true;
-		} else if ( href || onClick ) {
+		} else if ( href ) {
 			ItemComponent = 'a';
 		}
 

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -22,6 +22,7 @@ export default class PopoverMenuItem extends Component {
 		isSelected: PropTypes.bool,
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
+		onClick: PropTypes.func,
 		onMouseOver: PropTypes.func,
 		isExternalLink: PropTypes.bool,
 		itemComponent: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
@@ -45,7 +46,7 @@ export default class PopoverMenuItem extends Component {
 	};
 
 	render() {
-		const { children, className, href, icon, isSelected, isExternalLink } = this.props;
+		const { children, className, href, icon, isExternalLink, isSelected, onClick } = this.props;
 		const itemProps = omit(
 			this.props,
 			'icon',
@@ -60,10 +61,10 @@ export default class PopoverMenuItem extends Component {
 		} );
 
 		let ItemComponent = this.props.itemComponent;
-		if ( isExternalLink && href ) {
+		if ( isExternalLink && ( href || onClick ) ) {
 			ItemComponent = ExternalLink;
 			itemProps.icon = true;
-		} else if ( href ) {
+		} else if ( href || onClick ) {
 			ItemComponent = 'a';
 		}
 

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -49,7 +49,7 @@ import titanContactsIcon from 'calypso/assets/images/email-providers/titan/servi
 import titanMailIcon from 'calypso/assets/images/email-providers/titan/services/mail.svg';
 
 const removeEmailForwardMailbox = ( { dispatch, mailbox } ) => {
-	recordTracksEvent( 'calypso_domain_management_email_forwarding_delete_click', {
+	recordTracksEvent( 'calypso_email_management_email_forwarding_delete_click', {
 		destination: getEmailForwardAddress( mailbox ),
 		domain_name: mailbox.domain,
 		mailbox: mailbox.mailbox,

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -1,17 +1,16 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import {
 	getEmailForwardAddress,
 	hasGoogleAccountTOSWarning,
@@ -160,23 +159,8 @@ const getGSuiteMenuItems = ( { account, email, mailbox, translate } ) => {
 	];
 };
 
-const getEmailForwardMenuItems = ( {
-	currentRoute,
-	dispatch,
-	domain,
-	mailbox,
-	selectedSite,
-	translate,
-} ) => {
+const getEmailForwardMenuItems = ( { dispatch, mailbox, translate } ) => {
 	return [
-		{
-			href: emailManagementForwarding( selectedSite.slug, domain.name, currentRoute ),
-			isInternalLink: true,
-			materialIcon: 'create',
-			title: translate( 'Edit', {
-				comment: 'Edit an email forward',
-			} ),
-		},
 		{
 			isInternalLink: true,
 			materialIcon: 'delete',
@@ -191,8 +175,7 @@ const getEmailForwardMenuItems = ( {
 	];
 };
 
-const EmailMailboxActionMenu = ( { account, domain, mailbox, selectedSite } ) => {
-	const currentRoute = useSelector( getCurrentRoute );
+const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -209,11 +192,8 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox, selectedSite } ) =>
 
 		if ( hasEmailForwards( domain ) ) {
 			return getEmailForwardMenuItems( {
-				currentRoute,
 				dispatch,
-				domain,
 				mailbox,
-				selectedSite,
 				translate,
 			} );
 		}
@@ -255,6 +235,12 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox, selectedSite } ) =>
 			) }
 		</EllipsisMenu>
 	);
+};
+
+EmailMailboxActionMenu.propTypes = {
+	account: PropTypes.object.isRequired,
+	domain: PropTypes.object.isRequired,
+	mailbox: PropTypes.object.isRequired,
 };
 
 export default EmailMailboxActionMenu;

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -1,0 +1,223 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
+import {
+	getGmailUrl,
+	getGoogleAdminUrl,
+	getGoogleCalendarUrl,
+	getGoogleDocsUrl,
+	getGoogleDriveUrl,
+	getGoogleSheetsUrl,
+	getGoogleSlidesUrl,
+	hasGSuiteWithUs,
+} from 'calypso/lib/gsuite';
+import {
+	getTitanCalendarlUrl,
+	getTitanContactsUrl,
+	getTitanEmailUrl,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
+import gmailIcon from 'calypso/assets/images/email-providers/google-workspace/services/gmail.svg';
+import googleAdminIcon from 'calypso/assets/images/email-providers/google-workspace/services/admin.svg';
+import googleCalendarIcon from 'calypso/assets/images/email-providers/google-workspace/services/calendar.svg';
+import googleDocsIcon from 'calypso/assets/images/email-providers/google-workspace/services/docs.svg';
+import googleDriveIcon from 'calypso/assets/images/email-providers/google-workspace/services/drive.svg';
+import googleSheetsIcon from 'calypso/assets/images/email-providers/google-workspace/services/sheets.svg';
+import googleSlidesIcon from 'calypso/assets/images/email-providers/google-workspace/services/slides.svg';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { hasGoogleAccountTOSWarning, isEmailUserAdmin } from 'calypso/lib/emails';
+import MaterialIcon from 'calypso/components/material-icon';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import titanCalendarIcon from 'calypso/assets/images/email-providers/titan/services/calendar.svg';
+import titanContactsIcon from 'calypso/assets/images/email-providers/titan/services/contacts.svg';
+import titanMailIcon from 'calypso/assets/images/email-providers/titan/services/mail.svg';
+
+/**
+ * Returns the available menu items for Titan Emails
+ *
+ * @param {Object} titanMenuParams The argument for this function.
+ * @param {string} titanMenuParams.email The email address of the Titan account
+ * @param {Function} titanMenuParams.translate The translate function
+ * @returns Array of menu items
+ */
+const getTitanMenuItems = ( { email, translate } ) => {
+	return [
+		{
+			href: getTitanEmailUrl( email ),
+			image: titanMailIcon,
+			imageAltText: translate( 'Titan Mail icon' ),
+			title: translate( 'View Mail', {
+				comment: 'View the Email application (i.e. the webmail) for Titan',
+			} ),
+		},
+		{
+			href: getTitanCalendarlUrl( email ),
+			image: titanCalendarIcon,
+			imageAltText: translate( 'Titan Calendar icon' ),
+			title: translate( 'View Calendar', {
+				comment: 'View the Calendar application for Titan',
+			} ),
+		},
+		{
+			href: getTitanContactsUrl( email ),
+			image: titanContactsIcon,
+			imageAltText: translate( 'Titan Contacts icon' ),
+			title: translate( 'View Contacts', {
+				comment: 'View the Contacts application for Titan',
+			} ),
+		},
+	];
+};
+
+/**
+ * Get the list of applicable menu items for a G Suite or Google Workspace mailbox.
+ *
+ * @param {Object} gSuiteMenuParams Parameter for this function.
+ * @param {Object} gSuiteMenuParams.account The account the current mailbox is linked to.
+ * @param {string} gSuiteMenuParams.email The full email address for the current mailbox.
+ * @param {Object} gSuiteMenuParams.mailbox The mailbox object.
+ * @param {Function} gSuiteMenuParams.translate The translate function.
+ * @returns {Array|null} Returns an array of menu items or null if no items should be shown.
+ */
+const getGSuiteMenuItems = ( { account, email, mailbox, translate } ) => {
+	if ( hasGoogleAccountTOSWarning( account ) ) {
+		return null;
+	}
+
+	return [
+		{
+			href: getGmailUrl( email ),
+			image: gmailIcon,
+			imageAltText: translate( 'Gmail icon' ),
+			title: translate( 'View Gmail' ),
+		},
+		...( isEmailUserAdmin( mailbox )
+			? [
+					{
+						href: getGoogleAdminUrl( email ),
+						image: googleAdminIcon,
+						imageAltText: translate( 'Google Admin icon' ),
+						title: translate( 'View Admin' ),
+					},
+			  ]
+			: [] ),
+		{
+			href: getGoogleCalendarUrl( email ),
+			image: googleCalendarIcon,
+			imageAltText: translate( 'Google Calendar icon' ),
+			title: translate( 'View Calendar' ),
+		},
+		{
+			href: getGoogleDocsUrl( email ),
+			image: googleDocsIcon,
+			imageAltText: translate( 'Google Docs icon' ),
+			title: translate( 'View Docs' ),
+		},
+		{
+			href: getGoogleDriveUrl( email ),
+			image: googleDriveIcon,
+			imageAltText: translate( 'Google Drive icon' ),
+			title: translate( 'View Drive' ),
+		},
+		{
+			href: getGoogleSheetsUrl( email ),
+			image: googleSheetsIcon,
+			imageAltText: translate( 'Google Sheets icon' ),
+			title: translate( 'View Sheets' ),
+		},
+		{
+			href: getGoogleSlidesUrl( email ),
+			image: googleSlidesIcon,
+			imageAltText: translate( 'Google Slides icon' ),
+			title: translate( 'View Slides' ),
+		},
+	];
+};
+
+const getEmailForwardMenuItems = ( { currentRoute, domain, selectedSite, translate } ) => {
+	return [
+		{
+			href: emailManagementForwarding( selectedSite.slug, domain.name, currentRoute ),
+			isInternalLink: true,
+			materialIcon: 'create',
+			title: translate( 'Edit', {
+				comment: 'Edit an email forward',
+			} ),
+		},
+	];
+};
+
+const getMenuItems = ( {
+	account,
+	currentRoute,
+	domain,
+	email,
+	mailbox,
+	selectedSite,
+	translate,
+} ) => {
+	if ( hasTitanMailWithUs( domain ) ) {
+		return getTitanMenuItems( { email, translate } );
+	}
+
+	if ( hasGSuiteWithUs( domain ) ) {
+		return getGSuiteMenuItems( { account, email, mailbox, translate } );
+	}
+
+	if ( hasEmailForwards( domain ) ) {
+		return getEmailForwardMenuItems( { currentRoute, domain, selectedSite, translate } );
+	}
+
+	return null;
+};
+
+const EmailMailboxActionMenu = ( { account, domain, mailbox, selectedSite } ) => {
+	const currentRoute = useSelector( getCurrentRoute );
+	const translate = useTranslate();
+
+	const email = `${ mailbox.mailbox }@${ mailbox.domain }`;
+	const menuItems = getMenuItems( {
+		account,
+		currentRoute,
+		domain,
+		email,
+		mailbox,
+		selectedSite,
+		translate,
+	} );
+
+	if ( ! menuItems ) {
+		return null;
+	}
+
+	return (
+		<EllipsisMenu position="bottom" className="email-mailbox-action-menu__main">
+			{ menuItems.map(
+				( { href, image, imageAltText, isInternalLink = false, materialIcon, title } ) => (
+					<PopoverMenuItem
+						key={ href }
+						className="email-mailbox-action-menu__menu-item"
+						isExternalLink={ ! isInternalLink }
+						href={ href }
+					>
+						{ image && <img src={ image } alt={ imageAltText } /> }
+						{ materialIcon && <MaterialIcon icon={ materialIcon } /> }
+						{ title }
+					</PopoverMenuItem>
+				)
+			) }
+		</EllipsisMenu>
+	);
+};
+
+export default EmailMailboxActionMenu;

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -5,55 +5,19 @@ import React from 'react';
 import classNames from 'classnames';
 import { CompactCard } from '@automattic/components';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Badge from 'calypso/components/badge';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/email-mailbox-warnings';
+import EmailMailboxActionMenu from 'calypso/my-sites/email/email-management/home/email-mailbox-action-menu';
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
-import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import {
-	getEmailForwardAddress,
-	hasGoogleAccountTOSWarning,
-	isEmailForward,
-	isEmailUserAdmin,
-} from 'calypso/lib/emails';
-import {
-	getGmailUrl,
-	getGoogleAdminUrl,
-	getGoogleCalendarUrl,
-	getGoogleDocsUrl,
-	getGoogleDriveUrl,
-	getGoogleSheetsUrl,
-	getGoogleSlidesUrl,
-	hasGSuiteWithUs,
-} from 'calypso/lib/gsuite';
-import {
-	getTitanCalendarlUrl,
-	getTitanContactsUrl,
-	getTitanEmailUrl,
-	hasTitanMailWithUs,
-} from 'calypso/lib/titan';
-import gmailIcon from 'calypso/assets/images/email-providers/google-workspace/services/gmail.svg';
-import googleAdminIcon from 'calypso/assets/images/email-providers/google-workspace/services/admin.svg';
-import googleCalendarIcon from 'calypso/assets/images/email-providers/google-workspace/services/calendar.svg';
-import googleDocsIcon from 'calypso/assets/images/email-providers/google-workspace/services/docs.svg';
-import googleDriveIcon from 'calypso/assets/images/email-providers/google-workspace/services/drive.svg';
-import googleSheetsIcon from 'calypso/assets/images/email-providers/google-workspace/services/sheets.svg';
-import googleSlidesIcon from 'calypso/assets/images/email-providers/google-workspace/services/slides.svg';
+import { getEmailForwardAddress, isEmailForward, isEmailUserAdmin } from 'calypso/lib/emails';
 import Gridicon from 'calypso/components/gridicon';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import MaterialIcon from 'calypso/components/material-icon';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import SectionHeader from 'calypso/components/section-header';
-import titanCalendarIcon from 'calypso/assets/images/email-providers/titan/services/calendar.svg';
-import titanContactsIcon from 'calypso/assets/images/email-providers/titan/services/contacts.svg';
-import titanMailIcon from 'calypso/assets/images/email-providers/titan/services/mail.svg';
 
 const getListHeaderTextForAccountType = ( accountType, translate ) => {
 	if ( accountType === EMAIL_ACCOUNT_TYPE_FORWARD ) {
@@ -113,160 +77,6 @@ const getSecondaryContentForMailbox = ( mailbox ) => {
 	return null;
 };
 
-/**
- * Returns the available menu items for Titan Emails
- *
- * @param {string} email The email address of the Titan account
- * @param {Function} translate The translate function
- * @returns Array of menu items
- */
-const getTitanMenuItems = ( email, translate ) => {
-	return [
-		{
-			href: getTitanEmailUrl( email ),
-			image: titanMailIcon,
-			imageAltText: translate( 'Titan Mail icon' ),
-			title: translate( 'View Mail', {
-				comment: 'View the Email application (i.e. the webmail) for Titan',
-			} ),
-		},
-		{
-			href: getTitanCalendarlUrl( email ),
-			image: titanCalendarIcon,
-			imageAltText: translate( 'Titan Calendar icon' ),
-			title: translate( 'View Calendar', {
-				comment: 'View the Calendar application for Titan',
-			} ),
-		},
-		{
-			href: getTitanContactsUrl( email ),
-			image: titanContactsIcon,
-			imageAltText: translate( 'Titan Contacts icon' ),
-			title: translate( 'View Contacts', {
-				comment: 'View the Contacts application for Titan',
-			} ),
-		},
-	];
-};
-
-const getGSuiteMenuItems = ( { account, email, mailbox, translate } ) => {
-	if ( hasGoogleAccountTOSWarning( account ) ) {
-		return null;
-	}
-
-	return [
-		{
-			href: getGmailUrl( email ),
-			image: gmailIcon,
-			imageAltText: translate( 'Gmail icon' ),
-			title: translate( 'View Gmail' ),
-		},
-		...( isEmailUserAdmin( mailbox )
-			? [
-					{
-						href: getGoogleAdminUrl( email ),
-						image: googleAdminIcon,
-						imageAltText: translate( 'Google Admin icon' ),
-						title: translate( 'View Admin' ),
-					},
-			  ]
-			: [] ),
-		{
-			href: getGoogleCalendarUrl( email ),
-			image: googleCalendarIcon,
-			imageAltText: translate( 'Google Calendar icon' ),
-			title: translate( 'View Calendar' ),
-		},
-		{
-			href: getGoogleDocsUrl( email ),
-			image: googleDocsIcon,
-			imageAltText: translate( 'Google Docs icon' ),
-			title: translate( 'View Docs' ),
-		},
-		{
-			href: getGoogleDriveUrl( email ),
-			image: googleDriveIcon,
-			imageAltText: translate( 'Google Drive icon' ),
-			title: translate( 'View Drive' ),
-		},
-		{
-			href: getGoogleSheetsUrl( email ),
-			image: googleSheetsIcon,
-			imageAltText: translate( 'Google Sheets icon' ),
-			title: translate( 'View Sheets' ),
-		},
-		{
-			href: getGoogleSlidesUrl( email ),
-			image: googleSlidesIcon,
-			imageAltText: translate( 'Google Slides icon' ),
-			title: translate( 'View Slides' ),
-		},
-	];
-};
-
-const getEmailForwardMenuItems = ( { currentRoute, domain, selectedSite, translate } ) => {
-	return [
-		{
-			href: emailManagementForwarding( selectedSite.slug, domain.name, currentRoute ),
-			isInternalLink: true,
-			materialIcon: 'create',
-			title: translate( 'Edit', {
-				comment: 'Edit an email forward',
-			} ),
-		},
-	];
-};
-
-const getMenuItems = (
-	{ account, currentRoute, domain, email, mailbox, selectedSite },
-	translate
-) => {
-	if ( hasTitanMailWithUs( domain ) ) {
-		return getTitanMenuItems( email, translate );
-	}
-
-	if ( hasGSuiteWithUs( domain ) ) {
-		return getGSuiteMenuItems( { account, email, mailbox, translate } );
-	}
-
-	if ( hasEmailForwards( domain ) ) {
-		return getEmailForwardMenuItems( { currentRoute, domain, selectedSite, translate } );
-	}
-
-	return null;
-};
-
-const ActionMenu = ( { account, domain, mailbox, selectedSite } ) => {
-	const currentRoute = useSelector( getCurrentRoute );
-	const translate = useTranslate();
-	const email = `${ mailbox.mailbox }@${ mailbox.domain }`;
-	const menuItems = getMenuItems(
-		{ account, currentRoute, domain, email, mailbox, selectedSite },
-		translate
-	);
-	if ( ! menuItems ) {
-		return null;
-	}
-	return (
-		<EllipsisMenu position="bottom" className="email-plan-mailboxes-list__mailbox-action-menu">
-			{ menuItems.map(
-				( { href, image, imageAltText, isInternalLink = false, materialIcon, title } ) => (
-					<PopoverMenuItem
-						key={ href }
-						className="email-plan-mailboxes-list__mailbox-action-menu-item"
-						isExternalLink={ ! isInternalLink }
-						href={ href }
-					>
-						{ image && <img src={ image } alt={ imageAltText } /> }
-						{ materialIcon && <MaterialIcon icon={ materialIcon } /> }
-						{ title }
-					</PopoverMenuItem>
-				)
-			) }
-		</EllipsisMenu>
-	);
-};
-
 function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, selectedSite } ) {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
@@ -314,7 +124,7 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 					</Badge>
 				) }
 				<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
-				<ActionMenu
+				<EmailMailboxActionMenu
 					account={ account }
 					domain={ domain }
 					mailbox={ mailbox }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -77,7 +77,7 @@ const getSecondaryContentForMailbox = ( mailbox ) => {
 	return null;
 };
 
-function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, selectedSite } ) {
+function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes } ) {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
 
@@ -123,13 +123,10 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 						} ) }
 					</Badge>
 				) }
+
 				<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
-				<EmailMailboxActionMenu
-					account={ account }
-					domain={ domain }
-					mailbox={ mailbox }
-					selectedSite={ selectedSite }
-				/>
+
+				<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
 			</MailboxListItem>
 		);
 	} );
@@ -142,7 +139,6 @@ EmailPlanMailboxesList.propTypes = {
 	domain: PropTypes.object,
 	isLoadingEmails: PropTypes.bool,
 	mailboxes: PropTypes.array,
-	selectedSite: PropTypes.object,
 };
 
 export default EmailPlanMailboxesList;

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -97,6 +97,9 @@ class EmailPlan extends React.Component {
 				return;
 			}
 
+			// We've finished loading both sets of data. If the two data sources have the same
+			// number of mailboxes, don't re-fetch the data below - this should help to
+			// prevent fetch loops triggered via componentDidUpdate().
 			if ( this.getMailboxes().length === emailForwards.length ) {
 				return;
 			}

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -361,7 +361,6 @@ class EmailPlan extends React.Component {
 					domain={ domain }
 					mailboxes={ this.getMailboxes() }
 					isLoadingEmails={ isLoadingEmailAccounts }
-					selectedSite={ selectedSite }
 				/>
 
 				<div className="email-plan__actions">

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -199,7 +199,7 @@
 	margin-top: 15px;
 }
 
-.email-plan-mailboxes-list__mailbox-action-menu {
+.email-mailbox-action-menu__main {
 	position: absolute;
 	right: 16px;
 	top: 28px;
@@ -213,7 +213,7 @@
 	}
 }
 
-.popover__menu-item.email-plan-mailboxes-list__mailbox-action-menu-item {
+.popover__menu-item.email-mailbox-action-menu__menu-item {
 	align-items: center;
 	display: flex;
 	line-height: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes the following changes:
* The existing `ActionMenu` function and its helpers has been refactored into a new `EmailMailboxActionMenu` component (with some minor modifications to the arguments and code structure)
* The `PopoverMenuItem` now has documentation for its `onClick` prop and a note that external links require an `href` prop to be accessible
* We now have a new "Remove email forward" menu item for email forwards
* We have removed the existing "Edit" menu item for email forwards -- the only action for forwards other than removing a forward or resending the verification email is to create a new forward, and that's not a mailbox-specific action.
* The main `EmailPlan` component has the existing email forward state wired in so we can detect when updates occur and we need to refetch the email data for the current domain
   - The current implementation here is not ideal as we're bridging the email forwarding state changes across to the new email provider API, but we don't have that data cleanly handled via Redux yet, so we'll need to take that on separately

#### Testing instructions

* Run this branch locally or via the [live branch](https://calypso.live/?image=registry.a8c.com/calypso/app:build-8672).
* Set up two email forwards for a domain you own. (This is currently performed outside the email plan page.)
* Navigate to the email plan page for your domain with email forwards.
* Open your browser network tab.
* For one of the email forwards, open the action/kebab menu for the email.
* Verify that the only option in the menu is "Remove email forward".
* Click on the "Remove email forward" option.
* Verify that we triggered a `calypso_email_management_email_forwarding_delete_click` Tracks event.
* Verify that you see a success notice appear.
* Verify that the page is updated and no longer shows the removed email forward.
* Click on the "Remove email forward" menu item for the last email forward.
* Verify that we remove the forward as above and show the email plan page with "No mailboxes"

#### Screenshot

<img width="1157" alt="Screenshot 2021-06-22 at 21 08 32" src="https://user-images.githubusercontent.com/3376401/123019617-d4001200-d39e-11eb-8551-5a3bae816a6a.png">
