### PR TITLE
Partner Portal: Add Jetpack Debugger URL to license details

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -47,6 +47,7 @@ export default function LicenseDetails( {
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
+	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 
 	return (
 		<Card className="license-details">
@@ -69,11 +70,22 @@ export default function LicenseDetails( {
 					</div>
 				</li>
 
-				<li className="license-details__list-item license-details__list-item--wide">
+				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( 'Blog URL' ) }</h4>
 					{ siteUrl ? (
 						<a href={ siteUrl } target="_blank" rel="noopener noreferrer">
 							{ siteUrl }
+						</a>
+					) : (
+						<Gridicon icon="minus" />
+					) }
+				</li>
+
+				<li className="license-details__list-item">
+					<h4 className="license-details__label">{ translate( 'Jetpack Debugger URL' ) }</h4>
+					{ debugUrl ? (
+						<a href={ debugUrl } target="_blank" rel="noopener noreferrer">
+							{ debugUrl }
 						</a>
 					) : (
 						<Gridicon icon="minus" />

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -82,7 +82,7 @@ export default function LicenseDetails( {
 				</li>
 
 				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( 'Jetpack Debugger URL' ) }</h4>
+					<h4 className="license-details__label">{ translate( 'Jetpack Debugger' ) }</h4>
 					{ debugUrl ? (
 						<a href={ debugUrl } target="_blank" rel="noopener noreferrer">
 							{ debugUrl }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the Jetpack Debugger URL to the Partner Portal license detail

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal, and select a partner key if you are prompted
* Issue a new license and assign it to an existing site
* When the license is assigned to the site, check the list of licenses and make sure it has the Jetpack Debugger URL in the license details

![image](https://user-images.githubusercontent.com/5714212/121594712-d31cc700-ca13-11eb-8fb9-ac439156de1c.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
