### PR TITLE
State: Introduce current user clearing reducer

### DIFF
--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -7,6 +7,7 @@ import { get, isEqual, reduce } from 'lodash';
  * Internal dependencies
  */
 import {
+	CURRENT_USER_CLEAR,
 	CURRENT_USER_RECEIVE,
 	SITE_RECEIVE,
 	SITE_PLANS_FETCH_COMPLETED,
@@ -42,6 +43,8 @@ export const id = withSchemaValidation( idSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
 			return action.user.ID;
+		case CURRENT_USER_CLEAR:
+			return null;
 	}
 
 	return state;
@@ -51,6 +54,8 @@ export const user = ( state = null, action ) => {
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
 			return action.user;
+		case CURRENT_USER_CLEAR:
+			return null;
 	}
 
 	return state;
@@ -60,6 +65,8 @@ export const flags = withSchemaValidation( flagsSchema, ( state = [], action ) =
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
 			return get( action.user, 'meta.data.flags.active_flags', [] );
+		case CURRENT_USER_CLEAR:
+			return [];
 	}
 
 	return state;
@@ -84,6 +91,8 @@ export const currencyCode = withSchemaValidation( currencyCodeSchema, ( state = 
 		case SITE_PLANS_FETCH_COMPLETED: {
 			return get( action.plans, [ 0, 'currencyCode' ], state );
 		}
+		case CURRENT_USER_CLEAR:
+			return null;
 	}
 
 	return state;
@@ -120,6 +129,8 @@ export const capabilities = withSchemaValidation( capabilitiesSchema, ( state = 
 				state
 			);
 		}
+		case CURRENT_USER_CLEAR:
+			return {};
 	}
 
 	return state;
@@ -129,6 +140,8 @@ export const lasagnaJwt = withSchemaValidation( lasagnaSchema, ( state = null, a
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
 			return action.user.lasagna_jwt || null;
+		case CURRENT_USER_CLEAR:
+			return null;
 	}
 
 	return state;

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
 import reducer, { id, capabilities, currencyCode } from '../reducer';
 import { serialize, deserialize } from 'calypso/state/utils';
 import {
+	CURRENT_USER_CLEAR,
 	CURRENT_USER_RECEIVE,
 	PLANS_RECEIVE,
 	SITE_RECEIVE,
@@ -50,6 +51,14 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.equal( 73705554 );
+		} );
+
+		test( 'should clear the current user ID', () => {
+			const state = id( 73705554, {
+				type: CURRENT_USER_CLEAR,
+			} );
+
+			expect( state ).to.equal( null );
 		} );
 
 		test( 'should validate ID is positive', () => {
@@ -139,6 +148,12 @@ describe( 'reducer', () => {
 				],
 			} );
 			expect( state ).to.equal( 'CAD' );
+		} );
+		test( 'should reset currency code when we clear the user', () => {
+			const state = currencyCode( 'USD', {
+				type: CURRENT_USER_CLEAR,
+			} );
+			expect( state ).to.equal( null );
 		} );
 		test( 'should persist state', () => {
 			const original = 'JPY';
@@ -270,6 +285,19 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.equal( original );
+		} );
+
+		test( 'should reset to empty object when clearing current user', () => {
+			const original = deepFreeze( {
+				2916284: {
+					manage_options: false,
+				},
+			} );
+			const state = capabilities( original, {
+				type: CURRENT_USER_CLEAR,
+			} );
+
+			expect( state ).to.eql( {} );
 		} );
 
 		test( 'should persist state', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up on #53582 and introduces reducer handling when clearing the current user. 

A very straightforward reducer - when a `CURRENT_USER_CLEAR` action is dispatched, it resets each sub-reducer to its default state.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify tests pass: `yarn run test-client client/state/current-user/test/reducer.js`