### PR TITLE
Marketplace wait for plugin installation post purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -97,7 +97,6 @@ const MarketplaceThankYou = () => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const dispatch = useDispatch();
-	const [ isLoadingPageOpen, setIsLoadingPageOpen ] = useState( true );
 
 	const isFetchingTransferStatus = useSelector( ( state ) =>
 		isFetchingAutomatedTransferStatus( state, selectedSiteId ?? 0 )
@@ -125,7 +124,11 @@ const MarketplaceThankYou = () => {
 	}, [ postsPageUrl, yoastSeoPageUrl ] );
 
 	useEffect( () => {
-		if ( transferStatus !== 'complete' ) {
+		if (
+			isPluginInstalledDuringPurchase &&
+			transferStatus !== 'complete' &&
+			! isFetchingTransferStatus
+		) {
 			setTimeout( () => {
 				dispatch( fetchAutomatedTransferStatus( selectedSiteId ?? 0 ) );
 				setPollCount( ( c ) => c + 1 );
@@ -142,8 +145,8 @@ const MarketplaceThankYou = () => {
 
 	return (
 		<>
-			{ isLoadingPageOpen && transferStatus !== 'complete' ? (
-				<MarketplacePluginSetupStatus onCloseLoadingPage={ () => setIsLoadingPageOpen( false ) } />
+			{ isPluginInstalledDuringPurchase && transferStatus !== 'complete' ? (
+				<MarketplacePluginSetupStatus />
 			) : (
 				<>
 					<Masterbar>
@@ -162,7 +165,6 @@ const MarketplaceThankYou = () => {
 						</MarketplaceThankYouHeader>
 						<ThankYouBody>
 							<div>
-								<div>{ transferStatus }</div>
 								<MarketplaceThankyouSection>
 									<MarketplaceHeaderTitle className="marketplace-thank-you__body-header wp-brand-font">
 										{ translate( 'Yoast SEO Premium is installed' ) }
@@ -177,8 +179,6 @@ const MarketplaceThankYou = () => {
 									</MarketplaceHeaderTitle>
 									<MarketplaceNextSteps>
 										<h3>{ translate( 'Plugin setup' ) }</h3>
-										<h3>{ isFetchingTransferStatus }</h3>
-										<h3>{ transferStatus }</h3>
 										<div>
 											<p>
 												{ translate(

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -145,6 +145,7 @@ const MarketplaceThankYou = () => {
 									</p>
 									<div>
 										<FullWidthButton
+											//TODO: Menu links not properly loading after installing the plugin
 											href={ yoastSeoPageUrl }
 											primary
 											busy={ isRequestingMenu }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { isDesktop } from '@automattic/viewport';
 import { ThemeProvider } from 'emotion-theming';
@@ -14,8 +14,7 @@ import page from 'page';
  */
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import Item from 'calypso/layout/masterbar/item';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import getPreviousPath from 'calypso/state/selectors/get-previous-path';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import yoastInstalledImage from 'calypso/assets/images/marketplace/yoast-installed.svg';
 import theme from 'calypso/my-sites/plugins/marketplace/theme';
 import type { MarketplaceThemeProps } from 'calypso/my-sites/plugins/marketplace/theme';
@@ -27,11 +26,19 @@ import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import useSiteMenuItems from 'calypso/my-sites/sidebar-unified/use-site-menu-items';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import { getPurchaseFlowState } from 'calypso/state/plugins/marketplace/selectors';
+import {
+	isFetchingAutomatedTransferStatus,
+	getAutomatedTransferStatus,
+} from 'calypso/state/automated-transfer/selectors';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import MarketplacePluginSetupStatus from 'calypso/my-sites/plugins/marketplace/marketplace-plugin-setup-status';
 
 /**
  * style dependencies
  */
 import './style.scss';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 
 const MarketplaceThankYouContainer = styled.div< MarketplaceThemeProps >`
 	background-color: #fff;
@@ -86,8 +93,20 @@ const MarketplaceNextSteps = styled.div< MarketplaceThemeProps >`
 `;
 
 const MarketplaceThankYou = () => {
-	const selectedSite = useSelector( getSelectedSite );
-	const previousPath = useSelector( getPreviousPath );
+	const [ pollCount, setPollCount ] = useState( 0 );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const dispatch = useDispatch();
+	const [ isLoadingPageOpen, setIsLoadingPageOpen ] = useState( true );
+
+	const isFetchingTransferStatus = useSelector( ( state ) =>
+		isFetchingAutomatedTransferStatus( state, selectedSiteId ?? 0 )
+	);
+
+	const { isPluginInstalledDuringPurchase } = useSelector( getPurchaseFlowState );
+	const transferStatus = useSelector( ( state ) =>
+		getAutomatedTransferStatus( state, selectedSiteId ?? 0 )
+	);
 	const menuItems = useSiteMenuItems();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const { url: postsPageUrl } =
@@ -99,107 +118,132 @@ const MarketplaceThankYou = () => {
 	const translate = useTranslate();
 	const imageWidth = isDesktop() ? 200 : 150;
 
+	useEffect( () => {
+		if ( ! postsPageUrl || ! yoastSeoPageUrl ) {
+			dispatch( requestAdminMenu( selectedSiteId ?? 0 ) );
+		}
+	}, [ postsPageUrl, yoastSeoPageUrl ] );
+
+	useEffect( () => {
+		if ( transferStatus !== 'complete' ) {
+			setTimeout( () => {
+				dispatch( fetchAutomatedTransferStatus( selectedSiteId ?? 0 ) );
+				setPollCount( ( c ) => c + 1 );
+			}, 1500 );
+		}
+	}, [
+		isFetchingTransferStatus,
+		isPluginInstalledDuringPurchase,
+		pollCount,
+		setPollCount,
+		dispatch,
+		transferStatus,
+	] );
+
 	return (
 		<>
-			<Masterbar>
-				<Item
-					icon="cross"
-					// TODO: Immediately after purchasing a domain and going through a transfer the selected site id remains uncertain
-					// We have to prevent the user from entering the flow before we finish provisioning the SSL certificate forsomeone with a fresh domains
-					onClick={ () =>
-						previousPath
-							? page( previousPath )
-							: page(
-									`/plugins/wordpress-seo${ selectedSite?.slug ? `/${ selectedSite.slug }` : '' }`
-							  )
-					}
-					tooltip={ translate( 'Go to plugin' ) }
-					tipTarget="close"
-				/>
-			</Masterbar>
-			<MarketplaceThankYouContainer className="marketplace-thank-you__container checkout-thank-you">
-				<MarketplaceThankYouHeader>
-					<img alt="yoast logo" width={ imageWidth } src={ yoastInstalledImage }></img>
-				</MarketplaceThankYouHeader>
-				<ThankYouBody>
-					<div>
-						<MarketplaceThankyouSection>
-							<MarketplaceHeaderTitle className="marketplace-thank-you__body-header wp-brand-font">
-								{ translate( 'Yoast SEO Premium is installed' ) }
-							</MarketplaceHeaderTitle>
-						</MarketplaceThankyouSection>
-						<MarketplaceThankyouSection>
-							<MarketplaceHeaderTitle
-								subtitle
-								className="marketplace-thank-you__body-header wp-brand-font"
-							>
-								{ translate( 'What’s next?' ) }
-							</MarketplaceHeaderTitle>
-							<MarketplaceNextSteps>
-								<h3>{ translate( 'Plugin setup' ) }</h3>
-								<div>
+			{ isLoadingPageOpen && transferStatus !== 'complete' ? (
+				<MarketplacePluginSetupStatus onCloseLoadingPage={ () => setIsLoadingPageOpen( false ) } />
+			) : (
+				<>
+					<Masterbar>
+						<Item
+							icon="cross"
+							onClick={ () =>
+								page( `/marketplace/product/details/wordpress-seo/${ selectedSiteSlug }` )
+							}
+							tooltip={ translate( 'Go to plugin' ) }
+							tipTarget="close"
+						/>
+					</Masterbar>
+					<MarketplaceThankYouContainer className="marketplace-thank-you__container checkout-thank-you">
+						<MarketplaceThankYouHeader>
+							<img alt="yoast logo" width={ imageWidth } src={ yoastInstalledImage }></img>
+						</MarketplaceThankYouHeader>
+						<ThankYouBody>
+							<div>
+								<div>{ transferStatus }</div>
+								<MarketplaceThankyouSection>
+									<MarketplaceHeaderTitle className="marketplace-thank-you__body-header wp-brand-font">
+										{ translate( 'Yoast SEO Premium is installed' ) }
+									</MarketplaceHeaderTitle>
+								</MarketplaceThankyouSection>
+								<MarketplaceThankyouSection>
+									<MarketplaceHeaderTitle
+										subtitle
+										className="marketplace-thank-you__body-header wp-brand-font"
+									>
+										{ translate( 'What’s next?' ) }
+									</MarketplaceHeaderTitle>
+									<MarketplaceNextSteps>
+										<h3>{ translate( 'Plugin setup' ) }</h3>
+										<h3>{ isFetchingTransferStatus }</h3>
+										<h3>{ transferStatus }</h3>
+										<div>
+											<p>
+												{ translate(
+													'Get to know Yoast SEO and customize it, so you can hit the ground running.'
+												) }
+											</p>
+											<div>
+												<FullWidthButton
+													href={ yoastSeoPageUrl }
+													primary
+													busy={ isRequestingMenu }
+													// TODO: Menu links are not properly loading on initial request, post transfer so yoastSeoPageUrl will remain empty post transfer
+													// This should be fixed with perhaps a work around to periodically poll for the menu with various domains until it loads
+													// or maybe blocking the user from entering this flow until a domain acquires SSL
+													disabled={ !! yoastSeoPageUrl }
+												>
+													{ translate( 'Get started' ) }
+												</FullWidthButton>
+											</div>
+										</div>
+										<h3>{ translate( 'Start putting SEO to work' ) }</h3>
+										<div>
+											<p>
+												{ translate(
+													"Improve your site's performance and rank higher with a few tips."
+												) }
+											</p>
+											<div>
+												<FullWidthButton
+													href={ postsPageUrl }
+													busy={ isRequestingMenu }
+													disabled={ !! yoastSeoPageUrl }
+												>
+													{ translate( 'View posts' ) }
+												</FullWidthButton>
+											</div>
+										</div>
+									</MarketplaceNextSteps>
+								</MarketplaceThankyouSection>
+								<MarketplaceThankyouSection>
+									<MarketplaceHeaderTitle
+										subtitle
+										className="marketplace-thank-you__body-header wp-brand-font"
+									>
+										{ translate( 'How can we help?' ) }
+									</MarketplaceHeaderTitle>
 									<p>
 										{ translate(
-											'Get to know Yoast SEO and customize it, so you can hit the ground running.'
+											'Our Happiness Engineers are here if you need help, or if you have any questions.'
 										) }
 									</p>
-									<div>
-										<FullWidthButton
-											href={ yoastSeoPageUrl }
-											primary
-											busy={ isRequestingMenu }
-											// TODO: Menu links are not properly loading on initial request, post transfer so yoastSeoPageUrl will remain empty post transfer
-											// This should be fixed with perhaps a work around to periodically poll for the menu with various domains until it loads
-											// or maybe blocking the user from entering this flow until a domain acquires SSL
-											disabled={ !! yoastSeoPageUrl }
-										>
-											{ translate( 'Get started' ) }
-										</FullWidthButton>
-									</div>
-								</div>
-								<h3>{ translate( 'Start putting SEO to work' ) }</h3>
-								<div>
-									<p>
-										{ translate(
-											"Improve your site's performance and rank higher with a few tips."
-										) }
-									</p>
-									<div>
-										<FullWidthButton
-											href={ postsPageUrl }
-											busy={ isRequestingMenu }
-											disabled={ !! yoastSeoPageUrl }
-										>
-											{ translate( 'View posts' ) }
-										</FullWidthButton>
-									</div>
-								</div>
-							</MarketplaceNextSteps>
-						</MarketplaceThankyouSection>
-						<MarketplaceThankyouSection>
-							<MarketplaceHeaderTitle
-								subtitle
-								className="marketplace-thank-you__body-header wp-brand-font"
-							>
-								{ translate( 'How can we help?' ) }
-							</MarketplaceHeaderTitle>
-							<p>
-								{ translate(
-									'Our Happiness Engineers are here if you need help, or if you have any questions.'
-								) }
-							</p>
-							<VerticalNav>
-								<VerticalNavItem path={ '/help/contact' }>
-									{ translate( 'Ask a question' ) }
-								</VerticalNavItem>
-								<VerticalNavItem path={ 'https://wordpress.com/support' }>
-									{ translate( 'Support documentation' ) }
-								</VerticalNavItem>
-							</VerticalNav>
-						</MarketplaceThankyouSection>
-					</div>
-				</ThankYouBody>
-			</MarketplaceThankYouContainer>
+									<VerticalNav>
+										<VerticalNavItem path={ '/help/contact' }>
+											{ translate( 'Ask a question' ) }
+										</VerticalNavItem>
+										<VerticalNavItem path={ 'https://wordpress.com/support' }>
+											{ translate( 'Support documentation' ) }
+										</VerticalNavItem>
+									</VerticalNav>
+								</MarketplaceThankyouSection>
+							</div>
+						</ThankYouBody>
+					</MarketplaceThankYouContainer>
+				</>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -145,7 +145,6 @@ const MarketplaceThankYou = () => {
 									</p>
 									<div>
 										<FullWidthButton
-											//TODO: Menu links not properly loading after installing the plugin
 											href={ yoastSeoPageUrl }
 											primary
 											busy={ isRequestingMenu }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -119,7 +119,7 @@ const MarketplaceThankYou = () => {
 
 	useEffect( () => {
 		if ( ! postsPageUrl || ! yoastSeoPageUrl ) {
-			dispatch( requestAdminMenu( selectedSiteId ?? 0 ) );
+			selectedSiteId && dispatch( requestAdminMenu( selectedSiteId ) );
 		}
 	}, [ postsPageUrl, yoastSeoPageUrl ] );
 
@@ -130,7 +130,7 @@ const MarketplaceThankYou = () => {
 			! isFetchingTransferStatus
 		) {
 			setTimeout( () => {
-				dispatch( fetchAutomatedTransferStatus( selectedSiteId ?? 0 ) );
+				selectedSiteId && dispatch( fetchAutomatedTransferStatus( selectedSiteId ) );
 				setPollCount( ( c ) => c + 1 );
 			}, 1500 );
 		}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -3,6 +3,7 @@
 	.layout__content {
 		background-color: var( --studio-white );
 		height: 100vh;
+		min-height: 100vh;
 		padding: 0;
 		@media ( max-width: 782px ) {
 			padding: 0;

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
@@ -29,11 +29,12 @@ const StyledProgressBar = styled( ProgressBar )`
 	margin: 20px 0px;
 `;
 
-function WrappedMarketplacePluginSetup( {
-	onCloseLoadingPage,
-}: {
-	onCloseLoadingPage?: () => void;
-} ): JSX.Element {
+/**
+ * This component simulates progress for the purchase flow. It also does any async tasks required in the purchase flow. This includes installing any plugins required.
+ * TODO: Refactor component so that it can easily handle multiple speeds of simulated progress
+ */
+
+function WrappedMarketplacePluginSetup(): JSX.Element {
 	const translate = useTranslate();
 
 	const STEP_1 = translate( 'Installing plugin' );
@@ -58,19 +59,13 @@ function WrappedMarketplacePluginSetup( {
 	}, [ fetchAutomatedTransferStatus ] );
 
 	useEffect( () => {
-		if ( isPluginInstalledDuringPurchase ) {
-			if ( transferStatus === 'completed' ) {
-				onCloseLoadingPage && onCloseLoadingPage();
-			}
-		} else if ( pluginSlugToBeInstalled && selectedSiteId ) {
+		if ( pluginSlugToBeInstalled && selectedSiteId ) {
 			dispatch( initiateThemeTransfer( selectedSiteId, null, pluginSlugToBeInstalled ) );
-		} else if ( isPluginInstalledDuringPurchase ) {
-			// TODO: To be implemented: polling wait to be implemented to check for transfer
-		} else {
+		} else if ( ! isPluginInstalledDuringPurchase ) {
 			// Invalid State redirect to Yoast marketplace page for now, and maybe a marketplace home view in the future
-			// page(
-			// 	`/marketplace/product/details/wordpress-seo/${ selectedSiteId }?flags=marketplace-yoast`
-			// );
+			page(
+				`/marketplace/product/details/wordpress-seo/${ selectedSiteSlug }?flags=marketplace-yoast`
+			);
 		}
 	}, [ dispatch, pluginSlugToBeInstalled, isPluginInstalledDuringPurchase, selectedSiteId ] );
 
@@ -94,7 +89,7 @@ function WrappedMarketplacePluginSetup( {
 
 	useEffect( () => {
 		if ( transferStatus === 'complete' ) {
-			// TODO: Make sure the primary domain is set to the relevant domain before redireting to thank-you page
+			// TODO: Make sure the primary domain is set to the relevant domain before redirecting to thank-you page
 			setSimulatedProgressPercentage( 100 );
 			setTimeout( () => {
 				page( `/marketplace/thank-you/${ selectedSiteId }?flags=marketplace-yoast` );
@@ -108,7 +103,7 @@ function WrappedMarketplacePluginSetup( {
 
 	const currentNumericStep = steps.indexOf( currentStep ) + 1;
 
-	/* translators: %(currentStep)s  Is the current step number, given that steps are set of counting numbers representing each step starting from 1, %(stepCount)s  Is the total numer of steps, Eg: Step 1 of 3  */
+	/* translators: %(currentStep)s  Is the current step number, given that steps are set of counting numbers representing each step starting from 1, %(stepCount)s  Is the total number of steps, Eg: Step 1 of 3  */
 	const stepIndication = translate( 'Step %(currentStep)s of %(stepCount)s', {
 		args: { currentStep: currentNumericStep, stepCount: steps.length },
 	} );
@@ -128,14 +123,10 @@ function WrappedMarketplacePluginSetup( {
 	);
 }
 
-export default function MarketplacePluginSetup( {
-	onCloseLoadingPage,
-}: {
-	onCloseLoadingPage?: () => void;
-} ): JSX.Element {
+export default function MarketplacePluginSetup(): JSX.Element {
 	return (
 		<ThemeProvider theme={ theme }>
-			<WrappedMarketplacePluginSetup onCloseLoadingPage={ onCloseLoadingPage } />
+			<WrappedMarketplacePluginSetup />
 		</ThemeProvider>
 	);
 }

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
@@ -100,6 +100,9 @@ function WrappedMarketplacePluginSetup(): JSX.Element {
 		args: { currentStep: currentNumericStep, stepCount: steps.length },
 	} );
 
+	if ( simulatedProgressPercentage > 50 && currentStage === 1 ) {
+		setCurrentStage( 2 );
+	}
 	return (
 		<>
 			{ selectedSiteId ? <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> : '' }

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
@@ -100,15 +100,6 @@ function WrappedMarketplacePluginSetup(): JSX.Element {
 		args: { currentStep: currentNumericStep, stepCount: steps.length },
 	} );
 
-	if ( simulatedProgressPercentage > 50 && currentStage === STAGE_1 ) {
-		setCurrentStage( STAGE_2 );
-	}
-
-	const currentNumericStage = stages.indexOf( currentStage ) + 1;
-	const stageIndication = translate( 'Step %(currentStage)s of %(stageCount)s', {
-		args: { currentStage: currentNumericStage, stageCount: stages.length },
-	} );
-
 	return (
 		<>
 			{ selectedSiteId ? <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> : '' }

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
@@ -100,9 +100,15 @@ function WrappedMarketplacePluginSetup(): JSX.Element {
 		args: { currentStep: currentNumericStep, stepCount: steps.length },
 	} );
 
-	if ( simulatedProgressPercentage > 50 && currentStage === 1 ) {
-		setCurrentStage( 2 );
+	if ( simulatedProgressPercentage > 50 && currentStage === STAGE_1 ) {
+		setCurrentStage( STAGE_2 );
 	}
+
+	const currentNumericStage = stages.indexOf( currentStage ) + 1;
+	const stageIndication = translate( 'Step %(currentStage)s of %(stageCount)s', {
+		args: { currentStage: currentNumericStage, stageCount: stages.length },
+	} );
+
 	return (
 		<>
 			{ selectedSiteId ? <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> : '' }

--- a/client/my-sites/plugins/marketplace/marketplace-test/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-test/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import page from 'page';
 import styled from '@emotion/styled';
 
@@ -11,40 +11,225 @@ import styled from '@emotion/styled';
  */
 import CardHeading from 'calypso/components/card-heading';
 import { Button, Card } from '@automattic/components';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import { getAutomatedTransfer } from 'calypso/state/automated-transfer/selectors';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+// import { getPlugins, isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 
 export const Container = styled.div`
-	margin: 25px;
+	margin: 0 25px;
 	padding: 25px;
 `;
 
 export default function MarketplaceTest() {
 	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	// This selector is not working
+	// const pluginDetails = useSelector( ( state ) => getPlugins( state, selectedSiteId ) );
+	const pluginDetails = useSelector(
+		( state ) => state.plugins.installed.plugins[ selectedSiteId ]
+	);
+	const [ infiniteLoopCount, setInfiniteLoopCount ] = useState( 0 );
 	const marketplacePages = [
 		{ name: 'Plugin Details Page', path: '/marketplace/product/details/wordpress-seo' },
 		{ name: 'Loading Page', path: '/marketplace/product/setup' },
 		{ name: 'Domains Page', path: '/marketplace/domain' },
 		{ name: 'Thank You Page', path: '/marketplace/thank-you' },
 	];
+	const dispatch = useDispatch();
+	const transferDetails = useSelector( ( state ) =>
+		getAutomatedTransfer( state, selectedSite?.ID ?? 0 )
+	);
 
+	//Infinite Loop
+	useEffect( () => {
+		setTimeout( () => {
+			dispatch( fetchAutomatedTransferStatus( selectedSite?.ID ?? 0 ) );
+
+			setInfiniteLoopCount( ( l ) => l + 1 );
+		}, 4000 );
+	}, [ infiniteLoopCount, fetchAutomatedTransferStatus, selectedSite ] );
+
+	const { ID, URL, domain, options } = selectedSite;
+	const { is_wpcom_atomic, is_automated_transfer } = options;
 	return (
 		<Container>
+			{ selectedSiteId && <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> }
 			<SidebarNavigation />
-			<CardHeading tagName="h1" size={ 32 }>
-				Marketplace Test Page With Links For Various Pages
-			</CardHeading>
-			<CardHeading tagName="h1" size={ 21 }>
-				Currrent Site : { selectedSite?.domain }
-			</CardHeading>
-			{ marketplacePages.map( ( p ) => {
-				const path = `${ p.path }${ selectedSite?.domain ? `/${ selectedSite.domain }` : '' }`;
-				return (
-					<Card key={ path }>
-						<Button onClick={ () => page( path ) }>{ p.name }</Button>
-					</Card>
-				);
-			} ) }
+			<Card key="heading">
+				<CardHeading tagName="h1" size={ 24 }>
+					Marketplace Test Page
+				</CardHeading>
+				<CardHeading tagName="h1" size={ 24 }>
+					<div>Currrent Site : { selectedSite?.domain }</div>
+				</CardHeading>
+			</Card>
+			<Card key="navigation-links">
+				{ marketplacePages.map( ( p ) => {
+					const path = `${ p.path }${ selectedSite?.domain ? `/${ selectedSite.domain }` : '' }`;
+					return (
+						<Button key={ p.path } onClick={ () => page( path ) }>
+							{ p.name }
+						</Button>
+					);
+				} ) }
+			</Card>
+			<Card key="important-state">
+				<Card key="site-information">
+					<CardHeading tagName="h1" size={ 21 }>
+						Selected Site details selector <strong>getSelectedSite</strong>
+					</CardHeading>
+					<div>ID : { ID }</div>
+					<div>URL : { URL }</div>
+					<div>domain : { domain }</div>
+					<div>options.is_wpcom_atomic : { is_wpcom_atomic?.toString() }</div>
+					<div>options.is_automated_transfer : { is_automated_transfer?.toString() }</div>
+				</Card>
+				<Card key="transfer-information">
+					<CardHeading tagName="h1" size={ 21 }>
+						Transfer Details
+						<div>
+							selector:<strong>transferDetails</strong>
+						</div>
+						<div>
+							dispatch:<strong>fetchAutomatedTransferStatus</strong>
+						</div>
+					</CardHeading>
+					{ Object.entries( transferDetails ).map( ( entry, i ) => (
+						<div key={ i }>
+							{ JSON.stringify( entry[ 0 ] ) } : { JSON.stringify( entry[ 1 ] ) }
+						</div>
+					) ) }
+				</Card>
+			</Card>
+			<Card key="installed-plugins">
+				<CardHeading tagName="h1" size={ 21 }>
+					3rd Party Plugins Installed
+				</CardHeading>
+				{ pluginDetails &&
+					pluginDetails
+						.filter( ( plugin ) => plugin.author !== 'Automattic' )
+						.map( ( details ) => (
+							<Card key={ details.id }>
+								{ Object.entries( details )
+									.filter(
+										( [ key ] ) =>
+											! [ 'description', 'network', 'autoupdate', 'version', 'id' ].includes( key )
+									)
+									.map( ( [ key, value ] ) => (
+										<div key={ key }>
+											{ key } : { JSON.stringify( value ) }
+										</div>
+									) ) }
+							</Card>
+						) ) }
+			</Card>
 		</Container>
 	);
 }
+
+//////SelectedSite Details Sample
+// eslint-disable-next-line
+const selectedSiteBusinessPlanNotTransferredSample = {
+	selectedSite: {
+		ID: 194170136,
+		name: 'yoasttesting',
+		description: '',
+		URL: 'http://yoasttesting1623216043388.blog',
+		capabilities: {
+			edit_pages: true,
+			edit_posts: true,
+			edit_others_posts: true,
+			edit_others_pages: true,
+			delete_posts: true,
+			delete_others_posts: true,
+			edit_theme_options: true,
+			edit_users: true,
+			list_users: true,
+			manage_categories: true,
+			manage_options: true,
+			moderate_comments: true,
+			activate_wordads: true,
+			promote_users: true,
+			publish_posts: true,
+			upload_files: true,
+			delete_users: false,
+			remove_users: true,
+			own_site: true,
+			view_hosting: true,
+			view_stats: true,
+			activate_plugins: true,
+		},
+		jetpack: false,
+		is_multisite: true,
+		lang: 'en',
+		visible: true,
+		is_private: false,
+		is_coming_soon: true,
+		single_user_site: true,
+		is_vip: false,
+		options: {
+			timezone: 'Asia/Colombo',
+			gmt_offset: 5.5,
+			videopress_enabled: true,
+			upgraded_filetypes_enabled: true,
+			admin_url: 'https://yoasttesting1623216043388.wordpress.com/wp-admin/',
+			is_mapped_domain: true,
+			is_redirect: false,
+			unmapped_url: 'https://yoasttesting1623216043388.wordpress.com',
+			default_post_format: '0',
+			allowed_file_types: [],
+			show_on_front: 'page',
+			default_comment_status: true,
+			default_ping_status: true,
+			software_version: '5.7.2',
+			created_at: '2021-06-09T05:22:03+00:00',
+			wordads: false,
+			publicize_permanently_disabled: false,
+			frame_nonce: '879790f6cd',
+			jetpack_frame_nonce: '879790f6cd',
+			page_on_front: 2,
+			page_for_posts: 0,
+			advanced_seo_front_page_description: '',
+			advanced_seo_title_formats: [],
+			verification_services_codes: null,
+			podcasting_archive: null,
+			is_domain_only: false,
+			is_automated_transfer: false,
+			is_wpcom_atomic: false,
+			is_wpcom_store: false,
+			woocommerce_is_active: false,
+			design_type: null,
+			site_segment: null,
+			is_wpforteams_site: false,
+			p2_hub_blog_id: null,
+			site_creation_flow: 'gutenboarding',
+			is_cloud_eligible: false,
+			anchor_podcast: false,
+		},
+		plan: {
+			product_id: 1008,
+			product_slug: 'business-bundle',
+			product_name_short: 'Business',
+			expired: false,
+			user_is_owner: true,
+			is_free: false,
+		},
+		products: [],
+		jetpack_modules: null,
+		launch_status: 'unlaunched',
+		site_migration: null,
+		is_fse_active: false,
+		is_fse_eligible: false,
+		is_core_site_editor_enabled: false,
+		domain: 'yoasttesting1623216043388.blog',
+		hasConflict: false,
+		is_customizable: true,
+		is_previewable: true,
+		slug: 'yoasttesting1623216043388.blog',
+		title: 'yoasttesting',
+		wpcom_url: 'yoasttesting1623216043388.wordpress.com',
+	},
+};

--- a/client/my-sites/plugins/marketplace/marketplace-test/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-test/index.tsx
@@ -13,7 +13,10 @@ import CardHeading from 'calypso/components/card-heading';
 import { Button, Card } from '@automattic/components';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import {
+	fetchAutomatedTransferStatus,
+	requestEligibility,
+} from 'calypso/state/automated-transfer/actions';
 import { getAutomatedTransfer } from 'calypso/state/automated-transfer/selectors';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 // import { getPlugins, isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
@@ -24,9 +27,9 @@ export const Container = styled.div`
 `;
 
 export default function MarketplaceTest() {
-	const selectedSite = useSelector( getSelectedSite );
+	const selectedSite = useSelector( getSelectedSite ) || {};
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	// This selector is not working
+	// This selector is not working need to investigate why that is
 	// const pluginDetails = useSelector( ( state ) => getPlugins( state, selectedSiteId ) );
 	const pluginDetails = useSelector(
 		( state ) => state.plugins.installed.plugins[ selectedSiteId ]
@@ -47,12 +50,12 @@ export default function MarketplaceTest() {
 	useEffect( () => {
 		setTimeout( () => {
 			dispatch( fetchAutomatedTransferStatus( selectedSite?.ID ?? 0 ) );
-
+			dispatch( requestEligibility( selectedSite?.ID ?? 0 ) );
 			setInfiniteLoopCount( ( l ) => l + 1 );
 		}, 4000 );
 	}, [ infiniteLoopCount, fetchAutomatedTransferStatus, selectedSite ] );
 
-	const { ID, URL, domain, options } = selectedSite;
+	const { ID, URL, domain, options = {} } = selectedSite;
 	const { is_wpcom_atomic, is_automated_transfer } = options;
 	return (
 		<Container>
@@ -63,7 +66,7 @@ export default function MarketplaceTest() {
 					Marketplace Test Page
 				</CardHeading>
 				<CardHeading tagName="h1" size={ 24 }>
-					<div>Currrent Site : { selectedSite?.domain }</div>
+					<div>Current Site : { selectedSite?.domain }</div>
 				</CardHeading>
 			</Card>
 			<Card key="navigation-links">
@@ -129,107 +132,3 @@ export default function MarketplaceTest() {
 		</Container>
 	);
 }
-
-//////SelectedSite Details Sample
-// eslint-disable-next-line
-const selectedSiteBusinessPlanNotTransferredSample = {
-	selectedSite: {
-		ID: 194170136,
-		name: 'yoasttesting',
-		description: '',
-		URL: 'http://yoasttesting1623216043388.blog',
-		capabilities: {
-			edit_pages: true,
-			edit_posts: true,
-			edit_others_posts: true,
-			edit_others_pages: true,
-			delete_posts: true,
-			delete_others_posts: true,
-			edit_theme_options: true,
-			edit_users: true,
-			list_users: true,
-			manage_categories: true,
-			manage_options: true,
-			moderate_comments: true,
-			activate_wordads: true,
-			promote_users: true,
-			publish_posts: true,
-			upload_files: true,
-			delete_users: false,
-			remove_users: true,
-			own_site: true,
-			view_hosting: true,
-			view_stats: true,
-			activate_plugins: true,
-		},
-		jetpack: false,
-		is_multisite: true,
-		lang: 'en',
-		visible: true,
-		is_private: false,
-		is_coming_soon: true,
-		single_user_site: true,
-		is_vip: false,
-		options: {
-			timezone: 'Asia/Colombo',
-			gmt_offset: 5.5,
-			videopress_enabled: true,
-			upgraded_filetypes_enabled: true,
-			admin_url: 'https://yoasttesting1623216043388.wordpress.com/wp-admin/',
-			is_mapped_domain: true,
-			is_redirect: false,
-			unmapped_url: 'https://yoasttesting1623216043388.wordpress.com',
-			default_post_format: '0',
-			allowed_file_types: [],
-			show_on_front: 'page',
-			default_comment_status: true,
-			default_ping_status: true,
-			software_version: '5.7.2',
-			created_at: '2021-06-09T05:22:03+00:00',
-			wordads: false,
-			publicize_permanently_disabled: false,
-			frame_nonce: '879790f6cd',
-			jetpack_frame_nonce: '879790f6cd',
-			page_on_front: 2,
-			page_for_posts: 0,
-			advanced_seo_front_page_description: '',
-			advanced_seo_title_formats: [],
-			verification_services_codes: null,
-			podcasting_archive: null,
-			is_domain_only: false,
-			is_automated_transfer: false,
-			is_wpcom_atomic: false,
-			is_wpcom_store: false,
-			woocommerce_is_active: false,
-			design_type: null,
-			site_segment: null,
-			is_wpforteams_site: false,
-			p2_hub_blog_id: null,
-			site_creation_flow: 'gutenboarding',
-			is_cloud_eligible: false,
-			anchor_podcast: false,
-		},
-		plan: {
-			product_id: 1008,
-			product_slug: 'business-bundle',
-			product_name_short: 'Business',
-			expired: false,
-			user_is_owner: true,
-			is_free: false,
-		},
-		products: [],
-		jetpack_modules: null,
-		launch_status: 'unlaunched',
-		site_migration: null,
-		is_fse_active: false,
-		is_fse_eligible: false,
-		is_core_site_editor_enabled: false,
-		domain: 'yoasttesting1623216043388.blog',
-		hasConflict: false,
-		is_customizable: true,
-		is_previewable: true,
-		slug: 'yoasttesting1623216043388.blog',
-		title: 'yoasttesting',
-		wpcom_url: 'yoasttesting1623216043388.wordpress.com',
-	},
-};


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Busy wait after Yoast Premium Purchase
We need to busy wait after going through checkout with Yoast Premium purchase, until site transfer is properly completed. This is because the site transfer "initiation" happens as part of the checkout when purchasing Yoast premium.

- New information added to the test page. (Testing not required)
- Located at :http://calypso.localhost:3000/marketplace/test/${siteUrl}

Image: https://user-images.githubusercontent.com/3422709/121339971-aba6fb00-c93c-11eb-8de3-3abb57f8f064.png


#### Testing instructions

1. Setup a fresh site on an a8c account with a business plan (non transferred)
2. Go to the marketplace product details page

    - Eg: http://calypso.localhost:3000/marketplace/product/details/wordpress-seo/${siteUrl}
3. Click on Yoast Premium
4. Pay and checkout
5. A loading page should appear
6. After the loading progress is completed the thank you page should appear.
7. In the home page Yoast SEO should be available