### PR TITLE
Themes Thanks Modal: render link buttons as anchor elements

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -4,8 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import page from 'page';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -47,7 +46,7 @@ class ThanksModal extends Component {
 		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
 		// Connected props
 		clearActivated: PropTypes.func.isRequired,
-		refreshSite: PropTypes.func.isRequired,
+		requestSite: PropTypes.func.isRequired,
 		currentTheme: PropTypes.shape( {
 			author: PropTypes.string,
 			author_uri: PropTypes.string,
@@ -66,7 +65,7 @@ class ThanksModal extends Component {
 	componentDidUpdate( prevProps ) {
 		// re-fetch the site to ensure we have the right cusotmizer link for FSE or not
 		if ( prevProps.hasActivated === false && this.props.hasActivated === true ) {
-			this.props.refreshSite( this.props.siteId );
+			this.props.requestSite( this.props.siteId );
 		}
 	}
 
@@ -79,9 +78,8 @@ class ThanksModal extends Component {
 		trackClick( 'current theme', eventName, verb );
 	};
 
-	visitSite = () => {
+	trackVisitSite = () => {
 		this.trackClick( 'visit site' );
-		window.open( this.props.siteUrl, '_blank' );
 	};
 
 	goBack = () => {
@@ -110,20 +108,15 @@ class ThanksModal extends Component {
 	learnThisTheme = () => {
 		this.trackClick( 'learn this theme' );
 		this.onCloseModal();
-		page( this.props.detailsUrl );
 	};
 
 	goToCustomizer = () => {
-		const { customizeUrl, shouldEditHomepageWithGutenberg } = this.props;
-
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
-
-		shouldEditHomepageWithGutenberg ? page( customizeUrl ) : window.open( customizeUrl, '_blank' );
 	};
 
 	renderThemeInfo = () => {
-		return translate( '{{a}}Learn more about{{/a}} this theme.', {
+		return this.props.translate( '{{a}}Learn more about{{/a}} this theme.', {
 			components: {
 				a: <a href={ this.props.detailsUrl } onClick={ this.onLinkClick( 'theme info' ) } />,
 			},
@@ -131,7 +124,7 @@ class ThanksModal extends Component {
 	};
 
 	renderCustomizeInfo = () => {
-		return translate( '{{a}}Customize{{/a}} this design.', {
+		return this.props.translate( '{{a}}Customize{{/a}} this design.', {
 			components: {
 				a: <a href={ this.props.customizeUrl } onClick={ this.onLinkClick( 'customize' ) } />,
 			},
@@ -142,7 +135,7 @@ class ThanksModal extends Component {
 		const { author_uri: authorUri } = this.props.currentTheme;
 
 		if ( this.props.forumUrl ) {
-			return translate( 'Have questions? Stop by our {{a}}support forums{{/a}}.', {
+			return this.props.translate( 'Have questions? Stop by our {{a}}support forums{{/a}}.', {
 				components: {
 					a: <a href={ this.props.forumUrl } onClick={ this.onLinkClick( 'support' ) } />,
 				},
@@ -150,7 +143,7 @@ class ThanksModal extends Component {
 		}
 
 		if ( authorUri ) {
-			return translate( 'Have questions? {{a}}Contact the theme author.{{/a}}', {
+			return this.props.translate( 'Have questions? {{a}}Contact the theme author.{{/a}}', {
 				components: {
 					a: <a href={ authorUri } onClick={ this.onLinkClick( 'org author' ) } />,
 				},
@@ -168,7 +161,7 @@ class ThanksModal extends Component {
 		return (
 			<div>
 				<h1>
-					{ translate( 'Thanks for choosing {{br/}} %(themeName)s', {
+					{ this.props.translate( 'Thanks for choosing {{br/}} %(themeName)s', {
 						args: { themeName },
 						components: {
 							br: promptSwitchingEditors ? null : <br />,
@@ -176,13 +169,13 @@ class ThanksModal extends Component {
 					} ) }
 				</h1>
 				<span>
-					{ translate( 'by %(themeAuthor)s', {
+					{ this.props.translate( 'by %(themeAuthor)s', {
 						args: { themeAuthor },
 					} ) }
 				</span>
 				{ promptSwitchingEditors && (
 					<p className="thanks-modal__gutenberg-prompt">
-						{ translate(
+						{ this.props.translate(
 							'This theme is intended to work with the new WordPress editor. We recommend activating that first. {{supportLink/}}.',
 							{
 								components: {
@@ -192,7 +185,7 @@ class ThanksModal extends Component {
 											supportLink="https://wordpress.com/support/replacing-the-older-wordpress-com-editor-with-the-wordpress-block-editor/"
 											showIcon={ false }
 										>
-											{ translate( 'Learn more' ) }
+											{ this.props.translate( 'Learn more' ) }
 										</InlineSupportLink>
 									),
 								},
@@ -215,14 +208,14 @@ class ThanksModal extends Component {
 	getEditSiteLabel = () => {
 		const { shouldEditHomepageWithGutenberg, hasActivated } = this.props;
 		if ( ! hasActivated ) {
-			return translate( 'Activating theme…' );
+			return this.props.translate( 'Activating theme…' );
 		}
 
-		const gutenbergContent = translate( 'Edit homepage' );
+		const gutenbergContent = this.props.translate( 'Edit homepage' );
 		const customizerContent = (
 			<>
 				<Gridicon icon="external" />
-				{ translate( 'Customize site' ) }
+				{ this.props.translate( 'Customize site' ) }
 			</>
 		);
 
@@ -236,7 +229,7 @@ class ThanksModal extends Component {
 	getViewSiteLabel = () => (
 		<span className="thanks-modal__button-customize">
 			<Gridicon icon="external" />
-			{ translate( 'View site' ) }
+			{ this.props.translate( 'View site' ) }
 		</span>
 	);
 
@@ -247,12 +240,15 @@ class ThanksModal extends Component {
 			? {
 					action: 'view',
 					label: this.getViewSiteLabel(),
-					onClick: this.visitSite,
+					onClick: this.trackVisitSite,
+					href: this.props.siteUrl,
+					target: '_blank',
 			  }
 			: {
 					action: 'learn',
-					label: translate( 'Learn about this theme' ),
+					label: this.props.translate( 'Learn about this theme' ),
 					onClick: this.learnThisTheme,
+					href: this.props.detailsUrl,
 			  };
 
 		return [
@@ -266,6 +262,8 @@ class ThanksModal extends Component {
 				isPrimary: true,
 				disabled: ! hasActivated,
 				onClick: this.goToCustomizer,
+				href: this.props.customizeUrl,
+				target: shouldEditHomepageWithGutenberg ? null : '_blank',
 			},
 		];
 	};
@@ -324,10 +322,8 @@ export default connect(
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
 		};
 	},
-	( dispatch ) => {
-		return {
-			clearActivated: ( siteId ) => dispatch( clearActivated( siteId ) ),
-			refreshSite: ( siteId ) => dispatch( requestSite( siteId ) ),
-		};
+	{
+		clearActivated,
+		requestSite,
 	}
-)( ThanksModal );
+)( localize( ThanksModal ) );

--- a/packages/components/src/dialog/button-bar.tsx
+++ b/packages/components/src/dialog/button-bar.tsx
@@ -5,6 +5,11 @@ import React, { isValidElement, cloneElement } from 'react';
 import type { ReactElement, ReactNode, FunctionComponent } from 'react';
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import Button from '../button';
+
 export type BaseButton = {
 	action: string;
 	disabled?: boolean;
@@ -13,6 +18,8 @@ export type BaseButton = {
 	additionalClassNames?: string;
 	isPrimary?: boolean;
 	onClick?: ( closeDialog: () => void ) => void;
+	href?: string;
+	target?: string;
 };
 
 export type Button = ReactElement | BaseButton;
@@ -37,21 +44,23 @@ const ButtonBar: FunctionComponent< Props > = ( { buttons, baseClassName, onButt
 					return cloneElement( button, { key } );
 				}
 
-				const classes = classnames( button.className || 'button', button.additionalClassNames, {
+				const classes = classnames( button.className, button.additionalClassNames, {
 					'is-primary': button.isPrimary || buttons.length === 1,
 				} );
 
 				return (
-					<button
+					<Button
 						key={ key }
 						className={ classes }
 						data-e2e-button={ button.action }
 						data-tip-target={ `dialog-base-action-${ button.action }` }
 						onClick={ () => onButtonClick( button ) }
 						disabled={ !! button.disabled }
+						href={ button.href }
+						target={ button.target }
 					>
 						<span className={ baseClassName + '__button-label' }>{ button.label }</span>
-					</button>
+					</Button>
 				);
 			} ) }
 		</div>

--- a/test/e2e/lib/components/theme-dialog-component.js
+++ b/test/e2e/lib/components/theme-dialog-component.js
@@ -25,14 +25,14 @@ export default class ThemeDialogComponent extends AsyncBaseContainer {
 	async goToThemeDetail() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.dialog button[data-e2e-button="learn"]' )
+			By.css( '.dialog a[data-e2e-button="learn"]' )
 		);
 	}
 
 	async customizeSite() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.dialog button[data-e2e-button="customizeSite"]' )
+			By.css( '.dialog a[data-e2e-button="customizeSite"]' )
 		);
 		return await driverHelper.waitUntilAbleToSwitchToWindow( this.driver, 1 );
 	}


### PR DESCRIPTION
Improving navigation in Themes Thanks Modal, fixing issues identified in https://github.com/Automattic/wp-calypso/pull/53443#discussion_r648020724

After you activate a theme on a site, you'll see a thanks modal with buttons:

<img width="771" alt="Screenshot 2021-06-10 at 9 57 53" src="https://user-images.githubusercontent.com/664258/121490587-739fc680-c9d5-11eb-916d-0f41635882ec.png">

Both buttons navigate to another page and can be `<a href>` links, just styled as buttons. That improves accessibility, allows for progressive enhancement etc.

This PR converts these buttons to links with a `href` attribute, instead of doing the navigation with JavaScript in `onClick` handlers.

I needed to patch the `<Dialog>` component to use the `<Button>` component instead of a native `<button>` element.

The modal has another variant that depends on the value of the `shouldEditHomepageWithGutenberg` prop:

<img width="771" alt="Screenshot 2021-06-10 at 9 58 27" src="https://user-images.githubusercontent.com/664258/121490969-d1cca980-c9d5-11eb-89ac-e071ccbd652d.png">

When testing, it's easiest to toggle the prop's value in React Devtools:

<img width="487" alt="Screenshot 2021-06-10 at 9 59 06" src="https://user-images.githubusercontent.com/664258/121491680-7818af00-c9d6-11eb-9a7c-c870625ccc61.png">

When testing, also verify that links that are supposed to open in a new window do so also in the new version.