### PR TITLE
Editor Stats - add `editor type` tracking for block widgets editors

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -77,7 +77,11 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// (at least at the time of writing), which is why we can rely on this method.
 	if (
 		select( 'core/edit-post' )?.isInserterOpened() ||
-		select( 'core/edit-site' )?.isInserterOpened()
+		select( 'core/edit-site' )?.isInserterOpened() ||
+		select( 'core/edit-widgets' )?.isInserterOpened() ||
+		document
+			.querySelector( '.customize-widgets-layout__inserter-panel' )
+			?.contains( document.activeElement )
 	) {
 		return 'header-inserter';
 	}
@@ -306,7 +310,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		   to update via `replaceInnerBlocks`.
 
 		3. Performing undo or redo related to template parts and reusable blocks
-		   will update the instances via `replaceInnerBlocks`. 
+		   will update the instances via `replaceInnerBlocks`.
 	*/
 	const parentBlock = select( 'core/block-editor' ).getBlocksByClientId( rootClientId )?.[ 0 ];
 	if ( parentBlock ) {

--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -12,5 +12,13 @@ export const getEditorType = () => {
 		return 'site';
 	}
 
+	if ( document.querySelector( '#widgets-editor' ) ) {
+		return 'widgets';
+	}
+
+	if ( document.querySelector( '#customize-controls .customize-widgets__sidebar-section.open' ) ) {
+		return 'customize-widgets';
+	}
+
 	return undefined;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds support for `widgets` and `customize-widgets` as `editor_type` values in block editor tracking events.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the new widgets editors in both the widgets editor and customizer->widgets editor as outlined here - p58i-axR-p2
* Follow steps to enable tracking debugging PCYsg-nrf-p2
* Add some blocks in the editors and verify that the `editor_type` appears as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53410