### PR TITLE
Fix nav unification forcing content spacing on tablet

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -253,7 +253,9 @@
 			transform: translateX( -100% );
 			padding: 71px 24px 24px;
 		}
+	}
 
+	@media only screen and ( max-width: 660px ) {
 		.layout.focus-sites:not( .is-section-post-editor ) .layout__primary .main,
 		.layout.focus-sidebar:not( .is-section-post-editor ) .layout__primary .main {
 			transform: translateX( 100% );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix content spacing when toggling nav between screen widths `660px` and `782px`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso.live link generated below
* Visit Calypso Home screen of a selected site
* Reduce screen widths between `660px` and `782px` to ensure original issue is fixed and not created unnecessary spacing between nav and content
* Try various other widths to ensure no regressions with navigation is occurring due to change.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/53574
