### PR TITLE
E2E: Fix flaky "invite user as editor" spec

### DIFF
--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -10,7 +10,6 @@ import config from 'config';
 import LoginFlow from '../../lib/flows/login-flow.js';
 
 import AcceptInvitePage from '../../lib/pages/accept-invite-page.js';
-import PostsPage from '../../lib/pages/posts-page.js';
 import PeoplePage from '../../lib/pages/people-page.js';
 import RevokePage from '../../lib/pages/revoke-page.js';
 import InvitePeoplePage from '../../lib/pages/invite-people-page.js';
@@ -92,8 +91,6 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	} );
 
 	it( 'User has been added as Editor', async function () {
-		await PostsPage.Expect( this.driver );
-
 		inviteAccepted = true;
 		const noticesComponent = await NoticesComponent.Expect( this.driver );
 		const invitesMessageTitleDisplayed = await noticesComponent.getNoticeContent();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a flaky test where loading the Posts page after inviting a user takes longer than expected. We don't really need to wait for that page as we're already checking the confirmation notice:

Example failure: https://teamcity.a8c.com/buildConfiguration/calypso_RunCalypsoE2eDesktopTests/6281152?buildTab=tests&expandedTest=6185525034738355787

#### Testing instructions

All tests should pass.