### PR TITLE
Explat: Use analytics getCurrentUser() instead of lib/user

### DIFF
--- a/client/lib/explat/internals/anon-id.ts
+++ b/client/lib/explat/internals/anon-id.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	getCurrentUser,
 	recordTracksEvent,
 	getTracksAnonymousUserId,
 	getTracksLoadPromise,
@@ -10,7 +11,6 @@ import {
 /**
  * Internal dependencies
  */
-import userUtils from 'calypso/lib/user/utils';
 import { logError } from './log-error';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
@@ -65,7 +65,7 @@ export const initializeAnonId = async (): Promise< string | null > => {
 				return;
 			}
 
-			if ( anonIdPollingIntervalMaxAttempts - 1 <= attempt || userUtils.isLoggedIn() ) {
+			if ( anonIdPollingIntervalMaxAttempts - 1 <= attempt || getCurrentUser() ) {
 				clearInterval( anonIdPollingInterval );
 				res( null );
 				return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently in the Explat library we use `isLoggedIn()` from `lib/user/utils` to check if the user is logged in. However, in #24004 we're trying to get rid of that legacy user library. 

Since Explat doesn't really rely on the Calypso Redux store directly (nor we want to introduce that as a dependency), this PR suggests using the `getCurrentUser()` from the `@automattic/calypso-analytics` package. My personal opinion is that this is a worthy replacement, as the analytics package current user will be populated [early enough at boot time](https://github.com/Automattic/wp-calypso/blob/trunk/client/boot/common.js#L295), and the analytics package is already a dependency of the Explat library.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go to `/jetpack/connect/store` as both logged out and logged in user, and verify things continue to work the same way, with no errors introduced (that page has an experiment running)
* Verify Explat continues to work as before.
* Verify all tests continue to pass.