### PR TITLE
Login: Use user store library to clear local storage

### DIFF
--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -6,7 +6,7 @@ import type { Dispatch } from 'redux';
 /**
  * Internal dependencies
  */
-import user from 'calypso/lib/user';
+import { clearStore, getUserId } from 'calypso/lib/user/store';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getRedirectToSanitized, isTwoFactorEnabled } from 'calypso/state/login/selectors';
 
@@ -24,11 +24,11 @@ export const rebootAfterLogin = ( tracksEventArgs: Record< string, unknown > ) =
 	// Redirects to / if no redirect url is available
 	const url = getRedirectToSanitized( getState() ) || '/';
 
-	// user data is persisted in localstorage at `lib/user/user` line 157
+	// user ID is persisted in localstorage
 	// therefore we need to reset it before we redirect, otherwise we'll get
 	// mixed data from old and new user
-	if ( user().get() ) {
-		await user().clear();
+	if ( getUserId() ) {
+		await clearStore();
 	}
 
 	// We want to differentiate users going to `/oauth2/authorize` that are coming from

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -6,7 +6,7 @@ import type { Dispatch } from 'redux';
 /**
  * Internal dependencies
  */
-import { clearStore, getUserId } from 'calypso/lib/user/store';
+import { clearStore, getStoredUserId } from 'calypso/lib/user/store';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getRedirectToSanitized, isTwoFactorEnabled } from 'calypso/state/login/selectors';
 
@@ -27,7 +27,7 @@ export const rebootAfterLogin = ( tracksEventArgs: Record< string, unknown > ) =
 	// user ID is persisted in localstorage
 	// therefore we need to reset it before we redirect, otherwise we'll get
 	// mixed data from old and new user
-	if ( getUserId() ) {
+	if ( getStoredUserId() ) {
 		await clearStore();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the `rebootAfterLogin` action thunk to use the user store library for clearing the local storage instead of `lib/user`.

~Relies on #53663 and needs to be rebased once that's merged.~

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Follow the test instructions in #15041 and verify things still work the same as before.
