### PR TITLE
Emails: Fix bottom margin of cards in Email Comparison page

### DIFF
--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -166,6 +166,7 @@
 
 		.email-providers-comparison__provider-form {
 			flex-grow: 1;
+			margin-bottom: 20px;
 
 			@include breakpoint-deprecated( '>1040px' ) {
 				margin-top: 0;
@@ -192,7 +193,7 @@
 			margin-bottom: 2.5em;
 
 			@include breakpoint-deprecated( '>1040px' ) {
-				margin-bottom: 0;
+				margin-bottom: 14px;
 				margin-left: 2em;
 				margin-top: 0;
 			}


### PR DESCRIPTION
This pull request makes sure the bottom margin of cards is the same on the `Email Comparison` page - may they be collapsed or expanded:

Before | After
------ | -----
<img width="624" alt="before" src="https://user-images.githubusercontent.com/594356/121902782-edaeb300-cd27-11eb-8050-0be29388abd9.png"> | <img width="623" alt="after" src="https://user-images.githubusercontent.com/594356/121902796-f2736700-cd27-11eb-9c4c-7379b06d3143.png">

#### Testing instructions

1. Run `git checkout fix/email-comparison-page` and start your server, or open a [live branch](https://calypso.live/?branch=fix/email-comparison-page)
2. Open the [`Email Comparison` page](http://calypso.localhost:3000/email)
3. Assert that the bottom margin of cards are now the same when forms are expanded
4. Assert that the margin is correct when reducing the width of your browser