### PR TITLE
Refactor simulated progressbar to be a seperate component

### DIFF
--- a/client/my-sites/plugins/marketplace/components/simulated-progressbar/index.tsx
+++ b/client/my-sites/plugins/marketplace/components/simulated-progressbar/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import { ProgressBar } from '@automattic/components';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+	text-align: center;
+`;
+const StyledProgressBar = styled( ProgressBar )`
+	margin: 20px 0px;
+`;
+
+const Title = styled.h1`
+	font-size: 2rem;
+`;
+
+export function resolveStep(
+	steps: TranslateResult[],
+	currentPercentage: number
+): TranslateResult {
+	const totalSteps = steps.length;
+	const perStepPercentage = 100 / totalSteps;
+	const quotient = Math.floor( currentPercentage / perStepPercentage );
+
+	if ( currentPercentage <= perStepPercentage ) {
+		return steps[ 0 ];
+	} else if ( currentPercentage >= perStepPercentage * totalSteps ) {
+		return steps[ steps.length - 1 ];
+	}
+	return steps[ quotient ];
+}
+
+export default function SimulatedProgressbar( {
+	steps,
+}: {
+	steps: TranslateResult[];
+} ): JSX.Element {
+	const translate = useTranslate();
+	const [ currentStep, setCurrentStep ] = useState( steps[ 0 ] );
+	const [ simulatedProgressPercentage, setSimulatedProgressPercentage ] = useState( 1 );
+
+	const SIMULATION_REFRESH_INTERVAL = 2000;
+	const INCREMENTED_PERCENTAGE_SIZE_ON_STEP = 6;
+	const MAX_PERCENTAGE_SIMULATED = 100 - INCREMENTED_PERCENTAGE_SIZE_ON_STEP * 2;
+	useEffect( () => {
+		setTimeout(
+			() => {
+				if ( simulatedProgressPercentage < MAX_PERCENTAGE_SIMULATED ) {
+					setSimulatedProgressPercentage(
+						( previousPercentage ) => previousPercentage + INCREMENTED_PERCENTAGE_SIZE_ON_STEP
+					);
+				}
+			},
+
+			SIMULATION_REFRESH_INTERVAL
+		);
+	}, [ MAX_PERCENTAGE_SIMULATED, simulatedProgressPercentage ] );
+
+	const newStep = resolveStep( steps, simulatedProgressPercentage );
+	if ( newStep !== currentStep ) setCurrentStep( newStep );
+
+	const currentNumericStep = steps.indexOf( currentStep ) + 1;
+
+	/* translators: %(currentStep)s  Is the current step number, given that steps are set of counting numbers representing each step starting from 1, %(stepCount)s  Is the total number of steps, Eg: Step 1 of 3  */
+	const stepIndication = translate( 'Step %(currentStep)s of %(stepCount)s', {
+		args: { currentStep: currentNumericStep, stepCount: steps.length },
+	} );
+
+	return (
+		<Container>
+			<Title className="simulated-progressbar__title wp-brand-font">{ currentStep }</Title>
+			<StyledProgressBar value={ simulatedProgressPercentage } color="#C9356E" compact />
+			<div>{ stepIndication }</div>
+		</Container>
+	);
+}

--- a/client/my-sites/plugins/marketplace/components/simulated-progressbar/index.tsx
+++ b/client/my-sites/plugins/marketplace/components/simulated-progressbar/index.tsx
@@ -33,7 +33,11 @@ export function resolveStep(
 	return steps[ quotient ];
 }
 
-export default function SimulatedProgressbar( {
+const SIMULATION_REFRESH_INTERVAL = 2000;
+const INCREMENTED_PERCENTAGE_SIZE_ON_STEP = 6;
+const MAX_PERCENTAGE_SIMULATED = 100 - INCREMENTED_PERCENTAGE_SIZE_ON_STEP * 2;
+
+export default function SimulatedProgressBar( {
 	steps,
 }: {
 	steps: TranslateResult[];
@@ -42,9 +46,6 @@ export default function SimulatedProgressbar( {
 	const [ currentStep, setCurrentStep ] = useState( steps[ 0 ] );
 	const [ simulatedProgressPercentage, setSimulatedProgressPercentage ] = useState( 1 );
 
-	const SIMULATION_REFRESH_INTERVAL = 2000;
-	const INCREMENTED_PERCENTAGE_SIZE_ON_STEP = 6;
-	const MAX_PERCENTAGE_SIMULATED = 100 - INCREMENTED_PERCENTAGE_SIZE_ON_STEP * 2;
 	useEffect( () => {
 		setTimeout(
 			() => {
@@ -57,10 +58,12 @@ export default function SimulatedProgressbar( {
 
 			SIMULATION_REFRESH_INTERVAL
 		);
-	}, [ MAX_PERCENTAGE_SIMULATED, simulatedProgressPercentage ] );
+	}, [ simulatedProgressPercentage ] );
 
 	const newStep = resolveStep( steps, simulatedProgressPercentage );
-	if ( newStep !== currentStep ) setCurrentStep( newStep );
+	if ( newStep !== currentStep ) {
+		setCurrentStep( newStep );
+	}
 
 	const currentNumericStep = steps.indexOf( currentStep ) + 1;
 

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/index.tsx
@@ -18,7 +18,7 @@ import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getPurchaseFlowState } from 'calypso/state/plugins/marketplace/selectors';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
-import SimulatedProgressbar from 'calypso/my-sites/plugins/marketplace/components/simulated-progressbar';
+import SimulatedProgressBar from 'calypso/my-sites/plugins/marketplace/components/simulated-progressbar';
 
 /**
  * Style dependencies
@@ -72,7 +72,7 @@ function WrappedMarketplacePluginSetup(): JSX.Element {
 			<Masterbar></Masterbar>
 			<div className="marketplace-plugin-setup-status__root">
 				<div>
-					<SimulatedProgressbar steps={ steps } />
+					<SimulatedProgressBar steps={ steps } />
 				</div>
 			</div>
 		</>

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/style.scss
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-setup-status/style.scss
@@ -20,12 +20,9 @@
 	margin-top: 350px;
 	display: flex;
 	justify-content: center;
-	h1 {
-		font-size: 2rem;
-	}
+
 	> div {
 		width: 90%;
-		text-align: center;
 		max-width: 509px;
 	}
 }

--- a/client/my-sites/plugins/marketplace/marketplace-test/component-demo.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-test/component-demo.tsx
@@ -9,7 +9,7 @@ import { TranslateResult } from 'i18n-calypso';
  * Internal dependencies
  */
 import CardHeading from 'calypso/components/card-heading';
-import SimulatedProgressbar from 'calypso/my-sites/plugins/marketplace/components/simulated-progressbar';
+import SimulatedProgressBar from 'calypso/my-sites/plugins/marketplace/components/simulated-progressbar';
 
 export default function ComponentDemo(): JSX.Element {
 	const steps: TranslateResult[] = [
@@ -24,7 +24,7 @@ export default function ComponentDemo(): JSX.Element {
 				A simulated progress bar for steps : { JSON.stringify( steps ) }
 			</CardHeading>
 			<hr />
-			<SimulatedProgressbar steps={ steps } />
+			<SimulatedProgressBar steps={ steps } />
 		</CompactCard>
 	);
 }

--- a/client/my-sites/plugins/marketplace/marketplace-test/component-demo.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-test/component-demo.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { CompactCard } from '@automattic/components';
+import { TranslateResult } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'calypso/components/card-heading';
+import SimulatedProgressbar from 'calypso/my-sites/plugins/marketplace/components/simulated-progressbar';
+
+export default function ComponentDemo(): JSX.Element {
+	const steps: TranslateResult[] = [
+		'Some Awesome Step 1',
+		'Some Awesome Step 2',
+		'Some Awesome Step 3',
+		'Some Awesome Step 4',
+	];
+	return (
+		<CompactCard>
+			<CardHeading tagName="h1" size={ 21 }>
+				A simulated progress bar for steps : { JSON.stringify( steps ) }
+			</CardHeading>
+			<hr />
+			<SimulatedProgressbar steps={ steps } />
+		</CompactCard>
+	);
+}

--- a/client/my-sites/plugins/marketplace/marketplace-test/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-test/index.tsx
@@ -5,58 +5,113 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import page from 'page';
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { Button, Card, CompactCard } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
 import CardHeading from 'calypso/components/card-heading';
-import { Button, Card } from '@automattic/components';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
 	fetchAutomatedTransferStatus,
 	requestEligibility,
 } from 'calypso/state/automated-transfer/actions';
-import { getAutomatedTransfer } from 'calypso/state/automated-transfer/selectors';
+import { getAutomatedTransfer, getEligibility } from 'calypso/state/automated-transfer/selectors';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
-// import { getPlugins, isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { WarningList } from 'calypso/blocks/eligibility-warnings/warning-list';
+import {
+	getPluginOnSite,
+	getPlugins,
+	isRequestingForSites,
+} from 'calypso/state/plugins/installed/selectors';
+import { getBlockingMessages } from 'calypso/blocks/eligibility-warnings/hold-list';
+import { isAtomicSiteWithoutBusinessPlan } from 'calypso/blocks/eligibility-warnings/utils';
+import Notice from 'calypso/components/notice';
+import ComponentDemo from 'calypso/my-sites/plugins/marketplace/marketplace-test/component-demo';
 
 export const Container = styled.div`
 	margin: 0 25px;
 	padding: 25px;
 `;
 
-export default function MarketplaceTest() {
-	const selectedSite = useSelector( getSelectedSite ) || {};
+function level1ObjectMap( obj: any, entryFilter = ( [ i ]: any[] ) => i ): any[] {
+	return Object.entries( obj )
+		.filter( entryFilter )
+		.map( ( entry ) => ( { key: entry[ 0 ], value: JSON.stringify( entry[ 1 ] ) } ) );
+}
+
+export default function MarketplaceTest(): JSX.Element {
+	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	// This selector is not working need to investigate why that is
-	// const pluginDetails = useSelector( ( state ) => getPlugins( state, selectedSiteId ) );
-	const pluginDetails = useSelector(
-		( state ) => state.plugins.installed.plugins[ selectedSiteId ]
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
+	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
+	const isRequestingForSite = useSelector( ( state ) =>
+		isRequestingForSites( state, [ selectedSiteId ] )
 	);
+	const yoastPluginOnSite = useSelector( ( state ) =>
+		getPluginOnSite( state, selectedSiteId, 'wordpress-seo-premium' )
+	);
+	const contactFormPlugin = useSelector( ( state ) =>
+		getPluginOnSite( state, selectedSiteId, 'contact-form-7' )
+	);
+
 	const [ infiniteLoopCount, setInfiniteLoopCount ] = useState( 0 );
+
+	const dispatch = useDispatch();
+	const transferDetails = useSelector( ( state ) => getAutomatedTransfer( state, selectedSiteId ) );
+	const eligibilityDetails = useSelector( ( state ) => getEligibility( state, selectedSiteId ) );
 	const marketplacePages = [
 		{ name: 'Plugin Details Page', path: '/marketplace/product/details/wordpress-seo' },
 		{ name: 'Loading Page', path: '/marketplace/product/setup' },
 		{ name: 'Domains Page', path: '/marketplace/domain' },
 		{ name: 'Thank You Page', path: '/marketplace/thank-you' },
 	];
-	const dispatch = useDispatch();
-	const transferDetails = useSelector( ( state ) =>
-		getAutomatedTransfer( state, selectedSite?.ID ?? 0 )
-	);
 
 	//Infinite Loop
 	useEffect( () => {
-		setTimeout( () => {
-			dispatch( fetchAutomatedTransferStatus( selectedSite?.ID ?? 0 ) );
-			dispatch( requestEligibility( selectedSite?.ID ?? 0 ) );
-			setInfiniteLoopCount( ( l ) => l + 1 );
-		}, 4000 );
-	}, [ infiniteLoopCount, fetchAutomatedTransferStatus, selectedSite ] );
+		if ( ! transferDetails.fetchingStatus ) {
+			setTimeout( () => {
+				dispatch( fetchAutomatedTransferStatus( selectedSite?.ID ?? 0 ) );
+				dispatch( requestEligibility( selectedSite?.ID ?? 0 ) );
+				setInfiniteLoopCount( ( l ) => l + 1 );
+			}, 5000 );
+		}
+	}, [ infiniteLoopCount, selectedSite, dispatch, transferDetails.fetchingStatus ] );
+
+	//Infinite Loop
+	useEffect( () => {
+		if ( selectedSiteId ) {
+			setTimeout( () => {
+				dispatch( fetchAutomatedTransferStatus( selectedSiteId ) );
+				dispatch( requestEligibility( selectedSiteId ) );
+				setInfiniteLoopCount( ( l ) => l + 1 );
+			}, 4000 );
+		}
+	}, [ infiniteLoopCount, selectedSite, dispatch, selectedSiteId ] );
 
 	const { ID, URL, domain, options = {} } = selectedSite;
 	const { is_wpcom_atomic, is_automated_transfer } = options;
+
+	const allBlockingMessages = getBlockingMessages( translate );
+	const holds = eligibilityDetails.eligibilityHolds || [];
+	const raisedBlockingMessages = holds
+		.filter( ( message: any ) => allBlockingMessages[ message ] )
+		.map( ( message: string ) => allBlockingMessages[ message ] );
+	const hardBlockSingleMessages = holds.filter(
+		( message: string ) => message !== 'TRANSFER_ALREADY_EXISTS' || ! allBlockingMessages[ message ]
+	);
+	const hasHardBlock =
+		isAtomicSiteWithoutBusinessPlan( holds ) || hardBlockSingleMessages.length > 0;
 	return (
 		<Container>
 			{ selectedSiteId && <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> }
@@ -71,7 +126,7 @@ export default function MarketplaceTest() {
 			</Card>
 			<Card key="navigation-links">
 				{ marketplacePages.map( ( p ) => {
-					const path = `${ p.path }${ selectedSite?.domain ? `/${ selectedSite.domain }` : '' }`;
+					const path = `${ p.path }/${ selectedSiteSlug }`;
 					return (
 						<Button key={ p.path } onClick={ () => page( path ) }>
 							{ p.name }
@@ -89,6 +144,9 @@ export default function MarketplaceTest() {
 					<div>domain : { domain }</div>
 					<div>options.is_wpcom_atomic : { is_wpcom_atomic?.toString() }</div>
 					<div>options.is_automated_transfer : { is_automated_transfer?.toString() }</div>
+					<div>selector : isSiteWpcomAtomic : { isAtomicSite?.toString() }</div>
+					<div>selector : getSelectedSiteId : { selectedSiteId }</div>
+					<div>selector : getSelectedSiteSlug : { selectedSiteSlug }</div>
 				</Card>
 				<Card key="transfer-information">
 					<CardHeading tagName="h1" size={ 21 }>
@@ -100,14 +158,80 @@ export default function MarketplaceTest() {
 							dispatch:<strong>fetchAutomatedTransferStatus</strong>
 						</div>
 					</CardHeading>
-					{ Object.entries( transferDetails ).map( ( entry, i ) => (
+					<div>keys: { Object.keys( transferDetails ).join( ', ' ) }</div>
+					{ level1ObjectMap( transferDetails, ( [ key ] ) => key !== 'eligibility' ).map(
+						( entry, i ) => (
+							<div key={ i }>
+								{ entry.key } : { entry.value }
+							</div>
+						)
+					) }
+					<CardHeading tagName="h1" size={ 21 }>
+						Eligibility Details
+						<div>
+							selector:<strong>getEligibility</strong>
+						</div>
+						<div>
+							dispatch:<strong>fetchAutomatedTransferStatus</strong>
+						</div>
+					</CardHeading>
+					{ level1ObjectMap( eligibilityDetails ).map( ( entry, i ) => (
 						<div key={ i }>
-							{ JSON.stringify( entry[ 0 ] ) } : { JSON.stringify( entry[ 1 ] ) }
+							{ entry.key } : { entry.value }
 						</div>
 					) ) }
 				</Card>
+				<CompactCard>
+					<CardHeading tagName="h1" size={ 21 }>
+						Warnings
+					</CardHeading>
+					<WarningList
+						warnings={ transferDetails?.eligibility?.eligibilityWarnings ?? [] }
+						context="plugins"
+						translate={ translate }
+					/>
+				</CompactCard>
+				<CompactCard>
+					<CardHeading tagName="h1" size={ 21 }>
+						Blocking Messages
+					</CardHeading>
+					{ hasHardBlock &&
+						raisedBlockingMessages.map( ( message ) => (
+							<Notice
+								status={ message.status }
+								text={ message.message }
+								showDismiss={ false }
+							></Notice>
+						) ) }
+				</CompactCard>
 			</Card>
 			<Card key="installed-plugins">
+				<Card>
+					<CardHeading tagName="h1" size={ 21 }>
+						Plugin Statuses : selector : getPluginOnSite
+						<div>
+							selector : isRequestingForSite : { JSON.stringify( { isRequestingForSite } ) }
+						</div>
+					</CardHeading>
+					<Card>
+						Yoast plugin Query : Type of - { typeof yoastPluginOnSite }
+						{ yoastPluginOnSite &&
+							level1ObjectMap( yoastPluginOnSite ).map( ( { key, value } ) => (
+								<div key={ key }>
+									{ key } : { value }
+								</div>
+							) ) }
+					</Card>
+					<Card>
+						Contact Form plugin Query: Type of - { typeof contactFormPlugin }
+						{ contactFormPlugin &&
+							level1ObjectMap( contactFormPlugin ).map( ( { key, value } ) => (
+								<div key={ key }>
+									{ key } : { value }
+								</div>
+							) ) }
+					</Card>
+				</Card>
 				<CardHeading tagName="h1" size={ 21 }>
 					3rd Party Plugins Installed
 				</CardHeading>
@@ -116,19 +240,20 @@ export default function MarketplaceTest() {
 						.filter( ( plugin ) => plugin.author !== 'Automattic' )
 						.map( ( details ) => (
 							<Card key={ details.id }>
-								{ Object.entries( details )
-									.filter(
-										( [ key ] ) =>
-											! [ 'description', 'network', 'autoupdate', 'version', 'id' ].includes( key )
-									)
-									.map( ( [ key, value ] ) => (
-										<div key={ key }>
-											{ key } : { JSON.stringify( value ) }
-										</div>
-									) ) }
+								<em>keys: { Object.keys( details ).join( ', ' ) }</em>
+								{ level1ObjectMap(
+									details,
+									( [ key ] ) =>
+										! [ 'description', 'network', 'autoupdate', 'version' ].includes( key )
+								).map( ( { key, value } ) => (
+									<div key={ key }>
+										{ key } : { value }
+									</div>
+								) ) }
 							</Card>
 						) ) }
 			</Card>
+			<ComponentDemo />
 		</Container>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Encapsulated the logic of the simulated progress bar into a separate component
* Added new data indicators to marketing test page. (Review not required since this will be a developer debug view only)

#### Testing instructions

1. Purchase yoast premium with a business plan on a custom primary domain.
2. Make sure the progress bar works as expected
---
1. Check the marketing test page to make sure the simulated progressbar worked as expected
![image](https://user-images.githubusercontent.com/3422709/122166219-ec4fc880-ce96-11eb-8a87-32a8e9d6a557.png)