### PR TITLE
Playwright: migrate `wp-media-edit-spec` with additional tests

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -35,6 +35,6 @@ export async function waitForElementEnabled(
 	const elementHandle = await page.waitForSelector( selector, options );
 	await Promise.all( [
 		elementHandle.waitForElementState( 'enabled', options ),
-		page.evaluate( ( element: any ) => element.ariaDisabled !== 'true', elementHandle ),
+		page.waitForFunction( ( element: any ) => element.ariaDisabled !== 'true', elementHandle ),
 	] );
 }

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+import { ElementHandle, Page } from 'playwright';
+
+/**
+ * Returns a boolean value on whether the element is considered 'disabled'.
+ *
+ * There are two definitions of disabled on wp-calypso:
+ * 		- traditional: set the `disabled` property on element.
+ * 		- aria: using the `aria-disabled` attribute.
+ *
+ * Playwright's `isEnabled` method does not look into `aria-disabled = "true"` when determining
+ * actionability. This means test steps may fail if it depends on the built-in `isEnabled` to
+ * assert actionability.
+ *
+ * @param {ElementHandle} elementHandle Element on page.
+ * @returns {Promise<boolean} True if ElementHandle is considered disabled, false otherwise.
+ */
+export async function isElementEnabled( elementHandle: ElementHandle ): Promise< boolean > {
+	const isEnabled = await elementHandle.isEnabled();
+	const isAriaEnabled = await elementHandle.getAttribute( 'aria-disabled' );
+
+	// If there is no `aria-disabled` attribute, then only take into account whether the element
+	// contains a `disabled` property set. For more information, see
+	// https://playwright.dev/docs/actionability#enabled.
+	if ( ! isAriaEnabled ) {
+		return isEnabled;
+	}
+
+	// Otherwise, check both the property set and aria for whether the element is considered 'disabled'.
+	return isEnabled && isAriaEnabled === 'true';
+}
+
+/**
+ * Waits for the element specified by the selector to become enabled.
+ *
+ * This function takes into account both `disabled` property and `aria-disabled="false"` attributes
+ * to determine whether the element is enabled.
+ *
+ * @param {Page} page Page object.
+ * @param {string} selector Selector of the target element.
+ * @param {{[key: string]: number}} options Object parameter.
+ * @param {number} options.timeout Timeout to override the default value.
+ *
+ */
+export async function waitForElementEnabled(
+	page: Page,
+	selector: string,
+	options?: { timeout?: number }
+): Promise< ElementHandle > {
+	const timeout = ( options?.timeout
+		? options?.timeout
+		: config.get( 'playwrightTimeoutMS' ) ) as number;
+	const elementHandle = await page.waitForSelector( selector );
+
+	for ( let i = 0; i <= timeout; i + 1000 ) {
+		const isEnabled = await isElementEnabled( elementHandle );
+		if ( isEnabled ) {
+			return elementHandle;
+		}
+	}
+
+	throw new Error( `Failed to wait for requested selector ${ selector } to be enabled.` );
+}

--- a/packages/calypso-e2e/src/index.ts
+++ b/packages/calypso-e2e/src/index.ts
@@ -5,5 +5,6 @@ export * as BrowserHelper from './browser-helper';
 export * as BrowserManager from './browser-manager';
 export * as MediaHelper from './media-helper';
 export * as DataHelper from './data-helper';
+export * as ElementHelper from './element-helper';
 export * from './lib';
 export * from './hooks';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -9,3 +9,4 @@ export * from './marketing-page';
 export * from './settings-page';
 export * from './themes-page';
 export * from './themes-detail-page';
+export * from './media-page';

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -71,7 +71,10 @@ export class MediaPage extends BaseContainer {
 	async selectItem( index: number ): Promise< void > {
 		// Playwright is able to select the nth matching item given a selector.
 		// See https://playwright.dev/docs/selectors#pick-n-th-match-from-the-query-result.
-		const elementHandle = await this.page.click( `:nth-match(${ selectors.items }, ${ index })` );
+		const elementHandle = await this.page.waitForSelector(
+			`:nth-match(${ selectors.items }, ${ index })`
+		);
+		await elementHandle.click();
 		await this.page.waitForFunction(
 			( element: any ) => element.classList.contains( 'is-selected' ),
 			elementHandle

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -10,7 +10,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	// Navigation tabs
-	navtabs: '.section-nav-tabs',
+	navTabs: '.section-nav-tabs',
 
 	// Gallery view
 	gallery: '.media-library__content',
@@ -91,21 +91,18 @@ export class MediaPage extends BaseContainer {
 	/**
 	 * Clicks on the navigation tab.
 	 *
-	 * @param {[key: string]: string } param0 Parameter object.
-	 * @param {string} param0.name Name of the tab to click.
+	 * @param {string} name Name of the tab to click.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async clickTab( {
-		name,
-	}: {
-		name: 'All' | 'Images' | 'Documents' | 'Videos' | 'Audio';
-	} ): Promise< void > {
-		await this.page.waitForSelector( selectors.navtabs );
-		await this.page.click( `${ selectors.navtabs } span:has-text("${ name }")` );
+	async clickTab( name: 'All' | 'Images' | 'Documents' | 'Videos' | 'Audio' ): Promise< void > {
+		await this.page.waitForSelector( selectors.navTabs );
+		const gallery = await this.page.waitForSelector( selectors.gallery );
+		await this.page.click( `${ selectors.navTabs } span:has-text("${ name }")` );
 		// Wait for all placeholders to disappear.
 		// Alternatively, waiting for `networkidle` will achieve the same objective
 		// at the cost of much longer resolving time (~20s).
 		await this.page.waitForSelector( '.is-placeholder', { state: 'hidden' } );
+		await gallery.waitForElementState( 'stable' );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -82,9 +82,7 @@ export class MediaPage extends BaseContainer {
 		await element.waitForElementState( 'visible' );
 		await element.click();
 		await element.waitForElementState( 'stable' );
-		const isSelected = await element.evaluate( ( node ) =>
-			node.classList.contains( 'is-selected' )
-		);
+		const isSelected = await element.getAttribute( 'class' ).includes( 'is-selected' );
 		if ( ! isSelected ) {
 			throw new Error( `Failed to select requested item number ${ item }` );
 		}

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -3,7 +3,6 @@
  */
 import { BaseContainer } from '../base-container';
 import { waitForElementEnabled } from '../../element-helper';
-// import { getViewportName } from '../../browser-helper';
 
 /**
  * Type dependencies
@@ -59,7 +58,7 @@ export class MediaPage extends BaseContainer {
 	}
 
 	/**
-	 * Given a 1-indexed number `n`, click on the nth item in the media gallery.
+	 * Given a 1-indexed number `n`, click and select the nth item in the media gallery.
 	 *
 	 * Note that if the media gallery has been filtered (eg. Images only), this method
 	 * will select the `nth` item in the filtered gallery as shown.
@@ -69,7 +68,7 @@ export class MediaPage extends BaseContainer {
 	 * @throws {Error} If requested item could not be located in the gallery, or if the click action
 	 * failed to select the gallery item.
 	 */
-	async clickItem( index: number ): Promise< void > {
+	async selectItem( index: number ): Promise< void > {
 		// Playwright is able to select the nth matching item given a selector.
 		// See https://playwright.dev/docs/selectors#pick-n-th-match-from-the-query-result.
 		const element = await this.page.waitForSelector(

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -1,0 +1,98 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	// Gallery view
+	gallery: '.media-frame-content',
+	items: '.attachments li',
+
+	// Item clicked view
+	editButton: '.edit-attachment',
+
+	// Image edit view
+	imageEditor: '.image-editor',
+	imagePreview: '.imgedit-crop-wrap img',
+	undoButton: 'imgedit-undo',
+	rotateButton: '.imgedit-r',
+	cancelButton: '.imgedit-cancel-btn',
+};
+
+/**
+ * Represents an instance of the WPCOM Media library page.
+ *
+ * @augments {BaseContainer}
+ */
+export class MediaPage extends BaseContainer {
+	/**
+	 * Constructs an instance of the MediaPage object.
+	 *
+	 * @param {Page} page Underlying page on which interactions take place.
+	 */
+	constructor( page: Page ) {
+		super( page, selectors.gallery );
+	}
+
+	/**
+	 * Given a 1-indexed number `n`, click on the nth item in the media gallery.
+	 *
+	 * @param {[key: string]: number } param0 Parameter object.
+	 * @param {number} param0.item nth media gallery item to be selected.
+	 * @returns {Promise<void>} No return value.
+	 * @throws {Error} If media gallery contains less items than the requested item.
+	 */
+	async click( { item }: { item: number } ): Promise< void > {
+		const items = await this.page.$$( selectors.items );
+
+		if ( item > items.length ) {
+			throw new Error(
+				`Was requested item ${ item } but only ${ items.length } items in the media gallery.`
+			);
+		}
+
+		const target = items[ item - 1 ];
+		await target.click();
+	}
+
+	/**
+	 * Clicks on the edit image button to enter image editor.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async editImage(): Promise< void > {
+		await this.page.click( selectors.editButton );
+		await this.page.waitForSelector( selectors.imageEditor );
+	}
+
+	/**
+	 * Rotates the image.
+	 *
+	 * @param {[key: string]: string } param0 Parameter object.
+	 * @param {string} param0.direction Rotation direction specified by either left or right.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async rotateImage( { direction }: { direction: 'left' | 'right' } ): Promise< void > {
+		const preview = await this.page.waitForSelector( selectors.imagePreview );
+		const selector = `${ selectors.rotateButton }${ direction }`;
+		await this.page.click( selector );
+		await preview.waitForElementState( 'stable' );
+		const undoButton = await this.page.waitForSelector( selectors.undoButton );
+		await undoButton.isEnabled();
+	}
+
+	/**
+	 * Cancels the image editing process and returns to the image view screen.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async cancelEdit(): Promise< void > {
+		const cancelButton = await this.page.waitForSelector( selectors.cancelButton );
+		await cancelButton.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
+import { waitForElementEnabled } from '../../element-helper';
 
 /**
  * Type dependencies
@@ -123,8 +124,7 @@ export class MediaPage extends BaseContainer {
 		const selector = `${ selectors.imageEditorToolbarButton } span:text("Rotate")`;
 		await this.page.click( selector );
 		await preview.waitForElementState( 'stable' );
-		const undoButton = await this.page.waitForSelector( selectors.imageEditorResetButton );
-		await undoButton.waitForElementState( 'enabled' );
+		await waitForElementEnabled( this.page, selectors.imageEditorResetButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -71,20 +71,11 @@ export class MediaPage extends BaseContainer {
 	async selectItem( index: number ): Promise< void > {
 		// Playwright is able to select the nth matching item given a selector.
 		// See https://playwright.dev/docs/selectors#pick-n-th-match-from-the-query-result.
-		const element = await this.page.waitForSelector(
-			`:nth-match(${ selectors.items }, ${ index })`
+		const elementHandle = await this.page.click( `:nth-match(${ selectors.items }, ${ index })` );
+		await this.page.waitForFunction(
+			( element: any ) => element.classList.contains( 'is-selected' ),
+			elementHandle
 		);
-
-		// Wait for the target element to be stable before checking for the `is-selected` class.
-		// Otherwise, Playwright executes too fast and the method throws despite successfully selecting.
-		await element.waitForElementState( 'visible' );
-		await element.click();
-		await element.waitForElementState( 'stable' );
-		const classAttributes = ( await element.getAttribute( 'class' ) ) as string;
-		const isSelected = classAttributes.includes( 'is-selected' );
-		if ( ! isSelected ) {
-			throw new Error( `Failed to select requested item number ${ index }` );
-		}
 	}
 
 	/**
@@ -121,7 +112,6 @@ export class MediaPage extends BaseContainer {
 	 */
 	async editImage(): Promise< void > {
 		await this.page.click( selectors.editButton );
-		await this.page.waitForSelector( selectors.mediaModalPreview );
 		await this.page.click( selectors.mediaModalEditButton );
 		await this.page.waitForSelector( selectors.imageEditorCanvas );
 	}
@@ -132,10 +122,9 @@ export class MediaPage extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async rotateImage(): Promise< void > {
-		const preview = await this.page.waitForSelector( selectors.imageEditorCanvas );
+		await this.page.waitForSelector( selectors.imageEditorCanvas );
 		const selector = `${ selectors.imageEditorToolbarButton } span:text("Rotate")`;
 		await this.page.click( selector );
-		await preview.waitForElementState( 'stable' );
 		await waitForElementEnabled( this.page, selectors.imageEditorResetButton );
 	}
 
@@ -145,8 +134,7 @@ export class MediaPage extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async cancelImageEdit(): Promise< void > {
-		const cancelButton = await this.page.waitForSelector( selectors.imageEditorCancelButton );
-		await cancelButton.click();
+		await this.page.click( selectors.imageEditorCancelButton );
 		await this.page.waitForSelector( selectors.mediaModal );
 	}
 }

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -7,6 +7,7 @@
 	"startBrowserTimeoutMS": 60000,
 	"startAppTimeoutMS": 240000,
 	"afterHookTimeoutMS": 60000,
+	"playwrightTimeoutMS": 30000,
 	"browser": "chrome",
 	"proxy": "direct",
 	"saveAllScreenshots": false,

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -7,7 +7,6 @@
 	"startBrowserTimeoutMS": 60000,
 	"startAppTimeoutMS": 240000,
 	"afterHookTimeoutMS": 60000,
-	"playwrightTimeoutMS": 30000,
 	"browser": "chrome",
 	"proxy": "direct",
 	"saveAllScreenshots": false,

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { DataHelper, LoginFlow, MediaPage, SidebarComponent } from '@automattic/calypso-e2e';
+
+describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
+	let mediaPage;
+
+	it( 'Log In', async function () {
+		const loginFlow = new LoginFlow( this.page );
+		await loginFlow.login();
+	} );
+
+	it( 'Navigate to Media', async function () {
+		const sidebarComponent = await SidebarComponent.Expect( this.page );
+		await sidebarComponent.gotoMenu( { heading: 'Media' } );
+	} );
+
+	it( 'See media content', async function () {
+		mediaPage = await MediaPage.Expect( this.page );
+	} );
+
+	it( 'Select the first media item', async function () {
+		await mediaPage.click( { item: 1 } );
+	} );
+
+	it( 'Click to edit selected media', async function () {
+		await mediaPage.editImage();
+	} );
+
+	it( 'Rotate image to the left', async function () {
+		await mediaPage.rotateImage( { direction: 'left' } );
+	} );
+
+	it( 'Cancel image edit', async function () {
+		await mediaPage.cancelEdit();
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -31,7 +31,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 			} );
 
 			it( 'Select the first image item', async function () {
-				await mediaPage.clickItem( 1 );
+				await mediaPage.selectItem( 1 );
 			} );
 
 			it( 'Click to edit selected image', async function () {

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -4,35 +4,79 @@
 import { DataHelper, LoginFlow, MediaPage, SidebarComponent } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
-	let mediaPage;
+	describe( 'Edit Image (Simple)', function () {
+		let mediaPage;
 
-	it( 'Log In', async function () {
-		const loginFlow = new LoginFlow( this.page );
-		await loginFlow.login();
+		it( 'Log In', async function () {
+			const loginFlow = new LoginFlow( this.page );
+			await loginFlow.login();
+		} );
+
+		it( 'Navigate to Media', async function () {
+			const sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.gotoMenu( { heading: 'Media' } );
+		} );
+
+		it( 'See media gallery', async function () {
+			mediaPage = await MediaPage.Expect( this.page );
+		} );
+
+		it( 'Show only images', async function () {
+			await mediaPage.clickTab( { name: 'Images' } );
+		} );
+
+		it( 'Select the first image item', async function () {
+			await mediaPage.clickOn( { item: 1 } );
+		} );
+
+		it( 'Click to edit selected image', async function () {
+			await mediaPage.editImage();
+		} );
+
+		it( 'Rotate image', async function () {
+			await mediaPage.rotateImage();
+		} );
+
+		it( 'Cancel image edit', async function () {
+			await mediaPage.cancelImageEdit();
+		} );
 	} );
 
-	it( 'Navigate to Media', async function () {
-		const sidebarComponent = await SidebarComponent.Expect( this.page );
-		await sidebarComponent.gotoMenu( { heading: 'Media' } );
-	} );
+	describe( 'Edit Image (Atomic)', function () {
+		let mediaPage;
 
-	it( 'See media content', async function () {
-		mediaPage = await MediaPage.Expect( this.page );
-	} );
+		it( 'Log In', async function () {
+			const loginFlow = new LoginFlow( this.page, 'wooCommerceUser' );
+			await loginFlow.login();
+		} );
 
-	it( 'Select the first media item', async function () {
-		await mediaPage.click( { item: 1 } );
-	} );
+		it( 'Navigate to Media', async function () {
+			const sidebarComponent = await SidebarComponent.Expect( this.page );
+			await sidebarComponent.gotoMenu( { heading: 'Media' } );
+		} );
 
-	it( 'Click to edit selected media', async function () {
-		await mediaPage.editImage();
-	} );
+		it( 'See media gallery', async function () {
+			mediaPage = await MediaPage.Expect( this.page );
+		} );
 
-	it( 'Rotate image to the left', async function () {
-		await mediaPage.rotateImage( { direction: 'left' } );
-	} );
+		it( 'Show only images', async function () {
+			await mediaPage.clickTab( { name: 'Images' } );
+		} );
 
-	it( 'Cancel image edit', async function () {
-		await mediaPage.cancelEdit();
+		it( 'Select the first image item', async function () {
+			await mediaPage.clickOn( { item: 1 } );
+		} );
+
+		it( 'Click to edit selected image', async function () {
+			await mediaPage.editImage();
+		} );
+
+		it( 'Rotate image', async function () {
+			await mediaPage.rotateImage();
+		} );
+
+		it( 'Cancel image edit', async function () {
+			await mediaPage.cancelImageEdit();
+		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -9,12 +9,12 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 
 		it( 'Log In', async function () {
 			const loginFlow = new LoginFlow( this.page );
-			await loginFlow.login();
+			await loginFlow.logIn();
 		} );
 
 		it( 'Navigate to Media', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { heading: 'Media' } );
+			await sidebarComponent.gotoMenu( { item: 'Media' } );
 		} );
 
 		it( 'See media gallery', async function () {
@@ -22,11 +22,11 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		} );
 
 		it( 'Show only images', async function () {
-			await mediaPage.clickTab( { name: 'Images' } );
+			await mediaPage.clickTab( 'Images' );
 		} );
 
 		it( 'Select the first image item', async function () {
-			await mediaPage.clickOn( { item: 1 } );
+			await mediaPage.clickItem( 1 );
 		} );
 
 		it( 'Click to edit selected image', async function () {
@@ -47,12 +47,12 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 
 		it( 'Log In', async function () {
 			const loginFlow = new LoginFlow( this.page, 'wooCommerceUser' );
-			await loginFlow.login();
+			await loginFlow.logIn();
 		} );
 
 		it( 'Navigate to Media', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { heading: 'Media' } );
+			await sidebarComponent.gotoMenu( { item: 'Media' } );
 		} );
 
 		it( 'See media gallery', async function () {
@@ -60,11 +60,11 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		} );
 
 		it( 'Show only images', async function () {
-			await mediaPage.clickTab( { name: 'Images' } );
+			await mediaPage.clickTab( 'Images' );
 		} );
 
 		it( 'Select the first image item', async function () {
-			await mediaPage.clickOn( { item: 1 } );
+			await mediaPage.clickItem( 1 );
 		} );
 
 		it( 'Click to edit selected image', async function () {

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -4,79 +4,47 @@
 import { DataHelper, LoginFlow, MediaPage, SidebarComponent } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
-	describe( 'Edit Image (Simple)', function () {
-		let mediaPage;
+	// Parametrized test.
+	[
+		[ 'Simple', 'defaultUser' ],
+		[ 'Atomic', 'wooCommerceUser' ],
+	].forEach( function ( [ siteType, user ] ) {
+		describe( `Edit Image (${ siteType })`, function () {
+			let mediaPage;
 
-		it( 'Log In', async function () {
-			const loginFlow = new LoginFlow( this.page );
-			await loginFlow.logIn();
-		} );
+			it( 'Log In', async function () {
+				const loginFlow = new LoginFlow( this.page, user );
+				await loginFlow.logIn();
+			} );
 
-		it( 'Navigate to Media', async function () {
-			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { item: 'Media' } );
-		} );
+			it( 'Navigate to Media', async function () {
+				const sidebarComponent = await SidebarComponent.Expect( this.page );
+				await sidebarComponent.gotoMenu( { item: 'Media' } );
+			} );
 
-		it( 'See media gallery', async function () {
-			mediaPage = await MediaPage.Expect( this.page );
-		} );
+			it( 'See media gallery', async function () {
+				mediaPage = await MediaPage.Expect( this.page );
+			} );
 
-		it( 'Show only images', async function () {
-			await mediaPage.clickTab( 'Images' );
-		} );
+			it( 'Show only images', async function () {
+				await mediaPage.clickTab( 'Images' );
+			} );
 
-		it( 'Select the first image item', async function () {
-			await mediaPage.clickItem( 1 );
-		} );
+			it( 'Select the first image item', async function () {
+				await mediaPage.clickItem( 1 );
+			} );
 
-		it( 'Click to edit selected image', async function () {
-			await mediaPage.editImage();
-		} );
+			it( 'Click to edit selected image', async function () {
+				await mediaPage.editImage();
+			} );
 
-		it( 'Rotate image', async function () {
-			await mediaPage.rotateImage();
-		} );
+			it( 'Rotate image', async function () {
+				await mediaPage.rotateImage();
+			} );
 
-		it( 'Cancel image edit', async function () {
-			await mediaPage.cancelImageEdit();
-		} );
-	} );
-
-	describe( 'Edit Image (Atomic)', function () {
-		let mediaPage;
-
-		it( 'Log In', async function () {
-			const loginFlow = new LoginFlow( this.page, 'wooCommerceUser' );
-			await loginFlow.logIn();
-		} );
-
-		it( 'Navigate to Media', async function () {
-			const sidebarComponent = await SidebarComponent.Expect( this.page );
-			await sidebarComponent.gotoMenu( { item: 'Media' } );
-		} );
-
-		it( 'See media gallery', async function () {
-			mediaPage = await MediaPage.Expect( this.page );
-		} );
-
-		it( 'Show only images', async function () {
-			await mediaPage.clickTab( 'Images' );
-		} );
-
-		it( 'Select the first image item', async function () {
-			await mediaPage.clickItem( 1 );
-		} );
-
-		it( 'Click to edit selected image', async function () {
-			await mediaPage.editImage();
-		} );
-
-		it( 'Rotate image', async function () {
-			await mediaPage.rotateImage();
-		} );
-
-		it( 'Cancel image edit', async function () {
-			await mediaPage.cancelImageEdit();
+			it( 'Cancel image edit', async function () {
+				await mediaPage.cancelImageEdit();
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `wp-media-edit-spec` to Playwright and adds new test cases not implemented in the original file.

- test the sidebar navigation to media, filtering media type using tab bar, rotating image and cancel.
- implement the above tests for both Simple and Atomic sites.

#### Testing instructions

TeamCity
- ensure Playwright E2E tests on this branch completes as expected.

Local
- pull the branch
- transpile TypeScript code
- run the migrated spec file with `mocha --config .mocharc_playwright.yml specs/specs-playwright/wp-media__edit-spec.js`

Parent: #53566 
Related to #52849