### PR TITLE
Revert "Jetpack Checkout: Set post purchase destination to wp-admin recommendations page."

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -33,7 +33,7 @@ import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_RESET_PLANS,
 	JETPACK_REDIRECT_URL,
-	redirectCheckoutToWpAdmin,
+	redirectCloudCheckoutToWpAdmin,
 } from '@automattic/calypso-products';
 import { persistSignupDestination, retrieveSignupDestination } from 'calypso/signup/storageUtils';
 import { badNaiveClientSideRollout } from 'calypso/lib/naive-client-side-rollout';
@@ -290,10 +290,10 @@ function getFallbackDestination( {
 		if ( isJetpackNotAtomic && purchasedProduct ) {
 			debug( 'the site is jetpack and bought a jetpack product', siteSlug, purchasedProduct );
 
-			// Jetpack Cloud will either redirect to wp-admin (if JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN
+			// Jetpack Cloud will either redirect to wp-admin (if JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN
 			// flag is set), or otherwise will redirect to a Jetpack Redirect API url (source=jetpack-checkout-thankyou)
 			if ( isJetpackCloud() ) {
-				if ( redirectCheckoutToWpAdmin() && adminUrl ) {
+				if ( redirectCloudCheckoutToWpAdmin() && adminUrl ) {
 					debug( 'checkout is Jetpack Cloud, returning wp-admin url' );
 					return `${ adminUrl }admin.php?page=jetpack#/recommendations`;
 				}
@@ -303,9 +303,7 @@ function getFallbackDestination( {
 				) }`;
 			}
 			// Otherwise if not Jetpack Cloud:
-			return redirectCheckoutToWpAdmin() && adminUrl
-				? `${ adminUrl }admin.php?page=jetpack#/recommendations`
-				: `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;
+			return `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;
 		}
 
 		// If we just purchased a legacy Jetpack plan, redirect to the Jetpack onboarding plugin install flow.

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -12,14 +12,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_ECOMMERCE,
 	JETPACK_REDIRECT_URL,
-	redirectCheckoutToWpAdmin,
+	redirectCloudCheckoutToWpAdmin,
 } from '@automattic/calypso-products';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud', () => jest.fn() );
 jest.mock( '@automattic/calypso-products', () => ( {
 	...jest.requireActual( '@automattic/calypso-products' ),
-	redirectCheckoutToWpAdmin: jest.fn(),
+	redirectCloudCheckoutToWpAdmin: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/calypso-config', () => {
@@ -41,7 +41,7 @@ const defaultArgs = {
 describe( 'getThankYouPageUrl', () => {
 	beforeEach( () => {
 		isJetpackCloud.mockImplementation( () => false );
-		redirectCheckoutToWpAdmin.mockImplementation( () => false );
+		redirectCloudCheckoutToWpAdmin.mockImplementation( () => false );
 	} );
 
 	it( 'redirects to the root page when no site is set', () => {
@@ -262,9 +262,9 @@ describe( 'getThankYouPageUrl', () => {
 		);
 	} );
 
-	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product', () => {
+	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCloudCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product', () => {
 		isJetpackCloud.mockImplementation( () => true );
-		redirectCheckoutToWpAdmin.mockImplementation( () => true );
+		redirectCloudCheckoutToWpAdmin.mockImplementation( () => true );
 		const adminUrl = 'https://my.site/wp-admin/';
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -223,6 +223,6 @@ export const JETPACK_ANTI_SPAM_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/u
 // If JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN is true, checkout will redirect to the site's wp-admin,
 // otherwise it will redirect to the JETPACK_REDIRECT_URL. Checkout references these constants in:
 // client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
-export const JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN = true;
+export const JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN = true;
 export const JETPACK_REDIRECT_URL =
 	'https://jetpack.com/redirect/?source=jetpack-checkout-thankyou';

--- a/packages/calypso-products/src/plans-utilities.js
+++ b/packages/calypso-products/src/plans-utilities.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import {
-	JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN,
+	JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN,
 	BEST_VALUE_PLANS,
 	TERM_MONTHLY,
 	PLAN_MONTHLY_PERIOD,
@@ -39,4 +39,4 @@ export function getTermDuration( term ) {
 	}
 }
 
-export const redirectCheckoutToWpAdmin = () => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
+export const redirectCloudCheckoutToWpAdmin = () => !! JETPACK_CLOUD_REDIRECT_CHECKOUT_TO_WPADMIN;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#53345

This breaks PayPal purchases for jetpack; reverting temporarily while we fix it.

More details in /Automattic/payments-shilling/issues/386

