### PR TITLE
Publicize: Activate module from Tools > Marketing > Connections

### DIFF
--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -86,7 +85,6 @@ const SharingServicesGroup = ( {
 			return;
 		}
 
-		// Strict boolean comparison to handle unset initial state while fetching modules from the API.
 		if ( isPublicizeActive && ! wasPublicizeActive ) {
 			fetchServices();
 		}
@@ -101,6 +99,7 @@ const SharingServicesGroup = ( {
 		return null;
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="sharing-services-group">
 			<SectionHeader label={ title } />

--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -48,7 +48,6 @@ export default function () {
 		'/marketing/connections/:domain',
 		siteSelection,
 		navigation,
-		jetpackModuleActive( 'publicize', false ),
 		connections,
 		layout,
 		makeLayout,

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -8,7 +8,8 @@ import { filter } from 'lodash';
  */
 import config from '@automattic/calypso-config';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { isJetpackSite, isJetpackModuleActive } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteGoogleMyBusinessEligible from 'calypso/state/selectors/is-site-google-my-business-eligible';
 
 import 'calypso/state/sharing/init';

--- a/client/state/sharing/services/test/selectors.js
+++ b/client/state/sharing/services/test/selectors.js
@@ -123,6 +123,17 @@ describe( 'selectors', () => {
 					},
 				},
 			},
+			jetpack: {
+				modules: {
+					items: {
+						2916284: {
+							publicize: {
+								active: true,
+							},
+						},
+					},
+				},
+			},
 			sites: {
 				items: {
 					2916284: {
@@ -131,7 +142,6 @@ describe( 'selectors', () => {
 						URL: 'https://example.com',
 						options: {
 							unmapped_url: 'https://example.wordpress.com',
-							active_modules: [ 'publicize' ],
 						},
 						jetpack: true,
 					},
@@ -178,9 +188,9 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should omit services if required module is not activated', () => {
-			state.sites.items[ 2916284 ].options.active_modules = [];
+			state.jetpack.modules.items[ 2916284 ].publicize.active = false;
 			const services = getEligibleKeyringServices( state, 2916284, 'other' );
-			state.sites.items[ 2916284 ].options.active_modules = [ 'publicize' ];
+			state.jetpack.modules.items[ 2916284 ].publicize.active = true;
 
 			expect( services ).to.eql( [] );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Displays a notice in "Tools > Marketing > Connections"  when the Publicize module is disabled, allowing users to enable it.

<img width="964" alt="Screen Shot 2021-06-11 at 13 38 10" src="https://user-images.githubusercontent.com/1233880/121697300-361e6480-cacd-11eb-8546-d21effef7c65.png">

This helps with the effort of removing the "Jetpack > Settings" submenu needed for https://github.com/Automattic/wp-calypso/issues/51342, since right now the Publicize module can be enabled only from that submenu.

#### Testing instructions

* Switch to an Atomic site.
* Go to Jetpack > Settings > Sharing.
* Disable the Publicize module.
* Go to Tools > Marketing > Connections.
* Make sure Calypso displays a notice indicating the Publicize module is disabled.
* Click on "Enable".
* Go to Jetpack > Settings > Sharing.
* Make sure the Publicize module has been enabled.
