### PR TITLE
State: Move post-invite-accept user fetching to action

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -9,7 +9,6 @@ import page from 'page';
  */
 import config from '@automattic/calypso-config';
 import {
-	INVITE_ACCEPTED,
 	JETPACK_DISCONNECT_RECEIVE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 	ROUTE_SET,
@@ -142,12 +141,6 @@ const handler = ( dispatch, action, getState ) => {
 
 				fetchAutomatedTransferStatusForSelectedSite( dispatch, getState );
 			}, 0 );
-			return;
-
-		case INVITE_ACCEPTED:
-			if ( ! [ 'follower', 'viewer' ].includes( action.invite.role ) ) {
-				user().fetch();
-			}
 			return;
 
 		case SITE_DELETE_RECEIVE:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when accepting an invite we'll redirect to `/posts/:siteId` but without ensuring the user's site count has been refreshed. That leads the user to hang on the invitation page. Caused by a regression we introduced in #53301.

This PR moves the user fetching to the action and waits for it to complete before continuing.

Fixes #53546

This PR ended up being related to #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* You're going to need 2 separate browser sessions for 2 separate users to test this.
* Create an account X without sites. To do that, start at `/start`, register, and just stop the flow. Verify you're logged in by going to `wordpress.com`.
* From another account (Y) send an Editor invitation to X to join the site.
* Go to the inbox of user X and copy the invitation button link.
* Change the `wordpress.com` part of the link to the `calypso.live` link or `calypso.localhost` link (wherever you're testing this branch)
* Accept.
* Verify you're redirected to `/posts/:siteId` and the posts list loads, and you can see the success notice.
* Verify e2e tests pass, particularly the one that is responsible for accepting an invite "User has been added as Editor".