### PR TITLE
Block Editor Tracking: Fix error caused by generalizing block variation tracking

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -31,10 +31,27 @@ function globalEventPropsHandler( block ) {
 		return {};
 	}
 
-	return {
-		variation_slug: select( 'core/blocks' ).getActiveBlockVariation( block.name, block.attributes )
-			?.name,
-	};
+	// `getActiveBlockVariation` selector is only available since Gutenberg 10.6.
+	// To avoid errors, we make sure the selector exists. If it doesn't,
+	// then we fallback to the old way.
+	const { getActiveBlockVariation } = select( 'core/blocks' );
+	if ( getActiveBlockVariation ) {
+		return {
+			variation_slug: getActiveBlockVariation( block.name, block.attributes )?.name,
+		};
+	}
+
+	// Pick up variation slug from `core/embed` block.
+	if ( block.name === 'core/embed' && block?.attributes?.providerNameSlug ) {
+		return { variation_slug: block.attributes.providerNameSlug };
+	}
+
+	// Pick up variation slug from `core/social-link` block.
+	if ( block.name === 'core/social-link' && block?.attributes?.service ) {
+		return { variation_slug: block.attributes.service };
+	}
+
+	return {};
 }
 /**
  * Looks up the block name based on its id.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/53606 causes an error on sites that use Gutenberg earlier than version 10.6.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site that uses Gutenberg version earlier than 10.6.
* Insert "Twitter" block, make sure it's inserted and no errors in the console.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53410 
