### PR TITLE
Theme Showcase: link theme activation error notice to /help

### DIFF
--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -10,6 +11,7 @@ import wpcom from 'calypso/lib/wp';
 import { THEME_ACTIVATE, THEME_ACTIVATE_FAILURE } from 'calypso/state/themes/action-types';
 import { themeActivated } from 'calypso/state/themes/actions/theme-activated';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 
 import 'calypso/state/themes/init';
 
@@ -56,7 +58,20 @@ export function activateTheme(
 				if ( error.error === 'theme_not_found' ) {
 					dispatch( errorNotice( translate( 'Theme not yet available for this site' ) ) );
 				} else {
-					dispatch( errorNotice( translate( 'Unable to activate theme. Contact support.' ) ) );
+					dispatch(
+						errorNotice(
+							translate(
+								'Unable to activate theme. {{contactSupportLink}}Contact support{{/contactSupportLink}}.',
+								{
+									components: {
+										contactSupportLink: (
+											<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />
+										),
+									},
+								}
+							)
+						)
+					);
 				}
 			} );
 	};


### PR DESCRIPTION
This adds a link to `/help` from the theme activation error notice.

Reported: pbAok1-2d9-p2

![error-notice](https://user-images.githubusercontent.com/942359/122409907-83795680-cf51-11eb-97d4-ec3d4cc921f5.gif)

**To test:**
- add `throw 'error';` before [the `activateTheme()` try/catch](https://github.com/Automattic/wp-calypso/blob/update/theme-activation-error-notice/client/state/themes/actions/activate-theme.js#L48)
- navigate to the Theme Showcase
- switch themes
- depending on where you throw the error, the theme might be activated, but the notice should be shown regardless
- verify that the notice is shown, that "Contact support" is a link, and that clicking it opens a new tab to `/help`