### PR TITLE
Checkout: Update AtomicStoreThankYouCard to use Redux user

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -20,7 +20,7 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import user from 'calypso/lib/user';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import wpcom from 'calypso/lib/wp';
 
 const VERIFY_EMAIL_ERROR_NOTICE = 'ecommerce-verify-email-error';
@@ -42,7 +42,7 @@ class AtomicStoreThankYouCard extends Component {
 		}
 	}
 
-	checkVerification = () => user().fetch();
+	checkVerification = () => this.props.fetchCurrentUser();
 
 	resendEmail = () => {
 		const { translate } = this.props;
@@ -183,5 +183,5 @@ export default connect(
 			planClass,
 		};
 	},
-	{ errorNotice, removeNotice }
+	{ errorNotice, fetchCurrentUser, removeNotice }
 )( localize( AtomicStoreThankYouCard ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the atomic store checkout thank you page to use Redux user fetching instead of `lib/user`.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Follow the testing instructions in #33812 and verify the flow still works the same way as it did before.