### PR TITLE
Help - Forums URL Input: Try "www." URLs Again

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -206,10 +206,21 @@ export class HelpContactForm extends React.PureComponent {
 				? new URL( this.state.userDeclaredUrl ).hostname
 				: new URL( 'http://' + this.state.userDeclaredUrl ).hostname;
 
-			this.props
-				.requestSite( query )
-				.then( ( siteData ) => this.setState( { siteData, errorData: null } ) )
-				.catch( ( error ) => this.setState( { errorData: error.error, siteData: null } ) );
+			const request = ( query ) =>
+				this.props
+					.requestSite( query )
+					.then( ( siteData ) =>
+						this.setState( { siteData, errorData: null, hasRetriedRequest: false } )
+					)
+					.catch( ( error ) => {
+						if ( url.includes( 'www.' ) && ! this.state.hasRetriedRequest ) {
+							this.setState( { hasRetriedRequest: true } );
+							return request( query.replace( 'www.', '' ) );
+						}
+						this.setState( { errorData: error.error, siteData: null, hasRetriedRequest: false } );
+					} );
+
+			return request( query );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sometimes, users may enter their site as `www.[URL]`. It would probably make sense to still conduct a check when this occurs. You can see this issue in practise here: 

- https://wordpress.com/forums/topic/i-cant-figure-out-login-info
- https://wordpress.com/forums/topic/payment-1053/

#### Testing instructions

Try entering the URL http://www.tonyschiessband.com, and verify that the site is now recognised.

<img width="1615" alt="Screenshot 2021-06-14 at 17 36 58" src="https://user-images.githubusercontent.com/43215253/121927643-3457d980-cd37-11eb-8429-a39ed77f5c6a.png">

It's important to conduct this check after the first API request (even though it means sending a second request) because it is possible for a site to contain a `www` domain and for it to be valid. For example, a site such as `www.cutiejea.com` should still work despite this change.

cc @jsnajdr 

Related to #52979
