### PR TITLE
Plans: Memoize PlansFilterBar to stop unnecessary re-renders

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -163,14 +163,17 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		return () => window.removeEventListener( 'resize', onResize );
 	}, [ onResize ] );
 
-	const filterBar = (
-		<div className="product-grid__filter-bar">
-			<PlansFilterBar
-				showDiscountMessage
-				onDurationChange={ onDurationChange }
-				duration={ duration }
-			/>
-		</div>
+	const filterBar = useMemo(
+		() => (
+			<div className="product-grid__filter-bar">
+				<PlansFilterBar
+					showDiscountMessage
+					onDurationChange={ onDurationChange }
+					duration={ duration }
+				/>
+			</div>
+		),
+		[ onDurationChange, duration ]
 	);
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Encapsulate the `plansFilterBar` variable inside `ProductGrid` in a `useMemo` expression so that React knows not to re-render it unless one of its dependent properties changes.

#### Testing instructions

* Open this PR in any experience (Calypso Blue/Green/Jetpack Connect).
* Visit the Plans/Pricing page.
* Verify that the monthly/yearly toggle still appears and behaves exactly as it does in production currently.

##### Notes

This change shouldn't result in any difference to visible behavior, but I encourage everyone to enable "Highlight updates when components render" in the React DevTools settings and watch to see if the PlansFilterBar renders itself more than once.

To dig deeper, consider hooking up `why-did-you-render` on your local testing environment. The instructions for doing so are too detailed for this PR description, but you can contact me directly if you'd like and I'll walk you through.

#### Reference captures

##### Before


https://user-images.githubusercontent.com/670067/122087651-91e93600-cdca-11eb-8aa5-5b5fc896a53e.mov

##### After

https://user-images.githubusercontent.com/670067/122087668-94e42680-cdca-11eb-8337-27a80cbfb517.mov