### PR TITLE
Tests: Update message formatting and get notifications working for Visual Regression

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -419,9 +419,7 @@ private object VisualRegressionTests : BuildType({
 			schedulingPolicy = daily {
 				hour = 3
 			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
+			branchFilter = "trunk"
 			triggerBuild = always()
 			withPendingChangesOnly = false
 		}

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -407,8 +407,8 @@ private object VisualRegressionTests : BuildType({
 				messageFormat = simpleMessageFormat()
 			}
 			branchFilter = """
-            	+:trunk
-            """.trimIndent()
+				+:trunk
+			""".trimIndent()
 			buildFailed = true
 			buildFinishedSuccessfully = true
 		}

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -406,9 +406,7 @@ private object VisualRegressionTests : BuildType({
 				sendTo = "#visual-regression-automated-tests"
 				messageFormat = simpleMessageFormat()
 			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
+			branchFilter = "trunk"
 			buildFailed = true
 			buildFinishedSuccessfully = true
 			buildFailedToStart = true
@@ -422,7 +420,9 @@ private object VisualRegressionTests : BuildType({
 			schedulingPolicy = daily {
 				hour = 3
 			}
-			branchFilter = "trunk"
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
 		}

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -404,15 +404,10 @@ private object VisualRegressionTests : BuildType({
 			notifierSettings = slackNotifier {
 				connection = "PROJECT_EXT_11"
 				sendTo = "#visual-regression-automated-tests"
-				messageFormat = verboseMessageFormat {
-	            	addBranch = false
-	            }
+				messageFormat = simpleMessageFormat()
 			}
-			buildFailedToStart = true
 			buildFailed = true
 			buildFinishedSuccessfully = true
-			firstSuccessAfterFailure = true
-			buildProbablyHanging = true
 		}
 	}
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -406,6 +406,9 @@ private object VisualRegressionTests : BuildType({
 				sendTo = "#visual-regression-automated-tests"
 				messageFormat = simpleMessageFormat()
 			}
+			branchFilter = """
+            	+:trunk
+            """.trimIndent()
 			buildFailed = true
 			buildFinishedSuccessfully = true
 		}

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -411,6 +411,9 @@ private object VisualRegressionTests : BuildType({
 			""".trimIndent()
 			buildFailed = true
 			buildFinishedSuccessfully = true
+			buildFailedToStart = true
+			firstSuccessAfterFailure = true
+			buildProbablyHanging = true
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR gets the slack notifications work for Visual Regression test runs. It also changes it to simple format.

#### Testing instructions

* The notifications are set to only be sent for trunk, but you can see in `#visual-regression-automated-tests` where I ran it without the branch filter. Nothing else to test
