### PR TITLE
Block Editor Tracking: Fix wrong delegated event ID

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
@@ -16,7 +16,7 @@ const gutenbergTabPanelName = ( tabPanel ) =>
  * @returns {import('./types').DelegateEventHandler} event object definition.
  */
 export default () => ( {
-	id: 'wpcom-inserter-menu-search-term',
+	id: 'wpcom-inserter-tab-panel-selected',
 	// It would be nice to filter out events where the tab `is-active` before
 	// the click, but we can't do that because the update has already happened
 	selector: ( e ) => gutenbergTabPanelName( e.target ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Note to myself: copy-paste less. Fixes the ID of the `wpcom-inserter-tab-panel-selected` delegated event.

#### Testing instructions

* Make sure the ID is correct 😄 
