### PR TITLE
User: Move all store interaction to store module

### DIFF
--- a/client/lib/user/store.js
+++ b/client/lib/user/store.js
@@ -15,3 +15,11 @@ export async function clearStore() {
 	store.clearAll();
 	await clearStorage();
 }
+
+export async function getUserId() {
+	return await store.get( 'wpcom_user_id' );
+}
+
+export async function setUserId( userId ) {
+	await store.set( 'wpcom_user_id', userId );
+}

--- a/client/lib/user/store.js
+++ b/client/lib/user/store.js
@@ -16,10 +16,10 @@ export async function clearStore() {
 	await clearStorage();
 }
 
-export async function getUserId() {
-	return await store.get( 'wpcom_user_id' );
+export function getStoredUserId() {
+	return store.get( 'wpcom_user_id' );
 }
 
-export async function setUserId( userId ) {
-	await store.set( 'wpcom_user_id', userId );
+export function setStoredUserId( userId ) {
+	return store.set( 'wpcom_user_id', userId );
 }

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { isEqual } from 'lodash';
-import store from 'store';
 import debugFactory from 'debug';
 import config from '@automattic/calypso-config';
 
@@ -17,7 +16,7 @@ import {
 } from 'calypso/lib/user/support-user-interop';
 import wpcom from 'calypso/lib/wp';
 import Emitter from 'calypso/lib/mixins/emitter';
-import { clearStore } from './store';
+import { clearStore, getUserId, setUserId } from './store';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
 
 const debug = debugFactory( 'calypso:user' );
@@ -88,11 +87,11 @@ User.prototype.initialize = async function () {
  * @param {number} userId The new user ID.
  **/
 User.prototype.clearStoreIfChanged = function ( userId ) {
-	const storedUserId = store.get( 'wpcom_user_id' );
+	const storedUserId = getUserId();
 
 	if ( storedUserId != null && storedUserId !== userId ) {
 		debug( 'Clearing localStorage because user changed' );
-		store.clearAll();
+		clearStore();
 	}
 };
 
@@ -168,7 +167,7 @@ User.prototype.handleFetchSuccess = function ( userData ) {
 	this.clearStoreIfChanged( userData.ID );
 
 	// Store user ID in local storage so that we can detect a change and clear the storage
-	store.set( 'wpcom_user_id', userData.ID );
+	setUserId( userData.ID );
 
 	this.data = userData;
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -16,7 +16,7 @@ import {
 } from 'calypso/lib/user/support-user-interop';
 import wpcom from 'calypso/lib/wp';
 import Emitter from 'calypso/lib/mixins/emitter';
-import { clearStore, getUserId, setUserId } from './store';
+import { clearStore, getStoredUserId, setStoredUserId } from './store';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
 
 const debug = debugFactory( 'calypso:user' );
@@ -87,7 +87,7 @@ User.prototype.initialize = async function () {
  * @param {number} userId The new user ID.
  **/
 User.prototype.clearStoreIfChanged = function ( userId ) {
-	const storedUserId = getUserId();
+	const storedUserId = getStoredUserId();
 
 	if ( storedUserId != null && storedUserId !== userId ) {
 		debug( 'Clearing localStorage because user changed' );
@@ -167,7 +167,7 @@ User.prototype.handleFetchSuccess = function ( userData ) {
 	this.clearStoreIfChanged( userData.ID );
 
 	// Store user ID in local storage so that we can detect a change and clear the storage
-	setUserId( userData.ID );
+	setStoredUserId( userData.ID );
 
 	this.data = userData;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the local storage interaction of the user library to the dedicated store module.

This will be necessary to port the rest of the instances that rely on the local storage user ID value.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Verify accepting an invitation for editor or a higher-privileged user still works well.