### PR TITLE
Block Editor Tracking: Add event subscribers system and add capture event listener

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -439,12 +439,21 @@ if (
 		},
 	} ) );
 
+	const delegateNonCaptureListener = ( event ) => {
+		delegateEventTracking( false, event );
+	};
+
+	const delegateCaptureListener = ( event ) => {
+		delegateEventTracking( true, event );
+	};
+
 	// Registers Plugin.
 	registerPlugin( 'wpcom-block-editor-tracking', {
 		render: () => {
-			EVENT_TYPES.forEach( ( eventType ) =>
-				document.addEventListener( eventType, delegateEventTracking )
-			);
+			EVENT_TYPES.forEach( ( eventType ) => {
+				document.addEventListener( eventType, delegateNonCaptureListener );
+				document.addEventListener( eventType, delegateCaptureListener, true );
+			} );
 			return null;
 		},
 	} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -49,6 +49,8 @@ const EVENTS_MAPPING = [
 	wpcomBlockPremiumContentPlanUpgrade(),
 	wpcomBlockPremiumContentStripeConnect(),
 ];
+const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
+const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );
 
 /**
  * Checks the event for a selector which matches
@@ -74,11 +76,13 @@ const getMatchingEventTarget = ( event, targetSelector ) => {
  * Matches an event against list of known events
  * and for each match fires an appropriate handler function.
  *
- * @param  {object} event DOM event for the click event.
+ * @param  {boolean} capture Value of capture flag of the event listener.
+ * @param  {object}  event   DOM event for the click event.
  * @returns {void}
  */
-export default ( event ) => {
-	const matchingEvents = EVENTS_MAPPING.reduce( ( acc, mapping ) => {
+export default ( capture, event ) => {
+	const eventsMappingBasedOnCapture = capture ? EVENTS_MAPPING_CAPTURE : EVENTS_MAPPING_NON_CAPTURE;
+	const matchingEvents = eventsMappingBasedOnCapture.reduce( ( acc, mapping ) => {
 		const target = getMatchingEventTarget( event, mapping.selector );
 
 		// Set `click` as default of mapping event type.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -55,7 +55,7 @@ const EVENTS_MAPPING = [
  * the desired target element. Accounts for event
  * bubbling.
  *
- * @param  {object} event                   the DOM Event
+ * @param  {object}          event          the DOM Event
  * @param  {string|Function} targetSelector the CSS selector for the target element
  * @returns {object}                        the target Element if found
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -100,11 +100,11 @@ export default ( capture, event ) => {
 
 	matchingEvents.forEach( ( match ) => {
 		debug( 'triggering "%s". target: "%s"', match.event, match.target );
-		subscribers?.[ match.mapping.id ].before.forEach( ( subscriber ) =>
+		subscribers[ match.mapping.id ]?.before.forEach( ( subscriber ) =>
 			subscriber( match.mapping, match.event, match.target )
 		);
 		match.mapping.handler( match.event, match.target );
-		subscribers?.[ match.mapping.id ].after.forEach( ( subscriber ) =>
+		subscribers[ match.mapping.id ]?.after.forEach( ( subscriber ) =>
 			subscriber( match.mapping, match.event, match.target )
 		);
 	} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
@@ -5,6 +5,7 @@ export interface DelegateEventHandler {
 	id: string;
 	selector: string | ( ( event: CallbackEventType ) => boolean );
 	type: DelegateEventHandlerType;
+	handler: DelegateEventHandlerCallback;
 }
 
 export interface DelegateEventHandlerCallback {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
@@ -5,6 +5,7 @@ export interface DelegateEventHandler {
 	id: string;
 	selector: string | ( ( event: CallbackEventType ) => boolean );
 	type: DelegateEventHandlerType;
+	capture?: boolean;
 	handler: DelegateEventHandlerCallback;
 }
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
@@ -1,17 +1,18 @@
+export type CallbackEventType = MouseEvent | KeyboardEvent;
 export type DelegateEventHandlerType = 'click' | 'keyup';
 
 export interface DelegateEventHandler {
 	id: string;
-	selector: string;
+	selector: string | ( ( event: CallbackEventType ) => boolean );
 	type: DelegateEventHandlerType;
 }
 
 export interface DelegateEventHandlerCallback {
-	( event: MouseEvent | KeyboardEvent, target: EventTarget ): void;
+	( event: CallbackEventType, target: EventTarget ): void;
 }
 
 export interface DelegateEventSubscriberCallback {
-	( mapping: DelegateEventHandler, event: MouseEvent | KeyboardEvent, target: EventTarget ): void;
+	( mapping: DelegateEventHandler, event: CallbackEventType, target: EventTarget ): void;
 }
 
 export type DelegateEventSubscriberType = 'before' | 'after';

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/types.ts
@@ -1,0 +1,17 @@
+export type DelegateEventHandlerType = 'click' | 'keyup';
+
+export interface DelegateEventHandler {
+	id: string;
+	selector: string;
+	type: DelegateEventHandlerType;
+}
+
+export interface DelegateEventHandlerCallback {
+	( event: MouseEvent | KeyboardEvent, target: EventTarget ): void;
+}
+
+export interface DelegateEventSubscriberCallback {
+	( mapping: DelegateEventHandler, event: MouseEvent | KeyboardEvent, target: EventTarget ): void;
+}
+
+export type DelegateEventSubscriberType = 'before' | 'after';

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-plan-upgrade.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-plan-upgrade.js
@@ -6,9 +6,10 @@ import tracksRecordEvent from './track-record-event';
 /**
  * Return the event definition object to track `wpcom_block_donations_upgrade_click`.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-block-donations-plan-upgrade',
 	selector: '.wp-block[data-type="a8c/donations"] .plan-nudge__button',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_block_donations_plan_upgrade_click' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-stripe-connect.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-stripe-connect.js
@@ -6,9 +6,10 @@ import tracksRecordEvent from './track-record-event';
 /**
  * Return the event definition object to track `wpcom_block_donations_stripe_connect_click `.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-block-donations-stripe-connect',
 	selector: '.wp-block[data-type="a8c/donations"] .stripe-nudge__button',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_block_donations_stripe_connect_click' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-close-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-close-click.js
@@ -6,9 +6,10 @@ import tracksRecordEvent from './track-record-event';
 /**
  * Return the event definition object to track `wpcom_block_editor_close_click`.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-block-editor-close-click',
 	selector: '.edit-post-header .edit-post-fullscreen-mode-close',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_block_editor_close_click' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-plan-upgrade.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-plan-upgrade.js
@@ -6,9 +6,10 @@ import tracksRecordEvent from './track-record-event';
 /**
  * Return the event definition object to track `wpcom_block_premium_content_upgrade_click`.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-block-premium-content-plan-upgrade',
 	selector: '.wp-block[data-type="premium-content/container"] .plan-nudge__button',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_block_premium_content_plan_upgrade_click' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
@@ -6,9 +6,10 @@ import tracksRecordEvent from './track-record-event';
 /**
  * Return the event definition object to track `wpcom_block_premium_content_stripe_connect_click `.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-block-premium-content-stripe-connect',
 	selector: '.wp-block[data-type="premium-content/container"] .stripe-nudge__button',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_block_premium_content_stripe_connect_click' ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -115,9 +115,10 @@ function selectorHandler() {
  * adding the context event property with the `inserter_inline` value.
  * It also tracks `wpcom_block_picker_no_results` if the search term doesn't return any results.
  *
- * @returns {{handler: Function, selector: string|Function, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-inserter-inline-search-term',
 	selector: selectorHandler,
 	type: 'keyup',
 	handler: debounce( trackInserterInlineSearchTerm, 500 ),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
@@ -13,9 +13,10 @@ const gutenbergTabPanelName = ( tabPanel ) =>
 /**
  * Return the event definition object to track `wpcom_block_picker_tab_panel_selected`.
  *
- * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
+	id: 'wpcom-inserter-menu-search-term',
 	// It would be nice to filter out events where the tab `is-active` before
 	// the click, but we can't do that because the update has already happened
 	selector: ( e ) => gutenbergTabPanelName( e.target ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add subscriber system for delegated events. Subscribers allow us to do side-effects **before** or **after** a delegated event is handled. We only have a single use-case for now, but very likely we will have other use-cases. 
* Also adds a "capture" event listener option. This can be toggled for event definitions by adding `capture: true`. By default event listeners are bubbling. If `capture` is `true` then the capture listener will be used. To learn more about bubbling vs capturing see: https://javascript.info/bubbling-and-capturing . Basically our goal is to run certain event listeners **before** the block editor's listener is called. We can achieve this by using capturing instead of bubbling.

See https://github.com/Automattic/wp-calypso/pull/53592 for an example

#### Testing instructions

* https://github.com/Automattic/wp-calypso/pull/53592
