### PR TITLE
Playwright: migrate wp-inline-help-support-search-spec

### DIFF
--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -5,3 +5,4 @@ export * from './navbar-component';
 export * from './likes-component';
 export * from './sidebar-component';
 export * from './support-component';
+export * from './support-article-component';

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -4,3 +4,4 @@
 export * from './navbar-component';
 export * from './likes-component';
 export * from './sidebar-component';
+export * from './support-component';

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -34,7 +34,7 @@ export class SidebarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async _postInit(): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForLoadState( 'domcontentloaded' );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/support-article-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-article-component.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	main: '.support-article-dialog__base .dialog__content',
+};
+
+/**
+ * Represents the Support article dialog shown when a user clicks on a support article link from the Support popover.
+ *
+ * @augments {BaseContainer}
+ */
+export class SupportArticleComponent extends BaseContainer {
+	/**
+	 * Construct an instance of the Support Article component.
+	 *
+	 * @param {Page} page Underlying page with which the component will interact.
+	 */
+	constructor( page: Page ) {
+		super( page, selectors.main );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -213,12 +213,16 @@ export class SupportComponent extends BaseContainer {
 	async search( text: string ): Promise< void > {
 		await this.page.fill( selectors.searchInput, text );
 
-		if ( ! text ) {
-			await this.page.waitForSelector( selectors.spinner, { state: 'hidden' } );
-		} else {
+		if ( text.trim() ) {
+			// If there is valid search string, then there should be a network request made
+			// resulting in a spinner. The spinner will then disappear when either the results are
+			// displayed, or no results are found.
 			await this.page.waitForSelector( selectors.spinner );
-			await this.page.waitForSelector( selectors.spinner, { state: 'hidden' } );
+			await this.page.waitForSelector( selectors.spinner, { state: 'hidden', timeout: 60000 } );
 		}
+
+		// In all cases, wait for the 'load' state to be fired to add a brief (~1ms) wait between actions.
+		await this.page.waitForLoadState( 'load' );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
+import { SupportArticleComponent } from './support-article-component';
 
 /**
  * Type dependencies
@@ -25,13 +26,33 @@ const selectors = {
 	supportItems: '[aria-labelledby="inline-search--api_help"] li',
 	adminItems: '[aria-labelledby="inline-search--admin_section"] li',
 	emptyResults: '.inline-help__empty-results',
+
+	readMoreButton: 'text=Read more',
 };
 
+/**
+ * Represents the Support popover available on most WPCOM screens.
+ *
+ * @augments {BaseContainer}
+ */
 export class SupportComponent extends BaseContainer {
+	/**
+	 * Construct an instance of the Support component.
+	 *
+	 * @param {Page} page Underlying page with which the component will interact.
+	 */
 	constructor( page: Page ) {
 		super( page, selectors.supportButton );
 	}
 
+	/**
+	 * Click on the support button (?).
+	 * This method will toggle the status of the support popover.
+	 * If the support popover is closed, it will be opened.
+	 * If the support popover is open, it will be closed.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async clickSupportButton(): Promise< void > {
 		const isPopoverOpen = await this.page.isVisible( selectors.supportPopover );
 
@@ -42,27 +63,56 @@ export class SupportComponent extends BaseContainer {
 		}
 	}
 
+	/**
+	 * Opens the support popover from the closed state.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async openPopover(): Promise< void > {
 		await this.page.click( selectors.supportButton );
 		await this.page.waitForSelector( selectors.supportPopover, { state: 'visible' } );
 	}
 
+	/**
+	 * Closes the support popover from the open state.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async closePopover(): Promise< void > {
 		await this.page.click( selectors.supportButton );
 		await this.page.waitForSelector( selectors.supportPopover, { state: 'hidden' } );
 	}
 
+	/**
+	 * Given a selector, returns an array of ElementHandles that match the given selector.
+	 * Prior to selecing the elements, this method will wait for the 'domcontentloaded' event
+	 * to be fired.
+	 *
+	 * @param {string} selector Selector on page to look for.
+	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles that match the given selector.
+	 */
 	async getResults( selector: string ): Promise< ElementHandle[] > {
 		await this.page.waitForLoadState( 'domcontentloaded' );
 		return await this.page.$$( selector );
 	}
 
-	/* Returns the overall number of results, not distinguishing the support and admin results.
+	/* Returns the overall number of results, not distinguishing the support & admin results. */
+
+	/**
+	 * Returns an array of ElementHandles that reference support entries regardless of its
+	 * classification on page (admin links, support articles, suggestions).
+	 *
+	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles matching the broad definition of support items.
 	 */
 	async getOverallResults(): Promise< ElementHandle[] > {
 		return await this.getResults( selectors.results );
 	}
 
+	/**
+	 * Returns the number of support items that are shown on screen regardless of its classification.
+	 *
+	 * @returns {Promise<number>} Number of search result items shown in the popover.
+	 */
 	async getOverallResultsCount(): Promise< number > {
 		const items = await this.getOverallResults();
 		return items.length;
@@ -70,10 +120,20 @@ export class SupportComponent extends BaseContainer {
 
 	/* Returns the results for support entries. */
 
+	/**
+	 * Returns an array of ElementHandles that are of the support article category.
+	 *
+	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles referencing support pages.
+	 */
 	async getSupportResults(): Promise< ElementHandle[] > {
 		return await this.getResults( selectors.supportItems );
 	}
 
+	/**
+	 * Returns the number of support items that are of the support article category.
+	 *
+	 * @returns {Promise<number>} Number of search result items that link to support pages.
+	 */
 	async getSupportResultsCount(): Promise< number > {
 		const items = await this.getSupportResults();
 		return items.length;
@@ -81,29 +141,58 @@ export class SupportComponent extends BaseContainer {
 
 	/* Returns the results for admin entries. */
 
+	/**
+	 * Returns an array of ElementHandles that are of the administrative links category.
+	 *
+	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles referencing administrative pages.
+	 */
 	async getAdminResults(): Promise< ElementHandle[] > {
 		return await this.getResults( selectors.adminItems );
 	}
 
+	/**
+	 * Returns the number of support items that are of the administrative links category.
+	 *
+	 * @returns {Promise<number>} Number of search result items that link to administrative pages.
+	 */
 	async getAdminResultsCount(): Promise< number > {
 		const items = await this.getAdminResults();
 		return items.length;
 	}
 
+	/**
+	 * Checks whether popover search shows no results as expected.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 * @throws {Error} If any search results are shown unexpectedly.
+	 */
 	async noResults(): Promise< void > {
-		const adminResults = await this.getAdminResults();
-		assert.deepStrictEqual( [], adminResults );
-		const supportResults = await this.getSupportResults();
-		assert.deepStrictEqual( [], supportResults );
-		await this.page.waitForSelector( selectors.emptyResults );
+		// Note that even for a search query like ;;;ppp;;; that produces no search results,
+		// some links are shown in the popover under the heading `Helpful resources for this section`.
+		try {
+			const adminResults = await this.getAdminResults();
+			assert.deepStrictEqual( [], adminResults );
+			const supportResults = await this.getSupportResults();
+			assert.deepStrictEqual( [], supportResults );
+			await this.page.waitForSelector( selectors.emptyResults );
+		} catch ( err ) {
+			throw new Error( `Support search results are shown unexpectedly.` );
+		}
 	}
 
+	/**
+	 * Click on the nth result specified by the target value.
+	 *
+	 * @param {number} target The nth result to click.
+	 * @returns {Promise<void>} No return value.
+	 * @throws {Error} If the specified target exceeds the number of results shown on page.
+	 */
 	async clickResult( target: number ): Promise< void > {
 		const popOver = await this.page.waitForSelector( selectors.supportPopover );
 		await popOver.waitForElementState( 'stable' );
-		const items = await this.getOverallResultItems();
+		const items = await this.getOverallResults();
 
-		const resultCount = await this.getOverallResultsCount();
+		const resultCount = items.length;
 		if ( resultCount < target ) {
 			throw new Error(
 				`Support popover shows ${ resultCount } entries, was asked to click on entry ${ target }`
@@ -111,8 +200,16 @@ export class SupportComponent extends BaseContainer {
 		}
 
 		await items[ target ].click();
+		await this.page.click( selectors.readMoreButton );
+		await SupportArticleComponent.Expect( this.page );
 	}
 
+	/**
+	 * Fills the support popover search input and waits for the query to complete.
+	 *
+	 * @param {string} text Search keyword to be entered into the search field.
+	 * @returns {Promise<void>} No return value.
+	 */
 	async search( text: string ): Promise< void > {
 		await this.page.fill( selectors.searchInput, text );
 
@@ -124,6 +221,11 @@ export class SupportComponent extends BaseContainer {
 		}
 	}
 
+	/**
+	 * Clears the search field of all keywords.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async clearSearch(): Promise< void > {
 		await this.page.click( selectors.clearSearch );
 	}

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -1,0 +1,109 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { ElementHandle, Page } from 'playwright';
+
+const selectors = {
+	supportButton: '.inline-help__button',
+	supportPopover: '.inline-help__popover',
+	searchInput: '.form-text-input.search__input',
+	resultsList: '.inline-help__results',
+	results: '.inline-help__results-item',
+
+	supportItems: '[aria-labelledby="inline-search--api_help"] li',
+	adminItems: '[aria-labelledby="inline-search--admin_section"] li',
+};
+
+export class SupportComponent extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.supportButton );
+	}
+
+	async clickSupportButton(): Promise< void > {
+		const isPopoverOpen = await this.page.isVisible( selectors.supportPopover );
+
+		if ( isPopoverOpen ) {
+			await this.closePopover();
+		} else {
+			await this.openPopover();
+		}
+	}
+
+	async openPopover(): Promise< void > {
+		await this.page.click( selectors.supportButton );
+		await this.page.waitForSelector( selectors.supportPopover, { state: 'visible' } );
+	}
+
+	async closePopover(): Promise< void > {
+		await this.page.click( selectors.supportButton );
+		await this.page.waitForSelector( selectors.supportPopover, { state: 'hidden' } );
+	}
+
+	async getResults( selector: string ): Promise< ElementHandle[] > {
+		await this.page.waitForLoadState( 'domcontentloaded' );
+		return await this.page.$$( selector );
+	}
+
+	/* Returns the overall number of results, not distinguishing the support and admin results.
+	 */
+	async getOverallResultItems(): Promise< ElementHandle[] > {
+		return await this.getResults( selectors.results );
+	}
+
+	async getOverallResultsCount(): Promise< number > {
+		const items = await this.getOverallResultItems();
+		return items.length;
+	}
+
+	/* Returns the results for support entries. */
+
+	async getSupportResults(): Promise< ElementHandle[] > {
+		return await this.getResults( selectors.supportItems );
+	}
+
+	async getSupportResultsCount(): Promise< number > {
+		const items = await this.getSupportResults();
+		return items.length;
+	}
+
+	/* Returns the results for admin entries. */
+
+	async getAdminResults(): Promise< ElementHandle[] > {
+		return await this.getResults( selectors.adminItems );
+	}
+
+	async getAdminResultsCount(): Promise< number > {
+		const items = await this.getAdminResults();
+		return items.length;
+	}
+
+	async clickResult( target: number ): Promise< void > {
+		const popOver = await this.page.waitForSelector( selectors.supportPopover );
+		await popOver.waitForElementState( 'stable' );
+		const items = await this.getOverallResultItems();
+
+		const resultCount = await this.getOverallResultsCount();
+		if ( resultCount < target ) {
+			throw new Error(
+				`Support popover shows ${ resultCount } entries, was asked to click on entry ${ target }`
+			);
+		}
+
+		await items[ target ].click();
+	}
+
+	async search( text: string ): Promise< void > {
+		await this.page.fill( selectors.searchInput, text );
+
+		if ( ! text ) {
+			await this.page.waitForLoadState( 'domcontentloaded' );
+		} else {
+			await this.page.waitForLoadState( 'networkidle' );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import assert from 'assert';
+
+/**
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
@@ -12,11 +17,14 @@ const selectors = {
 	supportButton: '.inline-help__button',
 	supportPopover: '.inline-help__popover',
 	searchInput: '.form-text-input.search__input',
+	spinner: '.spinner',
+	clearSearch: '[aria-label="Close Search"]',
+
 	resultsList: '.inline-help__results',
 	results: '.inline-help__results-item',
-
 	supportItems: '[aria-labelledby="inline-search--api_help"] li',
 	adminItems: '[aria-labelledby="inline-search--admin_section"] li',
+	emptyResults: '.inline-help__empty-results',
 };
 
 export class SupportComponent extends BaseContainer {
@@ -51,12 +59,12 @@ export class SupportComponent extends BaseContainer {
 
 	/* Returns the overall number of results, not distinguishing the support and admin results.
 	 */
-	async getOverallResultItems(): Promise< ElementHandle[] > {
+	async getOverallResults(): Promise< ElementHandle[] > {
 		return await this.getResults( selectors.results );
 	}
 
 	async getOverallResultsCount(): Promise< number > {
-		const items = await this.getOverallResultItems();
+		const items = await this.getOverallResults();
 		return items.length;
 	}
 
@@ -82,6 +90,14 @@ export class SupportComponent extends BaseContainer {
 		return items.length;
 	}
 
+	async noResults(): Promise< void > {
+		const adminResults = await this.getAdminResults();
+		assert.deepStrictEqual( [], adminResults );
+		const supportResults = await this.getSupportResults();
+		assert.deepStrictEqual( [], supportResults );
+		await this.page.waitForSelector( selectors.emptyResults );
+	}
+
 	async clickResult( target: number ): Promise< void > {
 		const popOver = await this.page.waitForSelector( selectors.supportPopover );
 		await popOver.waitForElementState( 'stable' );
@@ -101,9 +117,14 @@ export class SupportComponent extends BaseContainer {
 		await this.page.fill( selectors.searchInput, text );
 
 		if ( ! text ) {
-			await this.page.waitForLoadState( 'domcontentloaded' );
+			await this.page.waitForSelector( selectors.spinner, { state: 'hidden' } );
 		} else {
-			await this.page.waitForLoadState( 'networkidle' );
+			await this.page.waitForSelector( selectors.spinner );
+			await this.page.waitForSelector( selectors.spinner, { state: 'hidden' } );
 		}
+	}
+
+	async clearSearch(): Promise< void > {
+		await this.page.click( selectors.clearSearch );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -5,3 +5,4 @@ export * from './login-page';
 export * from './gutenberg-editor-page';
 export * from './my-home-page';
 export * from './marketing-page';
+export * from './settings-page';

--- a/packages/calypso-e2e/src/lib/pages/settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/settings-page.ts
@@ -16,10 +16,20 @@ const selectors = {
  * Represents the Settings page.
  */
 export class SettingsPage extends BaseContainer {
+	/**
+	 * Construct an instance of the SettingsPage.
+	 *
+	 * @param {Page} page Underlying page where interactions take place.
+	 */
 	constructor( page: Page ) {
 		super( page, selectors.main );
 	}
 
+	/**
+	 * Post-initialization checks.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
 	async _postInit(): Promise< void > {
 		await this.page.waitForLoadState( 'domcontentloaded' );
 	}

--- a/packages/calypso-e2e/src/lib/pages/settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/settings-page.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	main: '#primary',
+};
+
+/**
+ * Represents the Settings page.
+ */
+export class SettingsPage extends BaseContainer {
+	constructor( page: Page ) {
+		super( page, selectors.main );
+	}
+
+	async _postInit(): Promise< void > {
+		await this.page.waitForLoadState( 'domcontentloaded' );
+	}
+}

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -61,7 +61,50 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		} );
 	} );
 
-	describe( 'Empty search string', async function () {
+	describe( 'Search for a support topic and open a support page article', function () {
+		let supportComponent;
+
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( this.page );
+			await loginFlow.login();
+		} );
+
+		it( 'Open Settings page', async function () {
+			await MyHomePage.Expect( this.page );
+			const sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.clickMenuItem( 'Settings' );
+		} );
+
+		it( 'Open support popover', async function () {
+			await SettingsPage.Expect( this.page );
+			supportComponent = await SupportComponent.Expect( this.page );
+			await supportComponent.clickSupportButton();
+		} );
+
+		it( 'Displays six entries by default', async function () {
+			const defaultResults = await supportComponent.getOverallResultsCount();
+			assert.strictEqual( 6, defaultResults );
+		} );
+
+		it( 'Enter search keyword', async function () {
+			const keyword = 'domain';
+			await supportComponent.search( keyword );
+		} );
+
+		it( 'Search results are shown', async function () {
+			const supportCount = await supportComponent.getSupportResultsCount();
+			assert.strictEqual( 4, supportCount );
+
+			const adminCount = await supportComponent.getAdminResultsCount();
+			assert.strictEqual( 3, adminCount );
+		} );
+
+		it( 'Click on first link', async function () {
+			await supportComponent.clickResult( 1 );
+		} );
+	} );
+
+	describe( 'Empty search string', function () {
 		let supportComponent;
 
 		it( 'Log in', async function () {
@@ -97,7 +140,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		} );
 	} );
 
-	describe( 'Invalid search string', async function () {
+	describe( 'Invalid search string', function () {
 		let supportComponent;
 
 		it( 'Log in', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -49,5 +49,86 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 			const adminCount = await supportComponent.getAdminResultsCount();
 			assert.strictEqual( 3, adminCount );
 		} );
+
+		it( 'Clear keyword', async function () {
+			await supportComponent.clearSearch();
+			const defaultResults = await supportComponent.getOverallResultsCount();
+			assert.strictEqual( 6, defaultResults );
+			const supportResults = await supportComponent.getSupportResultsCount();
+			assert.strictEqual( 0, supportResults );
+			const adminResults = await supportComponent.getAdminResultsCount();
+			assert.strictEqual( 0, adminResults );
+		} );
+	} );
+
+	describe( 'Empty search string', async function () {
+		let supportComponent;
+
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( this.page );
+			await loginFlow.login();
+		} );
+
+		it( 'Open Settings page', async function () {
+			await MyHomePage.Expect( this.page );
+			const sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.clickMenuItem( 'Settings' );
+		} );
+
+		it( 'Open support popover', async function () {
+			await SettingsPage.Expect( this.page );
+			supportComponent = await SupportComponent.Expect( this.page );
+			await supportComponent.clickSupportButton();
+		} );
+
+		it( 'Displays six entries by default', async function () {
+			const defaultResults = await supportComponent.getOverallResultsCount();
+			assert.strictEqual( 6, defaultResults );
+		} );
+
+		it( 'Enter invalid search keyword', async function () {
+			const keyword = '';
+			await supportComponent.search( keyword );
+		} );
+
+		it( 'Continues to display default results', async function () {
+			const defaultResults = await supportComponent.getOverallResultsCount();
+			assert.strictEqual( 6, defaultResults );
+		} );
+	} );
+
+	describe( 'Invalid search string', async function () {
+		let supportComponent;
+
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( this.page );
+			await loginFlow.login();
+		} );
+
+		it( 'Open Settings page', async function () {
+			await MyHomePage.Expect( this.page );
+			const sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.clickMenuItem( 'Settings' );
+		} );
+
+		it( 'Open support popover', async function () {
+			await SettingsPage.Expect( this.page );
+			supportComponent = await SupportComponent.Expect( this.page );
+			await supportComponent.clickSupportButton();
+		} );
+
+		it( 'Displays six entries by default', async function () {
+			const defaultResults = await supportComponent.getOverallResultsCount();
+			assert.strictEqual( 6, defaultResults );
+		} );
+
+		it( 'Enter invalid search keyword', async function () {
+			const keyword = ';;;ppp;;;';
+			await supportComponent.search( keyword );
+		} );
+
+		it( 'No search results are shown', async function () {
+			await supportComponent.noResults();
+		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -12,7 +12,7 @@ import {
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Support' ), function () {
-	describe( 'Search for a support topic', function () {
+	describe( 'Search for a support topic then close popover', function () {
 		let supportComponent;
 
 		it( 'Log in', async function () {
@@ -32,9 +32,9 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 			await supportComponent.clickSupportButton();
 		} );
 
-		it( 'Displays six entries by default', async function () {
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.strictEqual( 6, defaultResults );
+		it( 'Displays default entries', async function () {
+			const results = await supportComponent.getOverallResultsCount();
+			assert.notStrictEqual( 0, results );
 		} );
 
 		it( 'Enter search keyword', async function () {
@@ -53,11 +53,15 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Clear keyword', async function () {
 			await supportComponent.clearSearch();
 			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.strictEqual( 6, defaultResults );
+			assert.notStrictEqual( 0, defaultResults );
 			const supportResults = await supportComponent.getSupportResultsCount();
 			assert.strictEqual( 0, supportResults );
 			const adminResults = await supportComponent.getAdminResultsCount();
 			assert.strictEqual( 0, adminResults );
+		} );
+
+		it( 'Close support popover', async function () {
+			await supportComponent.closePopover();
 		} );
 	} );
 
@@ -81,9 +85,9 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 			await supportComponent.clickSupportButton();
 		} );
 
-		it( 'Displays six entries by default', async function () {
+		it( 'Displays default entries', async function () {
 			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.strictEqual( 6, defaultResults );
+			assert.notStrictEqual( 0, defaultResults );
 		} );
 
 		it( 'Enter search keyword', async function () {
@@ -124,19 +128,19 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 			await supportComponent.clickSupportButton();
 		} );
 
-		it( 'Displays six entries by default', async function () {
+		it( 'Displays default entries', async function () {
 			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.strictEqual( 6, defaultResults );
+			assert.notStrictEqual( 0, defaultResults );
 		} );
 
 		it( 'Enter invalid search keyword', async function () {
-			const keyword = '';
+			const keyword = '        ';
 			await supportComponent.search( keyword );
 		} );
 
 		it( 'Continues to display default results', async function () {
 			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.strictEqual( 6, defaultResults );
+			assert.notStrictEqual( 0, defaultResults );
 		} );
 	} );
 
@@ -160,9 +164,9 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 			await supportComponent.clickSupportButton();
 		} );
 
-		it( 'Displays six entries by default', async function () {
+		it( 'Displays default entries', async function () {
 			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.strictEqual( 6, defaultResults );
+			assert.notStrictEqual( 0, defaultResults );
 		} );
 
 		it( 'Enter invalid search keyword', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import {
+	DataHelper,
+	LoginFlow,
+	SidebarComponent,
+	MyHomePage,
+	SettingsPage,
+	SupportComponent,
+} from '@automattic/calypso-e2e';
+
+describe( DataHelper.createSuiteTitle( 'Support' ), function () {
+	describe( 'Search for a support topic', function () {
+		let supportComponent;
+
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( this.page );
+			await loginFlow.login();
+		} );
+
+		it( 'Open Settings page', async function () {
+			await MyHomePage.Expect( this.page );
+			const sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.clickMenuItem( 'Settings' );
+		} );
+
+		it( 'Open support popover', async function () {
+			await SettingsPage.Expect( this.page );
+			supportComponent = await SupportComponent.Expect( this.page );
+			await supportComponent.clickSupportButton();
+		} );
+
+		it( 'Displays six entries by default', async function () {
+			const defaultResults = await supportComponent.getOverallResultsCount();
+			assert.strictEqual( 6, defaultResults );
+		} );
+
+		it( 'Enter search keyword', async function () {
+			const keyword = 'domain';
+			await supportComponent.search( keyword );
+		} );
+
+		it( 'Search results are shown', async function () {
+			const supportCount = await supportComponent.getSupportResultsCount();
+			assert.strictEqual( 4, supportCount );
+
+			const adminCount = await supportComponent.getAdminResultsCount();
+			assert.strictEqual( 3, adminCount );
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -34,6 +34,8 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 
 		it( 'Displays default entries', async function () {
 			const results = await supportComponent.getOverallResultsCount();
+			// Default entries varies from 5 on TeamCity to 6 when run locally.
+			// This statement would check that at least 5 items are visible to compensate.
 			assert.ok( results >= 5 );
 		} );
 
@@ -86,8 +88,8 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		} );
 
 		it( 'Displays default entries', async function () {
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.notStrictEqual( 0, defaultResults );
+			const results = await supportComponent.getOverallResultsCount();
+			assert.ok( results >= 5 );
 		} );
 
 		it( 'Enter search keyword', async function () {
@@ -129,8 +131,8 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		} );
 
 		it( 'Displays default entries', async function () {
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.notStrictEqual( 0, defaultResults );
+			const results = await supportComponent.getOverallResultsCount();
+			assert.ok( results >= 5 );
 		} );
 
 		it( 'Enter invalid search keyword', async function () {
@@ -165,8 +167,8 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		} );
 
 		it( 'Displays default entries', async function () {
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			assert.notStrictEqual( 0, defaultResults );
+			const results = await supportComponent.getOverallResultsCount();
+			assert.ok( results >= 5 );
 		} );
 
 		it( 'Enter invalid search keyword', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -34,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 
 		it( 'Displays default entries', async function () {
 			const results = await supportComponent.getOverallResultsCount();
-			assert.notStrictEqual( 0, results );
+			assert.ok( results >= 5 );
 		} );
 
 		it( 'Enter search keyword', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wp-inlne-help-support-search` spec to Playwright.

As usual, new components and pages were created as part of the migration.

#### Testing instructions

TeamCity
- ensure required tests pass (Playwright E2E, Unit Tests, Code Style)

Local
- following the instructions [here](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/docs/running-tests.md#running-tests-playwright), ensure the newly written tests pass at the least. 

Related to #52849
