### PR TITLE
Minor reskinned signup style improvments

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -551,11 +551,7 @@ class SignupForm extends Component {
 					</>
 				) }
 
-				<FormLabel htmlFor="email">
-					{ this.props.isReskinned
-						? this.props.translate( 'Email address' )
-						: this.props.translate( 'Your email address' ) }
-				</FormLabel>
+				<FormLabel htmlFor="email">{ this.props.translate( 'Your email address' ) }</FormLabel>
 				<FormTextInput
 					autoCapitalize="off"
 					autoCorrect="off"
@@ -605,11 +601,7 @@ class SignupForm extends Component {
 					</>
 				) }
 
-				<FormLabel htmlFor="password">
-					{ this.props.isReskinned
-						? this.props.translate( 'Password' )
-						: this.props.translate( 'Choose a password' ) }
-				</FormLabel>
+				<FormLabel htmlFor="password">{ this.props.translate( 'Choose a password' ) }</FormLabel>
 				<FormPasswordInput
 					className="signup-form__input"
 					disabled={ this.state.submitting || this.props.disabled }
@@ -975,7 +967,11 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.horizontal && <div className="signup-form__separator"></div> }
+				{ this.props.horizontal && (
+					<div className="signup-form__separator">
+						<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
+					</div>
+				) }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 					<SocialSignupForm

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -724,7 +724,7 @@ class Signup extends React.Component {
 						return null;
 					}
 
-					this.isReskinned = 'treatment' === experimentAssignment?.variationName;
+					this.isReskinned = true; //'treatment' === experimentAssignment?.variationName;
 					this.isReskinned
 						? document.body.classList.add( 'is-white-signup' )
 						: document.body.classList.remove( 'is-white-signup' );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -184,7 +184,7 @@ export class UserStep extends Component {
 			if ( this.props.isReskinned ) {
 				const loginUrl = this.getLoginLink();
 				subHeaderText = translate(
-					'Create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
+					'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
 					{
 						components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
 					}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -2,7 +2,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-
 body.is-section-signup {
 	// Use WordPress.com’s brand color for the signup background
 	background: var( --color-wordpress-com );
@@ -314,7 +313,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 
 	.signup-form__terms-of-service-link a,
 	.signup-form__social-buttons-tos a {
-		color: var( --studio-gray-60 );
+		color: var( --studio-gray-50 );
 		text-decoration: underline;
 	}
 
@@ -590,7 +589,7 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 			}
 
 			> svg {
-				border: 1px solid #d5d5d7;
+				border: 1px solid var( --studio-gray-10 );
 				padding: 12px;
 				border-radius: 24px; /* stylelint-disable-line scales/radii */
 			}
@@ -661,7 +660,8 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 				@media screen and ( max-width: $breakpoint-mobile ) {
 					margin-top: 0;
 
-					&::before, &::after {
+					&::before,
+					&::after {
 						content: '';
 						display: block;
 						margin: 40px auto 24px;
@@ -705,7 +705,7 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 				height: 44px;
 				max-width: 408px;
 				border-radius: 4px; /* stylelint-disable-line */
-				border: 1px solid #d5d5d7;
+				border: 1px solid var( --studio-gray-10 );
 			}
 
 			.form-password-input {
@@ -760,6 +760,7 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 				padding: 24px 0;
 				font-size: 0.75rem;
 				z-index: 1;
+				color: var( --studio-gray-50 );
 
 				@media screen and ( max-width: $breakpoint-mobile ) {
 					padding: 0 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Part II of implementing the changes in https://github.com/Automattic/wp-calypso/issues/52852.

#### A/C
- [x] Update the input label copy to read; "Your email address" and "Choose a password"
- [x] Add "OR" between the two dividing columns
- [x] Add the word "First" to the subtitle of the page. It should now read; "First, create your WordPress.com account. Have an account? Log in"
- [x] Updates to styles:
	- [x] Inputs borders color to become (#c3c4c7 => `--studio-gray-10`)
	- [x] Social buttons borders color to become (#c3c4c7 => `--studio-gray-10`)
	- [x] Subtexts color to be (#646970 `--studio-gray-50`)

### Note
This PR jumps the isReskinned value to true. Change this jumper before merging.

Fixes https://github.com/Automattic/wp-calypso/issues/52852
