### PR TITLE
Colour Schemes: Change Dark scheme to 'Default' and align color scheme grid

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -34,6 +34,14 @@ import ectoplasmImg from 'calypso/assets/images/color-schemes/color-scheme-thumb
 export default function ( translate ) {
 	return compact( [
 		{
+			label: translate( 'Default' ),
+			value: 'classic-dark',
+			thumbnail: {
+				cssClass: 'is-classic-dark',
+				imageUrl: classicDarkImg,
+			},
+		},
+		{
 			label: translate( 'Aquatic' ),
 			value: 'aquatic',
 			thumbnail: {
@@ -63,14 +71,6 @@ export default function ( translate ) {
 			thumbnail: {
 				cssClass: 'is-classic-bright',
 				imageUrl: classicBrightImg,
-			},
-		},
-		{
-			label: translate( 'Classic Dark' ),
-			value: 'classic-dark',
-			thumbnail: {
-				cssClass: 'is-classic-dark',
-				imageUrl: classicDarkImg,
 			},
 		},
 		{

--- a/client/components/forms/form-radios-bar/style.scss
+++ b/client/components/forms/form-radios-bar/style.scss
@@ -8,8 +8,6 @@
 }
 
 .form-radios-bar .form-radio-with-thumbnail {
-	flex-grow: 1;
-	min-width: 136px;
-	max-width: 150px;
+	width: 141px;
 	margin-bottom: 10px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change Dark color scheme name to 'Default'
* Align color scheme grid

#### Testing instructions

* Apply this change to your calypso instance
* Go to `/me/account`
* The dark color scheme should be first on the list and called **Default**
* The color scheme grid should be aligned

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/375980/122250485-13f75e80-cea0-11eb-8093-63c735da7f80.png) | ![image](https://user-images.githubusercontent.com/375980/122251059-8f591000-cea0-11eb-8e07-81d4238a9436.png) |


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/52837
