### PR TITLE
Template Selector: fix layout after Gutenberg 10.8

### DIFF
--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -67,7 +67,7 @@ $sidebar-width-desktop: 324px;
 		-webkit-overflow-scrolling: touch;
 		// prevents a 1px strip of content being visible after scrolling
 		margin-top: -1px;
-		padding: 60px 16px 16px;
+		padding: 61px 16px 16px;
 
 		&::before {
 			margin-bottom: 0;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -35,6 +35,10 @@ $sidebar-width-desktop: 324px;
 
 // Overrides of the Gutenberg modal component
 .page-pattern-modal {
+	&.components-modal__frame {
+		max-height: none;
+	}
+
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		width: calc( 100% - 32px );
 		height: 90vh;
@@ -61,6 +65,11 @@ $sidebar-width-desktop: 324px;
 	.components-modal__header {
 		border-bottom: none;
 		margin-right: -16px;
+
+		.components-button {
+			left: 31px;
+			top: -11px;
+		}
 	}
 }
 

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -65,9 +65,8 @@ $sidebar-width-desktop: 324px;
 	.components-modal__content {
 		overflow-y: scroll;
 		-webkit-overflow-scrolling: touch;
-		// prevents a 1px strip of content being visible after scrolling
-		margin-top: -1px;
-		padding: 61px 16px 16px;
+		margin-top: 60px;
+		padding: 0 16px 16px;
 
 		&::before {
 			margin-bottom: 0;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -63,6 +63,7 @@ $sidebar-width-desktop: 324px;
 		padding: 3px 16px 16px;
 
 		&::before {
+			// this is functioning like a clearfix in the core component, but we don't need it
 			display: none;
 		}
 	}

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -65,18 +65,16 @@ $sidebar-width-desktop: 324px;
 	.components-modal__content {
 		overflow-y: scroll;
 		-webkit-overflow-scrolling: touch;
-		margin-top: 60px;
-		padding: 0 16px 16px;
+		padding: 3px 16px 16px;
 
 		&::before {
-			margin-bottom: 0;
+			display: none;
 		}
 	}
 
 	.components-modal__header {
 		border-bottom: none;
 		margin-right: -16px;
-		background-color: #fff;
 	}
 
 }

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -67,18 +67,19 @@ $sidebar-width-desktop: 324px;
 		-webkit-overflow-scrolling: touch;
 		// prevents a 1px strip of content being visible after scrolling
 		margin-top: -1px;
-		padding: 0 16px 16px;
+		padding: 60px 16px 16px;
+
+		&::before {
+			margin-bottom: 0;
+		}
 	}
 
 	.components-modal__header {
 		border-bottom: none;
 		margin-right: -16px;
-
-		.components-button {
-			left: 31px;
-			top: -11px;
-		}
+		background-color: #fff;
 	}
+
 }
 
 .page-pattern-modal__heading {

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -35,8 +35,6 @@ $sidebar-width-desktop: 324px;
 
 // Overrides of the Gutenberg modal component
 .page-pattern-modal {
-	position: relative;
-
 	&.components-modal__frame {
 		max-height: none;
 	}
@@ -47,7 +45,6 @@ $sidebar-width-desktop: 324px;
 		// prevents a 1px strip of content being visible after scrolling
 		overflow-y: hidden;
 		padding-bottom: 24px;
-		top: 20px;
 		.components-modal__content {
 			padding: 0 32px 24px;
 		}

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -35,8 +35,15 @@ $sidebar-width-desktop: 324px;
 
 // Overrides of the Gutenberg modal component
 .page-pattern-modal {
+	position: relative;
+
 	&.components-modal__frame {
 		max-height: none;
+	}
+
+	@media screen and ( max-width: $breakpoint-mobile ) {
+		height: calc( 100vh - 55px );
+		top: 50px; // don't get hidden by the adminbar
 	}
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
@@ -45,6 +52,7 @@ $sidebar-width-desktop: 324px;
 		// prevents a 1px strip of content being visible after scrolling
 		overflow-y: hidden;
 		padding-bottom: 24px;
+		top: 20px;
 		.components-modal__content {
 			padding: 0 32px 24px;
 		}

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -41,11 +41,6 @@ $sidebar-width-desktop: 324px;
 		max-height: none;
 	}
 
-	@media screen and ( max-width: $breakpoint-mobile ) {
-		height: calc( 100vh - 55px );
-		top: 50px; // don't get hidden by the adminbar
-	}
-
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		width: calc( 100% - 32px );
 		height: 90vh;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -69,7 +69,6 @@ $sidebar-width-desktop: 324px;
 		border-bottom: none;
 		margin-right: -16px;
 	}
-
 }
 
 .page-pattern-modal__heading {


### PR DESCRIPTION
fixes #53754

#### Changes proposed in this Pull Request

Override max-height and reposition the close button.

| Before  | After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/87168/122245648-926af500-cece-11eb-9db8-5d8ae049ec8f.png)  | <img width="1276" alt="Screen Shot 2021-06-16 at 10 57 23" src="https://user-images.githubusercontent.com/195089/122253289-a5ab9f80-ce91-11eb-9a45-737264cc7f21.png">
  |

#### Testing instructions

Run on sandbox: `install-plugin.sh etk fix/page-template-modal-height`

Invoke the modal by creating a new page on a sandboxed site. Verify it's working.