### PR TITLE
State: Update account close to use local storage module

### DIFF
--- a/client/state/account/actions.js
+++ b/client/state/account/actions.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import user from 'calypso/lib/user';
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
+import { clearStore } from 'calypso/lib/user/store';
 
 import 'calypso/state/data-layer/wpcom/me/account/close';
 import 'calypso/state/account/init';
@@ -15,7 +15,7 @@ export function closeAccount() {
 
 export function closeAccountSuccess() {
 	return async ( dispatch ) => {
-		await user().clear();
+		await clearStore();
 		dispatch( {
 			type: ACCOUNT_CLOSE_SUCCESS,
 		} );

--- a/client/state/account/actions.js
+++ b/client/state/account/actions.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
-import { clearStore } from 'calypso/lib/user/store';
 
 import 'calypso/state/data-layer/wpcom/me/account/close';
 import 'calypso/state/account/init';
@@ -14,10 +13,7 @@ export function closeAccount() {
 }
 
 export function closeAccountSuccess() {
-	return async ( dispatch ) => {
-		await clearStore();
-		dispatch( {
-			type: ACCOUNT_CLOSE_SUCCESS,
-		} );
+	return {
+		type: ACCOUNT_CLOSE_SUCCESS,
 	};
 }

--- a/client/state/account/test/actions.js
+++ b/client/state/account/test/actions.js
@@ -4,10 +4,6 @@
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
 import { closeAccount, closeAccountSuccess } from 'calypso/state/account/actions';
 
-jest.mock( 'calypso/lib/user/store', () => {
-	return { clearStore: jest.fn() };
-} );
-
 describe( 'actions', () => {
 	describe( '#closeAccount', () => {
 		test( 'should return an action when an account is closed', () => {
@@ -19,10 +15,8 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#closeAccountSuccess', () => {
-		test( 'should dispatch an action when an account is closed successfully', async () => {
-			const spy = jest.fn();
-			await closeAccountSuccess()( spy );
-			expect( spy ).toHaveBeenCalledWith( {
+		test( 'should dispatch an action when an account is closed successfully', () => {
+			expect( closeAccountSuccess() ).toEqual( {
 				type: ACCOUNT_CLOSE_SUCCESS,
 			} );
 		} );

--- a/client/state/account/test/actions.js
+++ b/client/state/account/test/actions.js
@@ -4,8 +4,8 @@
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
 import { closeAccount, closeAccountSuccess } from 'calypso/state/account/actions';
 
-jest.mock( 'calypso/lib/user', () => () => {
-	return { clear: jest.fn() };
+jest.mock( 'calypso/lib/user/store', () => {
+	return { clearStore: jest.fn() };
 } );
 
 describe( 'actions', () => {

--- a/client/state/data-layer/wpcom/me/account/close/test/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/test/index.js
@@ -11,10 +11,6 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { closeAccount } from 'calypso/state/account/actions';
 import { ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
 
-jest.mock( 'calypso/lib/user/store', () => {
-	return { clearStore: jest.fn() };
-} );
-
 describe( 'account-close', () => {
 	describe( 'requestAccountClose', () => {
 		test( 'should dispatch a HTTP request', () => {
@@ -43,11 +39,8 @@ describe( 'account-close', () => {
 	} );
 
 	describe( 'receiveAccountCloseSuccess', () => {
-		test( 'should dispatch a success action', async () => {
-			const spy = jest.fn();
-			await receiveAccountCloseSuccess()( spy );
-
-			expect( spy ).toHaveBeenCalledWith( {
+		test( 'should return success action', () => {
+			expect( receiveAccountCloseSuccess() ).toEqual( {
 				type: ACCOUNT_CLOSE_SUCCESS,
 			} );
 		} );

--- a/client/state/data-layer/wpcom/me/account/close/test/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/test/index.js
@@ -11,8 +11,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { closeAccount } from 'calypso/state/account/actions';
 import { ACCOUNT_CLOSE_SUCCESS } from 'calypso/state/action-types';
 
-jest.mock( 'calypso/lib/user', () => () => {
-	return { clear: jest.fn() };
+jest.mock( 'calypso/lib/user/store', () => {
+	return { clearStore: jest.fn() };
 } );
 
 describe( 'account-close', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the `closeAccountSuccess` action thunk to use the user store library for clearing the local storage instead of `lib/user`.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go to `/me/account/close`
* Follow the instructions on the page to close an account.
* Verify you can close the account successfully without any errors.
* Verify unit tests pass.