### PR TITLE
Logged Out Visitor Checkout: make the logged-out checkout work for users that have a WP.com account

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -391,7 +391,9 @@ export default compose(
 		const shouldShowAppBanner = getShouldShowAppBanner( getSelectedSite( state ) );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
-		const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
+		const isJetpack =
+			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
+			startsWith( currentRoute, '/checkout/jetpack' );
 		const isCheckoutFromGutenboarding =
 			'checkout' === sectionName && '1' === currentQuery?.preLaunch;
 		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -56,6 +56,7 @@ import {
 	hasDomainRegistration,
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
+import { addQueryArgs } from 'calypso/lib/route';
 import PaymentMethodStep from './payment-method-step';
 import CheckoutHelpLink from './checkout-help-link';
 import type { CountryListItem } from '../types/country-list-item';
@@ -179,13 +180,15 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const emailTakenLoginRedirectMessage = ( emailAddress: string ) => {
-		const { pathname, search } = window.location;
+		const { href, pathname } = window.location;
 		const isJetpackCheckout = pathname.includes( '/checkout/jetpack' );
 
 		// Users with a WP.com account should return to the checkout page
-		// once they are logged in to complete the process.
+		// once they are logged in to complete the process. The flow for them is
+		// checkout -> login -> checkout.
+		const currentURLQueryParameters = Object.fromEntries( new URL( href ).searchParams.entries() );
 		const redirectTo = isJetpackCheckout
-			? pathname + search + '&flow=logged-out-checkout'
+			? addQueryArgs( { ...currentURLQueryParameters, flow: 'logged-out-checkout' }, pathname )
 			: '/checkout/no-site?cart=no-user';
 
 		const loginUrl = login( { redirectTo, emailAddress } );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -179,7 +179,16 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const emailTakenLoginRedirectMessage = ( emailAddress: string ) => {
-		const loginUrl = login( { redirectTo: '/checkout/no-site?cart=no-user', emailAddress } );
+		const { pathname, search } = window.location;
+		const isJetpackCheckout = pathname.includes( '/checkout/jetpack' );
+
+		// Users with a WP.com account should return to the checkout page
+		// once they are logged in to complete the process.
+		const redirectTo = isJetpackCheckout
+			? pathname + search + '&flow=logged-out-checkout'
+			: '/checkout/no-site?cart=no-user';
+
+		const loginUrl = login( { redirectTo, emailAddress } );
 
 		return translate(
 			'That email address is already in use. If you have an existing account, {{a}}please log in{{/a}}.',

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -53,6 +53,7 @@ export function checkout( context, next ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const selectedSite = getSelectedSite( state );
+
 	const hasSite = getCurrentUserVisibleSiteCount( state ) >= 1;
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 	const isDisallowedForSitePicker =
@@ -60,9 +61,10 @@ export function checkout( context, next ) {
 		( isLoggedOut || ! hasSite || isDomainOnlyFlow );
 	const jetpackPurchaseToken = context.query.purchasetoken;
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
+	const isUserComingFromLoginForm = context.query?.flow === 'logged-out-checkout';
 	const isJetpackCheckout =
 		context.pathname.includes( '/checkout/jetpack' ) &&
-		( isLoggedOut || context.query?.flow === 'logged-out-checkout' ) &&
+		( isLoggedOut || isUserComingFromLoginForm ) &&
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const jetpackSiteSlug = context.params.siteSlug;
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -53,7 +53,6 @@ export function checkout( context, next ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const selectedSite = getSelectedSite( state );
-
 	const hasSite = getCurrentUserVisibleSiteCount( state ) >= 1;
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 	const isDisallowedForSitePicker =

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -62,7 +62,7 @@ export function checkout( context, next ) {
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
 	const isJetpackCheckout =
 		context.pathname.includes( '/checkout/jetpack' ) &&
-		isLoggedOut &&
+		( isLoggedOut || context.query?.flow === 'logged-out-checkout' ) &&
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const jetpackSiteSlug = context.params.siteSlug;
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -51,13 +51,7 @@ export default function () {
 
 	// Handle logged-in user visiting Jetpack checkout
 	if ( isEnabled( 'jetpack/userless-checkout' ) ) {
-		page(
-			'/checkout/jetpack/:product/:domainOrProduct',
-			siteSelection,
-			checkout,
-			makeLayout,
-			clientRender
-		);
+		page( '/checkout/jetpack/:siteSlug/:productSlug', checkout, makeLayout, clientRender );
 		page(
 			'/checkout/jetpack/thank-you/:site/:product',
 			siteSelection,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the new logged-out checkout work for logged-out users that have a WP.com. These users will have to visit the Login page before they can complete the checkout process. We can detect these users with the `?flow=logged-out-checkout` query parameter which gets set once we know a user will have to login before continuing. Make sure to see the recording posted below to understand the idea behind this PR.

#### Testing instructions

Prerequisite: being logged out of WP.com.

* Download this PR.
* Start Calypso Blue with `yarn start`.
* Create a JN site.
* Connect the site (site-connected only).
* On the Pricing page, select a Jetpack product.
* On the Checkout page, replace `wordpress.com` with `calypso.localhost:3000` leaving the rest of the URL intact.
* Enter an email address that is linked to a WP.com account (you can use your A8c account).
* Click the message that leads you to the Login page.
* Login with your WP.com account.
* Make sure you're redirected to the Checkout page again.
* Complete the purchase.
* Make sure you're redirected to the Thank you page.
* Make sure you're logged in WP.com.
* Make sure that your site has a subscription.

Related to 1200152453830945-as-1200450755264307

#### Demo

https://user-images.githubusercontent.com/3418513/121588216-a8c30d80-ca03-11eb-918a-736bcf0f742c.mp4

