### PR TITLE
Media Settings Writing: show only for jetpack self-hosted sites.

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -98,26 +98,25 @@ class SiteSettingsFormWriting extends Component {
 					updateFields={ updateFields }
 				/>
 
-				{ siteIsJetpack &&
-					! siteIsAutomatedTransfer(
-						<div>
-							<SettingsSectionHeader
-								disabled={ isRequestingSettings || isSavingSettings }
-								isSaving={ isSavingSettings }
-								onButtonClick={ handleSubmitForm }
-								showButton
-								title={ translate( 'Media' ) }
-							/>
-							<MediaSettingsWriting
-								siteId={ siteId }
-								handleAutosavingToggle={ handleAutosavingToggle }
-								onChangeField={ onChangeField }
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-								fields={ fields }
-							/>
-						</div>
-					) }
+				{ siteIsJetpack && ! siteIsAutomatedTransfer && (
+					<div>
+						<SettingsSectionHeader
+							disabled={ isRequestingSettings || isSavingSettings }
+							isSaving={ isSavingSettings }
+							onButtonClick={ handleSubmitForm }
+							showButton
+							title={ translate( 'Media' ) }
+						/>
+						<MediaSettingsWriting
+							siteId={ siteId }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							onChangeField={ onChangeField }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					</div>
+				) }
 
 				<SettingsSectionHeader
 					disabled={ isRequestingSettings || isSavingSettings }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -56,6 +56,7 @@ class SiteSettingsFormWriting extends Component {
 			siteId,
 			siteIsJetpack,
 			translate,
+			siteIsAutomatedTransfer,
 			updateFields,
 			showAdvancedDashboard,
 		} = this.props;
@@ -97,25 +98,26 @@ class SiteSettingsFormWriting extends Component {
 					updateFields={ updateFields }
 				/>
 
-				{ siteIsJetpack && (
-					<div>
-						<SettingsSectionHeader
-							disabled={ isRequestingSettings || isSavingSettings }
-							isSaving={ isSavingSettings }
-							onButtonClick={ handleSubmitForm }
-							showButton
-							title={ translate( 'Media' ) }
-						/>
-						<MediaSettingsWriting
-							siteId={ siteId }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							onChangeField={ onChangeField }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					</div>
-				) }
+				{ siteIsJetpack &&
+					! siteIsAutomatedTransfer(
+						<div>
+							<SettingsSectionHeader
+								disabled={ isRequestingSettings || isSavingSettings }
+								isSaving={ isSavingSettings }
+								onButtonClick={ handleSubmitForm }
+								showButton
+								title={ translate( 'Media' ) }
+							/>
+							<MediaSettingsWriting
+								siteId={ siteId }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								onChangeField={ onChangeField }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields }
+							/>
+						</div>
+					) }
 
 				<SettingsSectionHeader
 					disabled={ isRequestingSettings || isSavingSettings }
@@ -213,6 +215,7 @@ const connectComponent = connect(
 				! siteIsAutomatedTransfer,
 			isPodcastingSupported,
 			showAdvancedDashboard,
+			siteIsAutomatedTransfer,
 		};
 	},
 	{ requestPostTypes },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the media panel
![](https://cln.sh/VEGY8C+)
available in `https://wordpress.com/settings/writing` as it was displaying only for Atomic sites AND they are already available in `/wp-admin/options-media.php` 

#### Testing instructions

- Go to `https://wordpress.com/settings/writing` of a Simple and Atomic site
- Inspect that the media panel doesn't appear

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #36415
