### PR TITLE
Activate Google Analytics on Jetpack Cloud/Calypso Green

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -26,6 +26,7 @@
 	],
 	"oauth_client_id": 69041,
 	"features": {
+		"ad-tracking": true,
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
@@ -69,5 +70,6 @@
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f"
+	"theme_color": "#2fb41f",
+	"google_analytics_key": "G-K8CRH0LL00"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -26,6 +26,7 @@
 	],
 	"oauth_client_id": 69040,
 	"features": {
+		"ad-tracking": false,
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
@@ -72,5 +73,6 @@
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f"
+	"theme_color": "#2fb41f",
+	"google_analytics_key": "G-K8CRH0LL00"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a Google Analytics key to Jetpack Cloud, allowing GA tracking on cloud.jetpack.com within the Jetpack.com property

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

