### PR TITLE
State: Update middleware to fetch user with Redux

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -17,7 +17,7 @@ import {
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 } from 'calypso/state/action-types';
-import user from 'calypso/lib/user';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
 import { isFetchingAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -145,7 +145,7 @@ const handler = ( dispatch, action, getState ) => {
 
 		case SITE_DELETE_RECEIVE:
 		case JETPACK_DISCONNECT_RECEIVE:
-			user().fetch();
+			dispatch( fetchCurrentUser() );
 			return;
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the state middleware to use Redux user fetching instead of `lib/user` at site deletion and Jetpack disconnection.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Delete a WP.com simple site and verify that:
  * A request to `/me` is issued - see the network tab.
  * The site count in the "current site" area at the top of the "my-sites" sidebar reduces the count by 1 correctly.
* Disconnect a Jetpack site and go through the same 2 steps.