### PR TITLE
User: Move getLogoutUrl to shared-utils

### DIFF
--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import config from '@automattic/calypso-config';
+
+/**
  * Internal dependencies
  */
 import { decodeEntities } from 'calypso/lib/formatting/decode-entities';
@@ -71,4 +76,30 @@ export function getComputedAttributes( attributes ) {
 		localeVariant: attributes.locale_variant,
 		isRTL: !! ( language && language.rtl ),
 	};
+}
+
+export function getLogoutUrl( userData, redirect ) {
+	let url;
+	let subdomain = '';
+
+	// If logout_URL isn't set, then go ahead and return the logout URL
+	// without a proper nonce as a fallback.
+	// Note: we never want to use logout_URL in the desktop app
+	if ( ! userData.logout_URL || config.isEnabled( 'always_use_logout_url' ) ) {
+		// Use localized version of the homepage in the redirect
+		if ( userData.localeSlug && userData.localeSlug !== '' && userData.localeSlug !== 'en' ) {
+			subdomain = userData.localeSlug + '.';
+		}
+
+		url = config( 'logout_url' ).replace( '|subdomain|', subdomain );
+	} else {
+		url = userData.logout_URL;
+	}
+
+	if ( 'string' === typeof redirect ) {
+		redirect = '&redirect_to=' + encodeURIComponent( redirect );
+		url += redirect;
+	}
+
+	return url;
 }

--- a/client/lib/user/test/shared-utils.js
+++ b/client/lib/user/test/shared-utils.js
@@ -1,11 +1,12 @@
 /**
+ * External dependencies
+ */
+import config from '@automattic/calypso-config';
+
+/**
  * Internal dependencies
  */
-import UserUtils from '../utils';
-import config from '@automattic/calypso-config';
-import User from 'calypso/lib/user';
-
-const user = User();
+import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 
 jest.mock( '@automattic/calypso-config', () => {
 	const mock = jest.fn();
@@ -23,8 +24,8 @@ describe( 'UserUtils', () => {
 		} );
 
 		test( 'uses userData.logout_URL when available', () => {
-			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata' } );
-			expect( UserUtils.getLogoutUrl() ).toBe( '/userdata' );
+			const user = { logout_URL: '/userdata' };
+			expect( getLogoutUrl( user ) ).toBe( '/userdata' );
 		} );
 	} );
 
@@ -35,20 +36,20 @@ describe( 'UserUtils', () => {
 
 		test( 'works when |subdomain| is not present', () => {
 			config.mockImplementation( configMock( { logout_url: 'wp.com/without-domain' } ) );
-			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata', localeSlug: 'es' } );
-			expect( UserUtils.getLogoutUrl() ).toBe( 'wp.com/without-domain' );
+			const user = { logout_URL: '/userdata', localeSlug: 'es' };
+			expect( getLogoutUrl( user ) ).toBe( 'wp.com/without-domain' );
 		} );
 
 		test( 'replaces |subdomain| when present and have non-default locale', () => {
 			config.mockImplementation( configMock( { logout_url: '|subdomain|wp.com/with-domain' } ) );
-			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata', localeSlug: 'es' } );
-			expect( UserUtils.getLogoutUrl() ).toBe( 'es.wp.com/with-domain' );
+			const user = { logout_URL: '/userdata', localeSlug: 'es' };
+			expect( getLogoutUrl( user ) ).toBe( 'es.wp.com/with-domain' );
 		} );
 
 		test( 'replaces |subdomain| when present but no locale', () => {
 			config.mockImplementation( configMock( { logout_url: '|subdomain|wp.com/with-domain' } ) );
-			jest.spyOn( user, 'get' ).mockReturnValue( { logout_URL: '/userdata' } );
-			expect( UserUtils.getLogoutUrl() ).toBe( 'wp.com/with-domain' );
+			const user = { logout_URL: '/userdata' };
+			expect( getLogoutUrl( user ) ).toBe( 'wp.com/with-domain' );
 		} );
 	} );
 } );

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -1,52 +1,12 @@
 /**
- * External dependencies
- */
-
-import debugModule from 'debug';
-
-/**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import user from 'calypso/lib/user';
-
-/**
- * Module Variables
- */
-const debug = debugModule( 'calypso:user:utilities' );
+import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 
 const userUtils = {
-	getLogoutUrl( redirect ) {
-		const userData = user().get();
-		let url;
-		let subdomain = '';
-
-		// If logout_URL isn't set, then go ahead and return the logout URL
-		// without a proper nonce as a fallback.
-		// Note: we never want to use logout_URL in the desktop app
-		if ( ! userData.logout_URL || config.isEnabled( 'always_use_logout_url' ) ) {
-			// Use localized version of the homepage in the redirect
-			if ( userData.localeSlug && userData.localeSlug !== '' && userData.localeSlug !== 'en' ) {
-				subdomain = userData.localeSlug + '.';
-			}
-
-			url = config( 'logout_url' ).replace( '|subdomain|', subdomain );
-		} else {
-			url = userData.logout_URL;
-		}
-
-		if ( 'string' === typeof redirect ) {
-			redirect = '&redirect_to=' + encodeURIComponent( redirect );
-			url += redirect;
-		}
-
-		debug( 'Logout Url: ' + url );
-
-		return url;
-	},
-
 	logout( redirect ) {
-		const logoutUrl = userUtils.getLogoutUrl( redirect );
+		const logoutUrl = getLogoutUrl( user().get(), redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
 		user()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves `getLogoutUrl()` from `utils` to `shared-utils` in order to make it usable outside of `lib/user`. We're introducing a change to it as well, where the `user` argument is now provided separately, in order to make this a truly independent utility function.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Verify all tests pass.
* Verify that after closing your account, the user still logs out correctly.