### PR TITLE
Emails: Add route for Email Comparison page

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -7,15 +7,16 @@ import { isEnabled } from '@automattic/calypso-config';
 /**
  * Internal Dependencies
  */
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
 import EmailManagement from 'calypso/my-sites/email/email-management';
+import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
+import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import TitanAddMailboxes from 'calypso/my-sites/email/titan-add-mailboxes';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import TitanControlPanelRedirect from 'calypso/my-sites/email/email-management/titan-control-panel-redirect';
 import TitanManageMailboxes from 'calypso/my-sites/email/email-management/titan-manage-mailboxes';
 import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan-management-iframe';
-import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 
 export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
@@ -73,6 +74,16 @@ export default {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<TitanAddMailboxes selectedDomainName={ pageContext.params.domain } />
+			</CalypsoShoppingCartProvider>
+		);
+
+		next();
+	},
+
+	emailManagementPurchaseNewEmailAccount( pageContext, next ) {
+		pageContext.primary = (
+			<CalypsoShoppingCartProvider>
+				<EmailProvidersComparison selectedDomainName={ pageContext.params.domain } />
 			</CalypsoShoppingCartProvider>
 		);
 

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -11,7 +11,6 @@ import React from 'react';
  */
 import { Card } from '@automattic/components';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
@@ -29,7 +28,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
-import { hasGSuiteSupportedDomain, hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import Main from 'calypso/components/main';
@@ -61,7 +60,6 @@ class EmailManagementHome extends React.Component {
 			selectedSite,
 			selectedDomainName,
 			currentRoute,
-			userCanPurchaseGSuite,
 		} = this.props;
 
 		if ( ! hasSiteDomainsLoaded || ! hasSitesLoaded || ! selectedSite ) {
@@ -82,14 +80,10 @@ class EmailManagementHome extends React.Component {
 
 			if ( ! domainHasEmail( selectedDomain ) ) {
 				return this.renderContentWithHeader(
-					<EmailProvidersComparison
-						domain={ selectedDomain }
-						isGSuiteSupported={
-							userCanPurchaseGSuite && hasGSuiteSupportedDomain( [ selectedDomain ] )
-						}
-					/>
+					<EmailProvidersComparison selectedDomainName={ selectedDomainName } />
 				);
 			}
+
 			return this.renderContentWithHeader(
 				<EmailPlan selectedSite={ selectedSite } domain={ selectedDomain } />
 			);
@@ -105,14 +99,8 @@ class EmailManagementHome extends React.Component {
 		const domainsWithNoEmail = nonWpcomDomains.filter( ( domain ) => ! domainHasEmail( domain ) );
 
 		if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
-			const firstDomainWithNoEmail = domainsWithNoEmail[ 0 ];
 			return this.renderContentWithHeader(
-				<EmailProvidersComparison
-					domain={ firstDomainWithNoEmail }
-					isGSuiteSupported={
-						userCanPurchaseGSuite && hasGSuiteSupportedDomain( [ firstDomainWithNoEmail ] )
-					}
-				/>
+				<EmailProvidersComparison selectedDomainName={ domainsWithNoEmail[ 0 ].name } />
 			);
 		}
 
@@ -186,6 +174,5 @@ export default connect( ( state ) => {
 		selectedSite: getSelectedSite( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
-		userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 	};
 } )( localize( EmailManagementHome ) );

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -9,7 +9,7 @@ import { Button, Card } from '@automattic/components';
  * Internal dependencies
  */
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
-import { emailManagement } from 'calypso/my-sites/email/paths';
+import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import SectionHeader from 'calypso/components/section-header';
 
 class EmailListInactive extends React.Component {
@@ -25,7 +25,13 @@ class EmailListInactive extends React.Component {
 				<Card key={ domain.name }>
 					<span>{ domain.name }</span>
 					{ canCurrentUserAddEmail( domain ) && (
-						<Button href={ emailManagement( selectedSiteSlug, domain.name, currentRoute ) }>
+						<Button
+							href={ emailManagementPurchaseNewEmailAccount(
+								selectedSiteSlug,
+								domain.name,
+								currentRoute
+							) }
+						>
 							{ translate( 'Add Email' ) }
 						</Button>
 					) }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -16,12 +16,7 @@ import Main from 'calypso/components/main';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
-import {
-	hasGSuiteSupportedDomain,
-	hasGSuiteWithAnotherProvider,
-	hasGSuiteWithUs,
-} from 'calypso/lib/gsuite';
-import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import { hasGSuiteWithAnotherProvider, hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import hasLoadedGSuiteUsers from 'calypso/state/selectors/has-loaded-gsuite-users';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
@@ -129,13 +124,7 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const {
-			domains,
-			hasGSuiteUsersLoaded,
-			hasSiteDomainsLoaded,
-			selectedDomainName,
-			userCanPurchaseGSuite,
-		} = this.props;
+		const { domains, hasGSuiteUsersLoaded, hasSiteDomainsLoaded, selectedDomainName } = this.props;
 
 		if ( ! hasGSuiteUsersLoaded || ! hasSiteDomainsLoaded ) {
 			return <Placeholder />;
@@ -155,15 +144,9 @@ class EmailManagement extends React.Component {
 			return this.emptyContent();
 		}
 
-		const selectedDomain = validDomains[ 0 ];
-		const isGSuiteSupported = hasGSuiteSupportedDomain( [ selectedDomain ] );
-
 		return (
 			<CalypsoShoppingCartProvider>
-				<EmailProvidersComparison
-					domain={ selectedDomain }
-					isGSuiteSupported={ isGSuiteSupported && userCanPurchaseGSuite }
-				/>
+				<EmailProvidersComparison selectedDomainName={ validDomains[ 0 ].name } />
 			</CalypsoShoppingCartProvider>
 		);
 	}
@@ -282,6 +265,5 @@ export default connect( ( state ) => {
 		previousRoute: getPreviousRoute( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
-		userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 	};
 } )( localize( EmailManagement ) );

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -19,12 +19,18 @@ import {
 } from 'calypso/lib/titan/new-mailbox';
 import { areAllUsersValid, getItemsForCart, newUsers } from 'calypso/lib/gsuite/new-users';
 import { Button } from '@automattic/components';
-import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
+import {
+	canCurrentUserAddEmail,
+	getCurrentUserCannotAddEmailReason,
+	getSelectedDomain,
+} from 'calypso/lib/domains';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import EmailProviderCard from './email-provider-card';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	getEmailForwardingFeatures,
 	getGoogleFeatures,
@@ -36,10 +42,15 @@ import {
 	GSUITE_BASIC_SLUG,
 } from 'calypso/lib/gsuite/constants';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
-import { getAnnualPrice, getGoogleMailServiceFamily, getMonthlyPrice } from 'calypso/lib/gsuite';
+import {
+	getAnnualPrice,
+	getGoogleMailServiceFamily,
+	getMonthlyPrice,
+	hasGSuiteSupportedDomain,
+} from 'calypso/lib/gsuite';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getTitanProductName } from 'calypso/lib/titan';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
@@ -54,6 +65,7 @@ import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powe
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import gSuiteLogo from 'calypso/assets/images/email-providers/gsuite.svg';
 import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -67,8 +79,19 @@ const identityMap = ( item ) => item;
 
 class EmailProvidersComparison extends React.Component {
 	static propTypes = {
-		domain: PropTypes.object.isRequired,
+		// Props passed to this component
+		selectedDomainName: PropTypes.string.isRequired,
+
+		// Props injected via connect()
+		currencyCode: PropTypes.string,
+		currentRoute: PropTypes.string,
+		domain: PropTypes.object,
+		gSuiteProduct: PropTypes.object,
 		isGSuiteSupported: PropTypes.bool.isRequired,
+		productsList: PropTypes.object.isRequired,
+		selectedSiteId: PropTypes.number,
+		selectedSiteSlug: PropTypes.string,
+		titanMailProduct: PropTypes.object,
 	};
 
 	isMounted = false;
@@ -76,16 +99,13 @@ class EmailProvidersComparison extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const isDomainEligibleForEmail = this.isDomainEligibleForEmail( props.domain );
-		const hasEmailForwards = this.doesDomainHaveEmailForwards( props.domain );
-
 		this.state = {
 			googleUsers: [],
-			titanMailboxes: [ buildNewTitanMailbox( props.domain.name, false ) ],
+			titanMailboxes: [ buildNewTitanMailbox( props.selectedDomainName, false ) ],
 			expanded: {
-				forwarding: hasEmailForwards && ! isDomainEligibleForEmail,
+				forwarding: false,
 				google: false,
-				titan: isDomainEligibleForEmail,
+				titan: true,
 			},
 			addingToCart: false,
 			validatedTitanMailboxUuids: [],
@@ -119,11 +139,11 @@ class EmailProvidersComparison extends React.Component {
 	};
 
 	goToEmailForwarding = () => {
-		const { domain, currentRoute, selectedSiteSlug } = this.props;
+		const { currentRoute, selectedDomainName, selectedSiteSlug } = this.props;
 
 		recordTracksEvent( 'calypso_email_providers_add_click', { provider: 'email-forwarding' } );
 
-		page( emailManagementForwarding( selectedSiteSlug, domain.name, currentRoute ) );
+		page( emailManagementForwarding( selectedSiteSlug, selectedDomainName, currentRoute ) );
 	};
 
 	onTitanMailboxesChange = ( updatedMailboxes ) =>
@@ -253,12 +273,6 @@ class EmailProvidersComparison extends React.Component {
 	renderEmailForwardingCard() {
 		const { domain, translate } = this.props;
 
-		const showExpandButton =
-			this.doesDomainHaveEmailForwards( domain ) || this.isDomainEligibleForEmail( domain );
-		const buttonLabel = this.doesDomainHaveEmailForwards( domain )
-			? translate( 'Manage email forwarding' )
-			: translate( 'Add email forwarding' );
-
 		return (
 			<EmailProviderCard
 				providerKey="forwarding"
@@ -269,8 +283,8 @@ class EmailProvidersComparison extends React.Component {
 				) }
 				detailsExpanded={ this.state.expanded.forwarding }
 				onExpandedChange={ this.onExpandedStateChange }
-				buttonLabel={ buttonLabel }
-				showExpandButton={ showExpandButton }
+				buttonLabel={ translate( 'Add email forwarding' ) }
+				showExpandButton={ this.isDomainEligibleForEmail( domain ) }
 				expandButtonLabel={ translate( 'Add email forwarding' ) }
 				onButtonClick={ this.goToEmailForwarding }
 				features={ getEmailForwardingFeatures() }
@@ -279,7 +293,14 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderGoogleCard() {
-		const { currencyCode, domain, gSuiteProduct, isGSuiteSupported, translate } = this.props;
+		const {
+			currencyCode,
+			domain,
+			gSuiteProduct,
+			isGSuiteSupported,
+			selectedDomainName,
+			translate,
+		} = this.props;
 
 		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {
@@ -314,16 +335,16 @@ class EmailProvidersComparison extends React.Component {
 		// If we don't have any users, initialize the list to have 1 empty user
 		const googleUsers =
 			( this.state.googleUsers ?? [] ).length === 0
-				? newUsers( domain.name )
+				? newUsers( selectedDomainName )
 				: this.state.googleUsers;
 
-		const formFields = (
+		const formFields = domain ? (
 			<FormFieldset>
 				<GSuiteNewUserList
 					extraValidation={ identityMap }
 					domains={ [ domain ] }
 					onUsersChange={ this.onGoogleUsersChange }
-					selectedDomainName={ domain.name }
+					selectedDomainName={ selectedDomainName }
 					users={ googleUsers }
 					onReturnKeyPress={ this.onGoogleFormReturnKeyPress }
 					showLabels={ true }
@@ -343,6 +364,8 @@ class EmailProvidersComparison extends React.Component {
 					</Button>
 				</GSuiteNewUserList>
 			</FormFieldset>
+		) : (
+			<FormFieldset></FormFieldset>
 		);
 
 		return (
@@ -373,7 +396,7 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderTitanCard() {
-		const { currencyCode, domain, titanMailProduct, translate } = this.props;
+		const { currencyCode, domain, selectedDomainName, titanMailProduct, translate } = this.props;
 
 		const formattedPrice = translate( '{{price/}} /user /month billed monthly', {
 			components: {
@@ -399,7 +422,7 @@ class EmailProvidersComparison extends React.Component {
 			<TitanNewMailboxList
 				onMailboxesChange={ this.onTitanMailboxesChange }
 				mailboxes={ this.state.titanMailboxes }
-				domain={ domain.name }
+				domain={ selectedDomainName }
 				onReturnKeyPress={ this.onTitanFormReturnKeyPress }
 				showLabels={ true }
 				validatedMailboxUuids={ this.state.validatedTitanMailboxUuids }
@@ -449,7 +472,8 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderHeaderSection() {
-		const { domain, translate } = this.props;
+		const { selectedDomainName, translate } = this.props;
+
 		const image = {
 			path: emailIllustration,
 			align: 'right',
@@ -457,7 +481,7 @@ class EmailProvidersComparison extends React.Component {
 
 		const translateArgs = {
 			args: {
-				domainName: domain.name,
+				domainName: selectedDomainName,
 			},
 			comment: '%(domainName)s is the domain name, e.g example.com',
 		};
@@ -478,10 +502,6 @@ class EmailProvidersComparison extends React.Component {
 				</p>
 			</PromoCard>
 		);
-	}
-
-	doesDomainHaveEmailForwards( domain ) {
-		return domain.emailForwardsCount > 0;
 	}
 
 	isDomainEligibleForEmail( domain ) {
@@ -523,15 +543,22 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	render() {
-		const { isGSuiteSupported } = this.props;
+		const { isGSuiteSupported, selectedSiteId } = this.props;
 
 		return (
 			<>
+				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
+
 				{ this.renderHeaderSection() }
+
 				{ this.renderDomainEligibilityNotice() }
+
 				{ this.renderTitanCard() }
+
 				{ this.renderGoogleCard() }
+
 				{ this.renderEmailForwardingCard() }
+
 				<TrackComponentView
 					eventName="calypso_email_providers_comparison_page_view"
 					eventProperties={ {
@@ -545,18 +572,32 @@ class EmailProvidersComparison extends React.Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const productSlug = config.isEnabled( 'google-workspace-migration' )
 			? GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
 			: GSUITE_BASIC_SLUG;
 
+		const selectedSiteId = getSelectedSiteId( state );
+		const domains = getDomainsBySiteId( state, selectedSiteId );
+		const domain = getSelectedDomain( {
+			domains,
+			selectedDomainName: ownProps.selectedDomainName,
+		} );
+
+		const isGSuiteSupported = domain
+			? canUserPurchaseGSuite( state ) && hasGSuiteSupportedDomain( [ domain ] )
+			: true;
+
 		return {
 			currencyCode: getCurrentUserCurrencyCode( state ),
-			gSuiteProduct: getProductBySlug( state, productSlug ),
-			titanMailProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
 			currentRoute: getCurrentRoute( state ),
+			domain,
+			gSuiteProduct: getProductBySlug( state, productSlug ),
+			isGSuiteSupported,
 			productsList: getProductsList( state ),
+			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
+			titanMailProduct: getProductBySlug( state, TITAN_MAIL_MONTHLY_SLUG ),
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -55,6 +55,7 @@ import { getTitanProductName } from 'calypso/lib/titan';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
 import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
+import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -364,9 +365,7 @@ class EmailProvidersComparison extends React.Component {
 					</Button>
 				</GSuiteNewUserList>
 			</FormFieldset>
-		) : (
-			<FormFieldset></FormFieldset>
-		);
+		) : null;
 
 		return (
 			<EmailProviderCard
@@ -546,7 +545,7 @@ class EmailProvidersComparison extends React.Component {
 		const { isGSuiteSupported, selectedSiteId } = this.props;
 
 		return (
-			<>
+			<Main wideLayout>
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
 				{ this.renderHeaderSection() }
@@ -566,7 +565,7 @@ class EmailProvidersComparison extends React.Component {
 						layout: 'stacked',
 					} }
 				/>
-			</>
+			</Main>
 		);
 	}
 }

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -104,6 +104,23 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
+			paths.emailManagementPurchaseNewEmailAccount(
+				':site',
+				':domain',
+				paths.emailManagementAllSitesPrefix
+			),
+			paths.emailManagementPurchaseNewEmailAccount( ':site', ':domain' ),
+		],
+		handlers: [
+			...commonHandlers,
+			controller.emailManagementPurchaseNewEmailAccount,
+			makeLayout,
+			clientRender,
+		],
+	} );
+
+	registerMultiPage( {
+		paths: [
 			paths.emailManagementNewTitanAccount(
 				':site',
 				':domain',

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -26,10 +26,10 @@ function resolveRootPath( relativeTo ) {
 /**
  * Retrieves the url of the Add New Mailboxes page either for G Suite or Google Workspace:
  *
- * https://wordpress.com/email/:domainName/google-workspace/add-users/:siteName
- * https://wordpress.com/email/:domainName/gsuite/add-users/:siteName
- * https://wordpress.com/email/google-workspace/add-users/:siteName
- * https://wordpress.com/email/gsuite/add-users/:siteName
+ *   https://wordpress.com/email/:domainName/google-workspace/add-users/:siteName
+ *   https://wordpress.com/email/:domainName/gsuite/add-users/:siteName
+ *   https://wordpress.com/email/google-workspace/add-users/:siteName
+ *   https://wordpress.com/email/gsuite/add-users/:siteName
  *
  * @param {string} siteName - slug of the current site
  * @param {string} domainName - domain name of the account to add users to
@@ -118,6 +118,20 @@ export function emailManagement( siteName, domainName, relativeTo = null ) {
 
 export function emailManagementForwarding( siteName, domainName, relativeTo = null ) {
 	return emailManagementEdit( siteName, domainName, 'forwarding', relativeTo );
+}
+
+/**
+ * Retrieves the url of the Email Comparison page:
+ *
+ *   https://wordpress.com/email/:domainName/purchase/:siteName
+ *
+ * @param {string} siteName - slug of the current site
+ * @param {string} domainName - domain name of the account to add users to
+ * @param {string} relativeTo - optional path prefix
+ * @returns {string} the corresponding url
+ */
+export function emailManagementPurchaseNewEmailAccount( siteName, domainName, relativeTo = null ) {
+	return emailManagementEdit( siteName, domainName, 'purchase', relativeTo );
 }
 
 export function emailManagementEdit(


### PR DESCRIPTION
This pull request is a preliminary step to implementing an [upgrade path](https://github.com/Automattic/wp-calypso/pull/53307) from email forwards to Professional Email and Google Workspace. It introduces a dedicated route for the `Email Comparison` page at:

```
https://wordpress.com/email/:domainName/purchase/:siteName
```

Previously, this page would be accessible from the url of the `Email Plan` page:

```
https://wordpress.com/email/:domainName/manage/:siteName
```

Now we have two separate routes, something that will allow us to show the `Email Plan` page for a domain that has email forwards while redirecting the user to the `Email Comparison` page if they wish to upgrade to a more powerful email solutions.

The `EmailProvidersComparison` component accepts a domain name and is responsible for loading any required data now. This change itself was much more complex than anticipated, as this component was not designed with that in mind and was expecting most of the data - especially a `domain` object - to be always present.

#### Testing instructions

1. Run `git checkout add/route-for-email-comparison-page` and start your server, or open a [live branch](https://calypso.live/?branch=add/route-for-email-comparison-page)
2. Log into a WordPress.com account that has a site with a domain but no email product yet
3. Open the [`Emails` page](http://calypso.localhost:3000/emails)
4. Click the `Add Email` button located in front of the domain name
5. Assert that the `Email Comparison` page displays and works as before
6. Append `?flags=force-sympathy` to the url (to disable state rehydration), then refresh the page
7. Assert that the `Email Comparison` page still works fine