### PR TITLE
Add support for PHP version 8.0

### DIFF
--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -59,6 +59,12 @@ const PhpVersionCard = ( {
 				} ),
 				value: recommendedValue,
 			},
+			{
+				label: translate( '8.0', {
+					comment: 'PHP Version for a version switcher',
+				} ),
+				value: '8.0',
+			},
 		];
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Include PHP Version 8.0 in the list of PHP Versions under Hosting Configuration to allow support for sites to upgrade to PHP 8 on Atomic.

#### Testing instructions

Should see the option for PHP Version '8.0' in the Hosting Configuration list.

![wp-calypso-php-8-0-support](https://user-images.githubusercontent.com/80767638/121618280-2733a580-ca2c-11eb-953a-93491d1cccff.png)

