### PR TITLE
My Home: Add aria labels and list markup to site setup checklist

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -4,7 +4,7 @@
 import { Card } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
-import React, { useEffect, useState, Fragment } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import classnames from 'classnames';
 
@@ -250,64 +250,66 @@ const SiteSetupList = ( {
 
 			<div className="site-setup-list__nav">
 				<CardHeading>{ translate( 'Site setup' ) }</CardHeading>
-				{ tasks.map( ( task ) => {
-					const enhancedTask = getTask( task );
-					const isCurrent = task.id === currentTask.id;
-					const isCompleted = task.isCompleted;
+				<ul className="site-setup-list__list">
+					{ tasks.map( ( task ) => {
+						const enhancedTask = getTask( task );
+						const isCurrent = task.id === currentTask.id;
+						const isCompleted = task.isCompleted;
 
-					return (
-						<Fragment key={ task.id }>
-							<NavItem
-								key={ task.id }
-								taskId={ task.id }
-								text={ enhancedTask.label || enhancedTask.title }
-								isCompleted={ isCompleted }
-								isCurrent={
-									useAccordionLayout ? isCurrent && showAccordionSelectedTask : isCurrent
-								}
-								onClick={
-									useAccordionLayout && isCurrent && showAccordionSelectedTask
-										? () => {
-												setShowAccordionSelectedTask( false );
-										  }
-										: () => {
-												setShowAccordionSelectedTask( true );
-												setTaskIsManuallySelected( true );
-												setCurrentTaskId( task.id );
-										  }
-								}
-								useAccordionLayout={ useAccordionLayout }
-							/>
-							{ useAccordionLayout && isCurrent && showAccordionSelectedTask ? (
-								<CurrentTaskItem
-									currentTask={ currentTask }
-									skipTask={ () => {
-										setTaskIsManuallySelected( false );
-										skipTask(
-											dispatch,
-											currentTask,
-											tasks,
-											siteId,
-											currentView,
-											setIsLoading,
-											isPodcastingSite
-										);
-									} }
-									startTask={ () =>
-										startTask(
-											dispatch,
-											currentTask,
-											siteId,
-											advanceToNextIncompleteTask,
-											isPodcastingSite
-										)
+						return (
+							<li key={ task.id }>
+								<NavItem
+									key={ task.id }
+									taskId={ task.id }
+									text={ enhancedTask.label || enhancedTask.title }
+									isCompleted={ isCompleted }
+									isCurrent={
+										useAccordionLayout ? isCurrent && showAccordionSelectedTask : isCurrent
+									}
+									onClick={
+										useAccordionLayout && isCurrent && showAccordionSelectedTask
+											? () => {
+													setShowAccordionSelectedTask( false );
+											  }
+											: () => {
+													setShowAccordionSelectedTask( true );
+													setTaskIsManuallySelected( true );
+													setCurrentTaskId( task.id );
+											  }
 									}
 									useAccordionLayout={ useAccordionLayout }
 								/>
-							) : null }
-						</Fragment>
-					);
-				} ) }
+								{ useAccordionLayout && isCurrent && showAccordionSelectedTask ? (
+									<CurrentTaskItem
+										currentTask={ currentTask }
+										skipTask={ () => {
+											setTaskIsManuallySelected( false );
+											skipTask(
+												dispatch,
+												currentTask,
+												tasks,
+												siteId,
+												currentView,
+												setIsLoading,
+												isPodcastingSite
+											);
+										} }
+										startTask={ () =>
+											startTask(
+												dispatch,
+												currentTask,
+												siteId,
+												advanceToNextIncompleteTask,
+												isPodcastingSite
+											)
+										}
+										useAccordionLayout={ useAccordionLayout }
+									/>
+								) : null }
+							</li>
+						);
+					} ) }
+				</ul>
 			</div>
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -35,9 +36,18 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useAccordionL
 		>
 			<div className="nav-item__status">
 				{ isCompleted ? (
-					<Gridicon className="nav-item__complete" icon="checkmark" size={ 18 } />
+					<Gridicon
+						aria-label={ translate( 'Task complete' ) }
+						className="nav-item__complete"
+						icon="checkmark"
+						size={ 18 }
+					/>
 				) : (
-					<div className="nav-item__pending" />
+					<div
+						role="img"
+						aria-label={ translate( 'Task incomplete' ) }
+						className="nav-item__pending"
+					/>
 				) }
 			</div>
 			<div className="nav-item__text">

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -33,6 +33,20 @@
 		}
 	}
 
+	.site-setup-list__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li {
+			border-bottom: 1px solid var( --color-border-subtle );
+
+			&:last-child {
+				border-bottom: none;
+			}
+		}
+	}
+
 	.card-heading {
 		padding: 16px 24px;
 		border-bottom: 1px solid var( --color-border-subtle );
@@ -44,16 +58,11 @@
 		display: flex;
 		align-items: center;
 		padding: 16px 24px;
-		border-bottom: 1px solid var( --color-border-subtle );
 		transition: all 0.1s;
 		cursor: pointer;
 		width: 100%;
 		margin: 0;
 		color: var( --color-text );
-
-		&:last-child {
-			border-bottom: none;
-		}
 
 		&:hover {
 			background-color: var( --color-neutral-0 );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -92,6 +92,8 @@
 		width: 8px;
 		height: 8px;
 		background-color: var( --color-neutral-20 );
+		// Using percentage because we're drawing a circle in CSS
+		// stylelint-disable-next-line declaration-property-unit-allowed-list
 		border-radius: 50%;
 		margin: 5px;
 		transition: all 0.1s;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `aria-label`s for the icons in the checklist
  * The tick icon has the label "Task complete"
  * The gray circle icon has the label "Task incomplete"
* Make the checklist a real "list" semantically

The diff in GH makes it look scarier than it is. Ignoring the indentation change it wraps the checklist in a `<ul>` and replaces a `<Fragment>` with a `<li>`.

This change is important because we want to be supporting users who use assistive technology anyway. But this came up because we were discussing whether to change the task labels when the task gets completed. Previously that would have been the only way for screen readers to tell the difference between a complete and incomplete task. Adding the aria labels in this PR means we can make the decision about task labels independently of a11y concerns.

In mobile view the checklist switches to an accordian view. We should really be using GB's according component for this since it has better support for assistive technology.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site where site setup isn't complete using calypso.live
* Open the same site in production and compare that the checklist looks the same
* You can also check in voiceover that the icon labels are being read (although My Home doesn't have great support for a11y so it might be hard to move the narrator to the list)
* Test in mobile view, the checklist should switch to an accordian view and work as it used to

This change has actually improved the placement of one of the borders in accordian view.
**Before**
<img width="381" alt="Screenshot 2021-06-10 at 10 49 19 AM" src="https://user-images.githubusercontent.com/1500769/121440312-c1b7c880-c9db-11eb-978d-b8a7c73e2f3e.png">

**After**
<img width="381" alt="Screenshot 2021-06-10 at 10 49 06 AM" src="https://user-images.githubusercontent.com/1500769/121440329-c8464000-c9db-11eb-889c-c8d38babbf73.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to the discussion in #52936, although not the main issue.
