### PR TITLE
Removing domain card from thank you if the user has no domain credit.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import PurchaseDetail from 'calypso/components/purchase-detail';
-import { hasCustomDomain } from 'calypso/lib/site/utils';
 
 /**
  * Image dependencies
@@ -54,8 +53,6 @@ const CustomDomainPurchaseDetail = ( {
 				href={ `/domains/add/${ selectedSite.slug }` }
 			/>
 		);
-	} else if ( ! hasDomainCredit && hasCustomDomain( selectedSite ) ) {
-		return null;
 	} else if ( hasNonPrimaryDomainsFlag && registeredDomain ) {
 		const actionButton = {};
 		actionButton.buttonText = translate( 'Change primary domain' );

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import PurchaseDetail from 'calypso/components/purchase-detail';
-import { hasCustomDomain } from 'calypso/lib/site/utils';
 
 /**
  * Image dependencies
@@ -52,24 +51,6 @@ const CustomDomainPurchaseDetail = ( {
 				}
 				buttonText={ translate( 'Claim your free domain' ) }
 				href={ `/domains/add/${ selectedSite.slug }` }
-			/>
-		);
-	} else if ( ! hasDomainCredit && hasCustomDomain( selectedSite ) ) {
-		const actionButton = {};
-		actionButton.buttonText = translate( 'Manage my domains' );
-		actionButton.href = `/domains/manage/${ selectedSite.slug }`;
-		return (
-			<PurchaseDetail
-				icon={ <img alt="" src={ customDomainIcon } /> }
-				title={ translate( 'Custom Domain' ) }
-				description={ translate(
-					'Your plan includes one year of your custom domain {{em}}%(siteDomain)s{{/em}}, your own personal corner of the web.',
-					{
-						args: { siteDomain: selectedSite.domain },
-						components: { em: <em /> },
-					}
-				) }
-				{ ...actionButton }
 			/>
 		);
 	} else if ( hasNonPrimaryDomainsFlag && registeredDomain ) {

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import PurchaseDetail from 'calypso/components/purchase-detail';
+import { hasCustomDomain } from 'calypso/lib/site/utils';
 
 /**
  * Image dependencies
@@ -53,6 +54,8 @@ const CustomDomainPurchaseDetail = ( {
 				href={ `/domains/add/${ selectedSite.slug }` }
 			/>
 		);
+	} else if ( ! hasDomainCredit && hasCustomDomain( selectedSite ) ) {
+		return null;
 	} else if ( hasNonPrimaryDomainsFlag && registeredDomain ) {
 		const actionButton = {};
 		actionButton.buttonText = translate( 'Change primary domain' );


### PR DESCRIPTION
If a user has an existing paid plan and has already used their domain credit and upgrades to a higher plan, we should not show them the card that promises a year free domain on the thank you page. Issue reported at pNPgK-5cd-p2.

Here are before and after screen captures showing the issue and the fix:

*Before*
![CleanShot 2021-06-16 at 15 47 51](https://user-images.githubusercontent.com/35781181/122578413-d7537080-d021-11eb-8cbc-d8e2b56b418a.gif)

*After*
![CleanShot 2021-06-18 at 10 35 18](https://user-images.githubusercontent.com/35781181/122578533-f4883f00-d021-11eb-861d-1432dcacb509.gif)

Note that the domain card is not present on the Thank You page in the second capture.


#### Changes proposed in this Pull Request

* Remove the domain card from the checkout Thank You page for users who don't have a domain credit.

#### Testing instructions

* Checkout this PR and start Calypso
* Use a test site on a paid plan that has a custom domain set as Primary and no domain credits.
* You can remove domain credits from your site in Store Admin by clicking the "D" button shown in this screenshot:
![CleanShot 2021-06-18 at 10 46 57@2x](https://user-images.githubusercontent.com/35781181/122579231-b3dcf580-d022-11eb-947f-5a6d3bc700a8.png)
* Upgrade that site to Premium or Business plan.
* Confirm that you don't see a card on the Thank You page that says you'll get a free domain for a year.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Martech board 646.
