### PR TITLE
My Home: Remove icons from educational material cards on My Home 

### DIFF
--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -30,7 +30,6 @@ const EducationEarn = ( { siteSlug } ) => {
 				{
 					calypsoLink: true,
 					url: `/earn/${ siteSlug }`,
-					icon: 'arrow-right',
 					text: translate( 'Start making money' ),
 				},
 			] }

--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -30,7 +30,6 @@ const FreePhotoLibrary = () => {
 					postId: 145498,
 					url: localizeUrl( 'https://wordpress.com/support/free-photo-library/' ),
 					text: translate( 'Learn more' ),
-					materialIcon: 'play_circle_outline',
 				},
 			] }
 			illustration={ freePhotoLibraryVideoPrompt }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the short-term design changes being made to My Home pd2qGl-4i-p2

* Remove icon from "Start making money" link on the "Make money from your website" card
* Remove icon from "Learn more" link on the "The WordPress.com free photo library" card

**Before**
<img width="629" alt="Screenshot 2021-06-10 at 3 28 14 PM" src="https://user-images.githubusercontent.com/1500769/121460103-7cf25880-ca00-11eb-93e5-24cc2cfb9ee9.png">


**After**
<img width="629" alt="Screenshot 2021-06-10 at 3 27 46 PM" src="https://user-images.githubusercontent.com/1500769/121460081-75cb4a80-ca00-11eb-800b-0fe74b557bdb.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using the "default" view, since it shows all of the educational cards at the same time. Do that with `/home/{{ site }}?dev=true&view=VIEW_DEFAULT`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53141
