### PR TITLE
`useRemoveViewerMutation`: align with current practices

### DIFF
--- a/client/data/viewers/use-remove-viewer-mutation.js
+++ b/client/data/viewers/use-remove-viewer-mutation.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 
 /**
@@ -10,9 +11,9 @@ import wp from 'calypso/lib/wp';
 
 function useRemoveViewer() {
 	const queryClient = useQueryClient();
-	const { mutate: removeViewer, ...rest } = useMutation(
+	const mutation = useMutation(
 		( { siteId, viewerId } ) => {
-			return wp.undocumented().site( siteId ).removeViewer( viewerId );
+			return wp.req.post( `/sites/${ siteId }/viewers/${ viewerId }/delete` );
 		},
 		{
 			onSuccess( data, variables ) {
@@ -22,7 +23,12 @@ function useRemoveViewer() {
 		}
 	);
 
-	return { removeViewer, ...rest };
+	const { mutate } = mutation;
+	const removeViewer = useCallback( ( siteId, viewerId ) => mutate( { siteId, viewerId } ), [
+		mutate,
+	] );
+
+	return { removeViewer, ...mutation };
 }
 
 export default useRemoveViewer;

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -94,15 +94,6 @@ UndocumentedSite.prototype.shortcodes = function ( attributes, callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/shortcodes/render', attributes, callback );
 };
 
-UndocumentedSite.prototype.removeViewer = function ( viewerId, callback ) {
-	return this.wpcom.req.post(
-		{
-			path: '/sites/' + this._id + '/viewers/' + viewerId + '/delete',
-		},
-		callback
-	);
-};
-
 UndocumentedSite.prototype.setOption = function ( query, callback ) {
 	return this.wpcom.req.post(
 		'/sites/' + this._id + '/option',

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -10,7 +10,7 @@ import { useDispatch } from 'react-redux';
  */
 import Viewers from './viewers';
 import useViewersQuery from 'calypso/data/viewers/use-viewers-query';
-import useRemoveViewer from 'calypso/data/viewers/remove-viewer';
+import useRemoveViewer from 'calypso/data/viewers/use-remove-viewer-mutation';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 
 const useErrorNotice = ( error, refetch ) => {

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -51,7 +51,7 @@ class Viewers extends React.Component {
 						'People',
 						'Clicked Remove Button In Remove Viewer Confirmation'
 					);
-					this.props.removeViewer( { siteId: this.props.site.ID, viewerId: viewer.ID } );
+					this.props.removeViewer( this.props.site.ID, viewer.ID );
 				} else {
 					this.props.recordGoogleEvent(
 						'People',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `wp.req.post` directly instead of `Undocumented.removeViewer()`
* Remove `Undocumented.removeViewer()`
* Align `removeViewer` with mutation practices (e.g. function signature)
* Rename `remove-viewer.js` to `use-remove-viewer-mutation.js` to follow naming convention

#### Testing instructions

* On a site which has viewers (e.g. private site or P2) go to `/people/viewers/<site-slug>`
* Attempt to remove a viewer and make sure it behaves exactly like on prod
