### PR TITLE
Block Editor Tracking: Scope inserter tab selected selector and ignore active tabs

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
@@ -17,12 +17,16 @@ const gutenbergTabPanelName = ( tabPanel ) =>
  */
 export default () => ( {
 	id: 'wpcom-inserter-tab-panel-selected',
-	// It would be nice to filter out events where the tab `is-active` before
-	// the click, but we can't do that because the update has already happened
-	selector: ( e ) => gutenbergTabPanelName( e.target ),
+	selector: `.block-editor-inserter__tabs .components-tab-panel__tabs button:not(.is-active)`,
 	type: 'click',
-	handler: ( _event, tabName ) =>
+	// Using capture event listener to make sure the tab is not set to active
+	// before this event listener runs. This way we can prevent the listener
+	// from triggering when the tab is already active.
+	capture: true,
+	handler: ( event ) => {
+		const tabName = gutenbergTabPanelName( event.target );
 		tracksRecordEvent( 'wpcom_block_picker_tab_panel_selected', {
 			tab: tabName,
-		} ),
+		} );
+	},
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Scope "inserter tab selected" event selector and ignore active tab clicks

#### Testing instructions

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Open Site Editor
* Open Global Styles
* Switch to Block Type tab
* Switch back to Root tab
* Make sure no `wpcom_block_picker_tab_panel_selected` events are triggered
* Open block inserter
* Switch to Patterns tab
* Make sure `wpcom_block_picker_tab_panel_selected` is triggered with `tab = 'patterns'` 
* Switch to Blocks tab
* Make sure `wpcom_block_picker_tab_panel_selected` is triggered with `tab = 'blocks'` 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/53456#pullrequestreview-686187438
Related #53410 
