### PR TITLE
Update themes test to account for new modal

### DIFF
--- a/test/e2e/lib/components/theme-switch-confirmation-component.js
+++ b/test/e2e/lib/components/theme-switch-confirmation-component.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import AsyncBaseContainer from '../async-base-container.js';
+import * as driverHelper from '../driver-helper.js';
+
+export default class ThemeSwitchConfirmationComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.themes__auto-loading-homepage-modal' ) );
+	}
+
+	async _postInit() {
+		return await driverHelper.waitUntilElementLocatedAndVisible(
+			this.driver,
+			By.css( '.themes__auto-loading-homepage-modal h1' ),
+			this.explicitWaitMS
+		);
+	}
+
+	async activateTheme() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.dialog button[data-e2e-button="activeTheme"]' )
+		);
+	}
+}

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
@@ -14,6 +14,7 @@ import LoginFlow from '../../lib/flows/login-flow.js';
 import CustomizerPage from '../../lib/pages/customizer-page';
 import ThemesPage from '../../lib/pages/themes-page.js';
 import ThemeDialogComponent from '../../lib/components/theme-dialog-component.js';
+import ThemeSwitchConfirmationComponent from '../../lib/components/theme-switch-confirmation-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component';
 import WPAdminCustomizerPage from '../../lib/pages/wp-admin/wp-admin-customizer-page.js';
 import WPAdminLogonPage from '../../lib/pages/wp-admin/wp-admin-logon-page.js';
@@ -25,7 +26,7 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 // NOTE: test in jetpack env is failing due to some strange issue, when switching to new tab. It fails only in CI
-describe.skip( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function () {
+describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	it( 'Login', async function () {
@@ -42,12 +43,17 @@ describe.skip( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, fun
 		const themesPage = await ThemesPage.Expect( this.driver );
 		await themesPage.waitUntilThemesLoaded();
 		await themesPage.showOnlyFreeThemes();
-		await themesPage.searchFor( 'Twenty F' );
-		await themesPage.waitForThemeStartingWith( 'Twenty F' );
+		await themesPage.searchFor( 'Twenty Twen' );
+		await themesPage.waitForThemeStartingWith( 'Twenty Twen' );
 		await themesPage.clickNewThemeMoreButton();
 		const displayed = await themesPage.popOverMenuDisplayed();
 		assert( displayed, true, 'Popover menu not displayed' );
 		return await themesPage.clickPopoverItem( 'Activate' );
+	} );
+
+	it( 'Can see the theme switch confirmation dialog', async function () {
+		const themeSwitchConfirmationComponent = await ThemeSwitchConfirmationComponent.Expect( this.driver );
+		await themeSwitchConfirmationComponent.activateTheme();
 	} );
 
 	it( 'Can see the theme thanks dialog', async function () {

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
@@ -52,7 +52,9 @@ describe( `[${ host }] Activating Themes: (${ screenSize }) @parallel`, function
 	} );
 
 	it( 'Can see the theme switch confirmation dialog', async function () {
-		const themeSwitchConfirmationComponent = await ThemeSwitchConfirmationComponent.Expect( this.driver );
+		const themeSwitchConfirmationComponent = await ThemeSwitchConfirmationComponent.Expect(
+			this.driver
+		);
 		await themeSwitchConfirmationComponent.activateTheme();
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates and re-enables the theme switch test. A new modal was added that shows on certain themes. Because it doesn't show on all themes I also had to change our search so that the themes we're searching for and switching between both have the modal.

#### Testing instructions

Make sure `Activating Themes` test passes in CI
