### PR TITLE
Fix Themes Placeholders Loading

### DIFF
--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEmpty, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ class QueryThemes extends Component {
 
 export default connect(
 	( state, { query, siteId } ) => ( {
-		hasThemes: ! isEmpty( getThemesForQuery( state, siteId, query ) ),
+		hasThemes: getThemesForQuery( state, siteId, query ) !== null,
 		isRequesting: isRequestingThemesForQuery( state, siteId, query ),
 	} ),
 	{ requestThemes }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check for `null` rather than an empty array as the selector returns `null` when nothing has been fetched. This prevents the request being sent continuously and trigger placeholders to render.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Loading Calypso.live link
* Select an Atomic Business site.
* Go to `/themes/your-site-id.wpcomstaging.com`
* Scroll down to and click "Show all themes"
* Click one of the newly revealed themes and allow page to load
* Click "Back"
* Original bug that was showing loading placeholders amongst the themes should be fixed.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/52893
