### PR TITLE
Add UI blocks to purchase flow if the site is ineligible to install plugins or transfer

### DIFF
--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
@@ -5,6 +5,8 @@ import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import page from 'page';
+import { useTranslate } from 'i18n-calypso';
+import formatCurrency from '@automattic/format-currency';
 
 /**
  * Internal dependencies
@@ -17,7 +19,6 @@ import {
 import PluginProductMappingInterface, {
 	getProductSlug,
 } from 'calypso/my-sites/plugins/marketplace/constants';
-import formatCurrency from '@automattic/format-currency';
 import { getCurrentUserCurrencyCode } from 'calypso/state/current-user/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import {
@@ -35,6 +36,12 @@ import {
 	setPrimaryDomainCandidate,
 	setIsPluginInstalledDuringPurchase,
 } from 'calypso/state/plugins/marketplace/actions';
+import { getBlockingMessages } from 'calypso/blocks/eligibility-warnings/hold-list';
+import { getEligibility } from 'calypso/state/automated-transfer/selectors';
+import { isAtomicSiteWithoutBusinessPlan } from 'calypso/blocks/eligibility-warnings/utils';
+import { requestEligibility } from 'calypso/state/automated-transfer/actions';
+import Notice from 'calypso/components/notice';
+import { eligibilityHolds } from 'calypso/state/automated-transfer/constants';
 
 interface MarketplacePluginDetailsInterface {
 	marketplacePluginSlug: keyof PluginProductMappingInterface;
@@ -43,6 +50,7 @@ interface MarketplacePluginDetailsInterface {
 function MarketplacePluginDetails( {
 	marketplacePluginSlug,
 }: MarketplacePluginDetailsInterface ): JSX.Element {
+	const translate = useTranslate();
 	const productSlug = getProductSlug( marketplacePluginSlug );
 	const { replaceProductsInCart } = useShoppingCart();
 	const products = useSelector( getProductsList );
@@ -58,10 +66,12 @@ function MarketplacePluginDetails( {
 	const wporgFetching = useSelector( ( state ) =>
 		isWporgPluginFetching( state, marketplacePluginSlug )
 	);
+	const eligibilityDetails = useSelector( ( state ) => getEligibility( state, selectedSiteId ) );
 
 	useEffect( () => {
 		dispatch( wporgFetchPluginData( marketplacePluginSlug ) );
-	}, [ dispatch, marketplacePluginSlug ] );
+		selectedSiteId && dispatch( requestEligibility( selectedSiteId ) );
+	}, [ dispatch, marketplacePluginSlug, selectedSiteId ] );
 
 	const onAddYoastPremiumToCart = async () => {
 		dispatch( setIsPluginInstalledDuringPurchase( true ) );
@@ -73,11 +83,28 @@ function MarketplacePluginDetails( {
 		return replaceProductsInCart( [] );
 	};
 
+	const allBlockingMessages = getBlockingMessages( translate );
+	const holds = eligibilityDetails.eligibilityHolds || [];
+	const raisedBlockingMessages = holds
+		.filter( ( message: string ) => allBlockingMessages.hasOwnProperty( message ) )
+		.map( ( message: string ) => allBlockingMessages[ message ] );
+	const hasHardBlockSingleMessage = holds.some(
+		( message: string ) =>
+			message !== eligibilityHolds.TRANSFER_ALREADY_EXISTS &&
+			allBlockingMessages.hasOwnProperty( message )
+	);
+	const hasHardBlock = isAtomicSiteWithoutBusinessPlan( holds ) || hasHardBlockSingleMessage;
+
 	return (
 		<>
 			<SidebarNavigation />
+			{ hasHardBlock &&
+				raisedBlockingMessages.map( ( message ) => (
+					<Notice status={ message.status } text={ message.message } showDismiss={ false }></Notice>
+				) ) }
 			{ ! wporgFetching ? (
 				<PurchaseArea
+					isDisabled={ hasHardBlock }
 					siteDomains={ siteDomains }
 					isProductListLoading={ isProductListLoading }
 					displayCost={ displayCost }

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/purchase-area.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/purchase-area.tsx
@@ -19,6 +19,7 @@ interface PurchaseArea {
 	onNavigateToDomainsSelection: () => void;
 	onRemoveEverythingFromCart: () => Promise< ResponseCart >;
 	onInstallPluginManually: ( primaryDomain: string ) => Promise< void >;
+	isDisabled: boolean;
 }
 
 export default function PurchaseArea( {
@@ -31,6 +32,7 @@ export default function PurchaseArea( {
 	onNavigateToDomainsSelection,
 	onRemoveEverythingFromCart,
 	onInstallPluginManually,
+	isDisabled,
 }: PurchaseArea ): JSX.Element {
 	const [ isButtonClicked, setIsButtonClicked ] = useState( false );
 
@@ -84,13 +86,22 @@ export default function PurchaseArea( {
 			<div className="marketplace-plugin-details__name">{ wporgPluginName }</div>
 			<div>
 				<h2>Yoast Premium cost : { ! isProductListLoading ? displayCost : '' }</h2>
-				<Button busy={ isButtonClicked } onClick={ () => onAddPlugin( true ) } primary>
+				<Button
+					busy={ isButtonClicked }
+					onClick={ () => onAddPlugin( true ) }
+					disabled={ isDisabled }
+				>
 					Buy Yoast Premium
 				</Button>
 			</div>
 			<div>
 				<h2>Yoast Free cost : Free</h2>
-				<Button busy={ isButtonClicked } onClick={ () => onAddPlugin( false ) } primary>
+				<Button
+					busy={ isButtonClicked }
+					onClick={ () => onAddPlugin( false ) }
+					primary
+					disabled={ isDisabled }
+				>
 					Add Yoast Free
 				</Button>
 			</div>


### PR DESCRIPTION

#### Changes proposed in this Pull Request
Blocks the purchase flow of the Yoast plugin if there are blocking eligibility checks.

![image](https://user-images.githubusercontent.com/3422709/122198968-41033b80-ceb7-11eb-82b2-0a3c6dd5bb2c.png)

#### Testing instructions
1. Create a fresh site with a Business Plan
2. Purchase a custom domain and assign the domain as primary
3. Immediately Go to the marketplace product details page
    - Eg: http://calypso.localhost:3000/marketplace/product/details/wordpress-seo/${siteUrl}
4. The buttons should be disabled and above shown message should appear
