### PR TITLE
Fix disabled "Save Password" button in /me/security/password

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -57,6 +57,18 @@ UndocumentedMe.prototype.purchases = function ( callback ) {
 	return this.wpcom.req.get( '/me/purchases', callback );
 };
 
+UndocumentedMe.prototype.validatePassword = function ( password, callback ) {
+	const args = {
+		apiVersion: '1.1',
+		path: '/me/settings/password/validate',
+		body: {
+			password: password,
+		},
+	};
+
+	return this.wpcom.req.post( args, callback );
+};
+
 UndocumentedMe.prototype.sendSMSValidationCode = function ( callback ) {
 	const args = {
 		apiVersion: '1.1',
@@ -92,6 +104,28 @@ UndocumentedMe.prototype.getAppAuthCodes = function ( callback ) {
 	};
 
 	return this.wpcom.req.get( args, callback );
+};
+
+UndocumentedMe.prototype.validateUsername = function ( username, callback ) {
+	const args = {
+		apiVersion: '1.1',
+		path: '/me/username/validate/' + username,
+	};
+
+	return this.wpcom.req.get( args, callback );
+};
+
+UndocumentedMe.prototype.changeUsername = function ( username, action, callback ) {
+	const args = {
+		apiVersion: '1.1',
+		path: '/me/username',
+		body: {
+			username: username,
+			action: action,
+		},
+	};
+
+	return this.wpcom.req.post( args, callback );
 };
 
 UndocumentedMe.prototype.getPeerReferralLink = function ( callback ) {

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -43,7 +43,9 @@ class AccountPassword extends React.Component {
 		pendingValidation: true,
 	};
 
-	debouncedPasswordValidate = debounce( this.validatePassword, 300 );
+	componentDidMount() {
+		this.debouncedPasswordValidate = debounce( this.validatePassword, 300 );
+	}
 
 	componentDidUpdate( prevProps ) {
 		if (
@@ -74,9 +76,7 @@ class AccountPassword extends React.Component {
 		}
 
 		try {
-			const validationResult = await wpcom.req.post( '/me/settings/password/validate', {
-				password,
-			} );
+			const validationResult = await wpcom.me().validatePassword( password );
 
 			this.setState( { pendingValidation: false, validation: validationResult } );
 		} catch ( err ) {

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -43,6 +43,8 @@ class AccountPassword extends React.Component {
 		pendingValidation: true,
 	};
 
+	debouncedPasswordValidate = debounce( this.validatePassword, 300 );
+
 	componentDidUpdate( prevProps ) {
 		if (
 			prevProps.isPendingPasswordChange &&
@@ -82,8 +84,6 @@ class AccountPassword extends React.Component {
 			return;
 		}
 	};
-
-	debouncedPasswordValidate = debounce( this.validatePassword, 300 );
 
 	handlePasswordChange = ( event ) => {
 		const newPassword = event.currentTarget.value;

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -124,7 +124,10 @@ class Account extends React.Component {
 		validationResult: false,
 	};
 
-	debouncedUsernameValidate = debounce( this.validateUsername, 600 );
+	componentDidMount() {
+		debug( this.constructor.displayName + ' component is mounted.' );
+		this.debouncedUsernameValidate = debounce( this.validateUsername, 600 );
+	}
 
 	componentDidUpdate() {
 		if ( ! this.hasUnsavedUserSettings( ACCOUNT_FIELDS.concat( INTERFACE_FIELDS ) ) ) {
@@ -288,9 +291,10 @@ class Account extends React.Component {
 		}
 
 		try {
-			const { success, allowed_actions } = await wpcom.req.get(
-				`/me/username/validate/${ username }`
-			);
+			const { success, allowed_actions } = await wpcom
+				.undocumented()
+				.me()
+				.validateUsername( username );
 
 			this.setState( {
 				validationResult: { success, allowed_actions, validatedUsername: username },
@@ -472,7 +476,7 @@ class Account extends React.Component {
 		this.setState( { submittingForm: true } );
 
 		try {
-			await wpcom.req.post( '/me/username', { username, action } );
+			await wpcom.undocumented().me().changeUsername( username, action );
 			this.setState( { submittingForm: false } );
 
 			this.props.markSaved();

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -124,6 +124,8 @@ class Account extends React.Component {
 		validationResult: false,
 	};
 
+	debouncedUsernameValidate = debounce( this.validateUsername, 600 );
+
 	componentDidUpdate() {
 		if ( ! this.hasUnsavedUserSettings( ACCOUNT_FIELDS.concat( INTERFACE_FIELDS ) ) ) {
 			this.props.markSaved();
@@ -297,8 +299,6 @@ class Account extends React.Component {
 			this.setState( { validationResult: error } );
 		}
 	}
-
-	debouncedUsernameValidate = debounce( this.validateUsername, 600 );
 
 	hasEmailValidationError() {
 		return !! this.state.emailValidationError;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/53658 we removed/refactored some code, but it ended up causing the `/me/security` page to crash (see: https://github.com/Automattic/wp-calypso/issues/53670). 

We then attempted a fix in https://github.com/Automattic/wp-calypso/pull/53671, which did solve the problem, but a problem with the "Save Password" button being always disabled regardless of input changes, remained (or was introduced).

We'll revert both for now to fix the issue, and then come back to them later with a solution that still allows for the deprecated code in https://github.com/Automattic/wp-calypso/pull/53658 to be removed.

#### Testing instructions

1. Go to 'https://wordpress.com/me/security', it should load fine;
2. Go 'https://wordpress.com/me/security/password' and try to change the password to a new valid password. The button should become enabled and you'll be able to click it.

