### PR TITLE
My Home: "Create a logo" link renamed to "Create a logo with Fiverr"

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
+import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import page from 'page';
 
 /**
@@ -140,7 +140,13 @@ export const QuickLinks = ( {
 				href="https://wp.me/logo-maker"
 				onClick={ trackDesignLogoAction }
 				target="_blank"
-				label={ translate( 'Create a logo' ) }
+				label={
+					getLocaleSlug() === 'en' ||
+					getLocaleSlug() === 'en-gb' ||
+					i18nCalypso.hasTranslation( 'Create a logo with Fiverr' )
+						? translate( 'Create a logo with Fiverr' )
+						: translate( 'Create a logo' )
+				}
 				external
 				iconSrc={ fiverrIcon }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the short-term design changes being made to My Home pd2qGl-4i-p2

* Rename link to "Create a logo with Fiverr". It's got a nice symmetry with the Anchor link now
* Only use the new copy once translations are ready

![Screen Shot on 2021-06-10 at 15:52:06](https://user-images.githubusercontent.com/1500769/121461890-d5772500-ca03-11eb-9539-95d45a79823a.png)


The i18n bot shot ping this GH thread once translations are done, which is a prompt that we can remove the fallback and calls to `hasTranslation()`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Take a look at the "Quick links" card on My Home
   * Try in `en`
   * Try in `en-gb` (search for `UK` in the language picker)
   * Try in a non-English language and make sure it's still using the old label

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53141
