### PR TITLE
Checkout: Remove props to CalypsoShoppingCartProvider

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useMemo, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Icon, wordpress } from '@wordpress/icons';
 import { Modal } from '@wordpress/components';
@@ -15,8 +15,6 @@ import type { RequestCart } from '@automattic/shopping-cart';
 import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/payment-method-helpers';
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import getCartKey from 'calypso/my-sites/checkout/get-cart-key';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import wp from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
@@ -51,13 +49,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 
 	const translate = useTranslate();
 
-	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );
-
-	const cartKey = useMemo( () => getCartKey( { selectedSite: site, isLoggedOutCart } ), [
-		site,
-		isLoggedOutCart,
-	] );
 
 	useEffect( () => {
 		return () => {
@@ -90,7 +82,7 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			shouldCloseOnClickOutside={ false }
 			icon={ <Icon icon={ wordpress } size={ 36 } /> }
 		>
-			<CalypsoShoppingCartProvider cartKey={ cartKey }>
+			<CalypsoShoppingCartProvider>
 				<StripeHookProvider
 					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
 					locale={ translate.locale }

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -3,8 +3,12 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { ShoppingCartProvider, useShoppingCart } from '@automattic/shopping-cart';
-import type { RequestCart, ResponseCart } from '@automattic/shopping-cart';
+import {
+	ShoppingCartProvider,
+	useShoppingCart,
+	getEmptyResponseCart,
+} from '@automattic/shopping-cart';
+import type { RequestCart } from '@automattic/shopping-cart';
 
 /**
  * Internal Dependencies
@@ -13,27 +17,41 @@ import wp from 'calypso/lib/wp';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from './get-cart-key';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-// Aliasing wpcom functions explicitly bound to wpcom is required here;
-// otherwise we get `this is not defined` errors.
-const wpcom = wp.undocumented();
-const wpcomGetCart = ( cartKey: string ) => wpcom.getCart( cartKey );
+const wpcomGetCart = ( cartKey: string ) => wp.req.get( `/me/shopping-cart/${ cartKey }` );
 const wpcomSetCart = ( cartKey: string, cartData: RequestCart ) =>
-	wpcom.setCart( cartKey, cartData );
+	wp.req.post( `/me/shopping-cart/${ cartKey }`, cartData );
+
+const emptyCart = getEmptyResponseCart();
 
 // A convenience wrapper around ShoppingCartProvider to set the necessary props for calypso
 export default function CalypsoShoppingCartProvider( {
 	children,
-	cartKey,
-	getCart,
 }: {
 	children: React.ReactNode;
-	cartKey?: string | number | null | undefined;
-	getCart?: ( cartKey: string ) => Promise< ResponseCart >;
 } ): JSX.Element {
 	const selectedSite = useSelector( getSelectedSite );
-	const finalCartKey = cartKey === undefined ? getCartKey( { selectedSite } ) : cartKey;
 	const cartKeysThatDoNotAllowRefetch = [ 'no-site', 'no-user' ];
+	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
+	const currentUrl = window.location.href;
+	const searchParams = new URLSearchParams( window.location.search );
+	const jetpackPurchaseToken = searchParams.has( 'purchasetoken' );
+	const jetpackPurchaseNonce = searchParams.has( 'purchaseNonce' );
+	const isJetpackCheckout =
+		currentUrl.includes( '/checkout/jetpack' ) &&
+		isLoggedOutCart &&
+		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
+	const isNoSiteCart =
+		isJetpackCheckout ||
+		( ! isLoggedOutCart &&
+			currentUrl.includes( '/checkout/no-site' ) &&
+			'no-user' === searchParams.get( 'cart' ) );
+
+	const getCart = isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( emptyCart ) : undefined;
+
+	const finalCartKey = getCartKey( { selectedSite, isLoggedOutCart, isNoSiteCart } );
+
 	const refetchOnWindowFocus: boolean =
 		Boolean( selectedSite?.ID ) &&
 		Boolean( finalCartKey ) &&
@@ -46,9 +64,6 @@ export default function CalypsoShoppingCartProvider( {
 		[ refetchOnWindowFocus ]
 	);
 
-	// If cartKey is null, we pass that to ShoppingCartProvider because it is
-	// probably intentional to delay loading. If cartKey is undefined, we try to
-	// get our own.
 	return (
 		<ShoppingCartProvider
 			cartKey={ finalCartKey }

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -34,18 +34,18 @@ export default function CalypsoShoppingCartProvider( {
 	const selectedSite = useSelector( getSelectedSite );
 	const cartKeysThatDoNotAllowRefetch = [ 'no-site', 'no-user' ];
 	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
-	const currentUrl = window.location.href;
+	const currentUrlPath = window.location.pathname;
 	const searchParams = new URLSearchParams( window.location.search );
 	const jetpackPurchaseToken = searchParams.has( 'purchasetoken' );
 	const jetpackPurchaseNonce = searchParams.has( 'purchaseNonce' );
 	const isJetpackCheckout =
-		currentUrl.includes( '/checkout/jetpack' ) &&
+		currentUrlPath.includes( '/checkout/jetpack' ) &&
 		isLoggedOutCart &&
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const isNoSiteCart =
 		isJetpackCheckout ||
 		( ! isLoggedOutCart &&
-			currentUrl.includes( '/checkout/no-site' ) &&
+			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );
 
 	const getCart = isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( emptyCart ) : undefined;

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -1,13 +1,11 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useCallback, useMemo } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import debugFactory from 'debug';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { getEmptyResponseCart } from '@automattic/shopping-cart';
 
 /**
  * Internal Dependencies
@@ -19,13 +17,8 @@ import { fetchStripeConfiguration } from './composite-checkout/payment-method-he
 import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import Recaptcha from 'calypso/signup/recaptcha';
-import getCartKey from './get-cart-key';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
-
-const emptyCart = getEmptyResponseCart();
-
-const debug = debugFactory( 'calypso:checkout-system-decider' );
 
 export default function CheckoutSystemDecider( {
 	productAliasFromUrl,
@@ -82,17 +75,6 @@ export default function CheckoutSystemDecider( {
 		[ reduxDispatch ]
 	);
 
-	const cartKey = useMemo(
-		() =>
-			getCartKey( {
-				selectedSite,
-				isLoggedOutCart,
-				isNoSiteCart,
-			} ),
-		[ selectedSite, isLoggedOutCart, isNoSiteCart ]
-	);
-	debug( 'cartKey is', cartKey );
-
 	let siteSlug = selectedSite?.slug;
 
 	if ( ! siteSlug ) {
@@ -103,17 +85,13 @@ export default function CheckoutSystemDecider( {
 		}
 	}
 
-	// If we do not have a site or user, we cannot fetch the initial cart from
-	// the server, so we'll just mock it as an empty cart here.
-	const getCart = isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( emptyCart ) : undefined;
-
 	return (
 		<>
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
-				<CalypsoShoppingCartProvider cartKey={ cartKey } getCart={ getCart }>
+				<CalypsoShoppingCartProvider>
 					<StripeHookProvider
 						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
 						locale={ locale }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`CalypsoShoppingCartProvider` is used in several places within calypso to provide access to the shopping cart endpoint via the `@automattic/shopping-cart` package. It's a convenience wrapper for `ShoppingCartProvider` that fills in the props required by that component. Normally it can be used without any props, but there are a few places in calypso where special props are needed: checkout itself and the editor checkout modal.

To avoid unnecessary API calls and to simplify use, it would be nice to wrap all of calypso in `CalypsoShoppingCartProvider` rather than sprinkling it in places where it's needed. This is made difficult by the two special cases of its use.

To help with this issue, this PR attempts to bring all those special cases into `CalypsoShoppingCartProvider` directly, so that the component works the same wherever it is used.

#### Testing instructions

The good news is that testing this is quite easy; we just need to know if checkout loads and if any change made to the cart is correctly persisted (eg: adding a product from the URL, removing an item from the cart, changing the billing address, or adding/removing a coupon - if any one of these works, then it all will work).

The bad news is that there's a lot of checkout flows that this touches. We need to test:

- Regular checkout shopping cart operations
- Shopping cart operations in registrationless checkout
- Shopping cart operations in Jetpack (registrationless) checkout
- Shopping cart operations in siteless checkout
- Shopping cart operations in the editor checkout modal
- Shopping cart operations in the registrationless editor checkout modal