### PR TITLE
Add tracks events to Jetpack logged-out checkout.

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -41,6 +41,7 @@ export default function CheckoutSystemDecider( {
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
+	isUserComingFromLoginForm,
 } ) {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
@@ -133,6 +134,7 @@ export default function CheckoutSystemDecider( {
 							isJetpackCheckout={ isJetpackCheckout }
 							jetpackSiteSlug={ jetpackSiteSlug }
 							jetpackPurchaseToken={ jetpackPurchaseToken }
+							isUserComingFromLoginForm={ isUserComingFromLoginForm }
 						/>
 					</StripeHookProvider>
 				</CalypsoShoppingCartProvider>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React, { useEffect, useState, useCallback } from 'react';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Checkout,
 	CheckoutStep,
@@ -58,6 +58,7 @@ import {
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/route';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PaymentMethodStep from './payment-method-step';
 import CheckoutHelpLink from './checkout-help-link';
 import type { CountryListItem } from '../types/country-list-item';
@@ -162,6 +163,7 @@ export default function WPCheckout( {
 	const total = useTotal();
 	const activePaymentMethod = usePaymentMethod();
 	const onEvent = useEvents();
+	const reduxDispatch = useReduxDispatch();
 
 	const areThereDomainProductsInCart =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
@@ -194,10 +196,12 @@ export default function WPCheckout( {
 
 		const loginUrl = login( { redirectTo, emailAddress } );
 
-		recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
-			email: emailAddress,
-			checkout_flow: isJetpackCheckout ? 'site_only_checkout' : 'wpcom_registrationless',
-		} );
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
+				email: emailAddress,
+				checkout_flow: isJetpackCheckout ? 'site_only_checkout' : 'wpcom_registrationless',
+			} )
+		);
 
 		return translate(
 			'That email address is already in use. If you have an existing account, {{a}}please log in{{/a}}.',
@@ -206,12 +210,14 @@ export default function WPCheckout( {
 					a: (
 						<a
 							onClick={ () =>
-								recordTracksEvent( 'calypso_checkout_composite_login_click', {
-									email: emailAddress,
-									checkout_flow: isJetpackCheckout
-										? 'site_only_checkout'
-										: 'wpcom_registrationless',
-								} )
+								reduxDispatch(
+									recordTracksEvent( 'calypso_checkout_composite_login_click', {
+										email: emailAddress,
+										checkout_flow: isJetpackCheckout
+											? 'site_only_checkout'
+											: 'wpcom_registrationless',
+									} )
+								)
 							}
 							href={ loginUrl }
 						/>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Checkout,
 	CheckoutStep,
@@ -193,12 +194,9 @@ export default function WPCheckout( {
 
 		const loginUrl = login( { redirectTo, emailAddress } );
 
-		onEvent( {
-			type: 'WPCOM_EMAIL_ALREADY_EXISTS',
-			payload: {
-				email: emailAddress,
-				checkoutFlow: isJetpackCheckout ? 'site_only_checkout' : 'wpcom_registrationless',
-			},
+		recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
+			email: emailAddress,
+			checkout_flow: isJetpackCheckout ? 'site_only_checkout' : 'wpcom_registrationless',
 		} );
 
 		return translate(
@@ -208,14 +206,11 @@ export default function WPCheckout( {
 					a: (
 						<a
 							onClick={ () =>
-								onEvent( {
-									type: 'REDIRECT_TO_LOGIN',
-									payload: {
-										email: emailAddress,
-										checkoutFlow: isJetpackCheckout
-											? 'jetpack_site_only'
-											: 'wpcom_registrationless',
-									},
+								recordTracksEvent( 'calypso_checkout_composite_login_click', {
+									email: emailAddress,
+									checkout_flow: isJetpackCheckout
+										? 'site_only_checkout'
+										: 'wpcom_registrationless',
 								} )
 							}
 							href={ loginUrl }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -193,11 +193,34 @@ export default function WPCheckout( {
 
 		const loginUrl = login( { redirectTo, emailAddress } );
 
+		onEvent( {
+			type: 'WPCOM_EMAIL_ALREADY_EXISTS',
+			payload: {
+				email: emailAddress,
+				checkoutFlow: isJetpackCheckout ? 'site_only_checkout' : 'wpcom_registrationless',
+			},
+		} );
+
 		return translate(
 			'That email address is already in use. If you have an existing account, {{a}}please log in{{/a}}.',
 			{
 				components: {
-					a: <a href={ loginUrl } />,
+					a: (
+						<a
+							onClick={ () =>
+								onEvent( {
+									type: 'REDIRECT_TO_LOGIN',
+									payload: {
+										email: emailAddress,
+										checkoutFlow: isJetpackCheckout
+											? 'jetpack_site_only'
+											: 'wpcom_registrationless',
+									},
+								} )
+							}
+							href={ loginUrl }
+						/>
+					),
 				},
 			}
 		);

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -202,6 +202,18 @@ export default function CompositeCheckout( {
 		[ reduxDispatch ]
 	);
 
+	const checkoutFlow: string = useMemo( () => {
+		if ( isLoggedOutCart ) {
+			if ( isJetpackCheckout ) {
+				return isUserComingFromLoginForm
+					? 'jetpack_site_only_coming_from_login'
+					: 'Jetpack_site_only';
+			}
+			return 'wpcom_registrationless';
+		}
+		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
+	}, [ isLoggedOutCart, isJetpackCheckout, isUserComingFromLoginForm, isJetpackNotAtomic ] );
+
 	const countriesList = useCountryList( overrideCountryList || [] );
 
 	const {
@@ -404,19 +416,6 @@ export default function CompositeCheckout( {
 		siteId,
 		productSlug: planSlugs.length > 0 ? planSlugs[ 0 ] : undefined,
 	} );
-
-	let checkoutFlow = '';
-	if ( isLoggedOutCart ) {
-		if ( isJetpackCheckout ) {
-			checkoutFlow = isUserComingFromLoginForm
-				? 'jetpack_site_only_coming_from_login'
-				: 'Jetpack_site_only';
-		} else {
-			checkoutFlow = 'wpcom_registrationless';
-		}
-	} else {
-		checkoutFlow = isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
-	}
 
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(
 		purchaseId,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -207,7 +207,7 @@ export default function CompositeCheckout( {
 			if ( isJetpackCheckout ) {
 				return isUserComingFromLoginForm
 					? 'jetpack_site_only_coming_from_login'
-					: 'Jetpack_site_only';
+					: 'jetpack_site_only';
 			}
 			return 'wpcom_registrationless';
 		}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -61,6 +61,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isFocusedLaunch,
 	siteSlug,
 	isJetpackCheckout = false,
+	checkoutFlow,
 }: {
 	createUserAndSiteBeforeTransaction?: boolean;
 	productAliasFromUrl?: string | undefined;
@@ -71,7 +72,8 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell?: boolean;
 	isFocusedLaunch?: boolean;
 	siteSlug: string | undefined;
-	isJetpackCheckout?: boolean;
+	isJetpackCheckout: boolean;
+	checkoutFlow: string;
 } ): PaymentCompleteCallback {
 	const { responseCart } = useShoppingCart();
 	const reduxDispatch = useDispatch();
@@ -119,6 +121,7 @@ export default function useCreatePaymentCompleteCallback( {
 					transactionResult,
 					redirectUrl: url,
 					responseCart,
+					checkoutFlow,
 					reduxDispatch,
 				} );
 			} catch ( err ) {
@@ -232,6 +235,7 @@ export default function useCreatePaymentCompleteCallback( {
 			createUserAndSiteBeforeTransaction,
 			isFocusedLaunch,
 			isJetpackCheckout,
+			checkoutFlow,
 		]
 	);
 }
@@ -314,12 +318,14 @@ function recordPaymentCompleteAnalytics( {
 	transactionResult,
 	redirectUrl,
 	responseCart,
+	checkoutFlow,
 	reduxDispatch,
 }: {
 	paymentMethodId: string | null;
 	transactionResult: WPCOMTransactionEndpointResponse | undefined;
 	redirectUrl: string;
 	responseCart: ResponseCart;
+	checkoutFlow: string;
 	reduxDispatch: ReturnType< typeof useDispatch >;
 } ) {
 	const wpcomPaymentMethod = paymentMethodId
@@ -356,6 +362,7 @@ function recordPaymentCompleteAnalytics( {
 			currency: responseCart.currency,
 			payment_method: wpcomPaymentMethod || '',
 			device,
+			checkout_flow: checkoutFlow,
 		} )
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -21,6 +21,7 @@ export default function useRecordCheckoutLoaded( {
 	responseCart,
 	storedCards,
 	productAliasFromUrl,
+	checkoutFlow,
 }: {
 	recordEvent: ( action: ReactStandardAction ) => void;
 	isLoading: boolean;
@@ -28,6 +29,7 @@ export default function useRecordCheckoutLoaded( {
 	responseCart: ResponseCart;
 	storedCards: StoredCard[];
 	productAliasFromUrl: string | undefined | null;
+	checkoutFlow: string;
 } ): void {
 	const hasRecordedCheckoutLoad = useRef( false );
 	if ( ! isLoading && ! hasRecordedCheckoutLoad.current ) {
@@ -39,6 +41,7 @@ export default function useRecordCheckoutLoaded( {
 				apple_pay_available: isApplePayAvailable,
 				product_slug: productAliasFromUrl,
 				is_renewal: hasRenewalItem( responseCart ),
+				checkout_flow: checkoutFlow,
 			},
 		} );
 		hasRecordedCheckoutLoad.current = true;

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -44,6 +44,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							apple_pay_available: action.payload?.apple_pay_available,
 							product_slug: action.payload?.product_slug,
 							is_composite: true,
+							checkout_flow: action.payload?.checkout_flow,
 						} )
 					);
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
@@ -311,6 +312,22 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				case 'VALIDATE_DOMAIN_CONTACT_INFO': {
 					// TODO: Decide what to do here
 					return;
+				}
+				case 'WPCOM_EMAIL_ALREADY_EXISTS': {
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
+							email: action.payload?.email,
+							checkout_flow: action.payload?.checkoutFlow,
+						} )
+					);
+				}
+				case 'REDIRECT_TO_LOGIN': {
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_login_click', {
+							email: action.payload?.email,
+							checkout_flow: action.payload?.checkpoutFlow,
+						} )
+					);
 				}
 				case 'SHOW_MODAL_AUTHORIZATION': {
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -313,22 +313,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					// TODO: Decide what to do here
 					return;
 				}
-				case 'WPCOM_EMAIL_ALREADY_EXISTS': {
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
-							email: action.payload?.email,
-							checkout_flow: action.payload?.checkoutFlow,
-						} )
-					);
-				}
-				case 'REDIRECT_TO_LOGIN': {
-					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_login_click', {
-							email: action.payload?.email,
-							checkout_flow: action.payload?.checkpoutFlow,
-						} )
-					);
-				}
 				case 'SHOW_MODAL_AUTHORIZATION': {
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -62,10 +62,9 @@ export function checkout( context, next ) {
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
 	const isUserComingFromLoginForm = context.query?.flow === 'logged-out-checkout';
 	const isJetpackCheckout =
-		( context.pathname.includes( '/checkout/jetpack' ) &&
-			( isLoggedOut || isUserComingFromLoginForm ) &&
-			( !! jetpackPurchaseToken || !! jetpackPurchaseNonce ) ) ??
-		false;
+		context.pathname.includes( '/checkout/jetpack' ) &&
+		( isLoggedOut || isUserComingFromLoginForm ) &&
+		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const jetpackSiteSlug = context.params.siteSlug;
 
 	// Do not use Jetpack checkout for Jetpack Anti Spam

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -62,9 +62,10 @@ export function checkout( context, next ) {
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
 	const isUserComingFromLoginForm = context.query?.flow === 'logged-out-checkout';
 	const isJetpackCheckout =
-		context.pathname.includes( '/checkout/jetpack' ) &&
-		( isLoggedOut || isUserComingFromLoginForm ) &&
-		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
+		( context.pathname.includes( '/checkout/jetpack' ) &&
+			( isLoggedOut || isUserComingFromLoginForm ) &&
+			( !! jetpackPurchaseToken || !! jetpackPurchaseNonce ) ) ??
+		false;
 	const jetpackSiteSlug = context.params.siteSlug;
 
 	// Do not use Jetpack checkout for Jetpack Anti Spam
@@ -129,6 +130,7 @@ export function checkout( context, next ) {
 			isJetpackCheckout={ isJetpackCheckout }
 			jetpackSiteSlug={ jetpackSiteSlug }
 			jetpackPurchaseToken={ jetpackPurchaseToken || jetpackPurchaseNonce }
+			isUserComingFromLoginForm={ isUserComingFromLoginForm }
 		/>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds tracks events to the Jetpack logged-out checkout flow. More specifically it adds events & properties for the purpose of being able to measure the number of new account signups vs existing account logins during the logged-out(site-only) checkout flow.

Asana Task: 1189109545411729-as-1199371465586276

#### Implementation notes:

1. Adds a `checkout_flow` property to the `calypso_checkout_page_view` event.  This `checkout_flow` property value will be one of:
    - `wpcom_checkout`
    - `jetpack_checkout`
    - `Jetpack_site_only`
    - `jetpack_site_only_coming_from_login`
    - `wpcom_registrationless`
2. Adds the `checkout_flow` property to the `calypso_checkout_composite_payment_complete` event.
3. Adds a `calypso_checkout_wpcom_email_exists` event that occurs when the user enters an email that is already associated with a WordPress.com account.
4. Adds a `calypso_checkout_composite_login_click` event that occurs when the user clicks the link to log into their existing account.

#### Testing instructions

* Download this PR.
* Start Calypso Blue with `yarn start`.
* Create a JN site.
* Connect the site (site-connected only - logged out of wordpress.com).  
* On the Pricing page, select a Jetpack product.
* On the Checkout page, replace `wordpress.com` with `calypso.localhost:3000` leaving the rest of the URL intact.
* Open Chrome developer tools and enter into the console, `localStorage.debug='calypso:analytics*';` Make sure you have the `Preserve Log` option selected.
* Refresh the checkout page and to ensure you are receiving the Tracks events output in the console.
* Verify that you receive the `calypso_checkout_page_view` event and that it contains the `checkout_flow` property with the value `jetpack_site_only`.
* Enter an email address that is linked to a WP.com account (you can use your A8c account). Enter your zipcode and country, and click "Continue".
* Here at this step you may see Invalid prop type warnings in the console..  These existed previously and are unrelated to the changes in this PR. I will fix it in a following PR, so please disregard the warning for now, if you don't mind..
* Verify that you receive the `calypso_checkout_wpcom_email_exists` event with props, `email` and `checkout_flow`.
* Under the Email field, click the "Please log in" link.
* Verify that you receive the `calypso_checkout_composite_login_click` event with props, `email` and `checkout_flow`.
* Login with your WP.com account.
* Once redirected to the Checkout page again, check the `calypso_checkout_page_view` event again and verify that it contains the `checkout_flow` property with the value `jetpack_site_only_coming_from_login`.
* Complete the purchase.
* Verify you receive the `calypso_checkout_composite_payment_complete` event and that it contains the prop `checkout_flow` and it's value is `jetpack_site_only_coming_from_login`;

If you feel so inclined, to be thorough, you can create another JN site and complete these steps again, except instead of entering an email address that is already linked to an existing WordPress.com account, you can enter an email that is **_not_** associated to any WordPress.com account, and complete the purchase. (To do this you'll need to add, `define( 'USE_STORE_SANDBOX', true );` into `/wp-content/mu-plugins/0-sandbox.php` in your sandbox. And point `public-api.wordpress.com` to your sandbox IP (in your hosts file). This is so we can use checkout with a test credit card. See p1HpG7-c5P-p2 for instructions on testing out the logged-out visitor checkout flow using a test credit card.)
When testing this flow, in the final `calypso_checkout_composite_payment_complete` event, verify that it contains the prop `checkout_flow` and it's value is `jetpack_site_only`;
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
