### PR TITLE
Preferences: Memoize pref handlers, add styling

### DIFF
--- a/client/lib/preferences-helper/array-preference.js
+++ b/client/lib/preferences-helper/array-preference.js
@@ -2,11 +2,9 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
-class ArrayPreference extends Component {
+export default class ArrayPreference extends Component {
 	static propTypes = {
 		name: PropTypes.string.isRequired,
 		value: PropTypes.array.isRequired,
@@ -16,7 +14,7 @@ class ArrayPreference extends Component {
 		const { value } = this.props;
 
 		return (
-			<ul className="preferences-helper__list">
+			<ul className="preferences-helper__array-preference">
 				{ value.map( ( preference, index ) => (
 					<li key={ index }>{ JSON.stringify( preference ) }</li>
 				) ) }
@@ -24,5 +22,3 @@ class ArrayPreference extends Component {
 		);
 	}
 }
-
-export default connect( null, null )( localize( ArrayPreference ) );

--- a/client/lib/preferences-helper/boolean-preference.tsx
+++ b/client/lib/preferences-helper/boolean-preference.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import React, {
 	FunctionComponent,
@@ -22,6 +23,7 @@ interface Props {
 
 const BooleanPreference: FunctionComponent< Props > = ( { name, value } ) => {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 
 	const [ localValue, setLocalValue ] = useState( value );
 
@@ -45,18 +47,18 @@ const BooleanPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__save-pref-button"
+						className="preferences-helper__preference-save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
-						{ 'save' }
-					</button>{ ' ' }
+						{ translate( 'save' ) }
+					</button>
 					<button
-						className="preferences-helper__reset-pref-button"
+						className="preferences-helper__preference-reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>
-						{ 'reset' }
+						{ translate( 'reset' ) }
 					</button>
 				</>
 			) }

--- a/client/lib/preferences-helper/number-preference.tsx
+++ b/client/lib/preferences-helper/number-preference.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import React, {
 	FunctionComponent,
@@ -22,6 +23,7 @@ interface Props {
 
 const NumberPreference: FunctionComponent< Props > = ( { name, value } ) => {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 
 	const [ localValue, setLocalValue ] = useState( value );
 
@@ -45,18 +47,18 @@ const NumberPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__save-pref-button"
+						className="preferences-helper__preference-save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
-						{ 'save' }
-					</button>{ ' ' }
+						{ translate( 'save' ) }
+					</button>
 					<button
-						className="preferences-helper__reset-pref-button"
+						className="preferences-helper__preference-reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>
-						{ 'reset' }
+						{ translate( 'reset' ) }
 					</button>
 				</>
 			) }

--- a/client/lib/preferences-helper/object-preference.tsx
+++ b/client/lib/preferences-helper/object-preference.tsx
@@ -34,11 +34,11 @@ const ObjectPreference: FunctionComponent< Props > = ( { value } ) => {
 	};
 
 	return (
-		<ul className="preferences-helper__list">
+		<ul className="preferences-helper__object-preference">
 			{ value &&
 				Object.keys( value ).map( ( property ) => (
 					<li key={ property }>
-						<span>{ property }</span>
+						<span className="preferences-helper__object-preference-property">{ property }</span>
 						{ renderProperty( property, value[ property ] ) }
 					</li>
 				) ) }

--- a/client/lib/preferences-helper/preference-list.js
+++ b/client/lib/preferences-helper/preference-list.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,41 +13,55 @@ import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import Preference from './preference';
 
-class PreferenceList extends Component {
-	render() {
-		const { preferences, translate } = this.props;
-		return (
-			<div>
-				<QueryPreferences />
-				<a
-					href={ '/devdocs/client/state/preferences/README.md' }
-					title={ translate( 'Preferences' ) }
-				>
-					{ translate( 'Preferences' ) }
-				</a>
-				<Card className="preferences-helper__current-preferences">
-					{ ! isEmpty( preferences ) ? (
-						Object.keys( preferences ).map( ( preferenceName ) => (
-							<Preference
-								key={ preferenceName }
-								name={ preferenceName }
-								value={ preferences[ preferenceName ] }
-							/>
-						) )
-					) : (
-						<h5 className="preferences-helper__preference-header">
-							{ translate( 'No Preferences' ) }
-						</h5>
-					) }
-				</Card>
-			</div>
-		);
-	}
-}
+const PreferenceList = () => {
+	const translate = useTranslate();
 
-export default connect(
-	( state ) => ( {
-		preferences: getAllRemotePreferences( state ),
-	} ),
-	null
-)( localize( PreferenceList ) );
+	const preferences = useSelector( getAllRemotePreferences );
+	const sortedPreferenceItems = useMemo( () => {
+		if ( ! preferences ) {
+			return [];
+		}
+
+		return Object.keys( preferences )
+			.sort()
+			.map( ( preferenceName ) => (
+				<Preference
+					key={ preferenceName }
+					name={ preferenceName }
+					value={ preferences[ preferenceName ] }
+				/>
+			) );
+	}, [ preferences ] );
+
+	return (
+		<>
+			<QueryPreferences />
+			<a
+				href={ '/devdocs/client/state/preferences/README.md' }
+				title={ translate( 'Preferences' ) }
+			>
+				{ translate( 'Preferences' ) }
+			</a>
+			<Card className="preferences-helper__current-preferences">
+				{ sortedPreferenceItems.length > 0 ? (
+					<table className="preferences-helper__preferences-table">
+						<thead>
+							<tr>
+								<th className="preferences-helper__header-unset">{ translate( 'Delete' ) }</th>
+								<th className="preferences-helper__header-name">{ translate( 'Name' ) }</th>
+								<th className="preferences-helper__header-value">{ translate( 'Value(s)' ) }</th>
+							</tr>
+						</thead>
+						<tbody>{ sortedPreferenceItems }</tbody>
+					</table>
+				) : (
+					<h5 className="preferences-helper__no-preferences">
+						{ translate( 'No preferences are currently set' ) }
+					</h5>
+				) }
+			</Card>
+		</>
+	);
+};
+
+export default PreferenceList;

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { partial, isPlainObject } from 'lodash';
+import React, { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { isPlainObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,46 +16,58 @@ import BooleanPreference from './boolean-preference';
 import StringPreference from './string-preference';
 import NumberPreference from './number-preference';
 
-class Preference extends Component {
-	render() {
-		const { name, value, translate, unsetPreference } = this.props;
+const Preference = ( { name, value } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
 
-		let preferenceHandler = (
+	const preferenceHandler = useMemo( () => {
+		if ( Array.isArray( value ) ) {
+			return <ArrayPreference name={ name } value={ value } />;
+		}
+
+		if ( isPlainObject( value ) ) {
+			return <ObjectPreference name={ name } value={ value } />;
+		}
+
+		if ( 'string' === typeof value ) {
+			return <StringPreference name={ name } value={ value } />;
+		}
+
+		if ( 'boolean' === typeof value ) {
+			return <BooleanPreference name={ name } value={ value } />;
+		}
+
+		if ( 'number' === typeof value ) {
+			return <NumberPreference name={ name } value={ value } />;
+		}
+
+		return (
 			<ul>
 				<li key={ name }>{ value.toString() } </li>
 			</ul>
 		);
+	}, [ name, value ] );
 
-		if ( Array.isArray( value ) ) {
-			preferenceHandler = <ArrayPreference name={ name } value={ value } />;
-		} else if ( isPlainObject( value ) ) {
-			preferenceHandler = <ObjectPreference name={ name } value={ value } />;
-		} else if ( 'string' === typeof value ) {
-			preferenceHandler = <StringPreference name={ name } value={ value } />;
-		} else if ( 'boolean' === typeof value ) {
-			preferenceHandler = <BooleanPreference name={ name } value={ value } />;
-		} else if ( 'number' === typeof value ) {
-			preferenceHandler = <NumberPreference name={ name } value={ value } />;
-		}
+	const unsetPreference = useCallback( () => dispatch( savePreference( name, null ) ), [
+		dispatch,
+		name,
+	] );
 
-		return (
-			<div>
-				<div className="preferences-helper__preference-header">
-					<button
-						className="preferences-helper__unset"
-						onClick={ partial( unsetPreference, name, null ) }
-						title={ translate( 'Unset Preference' ) }
-					>
-						{ 'X' }
-					</button>
-					<span>{ name }</span>
-				</div>
-				{ preferenceHandler }
+	return (
+		<div>
+			<div className="preferences-helper__preference-header">
+				<button
+					className="preferences-helper__unset"
+					onClick={ unsetPreference }
+					title={ translate( 'Unset Preference' ) }
+				>
+					{ 'X' }
+				</button>
+				<span>{ name }</span>
 			</div>
-		);
-	}
-}
+			{ preferenceHandler }
+		</div>
+	);
+};
 
-export default connect( null, {
-	unsetPreference: savePreference,
-} )( localize( Preference ) );
+export default Preference;

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -22,23 +22,53 @@ const Preference = ( { name, value } ) => {
 
 	const preferenceHandler = useMemo( () => {
 		if ( Array.isArray( value ) ) {
-			return <ArrayPreference name={ name } value={ value } />;
+			return (
+				<ArrayPreference
+					className="preferences-helper__preference-value"
+					name={ name }
+					value={ value }
+				/>
+			);
 		}
 
 		if ( isPlainObject( value ) ) {
-			return <ObjectPreference name={ name } value={ value } />;
+			return (
+				<ObjectPreference
+					className="preferences-helper__preference-value"
+					name={ name }
+					value={ value }
+				/>
+			);
 		}
 
 		if ( 'string' === typeof value ) {
-			return <StringPreference name={ name } value={ value } />;
+			return (
+				<StringPreference
+					className="preferences-helper__preference-value"
+					name={ name }
+					value={ value }
+				/>
+			);
 		}
 
 		if ( 'boolean' === typeof value ) {
-			return <BooleanPreference name={ name } value={ value } />;
+			return (
+				<BooleanPreference
+					className="preferences-helper__preference-value"
+					name={ name }
+					value={ value }
+				/>
+			);
 		}
 
 		if ( 'number' === typeof value ) {
-			return <NumberPreference name={ name } value={ value } />;
+			return (
+				<NumberPreference
+					className="preferences-helper__preference-value"
+					name={ name }
+					value={ value }
+				/>
+			);
 		}
 
 		return (
@@ -54,19 +84,17 @@ const Preference = ( { name, value } ) => {
 	] );
 
 	return (
-		<div>
-			<div className="preferences-helper__preference-header">
-				<button
-					className="preferences-helper__unset"
-					onClick={ unsetPreference }
-					title={ translate( 'Unset Preference' ) }
-				>
-					{ 'X' }
+		<tr>
+			<td className="preferences-helper__preference-unset">
+				<button onClick={ unsetPreference } title={ translate( 'Unset Preference' ) }>
+					<span role="img" aria-label={ translate( 'Unset Preference' ) }>
+						&#10060;
+					</span>
 				</button>
-				<span>{ name }</span>
-			</div>
-			{ preferenceHandler }
-		</div>
+			</td>
+			<td className="preferences-helper__preference-name">{ name }</td>
+			<td className="preferences-helper__preference-value">{ preferenceHandler }</td>
+		</tr>
 	);
 };
 

--- a/client/lib/preferences-helper/string-preference.tsx
+++ b/client/lib/preferences-helper/string-preference.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import React, {
 	FunctionComponent,
@@ -22,6 +23,7 @@ interface Props {
 
 const StringPreference: FunctionComponent< Props > = ( { name, value } ) => {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 
 	const [ localValue, setLocalValue ] = useState( value );
 
@@ -45,18 +47,18 @@ const StringPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__save-pref-button"
+						className="preferences-helper__preference-save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
-						{ 'save' }
-					</button>{ ' ' }
+						{ translate( 'save' ) }
+					</button>
 					<button
-						className="preferences-helper__reset-pref-button"
+						className="preferences-helper__preference-reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>
-						{ 'reset' }
+						{ translate( 'reset' ) }
 					</button>
 				</>
 			) }

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -1,55 +1,128 @@
 .preferences-helper__current-preferences {
 	display: none;
+	line-height: initial;
+	text-transform: initial;
 }
 
-.preferences-helper__list {
-	margin: 5px 0 8px 20px;
+.preferences-helper__preferences-table {
+	border-collapse: collapse;
+	border-spacing: 1rem;
 
-	li {
-		font-weight: normal;
-		text-transform: initial;
-		margin-right: 5px;
+	th {
+		padding: 4px 8px;
+		border-bottom: 1px solid var( --color-neutral-50 );
+		text-transform: uppercase;
+	}
+
+	td {
+		padding: 12px 8px;
+		border-bottom: 1px solid var( --color-neutral-5 );
+	}
+
+	tr:last-child td {
+		border-bottom: none;
 	}
 }
 
-.preferences-helper__unset {
-	color: var( --color-accent );
-	cursor: pointer;
+.preferences-helper__header-unset {
+	text-align: center;
 }
 
-.preferences-helper__preference-header {
-	text-transform: initial;
-	margin-top: 5px;
+.preferences-helper__header-name {
+	text-align: right;
+}
+
+.preferences-helper__no-preferences {
+	text-align: center;
+
+	font-size: 1.5rem;
 	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
+}
+
+.preferences-helper__boolean-preference input {
+	margin: initial;
+}
+
+.preferences-helper__array-preference,
+.preferences-helper__object-preference {
+	margin: initial;
+	list-style: none;
+
+	li {
+		font-weight: normal;
+	}
+}
+
+.preferences-helper__object-preference li {
+	margin-bottom: 8px;
+}
+
+.preferences-helper__object-preference-property {
+	display: block;
+	margin-bottom: 4px;
+	font-family: monospace;
+}
+
+.preferences-helper__array-preference {
+	font-family: monospace;
+}
+
+.preferences-helper__preference-unset {
+	text-align: center;
+	color: var( --color-accent );
 
 	button {
-		display: inline;
-		margin-right: 5px;
+		cursor: pointer;
 	}
 }
 
-.preferences-helper__save-pref-button {
-	color: var( --color-accent );
+.preferences-helper__preference-name {
+	text-align: right;
+	font-family: monospace;
+	font-weight: 600;
+}
+
+.preferences-helper__preference-save {
+	margin: 0 4px;
+	padding: 4px 8px;
+
+	border-radius: 2px;
+	background-color: var( --color-accent );
+	color: var( --color-text-inverted );
+	font-weight: 600;
+
 	cursor: pointer;
 	&:disabled {
-		color: var( --color-neutral );
+		background-color: var( --color-neutral );
 	}
 }
 
-.preferences-helper__reset-pref-button {
+.preferences-helper__preference-reset {
+	margin: 0 4px;
+	padding: 4px 8px;
+
+	border-radius: 2px;
+	border: 1px solid var( --color-warning );
 	color: var( --color-warning );
+	font-weight: 600;
+
 	cursor: pointer;
+
 	&:disabled {
-		color: var( --color-neutral );
+		color: var( --color-text-subtle );
 	}
 }
 
-.boolean-preference {
-	input {
-		appearance: checkbox;
-	}
+.number-preference input,
+.string-preference input {
+	margin: 4px 1rem 4px 0;
+}
+
+.boolean-preference input {
+	margin: 8px 1rem 8px 0;
+	appearance: checkbox;
 }
 
 .environment.is-prefs:hover .preferences-helper__current-preferences.card {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Encapsulate the logic to choose a correct preference handler in a `useMemo`, to reduce unnecessary re-renders when the Preferences Helper is visible.
* Encapsulate the `unsetPreference` action in a `useCallback`, to reduce unnecessary re-renders when the Preferences Helper is visible.
* Make a few `Preference` components functional (as opposed to class-based).
* Re-style and add translations to the Preferences Helper to make it a little friendlier. 🙂 

#### Testing instructions

* In a local testing environment, start Calypso Blue.
* Open the Preferences Helper by going to the bottom right corner, hovering over the environment name, and then hovering over **PREFERENCES** in the menu that pops out.
* Verify that you're able to manage your user preferences just as in production: deleting should be possible for all items, and altering should be possible for all but the most complex data types. Be sure to test and compare the visibility and behavior of the "save" and "reset" buttons for preference types where they're applicable.

#### Reference captures

##### Before

<img width="493" alt="Screen Shot 2021-06-21 at 14 53 45" src="https://user-images.githubusercontent.com/670067/122819790-7f766d00-d2a0-11eb-9627-86bff218761e.png">

##### After

<img width="734" alt="Screen Shot 2021-06-21 at 14 53 02" src="https://user-images.githubusercontent.com/670067/122819720-6bcb0680-d2a0-11eb-874e-3f7d88c8a42a.png">
