### PR TITLE
Jetpack Connect: redirect to wp-admin if site owns a Jetpack product

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -864,7 +864,7 @@ export class JetpackAuthorize extends Component {
 			>
 				<div className="jetpack-connect__authorize-form">
 					<div className="jetpack-connect__logged-in-form">
-						{ authSiteId && <QuerySitePurchases siteId={ authSiteId } /> }
+						<QuerySitePurchases siteId={ authSiteId } />
 						<QueryUserConnection
 							siteId={ authSiteId }
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -29,6 +29,7 @@ import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserConnection from 'calypso/components/data/query-user-connection';
 import Spinner from 'calypso/components/spinner';
 import userUtilities from 'calypso/lib/user/utils';
@@ -37,6 +38,10 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import {
+	isFetchingSitePurchases,
+	siteHasJetpackProductPurchase,
+} from 'calypso/state/purchases/selectors';
 import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
 import { login } from 'calypso/lib/paths';
@@ -103,7 +108,9 @@ export class JetpackAuthorize extends Component {
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		isSiteBlocked: PropTypes.bool,
+		isRequestingSitePurchases: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
+		siteHasJetpackPaidProduct: PropTypes.bool,
 		retryAuth: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		user: PropTypes.object.isRequired,
@@ -248,7 +255,14 @@ export class JetpackAuthorize extends Component {
 			);
 			this.externalRedirectOnce( redirectAfterAuth );
 		} else {
-			page.redirect( this.getRedirectionTarget() );
+			const { target, isExternal } = this.getRedirectionTarget();
+
+			if ( isExternal ) {
+				window.location.href = target;
+				return;
+			}
+
+			page.redirect( target );
 		}
 
 		this.setState( { isRedirecting: true } );
@@ -674,14 +688,14 @@ export class JetpackAuthorize extends Component {
 
 	getRedirectionTarget() {
 		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
-		const { partnerSlug, selectedPlanSlug } = this.props;
+		const { partnerSlug, selectedPlanSlug, siteHasJetpackPaidProduct } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
 			config.isEnabled( 'jetpack/connect-redirect-pressable-credential-approval' ) &&
 			'pressable' === partnerSlug
 		) {
-			return `/start/pressable-nux?blogid=${ clientId }`;
+			return { target: `/start/pressable-nux?blogid=${ clientId }`, isExternal: false };
 		}
 
 		// If the redirect is part of a Jetpack plan or product go to the checkout page
@@ -692,13 +706,25 @@ export class JetpackAuthorize extends Component {
 			// Once we decide we want to redirect the user to the checkout page and that there is a
 			// valid plan, we can safely remove it from the session storage
 			clearPlan();
-			return `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
+			return {
+				target: `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`,
+				isExternal: false,
+			};
 		}
 
-		return addQueryArgs(
-			{ redirect: redirectAfterAuth },
-			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
-		);
+		// If the site has a Jetpack paid product, send the user back to wp-admin rather than
+		// to the Plans page.
+		if ( siteHasJetpackPaidProduct ) {
+			return { target: redirectAfterAuth, isExternal: true };
+		}
+
+		return {
+			target: addQueryArgs(
+				{ redirect: redirectAfterAuth },
+				`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
+			),
+			isExternal: false,
+		};
 	}
 
 	renderFooterLinks() {
@@ -792,6 +818,7 @@ export class JetpackAuthorize extends Component {
 
 		if (
 			this.props.isFetchingAuthorizationSite ||
+			this.props.isRequestingSitePurchases ||
 			this.isAuthorizing() ||
 			this.retryingAuth ||
 			authorizeSuccess
@@ -825,6 +852,8 @@ export class JetpackAuthorize extends Component {
 
 		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
 
+		const authSiteId = this.props.authQuery.clientId;
+
 		return (
 			<MainWrapper
 				isWoo={ this.isWooOnboarding() }
@@ -835,8 +864,9 @@ export class JetpackAuthorize extends Component {
 			>
 				<div className="jetpack-connect__authorize-form">
 					<div className="jetpack-connect__logged-in-form">
+						{ authSiteId && <QuerySitePurchases siteId={ authSiteId } /> }
 						<QueryUserConnection
-							siteId={ this.props.authQuery.clientId }
+							siteId={ authSiteId }
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
 						/>
 						<AuthFormHeader
@@ -877,12 +907,14 @@ const connectComponent = connect(
 			isFetchingAuthorizationSite: isRequestingSite( state, authQuery.clientId ),
 			isFetchingSites: isRequestingSites( state ),
 			isMobileAppFlow,
+			isRequestingSitePurchases: isFetchingSitePurchases( state ),
 			isSiteBlocked: isSiteBlockedSelector( state ),
 			isVip: isVipSite( state, authQuery.clientId ),
 			mobileAppRedirect,
 			partnerID: getPartnerIdFromQuery( state ),
 			partnerSlug: getPartnerSlugFromQuery( state ),
 			selectedPlanSlug,
+			siteHasJetpackPaidProduct: siteHasJetpackProductPurchase( state, authQuery.clientId ),
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -258,7 +258,7 @@ export class JetpackAuthorize extends Component {
 			const { target, isExternal } = this.getRedirectionTarget();
 
 			if ( isExternal ) {
-				window.location.href = target;
+				externalRedirect( target );
 				return;
 			}
 

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -19,6 +19,9 @@ exports[`JetpackAuthorize renders as expected 1`] = `
     <div
       className="jetpack-connect__logged-in-form"
     >
+      <QuerySitePurchases
+        siteId={98765}
+      />
       <Connect(QueryUserConnection)
         siteId={98765}
         siteIsOnSitesList={false}


### PR DESCRIPTION
#### Motivation

Related to 1164141197617539-as-1200421580859783

Currently, after users approve the connection, Jetpack Connect redirects them to either checkout or the plans page. This works fine for users who don't already own a paid product but can confuse users that recently purchased a product and connected their site at the user level (the purchase was made through the new logged-out visitor checkout).

In short, the flow for these users looks like this: 
```
Connect at the site level -> purchase product -> connect at the user level -> Plans page
```

And we want it to be:
```
Connect at the site level -> purchase product -> connect at the user level -> wp-admin
```

#### Changes proposed in this Pull Request

* After a successful connection attempt, redirect users who own a paid product back to their site's wp-admin dashboard.

#### Testing instructions

* Download this PR and start Calypso Blue with `yarn start`.

##### Making sure we are not introducing a regression

* Create a JN site.
* Go to Settings -> Jetpack Constants, check the `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` option and save the changes.
* Go to the Jetpack module and start the setup process.
* Once you're on `https://wordpress.com/jetpack/connect/authorize`, replace `https://wordpress.com` with `http://calypso.localhost:3000` leaving the rest of the URL intact.
* Approve the connection.
* Make sure you're redirected to the Plans page located at `/jetpack/connect/plans/:site`.


##### Testing the new redirect

* Using the same site as before, purchase any Jetpack product (you can use Store Admin to do it).
* Go to your site's wp-admin dashboard.
* Go to the At a Glance section and disconnect your site.
* Start the setup process (connection process).
* Once you're on `https://wordpress.com/jetpack/connect/authorize`, replace `https://wordpress.com` with `http://calypso.localhost:3000` leaving the rest of the URL intact.
* Approve the connection.
* Make sure you're redirected back to your site's wp-admin.

#### Demo – with Jetpack Free (nothing changes here)

https://user-images.githubusercontent.com/3418513/122070153-b55cb280-cdc3-11eb-8a9f-3eacdac3e1a9.mp4


#### Demo – with a paid product (redirect back to wp-admin)

https://user-images.githubusercontent.com/3418513/122070165-b7bf0c80-cdc3-11eb-957a-00ed29d77e00.mp4


