### PR TITLE
Move Sharing Buttons options above appearance

### DIFF
--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -168,17 +168,17 @@ class SharingButtons extends Component {
 						</NoticeAction>
 					</Notice>
 				) }
+				<ButtonsOptions
+					settings={ updatedSettings }
+					onChange={ this.handleChange }
+					saving={ isSaving }
+				/>
 				<ButtonsAppearance
 					buttons={ updatedButtons }
 					values={ updatedSettings }
 					onChange={ this.handleChange }
 					onButtonsChange={ this.handleButtonsChange }
 					initialized={ !! buttons && !! settings }
-					saving={ isSaving }
-				/>
-				<ButtonsOptions
-					settings={ updatedSettings }
-					onChange={ this.handleChange }
 					saving={ isSaving }
 				/>
 			</form>

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -254,7 +254,6 @@ class SharingButtonsOptions extends Component {
 			<Fragment>
 				<div className="sharing-buttons__panel">
 					{ siteId && <QueryPostTypes siteId={ siteId } /> }
-					<h4>{ translate( 'Options' ) }</h4>
 					<div className="sharing-buttons__fieldset-group">
 						{ this.getSharingShowOptionsElement() }
 						{ this.getCommentLikesOptionElement() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the location of the Sharing Button Options above the Appearance Panel on Marketing > Sharing Buttons

#### Testing instructions

* go to Tools > Marketing > Sharing Buttons and confirm that the 'Options' panel appears above the 'Appearance' panel

<img width="1284" alt="Screen Shot 2021-06-11 at 9 38 58 am" src="https://user-images.githubusercontent.com/1842363/121610482-7f54c100-ca99-11eb-8ed1-9b16ef36424d.png">


Related to #53604
