### PR TITLE
Invites: updates to /accept API response payload

### DIFF
--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -231,7 +231,7 @@ export function acceptInvite( invite ) {
 			);
 
 			if ( invite.role !== 'follower' && invite.role !== 'viewer' ) {
-				dispatch( receiveSite( data ) );
+				dispatch( receiveSite( data.site ) );
 				// @TODO: Replace with Redux user fetching once lib/user is fully reduxified
 				await user().fetch();
 			}

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -226,7 +226,7 @@ export function acceptInvite( invite ) {
 				{
 					activate: invite.activationKey,
 					include_domain_only: true,
-					apiVersion: '1.2',
+					apiVersion: '1.3',
 				}
 			);
 

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -13,7 +13,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { acceptedNotice } from 'calypso/my-sites/invites/utils';
 import { getInviteForSite } from 'calypso/state/invites/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { requestSites, receiveSites } from 'calypso/state/sites/actions';
+import { requestSites } from 'calypso/state/sites/actions';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -231,7 +231,6 @@ export function acceptInvite( invite ) {
 			);
 
 			if ( invite.role !== 'follower' && invite.role !== 'viewer' ) {
-				dispatch( receiveSites( data.sites ) );
 				// @TODO: Replace with Redux user fetching once lib/user is fully reduxified
 				await user().fetch();
 			}

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -13,7 +13,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { acceptedNotice } from 'calypso/my-sites/invites/utils';
 import { getInviteForSite } from 'calypso/state/invites/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { requestSites } from 'calypso/state/sites/actions';
+import { requestSite } from 'calypso/state/sites/actions';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -245,7 +245,7 @@ export function acceptInvite( invite ) {
 			} );
 
 			dispatch( inviteAccepted( invite ) );
-			await dispatch( requestSites() );
+			await dispatch( requestSite( invite.site.ID ) );
 			return data;
 		} catch ( error ) {
 			if ( error.message ) {

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -13,7 +13,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { acceptedNotice } from 'calypso/my-sites/invites/utils';
 import { getInviteForSite } from 'calypso/state/invites/selectors';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { requestSite } from 'calypso/state/sites/actions';
+import { receiveSite } from 'calypso/state/sites/actions';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -231,6 +231,7 @@ export function acceptInvite( invite ) {
 			);
 
 			if ( invite.role !== 'follower' && invite.role !== 'viewer' ) {
+				dispatch( receiveSite( data ) );
 				// @TODO: Replace with Redux user fetching once lib/user is fully reduxified
 				await user().fetch();
 			}
@@ -245,7 +246,6 @@ export function acceptInvite( invite ) {
 			} );
 
 			dispatch( inviteAccepted( invite ) );
-			await dispatch( requestSite( invite.site.ID ) );
 			return data;
 		} catch ( error ) {
 			if ( error.message ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Partly fixes an issue where accepting an invite becomes really slow once the user has a lot of sites already. The actual fix is done on the API side. This PR deals with changes on the response payload, and removes an unnecessary "full refresh" on the sites store to further improve performance.

* Update `/accept` payload expectations -- we will no longer receive a sites list after D62639-code is deployed.
* Use new endpoint version 1.3
* Replace unnecessary call to `requestSites()` with a call to `requestSite()` on the site that was recently joined by the user. h/t @tyxla for this suggestion

#### Testing instructions
- Apply D62639-code and sandbox your test site.

Browser A/User A:
1. Send an invite to User B.

Browser B/User B: 
1. Open the invite link from the email in a new tab, and replace `wordpress.com` with `calypso.locahost:3000`
2. You should be able to accept the invite without problems, and should get redirected to the accepted site's Calypso admin interface (or frontend, if a P2 site) upon accepting.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53454 
