### PR TITLE
State: Use user store library to store and retrieve local storage user ID

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -10,9 +10,9 @@ import { map, pick, throttle } from 'lodash';
 import { APPLY_STORED_STATE } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
 import { getAllStoredItems, setStoredItem, clearStorage } from 'calypso/lib/browser-storage';
+import { getStoredUserId } from 'calypso/lib/user/store';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import config from '@automattic/calypso-config';
-import user from 'calypso/lib/user';
 
 /**
  * Module variables
@@ -85,7 +85,7 @@ function shouldAddSympathy() {
 // scenario where state data may have been stored without this
 // check being performed.
 function verifyStoredRootState( state ) {
-	const currentUserId = user()?.get()?.ID ?? null;
+	const currentUserId = getStoredUserId() ?? null;
 	const storedUserId = state?.currentUser?.id ?? null;
 
 	if ( currentUserId !== storedUserId ) {
@@ -127,7 +127,7 @@ function getPersistenceKey( subkey, forceLoggedOutUser ) {
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user()?.get()?.ID ?? null );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : getStoredUserId() ?? null );
 }
 
 function getReduxStateKeyForUserId( userId ) {

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -13,7 +13,7 @@ import { useFakeTimers } from 'sinon';
  */
 import { withStorageKey } from '@automattic/state-utils';
 import * as browserStorage from 'calypso/lib/browser-storage';
-import userFactory from 'calypso/lib/user';
+import { getStoredUserId } from 'calypso/lib/user/store';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import { createReduxStore } from 'calypso/state';
 import signupReducer from 'calypso/state/signup/reducer';
@@ -38,10 +38,8 @@ const initialReducer = combineReducers( {
 	postTypes,
 } );
 
-jest.mock( 'calypso/lib/user', () => () => ( {
-	get: () => ( {
-		ID: 123456789,
-	} ),
+jest.mock( 'calypso/lib/user/store', () => ( {
+	getStoredUserId: () => 123456789,
 } ) );
 jest.mock( 'calypso/lib/user/support-user-interop', () => ( {
 	isSupportSession: jest.fn().mockReturnValue( false ),
@@ -292,13 +290,13 @@ describe( 'initial-state', () => {
 				let consoleErrorSpy;
 				let getStoredItemSpy;
 
-				const userId = userFactory().get().ID + 1;
+				const userId = getStoredUserId() + 1;
 				const savedState = {
 					[ `redux-state-${ userId }` ]: {
 						// Create an invalid state by forcing the user ID
 						// stored in the state to differ from the current
 						// mocked user ID.
-						currentUser: { id: userFactory().get().ID + 1 },
+						currentUser: { id: getStoredUserId() + 1 },
 						postTypes: {
 							items: {
 								2916284: {
@@ -715,7 +713,7 @@ describe( 'initial-state', () => {
 			store.dispatch( {
 				type: 'foo',
 				data: 1,
-				userId: userFactory().get().ID + 1,
+				userId: getStoredUserId() + 1,
 			} );
 
 			clock.tick( SERIALIZE_THROTTLE );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the instances of the user ID that rely on the old `lib/user` library to use the ID that we have in local storage. 

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Testing this mostly boils down to understanding #25907 and making sure things still work as described there with regards to the Redux store data. 

