### PR TITLE
Checkout: Allow pending page to handle redirecting to Jetpack URLs

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -50,8 +50,12 @@ class CheckoutPending extends PureComponent {
 			if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
 				const { receiptId } = transaction;
 
-				const redirectPath = redirectTo.replace( 'pending', receiptId );
-				page( redirectPath );
+				if ( redirectTo.startsWith( '/' ) ) {
+					const redirectPath = redirectTo.replace( 'pending', receiptId );
+					page( redirectPath );
+				} else {
+					window.location.href = redirectTo;
+				}
 
 				return;
 			}

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import { makeRedirectResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type {
@@ -43,31 +42,18 @@ export default async function genericRedirectProcessor(
 		throw new Error( 'Required purchase data is missing' );
 	}
 
-	const { protocol, hostname, port, pathname } = parseUrl(
-		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
-		true
-	);
-	const cancelUrlQuery = {};
-	const redirectToSuccessUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: getThankYouUrl(),
-	} );
-	const successUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname: `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`,
-		query: { redirectTo: redirectToSuccessUrl },
-	} );
-	const cancelUrl = formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname,
-		query: cancelUrlQuery,
-	} );
+	// The success URL will be a pending page where we will poll for the order
+	// until a webhook is received that confirms the payment, at which point the
+	// pending page will redirect to the thank-you page as returned by
+	// getThankYouUrl.
+	const thankYouUrl = encodeURIComponent( getThankYouUrl() );
+	const successUrlPath = `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`;
+	const successUrlBase = buildCalypsoUrl( successUrlPath );
+	const successUrlObject = new URL( successUrlBase );
+	successUrlObject.searchParams.set( 'redirectTo', thankYouUrl );
+	const successUrl = successUrlObject.href;
+
+	const cancelUrl = window.location.origin + window.location.pathname + window.location.search;
 
 	recordTransactionBeginAnalytics( {
 		paymentMethodId,
@@ -110,4 +96,10 @@ function isValidTransactionData( submitData: unknown ): submitData is RedirectTr
 		throw new Error( 'Transaction requires data and none was provided' );
 	}
 	return true;
+}
+
+function buildCalypsoUrl( path: string ): string {
+	const urlBase = window.location.origin;
+	const pathToJoin = path.startsWith( '/' ) ? path : `/${ path }`;
+	return `${ urlBase }${ pathToJoin }`;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -55,8 +55,7 @@ export default async function genericRedirectProcessor(
 	const successUrlObject = new URL( successUrlBase );
 	successUrlObject.searchParams.set( 'redirectTo', thankYouUrl );
 	const successUrl = successUrlObject.href;
-
-	const cancelUrl = ( origin ?? 'https://wordpress.com' ) + ( pathname ?? '' ) + ( search ?? '' );
+	const cancelUrl = `${ origin }${ pathname }${ search }`;
 
 	recordTransactionBeginAnalytics( {
 		paymentMethodId,

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -46,14 +46,17 @@ export default async function genericRedirectProcessor(
 	// until a webhook is received that confirms the payment, at which point the
 	// pending page will redirect to the thank-you page as returned by
 	// getThankYouUrl.
-	const thankYouUrl = encodeURIComponent( getThankYouUrl() );
+	const { origin = 'https://wordpress.com', pathname = '/', search = '' } =
+		typeof window !== 'undefined' ? window.location : {};
+	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
 	const successUrlPath = `/checkout/thank-you/${ siteSlug || 'no-site' }/pending`;
-	const successUrlBase = buildCalypsoUrl( successUrlPath );
+	const successUrlBase = `${ origin }${ successUrlPath }`;
+
 	const successUrlObject = new URL( successUrlBase );
 	successUrlObject.searchParams.set( 'redirectTo', thankYouUrl );
 	const successUrl = successUrlObject.href;
 
-	const cancelUrl = window.location.origin + window.location.pathname + window.location.search;
+	const cancelUrl = ( origin ?? 'https://wordpress.com' ) + ( pathname ?? '' ) + ( search ?? '' );
 
 	recordTransactionBeginAnalytics( {
 		paymentMethodId,
@@ -96,10 +99,4 @@ function isValidTransactionData( submitData: unknown ): submitData is RedirectTr
 		throw new Error( 'Transaction requires data and none was provided' );
 	}
 	return true;
-}
-
-function buildCalypsoUrl( path: string ): string {
-	const urlBase = window.location.origin;
-	const pathToJoin = path.startsWith( '/' ) ? path : `/${ path }`;
-	return `${ urlBase }${ pathToJoin }`;
 }

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -191,6 +191,80 @@ describe( 'genericRedirectProcessor', () => {
 		} );
 	} );
 
+	it( 'sends the correct data to the endpoint a relative thankYouUrl', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		const thankYouUrl = '/payments?id=5#begin';
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				getThankYouUrl: () => thankYouUrl,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=' +
+					encodeURIComponent( thankYouUrl ),
+			},
+		} );
+	} );
+
+	it( 'sends the correct data to the endpoint a fully-qualified thankYouUrl', async () => {
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		const expected = { payload: 'https://test-redirect-url', type: 'REDIRECT' };
+		const thankYouUrl = 'https://example.com:5000/payments?id=5#begin';
+		await expect(
+			genericRedirectProcessor( 'bancontact', submitData, {
+				...options,
+				getThankYouUrl: () => thankYouUrl,
+				siteSlug: 'example.wordpress.com',
+				siteId: 1234567,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			cart: {
+				...basicExpectedStripeRequest.cart,
+				blog_id: '1234567',
+				cart_key: '1234567',
+				coupon: '',
+				create_new_blog: false,
+			},
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				successUrl:
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending?redirectTo=' +
+					encodeURIComponent( thankYouUrl ),
+			},
+		} );
+	} );
+
 	it( 'sends the correct data to the endpoint with tax information', async () => {
 		const submitData = {
 			name: 'test name',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the checkout "pending" page, which accepts a `redirectTo` query param, to support redirecting to a fully qualified URL, and not just a local calypso path.

The pending page is most used by the Stripe redirect payment processor, so this also updates that processor to url-encode its redirect URL in case it might contain special characters like `#` so they are preserved for the actual redirect.

Finally, the redirect processor was building its success URL assuming that the thank-you url was always a relative path, but since it may be a fully qualified URL, this PR updates the processor to remove that assumption.

Requires D62783-code which makes sure that the `redirectTo` param is double-encoded during the transaction.

#### Testing instructions

- Apply D62783-code to your sandbox to make `redirectTo` double-encoded.
- Also apply D45443-code to your sandbox to force Bancontact to be available.
- Merge this PR with https://github.com/Automattic/wp-calypso/pull/53631
- Set your user currency to EUR.
- Purchase a new Jetpack plan in calypso checkout and select Bancontact as the payment method, entering any string in the "name" field.
- You'll be redirected to the Stripe test page. Press the button to approve the payment.
- Verify that you're redirected to a "pending" page briefly.
- Verify that you're redirected to your Jetpack site correctly.