### PR TITLE
Desktop: Fix console error on about page

### DIFF
--- a/desktop/app/lib/window-manager/index.js
+++ b/desktop/app/lib/window-manager/index.js
@@ -48,7 +48,7 @@ const windows = {
 		preload: getPath( 'preload_preferences.js' ),
 	},
 	secret: {
-		file: 'secret.html',
+		file: getPath( 'secret.html' ),
 		config: 'secretWindow',
 		handle: null,
 		preload: null,

--- a/desktop/public_desktop/about.html
+++ b/desktop/public_desktop/about.html
@@ -69,7 +69,7 @@
 	const version = config.version;
 	const build = config.build;
 
-  let versionType = '';
+	let versionType = '';
 	if ( build === 'development' )
 		versionType = 'dev';
 	else if ( build === 'updater' )

--- a/desktop/public_desktop/about.html
+++ b/desktop/public_desktop/about.html
@@ -69,19 +69,20 @@
 	const version = config.version;
 	const build = config.build;
 
+  let versionType = '';
 	if ( build === 'development' )
-		version += ' dev';
+		versionType = 'dev';
 	else if ( build === 'updater' )
-		version += ' updater';
+		versionType = 'updater';
 	else if ( build === 'release' )
-		version += ' release';
+		versionType = 'release';
 </script>
 
 <p><img src="app-logo.png" alt="WordPress.com" width="64" height="64" /></p>
 
 <p><strong>WordPress.com</strong></p>
 
-<p>Version <script type="text/javascript">document.write( version )</script></p>
+<p>Version <script type="text/javascript">document.write( version + ' ' + versionType )</script></p>
 
 <p>Copyright <a href="#">&copy;</a> Automattic, Inc. <br/>
 Proudly released under the GPL</p>

--- a/desktop/public_desktop/preload_about.js
+++ b/desktop/public_desktop/preload_about.js
@@ -3,6 +3,11 @@ const { ipcRenderer, contextBridge } = require( 'electron' );
 ( async () => {
 	const config = await ipcRenderer.invoke( 'get-config' );
 	contextBridge.exposeInMainWorld( 'electron', {
+		send: ( channel, ...args ) => {
+			if ( channel === 'secrets' ) {
+				ipcRenderer.send( channel, ...args );
+			}
+		},
 		config,
 	} );
 } )();


### PR DESCRIPTION
### Description

The about.html page had a `const version` which was being modified after being set causing a console error.
This resolves that by adding a second variable to handle the part which is variable.

The about page also has some easter eggs hidden which were not working correctly. This fixes that as well.

### Testing

- Ensure the version number and type shows correctly on the about page
- Ensure no errors in the console
- Try the easter eggs to ensure they work as expected