### PR TITLE
Fix blank screen when opening menu on mobile while on theme section

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -274,3 +274,11 @@
 		outline: 1px solid var( --color-sidebar-border );
 	}
 }
+
+// Ensure that the sidebar always remains on top.
+// Related issue: https://github.com/Automattic/wp-calypso/issues/53504
+.is-nav-unification {
+	.layout__secondary {
+		z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
+	}
+}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -33,12 +33,6 @@
 		padding-left: 32px;
 	}
 
-	.is-section-theme &,
-	.is-section-themes.has-no-sidebar & {
-		padding: 0;
-		margin: 0;
-	}
-
 	// Themes sets it own padding/margin
 	.is-section-theme.has-no-sidebar &,
 	.is-section-themes.has-no-sidebar & {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -103,6 +103,7 @@
 	background: var( --color-sidebar-background );
 	border-right: 1px solid var( --color-sidebar-border );
 	width: var( --sidebar-width-max );
+	z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
 	overflow: hidden;
 
 	@include breakpoint-deprecated( '<960px' ) {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -113,7 +113,6 @@
 	background: var( --color-sidebar-background );
 	border-right: 1px solid var( --color-sidebar-border );
 	width: var( --sidebar-width-max );
-	z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
 	overflow: hidden;
 
 	@include breakpoint-deprecated( '<960px' ) {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -60,12 +60,6 @@
 			padding-left: 24px;
 		}
 
-		.is-section-theme &,
-		.is-section-themes.has-no-sidebar & {
-			padding: 0;
-			margin: 0;
-		}
-
 		.is-section-preview & {
 			padding: 47px 0 0 ( 228px + 1px );
 		}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -33,6 +33,12 @@
 		padding-left: 32px;
 	}
 
+	.is-section-theme &,
+	.is-section-themes.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+
 	// Themes sets it own padding/margin
 	.is-section-theme.has-no-sidebar &,
 	.is-section-themes.has-no-sidebar & {
@@ -58,6 +64,17 @@
 
 		.has-no-sidebar & {
 			padding-left: 24px;
+		}
+
+		.is-section-theme.has-no-sidebar &,
+		.is-section-themes.has-no-sidebar & {
+			padding: 0;
+			margin: 0;
+		}
+	
+		.is-section-theme & {
+			padding: 0 0 0 calc( var( --sidebar-width-max ) );
+			margin: 0;
 		}
 
 		.is-section-preview & {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -34,9 +34,14 @@
 	}
 
 	// Themes sets it own padding/margin
-	.is-section-theme &,
+	.is-section-theme.has-no-sidebar &,
 	.is-section-themes.has-no-sidebar & {
 		padding: 0;
+		margin: 0;
+	}
+
+	.is-section-theme & {
+		padding: 0 0 0 calc( var( --sidebar-width-max ) );
 		margin: 0;
 	}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -102,7 +102,7 @@ const noop = () => {};
  * @param { object } context - Middleware context
  * @returns { object } React element containing the site selector and sidebar
  */
-function createNavigation( context ) {
+export function createNavigation( context ) {
 	const siteFragment = getSiteFragment( context.pathname );
 	let basePath = context.pathname;
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -574,6 +574,14 @@ $font-size: rem( 14px );
 			}
 		}
 
+		&.is-sidebar-overflow {
+			.focus-content.is-section-theme {
+				.layout__secondary {
+					transform: translateX( -100% );
+				}
+			}
+		}
+
 		.sidebar__menu.is-togglable:not( .is-toggle-open ).hovered {
 			// .hovered is handled in client/layout/sidebar/expandable.jsx. Needed for repositioning and hover intent.
 			position: relative;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -581,14 +581,6 @@ $font-size: rem( 14px );
 			}
 		}
 
-		&.is-sidebar-overflow {
-			.focus-content.is-section-theme {
-				.layout__secondary {
-					transform: translateX( -100% );
-				}
-			}
-		}
-
 		.sidebar__menu.is-togglable:not( .is-toggle-open ).hovered {
 			// .hovered is handled in client/layout/sidebar/expandable.jsx. Needed for repositioning and hover intent.
 			position: relative;

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -558,6 +558,15 @@ $font-size: rem( 14px );
 // Flyout menu (showing from >782px)
 @media screen and ( min-width: 783px ) {
 	.is-nav-unification {
+		.focus-content,
+		.focus-sites,
+		.focus-sidebar {
+			.sidebar,
+			.layout__secondary {
+				z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
+			}
+		}
+
 		// client/layout/style.scss
 		// layout/sidebar/style.scss
 		// TODO: For prototype only, this prevents the sidebar from being scrollable.
@@ -568,7 +577,6 @@ $font-size: rem( 14px );
 			.focus-sidebar {
 				.sidebar,
 				.layout__secondary {
-					z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
 					overflow: initial;
 				}
 			}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -561,8 +561,7 @@ $font-size: rem( 14px );
 		.focus-content,
 		.focus-sites,
 		.focus-sidebar {
-			.sidebar,
-			.layout__secondary {
+			.sidebar {
 				z-index: z-index( 'root', '.is-nav-unification .layout__secondary' );
 			}
 		}

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -14,6 +14,7 @@ import ThemeNotFoundError from './theme-not-found-error';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { requestTheme, setBackPath } from 'calypso/state/themes/actions';
 import { getTheme, getThemeRequestErrors } from 'calypso/state/themes/selectors';
+import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 
 const debug = debugFactory( 'calypso:themes' );
 
@@ -55,10 +56,12 @@ export function details( context, next ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}
 
+	context.store.dispatch( setNextLayoutFocus( 'sidebar' ) );
+
 	context.primary = (
 		<ThemeSheetComponent id={ slug } section={ section } pathName={ context.pathname } />
 	);
-	context.secondary = null; // When we're logged in, we need to remove the sidebar.
+
 	next();
 }
 

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -7,7 +7,8 @@ import {
 	redirectWithoutLocaleParamIfLoggedIn,
 } from 'calypso/controller';
 import { details, fetchThemeDetailsData } from './controller';
-import { siteSelection } from 'calypso/my-sites/controller';
+import { createNavigation, siteSelection } from 'calypso/my-sites/controller';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 
 function redirectToLoginIfSiteRequested( context, next ) {
@@ -19,6 +20,14 @@ function redirectToLoginIfSiteRequested( context, next ) {
 	next();
 }
 
+function addNavigationIfLoggedIn( context, next ) {
+	const state = context.store.getState();
+	if ( isUserLoggedIn( state ) ) {
+		context.secondary = createNavigation( context );
+	}
+	next();
+}
+
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
@@ -26,6 +35,7 @@ export default function ( router ) {
 		`/${ langParam }/theme/:slug/:section(setup|support)?/:site_id?`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectToLoginIfSiteRequested,
+		addNavigationIfLoggedIn,
 		siteSelection,
 		fetchThemeDetailsData,
 		details,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fix adds navigation to the context of the theme sheet view if the user is logged in. It changes the current behaviour on desktop because the navigation bar was not being rendered at all. Now it's being rendered and hidden.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Desktop
* Go to `http://calypso.localhost:3000/theme/twentytwentyone`
* You shouldn't see the sidebar
* If you click on My Sites the sidebar will open

##### Mobile
* Go to `http://calypso.localhost:3000/theme/twentytwentyone` on mobile (actual device or browser inspector)
* You shouldn't see the sidebar
* If you click on My Sites the sidebar will open and take the whole screen (same behaviour as in the rest of the site)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
 * https://github.com/Automattic/wp-calypso/issues/53593
 * https://github.com/Automattic/wp-calypso/issues/53504
 * https://github.com/Automattic/wp-calypso/issues/53506
