### PR TITLE
Rename "Contact support" link to "More help"

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -99,7 +99,7 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 						<span className="help-search__help-icon">
 							<Gridicon icon="help" size={ 36 } />
 						</span>
-						{ translate( 'Contact support' ) }
+						{ translate( 'More help' ) }
 					</a>
 				</div>
 			</Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the short-term design changes being made to My Home pd2qGl-4i-p2

* Rename "Contact support" link to "More help"

Translations already exist for "More help" so we can make the switch immediately
https://translate.wordpress.com/projects/wpcom/es/default?filters[term]=More+help

![Untitled](https://user-images.githubusercontent.com/1500769/121638093-8520c580-cade-11eb-95d1-be94967e351b.jpg)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on calypso.live
* Load My Home and see the link text has changed

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53141
