### PR TITLE
build: Speed up webpack rebuild by introducing a cache for webpack-rtl-plugin

### DIFF
--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -31,11 +31,7 @@ function middleware( app ) {
 	app.set( 'compiler', compiler );
 
 	if ( shouldProfile ) {
-		compiler.apply(
-			new webpack.ProgressPlugin( {
-				profile: true,
-			} )
-		);
+		new compiler.webpack.ProgressPlugin( { profile: true } ).apply( compiler );
 	}
 
 	// In development environment we need to wait for initial webpack compile


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix profile mode when using `yarn start`.
* Introduce a cache for WebpackRTL. Before this change it was computing RTL on all `.css` files all the time. This is important when compiling modules (i.e. start Calypso with `yarn start` and change a file). Now it only computes RTL for `.css` that have actually changed.

#### Testing instructions

* Start Calypso with `PROFILE=true yarn start`, you should see performance info
* Start Calypso (either `PROFILE=true yarn start` or just `yarn start`) and change a `.js` file. It should recompile a few seconds faster than before.
* Start Calypso, change to a RTL language and change a `.css` file. You should get your changes after recompilation+refresh.


#### Comparison:

Running `PROFILE=true yarn start` and changing a `.js` file (left) and `.css` file (right):

##### Before

![image](https://user-images.githubusercontent.com/975703/121914917-feb0f180-cd32-11eb-8c0a-13d06e8d9a96.png)

##### After


![image](https://user-images.githubusercontent.com/975703/121913675-e2608500-cd31-11eb-9941-a68e81724aa2.png)


(note that webpack doesn't dispaly steps with a duration `< 10ms` but it doesn't mean those steps are missing)
