### PR TITLE
[ErrorReporting] Use double-quotes to wrap the crossorigin attribute's value

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -35,7 +35,7 @@ function head_error_handler() {
 function add_crossorigin_to_script_els( $tag ) {
 	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	if ( preg_match( '/<script\s.*src=.*(s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com).*>/', $tag ) ) {
-		return str_replace( ' src', " crossorigin='anonymous' src", $tag );
+		return str_replace( ' src', ' crossorigin="anonymous" src', $tag );
 	};
 	return $tag;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we go through the script elements for the page to str-replace them to add the `crossorigin` attribute, we'll use double quotes to wrap its value, instead of single quotes.

### Why

This is done as a hot-fix for an issue (see: p1623854536001500-slack-C02AVA) that appeared after we released Gutenberg v10.8.1 on WPCOM. Some code is outputting in the clientside (using `document.write`) a string containing the aforementioned processed script elements. The problem is that the `document.write` also accepts a string as an argument, and in that particular case, it's wrapping the string with single-quotes. Since there doesn't seem to be any escaping being done there and since the string containing the `script` element contains a `crossorigin='anyonymous'` component with single-quotes **too**, it ends up resulting in invalid JavaScript and breaks.

### Risks

Since we're now using double-quotes to wrap the value of the `crossorigin` attribute in `script` elements, there's a risk that any code that is not careful to escape the strings when using outputting them to clientside JS, and that is wrapped by double-quotes, will break. I don't know enough about the code that caused this in Gutenberg to know how serious this risk is, all I can do is test on the sandbox (see instructions below).

#### Testing instructions

1. Enable jsconcat on the sandbox by creating `wp-content/mu-plugins/000-optimizations.php` with the following contents:

```php
<?php
define( 'FORCE_CONCAT', TRUE );
add_filter( 'wpcom_sandbox_staticize_subdomain', '__return_true' );
```

2. With the this branch checked out, cd to apps/editing-toolkit and run `yarn dev --sync` to sync a dev build of EDT to your sandbox (or use the `install-plugin.sh` to install it from this branch in the sandbox, see fieldguide);
3. Sandbox s0.wp.com (this is where this custom EDT build is served when the js minifier is active);
4. Try to reproduce the error reported in
5. Test that error reporting works, you can use [this](https://github.com/Automattic/wp-calypso/pull/49485#issuecomment-828029870) snippet.