### PR TITLE
My Home: Remove horizontal rules and update padding and typography

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -48,7 +48,7 @@
 
 	.quick-links__action-box-label {
 		color: var( --color-text );
-		font-size: $font-body;
+		font-size: $font-body-small;
 	}
 
 	.quick-links__action-box-subtitle {
@@ -86,5 +86,5 @@
 }
 
 .quick-links__action-box-label {
-	font-size: $font-body;
+	font-size: $font-body-small;
 }

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -26,9 +26,7 @@
 }
 
 .go-mobile__email-link {
-	margin: 24px 0 0;
 	padding-top: 20px;
-	border-top: 1px solid var( --color-neutral-5 );
 	color: var( --color-text-subtle );
 	display: none;
 

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -29,7 +29,6 @@ $min_results_height: 180px;
 
 	.help-search__footer {
 		margin-top: -#{$card_padding_large/2};
-		border-top: 1px solid var( --color-border-subtle );
 	}
 
 	.help-search__cta {
@@ -128,10 +127,8 @@ $min_results_height: 180px;
 	}
 
 	.inline-help__results {
-		margin: #{$search_results_top_spacing + 1px} #{-$card_padding_small} 0;
 		min-height: $min_results_height;
 		padding: #{$search_results_top_spacing / 2 - 1px} 0 0 0;
-		border-top: 1px solid var( --color-border-subtle );
 
 		@include break-mobile {
 			margin-left: -$card_padding_large;
@@ -182,7 +179,6 @@ $min_results_height: 180px;
 		min-height: $min_results_height;
 		margin: #{$search_results_top_spacing + 1} 0 0 #{-$search_results_top_spacing};
 		padding: #{$search_results_top_spacing / 2 - 1px} 0 0 0;
-		border-top: 1px solid var( --color-border-subtle );
 	}
 
 	.inline-help__results-placeholder-item {

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -11,10 +11,10 @@ $min_results_height: 180px;
 	}
 
 	.help-search__inner {
-		padding: 16px;
+		padding: 16px 16px 0;
 
 		@include break-mobile {
-			padding: 16px 24px;
+			padding: 16px 24px 0;
 		}
 	}
 
@@ -28,7 +28,7 @@ $min_results_height: 180px;
 	}
 
 	.help-search__footer {
-		margin-top: -#{$card_padding_large/2};
+		margin-bottom: 12px;
 	}
 
 	.help-search__cta {
@@ -132,7 +132,7 @@ $min_results_height: 180px;
 
 	.inline-help__results {
 		min-height: $min_results_height;
-		padding: #{$search_results_top_spacing / 2 - 1px} 0 0 0;
+		padding: #{$search_results_top_spacing - 1px} 0 0 0;
 
 		@include break-mobile {
 			margin-left: -$card_padding_large;

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -110,7 +110,6 @@ $min_results_height: 180px;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
-			margin-right: 8px;
 
 			.gridicon {
 				margin: 0 5px -3px 0;
@@ -133,11 +132,28 @@ $min_results_height: 180px;
 	.inline-help__results {
 		min-height: $min_results_height;
 		padding: #{$search_results_top_spacing - 1px} 0 0 0;
+		margin-left: -$card_padding_small;
+		margin-right: -$card_padding_small;
 
 		@include break-mobile {
 			margin-left: -$card_padding_large;
 			margin-right: -$card_padding_large;
 		}
+	}
+
+	.inline-help__results-title {
+		padding-left: $card_padding_small;
+		padding-right: $card_padding_small;
+
+		@include break-mobile {
+			padding-left: $card_padding_large;
+			padding-right: $card_padding_large;
+		}
+	}
+
+	.inline-help__empty-results {
+		padding-left: 0;
+		padding-right: 0;
 	}
 
 	.search-card {

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -58,6 +58,8 @@ $min_results_height: 180px;
 		background: var( --color-primary );
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
 		border: 1px solid var( --color-primary );
+		// Using percentage because we're drawing a circle in CSS
+		// stylelint-disable-next-line declaration-property-unit-allowed-list
 		border-radius: 100%;
 
 		&::before {
@@ -69,6 +71,8 @@ $min_results_height: 180px;
 			left: 4px;
 			content: '';
 			background: var( --color-surface );
+			// Using percentage because we're drawing a circle in CSS
+			// stylelint-disable-next-line declaration-property-unit-allowed-list
 			border-radius: 100%;
 		}
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -2,7 +2,6 @@
 
 .site-setup-list {
 	padding: 0;
-	@include grid-column( 1, 12 );
 	@include display-grid;
 	@include grid-template-columns( 12, 24px, 1fr );
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -1,18 +1,22 @@
+@import '../../../grid-mixins.scss';
+
 .site-setup-list {
 	padding: 0;
-	display: flex;
+	@include grid-column( 1, 12 );
+	@include display-grid;
+	@include grid-template-columns( 12, 24px, 1fr );
 
 	@include breakpoint-deprecated( '<960px' ) {
 		display: block;
 	}
 
 	.site-setup-list__nav {
-		width: 328px;
-		flex-shrink: 0;
 		border-left: 1px solid var( --color-border-subtle );
 
-		@include breakpoint-deprecated( '<1280px' ) {
-			width: 260px;
+		@include grid-column( 9, 4 );
+
+		@include breakpoint-deprecated( '<1040px' ) {
+			@include grid-column( 8, 5 );
 		}
 
 		@include breakpoint-deprecated( '<960px' ) {
@@ -124,7 +128,12 @@
 
 	.site-setup-list__task {
 		box-shadow: none;
-		flex: 1;
+
+		@include grid-column( 1, 8 );
+
+		@include breakpoint-deprecated( '<1040px' ) {
+			@include grid-column( 1, 7 );
+		}
 	}
 
 	.site-setup-list__task-actions {

--- a/client/my-sites/customer-home/grid-mixins.scss
+++ b/client/my-sites/customer-home/grid-mixins.scss
@@ -1,0 +1,20 @@
+@mixin display-grid {
+	display: -ms-grid;
+	display: grid;
+}
+@mixin grid-template-columns( $cols, $gap, $fr ) {
+	-ms-grid-columns: $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap
+		$fr $gap $fr $gap $fr;
+	grid-template-columns: repeat( $cols, [col-start] minmax( 0, $fr ) );
+	grid-column-gap: $gap;
+}
+@mixin grid-row( $row-start, $span ) {
+	-ms-grid-row: $row-start;
+	-ms-grid-row-span: $span;
+	grid-row: $row-start / span $span;
+}
+@mixin grid-column( $col-start, $span ) {
+	-ms-grid-column: $col-start * 2 - 1;
+	-ms-grid-column-span: $span + ( $span - 1 );
+	grid-column: $col-start / span $span;
+}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,23 +1,4 @@
-@mixin display-grid {
-	display: -ms-grid;
-	display: grid;
-}
-@mixin grid-template-columns( $cols, $gap, $fr ) {
-	-ms-grid-columns: $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap $fr $gap
-		$fr $gap $fr $gap $fr;
-	grid-template-columns: repeat( $cols, [col-start] minmax( 0, $fr ) );
-	grid-column-gap: $gap;
-}
-@mixin grid-row( $row-start, $span ) {
-	-ms-grid-row: $row-start;
-	-ms-grid-row-span: $span;
-	grid-row: $row-start / span $span;
-}
-@mixin grid-column( $col-start, $span ) {
-	-ms-grid-column: $col-start * 2 - 1;
-	-ms-grid-column-span: $span + ( $span - 1 );
-	grid-column: $col-start / span $span;
-}
+@import './grid-mixins.scss';
 
 .customer-home__heading {
 	display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the short-term design changes being made to My Home pd2qGl-4i-p2

* Remove horizontal rules from "Get help" card
* Remove horizontal rule from "Go mobile" card
* Update quick link font size so they match the "regular" Calypso font size for buttons
* Tidy padding in "Get help" card to try and match the mockup in Figma
* Fix the alignment of items in the "Get help" card so the left edge of the text aligns nicely with all the other text on phone layout
* Fix eslint warning

I was quite sure how to rationalise the font sizes. What I've seen from around Calypso is that controls tend to use size `14px` and body text or paragraphs tend to use `16px` (but not always). So I've gone with this. Is this what you were thinking @jeffgolenski? Or should I just force everything to use either 14 or 16?
![fontsize](https://user-images.githubusercontent.com/1500769/121841498-81857c80-cd32-11eb-8325-264b949b2345.jpg)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check it out at https://calypso.live/?branch=update/padding-lines-and-typography-my-home at various screen sizes
* Remember to try typing some queries into the help card

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53141
