### PR TITLE
Themes Showcase: Use Regex for locale param in path definition

### DIFF
--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -11,6 +11,7 @@ import { readFile } from 'fs/promises';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguage } from 'calypso/lib/i18n-utils';
 import { setLocaleRawData } from 'calypso/state/ui/language/actions';
+import config from 'calypso/server/config';
 
 export function ssrSetupLocaleMiddleware() {
 	const translationsCache = {};
@@ -24,6 +25,11 @@ export function ssrSetupLocaleMiddleware() {
 
 		if ( ! context.params.lang ) {
 			resetLocaleData();
+			return;
+		}
+
+		if ( ! config( 'magnificent_non_en_locales' ).includes( context.params.lang ) ) {
+			context.res.redirect( context.path.replace( `/${ context.params.lang }`, '' ) );
 			return;
 		}
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -4,16 +4,6 @@
 const fs = require( 'fs' ); // eslint-disable-line import/no-nodejs-modules
 const path = require( 'path' ); // eslint-disable-line import/no-nodejs-modules
 
-/**
- * Internal dependencies
- */
-const config = require( 'calypso/server/config' );
-
-/**
- * Locales path segment in RegExp string format.
- */
-const localePathSegment = config( 'magnificent_non_en_locales' )?.join( '|' );
-
 const sections = [
 	{
 		name: 'root',
@@ -222,7 +212,7 @@ const sections = [
 	// or it'll be falsely associated with the latter section.
 	{
 		name: 'themes',
-		paths: [ '/themes', `/(${ localePathSegment })/themes`, '/design' ],
+		paths: [ '/themes', `/([a-z]{2,3}|[a-z]{2}-[a-z]{2})/themes`, '/design' ],
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
@@ -231,7 +221,7 @@ const sections = [
 	},
 	{
 		name: 'theme',
-		paths: [ '/theme', `/(${ localePathSegment })/theme` ],
+		paths: [ '/theme', `/([a-z]{2,3}|[a-z]{2}-[a-z]{2})/theme` ],
 		module: 'calypso/my-sites/theme',
 		enableLoggedOut: true,
 		group: 'sites',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace explicitly listed locales in themes section path definition with locale slug matching Regex.
* Update `ssrSetupLocaleMiddleware` to omit the locale `param` and redirect for non-Mag-16 languages.

#### Testing instructions

* Open calypso.live in logged-out session
* Verify that going to `/{nonMag16Locale}/themes` and `/{nonMag16Locale}/theme/*` gets redirected to `/themes` (resp. `/theme/*`).
* Verify that going to `/{mag16Locale}/themes` and `/{mag16Locale}/theme/*` loads the translated page for the specified locale.

Related to pMz3w-dgj-p2#comment-89016
