### PR TITLE
naiveClientSideRollout: Use @automattic/calypso-analytics for current user

### DIFF
--- a/client/lib/naive-client-side-rollout/index.ts
+++ b/client/lib/naive-client-side-rollout/index.ts
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import user from 'calypso/lib/user';
+import { getCurrentUser } from '@automattic/calypso-analytics';
 
 /**
  * Hash function from:
@@ -45,7 +45,7 @@ function cyrb53( str: string, seed = 0 ) {
  * @returns Boolean of whether the user should have the feature enabled, i.e. true = rolled out, false = not rolled out.
  */
 export function badNaiveClientSideRollout( featureId: string, percentage: number ): boolean {
-	const maybeUserId = user()?.get()?.ID;
+	const maybeUserId = getCurrentUser()?.ID;
 
 	// zero-indexed buckets: 0-99
 	let bucket;

--- a/client/lib/naive-client-side-rollout/test/index.ts
+++ b/client/lib/naive-client-side-rollout/test/index.ts
@@ -1,15 +1,19 @@
 /**
+ * External dependencies
+ */
+import { getCurrentUser } from '@automattic/calypso-analytics';
+
+/**
  * Internal dependencies
  */
-import user from 'calypso/lib/user';
 import { badNaiveClientSideRollout } from '../index';
 
-jest.mock( 'calypso/lib/user' );
-const mockedUser = user as jest.MockedFunction< typeof user >;
+jest.mock( '@automattic/calypso-analytics' );
+const mockedUser = getCurrentUser as jest.MockedFunction< typeof getCurrentUser >;
 const setUserId = ( userId ) =>
-	mockedUser.mockImplementationOnce( ( ( () => ( {
-		get: () => ( { ID: userId } ),
-	} ) ) as unknown ) as typeof user );
+	mockedUser.mockImplementationOnce(
+		( () => ( { ID: userId } as unknown ) ) as typeof getCurrentUser
+	);
 
 // [a, b)
 const range = ( a, b ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently in the Explat library we use the `getCurrentUser()` from the `@automattic/calypso-analytics` package. That has been done in #53584.

This PR suggests updating `naiveClientSideRollout` to use the same. In my opinion, that should work well for the purpose, especially considering that this library is temporary. This change is similar to what we did in #53584.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify all tests pass.