### PR TITLE
Checkout: Re-enable Google Pay for currencies with a rarely used decimal

### DIFF
--- a/packages/wpcom-checkout/src/use-is-web-payment-available.ts
+++ b/packages/wpcom-checkout/src/use-is-web-payment-available.ts
@@ -78,7 +78,7 @@ export function useIsWebPayAvailable(
 		// These arrays let us easily turn off web payments for particular currencies.
 		// Other payment methods handle this on the backend in a similar way.
 		const applePayDisabledCurrencies: string[] = [];
-		const googlePayDisabledCurrencies: string[] = [ 'inr', 'idr', 'huf', 'twd' ];
+		const googlePayDisabledCurrencies: string[] = [];
 		const isApplePayAllowedForCurrency = ! applePayDisabledCurrencies.includes(
 			normalizedCurrency
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This re-enables the currencies that were disabled by https://github.com/Automattic/wp-calypso/pull/53382. They are decimal currencies that we must treat as zero-decimal for PayPal, but which we must treat as having rounded-away decimals for Stripe. D62369-code should correct how these currencies are handled by our backend payment system, so that their decimals will be used correctly in both cases, and therefore we can allow these to be used by Google Pay again.

#### Testing instructions

- Set your test user's currency to INR.
- Make sure the browser session you will be using to test has a Google Pay wallet with a valid card present.
- Apply D60830-code to allow using localtunnel to connect to the REST API.
- Use localtunnel to make local calypso accessible via HTTPS.
- Visit the localtunnel URL for local calypso.
- Add a product to your cart and visit checkout.
- Select Google Pay as a payment method and press the submit button.
- Verify that the total displayed in the Google Pay dialog matches the amount displayed in checkout.

There should be no need to actually complete the payment.