### PR TITLE
`useHappinessEngineersQuery`: use `wp.req.get` directly

### DIFF
--- a/client/data/happiness-engineers/use-happiness-engineers-query.js
+++ b/client/data/happiness-engineers/use-happiness-engineers-query.js
@@ -9,7 +9,7 @@ import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 const useHappinessEngineersQuery = () =>
-	useQuery( 'happinessEngineers', async () => await wpcom.undocumented().getHappinessEngineers(), {
+	useQuery( 'happinessEngineers', async () => await wpcom.req.get( '/meta/happiness-engineers/' ), {
 		refetchOnWindowFocus: false,
 	} );
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1082,17 +1082,6 @@ Undocumented.prototype.sitesExternalServices = function ( siteId, fn ) {
 };
 
 /**
- * Return a list of happiness engineers gravatar urls
- *
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getHappinessEngineers = function ( fn ) {
-	debug( 'meta/happiness-engineers/ query' );
-
-	return this.wpcom.req.get( { path: '/meta/happiness-engineers/' }, fn );
-};
-
-/**
  * Return a list of sharing buttons for the specified site, with optional
  * query parameters
  *


### PR DESCRIPTION
Just a minor janitorial change. I noticed the usage of `.undocumented()` method while going through existing queries.

#### Changes proposed in this Pull Request

* `useHappinessEngineersQuery`: use `wpcom.req.get` directly instead of `.undocumented()` method

#### Testing instructions

* Make sure testing instructions from #53157 are still valid
