### PR TITLE
Checkout: Add Fax field when .nl domain is in cart

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -59,6 +59,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		userCountryCode: PropTypes.string,
 		needsOnlyGoogleAppsDetails: PropTypes.bool,
 		needsAlternateEmailForGSuite: PropTypes.bool,
+		needsFax: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
 		translate: PropTypes.func,
 	};
@@ -287,6 +288,31 @@ export class ManagedContactDetailsFormFields extends Component {
 		);
 	}
 
+	renderContactDetailsFax() {
+		const { translate, needsFax } = this.props;
+
+		if ( ! needsFax ) {
+			return null;
+		}
+
+		return (
+			<>
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'fax',
+						Input,
+						{
+							label: translate( 'Fax' ),
+						},
+						{
+							customErrorMessage: this.props.contactDetailsErrors?.fax,
+						}
+					) }
+				</div>
+			</>
+		);
+	}
+
 	renderContactDetailsFields() {
 		const { translate, hasCountryStates } = this.props;
 		const form = getFormFromContactDetails(
@@ -312,6 +338,7 @@ export class ManagedContactDetailsFormFields extends Component {
 				</div>
 
 				{ this.renderContactDetailsEmailPhone() }
+				{ this.renderContactDetailsFax() }
 
 				{ countryCode && (
 					<RegionAddressFieldsets
@@ -452,11 +479,8 @@ function getMainFieldValues( form, countryCode, phoneCountryCode, hasCountryStat
 		state = '';
 	}
 
-	const fax = '';
-
 	return {
 		...mainFieldValues,
-		fax,
 		state,
 		phone: mainFieldValues.phone
 			? toIcannFormat( mainFieldValues.phone, countries[ phoneCountryCode ] )

--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { isDomainProduct, isDomainTransfer, isDomainMapping } from '@automattic/calypso-products';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
 import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 
@@ -44,6 +45,15 @@ export default function DomainContactDetails( {
 		! hasTransferProduct( responseCart );
 	const getIsFieldDisabled = () => isDisabled;
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
+	const needsFax = responseCart.products.some( ( product ) => {
+		if ( isDomainMapping( product ) ) {
+			return false;
+		}
+		if ( ! isDomainProduct( product ) || ! isDomainTransfer( product ) ) {
+			return false;
+		}
+		return product.meta.endsWith( '.nl' );
+	} );
 	const tlds = getAllTopLevelTlds( domainNames );
 
 	return (
@@ -51,6 +61,7 @@ export default function DomainContactDetails( {
 			<ManagedContactDetailsFormFields
 				needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
 				needsAlternateEmailForGSuite={ needsAlternateEmailForGSuite }
+				needsFax={ needsFax }
 				contactDetails={ contactDetails }
 				contactDetailsErrors={
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `.nl` TLD appears to require a "Fax" field in the contact details. This PR adds that field to checkout when a `.nl` domain registration or transfer is in the cart.

Related to https://github.com/Automattic/wp-calypso/issues/53679 although that was for domain mapping. 

Note that we do not appear to currently sell `.nl` domains, so this would just be for consistency with the [Edit Contact Details form](https://github.com/Automattic/wp-calypso/blob/34ead4d9acd36afd2b75ab3db0f9b1eaaf29106d/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx#L251-L256).

#### Testing instructions

(Note that if this is rebased over https://github.com/Automattic/wp-calypso/pull/53682 then the following instructions won't work any more and you'll have to come up with a hacked way to get a `.nl` domain in the cart, possibly by undoing the fixes in that PR.)

1. Start with a site that does not have a paid plan.
1. Visit http://calypso.localhost:3000/domains/add/example.com for your site and add a `.com`, `.live`, or `.blog` domain registration to the cart.
2. Without completing checkout, visit http://calypso.localhost:3000/domains/add/mapping/example.com for your site and add a `.nl` domain mapping to the cart. Proceed to checkout.
2. Verify that a "Fax" field is displayed in checkout.
2. Enter contact information for a Netherlands address, including the "Fax" field (Country: `Netherlands`, Address: `Markweg Zuid 6`, Postal Code: `4794 SN`, City: `Heijningen`, Phone number: `0630385222`)
3. Click "Continue" to validate the contact information step.
4. Verify that the information validates with no errors.