### PR TITLE
Fix API version in invites/accept REST call

### DIFF
--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -222,13 +222,11 @@ export function acceptInvite( invite ) {
 	return async ( dispatch ) => {
 		try {
 			const data = await wpcom.req.get(
-				{
-					path: `/sites/${ invite.site.ID }/invites/${ invite.inviteKey }/accept`,
-					apiVersion: '1.2',
-				},
+				`/sites/${ invite.site.ID }/invites/${ invite.inviteKey }/accept`,
 				{
 					activate: invite.activationKey,
 					include_domain_only: true,
+					apiVersion: '1.2',
 				}
 			);
 


### PR DESCRIPTION
Fixes regression introduced in #53588: https://github.com/Automattic/wp-calypso/pull/53588/files#r650786889

`apiVersion` can't be in `params`, because it's then overwritten by the default `1.1` value if it wasn't in `query`:

https://github.com/Automattic/wp-calypso/blob/trunk/packages/wpcom.js/src/lib/util/send-request.js#L50

Sad but true. A `wpcom` library bug that might be hard to fix due to backcompat.
