### PR TITLE
move `getWpcomFollowerRole` out of selector space

### DIFF
--- a/client/lib/get-wpcom-follower-role.js
+++ b/client/lib/get-wpcom-follower-role.js
@@ -1,23 +1,12 @@
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { getSite } from 'calypso/state/sites/selectors';
-
-/**
  * Retrieve the WPCOM follower role info, based on site settings
  *
- * @param  {object} state    Global state tree
- * @param  {number} siteId   Site ID
+ * @param  {boolean} isPrivateSite    Whether site is private or not
+ * @param  {Function} translate   `translate` function derived from `i18n-calypso`
  * @returns {object}         Follower role object
  */
-const getWpcomFollowerRole = ( state, siteId ) => {
-	const site = getSite( state, siteId );
-	const displayName = site.is_private
+const getWpcomFollowerRole = ( isPrivateSite, translate ) => {
+	const displayName = isPrivateSite
 		? translate( 'Viewer', { context: 'Role that is displayed in a select' } )
 		: translate( 'Follower', { context: 'Role that is displayed in a select' } );
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -19,6 +19,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import getWpcomFollowerRole from 'calypso/lib/get-wpcom-follower-role';
 import { generateInviteLinks, disableInviteLinks } from 'calypso/state/invites/actions';
 import { Card, Button } from '@automattic/components';
 import Main from 'calypso/components/main';
@@ -33,7 +34,7 @@ import FeatureExample from 'calypso/components/feature-example';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { isJetpackSite, getWpcomFollowerRole } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -57,6 +58,7 @@ import withSiteRoles from 'calypso/data/site-roles/with-site-roles';
  * Style dependencies
  */
 import './style.scss';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 /**
  * Module variables
@@ -496,7 +498,8 @@ class InvitePeople extends React.Component {
 	};
 
 	getInviteLinkRoles = () => {
-		const { siteRoles, wpcomFollowerRole } = this.props;
+		const { siteRoles, translate } = this.props;
+		const wpcomFollowerRole = getWpcomFollowerRole( this.props.isPrivateSite, translate );
 
 		if ( ! siteRoles || ! wpcomFollowerRole ) {
 			return [];
@@ -745,7 +748,7 @@ const mapStateToProps = ( state ) => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 		inviteLinks: getInviteLinksForSite( state, siteId ),
-		wpcomFollowerRole: getWpcomFollowerRole( state, siteId ),
+		isPrivateSite: isPrivateSite( state, siteId ),
 	};
 };
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -53,12 +53,12 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import wpcom from 'calypso/lib/wp';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import withSiteRoles from 'calypso/data/site-roles/with-site-roles';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 /**
  * Module variables

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { omit } from 'lodash';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,44 +14,38 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import getWpcomFollowerRole from 'calypso/lib/get-wpcom-follower-role';
 import QuerySites from 'calypso/components/data/query-sites';
-import { getSite, getWpcomFollowerRole } from 'calypso/state/sites/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import { ROLES_LIST } from './constants';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import useSiteRolesQuery from 'calypso/data/site-roles/use-site-roles-query';
 
 import './style.scss';
 
 const RoleSelect = ( props ) => {
+	const translate = useTranslate();
 	const { data } = useSiteRolesQuery( props.siteId );
 	const { isWPForTeamsSite } = props;
 
-	const {
-		site,
-		includeFollower,
-		wpcomFollowerRole,
-		siteId,
-		id,
-		explanation,
-		translate,
-		value,
-	} = props;
+	const { site, includeFollower, siteId, id, explanation, value } = props;
 
 	const omitProps = [
-		'isWPForTeamsSite',
-		'site',
-		'key',
-		'siteId',
-		'includeFollower',
-		'explanation',
-		'siteRoles',
 		'dispatch',
+		'explanation',
+		'id',
+		'includeFollower',
+		'isPrivateSite',
+		'isWPForTeamsSite',
+		'key',
 		'moment',
 		'numberFormat',
+		'site',
+		'siteId',
+		'siteRoles',
 		'translate',
 		'value',
-		'id',
-		'wpcomFollowerRole',
 	];
 
 	let siteRoles;
@@ -60,6 +54,7 @@ const RoleSelect = ( props ) => {
 		siteRoles = data;
 
 		if ( includeFollower ) {
+			const wpcomFollowerRole = getWpcomFollowerRole( props.isPrivateSite, translate );
 			siteRoles = siteRoles.concat( wpcomFollowerRole );
 		}
 	}
@@ -97,5 +92,5 @@ const RoleSelect = ( props ) => {
 export default connect( ( state, ownProps ) => ( {
 	site: getSite( state, ownProps.siteId ),
 	isWPForTeamsSite: isSiteWPForTeams( state, ownProps.siteId ),
-	wpcomFollowerRole: getWpcomFollowerRole( state, ownProps.siteId ),
-} ) )( localize( RoleSelect ) );
+	isPrivateSite: isPrivateSite( state, ownProps.siteId ),
+} ) )( RoleSelect );

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -59,4 +59,3 @@ export { default as getSelectedSiteWithFallback } from './get-site-with-fallback
 export { default as getSiteWooCommerceUrl } from './get-site-woocommerce-url';
 export { default as getSiteWooCommerceWizardUrl } from './get-site-woocommerce-wizard-url';
 export { default as getSiteWordPressSeoWizardUrl } from './get-site-wordpress-seo-wizard-url';
-export { default as getWpcomFollowerRole } from './get-wpcom-follower-role';


### PR DESCRIPTION
After [feedback from @jsnajdr](https://github.com/Automattic/wp-calypso/pull/53503#discussion_r647999932) I extracted `getWpcomFollowerRole` out of selector space.

> I think this function shouldn't be a selector at all, as it depends on an external translate function (a proper selector should depend only on state and nothing else) and doesn't react reliably to changes in locale.

Note: I'm not sure where it lives now is the best place for that function. Let me know if you think otherwise 👍🏻 

### Changes proposed in this Pull Request

* Move `getWpcomFollowerRole` out of selector space and make it a general helper function
* Move `getWpcomFollowerRole` to `lib/`

#### Testing instructions

You can test this with a simple private site, a simple public site and P2s:

- Go to `/people/new/<site-slug>` and make sure the follower role is shown as expected:
  - for private and P2 sites it should say _Viewer_
  - for any other site it should say _Follower_

follow up to #53503
