### PR TITLE
Partner Portal: Change landing page logic

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -30,6 +30,7 @@ import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/lice
 import PaymentMethodList from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-list';
 import PaymentMethodAdd from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add';
 import IssueLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license';
+import LandingPage from 'calypso/jetpack-cloud/sections/partner-portal/primary/landing-page';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
@@ -112,6 +113,13 @@ export function paymentMethodAddContext( context: PageJS.Context, next: () => vo
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	context.primary = <PaymentMethodAdd />;
+	context.footer = <JetpackComFooter />;
+	next();
+}
+
+export function landingPageContext( context: PageJS.Context, next: () => void ): void {
+	context.header = <Header />;
+	context.primary = <LandingPage />;
 	context.footer = <JetpackComFooter />;
 	next();
 }

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -88,11 +88,22 @@ export default function () {
 
 	// Billing Dashboard.
 	page(
-		`/partner-portal`,
+		`/partner-portal/billing`,
 		controller.requireAccessContext,
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.billingDashboardContext,
+		makeLayout,
+		clientRender
+	);
+
+	// Landing Page
+	page(
+		`/partner-portal`,
+		controller.requireAccessContext,
+		controller.requireTermsOfServiceConsentContext,
+		controller.requireSelectedPartnerKeyContext,
+		controller.landingPageContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
@@ -1,57 +1,25 @@
 /**
  * External dependencies
  */
-import React, { useEffect, ReactElement } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { LicenseCounts } from 'calypso/state/partner-portal/types';
-import {
-	hasFetchedLicenseCounts,
-	getLicenseCounts,
-} from 'calypso/state/partner-portal/licenses/selectors';
-import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
-import Main from 'calypso/components/main';
-import CardHeading from 'calypso/components/card-heading';
-import Spinner from 'calypso/components/spinner';
+import { getActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
 
-const getTotalCount = ( counts: LicenseCounts ): number => {
-	return Object.values( counts ).reduce( ( acc, count ) => {
-		if ( typeof count !== 'number' ) return acc;
-
-		return acc + count;
-	} );
-};
-
-export default function LandingPage(): ReactElement | null {
-	const translate = useTranslate();
-	const counts = useSelector( getLicenseCounts );
-	const hasFetched = useSelector( hasFetchedLicenseCounts );
-	const totalCount = getTotalCount( counts );
+export default function LandingPage(): React.ReactElement | null {
+	const activePartnerKey = useSelector( getActivePartnerKey );
 
 	useEffect( () => {
-		if ( ! hasFetched ) {
-			return;
-		}
-
-		if ( totalCount > 0 ) {
+		if ( activePartnerKey?.hasLicenses ) {
 			return page.redirect( '/partner-portal/billing' );
 		}
 
 		return page.redirect( '/partner-portal/licenses' );
-	}, [ totalCount, hasFetched ] );
+	}, [ activePartnerKey ] );
 
-	return (
-		<Main className="landing-page__partner-portal">
-			<QueryJetpackPartnerPortalLicenseCounts />
-
-			<CardHeading size={ 36 }>{ translate( 'Partner Portal' ) }</CardHeading>
-
-			{ ! hasFetched && <Spinner /> }
-		</Main>
-	);
+	return null;
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, ReactElement } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { LicenseCounts } from 'calypso/state/partner-portal/types';
+import {
+	hasFetchedLicenseCounts,
+	getLicenseCounts,
+} from 'calypso/state/partner-portal/licenses/selectors';
+import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
+import Main from 'calypso/components/main';
+import CardHeading from 'calypso/components/card-heading';
+import Spinner from 'calypso/components/spinner';
+
+const getTotalCount = ( counts: LicenseCounts ): number => {
+	return Object.values( counts ).reduce( ( acc, count ) => {
+		if ( typeof count !== 'number' ) return acc;
+
+		return acc + count;
+	} );
+};
+
+export default function LandingPage(): ReactElement | null {
+	const translate = useTranslate();
+	const counts = useSelector( getLicenseCounts );
+	const hasFetched = useSelector( hasFetchedLicenseCounts );
+	const totalCount = getTotalCount( counts );
+
+	useEffect( () => {
+		if ( ! hasFetched ) {
+			return;
+		}
+
+		if ( totalCount > 0 ) {
+			return page.redirect( '/partner-portal/billing' );
+		}
+
+		return page.redirect( '/partner-portal/licenses' );
+	}, [ totalCount, hasFetched ] );
+
+	return (
+		<Main className="landing-page__partner-portal">
+			<QueryJetpackPartnerPortalLicenseCounts />
+
+			<CardHeading size={ 36 }>{ translate( 'Partner Portal' ) }</CardHeading>
+
+			{ ! hasFetched && <Spinner /> }
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -54,9 +54,9 @@ class PartnerPortalSidebar extends Component< Props > {
 							label={ translate( 'Billing', {
 								comment: 'Jetpack sidebar navigation item',
 							} ) }
-							link="/partner-portal"
+							link="/partner-portal/billing"
 							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal' ) }
-							selected={ path === '/partner-portal' }
+							selected={ path === '/partner-portal/billing' }
 						/>
 
 						<SidebarItem

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -166,6 +166,7 @@ export function formatApiPartner( partner: APIPartner ): Partner {
 			name: key.name,
 			oAuth2Token: key.oauth2_token,
 			disabledOn: key.disabled_on,
+			hasLicenses: key.has_licenses,
 		} ) ),
 	};
 }

--- a/client/state/partner-portal/licenses/reducer.ts
+++ b/client/state/partner-portal/licenses/reducer.ts
@@ -17,6 +17,7 @@ import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/typ
 export const initialState = {
 	hasFetched: false,
 	isFetching: false,
+	hasFetchedLicenseCounts: false,
 	paginated: null,
 	counts: {
 		[ LicenseFilter.Attached ]: 0,
@@ -65,9 +66,22 @@ export const counts = ( state = initialState.counts, action: AnyAction ) => {
 	return state;
 };
 
+export const hasFetchedLicenseCounts = (
+	state = initialState.hasFetchedLicenseCounts,
+	action: AnyAction
+) => {
+	switch ( action.type ) {
+		case JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_RECEIVE:
+			return true;
+	}
+
+	return state;
+};
+
 export default combineReducers( {
 	hasFetched,
 	isFetching,
 	paginated,
 	counts,
+	hasFetchedLicenseCounts,
 } );

--- a/client/state/partner-portal/licenses/selectors.ts
+++ b/client/state/partner-portal/licenses/selectors.ts
@@ -27,3 +27,7 @@ export function getPaginatedLicenses(
 export function getLicenseCounts( state: PartnerPortalStore ): LicenseCounts {
 	return state.partnerPortal.licenses.counts;
 }
+
+export function hasFetchedLicenseCounts( state: PartnerPortalStore ): boolean {
+	return state.partnerPortal.licenses.hasFetchedLicenseCounts;
+}

--- a/client/state/partner-portal/licenses/test/selectors.js
+++ b/client/state/partner-portal/licenses/test/selectors.js
@@ -91,7 +91,7 @@ describe( 'selectors', () => {
 
 			expect( hasFetchedLicenseCounts( state ) ).toEqual( false );
 
-			state.partnerPortal.licenses.hasFetched = true;
+			state.partnerPortal.licenses.hasFetchedLicenseCounts = true;
 			expect( hasFetchedLicenseCounts( state ) ).toEqual( true );
 		} );
 	} );

--- a/client/state/partner-portal/licenses/test/selectors.js
+++ b/client/state/partner-portal/licenses/test/selectors.js
@@ -77,4 +77,22 @@ describe( 'selectors', () => {
 			expect( getLicenseCounts( state ) ).toEqual( expected );
 		} );
 	} );
+
+	describe( '#hasFetchedLicenseCounts()', () => {
+		test( 'should return the value of hasFetchedLicenseCounts', () => {
+			const { hasFetchedLicenseCounts } = selectors;
+			const state = {
+				partnerPortal: {
+					licenses: {
+						hasFetchedLicenseCounts: false,
+					},
+				},
+			};
+
+			expect( hasFetchedLicenseCounts( state ) ).toEqual( false );
+
+			state.partnerPortal.licenses.hasFetched = true;
+			expect( hasFetchedLicenseCounts( state ) ).toEqual( true );
+		} );
+	} );
 } );

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -57,6 +57,7 @@ export interface APIPartnerKey {
 	name: string;
 	oauth2_token: string;
 	disabled_on: string | null;
+	has_licenses: boolean;
 }
 
 export interface APIPartner {
@@ -100,6 +101,7 @@ export interface PartnerKey {
 	name: string;
 	oAuth2Token: string;
 	disabledOn: string | null;
+	hasLicenses: boolean;
 }
 
 export interface Partner {

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -144,6 +144,7 @@ export interface LicensesStore {
 	isFetching: boolean;
 	paginated: PaginatedItems< License > | null;
 	counts: LicenseCounts;
+	hasFetchedLicenseCounts: boolean;
 }
 
 interface CombinedStore {


### PR DESCRIPTION
Context: 1187494150150258-as-1200379075486875

#### Changes proposed in this Pull Request
* This PR adds a logic to redirect to the right landing page based on the number of licenses issued by a Partner

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_Note: If D63084-code hasn't been shipped yet, you'll have to apply that patch before checking the functionality in this PR_

* If you do not have a partner key, please contact Infinity for one or you will be unable to view the UI.
* Checkout PR locally, run yarn && yarn start-jetpack-cloud.
* Visit http://jetpack.cloud.localhost:3000/partner-portal, and make sure you get redirected to `/partner-portal/billing` if you have licenses or `/partner-portal/licenses` otherwise
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->