### PR TITLE
Signup: Add validation to cart products before submitting

### DIFF
--- a/client/lib/signup/cart.ts
+++ b/client/lib/signup/cart.ts
@@ -32,40 +32,39 @@ function addProductsToCart( cart: ResponseCart, newCartItems: RequestCartProduct
 
 export type ErrorCallback = ( error: unknown ) => void;
 
-export default {
-	createCart: function (
-		cartKey: string,
-		newCartItems: RequestCartProduct[],
-		callback: ErrorCallback
-	): void {
-		const newCart = {
-			...getEmptyResponseCart(),
-			cart_key: cartKey,
-		};
+export function createCart(
+	cartKey: string,
+	newCartItems: RequestCartProduct[],
+	callback: ErrorCallback
+): void {
+	const newCart = {
+		...getEmptyResponseCart(),
+		cart_key: cartKey,
+	};
 
-		const updatedCart = addProductsToCart( newCart, newCartItems );
+	const updatedCart = addProductsToCart( newCart, newCartItems );
 
-		wpcom.undocumented().setCart( cartKey, updatedCart, function ( postError: unknown ) {
-			callback( postError );
-		} );
-	},
-	addToCart: function (
-		cartKey: string,
-		newCartItems: RequestCartProduct[],
-		callback: ErrorCallback
-	): void {
-		wpcom.undocumented().getCart( cartKey, function ( error: unknown, data: ResponseCart ) {
-			if ( error ) {
-				return callback( error );
-			}
+	wpcom.undocumented().setCart( cartKey, updatedCart, function ( postError: unknown ) {
+		callback( postError );
+	} );
+}
 
-			if ( ! Array.isArray( newCartItems ) ) {
-				newCartItems = [ newCartItems ];
-			}
+export function addToCart(
+	cartKey: string,
+	newCartItems: RequestCartProduct[],
+	callback: ErrorCallback
+): void {
+	wpcom.undocumented().getCart( cartKey, function ( error: unknown, data: ResponseCart ) {
+		if ( error ) {
+			return callback( error );
+		}
 
-			const newCart = addProductsToCart( data, newCartItems );
+		if ( ! Array.isArray( newCartItems ) ) {
+			newCartItems = [ newCartItems ];
+		}
 
-			wpcom.undocumented().setCart( cartKey, newCart, callback );
-		} );
-	},
-};
+		const newCart = addProductsToCart( data, newCartItems );
+
+		wpcom.undocumented().setCart( cartKey, newCart, callback );
+	} );
+}

--- a/client/lib/signup/cart.ts
+++ b/client/lib/signup/cart.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import type { ResponseCart, RequestCart, RequestCartProduct } from '@automattic/shopping-cart';
-import { getEmptyResponseCart, convertResponseCartToRequestCart } from '@automattic/shopping-cart';
+import {
+	getEmptyResponseCart,
+	convertResponseCartToRequestCart,
+	createRequestCartProduct,
+} from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -14,10 +18,12 @@ import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 function addProductsToCart( cart: ResponseCart, newCartItems: RequestCartProduct[] ): RequestCart {
 	const productsData = productsList.get();
-	const newProducts = newCartItems.map( function ( cartItem ) {
-		cartItem.extra = { ...cartItem.extra, context: 'signup' };
-		return fillInSingleCartItemAttributes( cartItem, productsData );
-	} );
+	const newProducts = newCartItems
+		.map( function ( cartItem ) {
+			cartItem.extra = { ...cartItem.extra, context: 'signup' };
+			return fillInSingleCartItemAttributes( cartItem, productsData );
+		} )
+		.map( createRequestCartProduct );
 	return convertResponseCartToRequestCart( {
 		...cart,
 		products: [ ...cart.products, ...newProducts ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

According to our endpoint error logs, signup is frequently requesting new shopping carts be created with invalid products (products missing a `product_id` are appearing with `context: "signup"`). 

This PR adds a guard to make sure that an error is thrown if signup attempts to submit an invalid cart item. Since signup does not have error handling on its actions, an error like this will cause signup to hang forever. That's not ideal, and there may be a way to add an error handler...

#### Testing instructions

- On an existing site without a plan or domain (it's ok if the site has already been launched), visit http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=example.com with your site substituted at the end.
- Type a search string into the domain search field (this is necessary for some reason).
- Scroll down to the bottom and click "Skip Purchase" where it says "This is your current free site address".
- Verify that you reach the plan selection step.
