### PR TITLE
Fix signing up using invite link without entering a username

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -365,7 +365,8 @@ class SignupForm extends Component {
 
 		// When a user moves away from the signup form without having entered
 		// anything do not show error messages, think going to click log in.
-		if ( data.username.length === 0 && data.password.length === 0 && data.email.length === 0 ) {
+		// we do data.username?.length because username can be undefined when the username field isn't used
+		if ( ! data.username?.length && data.password.length === 0 && data.email.length === 0 ) {
 			return;
 		}
 

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -84,7 +84,10 @@ class InviteAcceptLoggedOut extends React.Component {
 		const { userData, bearerToken } = this.state;
 		return (
 			<WpcomLoginForm
-				log={ userData.username }
+				// in case the user signs up without a username, login for the first time using their email address
+				// users without a username are assigned one in the backend. But at this point, the client side don't have this generated username in memory yet
+				// so we failover to the email
+				log={ userData.username || userData.email }
 				authorization={ 'Bearer ' + bearerToken }
 				redirectTo={ window.location.href }
 			/>

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -18,8 +18,8 @@ export default class AcceptInvitePage extends AsyncBaseContainer {
 		return await this.driver.findElement( By.css( '#email' ) ).getAttribute( 'value' );
 	}
 
-	async enterUsernameAndPasswordAndSignUp( username, password ) {
-		await driverHelper.setWhenSettable( this.driver, By.css( '#username' ), username );
+	async enterEmailAndPasswordAndSignUp( email, password ) {
+		await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
 		await driverHelper.setWhenSettable( this.driver, By.css( '#password' ), password, true );
 		return await driverHelper.clickWhenClickable( this.driver, By.css( '.signup-form__submit' ) );
 	}

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -31,7 +31,7 @@ export default class AcceptInvitePage extends AsyncBaseContainer {
 	async waitUntilNotVisible() {
 		return await driverHelper.waitUntilElementNotLocated(
 			this.driver,
-			By.css( '#username' ),
+			By.css( '#email' ),
 			this.explicitWaitMS * 2
 		);
 	}

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -20,9 +20,9 @@ export default class LoginPage extends AsyncBaseContainer {
 		super( driver, By.css( '.wp-login__container' ), LoginPage.getLoginURL() );
 	}
 
-	async login( username, password, emailSSO = false, { retry = true, isPopup = false } = {} ) {
+	async login( email, password, emailSSO = false, { retry = true, isPopup = false } = {} ) {
 		const driver = this.driver;
-		const userNameLocator = By.css( '#usernameOrEmail' );
+		const emailLocator = By.css( '#usernameOrEmail' );
 		const passwordLocator = By.css( '#password' );
 		const changeAccountLocator = By.css( '#loginAsAnotherUser' );
 		const alreadyLoggedInLocator = By.css( '.continue-as-user' );
@@ -35,9 +35,9 @@ export default class LoginPage extends AsyncBaseContainer {
 		if ( isDisplayed ) {
 			await driverHelper.clickWhenClickable( driver, changeAccountLocator );
 		}
-		await driverHelper.setWhenSettable( driver, userNameLocator, username );
+		await driverHelper.setWhenSettable( driver, emailLocator, email );
 		await this.driver.sleep( 1000 );
-		await driver.findElement( userNameLocator ).sendKeys( Key.ENTER );
+		await driver.findElement( emailLocator ).sendKeys( Key.ENTER );
 
 		if ( emailSSO === false ) {
 			await driverHelper.setWhenSettable( driver, passwordLocator, password, {
@@ -58,7 +58,7 @@ export default class LoginPage extends AsyncBaseContainer {
 			try {
 				await driverHelper.waitUntilElementNotLocated(
 					driver,
-					userNameLocator,
+					emailLocator,
 					this.explicitWaitMS * 2
 				);
 			} catch ( e ) {
@@ -66,10 +66,10 @@ export default class LoginPage extends AsyncBaseContainer {
 					suppressDuplicateMessages: true,
 				} );
 				await driverManager.ensureNotLoggedIn( this.driver );
-				return await this.login( username, password, { retry: false } );
+				return await this.login( email, password, { retry: false } );
 			}
 		}
-		await driverHelper.waitUntilElementNotLocated( driver, userNameLocator );
+		await driverHelper.waitUntilElementNotLocated( driver, emailLocator );
 	}
 
 	async use2FAMethod( twoFAMethod ) {

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -131,7 +131,7 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 	it( 'As the invited user, I am no longer an editor on the site', async function () {
 		if ( 'WPCOM' !== dataHelper.getJetpackHost() ) return this.skip();
 		const loginPage = await LoginPage.Visit( this.driver );
-		await loginPage.login( newUserName, password );
+		await loginPage.login( newInviteEmailAddress, password );
 		await ReaderPage.Expect( this.driver );
 
 		const navBarComponent = await NavBarComponent.Expect( this.driver );

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -87,7 +87,7 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 		assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 		assert( headerInviteText.includes( 'editor' ) );
 
-		await acceptInvitePage.enterUsernameAndPasswordAndSignUp( newUserName, password );
+		await acceptInvitePage.enterEmailAndPasswordAndSignUp( newUserName, password );
 		return await acceptInvitePage.waitUntilNotVisible();
 	} );
 

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -87,7 +87,7 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 		assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 		assert( headerInviteText.includes( 'editor' ) );
 
-		await acceptInvitePage.enterEmailAndPasswordAndSignUp( newUserName, password );
+		await acceptInvitePage.enterEmailAndPasswordAndSignUp( newInviteEmailAddress, password );
 		return await acceptInvitePage.waitUntilNotVisible();
 	} );
 

--- a/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
@@ -96,7 +96,7 @@ describe.skip( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @par
 		assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 		assert( headerInviteText.includes( 'view' ) );
 
-		await acceptInvitePage.enterUsernameAndPasswordAndSignUp( newUserName, password );
+		await acceptInvitePage.enterEmailAndPasswordAndSignUp( newInviteEmailAddress, password );
 		removedViewerFlag = false;
 		return await acceptInvitePage.waitUntilNotVisible();
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR #53509 that removed the username field produced two bugs in the invite-link sign up flow.
	* Invisible bug: when people focused away from the form, an error was logged in the console.
	* When users input a new password and proceeded to sign up, they weren't signed in automatically, because the automatic login logic relied on the username to automate signing in. Now it fails over to email.
	* It broke the signing up by invitation tests, because they also relied on the username field.

#### Testing instructions

1. Send an invitation to yourself (youremail+**testinginvites@gmail.com**) from any WP.com site by going to https://wordpress.com/people/new/YOUR_SITE.wordpress.com 
2. Go to you email and copy the "Accept invitation" link. (by right clicking the button and copying link URL). Replace the host part of the URL (wordpress.com) with (https://container-goofy-pike.calypso.live) and go the new URL in a new incognito window. Should be sth like `https://container-goofy-pike.calypso.live/accept-invite/blabla...`.
3. Enable 3rd party cookies.
4. Your email should be pre-entered.
5. Focus away from the password field without entering anything, no error should be logged in the console.
6. Type a good password and sign up, you should be signed up and signed in automatically without any further input.

Related to https://github.com/Automattic/wp-calypso/pull/53509 and https://github.com/Automattic/wp-calypso/issues/52852
