### PR TITLE
Themes: Replace "Install Theme" with "Upload Theme"

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -77,7 +77,7 @@ const InstallThemeButton = connectOptions(
 				onClick={ clickHandler }
 				href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
 			>
-				{ translate( 'Install theme' ) }
+				{ translate( 'Upload theme' ) }
 			</Button>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces the button's text of "Upload theme" with "Install theme" 

I figured it'd be best to avoid renaming the whole file from `install-theme-button.jsx` to `upload-theme-button.jsx` because the link still references installing the theme and this is just a button text page, but let me know if that should happen and I'll update this!

#### Testing instructions

Visit `/themes/site` and verify the button now says "Upload theme".

<img width="1587" alt="Screenshot 2021-06-11 at 09 37 04" src="https://user-images.githubusercontent.com/43215253/121658130-f178d600-ca98-11eb-86f6-5fa365bd6005.png">

Fixes #53599