### PR TITLE
User: Remove unused `isLoggedIn()` from user utils

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -55,10 +55,6 @@ const userUtils = {
 				window.location.href = logoutUrl;
 			} );
 	},
-
-	isLoggedIn() {
-		return Boolean( user().data );
-	},
 };
 
 export default userUtils;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #53584 landed, `userUtils.isLoggedIn()` is no longer in use. Since we have other means of checking if the user is logged in already, let's remove that legacy one.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify the removed function is not in use anymore.