### PR TITLE
Remove account-related wpcom.undocumented() methods

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -57,18 +57,6 @@ UndocumentedMe.prototype.purchases = function ( callback ) {
 	return this.wpcom.req.get( '/me/purchases', callback );
 };
 
-UndocumentedMe.prototype.validatePassword = function ( password, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/settings/password/validate',
-		body: {
-			password: password,
-		},
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
 UndocumentedMe.prototype.sendSMSValidationCode = function ( callback ) {
 	const args = {
 		apiVersion: '1.1',
@@ -104,28 +92,6 @@ UndocumentedMe.prototype.getAppAuthCodes = function ( callback ) {
 	};
 
 	return this.wpcom.req.get( args, callback );
-};
-
-UndocumentedMe.prototype.validateUsername = function ( username, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/username/validate/' + username,
-	};
-
-	return this.wpcom.req.get( args, callback );
-};
-
-UndocumentedMe.prototype.changeUsername = function ( username, action, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/username',
-		body: {
-			username: username,
-			action: action,
-		},
-	};
-
-	return this.wpcom.req.post( args, callback );
 };
 
 UndocumentedMe.prototype.getPeerReferralLink = function ( callback ) {

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -43,9 +43,7 @@ class AccountPassword extends React.Component {
 		pendingValidation: true,
 	};
 
-	componentDidMount() {
-		this.debouncedPasswordValidate = debounce( this.validatePassword, 300 );
-	}
+	debouncedPasswordValidate = debounce( this.validatePassword, 300 );
 
 	componentDidUpdate( prevProps ) {
 		if (
@@ -76,7 +74,9 @@ class AccountPassword extends React.Component {
 		}
 
 		try {
-			const validationResult = await wpcom.me().validatePassword( password );
+			const validationResult = await wpcom.req.post( '/me/settings/password/validate', {
+				password,
+			} );
 
 			this.setState( { pendingValidation: false, validation: validationResult } );
 		} catch ( err ) {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -124,10 +124,7 @@ class Account extends React.Component {
 		validationResult: false,
 	};
 
-	componentDidMount() {
-		debug( this.constructor.displayName + ' component is mounted.' );
-		this.debouncedUsernameValidate = debounce( this.validateUsername, 600 );
-	}
+	debouncedUsernameValidate = debounce( this.validateUsername, 600 );
 
 	componentDidUpdate() {
 		if ( ! this.hasUnsavedUserSettings( ACCOUNT_FIELDS.concat( INTERFACE_FIELDS ) ) ) {
@@ -291,10 +288,9 @@ class Account extends React.Component {
 		}
 
 		try {
-			const { success, allowed_actions } = await wpcom
-				.undocumented()
-				.me()
-				.validateUsername( username );
+			const { success, allowed_actions } = await wpcom.req.get(
+				`/me/username/validate/${ username }`
+			);
 
 			this.setState( {
 				validationResult: { success, allowed_actions, validatedUsername: username },
@@ -476,7 +472,7 @@ class Account extends React.Component {
 		this.setState( { submittingForm: true } );
 
 		try {
-			await wpcom.undocumented().me().changeUsername( username, action );
+			await wpcom.req.post( '/me/username', { username, action } );
 			this.setState( { submittingForm: false } );
 
 			this.props.markSaved();


### PR DESCRIPTION
Removes three `wpcom.undocumented().me()` methods and replaces them with direct `wpcom.req` calls:
- `validatePassword`
- `validateUsername`
- `changeUsername`

There are also a few `debounce` wrappers around these functions, and I'm moving them out of `componentDidMount` methods into class field assignment, i.e., de facto into constructor. They belong there.

**How to test:**
- try to change your username (for a non-a11n test account)
- try to change your password
