### PR TITLE
Group radio buttons in "Cancel Purchase form"

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -359,8 +359,9 @@ class CancelPurchaseForm extends React.Component {
 			? this.state.questionOneText
 			: 'select_a_product';
 
-		const appendRadioOption = ( key, radioPrompt, textPlaceholder ) =>
+		const appendRadioOption = ( groupName, key, radioPrompt, textPlaceholder ) =>
 			( reasons[ key ] = radioTextOption(
+				groupName,
 				key,
 				questionOneRadio,
 				questionOneText,
@@ -371,6 +372,7 @@ class CancelPurchaseForm extends React.Component {
 			) );
 
 		const appendRadioOptionWithSelect = (
+			groupName,
 			key,
 			radioPrompt,
 			selectLabel,
@@ -378,6 +380,7 @@ class CancelPurchaseForm extends React.Component {
 			selected
 		) =>
 			( reasons[ key ] = radioSelectOption(
+				groupName,
 				key,
 				questionOneRadio,
 				this.onRadioOneChange,
@@ -389,24 +392,28 @@ class CancelPurchaseForm extends React.Component {
 			) );
 
 		appendRadioOption(
+			'questionOne',
 			'couldNotInstall',
 			translate( "I couldn't install a plugin/theme I wanted." ),
 			translate( 'What plugin/theme were you trying to install?' )
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'tooHard',
 			translate( 'It was too hard to set up my site.' ),
 			translate( 'Where did you run into problems?' )
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'didNotInclude',
 			translate( "This upgrade didn't include what I needed." ),
 			translate( 'What are we missing that you need?' )
 		);
 
 		appendRadioOptionWithSelect(
+			'questionOne',
 			'downgradeToAnotherPlan',
 			translate( "I'd like to downgrade to another plan." ),
 			translate( 'Mind telling us which one?' ),
@@ -415,33 +422,38 @@ class CancelPurchaseForm extends React.Component {
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'onlyNeedFree',
 			translate( 'The plan was too expensive.' ),
 			translate( 'How can we improve our upgrades?' )
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'couldNotActivate',
 			translate( 'I was unable to activate or use the product.' ),
 			translate( 'Where did you run into problems?' )
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'noLongerWantToTransfer',
 			translate( 'I no longer want to transfer my domain.' )
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'couldNotCompleteTransfer',
 			translate( 'Something went wrong and I could not complete the transfer.' )
 		);
 
 		appendRadioOption(
+			'questionOne',
 			'useDomainWithoutTransferring',
 			translate( 'I’m going to use my domain with WordPress.com without transferring it.' )
 		);
 
-		appendRadioOption( 'anotherReasonOne', translate( 'Another reason…' ), ' ' );
+		appendRadioOption( 'questionOne', 'anotherReasonOne', translate( 'Another reason…' ), ' ' );
 
 		return (
 			<div className="cancel-purchase-form__question">
@@ -460,8 +472,9 @@ class CancelPurchaseForm extends React.Component {
 			return null;
 		}
 
-		const appendRadioOption = ( key, radioPrompt, textPlaceholder ) =>
+		const appendRadioOption = ( groupName, key, radioPrompt, textPlaceholder ) =>
 			( reasons[ key ] = radioTextOption(
+				groupName,
 				key,
 				questionTwoRadio,
 				questionTwoText,
@@ -471,39 +484,48 @@ class CancelPurchaseForm extends React.Component {
 				textPlaceholder
 			) );
 
-		appendRadioOption( 'stayingHere', translate( "I'm staying here and using the free plan." ) );
+		appendRadioOption(
+			'questionTwo',
+			'stayingHere',
+			translate( "I'm staying here and using the free plan." )
+		);
 
 		appendRadioOption(
+			'questionTwo',
 			'otherWordPress',
 			translate( "I'm going to use WordPress somewhere else." ),
 			translate( 'Mind telling us where?' )
 		);
 
 		appendRadioOption(
+			'questionTwo',
 			'differentService',
 			translate( "I'm going to use a different service for my website or blog." ),
 			translate( 'Mind telling us which one?' )
 		);
 
 		appendRadioOption(
+			'questionTwo',
 			'noNeed',
 			translate( 'I no longer need a website or blog.' ),
 			translate( 'What will you do instead?' )
 		);
 
 		appendRadioOption(
+			'questionTwo',
 			'otherPlugin',
 			translate( 'I found a better plugin or service.' ),
 			translate( 'Mind telling us which one(s)?' )
 		);
 
 		appendRadioOption(
+			'questionTwo',
 			'leavingWP',
 			translate( "I'm moving my site off of WordPress." ),
 			translate( 'Any particular reason(s)?' )
 		);
 
-		appendRadioOption( 'anotherReasonTwo', translate( 'Another reason…' ), ' ' );
+		appendRadioOption( 'questionTwo', 'anotherReasonTwo', translate( 'Another reason…' ), ' ' );
 
 		return (
 			<div className="cancel-purchase-form__question">
@@ -518,9 +540,10 @@ class CancelPurchaseForm extends React.Component {
 		const { translate } = this.props;
 		const { importQuestionRadio, importQuestionText } = this.state;
 
-		const appendRadioOption = ( key, radioPrompt, textPlaceholder ) =>
+		const appendRadioOption = ( groupName, key, radioPrompt, textPlaceholder ) =>
 			reasons.push(
 				radioTextOption(
+					groupName,
 					key,
 					importQuestionRadio,
 					importQuestionText,
@@ -531,18 +554,24 @@ class CancelPurchaseForm extends React.Component {
 				)
 			);
 
-		appendRadioOption( 'happy', translate( 'I was happy.' ) );
+		appendRadioOption( 'importQuestion', 'happy', translate( 'I was happy.' ) );
 
 		appendRadioOption(
+			'importQuestion',
 			'look',
 			translate(
 				'Most of my content was imported, but it was too hard to get things looking right.'
 			)
 		);
 
-		appendRadioOption( 'content', translate( 'Not enough of my content was imported.' ) );
+		appendRadioOption(
+			'importQuestion',
+			'content',
+			translate( 'Not enough of my content was imported.' )
+		);
 
 		appendRadioOption(
+			'importQuestion',
 			'functionality',
 			translate( "I didn't have the functionality I have on my existing site." )
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/radio-option.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/radio-option.jsx
@@ -14,6 +14,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import SelectDropdown from 'calypso/components/select-dropdown';
 
 export const radioTextOption = (
+	groupName,
 	key,
 	radioValue,
 	textValue,
@@ -37,7 +38,7 @@ export const radioTextOption = (
 	return (
 		<FormLabel key={ key }>
 			<FormRadio
-				name={ key }
+				name={ groupName }
 				value={ key }
 				checked={ key === radioValue }
 				onChange={ onRadioChange }
@@ -49,6 +50,7 @@ export const radioTextOption = (
 };
 
 export const radioSelectOption = (
+	groupName,
 	key,
 	radioValue,
 	onRadioChange,
@@ -76,7 +78,7 @@ export const radioSelectOption = (
 		<React.Fragment key={ `fragment${ key }` }>
 			<FormLabel key={ key }>
 				<FormRadio
-					name={ key }
+					name={ groupName }
 					value={ key }
 					checked={ key === radioValue }
 					onChange={ onRadioChange }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This groups together radio buttons logically in the cancel purchase
form.
* There seems to be three logical groups: one for "question one",
another for "question two", and a third for "import questions", so they
have been grouped as such.
* This required some argument changes to `radioTextOption` and
`radioSelectOption` methods, but I checked and they do not seem to be
used anywhere else.

#### Testing instructions

1. Go to a user with purchases on WordPress.com, and then go to `/purchases/subscriptions` and try canceling your plan.
2. The radio buttons should now be logically grouped between questions one and two. You can use the keyboard to navigate between these radio options (up and down arrows within a group, and Tab between logical fields, just like any other radio button group).

https://user-images.githubusercontent.com/533/121996995-35d0e280-cdc7-11eb-83bd-d22a252fa013.mp4


Related to https://github.com/Automattic/wp-calypso/issues/48403
