### PR TITLE
Remove `jetpackModuleActive` import from Marketing routes definition

### DIFF
--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -6,7 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetpackModuleActive, navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	connections,
 	layout,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `jetpackModuleActive` import is no longer needed in the Marketing routes definition, since all its usages were removed in #53630 and #53632.

#### Testing instructions

N/A
