### PR TITLE
Domains: Improve mobile view

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -339,12 +339,12 @@ class DomainSearchResults extends React.Component {
 
 		return (
 			<div className="domain-search-results__domain-suggestions">
-				{ this.props.children }
 				{ suggestionCount }
 				{ featuredSuggestionElement }
 				{ suggestionElements }
 				{ unavailableOffer }
 				{ this.props.showSkipButton && domainSkipSuggestion }
+				{ this.props.children }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -264,7 +264,7 @@ body.is-section-signup.is-white-signup {
 		margin-left: 0;
 		margin-top: 0;
 		margin-bottom: 10px;
-		
+
 		.badge {
 			border-radius: 4px; /* stylelint-disable-line */
 			font-size: 0.75rem;
@@ -288,7 +288,7 @@ body.is-section-signup.is-white-signup {
 		@include break-mobile {
 			margin: 0 20px;
 		}
-		
+
 		@include break-large {
 			margin: 0;
 		}
@@ -345,13 +345,15 @@ body.is-section-signup.is-white-signup {
 			background: none;
 			border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
 			border-top: 1px solid #fff; //This white border is to prevent jumpiness while showing borders on hover
-			
+
 			@include break-mobile {
 				padding-left: 5px;
 				padding-right: 5px;
 			}
 
 			.domain-registration-suggestion__domain-title {
+				font-size: $font-body;
+
 				@include break-xlarge {
 					line-height: 3rem;
 				}
@@ -385,7 +387,7 @@ body.is-section-signup.is-white-signup {
 				line-height: 20px;
 				padding: 0.57em 1.17em;
 				font-weight: 500; /* stylelint-disable-line */
-				border-radius: 4px;  /* stylelint-disable-line */
+				border-radius: 4px; /* stylelint-disable-line */
 				box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 				border: 1px solid #c3c4c7;
 				letter-spacing: 0.32px;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -401,6 +401,7 @@ body.is-section-signup.is-white-signup {
 
 				@include break-mobile {
 					padding: 0.65em 2.8em;
+					width: auto;
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -282,7 +282,7 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.domain-suggestion {
-		flex-direction: row;
+		flex-direction: column;
 		box-shadow: none;
 
 		@include break-mobile {
@@ -384,6 +384,7 @@ body.is-section-signup.is-white-signup {
 			}
 
 			.domain-suggestion__action:not( .is-borderless ) {
+				width: 100%;
 				line-height: 20px;
 				padding: 0.57em 1.17em;
 				font-weight: 500; /* stylelint-disable-line */

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -283,6 +283,11 @@ body.is-section-signup.is-white-signup {
 
 	.domain-suggestion {
 		flex-direction: column;
+
+		@include break-mobile {
+			flex-direction: row;
+		}
+
 		box-shadow: none;
 
 		@include break-mobile {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -155,7 +155,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	border-radius: 4px; /* stylelint-disable-line */
 	margin: 0;
 	align-items: center;
-	background: #fdfdfd;
+	background: #ffffff;
 	border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
 
 	@include break-mobile {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -167,6 +167,10 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 
 	.domain-suggestion__action-container {
 		width: 100%;
+
+		@include break-mobile {
+			width: auto;
+		}
 	}
 
 	.button.domain-suggestion__action {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -79,11 +79,11 @@
 		width: 100%;
 	}
 
-    .domain-registration-suggestion__title-wrapper .domain-registration-suggestion__title {
-        width: auto;
-    }
+	.domain-registration-suggestion__title-wrapper .domain-registration-suggestion__title {
+		width: auto;
+	}
 
-    .domain-registration-suggestion__title {
+	.domain-registration-suggestion__title {
 		font-size: $font-title-small;
 		font-weight: 400;
 		line-height: 1.2;
@@ -165,8 +165,11 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		background: var( --color-surface );
 	}
 
+	.domain-suggestion__action-container {
+		width: 100%;
+	}
+
 	.button.domain-suggestion__action {
-		margin-top: 0;
 		font-weight: 500; /* stylelint-disable-line */
 		padding: 0.57em 1.17em;
 		border-radius: 4px; /* stylelint-disable-line */

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -107,7 +107,7 @@
 		&.is-free-domain,
 		&.is-sale-domain {
 			small {
-				font-size: 0.9em;
+				font-size: 0.9em; /* stylelint-disable-line */
 			}
 		}
 	}
@@ -239,19 +239,19 @@ body.is-section-signup.is-white-signup .featured-domain-suggestions {
 @include breakpoint-deprecated( '>660px' ) {
 	.domain-registration-suggestion__title {
 		.featured-domain-suggestions--title-in-18em & {
-			font-size: 1.8em;
+			font-size: 1.8em; /* stylelint-disable-line */
 		}
 		.featured-domain-suggestions--title-in-16em & {
-			font-size: 1.6em;
+			font-size: 1.6em; /* stylelint-disable-line */
 		}
 		.featured-domain-suggestions--title-in-14em & {
 			font-size: $font-title-small;
 		}
 		.featured-domain-suggestions--title-in-12em & {
-			font-size: 1.2em;
+			font-size: 1.2em; /* stylelint-disable-line */
 		}
 		.featured-domain-suggestions--title-in-10em & {
-			font-size: 1em;
+			font-size: 1em; /* stylelint-disable-line */
 		}
 	}
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -124,13 +124,19 @@ body.is-section-signup.is-white-signup {
 		box-shadow: none;
 
 		button.register-domain-step__next-page-button {
-			border: none;
-			color: #1d2327;
-			font-size: 0.875rem;
-			text-decoration-line: underline;
-			letter-spacing: -0.16px;
+			padding: 0.57em 1.17em;
+
+			border-radius: 4px; /* stylelint-disable-line */
+
+			line-height: rem( 20px );
 			font-weight: 500; /* stylelint-disable-line */
-			line-height: 1.25rem;
+			letter-spacing: 0.32px;
+
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+
+			@include break-mobile {
+				padding: 0.65em 2.8em;
+			}
 		}
 	}
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -205,11 +205,6 @@ class Signup extends React.Component {
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, undefined, locale ) );
 		}
-<<<<<<< HEAD
-=======
-
-		this.isReskinned = true;
->>>>>>> ae0aa7d789 (force reskin for testing)
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -205,6 +205,11 @@ class Signup extends React.Component {
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, undefined, locale ) );
 		}
+<<<<<<< HEAD
+=======
+
+		this.isReskinned = true;
+>>>>>>> ae0aa7d789 (force reskin for testing)
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

All proposed changes from #52905, **except for the search filters**, are implemented.

### Testing instructions
See gnYBUOBthTMckJRJr3pZmk-fi-2598%3A1 for reference.

1. Go to https://container-unruffled-nightingale.calypso.live/start/domains?flags=signup/reskin
2. Navigate to `/start/domains`.
3. Switch to a mobile viewport.
4. Search for a domain.
5. Ensure that:
    - [x] Font size for domain suggestions is `16px`.
    - [x] The 'Show more suggestions' link is now a button (same style as the 'Select' buttons in domain suggestions).
    - [x] The background of the first 2 domain suggestions is #ffffff.
    - [x] The border color of the active search bar is #646970.
    - [x] 'Already own a domain?' and 'Get a free plan' information containers are moved below the search results.

Fixes #52905