### PR TITLE
Displaying domain expiration date when auto-renew is enabled.

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { ToggleControl } from '@wordpress/components';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -39,9 +40,11 @@ class AutoRenewToggle extends Component {
 		siteSlug: PropTypes.string,
 		getChangePaymentMethodUrlFor: PropTypes.func,
 		paymentMethodUrl: PropTypes.string,
+		displayButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
+		displayButton: false,
 		fetchingUserPurchases: false,
 		getChangePaymentMethodUrlFor: getChangePaymentMethodPath,
 	};
@@ -198,7 +201,11 @@ class AutoRenewToggle extends Component {
 	}
 
 	renderTextStatus() {
-		const { translate, isEnabled } = this.props;
+		const { translate, isEnabled, displayButton } = this.props;
+
+		if ( displayButton ) {
+			return isEnabled ? translate( 'Disable auto renewal' ) : translate( 'Enable auto renewal' );
+		}
 
 		if ( this.isUpdatingAutoRenew() ) {
 			return translate( 'Auto-renew (…)' );
@@ -212,7 +219,7 @@ class AutoRenewToggle extends Component {
 	}
 
 	render() {
-		const { planName, siteDomain, purchase, withTextStatus } = this.props;
+		const { planName, siteDomain, purchase, withTextStatus, displayButton, isEnabled } = this.props;
 
 		if ( ! this.shouldRender( purchase ) ) {
 			return null;
@@ -220,12 +227,24 @@ class AutoRenewToggle extends Component {
 
 		return (
 			<>
-				<ToggleControl
-					checked={ this.getToggleUiStatus() }
-					disabled={ this.isUpdatingAutoRenew() }
-					onChange={ this.onToggleAutoRenew }
-					label={ withTextStatus && this.renderTextStatus() }
-				/>
+				{ displayButton ? (
+					<Button
+						busy={ this.isUpdatingAutoRenew() }
+						compact={ true }
+						label={ withTextStatus && this.renderTextStatus() }
+						onClick={ this.onToggleAutoRenew }
+						primary={ ! isEnabled }
+					>
+						{ withTextStatus && this.renderTextStatus() }
+					</Button>
+				) : (
+					<ToggleControl
+						checked={ this.getToggleUiStatus() }
+						disabled={ this.isUpdatingAutoRenew() }
+						onChange={ this.onToggleAutoRenew }
+						label={ withTextStatus && this.renderTextStatus() }
+					/>
+				) }
 				<AutoRenewDisablingDialog
 					isVisible={ this.state.showAutoRenewDisablingDialog }
 					planName={ planName }

--- a/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
@@ -3,12 +3,22 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
  */
 import { isExpiring, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
+
+const TextDiv = styled.div`
+	display: block;
+`;
+
+const ParentDiv = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
 
 function WrapDomainStatusButtons( props ) {
 	const wrapperClassNames = classNames( 'domain-types__wrap-me', props.className );
@@ -29,12 +39,13 @@ function DomainExpiryOrRenewal( { domain, isLoadingPurchase, moment, purchase, t
 		);
 	}
 
-	let text;
+	let renewalText;
+	let expirationText;
 
 	if ( domain.type === domainTypes.MAPPED && ! domain.expiry ) {
-		text = translate( 'Expires: Never' );
+		expirationText = translate( 'Expires: Never' );
 	} else if ( domain.expired ) {
-		text = translate( 'Expired: %(expiry_date)s', {
+		expirationText = translate( 'Expired: %(expiry_date)s', {
 			args: {
 				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
@@ -47,33 +58,44 @@ function DomainExpiryOrRenewal( { domain, isLoadingPurchase, moment, purchase, t
 		! shouldRenderExpiringCreditCard( purchase )
 	) {
 		if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
-			text = translate( 'Renews with your plan on %(renewal_date)s', {
+			renewalText = translate( 'Renews with your plan on %(renewal_date)s', {
 				args: {
 					renewal_date: moment( domain.autoRenewalDate ).format( 'LL' ),
 				},
 			} );
 		} else {
-			text = translate( 'Renews: %(renewal_date)s', {
+			renewalText = translate( 'Renews: %(renewal_date)s', {
 				args: {
 					renewal_date: moment( domain.autoRenewalDate ).format( 'LL' ),
 				},
 			} );
+
+			expirationText = translate( 'Expires: %(expiry_date)s', {
+				args: {
+					expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+				},
+			} );
 		}
 	} else if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
-		text = translate( 'Expires with your plan on %(expiry_date)s', {
+		expirationText = translate( 'Expires with your plan on %(expiry_date)s', {
 			args: {
 				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	} else {
-		text = translate( 'Expires: %(expiry_date)s', {
+		expirationText = translate( 'Expires: %(expiry_date)s', {
 			args: {
 				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	}
 
-	return <div>{ text }</div>;
+	return (
+		<ParentDiv>
+			{ renewalText && <TextDiv>{ renewalText }</TextDiv> }
+			{ expirationText && <TextDiv>{ expirationText }</TextDiv> }
+		</ParentDiv>
+	);
 }
 
 export { WrapDomainStatusButtons, DomainExpiryOrRenewal };

--- a/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
@@ -3,22 +3,12 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
  */
 import { isExpiring, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
-
-const TextDiv = styled.div`
-	display: block;
-`;
-
-const ParentDiv = styled.div`
-	display: flex;
-	flex-direction: column;
-`;
 
 function WrapDomainStatusButtons( props ) {
 	const wrapperClassNames = classNames( 'domain-types__wrap-me', props.className );
@@ -39,13 +29,12 @@ function DomainExpiryOrRenewal( { domain, isLoadingPurchase, moment, purchase, t
 		);
 	}
 
-	let renewalText;
-	let expirationText;
+	let text;
 
 	if ( domain.type === domainTypes.MAPPED && ! domain.expiry ) {
-		expirationText = translate( 'Expires: Never' );
+		text = translate( 'Expires: Never' );
 	} else if ( domain.expired ) {
-		expirationText = translate( 'Expired: %(expiry_date)s', {
+		text = translate( 'Expired: %(expiry_date)s', {
 			args: {
 				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
@@ -58,44 +47,33 @@ function DomainExpiryOrRenewal( { domain, isLoadingPurchase, moment, purchase, t
 		! shouldRenderExpiringCreditCard( purchase )
 	) {
 		if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
-			renewalText = translate( 'Renews with your plan on %(renewal_date)s', {
+			text = translate( 'Renews with your plan on %(renewal_date)s', {
 				args: {
 					renewal_date: moment( domain.autoRenewalDate ).format( 'LL' ),
 				},
 			} );
 		} else {
-			renewalText = translate( 'Renews: %(renewal_date)s', {
+			text = translate( 'Renews: %(renewal_date)s', {
 				args: {
 					renewal_date: moment( domain.autoRenewalDate ).format( 'LL' ),
 				},
 			} );
-
-			expirationText = translate( 'Expires: %(expiry_date)s', {
-				args: {
-					expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
-				},
-			} );
 		}
 	} else if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
-		expirationText = translate( 'Expires with your plan on %(expiry_date)s', {
+		text = translate( 'Expires with your plan on %(expiry_date)s', {
 			args: {
 				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	} else {
-		expirationText = translate( 'Expires: %(expiry_date)s', {
+		text = translate( 'Expires: %(expiry_date)s', {
 			args: {
 				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	}
 
-	return (
-		<ParentDiv>
-			{ renewalText && <TextDiv>{ renewalText }</TextDiv> }
-			{ expirationText && <TextDiv>{ expirationText }</TextDiv> }
-		</ParentDiv>
-	);
+	return <div>{ text }</div>;
 }
 
 export { WrapDomainStatusButtons, DomainExpiryOrRenewal };

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -351,7 +351,6 @@ class RegisteredDomainType extends React.Component {
 						domain={ domain }
 						isLoadingPurchase={ isLoadingPurchase }
 						moment={ this.props.moment }
-						translate={ this.props.translate }
 						selectedSite={ selectedSite }
 					/>
 				</Card>

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -36,7 +36,8 @@ import { shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import ExpiringSoon from '../card/notices/expiring-soon';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
-import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
+import { RenewOptionsRow } from './renew-options-row';
+import { WrapDomainStatusButtons } from './helpers';
 import OutboundTransferConfirmation from '../../components/outbound-transfer-confirmation';
 import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
 import PendingGSuiteTosNotice from 'calypso/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
@@ -345,9 +346,14 @@ class RegisteredDomainType extends React.Component {
 					{ this.renderPendingGSuiteTosNotice() }
 				</DomainStatus>
 				<Card compact={ true } className="domain-types__expiration-row">
-					<DomainExpiryOrRenewal { ...this.props } />
-					{ this.renderDefaultRenewButton() }
-					{ domain.currentUserCanManage && this.renderAutoRenew() }
+					<RenewOptionsRow
+						purchase={ purchase }
+						domain={ domain }
+						isLoadingPurchase={ isLoadingPurchase }
+						moment={ this.props.moment }
+						translate={ this.props.translate }
+						selectedSite={ selectedSite }
+					/>
 				</Card>
 				<DomainManagementNavigationEnhanced
 					domain={ domain }

--- a/client/my-sites/domains/domain-management/edit/domain-types/renew-options-row.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/renew-options-row.jsx
@@ -129,11 +129,14 @@ function RenewOptionsRow( { domain, isLoadingPurchase, moment, purchase, selecte
 						{ autoRenewStatus }
 					</ManualRenew>
 				) }
-				<BodyText>
-					<span>{ renewalText }</span>
-				</BodyText>
+				{ renewalText && (
+					<BodyText>
+						<span>{ renewalText }</span>
+					</BodyText>
+				) }
 				{ domain.currentUserCanManage && (
 					<AutoRenewToggle
+						displayButton={ true }
 						planName={ selectedSite.plan.product_name_short }
 						purchase={ purchase }
 						siteDomain={ selectedSite.domain }

--- a/client/my-sites/domains/domain-management/edit/domain-types/renew-options-row.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/renew-options-row.jsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import formatCurrency from '@automattic/format-currency';
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
+import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
+import { getRenewalPrice } from 'calypso/lib/purchases';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
+
+const ParentDiv = styled.div`
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	width: 100%;
+`;
+
+const Header = styled.div`
+	text-transform: uppercase;
+`;
+
+const BodyText = styled.p``;
+
+const RenewalPrice = styled.div`
+	flex-grow: 1;
+`;
+
+const AutoRenewal = styled.div`
+	flex-grow: 1;
+`;
+
+const Expiration = styled.div`
+	flex-grow: 1;
+`;
+
+function RenewOptionsRow( {
+	domain,
+	isLoadingPurchase,
+	moment,
+	purchase,
+	selectedSite,
+	translate,
+} ) {
+	const [ renewalText, setRenewalText ] = useState( null );
+
+	useEffect( () => {
+		if ( ! purchase ) return;
+
+		if ( 'manualRenew' !== purchase.expiryStatus ) {
+			if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
+				setRenewalText(
+					translate( 'Renews with your plan on %(renewal_date)s', {
+						args: {
+							renewal_date: moment.utc( purchase.renewDate ).format( 'LL' ),
+						},
+					} )
+				);
+			} else {
+				setRenewalText(
+					translate( 'Renews: %(renewal_date)s', {
+						args: {
+							renewal_date: moment.utc( purchase.renewDate ).format( 'LL' ),
+						},
+					} )
+				);
+			}
+		} else {
+			setRenewalText( 'Disabled' );
+		}
+	}, [ domain, purchase ] );
+
+	if ( isLoadingPurchase || ! selectedSite.ID ) {
+		return (
+			<div className="domain-types__expires-placeholder">
+				<p />
+			</div>
+		);
+	}
+
+	let expirationText;
+	const renewalPrice = getRenewalPrice( purchase );
+	const currencyCode = purchase.currencyCode;
+	const formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } );
+
+	if ( domain.type === domainTypes.MAPPED && ! domain.expiry ) {
+		expirationText = translate( 'Expires: Never' );
+	} else if ( domain.expired ) {
+		expirationText = translate( 'Expired: %(expiry_date)s', {
+			args: {
+				expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+			},
+		} );
+	} else {
+		expirationText = translate( 'Expires: %(expiry_date)s', {
+			args: {
+				expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+			},
+		} );
+	}
+
+	return (
+		<ParentDiv>
+			<RenewalPrice>
+				<Header>Renewal price</Header>
+				<BodyText>{ formattedPrice }/year</BodyText>
+			</RenewalPrice>
+			<AutoRenewal>
+				<Header>Auto renewal</Header>
+				<BodyText>{ renewalText }</BodyText>
+				{ domain.currentUserCanManage && selectedSite.ID && (
+					<AutoRenewToggle
+						planName={ selectedSite.plan.product_name_short }
+						purchase={ purchase }
+						siteDomain={ selectedSite.domain }
+						toggleSource="registered-domain-status"
+						withTextStatus={ true }
+					/>
+				) }
+			</AutoRenewal>
+			<Expiration>
+				<Header>Expiration date</Header>
+				<BodyText>{ expirationText }</BodyText>
+				<RenewButton
+					compact={ true }
+					purchase={ purchase }
+					selectedSite={ selectedSite }
+					subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
+					tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }
+				/>
+			</Expiration>
+		</ParentDiv>
+	);
+}
+
+export { RenewOptionsRow };


### PR DESCRIPTION
This PR updates the domain product info page to display the domain expiration date in addition to the renewal date (addressing the issue raised in Issue #53331). Discussed in pd2HMz-1j-p2.

Here's a screen capture showing the before and after states:
![CleanShot 2021-06-15 at 11 28 23](https://user-images.githubusercontent.com/35781181/122083018-7f70fb80-cdce-11eb-8872-a5d773bc716f.gif)

Here are screenshots of the final screens...
With autorenew DISABLED:
<img width="744" alt="CleanShot 2021-06-30 at 06 24 54@2x" src="https://user-images.githubusercontent.com/35781181/123945700-6c346300-d96c-11eb-8701-963133bd8cfa.png">

With autorenew ENABLED:
<img width="740" alt="CleanShot 2021-06-30 at 06 25 14@2x" src="https://user-images.githubusercontent.com/35781181/123945757-79e9e880-d96c-11eb-93f5-9db7fa7f22f3.png">

On mobile devices:
<img width="529" alt="CleanShot 2021-06-30 at 06 27 03@2x" src="https://user-images.githubusercontent.com/35781181/123945800-82daba00-d96c-11eb-96c9-ea86f447d8f8.png">


#### Testing instructions
* Checkout this PR.
* Go to a test site that includes a domain registered through WPcom.
* Enable auto-renew for the domain.
* Confirm that both the expiration and renewal dates are displayed.
* Confirm that the expiration date is displayed when auto-renew is disabled.

Closes #53331 
