### PR TITLE
Remove account-related wpcom.undocumented() methods (try 2)

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -57,18 +57,6 @@ UndocumentedMe.prototype.purchases = function ( callback ) {
 	return this.wpcom.req.get( '/me/purchases', callback );
 };
 
-UndocumentedMe.prototype.validatePassword = function ( password, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/settings/password/validate',
-		body: {
-			password: password,
-		},
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
 UndocumentedMe.prototype.sendSMSValidationCode = function ( callback ) {
 	const args = {
 		apiVersion: '1.1',
@@ -104,28 +92,6 @@ UndocumentedMe.prototype.getAppAuthCodes = function ( callback ) {
 	};
 
 	return this.wpcom.req.get( args, callback );
-};
-
-UndocumentedMe.prototype.validateUsername = function ( username, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/username/validate/' + username,
-	};
-
-	return this.wpcom.req.get( args, callback );
-};
-
-UndocumentedMe.prototype.changeUsername = function ( username, action, callback ) {
-	const args = {
-		apiVersion: '1.1',
-		path: '/me/username',
-		body: {
-			username: username,
-			action: action,
-		},
-	};
-
-	return this.wpcom.req.post( args, callback );
 };
 
 UndocumentedMe.prototype.getPeerReferralLink = function ( callback ) {

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -34,18 +34,12 @@ import wp from 'calypso/lib/wp';
  */
 import './style.scss';
 
-const wpcom = wp.undocumented();
-
 class AccountPassword extends React.Component {
 	state = {
 		password: '',
 		validation: null,
 		pendingValidation: true,
 	};
-
-	componentDidMount() {
-		this.debouncedPasswordValidate = debounce( this.validatePassword, 300 );
-	}
 
 	componentDidUpdate( prevProps ) {
 		if (
@@ -64,10 +58,10 @@ class AccountPassword extends React.Component {
 			pendingValidation: true,
 		} );
 		this.props.markChanged();
-		this.debouncedPasswordValidate();
+		this.validatePassword();
 	};
 
-	validatePassword = async () => {
+	validatePassword = debounce( async () => {
 		const password = this.state.password;
 
 		if ( '' === password ) {
@@ -76,18 +70,17 @@ class AccountPassword extends React.Component {
 		}
 
 		try {
-			const validationResult = await wpcom.me().validatePassword( password );
+			const validation = await wp.req.post( '/me/settings/password/validate', { password } );
 
-			this.setState( { pendingValidation: false, validation: validationResult } );
+			this.setState( { pendingValidation: false, validation } );
 		} catch ( err ) {
 			this.setState( { pendingValidation: false } );
-			return;
 		}
-	};
+	}, 300 );
 
 	handlePasswordChange = ( event ) => {
 		const newPassword = event.currentTarget.value;
-		this.debouncedPasswordValidate();
+		this.validatePassword();
 
 		this.setState( {
 			password: newPassword,


### PR DESCRIPTION
Second attempt to merge #53658 which turned to be quite a mess.

There are two things in `/me/account-password` that I'm doing better this time.

First, there is a very subtle difference between this:
```js
class Password extends Component {
  debouncedFoo = debounce( this.foo, 100 );
  foo() { ... }
}
```
and this:
```js
class Password extends Component {
  debouncedFoo = debounce( this.foo, 100 );
  foo = () => { ... }
}
```
In both cases, the `debouncedFoo` assignment is effectively done in constructor. It's equivalent to a statement
```js
this.debouncedFoo = debounce( this.foo, 100 );
```
in the constructor body.

But in the first case, `this.foo` is a class method, defined on prototype, and at the time when constructor is called it's already there. In the second case, however, it's a class property that hasn't been assigned yet. When written as statements in constructor, the logic looks like this:
```js
constructor() {
  this.debouncedFoo = debounce( this.foo, 100 );
  this.foo = () => { ... };
}
```
In this form, it's obvious it's going to fail.

Second, I was calling `wpcom.req.post` on a `wpcom` object that was a result of `wp.undocumented()` instead of being `wp` itself. But there's no `req` property on the `undocumented()` object.

How it all happened? I made changes to the `me/account/main.jsx` component and tested them. Then I went through exactly the same motions on the `me/account-password/index.jsx` component and this time tested only very superficially, if at all. And it turns out these same motions had a very different outcome and failed spectacularly. Deserves a post-mortem on a P2.

I'm making one additional improvement in this patch, hoping that it won't backfire (🙂). Instead of creating the `validateX` and `debouncedValidateX` methods, I just assign only one:
```js
validateX = debounce( async () => {
  ...
} );
```
This is more concise, and makes use of the fact that the unbounced method is never called.