### PR TITLE
My Home: Remove chevrons from internal links on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -10,7 +11,16 @@ import { CompactCard } from '@automattic/components';
 import MaterialIcon from 'calypso/components/material-icon';
 import Gridicon from 'calypso/components/gridicon';
 
-const ActionBox = ( { href, onClick, target, iconSrc, label, materialIcon, gridicon } ) => {
+const ActionBox = ( {
+	href,
+	onClick,
+	target,
+	iconSrc,
+	label,
+	materialIcon,
+	gridicon,
+	hideLinkIndicator,
+} ) => {
 	const buttonAction = { href, onClick, target };
 	const getIcon = () => {
 		if ( materialIcon ) {
@@ -25,7 +35,12 @@ const ActionBox = ( { href, onClick, target, iconSrc, label, materialIcon, gridi
 	};
 
 	return (
-		<CompactCard { ...buttonAction } displayAsLink className="quick-links__action-box">
+		<CompactCard
+			{ ...buttonAction }
+			className={ classnames( 'quick-links__action-box', {
+				'quick-links__action-box__hide-link-indicator': hideLinkIndicator,
+			} ) }
+		>
 			<div className="quick-links__action-box-image">{ getIcon() }</div>
 			<div className="quick-links__action-box-text">
 				<h6 className="quick-links__action-box-label">{ label }</h6>

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -105,6 +105,7 @@ export const QuickLinks = ( {
 			{ showCustomizer && (
 				<ActionBox
 					href={ menusUrl }
+					hideLinkIndicator
 					onClick={ trackEditMenusAction }
 					label={ translate( 'Edit menus' ) }
 					materialIcon="list"
@@ -113,6 +114,7 @@ export const QuickLinks = ( {
 			{ showCustomizer && (
 				<ActionBox
 					href={ customizeUrl }
+					hideLinkIndicator
 					onClick={ trackCustomizeThemeAction }
 					label={ translate( 'Customize theme' ) }
 					materialIcon="palette"

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -66,6 +66,12 @@
 		right: 20px;
 	}
 
+	&.quick-links__action-box__hide-link-indicator {
+		.card__link-indicator {
+			display: none;
+		}
+	}
+
 	&:hover {
 		background: var( --color-neutral-0 );
 

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .customer-home__layout-col-right {
 	@include breakpoint-deprecated( '<480px' ) {
 		.go-mobile__subheader.customer-home__card-subheader {
@@ -7,7 +10,11 @@
 }
 
 .go-mobile.card {
-	padding: 16px 24px;
+	padding: 16px;
+
+	@include break-mobile {
+		padding: 16px 24px;
+	}
 }
 
 .go-mobile__app-badges {

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -100,7 +100,6 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 							<Gridicon icon="help" size={ 36 } />
 						</span>
 						{ translate( 'Contact support' ) }
-						<Gridicon className="help-search__go-icon" icon="chevron-right" size={ 24 } />
 					</a>
 				</div>
 			</Card>

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -35,9 +35,13 @@ $min_results_height: 180px;
 	.help-search__cta {
 		display: flex;
 		align-items: center;
-		padding: 10px $card_padding_large;
+		padding: 10px $card_padding_small;
 		color: var( --color-text );
 		line-height: 1;
+
+		@include break-mobile {
+			padding: 10px $card_padding_large;
+		}
 
 		&:hover,
 		&:focus {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .task {
 	display: flex;
 	background: var( --color-surface );
@@ -8,7 +11,11 @@
 	.task__text,
 	.task__illustration {
 		box-sizing: border-box;
-		padding: 24px;
+		padding: 24px 16px;
+
+		@include break-mobile {
+			padding: 24px;
+		}
 
 		@include breakpoint-deprecated( '>1040px' ) {
 			padding: 32px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the short-term design changes being made to My Home pd2qGl-4i-p2

* Remove the chevron from the "Contact support" link in the "Get help" card
* Remove the chevron from the internal links in the "Quick links" card (the external links still show the external link indicator)

**Before**
<img width="797" alt="Screenshot 2021-06-10 at 2 45 51 PM" src="https://user-images.githubusercontent.com/1500769/121456770-af00bc00-c9fa-11eb-9615-f8e32c689a40.png">


**After**
<img width="797" alt="Screenshot 2021-06-10 at 2 46 18 PM" src="https://user-images.githubusercontent.com/1500769/121456757-a90adb00-c9fa-11eb-814a-5a73f66612a1.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should be able to test on calypso.live
* Make sure no alignment has broken on mobile layouts

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53141