### PR TITLE
Create useLocalStorage hook

### DIFF
--- a/client/lib/use-local-storage/README.md
+++ b/client/lib/use-local-storage/README.md
@@ -1,0 +1,17 @@
+# useLocalStorage hook
+
+A hook that works just like `useState()`, except the value is saved
+to `.localStorage`.
+
+State is serialized to JSON so that it can accept any data type. Versioning of
+state is left as an exercise for the consumer.
+
+## Motivation
+
+A typical way to take advantage of `.localStorage` in Calypso has been to save
+data to the Redux store, and then mark that it should be persisted. This is a
+fairly heavy-weight solution for a React component that just wants to save a
+simple user preference between page refreshes.
+
+If you're looking to cache server responses in `.localStorage` you might want to
+look at a solution based on `react-query` instead.

--- a/client/lib/use-local-storage/index.ts
+++ b/client/lib/use-local-storage/index.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useRef, useState } from 'react';
+
+export function useLocalStorage< T >(
+	storageKey: string,
+	initialValue: T | ( () => T )
+): [ T, ( newValue: T | ( ( oldValue: T ) => T ) ) => void ] {
+	const [ storedValue, setStoredValue ] = useState( () => {
+		const item = typeof window === 'undefined' ? null : window.localStorage.getItem( storageKey );
+		if ( item !== null ) {
+			try {
+				return JSON.parse( item ) as T;
+			} catch {
+				// Invalid data stored in localStorage, return initialValue
+			}
+		}
+
+		return initialValue instanceof Function ? initialValue() : initialValue;
+	} );
+
+	const prevValue = useRef( storedValue );
+
+	const setValue = useCallback(
+		( newValue: T | ( ( oldValue: T ) => T ) ) => {
+			const valueToStore = newValue instanceof Function ? newValue( prevValue.current ) : newValue;
+			setStoredValue( valueToStore );
+			prevValue.current = valueToStore;
+			if ( typeof window !== 'undefined' ) {
+				window.localStorage.setItem( storageKey, JSON.stringify( valueToStore ) );
+			}
+		},
+		[ prevValue, storageKey ]
+	);
+
+	return [ storedValue, setValue ];
+}

--- a/client/lib/use-local-storage/test/index.ts
+++ b/client/lib/use-local-storage/test/index.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalStorage } from '../';
+
+let originalLocalStorage;
+const mockLocalStorage = {
+	getItem: jest.fn( () => null ),
+	setItem: jest.fn(),
+};
+
+beforeAll( () => {
+	originalLocalStorage = window.localStorage;
+
+	Object.defineProperty( window, 'localStorage', {
+		value: mockLocalStorage,
+	} );
+} );
+
+beforeEach( () => {
+	mockLocalStorage.getItem.mockClear();
+	mockLocalStorage.setItem.mockClear();
+} );
+
+afterAll( () => {
+	Object.defineProperty( window, 'localStorage', {
+		value: originalLocalStorage,
+	} );
+} );
+
+test( 'returns initial value when localeStorage is empty', () => {
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+
+	expect( mockLocalStorage.getItem ).toBeCalledWith( 'key' );
+	expect( result.current[ 0 ] ).toBe( 113 );
+
+	// Doesn't save anything if the it's just the initial value being used
+	expect( mockLocalStorage.setItem ).not.toHaveBeenCalled();
+} );
+
+test( 'returns stored value instead of initial value', () => {
+	mockLocalStorage.getItem.mockImplementationOnce( () => JSON.stringify( 'not 113' ) );
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+
+	expect( mockLocalStorage.getItem ).toBeCalledWith( 'key' );
+	expect( result.current[ 0 ] ).toBe( 'not 113' );
+} );
+
+test( 'set initial value using callback', () => {
+	const { result } = renderHook( () => useLocalStorage( 'key', () => 113 ) );
+	expect( result.current[ 0 ] ).toBe( 113 );
+} );
+
+test( 'update value', () => {
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+	const updateState = result.current[ 1 ];
+	act( () => updateState( 114 ) );
+	expect( result.current[ 0 ] ).toBe( 114 );
+	expect( mockLocalStorage.setItem ).toHaveBeenCalledWith( 'key', JSON.stringify( 114 ) );
+} );
+
+test( 'update value using callback', () => {
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+	const updateState = result.current[ 1 ];
+	act( () => updateState( ( oldValue ) => oldValue + 1 ) );
+	expect( result.current[ 0 ] ).toBe( 114 );
+	expect( mockLocalStorage.setItem ).toHaveBeenCalledWith( 'key', JSON.stringify( 114 ) );
+} );
+
+test( 'get and set a JSON object', () => {
+	mockLocalStorage.getItem.mockImplementationOnce( () => JSON.stringify( { my_value: 113 } ) );
+
+	const { result } = renderHook( () => useLocalStorage( 'key', { my_value: 0 } ) );
+	const updateState = result.current[ 1 ];
+
+	expect( result.current[ 0 ] ).toEqual( { my_value: 113 } );
+
+	act( () => updateState( { my_value: 114 } ) );
+
+	expect( result.current[ 0 ] ).toEqual( { my_value: 114 } );
+	expect( mockLocalStorage.setItem ).toBeCalledWith( 'key', JSON.stringify( { my_value: 114 } ) );
+} );
+
+test( 'get and set falsy values', () => {
+	mockLocalStorage.getItem.mockImplementationOnce( () => JSON.stringify( null ) );
+
+	const { result } = renderHook( () => useLocalStorage( 'key', '' as '' | null ) );
+	const updateState = result.current[ 1 ];
+
+	expect( result.current[ 0 ] ).toEqual( null );
+
+	act( () => updateState( '' ) );
+
+	expect( result.current[ 0 ] ).toEqual( '' );
+	expect( mockLocalStorage.setItem ).toBeCalledWith( 'key', JSON.stringify( '' ) );
+} );
+
+test( 'return initial value if value in locale storage is invalid JSON', () => {
+	mockLocalStorage.getItem.mockImplementationOnce( () => 'this is not valid json' );
+
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+
+	expect( result.current[ 0 ] ).toBe( 113 );
+} );
+
+test( "setter reference doesn't change when value changes", () => {
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+
+	const oldSetter = result.current[ 1 ];
+
+	act( () => oldSetter( 114 ) );
+
+	const newSetter = result.current[ 1 ];
+	expect( newSetter ).toBe( oldSetter );
+} );

--- a/client/lib/use-local-storage/test/non-browser.ts
+++ b/client/lib/use-local-storage/test/non-browser.ts
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useLocalStorage } from '../';
+
+// We don't want `useLocalStorage` to break components that are running in tests
+test( 'behaves like useState when window is undefined', () => {
+	const { result } = renderHook( () => useLocalStorage( 'key', 113 ) );
+	const updateState = result.current[ 1 ];
+
+	expect( result.current[ 0 ] ).toBe( 113 );
+
+	act( () => updateState( 114 ) );
+
+	expect( result.current[ 0 ] ).toBe( 114 );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A hook that works just like `useState()`, except the value is saved to `localStorage`.

I pulled this out of #53207 which was originally moving some Redux state into `localStorage`. I've changed my mind about that, but I thought the dev work for the `useLocalStorage` hook could still be interesting so saved it for later.

I haven't got a proposed use for the hook though, just implementation and tests. Pinging @Automattic/team-calypso-frameworks in case they can think of a use for it that would make it worthwhile to keep around. Otherwise I'll just close the PR and move on.

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

