### PR TITLE
Signup: Remove obsolete lib/user remnant

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -154,7 +154,7 @@ export default {
 			// Planned to be rerun, see pbmo2S-Bv-p2#comment-1382
 			// Commented out for eslint, to rerun next() has to be placed below this.
 			// if (
-			// 	( ! user() || ! user().get() ) &&
+			// 	! isLoggedIn &&
 			// 	-1 === context.pathname.indexOf( 'free' ) &&
 			// 	-1 === context.pathname.indexOf( 'personal' ) &&
 			// 	-1 === context.pathname.indexOf( 'premium' ) &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates a legacy commented instance of `lib/user` in signup.

This is a very low-priority change, since that code is currently commented.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

No testing necessary.