### PR TITLE
Fix page view tracking for logged out users in cloud

### DIFF
--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -68,24 +68,38 @@ export class PageViewTracker extends React.Component {
 			path,
 			recorder = noop,
 			hasSelectedSiteLoaded,
+			isSelectedSiteNotRequested,
 			title,
-			properties,
 		} = this.props;
 
 		debug( `Queuing Page View: "${ title }" at "${ path }" with ${ delay }ms delay` );
 
-		if ( ! hasSelectedSiteLoaded || this.state.timer ) {
+		if ( this.state.timer ) {
+			return;
+		}
+
+		if ( isSelectedSiteNotRequested ) {
+			return this.recordViewWithProperties();
+		}
+
+		if ( ! hasSelectedSiteLoaded ) {
 			return;
 		}
 
 		if ( ! delay ) {
-			return recorder( path, title, 'default', properties );
+			return this.recordViewWithProperties();
 		}
 
 		this.setState( {
 			timer: setTimeout( () => recorder( path, title ), delay ),
 		} );
 	};
+
+	recordViewWithProperties() {
+		const { path, recorder = noop, title, properties } = this.props;
+
+		return recorder( path, title, 'default', properties );
+	}
 
 	render() {
 		return null;
@@ -102,9 +116,12 @@ const mapStateToProps = ( state ) => {
 		! currentSlug ||
 		( typeof currentSlug === 'number' && currentSlug === selectedSiteId ) ||
 		currentSlug === selectedSiteSlug;
+	const isSelectedSiteNotRequested =
+		currentSlug && ! selectedSiteId && ! state.sites.requesting[ currentSlug ];
 
 	return {
 		hasSelectedSiteLoaded,
+		isSelectedSiteNotRequested,
 		selectedSiteId,
 	};
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

For Jetpack cloud users that are not authenticated, visiting `/pricing/:site` does not dispatch the page view event (`/pricing/` does). This PR fixes it.

Fixes 1164141197617539-asboard

### Testing instructions

#### Prerequisites

- Download the PR and run both Calypso and Jetpack cloud
- Make sure you can see the page view events dispatched (either in the network panel, as debug messages in the console, or by adding logs in `recordPageView` in the code)

#### Calypso

- Visit `/plans/:site`, and make sure the `calypso_page_view` event is triggered with the path `/plans/:site` once.

#### Cloud

- Log out
- Visit `/pricing`, and make sure the `calypso_page_view` event is triggered with the path `/pricing` once.
- Visit `/pricing/:site`, and make sure the `calypso_page_view` event is triggered with the path `/pricing/:site` once.
- Sign in.
- Repeat the previous steps.
