### PR TITLE
Emails: Update Google icons in the survey page when cancelling Google Workspace

### DIFF
--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -14,6 +14,9 @@ import {
 	GSUITE_BUSINESS_SLUG,
 } from 'calypso/lib/gsuite/constants';
 import GSuiteSingleFeature from './single-feature';
+import googleDocsIcon from 'calypso/assets/images/email-providers/google-workspace/services/docs.svg';
+import googleDriveIcon from 'calypso/assets/images/email-providers/google-workspace/services/drive.svg';
+import gmailIcon from 'calypso/assets/images/email-providers/google-workspace/services/gmail.svg';
 
 /**
  * Style dependencies
@@ -64,7 +67,7 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 						? undefined
 						: translate( 'Professional ad-free email that works with most email clients.' )
 				}
-				imagePath={ '/calypso/images/g-suite/logo_gmail_48dp.svg' }
+				imagePath={ gmailIcon }
 				imageAlt={ 'Gmail Logo' }
 				compact={ compact }
 			/>
@@ -75,14 +78,14 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 						? undefined
 						: translate( 'Collaborate in real-time with documents, spreadsheets and slides.' )
 				}
-				imagePath={ '/calypso/images/g-suite/logo_docs_48dp.svg' }
+				imagePath={ googleDocsIcon }
 				imageAlt={ 'Google Docs Logo' }
 				compact={ compact }
 			/>
 			<GSuiteSingleFeature
 				title={ getStorageTitle() }
 				description={ getStorageText() }
-				imagePath={ '/calypso/images/g-suite/logo_drive_48dp.svg' }
+				imagePath={ googleDriveIcon }
 				imageAlt={ 'Google Drive Logo' }
 				compact={ compact }
 			/>

--- a/client/components/gsuite/gsuite-features/style.scss
+++ b/client/components/gsuite/gsuite-features/style.scss
@@ -63,6 +63,7 @@
 }
 
 .gsuite-features__feature-image {
+	width: 48px;
 	align-items: flex-start;
 	padding: 0 1em 0 0;
 }

--- a/client/components/gsuite/gsuite-features/test/__snapshots__/compact.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/compact.js.snap
@@ -12,7 +12,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures in a list 1`] = 
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -33,7 +33,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures in a list 1`] = 
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -54,7 +54,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures in a list 1`] = 
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div
@@ -103,7 +103,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with basic plan 
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -124,7 +124,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with basic plan 
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -145,7 +145,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with basic plan 
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div
@@ -194,7 +194,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with business pl
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -215,7 +215,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with business pl
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -236,7 +236,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with business pl
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div
@@ -285,7 +285,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with no productS
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -306,7 +306,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with no productS
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -327,7 +327,7 @@ exports[`GSuiteCompactFeatures it renders GSuiteCompactFeatures with no productS
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div

--- a/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
@@ -12,7 +12,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -36,7 +36,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -60,7 +60,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures in a list 1`] = `
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div
@@ -115,7 +115,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -139,7 +139,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -163,7 +163,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with basic plan 1`] = `
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div
@@ -218,7 +218,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -242,7 +242,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -266,7 +266,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures with business plan 1`] = `
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div
@@ -321,7 +321,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
     >
       <img
         alt="Gmail Logo"
-        src="/calypso/images/g-suite/logo_gmail_48dp.svg"
+        src="gmail.svg"
       />
     </div>
     <div
@@ -345,7 +345,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
     >
       <img
         alt="Google Docs Logo"
-        src="/calypso/images/g-suite/logo_docs_48dp.svg"
+        src="docs.svg"
       />
     </div>
     <div
@@ -369,7 +369,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
     >
       <img
         alt="Google Drive Logo"
-        src="/calypso/images/g-suite/logo_drive_48dp.svg"
+        src="drive.svg"
       />
     </div>
     <div


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Google product icons used in the survey component, when cancelling a Google Workspace were outdated. This pull request updates them, and it also updates the snapshots for Jest regarding the _GSuiteSingleFeature_ React component.

#### Testing instructions

**Case 1: Cancelling Google Workspace**

1. Go to upgrades
2. Go to emails
3. Choose a Google Workspace plan from your account
4. Go to _View billing and payment settings_
5. Next click on _Remove Google Workspace Business Starter_

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/122187140-0d142000-ce8f-11eb-8334-00cba83f0163.png) | ![image](https://user-images.githubusercontent.com/5689927/122187196-1bfad280-ce8f-11eb-93e9-38ba4912eb85.png)

**Case 2: Buying a domain**
1. Buy a domain from WordPress.com dashboard

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/122217085-5d01df80-cead-11eb-82dd-fe98df78faa4.png) | ![image](https://user-images.githubusercontent.com/5689927/122217163-6f7c1900-cead-11eb-80ba-eea13f14d608.png)


Related to [Asana ticket](https://app.asana.com/0/1200182182542585/1200123926701116)
