### PR TITLE
Signup: Use Redux for user fetching in signup actions

### DIFF
--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -1,9 +1,7 @@
 /**
  * Internal dependencies
  */
-import user from 'calypso/lib/user';
-
-// State actions and selectors
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { requestSites } from 'calypso/state/sites/actions';
 
@@ -14,7 +12,8 @@ async function fetchSitesUntilSiteAppears( siteSlug, reduxStore ) {
 }
 
 export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
-	Promise.all( [ fetchSitesUntilSiteAppears( siteSlug, reduxStore ), user().fetch() ] ).then(
-		onComplete
-	);
+	Promise.all( [
+		fetchSitesUntilSiteAppears( siteSlug, reduxStore ),
+		reduxStore.dispatch( fetchCurrentUser() ),
+	] ).then( onComplete );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the signup actions to use Redux user fetching instead of `lib/user`.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Go through the old signup flow, keep an eye on when a site is being created and verify it goes on successfully. 

cc @jsnajdr who recently worked very closely on this one in #53374.
