### PR TITLE
User: Abstract local storage clearing and use it in the Me sidebar

### DIFF
--- a/client/lib/user/store.js
+++ b/client/lib/user/store.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import store from 'store';
+
+/**
+ * Internal dependencies
+ */
+import { clearStorage } from 'calypso/lib/browser-storage';
+
+/**
+ * Empty localStorage cache to discard any user reference that the application may hold
+ */
+export async function clearStore() {
+	store.clearAll();
+	await clearStorage();
+}

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -17,8 +17,8 @@ import {
 } from 'calypso/lib/user/support-user-interop';
 import wpcom from 'calypso/lib/wp';
 import Emitter from 'calypso/lib/mixins/emitter';
+import { clearStore } from './store';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
-import { clearStorage } from 'calypso/lib/browser-storage';
 
 const debug = debugFactory( 'calypso:user' );
 
@@ -184,8 +184,7 @@ User.prototype.clear = async function () {
 	 * to discard any user reference that the application may hold
 	 */
 	this.data = false;
-	store.clearAll();
-	await clearStorage();
+	await clearStore();
 };
 
 User.prototype.set = function ( attributes ) {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -17,13 +17,13 @@ import SidebarFooter from 'calypso/layout/sidebar/footer';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
-import user from 'calypso/lib/user';
 import userUtilities from 'calypso/lib/user/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { logoutUser } from 'calypso/state/logout/actions';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar-unified/utils';
+import { clearStore } from 'calypso/lib/user/store';
 
 /**
  * Style dependencies
@@ -51,7 +51,7 @@ class MeSidebar extends React.Component {
 
 		try {
 			const { redirect_to } = await this.props.logoutUser( redirectTo );
-			await user().clear();
+			await clearStore();
 			window.location.href = redirect_to || '/';
 		} catch {
 			// The logout endpoint might fail if the nonce has expired.

--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -1,14 +1,9 @@
 /**
- * External dependencies
- */
-import store from 'store';
-
-/**
  * Internal dependencies
  */
 import userLibrary from 'calypso/lib/user';
-import { clearStorage } from 'calypso/lib/browser-storage';
 import { CURRENT_USER_CLEAR, CURRENT_USER_RECEIVE } from 'calypso/state/action-types';
+import { clearStore } from 'calypso/lib/user/store';
 
 /**
  * Returns an action object that sets the current user object on the store
@@ -37,8 +32,7 @@ export function clearCurrentUser() {
 		 * Clear internal user data and empty localStorage cache
 		 * to discard any user reference that the application may hold
 		 */
-		store.clearAll();
-		await clearStorage();
+		await clearStore();
 
 		dispatch( {
 			type: CURRENT_USER_CLEAR,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR abstracts the logic to clear the local storage when the user is being cleared. This abstraction is already useful in a couple of places where we were duplicating it:

* `lib/user` - in the `clear()` method.
* `state/current-user/actions` - in the `clearCurrentUser` thunk

This PR introduces a third usage of this abstraction - instead of using `user().clear()` in the Me sidebar, we're now using `clearStore`. This is all that is necessary in this case, since we've previously called the logout endpoint.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Checkout this branch and spin it up locally.
* Start as a logged-in user.
* Go to `/me`
* Click "Log out" in the sidebar
* Verify you log out correctly and there are no errors in the console.
* In the console type `localStorage` and verify its empty.
* In the console type `state.currentUser` and verify the user object is empty (contains a bunch of `null`s).