### PR TITLE
Invites: Use Redux user when accepting invite

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -17,6 +17,7 @@ import { acceptInvite as acceptInviteAction } from 'calypso/state/invites/action
 import user from 'calypso/lib/user';
 import { getLocaleFromPath, removeLocaleFromPath } from 'calypso/lib/i18n-utils';
 import { navigate } from 'calypso/lib/navigate';
+import { getCurrentUserEmail, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 /**
  * Module variables
@@ -24,7 +25,7 @@ import { navigate } from 'calypso/lib/navigate';
 const debug = debugModule( 'calypso:invite-accept:controller' );
 
 export function redirectWithoutLocaleifLoggedIn( context, next ) {
-	if ( user().get() && getLocaleFromPath( context.path ) ) {
+	if ( isUserLoggedIn( context.store.getState() ) && getLocaleFromPath( context.path ) ) {
 		return page.redirect( removeLocaleFromPath( context.path ) );
 	}
 
@@ -38,7 +39,7 @@ export function acceptInvite( context, next ) {
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
 		debug( 'invite_accepted is set in localStorage' );
-		if ( user().get().email === acceptedInvite.sentTo ) {
+		if ( getCurrentUserEmail( context.store.getState() ) === acceptedInvite.sentTo ) {
 			debug( 'Setting email_verified in user object' );
 			user().set( { email_verified: true } );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the invitation accept logic to use Redux for retrieving the current user instead of the old `lib/user` library. 

We're intentionally not touching the `user().set()` part, which requires more attention as it's related to some bigger refactors.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify accepting an invite still works as it did before.