### PR TITLE
Block Editor Stats - Generalize block variation tracking.

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -31,17 +31,10 @@ function globalEventPropsHandler( block ) {
 		return {};
 	}
 
-	// Pick up variation slug from `core/embed` block.
-	if ( block.name === 'core/embed' && block?.attributes?.providerNameSlug ) {
-		return { variation_slug: block.attributes.providerNameSlug };
-	}
-
-	// Pick up variation slug from `core/social-link` block.
-	if ( block.name === 'core/social-link' && block?.attributes?.service ) {
-		return { variation_slug: block.attributes.service };
-	}
-
-	return {};
+	return {
+		variation_slug: select( 'core/blocks' ).getActiveBlockVariation( block.name, block.attributes )
+			?.name,
+	};
 }
 /**
  * Looks up the block name based on its id.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Applies a generalized solution for tracking block variations in block tracking events.
* Instead of implementing variation tracking on an ad-hoc basis, we can update this to use `getActiveBlockVariation` from the core blocks store.  This will ensure our variation tracking is up to date with any changes to attribute schema, variation isActive functions, and as new blocks with variations are added to the library.
* This means that `variation_slug` will appear as a property for all block types, and will be populated as `undefined` if no variation is active.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Insert an embed block variation and verify that `variation_slug` of the tracking event is populated with the same value as before.
* Insert a social icons block, from there insert a social-link block variation and verify `variation_slug` is populated with the same value as before.
* For blocks without variations, such as paragraph, verify `variation_slug` is `undefined`.
* With FSE active, insert a "Header" block (variation of template part) and verify `variation_slug` is "header".

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
https://github.com/Automattic/wp-calypso/issues/53410