### PR TITLE
Urgent follow up: remove jumper flag for reskinned

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -740,7 +740,7 @@ class Signup extends React.Component {
 						return null;
 					}
 
-					this.isReskinned = true; //'treatment' === experimentAssignment?.variationName;
+					this.isReskinned = 'treatment' === experimentAssignment?.variationName;
 					this.isReskinned
 						? document.body.classList.add( 'is-white-signup' )
 						: document.body.classList.remove( 'is-white-signup' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up for https://github.com/Automattic/wp-calypso/pull/53549. It removes the boolean jumper to force enabling reskin.

#### Testing instructions

1. Incognito, go to /start/user.
2. Should be blue (not reskinned).


