### PR TITLE
My Home: Secondary area of My Home supports the support search card

### DIFF
--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -8,17 +8,20 @@ import React from 'react';
  */
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
 import QuickStartVideo from 'calypso/my-sites/customer-home/cards/education/quick-start-video';
+import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import LearnGrow from './learn-grow';
 import {
 	FEATURE_STATS,
 	SECTION_LEARN_GROW,
 	FEATURE_QUICK_START_VIDEO,
+	FEATURE_SUPPORT,
 } from 'calypso/my-sites/customer-home/cards/constants';
 
 const cardComponents = {
 	[ FEATURE_STATS ]: Stats,
 	[ FEATURE_QUICK_START_VIDEO ]: QuickStartVideo,
 	[ SECTION_LEARN_GROW ]: LearnGrow,
+	[ FEATURE_SUPPORT ]: HelpSearch,
 };
 
 const Secondary = ( { cards } ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the short-term design changes being made to My Home pd2qGl-4i-p2

* Add support to show the HelpSearch card in the secondary (left-hand) area of My Home

My Home renders the cards wherever the backend tells it to. However the `<Secondary>` component still needs code to support rendering the support card. This PR adds that support. The work of actually moving the support card to the secondary area is in D62612-code.

D62612-code updates all views except for the desktop app views. Old versions of the desktop app won't include this PR, so won't be able to render the support card in the new position.

![Untitled](https://user-images.githubusercontent.com/1500769/121469629-f2662500-ca10-11eb-8760-70e311862bf3.jpg)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D62612-code to your sandbox and proxy `public-api`
* Navigate to My Home and verify that the support search card is now on the left of My Home
* Test all the specific views to ensure the change has been made correctly. You can test a specific view using `/home/{{ site }}?dev=true&view={{ view id }}`
* View IDs where the support card should have moved (list of IDs from pd2qGl-2w-p2)
   * `VIEW_WP_FOR_TEAMS`
   * `VIEW_RENEW_EXPIRED_PLAN`
   * `VIEW_RENEW_EXPIRING_PLAN`
   * `VIEW_CELEBRATE_SITE_LAUNCH`
   * `VIEW_CELEBRATE_SITE_SETUP_COMPLETE`
   * `VIEW_CELEBRATE_SITE_MIGRATION`
   * `VIEW_SITE_SETUP_ECOMMERCE`
   * `VIEW_SITE_SETUP`
   * `VIEW_UNVERIFIED_EMAIL`
   * `VIEW_GO_MOBILE`
   * `VIEW_PODCASTING`
   * `VIEW_WEBINARS`
   * `VIEW_CONNECT_ACCOUNTS`
   * `VIEW_FIND_DOMAIN`
   * `VIEW_WP_COURSES`
   * `VIEW_EARN_FEATURES`
   * `VIEW_CLOUDFLARE`
   * `VIEW_DEFAULT`
   * `VIEW_FREE_EMAIL_TRIAL`
* View IDs where the support card should **not** have moved
   * `VIEW_DESKTOP_APP_DEPRECATED`
   * `VIEW_DESKTOP_APP`
* The moved support search card layout should be fine on mobile devices (keep in mind there are more tweaks to the layout coming for this card)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53141