### PR TITLE
Signup: Fix signup reskin logic

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -102,15 +102,19 @@ export default {
 		const isLoggedIn = isUserLoggedIn( context.store.getState() );
 		const currentFlowName = getFlowName( context.params, isLoggedIn );
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
+			// For 'new-launch' flow, 'is-white-signup' class name is being removed in client/signup/main.jsx
+			// Don't remove it here to prevent the flash of blue while the component is mounted
 			next();
-		} else if ( currentFlowName === 'onboarding' && config.isEnabled( 'signup/reskin' ) ) {
+		} else if (
+			config( 'reskinned_flows' ).includes( currentFlowName ) &&
+			config.isEnabled( 'signup/reskin' )
+		) {
 			next();
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||
 			context.pathname.indexOf( 'plan' ) >= 0 ||
 			context.pathname.indexOf( 'onboarding-registrationless' ) >= 0 ||
 			context.pathname.indexOf( 'wpcc' ) >= 0 ||
-			context.pathname.indexOf( 'launch-site' ) >= 0 ||
 			context.pathname.indexOf( 'launch-only' ) >= 0 ||
 			context.params.flowName === 'account' ||
 			context.params.flowName === 'crowdsignal' ||

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -125,6 +125,10 @@ function isWPForTeamsFlow( flowName ) {
 	return flowName === 'p2';
 }
 
+function isReskinnedFlow( flowName ) {
+	return config.isEnabled( 'signup/reskin' ) && config( 'reskinned_flows' ).includes( flowName );
+}
+
 class Signup extends React.Component {
 	static propTypes = {
 		store: PropTypes.object.isRequired,
@@ -226,7 +230,7 @@ class Signup extends React.Component {
 			this.updateShouldShowLoadingScreen( progress );
 		}
 
-		if ( ! config.isEnabled( 'signup/reskin' ) ) {
+		if ( ! isReskinnedFlow( flowName ) ) {
 			document.body.classList.remove( 'is-white-signup' );
 			debug( 'In componentWillReceiveProps, removed is-white-signup class' );
 		}
@@ -718,7 +722,7 @@ class Signup extends React.Component {
 
 		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
 
-		const isReskinned = config.isEnabled( 'signup/reskin' );
+		const isReskinned = isReskinnedFlow( this.props.flowName );
 
 		return (
 			<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -6,7 +6,8 @@ body.is-section-signup {
 	// Use WordPress.com’s brand color for the signup background
 	background: var( --color-wordpress-com );
 
-	&.is-white-signup {
+	&.is-white-signup,
+	&.is-new-launch-flow {
 		background: #fdfdfd;
 
 		.layout:not( .dops ) .wpcom-site__logo {
@@ -347,7 +348,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 	}
 }
 
-// Background color and plans grid overrides for new flow
+// Background color and plans grid overrides for 'new-launch' flow
 body.is-section-signup.is-new-launch-flow {
 	background: var( --color-white );
 
@@ -415,7 +416,7 @@ body.is-section-signup.is-new-launch-flow {
 	}
 }
 
-// Text and heading color override for new flow
+// Text and heading color override for 'new-launch' flow
 body.is-section-signup.is-new-launch-flow .layout:not( .dops ):not( .is-wccom-oauth-flow ) {
 	&.gravatar .formatted-header,
 	.formatted-header {
@@ -444,7 +445,7 @@ body.is-section-signup.is-new-launch-flow .layout:not( .dops ):not( .is-wccom-oa
 /**
  * Common styles for reskinSignupFlow a/b test
  */
-body.is-section-signup.is-white-signup .signup.is-onboarding {
+body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth-flow ) {
 	$gray-100: #101517;
 	$gray-60: #50575e;
 	$gray-50: #646970;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -149,5 +149,6 @@
 		}
 	],
 	"restricted_me_access": true,
-	"theme_color": "#055d9c"
+	"theme_color": "#055d9c",
+	"reskinned_flows": [ "onboarding", "launch-site" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Not only the `onboarding` flow can be reskinned. We now have a `reskinned_flows` Array in Calypso config that currently includes also `onboarding` and `launch-site` flow names.
* `new-launch` flow is not considered a reskinned flow. It just shares the white background with reskinned.
* Reskin styling doesn't leak to other signup flows that are not included in the `reskinned_flows` Array.

#### Testing instructions

Check the following flows with and without `signup/reskin` flag enabled. Reskinned styling should be applied correctly.
* `/start?flags=signup/reskin`
* `/start/launch-site?siteSlug={{SITE_SLUG}}&flags=signup/reskin`

The following flows should be the same regardless of the value of `signup/reskin` flag.
* `/start/new-launch?siteSlug={{SITE_SLUG}}&source=home&flags=signup/reskin`
* `/start/with-theme?theme=seedlet&flags=signup/reskin`
* `/start/personal?flags=signup/reskin`

**Note**: All the flows above should look the same as in production when the  `signup/reskin` flag is disabled.

Related to #53769 