### PR TITLE
nameservers: try different approach with `onSucces | onError` handlers

### DIFF
--- a/client/data/domains/nameservers/use-update-nameservers-mutation.js
+++ b/client/data/domains/nameservers/use-update-nameservers-mutation.js
@@ -9,7 +9,7 @@ import { useMutation, useQueryClient } from 'react-query';
  */
 import wp from 'calypso/lib/wp';
 
-function useUpdateNameserversMutation( domainName ) {
+function useUpdateNameserversMutation( domainName, queryOptions = {} ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
 		( { nameservers } ) =>
@@ -17,8 +17,10 @@ function useUpdateNameserversMutation( domainName ) {
 				nameservers: nameservers.map( ( nameserver ) => ( { nameserver } ) ),
 			} ),
 		{
-			onSuccess() {
+			...queryOptions,
+			onSuccess( ...args ) {
 				queryClient.invalidateQueries( [ 'domain-nameservers', domainName ] );
+				queryOptions.onSuccess?.( ...args );
 			},
 		}
 	);

--- a/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
+++ b/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
@@ -19,57 +19,26 @@ const noticeOptions = {
 	id: `nameserver-update-notification`,
 };
 
-const useSuccessNotice = ( isSuccess ) => {
-	const showNotice = useRef();
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	useEffect( () => {
-		showNotice.current = () => {
-			dispatch(
-				successNotice(
-					translate( 'Yay, the name servers have been successfully updated!' ),
-					noticeOptions
-				)
-			);
-		};
-	}, [ dispatch, translate ] );
-
-	useEffect( () => {
-		isSuccess && showNotice.current();
-	}, [ isSuccess ] );
-};
-
-const useErrorNotice = ( isError, error ) => {
-	const showNotice = useRef();
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	useEffect( () => {
-		showNotice.current = () => {
-			const defaultMessage = translate( 'An error occurred while updating the nameservers.' );
-			dispatch( errorNotice( error?.message ?? defaultMessage, noticeOptions ) );
-		};
-	}, [ dispatch, translate, error ] );
-
-	useEffect( () => {
-		isError && showNotice.current();
-	}, [ isError ] );
-};
-
 const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 	const WithDomainNameservers = ( props ) => {
 		const { selectedDomainName } = props;
+		const dispatch = useDispatch();
+		const translate = useTranslate();
 		const { data, isLoading, isError, error } = useDomainNameserversQuery( selectedDomainName );
-		const {
-			updateNameservers,
-			isSuccess: isUpdateSuccess,
-			isError: isUpdateError,
-			error: updateError,
-		} = useUpdateNameserversMutation( selectedDomainName );
-
-		useSuccessNotice( isUpdateSuccess );
-		useErrorNotice( isUpdateError, updateError );
+		const { updateNameservers } = useUpdateNameserversMutation( selectedDomainName, {
+			onSuccess() {
+				dispatch(
+					successNotice(
+						translate( 'Yay, the name servers have been successfully updated!' ),
+						noticeOptions
+					)
+				);
+			},
+			onError( err ) {
+				const defaultMessage = translate( 'An error occurred while updating the nameservers.' );
+				dispatch( errorNotice( err?.message ?? defaultMessage, noticeOptions ) );
+			},
+		} );
 
 		return (
 			<Wrapped


### PR DESCRIPTION
Merges into #53657

#### Changes proposed in this Pull Request

* Try a different approach when reacting to `onSuccess | onError` states when using `useUpdateNameserverMutation`

#### Testing instructions

* Follow the testing instructions of #53657
