### PR TITLE
Plan Grid: Allow purchase of monthly plans before site creation

### DIFF
--- a/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
+++ b/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
@@ -15,6 +15,10 @@ import { isWpComMonthlyPlan, isWpComFreePlan } from '@automattic/calypso-product
  */
 export default createSelector(
 	( state, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! siteId ) {
+			return true;
+		}
+
 		const currentPlanSlug = getCurrentPlan( state, siteId )?.productSlug;
 
 		return (


### PR DESCRIPTION
In #53216, a selector was introduced to determine if we should allow the
purchase of monthly plans. Unfortunately, this assumed that we always
had a site ID to check its current plan, but this isn't the case as the
site is created.

This meant that the monthly plan option was removed when a new customer
hit the `/start/plans` step.

#### Changes proposed in this Pull Request

This change fixes that by allowing monthly plans when the site ID is
`null`.

#### Testing instructions

* Go through the process of creating a site by visiting `/start`
* On the second step you'll see the plans grid
* Without this change, there will only be the annual plans displayed
* With this change, the tab options will be shown and you will be able to select the monthly plans


