### PR TITLE
Social Login: Use Redux to refresh user

### DIFF
--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -15,7 +15,7 @@ import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/act
 import FormButton from 'calypso/components/forms/form-button';
 import GoogleLoginButton from 'calypso/components/social-buttons/google';
 import AppleLoginButton from 'calypso/components/social-buttons/apple';
-import user from 'calypso/lib/user';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 
 class SocialLoginActionButton extends Component {
 	static propTypes = {
@@ -33,12 +33,12 @@ class SocialLoginActionButton extends Component {
 		fetchingUser: false,
 	};
 
-	refreshUser = () => {
-		user().fetch();
-
+	refreshUser = async () => {
 		this.setState( { fetchingUser: true } );
 
-		user().once( 'change', () => this.setState( { fetchingUser: false } ) );
+		await this.props.fetchCurrentUser();
+
+		this.setState( { fetchingUser: false } );
 	};
 
 	handleSocialServiceResponse = ( response ) => {
@@ -150,5 +150,6 @@ export default connect(
 	{
 		connectSocialUser,
 		disconnectSocialUser,
+		fetchCurrentUser,
 	}
 )( localize( SocialLoginActionButton ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates social login to use Redux user fetching instead of `lib/user`.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Go to `/me/security/social-login`
* Connect one of the accounts.
* Verify that during connection, the connect/disconnect buttons are disabled.
* Verify that shortly after connecting, a request to `/me` is issued
* Disconnect an active account.
* Verify that during disconnection, the connect/disconnect buttons are disabled.
* Verify that the user is refreshed again.
* Verify the flow works as it does in production.