### PR TITLE
Change priority on Infer Node when a url is providing, infering linkNode

### DIFF
--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -149,12 +149,12 @@ const themeNode = ( { site_slug, slug, version, uri, intent, section } ) => ( {
 const inferNode = ( range ) => {
 	const { type, url } = range;
 
-	if ( type ) {
-		return typedNode( range );
-	}
-
 	if ( url ) {
 		return linkNode( range );
+	}
+
+	if ( type ) {
+		return typedNode( range );
 	}
 
 	return range;

--- a/client/lib/notifications/test/note-block-parser.js
+++ b/client/lib/notifications/test/note-block-parser.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { parseBlock } from '../note-block-parser';
+
+describe( 'Test parsing blocks with url and type', () => {
+	test( 'block with url and type will be parsed like linkNode', () => {
+		const context = {
+			text: 'New Order: Order #339',
+			ranges: [
+				{
+					url: 'https://examplesite/wp-admin/post.php?post=339&action=edit',
+					indices: [ 11, 21 ],
+					type: 'a',
+					section: 'shop_order',
+					intent: 'edit',
+				},
+			],
+		};
+
+		const expected = [
+			'New Order: ',
+			{
+				type: 'link',
+				url: 'https://examplesite/wp-admin/post.php?post=339&action=edit',
+				intent: 'edit',
+				section: 'shop_order',
+				children: [ 'Order #339' ],
+			},
+		];
+
+		const result = parseBlock( context );
+
+		expect( result ).to.deep.equal( expected );
+	} );
+
+	test( 'old parsing when block contained type and url is not longer valid', () => {
+		const context = {
+			text: 'New Order: Order #339',
+			ranges: [
+				{
+					url: 'https://examplesite/wp-admin/post.php?post=339&action=edit',
+					indices: [ 11, 21 ],
+					type: 'a',
+					section: 'shop_order',
+					intent: 'edit',
+				},
+			],
+		};
+
+		const oldExpected = [
+			'New Order: ',
+			{
+				type: 'a',
+				children: [ 'Order #339' ],
+			},
+		];
+
+		const result = parseBlock( context );
+
+		expect( result ).to.deep.not.equal( oldExpected );
+		expect( result[ 1 ] ).to.have.ownPropertyDescriptor( 'url' );
+	} );
+} );

--- a/client/lib/notifications/test/note-block-parser.js
+++ b/client/lib/notifications/test/note-block-parser.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { parseBlock } from '../note-block-parser';
@@ -36,34 +31,6 @@ describe( 'Test parsing blocks with url and type', () => {
 
 		const result = parseBlock( context );
 
-		expect( result ).to.deep.equal( expected );
-	} );
-
-	test( 'old parsing when block contained type and url is not longer valid', () => {
-		const context = {
-			text: 'New Order: Order #339',
-			ranges: [
-				{
-					url: 'https://examplesite/wp-admin/post.php?post=339&action=edit',
-					indices: [ 11, 21 ],
-					type: 'a',
-					section: 'shop_order',
-					intent: 'edit',
-				},
-			],
-		};
-
-		const oldExpected = [
-			'New Order: ',
-			{
-				type: 'a',
-				children: [ 'Order #339' ],
-			},
-		];
-
-		const result = parseBlock( context );
-
-		expect( result ).to.deep.not.equal( oldExpected );
-		expect( result[ 1 ] ).to.have.ownPropertyDescriptor( 'url' );
+		expect( result ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the priority about how a node is inferred, since now a type `a` with the `href` is inferred like a `typedNode` instead of a `linkNode`. (Previously when a <a `href` ... /> were sent by the API it was sent like no type and href, but now it comes like type  `a` with the `href`)

#### Testing instructions

You can test it in the Activity Log of Jetpack 
* Connect your site to Jetpack. You can use free plan
* Create or edit a post
* Go to the Activity Log, in /activity-log/<your-website>, and see the post 

<img width="782" alt="Screen Shot 2021-06-11 at 16 07 06" src="https://user-images.githubusercontent.com/2747834/121743281-1e47e000-cacf-11eb-9059-515ddd204b67.png">

* You can note the title is a link, but not clickable
* Apply the fix and reload. Now the link will be valid
