### PR TITLE
Signup: Show filters button for domain step in reskinned

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -506,7 +506,8 @@ class RegisterDomainStep extends React.Component {
 			! Array.isArray( this.state.searchResults ) &&
 			! this.state.loadingResults &&
 			! this.props.showExampleSuggestions;
-		const showFilters = isKrackenUi && ! isRenderingInitialSuggestions && ! this.props.isReskinned;
+		const showFilters =
+			( isKrackenUi && ! isRenderingInitialSuggestions ) || this.props.isReskinned;
 
 		const showTldFilter =
 			( Array.isArray( this.state.availableTlds ) && this.state.availableTlds.length > 0 ) ||

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -178,6 +178,7 @@
 body.is-section-signup.is-white-signup {
 	$accent-blue: #117ac9;
 
+	.search-filters__popover,
 	.search-filters-extensions__popover {
 		@include break-medium {
 			transform: translateX( 65px );

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -180,16 +180,19 @@ body.is-section-signup.is-white-signup {
 
 	.search-filters__popover,
 	.search-filters-extensions__popover {
-		@include break-medium {
-			transform: translateX( 65px );
-		}
-
 		.token-field__suggestion {
 			&.is-selected {
 				background: $accent-blue;
 			}
 		}
 	}
+
+	.search-filters-extensions__popover {
+		@include break-medium {
+			transform: translateX( 65px );
+		}
+	}
+
 	.search-filters__popover-button {
 		order: 7;
 		margin-left: 1em;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes https://github.com/Automattic/wp-calypso/issues/53770

#### Testing instructions

1. Go to /start?flags=signup/reskin
2. Reach domain step.
3. You should see filters button there.

