### PR TITLE
TaxonomyCard: Use singular taxonomy name when count is 1

### DIFF
--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -50,7 +50,9 @@ const TaxonomyCard = ( {
 			<h2 className={ classes }>{ labels.name }</h2>
 			{ ! isLoading && (
 				<div className="taxonomies__card-content">
-					<Gridicon icon="tag" size={ 18 } /> { count } { labels.name }
+					<Gridicon icon="tag" size={ 18 } />
+					&nbsp;
+					{ count } { count === 1 ? labels.singular_name : labels.name }
 					{ defaultTerm && (
 						<span>
 							, { translate( 'default category:' ) } { decodeEntities( defaultTerm.name ) }

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -43,6 +43,11 @@ const TaxonomyCard = ( {
 		recordMCStat( 'taxonomy_manager', `manage_${ taxonomy }` );
 	};
 
+	let label;
+	if ( ! isLoading ) {
+		label = count === 1 ? labels.singular_name : labels.name;
+	}
+
 	return (
 		<CompactCard onClick={ recordAnalytics } href={ settingsLink }>
 			{ site && <QuerySiteSettings siteId={ site.ID } /> }
@@ -50,9 +55,7 @@ const TaxonomyCard = ( {
 			<h2 className={ classes }>{ labels.name }</h2>
 			{ ! isLoading && (
 				<div className="taxonomies__card-content">
-					<Gridicon icon="tag" size={ 18 } />
-					&nbsp;
-					{ count } { count === 1 ? labels.singular_name : labels.name }
+					<Gridicon icon="tag" size={ 18 } /> { count } { label }
 					{ defaultTerm && (
 						<span>
 							, { translate( 'default category:' ) } { decodeEntities( defaultTerm.name ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Before, `labels.name` was used after the count, which is always plural.
* This PR makes sure the singular taxonomy name (`labels.singular_name`) is used when the count is 1.

#### Before

![image](https://user-images.githubusercontent.com/75777864/121360530-cbd2bc00-c934-11eb-8148-cb5f31581d57.png)

#### After

![image](https://user-images.githubusercontent.com/75777864/121360550-d1300680-c934-11eb-8c29-06f6de67e43d.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to http://calypso.localhost:3000/settings/writing 
1. Choose a (test) site and make sure to have only 1 category and 1 tag. 
   (Or to just simulate, add a `count = 1;` line between the definition of `recordAnalytics` and the return statement.)
1. Make sure the texts are no longer plural: “1 Category” and “1 Tag”, instead of “1 Categories” and “1 Tags”.
1. Change the interface language and verify that the labels are translated.
1. Add more tags and categories (or remove the `count = 1` line if you went that route above) and verify that the texts are plural again.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 60-gh-Automattic/i18n-issues
