### PR TITLE
Themes: update theme install flow

### DIFF
--- a/client/my-sites/themes/controller-logged-in.jsx
+++ b/client/my-sites/themes/controller-logged-in.jsx
@@ -48,7 +48,9 @@ export function upload( context, next ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}
 
-	context.primary = <Upload />;
+	const noticeType = context.query.notice;
+
+	context.primary = <Upload noticeType={ noticeType } />;
 	next();
 }
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -223,12 +223,13 @@ class Upload extends React.Component {
 
 	renderUpgradeBanner() {
 		const { siteId, translate } = this.props;
+		const redirectTo = encodeURIComponent( `/themes/upload/${ siteId }?notice=purchase-success` );
 
 		return (
 			<UpsellNudge
 				title={ translate( 'Upgrade to the Business plan to access the theme install features' ) }
 				event="calypso_theme_install_upgrade_click"
-				href={ `/checkout/${ siteId }/business?redirect_to=/themes/upload/${ siteId }?notice=purchase-success` }
+				href={ `/checkout/${ siteId }/business?redirect_to=${ redirectTo }` }
 				plan={ PLAN_BUSINESS }
 				feature={ FEATURE_UPLOAD_THEMES }
 				showIcon={ true }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -12,6 +12,8 @@ import page from 'page';
  * Internal dependencies
  */
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -22,7 +24,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 // Necessary for ThanksModal
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
@@ -320,6 +321,8 @@ class Upload extends React.Component {
 		return (
 			<Main className="theme-upload" wideLayout>
 				<PageViewTracker path="/themes/upload/:site" title="Themes > Install" />
+				<DocumentHead title={ translate( 'Install Theme' ) } />
+
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -213,7 +213,7 @@ class Upload extends React.Component {
 			<UpsellNudge
 				title={ translate( 'Upgrade to the Business plan to access the theme install features' ) }
 				event="calypso_theme_install_upgrade_click"
-				href={ `/checkout/${ siteId }/business` }
+				href={ `/checkout/${ siteId }/business?redirect_to=/themes/upload/${ siteId }` }
 				plan={ PLAN_BUSINESS }
 				feature={ FEATURE_UPLOAD_THEMES }
 				showIcon={ true }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -98,10 +98,14 @@ class Upload extends React.Component {
 	};
 
 	componentDidMount() {
-		const { siteId, inProgress } = this.props;
+		const { siteId, inProgress, noticeType } = this.props;
 		! inProgress && this.props.clearThemeUpload( siteId );
 		if ( this.props.canUploadThemesOrPlugins ) {
 			this.redirectToWpAdmin();
+		}
+
+		if ( 'purchase-success' === noticeType ) {
+			this.purchaseSuccessMessage();
 		}
 	}
 
@@ -146,6 +150,11 @@ class Upload extends React.Component {
 			} ),
 			{ duration: 5000 }
 		);
+	}
+
+	purchaseSuccessMessage() {
+		const { translate } = this.props;
+		this.props.successNotice( translate( 'Your purchase has been completed!' ) );
 	}
 
 	failureMessage() {
@@ -213,7 +222,7 @@ class Upload extends React.Component {
 			<UpsellNudge
 				title={ translate( 'Upgrade to the Business plan to access the theme install features' ) }
 				event="calypso_theme_install_upgrade_click"
-				href={ `/checkout/${ siteId }/business?redirect_to=/themes/upload/${ siteId }` }
+				href={ `/checkout/${ siteId }/business?redirect_to=/themes/upload/${ siteId }?notice=purchase-success` }
 				plan={ PLAN_BUSINESS }
 				feature={ FEATURE_UPLOAD_THEMES }
 				showIcon={ true }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -273,7 +273,7 @@ class Upload extends React.Component {
 
 		const { showEligibility } = this.state;
 
-		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer; // TODO: show eligibility modal
+		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer;
 		const isDisabled = showEligibility || ( ! isOnAtomicPlan && ! isJetpack );
 
 		const WrapperComponent = isDisabled ? FeatureExample : Fragment;

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -402,7 +402,7 @@ const mapStateToProps = ( state ) => {
 		inProgress: isUploadInProgress( state, siteId ),
 		complete: isUploadComplete( state, siteId ),
 		failed: hasUploadFailed( state, siteId ),
-		themeId: getUploadedThemeId( state, siteId ),
+		themeId,
 		isMultisite: isJetpackSiteMultiSite( state, siteId ),
 		uploadedTheme: getCanonicalTheme( state, siteId, themeId ),
 		error: getUploadError( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -34,7 +34,10 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { uploadTheme, clearThemeUpload, initiateThemeTransfer } from 'calypso/state/themes/actions';
 
-import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import {
+	isFetchingSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
 import {
 	getSelectedSiteId,
 	getSelectedSite,
@@ -414,8 +417,8 @@ const mapStateToProps = ( state ) => {
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		canUploadThemesOrPlugins,
 		isOnAtomicPlan,
-		isTransferring: isAutomatedTransferActive( state, siteId ),
-		isFetchingPurchases: isFetchingSitePurchases( state ),
+		isFetchingPurchases:
+			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 	};
 };
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -68,7 +68,6 @@ import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
-	isAutomatedTransferActive,
 } from 'calypso/state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import WpAdminAutoLogin from 'calypso/components/wpadmin-auto-login';
@@ -268,7 +267,6 @@ class Upload extends React.Component {
 			isOnAtomicPlan,
 			isJetpack,
 			isAutomatedTransfer,
-			isTransferring,
 			selectedSite,
 			uploadedTheme,
 		} = this.props;
@@ -278,7 +276,7 @@ class Upload extends React.Component {
 		const uploadAction = isJetpack ? this.props.uploadTheme : this.props.initiateThemeTransfer; // TODO: show eligibility modal
 		const isDisabled = showEligibility || ( ! isOnAtomicPlan && ! isJetpack );
 
-		const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
+		const WrapperComponent = isDisabled ? FeatureExample : Fragment;
 
 		return (
 			<WrapperComponent>

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -12,7 +12,9 @@ import page from 'page';
  * Internal dependencies
  */
 import Main from 'calypso/components/main';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { Card, ProgressBar, Button } from '@automattic/components';
 import UploadDropZone from 'calypso/blocks/upload-drop-zone';
 import EmptyContent from 'calypso/components/empty-content';
@@ -154,8 +156,7 @@ class Upload extends React.Component {
 			incompatible: translate( 'Install problem: Incompatible theme.' ),
 			unsupported_mime_type: translate( 'Install problem: Not a valid zip file' ),
 			initiate_failure: translate(
-				'Install problem: Theme may not be valid. Check that your zip file contains only the theme ' +
-					'you are trying to install.'
+				'Install problem: Theme may not be valid. Check that your zip file contains only the theme you are trying to install.'
 			),
 		};
 
@@ -266,14 +267,35 @@ class Upload extends React.Component {
 		}
 
 		return (
-			<Main>
+			<Main wideLayout>
 				<PageViewTracker path="/themes/upload/:site" title="Themes > Install" />
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal source="upload" />
 				<AutoLoadingHomepageModal source="upload" />
+
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'Themes' ) }
+					subHeaderText={ translate(
+						'If you have a theme in .zip format, you may install or update it by uploading it here. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink
+										supportLink="https://wordpress.com/support/themes/uploading-setting-up-custom-themes/"
+										supportPostId={ 134784 }
+										showIcon={ false }
+									/>
+								),
+							},
+						}
+					) }
+					align="left"
+				/>
 				<HeaderCake backHref={ backPath }>{ translate( 'Install theme' ) }</HeaderCake>
+
 				{ showEligibility && (
 					<EligibilityWarnings backUrl={ backPath } onProceed={ this.onProceedClick } />
 				) }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -56,23 +56,17 @@ import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
 
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
-	getAutomatedTransferStatus,
 	isAutomatedTransferActive,
 } from 'calypso/state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import WpAdminAutoLogin from 'calypso/components/wpadmin-auto-login';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import {
-	PLAN_BUSINESS,
-	FEATURE_UPLOAD_THEMES,
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_THEMES } from '@automattic/calypso-products';
 
 /**
  * Style dependencies
@@ -365,7 +359,6 @@ const UploadWithOptions = ( props ) => {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const site = getSelectedSite( state );
 	const themeId = getUploadedThemeId( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
 	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
@@ -385,13 +378,12 @@ const mapStateToProps = ( state ) => {
 	return {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
-		isBusiness: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
-		selectedSite: site,
+		selectedSite: getSelectedSite( state ),
 		isJetpack,
 		inProgress: isUploadInProgress( state, siteId ),
 		complete: isUploadComplete( state, siteId ),
 		failed: hasUploadFailed( state, siteId ),
-		themeId,
+		themeId: getUploadedThemeId( state, siteId ),
 		isMultisite: isJetpackSiteMultiSite( state, siteId ),
 		uploadedTheme: getCanonicalTheme( state, siteId, themeId ),
 		error: getUploadError( state, siteId ),
@@ -404,7 +396,6 @@ const mapStateToProps = ( state ) => {
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		canUploadThemesOrPlugins,
 		isOnAtomicPlan,
-		transferState: getAutomatedTransferStatus( state, siteId ),
 		isTransferring: isAutomatedTransferActive( state, siteId ),
 	};
 };

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,3 +1,10 @@
+// View: placeholder with gradient
+.theme-upload {
+	.upload-drop-zone.is-disabled {
+		opacity: 1;
+	}
+}
+
 // View : theme successfully uploaded
 .theme-upload__theme-sheet {
 	font-size: $font-body-small;

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,5 +1,14 @@
 // View: placeholder with gradient
 .theme-upload {
+	.eligibility-warnings__warning {
+		max-width: 680px;
+	}
+	.eligibility-warnings__confirm-buttons {
+		padding-left: 40px;
+	}
+	.feature-example {
+		margin-top: 16px;
+	}
 	.upload-drop-zone.is-disabled {
 		opacity: 1;
 	}


### PR DESCRIPTION
This updates the flow eligibility flow for users that click "Install Theme" on the Theme Showcase.

**All users:**
- There should be a formatted header and "Install Theme" headercake

**For Jetpack and Atomic users:**
- the flow should be unchanged

**For Simple Site users on an Atomic-eligible plan:**
- they should see an eligibility warning, along with a greyed-out upload dropzone
- clicking "continue" should dismiss the warning and activate the dropzone
- the rest of the flow is unchanged

**For Simple Site users not on an Atomic-eligible plan:**
- they should see a Business plan nudge
- after Checkout, they should be redirected to the Install Theme page with a success notice
- they should now see the eligibility warning, along with a greyed-out upload dropzone
- clicking "continue" should dismiss the warning and activate the dropzone
- the rest of the flow is unchanged

Before: | After:
------------ | -------------
<img width="1463" alt="Screen Shot 2021-06-10 at 3 48 06 PM" src="https://user-images.githubusercontent.com/942359/121588039-70233400-ca03-11eb-8714-fc31ff6f7d3e.png"> | <img width="1463" alt="Screen Shot 2021-06-10 at 3 49 16 PM" src="https://user-images.githubusercontent.com/942359/121588062-76b1ab80-ca03-11eb-9d07-7ea6f3044cd3.png">

### To test:

**On a simple site with a Free, Personal, or Premium plan:**
- navigate to Appearance > Themes and click the "Install Theme" button in the top right
- verify that you see a nudge for the Business plan over a greyed-out (and disabled) drop-zone
- click the nudge and purchase a business plan in Checkout (there's a monthly option under "edit" in the first step if you're not sandboxing Store)
- verify that you're returned to the Install Theme page with a success notice, and that the nudge has been replaced with an Atomic eligibility warning
- click "continue" and then upload a theme to kick off the Atomic process
 - if Store was sandboxed for your purchase, the Atomic process will probably fail
 - if Store was not sandboxed for your purchase, the Atomic process will happen, but will require a reload on complete

**On a simple site with a Business plan:**
- visit the "Install Theme" page
- verify that you see the eligibility warning
- click "continue"
- verify that the drop-zone becomes active

**On an Atomic or Jetpack site:**
- visit the "Install Theme" page
- verify that the drop-zone is active and that uploading a theme installs it on your site
