### PR TITLE
Checkout: Fix missing keys in tax line items

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -85,7 +85,7 @@ export default function PaymentMethodStep( {
 			<WPOrderReviewSection>
 				<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
 				{ taxLineItems.map( ( taxLineItem ) => (
-					<NonProductLineItem tax lineItem={ taxLineItem } />
+					<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 				) ) }
 				{ creditsLineItem && responseCart.sub_total_integer > 0 && (
 					<NonProductLineItem subtotal lineItem={ creditsLineItem } />

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -99,8 +99,8 @@ export function getTaxBreakdownLineItemsFromCart( responseCart: ResponseCart ): 
 		return lineItem ? [ lineItem ] : [];
 	}
 	return responseCart.total_tax_breakdown.map(
-		( taxBreakdownItem: TaxBreakdownItem, index: number ): LineItem => {
-			const id = `tax-line-item-${ index }`;
+		( taxBreakdownItem: TaxBreakdownItem ): LineItem => {
+			const id = `tax-line-item-${ taxBreakdownItem.label ?? taxBreakdownItem.rate }`;
 			const label = taxBreakdownItem.label
 				? `${ taxBreakdownItem.label } (${ taxBreakdownItem.rate_display })`
 				: String( translate( 'Tax' ) );

--- a/packages/wpcom-checkout/test/transformations.js
+++ b/packages/wpcom-checkout/test/transformations.js
@@ -179,7 +179,7 @@ describe( 'getTaxBreakdownLineItemsFromCart', function () {
 		};
 		const expected = [
 			{
-				id: 'tax-line-item-0',
+				id: 'tax-line-item-GST',
 				type: 'tax',
 				label: 'GST (5%)',
 				amount: {
@@ -189,7 +189,7 @@ describe( 'getTaxBreakdownLineItemsFromCart', function () {
 				},
 			},
 			{
-				id: 'tax-line-item-1',
+				id: 'tax-line-item-PST',
 				type: 'tax',
 				label: 'PST (10%)',
 				amount: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/53421 added support for multiple tax line items to checkout, but it was missing a `key` property for some of those items, which causes console errors to be displayed by React and has the potential to cause rendering problems. This PR adds the missing keys.

#### Testing instructions

- Add a product to your cart and visit checkout.
- Verify there are no errors in the console.