### PR TITLE
Store quick links expanded state in preferences tree

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -24,8 +24,7 @@ import { getGSuiteSupportedDomains } from 'calypso/lib/gsuite';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import ActionBox from './action-box';
-import isHomeQuickLinksExpanded from 'calypso/state/selectors/is-home-quick-links-expanded';
-import { expandHomeQuickLinks, collapseHomeQuickLinks } from 'calypso/state/home/actions';
+import { useQuickLinksIsExpanded } from '../use-quick-links-is-expanded';
 
 /**
  * Image dependencies
@@ -55,11 +54,15 @@ export const QuickLinks = ( {
 	trackAnchorPodcastAction,
 	addEmailAction,
 	addDomainAction,
-	isExpanded,
-	expand,
-	collapse,
 } ) => {
 	const translate = useTranslate();
+
+	const [ isExpanded, setIsExpanded, isExpandedLoading ] = useQuickLinksIsExpanded();
+
+	// Wait until `isExpanded` is initialised before rendering
+	if ( isExpandedLoading ) {
+		return null;
+	}
 
 	const quickLinks = (
 		<div className="quick-links__boxes">
@@ -169,8 +172,8 @@ export const QuickLinks = ( {
 			header={ translate( 'Quick links' ) }
 			clickableHeader
 			expanded={ isExpanded }
-			onOpen={ expand }
-			onClose={ collapse }
+			onOpen={ () => setIsExpanded( true ) }
+			onClose={ () => setIsExpanded( false ) }
 		>
 			{ quickLinks }
 		</FoldableCard>
@@ -313,7 +316,6 @@ const mapStateToProps = ( state ) => {
 		siteSlug,
 		isStaticHomePage,
 		editHomePageUrl,
-		isExpanded: isHomeQuickLinksExpanded( state ),
 	};
 };
 
@@ -329,8 +331,6 @@ const mapDispatchToProps = {
 	trackAnchorPodcastAction,
 	addEmailAction,
 	addDomainAction,
-	expand: expandHomeQuickLinks,
-	collapse: collapseHomeQuickLinks,
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {

--- a/client/my-sites/customer-home/cards/actions/use-quick-links-is-expanded.ts
+++ b/client/my-sites/customer-home/cards/actions/use-quick-links-is-expanded.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getStoredItem } from 'calypso/lib/browser-storage';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+export function useQuickLinksIsExpanded(): [
+	boolean | null,
+	( isExpanded: boolean ) => void,
+	boolean
+] {
+	const dispatch = useDispatch();
+	const userId = useSelector( getCurrentUserId );
+	const value = useSelector( ( state ) => getPreference( state, 'homeQuickLinksToggleStatus' ) );
+
+	const [ isLoadingDeprecated, setIsLoadingDeprecated ] = useState( true );
+	const [ deprecatedValue, setDeprecatedValue ] = useState( null );
+
+	useEffect( () => {
+		// The expanded state was previously in a `home` tree in the Redux store.
+		// Now that the expanded state is in the `preferences` tree, this helper
+		// will migrate any existing state from the persisted Redux store so we
+		// can use it as the default.
+
+		if ( value !== null ) {
+			// Something already stored in preferences, no need to migrate from Redux store
+			setIsLoadingDeprecated( false );
+			return;
+		}
+
+		if ( ! userId ) {
+			// Logged out? Probably shouldn't be seeing the quick-expander. Included for completeness.
+			setIsLoadingDeprecated( false );
+			return;
+		}
+
+		getStoredItem( `redux-state-${ userId }:home` )
+			.then( ( result: any ) => {
+				setDeprecatedValue( result?.quickLinksToggleStatus || null );
+			} )
+			.catch( () => {
+				setDeprecatedValue( null );
+			} )
+			.finally( () => {
+				setIsLoadingDeprecated( false );
+			} );
+	}, [ value, setDeprecatedValue, userId ] );
+
+	const setIsExpanded = useCallback(
+		( isExpanded: boolean ) =>
+			dispatch(
+				savePreference( 'homeQuickLinksToggleStatus', isExpanded ? 'expanded' : 'collapsed' )
+			),
+		[ dispatch ]
+	);
+
+	let isExpanded = value !== 'collapsed';
+	if ( ! value && deprecatedValue ) {
+		isExpanded = deprecatedValue !== 'collapsed';
+	}
+
+	return [ isExpanded, setIsExpanded, isLoadingDeprecated ];
+}

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -24,8 +24,7 @@ import { getGSuiteSupportedDomains } from 'calypso/lib/gsuite';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import ActionBox from '../quick-links/action-box';
-import isHomeQuickLinksExpanded from 'calypso/state/selectors/is-home-quick-links-expanded';
-import { expandHomeQuickLinks, collapseHomeQuickLinks } from 'calypso/state/home/actions';
+import { useQuickLinksIsExpanded } from '../use-quick-links-is-expanded';
 
 /**
  * Style dependencies
@@ -43,11 +42,15 @@ export const QuickLinks = ( {
 	manageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	isExpanded,
-	expand,
-	collapse,
 } ) => {
 	const translate = useTranslate();
+
+	const [ isExpanded, setIsExpanded, isExpandedLoading ] = useQuickLinksIsExpanded();
+
+	// Wait until `isExpanded` is initialised before rendering
+	if ( isExpandedLoading ) {
+		return null;
+	}
 
 	const quickLinks = (
 		<div className="wp-for-teams-quick-links__boxes quick-links__boxes">
@@ -114,8 +117,8 @@ export const QuickLinks = ( {
 			header={ translate( 'Quick Links' ) }
 			clickableHeader
 			expanded={ isExpanded }
-			onOpen={ expand }
-			onClose={ collapse }
+			onOpen={ () => setIsExpanded( true ) }
+			onClose={ () => setIsExpanded( false ) }
 		>
 			{ quickLinks }
 		</FoldableCard>
@@ -206,7 +209,6 @@ const mapStateToProps = ( state ) => {
 		siteSlug,
 		isStaticHomePage,
 		editHomePageUrl,
-		isExpanded: isHomeQuickLinksExpanded( state ),
 	};
 };
 
@@ -217,8 +219,6 @@ const mapDispatchToProps = {
 	manageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	expand: expandHomeQuickLinks,
-	collapse: collapseHomeQuickLinks,
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -88,6 +88,10 @@ export const remoteValuesSchema = {
 				restore: { $ref: '#/definitions/dismissiblePrompt' },
 			},
 		},
+		homeQuickLinksToggleStatus: {
+			type: 'string',
+			enum: [ 'collapsed', 'expanded' ],
+		},
 	},
 	definitions: {
 		dismissiblePrompt: {


### PR DESCRIPTION
Pulled out of #53207. This approach migrates the old state into the preferences store, but I'm not convinced it's worth the extra complexity/LoC/bytes.

Moves the flag for whether the quick links are expanded or not out of
the home store and into the global calypso prefs store.

Uses a custom hook to load and save the preference because there is
logic needed to migrate state over from the old store, and because that
logic needs to be shared by two components:
- The main Quick Links most users see
- The Quick Links panel used by P2 (aka wp for teams)

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
