### PR TITLE
Sharing buttons: Enable module from Tools > Marketing > Sharing Buttons

### DIFF
--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -35,6 +35,9 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import { protectForm } from 'calypso/lib/protect-form';
+import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 
 class SharingButtons extends Component {
 	state = {
@@ -126,7 +129,16 @@ class SharingButtons extends Component {
 	}
 
 	render() {
-		const { buttons, isJetpack, isSaving, settings, siteId } = this.props;
+		const {
+			buttons,
+			isJetpack,
+			isSaving,
+			settings,
+			siteId,
+			isSharingButtonsModuleActive,
+			isFetchingModules,
+			translate,
+		} = this.props;
 		const updatedSettings = this.getUpdatedSettings();
 		const updatedButtons = this.state.buttonsPendingSave || buttons;
 
@@ -143,6 +155,19 @@ class SharingButtons extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySharingButtons siteId={ siteId } />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
+				{ isJetpack && ! isFetchingModules && ! isSharingButtonsModuleActive && (
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Adding sharing buttons need the Sharing Buttons module from Jetpack to be enabled'
+						) }
+					>
+						<NoticeAction onClick={ () => this.props.activateModule( siteId, 'sharedaddy' ) }>
+							{ translate( 'Enable' ) }
+						</NoticeAction>
+					</Notice>
+				) }
 				<ButtonsAppearance
 					buttons={ updatedButtons }
 					values={ updatedSettings }
@@ -167,7 +192,9 @@ const connectComponent = connect(
 		const settings = getSiteSettings( state, siteId );
 		const buttons = getSharingButtons( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
+		const isSharingButtonsModuleActive = isJetpackModuleActive( state, siteId, 'sharedaddy' );
 		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
+		const isFetchingModules = isFetchingJetpackModules( state, siteId );
 		const isSavingSettings = isSavingSiteSettings( state, siteId );
 		const isSavingButtons = isSavingSharingButtons( state, siteId );
 		const isSaveSettingsSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
@@ -176,7 +203,9 @@ const connectComponent = connect(
 
 		return {
 			isJetpack,
+			isSharingButtonsModuleActive,
 			isLikesModuleActive,
+			isFetchingModules,
 			isSaving: isSavingSettings || isSavingButtons,
 			isSaveSettingsSuccessful,
 			isSaveButtonsSuccessful,

--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -16,7 +16,7 @@ import SharingConnections from './connections/connections';
 import Traffic from './traffic/';
 import UltimateTrafficGuide from './ultimate-traffic-guide';
 import { requestSite } from 'calypso/state/sites/actions';
-import { getSiteSlug, isJetpackSite, isJetpackModuleActive } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
@@ -115,20 +115,6 @@ export const sharingButtons = ( context, next ) => {
 	if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
 		store.dispatch(
 			errorNotice( translate( 'You are not authorized to manage sharing settings for this site.' ) )
-		);
-	}
-
-	if (
-		siteId &&
-		isJetpackSite( state, siteId ) &&
-		! isJetpackModuleActive( state, siteId, 'sharedaddy' )
-	) {
-		store.dispatch(
-			errorNotice(
-				translate(
-					'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.'
-				)
-			)
 		);
 	}
 

--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -69,7 +69,6 @@ export default function () {
 		'/marketing/sharing-buttons/:domain',
 		siteSelection,
 		navigation,
-		jetpackModuleActive( 'sharedaddy' ),
 		sharingButtons,
 		layout,
 		makeLayout,

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -155,10 +154,9 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAtomic = isSiteWpcomAtomic( state, siteId );
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-	const hasSharedaddy = isJetpackModuleActive( state, siteId, 'sharedaddy' );
 
 	return {
-		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
+		showButtons: siteId && canManageOptions,
 		showConnections: !! siteId,
 		showTraffic: canManageOptions && !! siteId,
 		showBusinessTools: ( !! siteId && canManageOptions && ! isJetpack ) || isAtomic,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Displays a notice in "Tools > Marketing > Sharing Buttons"  when the Sharing buttons module is disabled, allowing users to enable it.

<img width="983" alt="Screen Shot 2021-06-11 at 16 51 13" src="https://user-images.githubusercontent.com/1233880/121706135-a03b0780-cad5-11eb-84c8-255eb2edb7d9.png">

This helps with the effort of removing the "Jetpack > Settings" submenu needed for https://github.com/Automattic/wp-calypso/issues/51342, since right now the Sharing buttons module can be enabled only from that submenu.

#### Testing instructions

* Switch to an Atomic site.
* Go to Jetpack > Settings > Sharing.
* Disable the Sharing buttons module.
* Go to Tools > Marketing > Sharing buttons.
* Make sure Calypso displays a notice indicating the module is disabled.
* Click on "Enable".
* Go to Jetpack > Settings > Sharing.
* Make sure the Sharing buttons module has been enabled.
