### PR TITLE
Update blocked plugins: Include Ultimate Reset

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -25,6 +25,7 @@ const incompatiblePlugins = new Set( [
 	'post-type-switcher',
 	'reset-wp',
 	'secure-file-manager',
+	`ultimate-reset`,
 	'ultimate-wp-reset',
 	'username-changer',
 	'username-updater',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update blocked plugins list to include Ultimate Reset, `ultimate-reset`.  This resets a site to a broken state which requires HE assistance to resolve.
* https://wordpress.org/plugins/ultimate-reset/

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick an Atomic site used for testing
* Try to install Ultimate Reset from Calypso. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to internal discussion p9F6qB-66l-p2#comment-40023

Requires 698-gh-Automattic/wpcomsh to be merged and deployed to block in WP-Admin.