### PR TITLE
Checkout: Ignore domain mappings for domain contact validation

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -7,6 +7,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { ContactDetailsType, ManagedContactDetails } from '@automattic/wpcom-checkout';
 import { Field, styled } from '@automattic/wpcom-checkout';
+import {
+	isDomainProduct,
+	isDomainTransfer,
+	isDomainMapping,
+	getDomain,
+} from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -19,7 +25,6 @@ import {
 import type { CountryListItem } from '../types/country-list-item';
 import TaxFields from './tax-fields';
 import DomainContactDetails from './domain-contact-details';
-import { isDomainProduct, isDomainTransfer, getDomain } from '@automattic/calypso-products';
 
 const ContactDetailsFormDescription = styled.p`
 	font-size: 14px;
@@ -46,6 +51,7 @@ export default function ContactDetailsContainer( {
 	const { responseCart } = useShoppingCart();
 	const domainNames: string[] = responseCart.products
 		.filter( ( product ) => isDomainProduct( product ) || isDomainTransfer( product ) )
+		.filter( ( product ) => ! isDomainMapping( product ) )
 		.map( getDomain );
 	const {
 		updateDomainContactFields,

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -3,6 +3,12 @@
  */
 import { isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
+import {
+	getDomain,
+	isDomainTransfer,
+	isDomainProduct,
+	isDomainMapping,
+} from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -17,7 +23,6 @@ import {
 } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import wp from 'calypso/lib/wp';
-import { getDomain, isDomainTransfer, isDomainProduct } from '@automattic/calypso-products';
 
 const wpcom = wp.undocumented();
 
@@ -106,6 +111,7 @@ export async function getTaxValidationResult( contactInfo ) {
 export async function getDomainValidationResult( products, contactInfo ) {
 	const domainNames = products
 		.filter( ( product ) => isDomainProduct( product ) || isDomainTransfer( product ) )
+		.filter( ( product ) => ! isDomainMapping( product ) )
 		.map( getDomain );
 	const formattedContactDetails = prepareContactDetailsForValidation( 'domains', contactInfo );
 	return wpcomValidateDomainContactInformation( formattedContactDetails, domainNames );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When validating domain contact details, we do not need to validate domains used only for domain mapping. This may cause additional but unnecessary required fields.

This PR ignores domain mapping products when determining the domain names to validate.

Fixes https://github.com/Automattic/wp-calypso/issues/53679

#### Testing instructions

1. Make sure you're using a site without a plan.
1. Visit http://calypso.localhost:3000/domains/add/example.com for your site and add a `.com`, `.live`, or `.blog` domain registration to the cart.
2. Without completing checkout, visit http://calypso.localhost:3000/domains/add/mapping/example.com for your site and add a `.nl` domain mapping to the cart. Proceed to checkout.
2. Enter contact information for a Netherlands address (Country: `Netherlands`, Address: `Markweg Zuid 6`, Postal Code: `4794 SN`, City: `Heijningen`, Phone number: `0630385222`)
3. Click "Continue" to validate the contact information step.
4. Verify that the information validates with no errors.