### PR TITLE
Tests- Add trigger and notifications for visual regression testing

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -404,7 +404,7 @@ private object VisualRegressionTests : BuildType({
     		notifierSettings = slackNotifier {
     			connection = "PROJECT_EXT_11"
     			sendTo = "#visual-regression-automated-tests"
-    			messageFormat = SimpleMessageFormat
+    			messageFormat = simpleMessageFormat
     		}
     		buildFailedToStart = true
     		buildFailed = true
@@ -413,7 +413,7 @@ private object VisualRegressionTests : BuildType({
     		buildProbablyHanging = true
     	}
     }
-    
+
     triggers {
     	schedule {
     		schedulingPolicy = daily {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -400,33 +400,33 @@ private object VisualRegressionTests : BuildType({
 	}
 
 	features {
-    	notifications {
-    		notifierSettings = slackNotifier {
-    			connection = "PROJECT_EXT_11"
-    			sendTo = "#visual-regression-automated-tests"
-    			messageFormat = verboseMessageFormat {
-                	addBranch = false
-                }
-    		}
-    		buildFailedToStart = true
-    		buildFailed = true
-    		buildFinishedSuccessfully = true
-    		firstSuccessAfterFailure = true
-    		buildProbablyHanging = true
-    	}
-    }
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#visual-regression-automated-tests"
+				messageFormat = verboseMessageFormat {
+	            	addBranch = false
+	            }
+			}
+			buildFailedToStart = true
+			buildFailed = true
+			buildFinishedSuccessfully = true
+			firstSuccessAfterFailure = true
+			buildProbablyHanging = true
+		}
+	}
 
-    triggers {
-    	schedule {
-    		schedulingPolicy = daily {
-    			hour = 3
-    		}
-    		branchFilter = """
-    			+:trunk
-    		""".trimIndent()
-    		triggerBuild = always()
-    		withPendingChangesOnly = false
-    	}
-    }
+	triggers {
+		schedule {
+			schedulingPolicy = daily {
+				hour = 3
+			}
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			triggerBuild = always()
+			withPendingChangesOnly = false
+		}
+	}
 })
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -404,7 +404,9 @@ private object VisualRegressionTests : BuildType({
     		notifierSettings = slackNotifier {
     			connection = "PROJECT_EXT_11"
     			sendTo = "#visual-regression-automated-tests"
-    			messageFormat = simpleMessageFormat
+    			messageFormat = verboseMessageFormat {
+                	addBranch = false
+                }
     		}
     		buildFailedToStart = true
     		buildFailed = true

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -398,5 +398,33 @@ private object VisualRegressionTests : BuildType({
 	failureConditions {
 		executionTimeoutMin = 30
 	}
+
+	features {
+    	notifications {
+    		notifierSettings = slackNotifier {
+    			connection = "PROJECT_EXT_11"
+    			sendTo = "#visual-regression-automated-tests"
+    			messageFormat = SimpleMessageFormat
+    		}
+    		buildFailedToStart = true
+    		buildFailed = true
+    		buildFinishedSuccessfully = true
+    		firstSuccessAfterFailure = true
+    		buildProbablyHanging = true
+    	}
+    }
+    
+    triggers {
+    	schedule {
+    		schedulingPolicy = daily {
+    			hour = 3
+    		}
+    		branchFilter = """
+    			+:trunk
+    		""".trimIndent()
+    		triggerBuild = always()
+    		withPendingChangesOnly = false
+    	}
+    }
 })
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a trigger and slack notifications for visual regression testing. It will have to be merged before the triggers and notifications will work.

#### Testing instructions

* Make sure the VR build passes for the [branch](https://teamcity.a8c.com/viewType.html?buildTypeId=calypso_VisualRegressionTests&branch_calypso_WPComTests=update%2Fvr-triggers-notifs&tab=buildTypeStatusDiv)

