### PR TITLE
fixed overflowing text sorted-grid date headings

### DIFF
--- a/client/components/sorted-grid/style.scss
+++ b/client/components/sorted-grid/style.scss
@@ -8,7 +8,7 @@
 .sorted-grid__label {
 	box-sizing: border-box;
 	display: flex;
-	height: 30px;
+	min-height: 30px;
 	padding: 6px 0;
 	margin: 0 10px 0 0;
 	color: var( --color-neutral-light );

--- a/client/components/sorted-grid/style.scss
+++ b/client/components/sorted-grid/style.scss
@@ -8,7 +8,6 @@
 .sorted-grid__label {
 	box-sizing: border-box;
 	display: flex;
-	min-height: 30px;
 	padding: 6px 0;
 	margin: 0 10px 0 0;
 	color: var( --color-neutral-light );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces {height: 30px} on the dates in the media board here <http://calypso.localhost:3000/media/:domain>  with {min-height: 30px}, which allows the text to take as much space as it needs.

#### Testing instructions

Before fix the dates above media tiles were overflowing.  To test, please compare http://calypso.localhost:3000/media/:domain on mobile width. Text should not overflow from the elements with class="sorted-grid_label.





