### PR TITLE
Fix: My Sites button on the theme info page is not working

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -229,6 +229,7 @@ class Layout extends Component {
 		return (
 			<MasterbarComponent
 				section={ this.props.sectionGroup }
+				sectionName={ this.props.sectionName }
 				isCheckout={ this.props.sectionName === 'checkout' }
 			/>
 		);

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -51,6 +51,7 @@ class MasterbarLoggedIn extends React.Component {
 		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		sectionName: PropTypes.string,
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -185,13 +186,14 @@ class MasterbarLoggedIn extends React.Component {
 			translate,
 			isCustomerHomeEnabled,
 			section,
+			sectionName,
 		} = this.props;
 		const homeUrl = isCustomerHomeEnabled
 			? `/home/${ siteSlug }`
 			: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
-		if ( this.props.isNavUnificationEnabled && 'sites' === section ) {
+		if ( this.props.isNavUnificationEnabled && 'sites' === section && 'theme' !== sectionName ) {
 			mySitesUrl = '';
 		}
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the My Sites button not working in the theme info page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select Appearance > Themes
* Choose any theme. You will see the details of the theme.
* Click on the My Sites button at the left top of the page.
* You should be taken to the My Home page of your current website.

![mysites_button](https://user-images.githubusercontent.com/212034/121338446-7ad4bf00-c958-11eb-8732-bb4da8420cc2.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #53506
