### PR TITLE
[iframe-bridge-server/handlePostTrash] Get store namespace from store definition if available, fallback to assuming it's a string literal

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -69,8 +69,19 @@ function transmitDraftId( calypsoPort ) {
 function handlePostTrash( calypsoPort ) {
 	use( ( registry ) => {
 		return {
-			dispatch: ( namespace ) => {
+			dispatch: ( store ) => {
+				/**
+				 * Gutenberg 10.8.0 changed the way wp-data stores are referenced and uses
+				 * the store definition as the ID.
+				 * We need to keep supporting the old approach to make sure this also
+				 * works when Gutenberg < 10.8.0 is being used.
+				 * More context:
+				 * - https://github.com/WordPress/gutenberg/issues/27088;
+				 * - https://github.com/WordPress/gutenberg/pull/32153.
+				 **/
+				const namespace = store.name ?? store;
 				const actions = { ...registry.dispatch( namespace ) };
+
 				if ( namespace === 'core/editor' && actions.trashPost ) {
 					actions.trashPost = () => {
 						debug( 'override core/editor trashPost action to use postlist trash' );


### PR DESCRIPTION
### Changes proposed in this Pull Request

We detected that the "Move to trash" functionality was (partially) breaking in Gutenberg v10.8.0 when it was used from Calypso. Further investigation showed us that this is due to Gutenberg 10.8.0 changing the way (most) wp-data stores are referenced and uses the store definition themselves as the ID.

To fix this, we first check if the `store` object passed in the `dispatch` callback function has a `name` attribute, if so, we use its value, if not, we fallback to just assuming `store` (which was called `namespace` before) is the string literal containing the name. We need to fallback because Calypso might be running sites that have Gutenberg < 10.8.0.

**Important:** This only fixes the iframe-server callback that handles the "Move to trash" functionality. It's possible there are other similar checks that might need a similar logic. 

Thanks @tyxla for the initial sleuthing 🙇🏻 

### Testing instructions

#### Will not fail with Gutenberg 10.8.0

The `iframe-bridge-server` is part of the `wpcom-block-editor` sub-app, to test it, follow the following steps:
1. Check out this branch in `wp-calypso` and `cd apps/wpcom-block-editor`;
2. Map `widgets.wp.com` to your sandbox's IP;
2. Run `yarn dev --sync` to sync this to your WPCOM sandbox (or `install-plugin.sh wpcom-block-editor fix/trashing-post-for-gb-10.8` in the sandbox);
3. Access an edge site (running GB v10.8.0) create a new post, publish and then in the post settings, click the "Move to trash" button. Make sure you're accessing through Calypso and not wp-admin!
4. It should work well and you shouldn't get any errors.

#### Will not fail with Gutenberg < 10.8.0

Repeat the same process above but this time in a non-edge site. "Move to trash" should work well, too.


### More context

* Gutenberg master issue for migrating to using store definition as ids: https://github.com/WordPress/gutenberg/issues/27088;
* PR that changed to store definitions, which ended up affecting the "Move to trash" functionality when used from Calyspo: https://github.com/WordPress/gutenberg/pull/32153;
* Initial discussion: p1623326650332900/1623257071.325700-slack-C7YPUHBB2.