### PR TITLE
Me: Enable the VAT details form in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,7 @@
 		"marketplace-yoast": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/vat-details": false,
+		"me/vat-details": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This enables the VAT form added in https://github.com/Automattic/wp-calypso/pull/53133 so that it will be accessible in the production environment.

#### Testing instructions

None needed.