### PR TITLE
Playwright: refactor how sidebar click actions are handled.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -53,11 +53,11 @@ export class SidebarComponent extends BaseContainer {
 	 * Heading is defined as the top-level menu item that is permanently visible on the sidebar, unless outside
 	 * of the viewport.
 	 *
-	 * Subheading is defined as the child-level menu item that is exposed only on hover or main heading being toggled.
+	 * Subheading is defined as the child-level menu item that is exposed only on hover or by toggling open the listing by clicking on the parent menu item.
 	 *
-	 * Note, in the current Nav Unification paradigm, clicking on certain combinations of sidebar menu items will cause
-	 * a navigation away to an entirely new page (eg. wp-admin). Attempting to reuse the SidebarComponent object
-	 * under this condition will trigger an exception.
+	 * Note, in the current Nav Unification paradigm, clicking on certain combinations of sidebar menu items will trigger
+	 * navigation away to an entirely new page (eg. wp-admin). Attempting to reuse the SidebarComponent object
+	 * under this condition will throw an exception from the Playwright engine.
 	 *
 	 * @param {{[key: string]: string}} param0 Named object parameter.
 	 * @param {string} param0.heading Plaintext representation of the top level heading.
@@ -72,12 +72,14 @@ export class SidebarComponent extends BaseContainer {
 		subheading?: string;
 	} ): Promise< void > {
 		if ( heading ) {
-			await this._click( { selector: `${ selectors.menuText } >> text=${ heading.trim() }` } );
+			heading = toTitleCase( heading.trim() );
+			await this._click( { selector: `${ selectors.menuText } >> text=${ heading }` } );
 		}
 
 		if ( subheading ) {
+			subheading = toTitleCase( subheading.trim() );
 			await this.sidebar.waitForSelector( selectors.expandedMenu );
-			await this._click( { selector: `span:has-text("${ subheading.trim() }")`, force: true } );
+			await this._click( { selector: `span:has-text("${ subheading }")`, force: true } );
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -11,7 +11,7 @@ import { ElementHandle, Page } from 'playwright';
 
 const selectors = {
 	sidebar: '.sidebar',
-	heading: '.sidebar > li:not(.sidebar__menu-item--child)',
+	heading: '.sidebar > li',
 	subheading: '.sidebar__menu-item--child',
 	expandedMenu: '.sidebar__menu--selected',
 };
@@ -79,7 +79,7 @@ export class SidebarComponent extends BaseContainer {
 			// Since the sub-headings are always hidden unless heading is selected, this works to
 			// our advantage.
 			const selector = `${ selectors.heading } span:has-text("${ heading }"):visible`;
-			await Promise.all( [ this.page.waitForNavigation(), this._click( { selector: selector } ) ] );
+			await Promise.all( [ this.page.waitForNavigation(), this._click( { selector } ) ] );
 		}
 
 		if ( subheading ) {
@@ -92,7 +92,7 @@ export class SidebarComponent extends BaseContainer {
 			const selector = `${ selectors.subheading } >> text="${ subheading }"`;
 			await Promise.all( [
 				this.page.waitForNavigation(),
-				this._click( { selector: selector, force: true } ),
+				this._click( { selector, force: true } ),
 			] );
 		}
 	}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -114,6 +114,7 @@ export class SidebarComponent extends BaseContainer {
 			await element.click();
 		} else {
 			await element.dispatchEvent( 'click' );
+			await this.page.waitForNavigation();
 		}
 		await this.page.waitForLoadState( 'domcontentloaded' );
 	}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -94,7 +94,7 @@ export class SidebarComponent extends BaseContainer {
 			);
 		}
 
-		await Promise.all( [ this.page.waitForNavigation(), this._click( selector ) ] );
+		await this._click( selector );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -13,7 +13,7 @@ describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
 
 	it( 'Navigate to Tools > Marketing page', async function () {
 		const sidebarComponent = await SidebarComponent.Expect( this.page );
-		await sidebarComponent.clickMenuItem( 'Tools' );
+		await sidebarComponent.gotoMenu( { heading: 'Tools' } );
 	} );
 
 	it( 'Click on Traffic tab', async function () {

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -13,7 +13,7 @@ describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
 
 	it( 'Navigate to Tools > Marketing page', async function () {
 		const sidebarComponent = await SidebarComponent.Expect( this.page );
-		await sidebarComponent.gotoMenu( { heading: 'Tools' } );
+		await sidebarComponent.gotoMenu( { item: 'Tools' } );
 	} );
 
 	it( 'Click on Traffic tab', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -23,7 +23,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.clickMenuItem( 'Settings' );
+			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -78,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.clickMenuItem( 'Settings' );
+			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -121,7 +121,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.clickMenuItem( 'Settings' );
+			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -157,7 +157,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.clickMenuItem( 'Settings' );
+			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -23,7 +23,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -78,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -121,7 +121,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -157,7 +157,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( this.page );
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { heading: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings' } );
 		} );
 
 		it( 'Open support popover', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR overhauls how the `SidebarComponent` clicks on, you guessed it, WPCOM sidebar.

Previous implementation used simple text selectors. While this worked well, it was pointed out that other matching text appearing before the sidebar would produce unexpected results. For instance, consider the case of `Settings`.

The word `Settings` appear at least in five places on a full WPCOM eCommerce account:
- Jetpack > Settings
- WooCommerce > Settings
- Analytics > Settings
- Users > Account Settings
- Settings

Plain text selector will resolve and match on the first item (Jetpack > Settings).

Major changes:

- require the calling method to provide named parameter values: `heading` and `subheading`, case-insensitive.
- build varying selectors tailored for the nature of the menu item.
- implement a helper `_click` method to click on the selector.
- address scrolling behavior of WPCOM sidebar through the use of optional boolean `force` parameter that programmatically generates a click action.

#### Testing instructions

TeamCity
- ensure all tests, especially the `SEO Preview` tests pass. This test clicks on the sidebar item `Tools` and is a good indicator of the general health of this change.

Local
- ensure the `SEO Preview` tests pass.

Related to #53323 
