### PR TITLE
WIP: Use an iframe to preview theme changes with new wpcom endpoint

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -29,6 +29,7 @@ import {
 	hideAutoLoadingHomepageWarning,
 	activate as activateTheme,
 } from 'calypso/state/themes/actions';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Style dependencies
@@ -118,6 +119,7 @@ class AutoLoadingHomepageModal extends Component {
 			hasAutoLoadingHomepage,
 			isCurrentTheme,
 			isVisible = false,
+			siteId,
 		} = this.props;
 
 		// Nothing to do when it's the current theme.
@@ -140,6 +142,15 @@ class AutoLoadingHomepageModal extends Component {
 		}
 
 		const { name: themeName, id: themeId } = this.props.theme;
+
+		// Depends on D62921-code
+		// const iframeSrc =
+		// 	'https://public-api.wordpress.com/rest/v1/theme/preview/twentytwentyone/179276076?font_headings=Open%20Sans&font_base=Chivo&site_title=Barnsbury&viewport_height=700&language=en&use_screenshot_overrides=true';
+		const iframeSrc = addQueryArgs(
+			`https://public-api.wordpress.com/rest/v1/theme/preview/${ themeId }/${ siteId }`
+			// Not sure if these do anything yet
+			/* { viewport_height: 200, language: 'en', use_screenshot_overrides: 'true' } */
+		);
 
 		return (
 			<Dialog
@@ -171,6 +182,31 @@ class AutoLoadingHomepageModal extends Component {
 							args: { themeName },
 						} ) }
 					</h1>
+					{ /* Rough WIP: Inline styles */ }
+					{ /* Something is making me make the wrapping div taller than I expected to see the bottom edge of the iframe.
+						Expected: 520 * 0.75 = 390
+					*/ }
+					<div
+						style={ {
+							width: '600px',
+							height: '520px',
+							padding: 0,
+							overflow: 'hidden',
+						} }
+					>
+						<iframe
+							title="Site Preview"
+							name="customize-preview-0"
+							sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"
+							src={ iframeSrc }
+							style={ {
+								width: '800px',
+								height: '520px',
+								border: '1px solid black',
+								transform: 'scale(0.75)',
+							} }
+						></iframe>
+					</div>
 					<FormLabel>
 						<FormRadio
 							value="keep_current_homepage"

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,6 +1,6 @@
 .themes__auto-loading-homepage-modal {
 	min-height: 90px;
-	max-width: 400px;
+	max-width: 1000px;
 	margin: 0 auto;
 
 	@include breakpoint-deprecated( '<480px' ) {


### PR DESCRIPTION
Requires D62921-code

#### Changes proposed in this Pull Request
* Proof of concept
* My current homepage looks like this
![2021-06-15_13-46](https://user-images.githubusercontent.com/937354/122107000-3629a780-cde0-11eb-94dc-df3241449d2c.png)
* When I start to switch to the 2021 theme, the modal includes an iframe that shows what my current homepage would look like with that theme applied:
* ![2021-06-16_16-12](https://user-images.githubusercontent.com/937354/122294503-ba9e2800-cebd-11eb-8193-6b9b1987db3a.png)

* More info in https://github.com/Automattic/wp-calypso/issues/53674

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53674
