### PR TITLE
Themes: Update front-end of auto-loading homepage confirmation modal.

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -213,18 +213,18 @@ class AutoLoadingHomepageModal extends Component {
 					</h1>
 					<div className="themes__theme-preview-items">
 						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
-							<div className="themes__iframe-wrapper">
-								<Spinner />
-								{ ! isNarrow && (
-									<iframe
-										scrolling="no"
-										loading="lazy"
-										title={ translate( 'Preview of current homepage with new theme applied' ) }
-										src={ iframeSrcKeepHomepage }
-									/>
-								) }
-							</div>
 							<FormLabel>
+								<div className="themes__iframe-wrapper">
+									<Spinner />
+									{ ! isNarrow && (
+										<iframe
+											scrolling="no"
+											loading="lazy"
+											title={ translate( 'Preview of current homepage with new theme applied' ) }
+											src={ iframeSrcKeepHomepage }
+										/>
+									) }
+								</div>
 								<FormRadio
 									value="keep_current_homepage"
 									checked={ 'keep_current_homepage' === this.state.homepageAction }
@@ -236,11 +236,11 @@ class AutoLoadingHomepageModal extends Component {
 							</FormLabel>
 						</div>
 						<div className="themes__theme-preview-item">
-							<img
-								src={ themeScreenshot }
-								alt={ translate( "Preview of new theme's default homepage" ) }
-							/>
 							<FormLabel>
+								<img
+									src={ themeScreenshot }
+									alt={ translate( "Preview of new theme's default homepage" ) }
+								/>
 								<FormRadio
 									value="use_new_homepage"
 									checked={ 'use_new_homepage' === this.state.homepageAction }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -35,6 +35,7 @@ import {
 } from 'calypso/state/themes/actions';
 import { addQueryArgs } from '@wordpress/url';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { preventWidows } from 'calypso/lib/formatting';
 
 /**
  * Style dependencies
@@ -209,7 +210,9 @@ class AutoLoadingHomepageModal extends Component {
 									value="keep_current_homepage"
 									checked={ 'keep_current_homepage' === this.state.homepageAction }
 									onChange={ this.handleHomepageAction }
-									label={ translate( 'Switch theme, preserving my homepage content.' ) }
+									label={ preventWidows(
+										translate( 'Switch theme, preserving my homepage content.' )
+									) }
 								/>
 							</FormLabel>
 						</div>
@@ -223,9 +226,11 @@ class AutoLoadingHomepageModal extends Component {
 									value="use_new_homepage"
 									checked={ 'use_new_homepage' === this.state.homepageAction }
 									onChange={ this.handleHomepageAction }
-									label={ translate( 'Replace my homepage content with the %(themeName)s demo.', {
-										args: { themeName },
-									} ) }
+									label={ preventWidows(
+										translate( 'Replace my homepage content with the %(themeName)s demo.', {
+											args: { themeName },
+										} )
+									) }
 								/>
 							</FormLabel>
 						</div>
@@ -233,8 +238,10 @@ class AutoLoadingHomepageModal extends Component {
 					<div className="themes__autoloading-homepage-option-description">
 						{ this.state.homepageAction === 'keep_current_homepage' && (
 							<p>
-								{ translate(
-									'Your new theme design will be applied without changing your homepage content.'
+								{ preventWidows(
+									translate(
+										'Your new theme design will be applied without changing your homepage content.'
+									)
 								) }{ ' ' }
 								<ExternalLink
 									href={ localizeUrl( 'https://wordpress.com/support/themes/#switch-themes' ) }
@@ -250,8 +257,10 @@ class AutoLoadingHomepageModal extends Component {
 								<span
 									// eslint-disable-next-line react/no-danger
 									dangerouslySetInnerHTML={ {
-										__html: translate(
-											'After activation, you can still access your old homepage content under Pages &rarr; Drafts.'
+										__html: preventWidows(
+											translate(
+												'After activation, you can still access your old homepage content under Pages &rarr; Drafts.'
+											)
 										),
 									} }
 								/>{ ' ' }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -16,6 +16,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
+import Spinner from 'calypso/components/spinner';
 import {
 	getCanonicalTheme,
 	hasActivatedTheme,
@@ -155,6 +156,7 @@ class AutoLoadingHomepageModal extends Component {
 		const iframeSrcKeepHomepage = addQueryArgs( 'https://' + this.props.siteDomain, {
 			theme: stylesheet,
 			hide_banners: 'true',
+			preview_overlay: 'true',
 		} );
 
 		return (
@@ -195,6 +197,7 @@ class AutoLoadingHomepageModal extends Component {
 					<div className="themes__theme-preview-items">
 						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
 							<div className="themes__iframe-wrapper">
+								<Spinner />
 								<iframe
 									loading="lazy"
 									title={ translate( 'Preview of current homepage with new theme applied' ) }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -172,37 +172,38 @@ class AutoLoadingHomepageModal extends Component {
 					eventName={ 'calypso_theme_autoloading_homepage_modal_view' }
 					eventProperties={ { theme: themeId } }
 				/>
-				<div>
+				<div className="themes__theme-preview-wrapper">
 					<h1>
 						{ translate( 'How would you like to use %(themeName)s?', {
 							args: { themeName },
 						} ) }
 					</h1>
-					<div className="themes__theme-preview-item">
-						<img src="https://placedog.net/500" alt="" />
-						<FormLabel>
-							<FormRadio
-								value="keep_current_homepage"
-								checked={ 'keep_current_homepage' === this.state.homepageAction }
-								onChange={ this.handleHomepageAction }
-								label={ translate( 'Switch theme, preserving my homepage content.' ) }
-							/>
-						</FormLabel>
+					<div className="themes__theme-preview-items">
+						<div className="themes__theme-preview-item">
+							<img src="https://placedog.net/500" alt="" />
+							<FormLabel>
+								<FormRadio
+									value="keep_current_homepage"
+									checked={ 'keep_current_homepage' === this.state.homepageAction }
+									onChange={ this.handleHomepageAction }
+									label={ translate( 'Switch theme, preserving my homepage content.' ) }
+								/>
+							</FormLabel>
+						</div>
+						<div className="themes__theme-preview-item">
+							<img src="https://placedog.net/500" alt="" />
+							<FormLabel>
+								<FormRadio
+									value="use_new_homepage"
+									checked={ 'use_new_homepage' === this.state.homepageAction }
+									onChange={ this.handleHomepageAction }
+									label={ translate( 'Replace my homepage content with the %(themeName)s demo.', {
+										args: { themeName },
+									} ) }
+								/>
+							</FormLabel>
+						</div>
 					</div>
-					<div className="themes__theme-preview-item">
-						<img src="https://placedog.net/500" alt="" />
-						<FormLabel>
-							<FormRadio
-								value="use_new_homepage"
-								checked={ 'use_new_homepage' === this.state.homepageAction }
-								onChange={ this.handleHomepageAction }
-								label={ translate( 'Replace my homepage content with the %(themeName)s demo.', {
-									args: { themeName },
-								} ) }
-							/>
-						</FormLabel>
-					</div>
-					<div style={ { clear: 'both' } } />
 					<div className="themes__autoloading-homepage-option-description">
 						{ this.state.homepageAction === 'keep_current_homepage' && (
 							<p>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -153,8 +153,7 @@ class AutoLoadingHomepageModal extends Component {
 			screenshot: themeScreenshot,
 		} = this.props.theme;
 
-		// is HTTPS always appropriate?
-		const iframeSrcKeepHomepage = addQueryArgs( 'https://' + this.props.siteDomain, {
+		const iframeSrcKeepHomepage = addQueryArgs( '//' + this.props.siteDomain, {
 			theme: stylesheet,
 			hide_banners: 'true',
 			preview_overlay: 'true',

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -26,11 +26,13 @@ import {
 	getPreActivateThemeId,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import {
 	acceptAutoLoadingHomepageWarning,
 	hideAutoLoadingHomepageWarning,
 	activate as activateTheme,
 } from 'calypso/state/themes/actions';
+import { addQueryArgs } from '@wordpress/url';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
@@ -142,7 +144,18 @@ class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const { name: themeName, id: themeId } = this.props.theme;
+		const {
+			name: themeName,
+			id: themeId,
+			stylesheet,
+			screenshot: themeScreenshot,
+		} = this.props.theme;
+
+		// is HTTPS always appropriate?
+		const iframeSrcKeepHomepage = addQueryArgs( 'https://' + this.props.siteDomain, {
+			theme: stylesheet,
+			hide_banners: 'true',
+		} );
 
 		return (
 			<Dialog
@@ -180,8 +193,14 @@ class AutoLoadingHomepageModal extends Component {
 						} ) }
 					</h1>
 					<div className="themes__theme-preview-items">
-						<div className="themes__theme-preview-item">
-							<img src="https://placedog.net/500" alt="" />
+						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
+							<div className="themes__iframe-wrapper">
+								<iframe
+									loading="lazy"
+									title={ translate( 'Preview of current homepage with new theme applied' ) }
+									src={ iframeSrcKeepHomepage }
+								/>
+							</div>
 							<FormLabel>
 								<FormRadio
 									value="keep_current_homepage"
@@ -192,7 +211,10 @@ class AutoLoadingHomepageModal extends Component {
 							</FormLabel>
 						</div>
 						<div className="themes__theme-preview-item">
-							<img src="https://placedog.net/500" alt="" />
+							<img
+								src={ themeScreenshot }
+								alt={ translate( "Preview of new theme's default homepage" ) }
+							/>
 							<FormLabel>
 								<FormRadio
 									value="use_new_homepage"
@@ -253,6 +275,7 @@ export default connect(
 
 		return {
 			siteId,
+			siteDomain: getSiteDomain( state, siteId ),
 			installingThemeId,
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -266,7 +266,7 @@ class AutoLoadingHomepageModal extends Component {
 									icon
 									target="__blank"
 								>
-									{ translate( 'Learn more' ) }
+									{ translate( 'Learn more.' ) }
 								</ExternalLink>
 							</p>
 						) }
@@ -287,7 +287,7 @@ class AutoLoadingHomepageModal extends Component {
 									icon
 									target="__blank"
 								>
-									{ translate( 'Learn more' ) }
+									{ translate( 'Learn more.' ) }
 								</ExternalLink>
 							</p>
 						) }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -245,7 +245,7 @@ class AutoLoadingHomepageModal extends Component {
 									checked={ 'use_new_homepage' === this.state.homepageAction }
 									onChange={ this.handleHomepageAction }
 									label={ preventWidows(
-										translate( 'Replace my homepage content with the %(themeName)s demo.', {
+										translate( 'Replace my homepage content with the %(themeName)s homepage.', {
 											args: { themeName },
 										} )
 									) }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -217,6 +217,7 @@ class AutoLoadingHomepageModal extends Component {
 								<Spinner />
 								{ ! isNarrow && (
 									<iframe
+										scrolling="no"
 										loading="lazy"
 										title={ translate( 'Preview of current homepage with new theme applied' ) }
 										src={ iframeSrcKeepHomepage }

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -244,7 +244,7 @@ class AutoLoadingHomepageModal extends Component {
 									)
 								) }{ ' ' }
 								<ExternalLink
-									href={ localizeUrl( 'https://wordpress.com/support/themes/#switch-themes' ) }
+									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
 									icon
 									target="__blank"
 								>
@@ -265,7 +265,7 @@ class AutoLoadingHomepageModal extends Component {
 									} }
 								/>{ ' ' }
 								<ExternalLink
-									href={ localizeUrl( 'https://wordpress.com/support/themes/#switch-themes' ) }
+									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
 									icon
 									target="__blank"
 								>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -31,6 +31,7 @@ import {
 	hideAutoLoadingHomepageWarning,
 	activate as activateTheme,
 } from 'calypso/state/themes/actions';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Style dependencies
@@ -211,7 +212,7 @@ class AutoLoadingHomepageModal extends Component {
 									'Your new theme design will be applied without changing your homepage content.'
 								) }{ ' ' }
 								<ExternalLink
-									href="https://wordpress.com/support/themes/#switch-themes"
+									href={ localizeUrl( 'https://wordpress.com/support/themes/#switch-themes' ) }
 									icon
 									target="__blank"
 								>
@@ -230,7 +231,7 @@ class AutoLoadingHomepageModal extends Component {
 									} }
 								/>{ ' ' }
 								<ExternalLink
-									href="https://wordpress.com/support/themes/#switch-themes"
+									href={ localizeUrl( 'https://wordpress.com/support/themes/#switch-themes' ) }
 									icon
 									target="__blank"
 								>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -14,6 +14,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import ExternalLink from 'calypso/components/external-link';
+import Gridicon from 'calypso/components/gridicon';
 import {
 	getCanonicalTheme,
 	hasActivatedTheme,
@@ -161,39 +163,81 @@ class AutoLoadingHomepageModal extends Component {
 				] }
 				onClose={ this.closeModalHandler( 'dismiss' ) }
 			>
+				<Gridicon
+					icon="cross"
+					className="themes__auto-loading-homepage-modal-close-icon"
+					onClick={ this.closeModalHandler( 'dismiss' ) }
+				/>
 				<TrackComponentView
 					eventName={ 'calypso_theme_autoloading_homepage_modal_view' }
 					eventProperties={ { theme: themeId } }
 				/>
 				<div>
 					<h1>
-						{ translate( 'How would you like to use %(themeName)s on your site?', {
+						{ translate( 'How would you like to use %(themeName)s?', {
 							args: { themeName },
 						} ) }
 					</h1>
-					<FormLabel>
-						<FormRadio
-							value="keep_current_homepage"
-							checked={ 'keep_current_homepage' === this.state.homepageAction }
-							onChange={ this.handleHomepageAction }
-							label={ translate( 'Switch to %(themeName)s without changing the homepage content.', {
-								args: { themeName },
-							} ) }
-						/>
-					</FormLabel>
-					<FormLabel>
-						<FormRadio
-							value="use_new_homepage"
-							checked={ 'use_new_homepage' === this.state.homepageAction }
-							onChange={ this.handleHomepageAction }
-							label={ translate(
-								'Replace the homepage content with the %(themeName)s demo content. The existing homepage will be saved as a draft under Pages → Drafts.',
-								{
+					<div className="themes__theme-preview-item">
+						<img src="https://placedog.net/500" alt="" />
+						<FormLabel>
+							<FormRadio
+								value="keep_current_homepage"
+								checked={ 'keep_current_homepage' === this.state.homepageAction }
+								onChange={ this.handleHomepageAction }
+								label={ translate( 'Switch theme, preserving my homepage content.' ) }
+							/>
+						</FormLabel>
+					</div>
+					<div className="themes__theme-preview-item">
+						<img src="https://placedog.net/500" alt="" />
+						<FormLabel>
+							<FormRadio
+								value="use_new_homepage"
+								checked={ 'use_new_homepage' === this.state.homepageAction }
+								onChange={ this.handleHomepageAction }
+								label={ translate( 'Replace my homepage content with the %(themeName)s demo.', {
 									args: { themeName },
-								}
-							) }
-						/>
-					</FormLabel>
+								} ) }
+							/>
+						</FormLabel>
+					</div>
+					<div style={ { clear: 'both' } } />
+					<div className="themes__autoloading-homepage-option-description">
+						{ this.state.homepageAction === 'keep_current_homepage' && (
+							<p>
+								{ translate(
+									'Your new theme design will be applied without changing your homepage content.'
+								) }{ ' ' }
+								<ExternalLink
+									href="https://wordpress.com/support/themes/#switch-themes"
+									icon
+									target="__blank"
+								>
+									{ translate( 'Learn more' ) }
+								</ExternalLink>
+							</p>
+						) }
+						{ this.state.homepageAction === 'use_new_homepage' && (
+							<p>
+								<span
+									// eslint-disable-next-line react/no-danger
+									dangerouslySetInnerHTML={ {
+										__html: translate(
+											'After activation, you can still access your old homepage content under Pages &rarr; Drafts.'
+										),
+									} }
+								/>{ ' ' }
+								<ExternalLink
+									href="https://wordpress.com/support/themes/#switch-themes"
+									icon
+									target="__blank"
+								>
+									{ translate( 'Learn more' ) }
+								</ExternalLink>
+							</p>
+						) }
+					</div>
 				</div>
 			</Dialog>
 		);

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,6 +1,4 @@
 .themes__auto-loading-homepage-modal {
-	min-height: 90px;
-	max-width: 400px;
 	margin: 0 auto;
 
 	@include breakpoint-deprecated( '<480px' ) {
@@ -12,6 +10,16 @@
 			margin: 0 auto 10px;
 			width: 100%;
 		}
+	}
+
+	.themes__auto-loading-homepage-modal-close-icon {
+		float: right;
+		cursor: pointer;
+	}
+
+	.themes__theme-preview-item {
+		float: left;
+		width: 48%;
 	}
 
 	.form-label {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -73,3 +73,21 @@
 		margin: 1em;
 	}
 }
+
+.themes__theme-preview-item-iframe-container {
+	display: flex;
+	flex-direction: column;
+
+	.themes__iframe-wrapper {
+		flex-grow: 1;
+		overflow: hidden;
+	}
+	iframe {
+		// flex-grow: 1;
+		height: 200%;
+		width: 200%;
+		max-width: 200%;
+		transform: scale( 0.5 );
+		transform-origin: top left;
+	}
+}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -33,6 +33,7 @@
 
 .themes__autoloading-homepage-option-description {
 	font-size: $font-body-small;
+	min-height: 80px;
 
 	@include break-medium {
 		width: 70%;
@@ -91,6 +92,7 @@
 		flex-grow: 1;
 		overflow: hidden;
 		position: relative;
+		pointer-events: none;
 	}
 	iframe {
 		height: 357%;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -76,7 +76,7 @@
 		.themes__iframe-wrapper {
 			display: block;
 			height: 100%;
-			max-height: 250px;
+			max-height: 235px;
 		}
 
 		.form-label {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -93,10 +93,10 @@
 		position: relative;
 	}
 	iframe {
-		height: 400%;
-		width: 400%;
-		max-width: 400%;
-		transform: scale( 0.25 );
+		height: 357%;
+		width: 357%;
+		max-width: 357%;
+		transform: scale( 0.28 );
 		transform-origin: top left;
 		position: absolute;
 		top: 0;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -2,28 +2,19 @@
 @import '@wordpress/base-styles/mixins';
 
 .themes__auto-loading-homepage-modal {
-	margin: 0 auto;
+	position: relative;
 
 	h1 {
 		margin-bottom: 1em;
 		text-align: center;
 	}
-
-	@include break-mobile {
-		box-sizing: border-box;
-		max-width: 100%;
-
-		+ .dialog__action-buttons .button {
-			display: block;
-			margin: 0 auto 1em;
-			width: 100%;
-		}
-	}
 }
 
 .themes__auto-loading-homepage-modal-close-icon {
 	cursor: pointer;
-	float: right;
+	position: absolute;
+	right: 20px;
+	top: 20px;
 }
 
 .themes__auto-loading-homepage-modal-homepage-hint {
@@ -37,6 +28,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	max-width: 700px;
 }
 
 .themes__autoloading-homepage-option-description {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -12,9 +12,18 @@
 
 .themes__auto-loading-homepage-modal-close-icon {
 	cursor: pointer;
+	width: 16px;
+	height: 16px;
 	position: absolute;
-	right: 20px;
-	top: 20px;
+	top: 10px;
+	right: 10px;
+
+	@include break-medium {
+		width: 24px;
+		height: 24px;
+		right: 20px;
+		top: 20px;
+	}
 }
 
 .themes__auto-loading-homepage-modal-homepage-hint {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -54,7 +54,16 @@
 	border: 1px solid var( --color-border-subtle );
 	border-radius: 2px;
 
+	img,
+	.themes__iframe-wrapper {
+		display: none;
+	}
+
 	@include break-medium {
+		img,
+		.themes__iframe-wrapper {
+			display: block;
+		}
 		width: 48%;
 		margin-left: 2%;
 
@@ -81,6 +90,7 @@
 	.themes__iframe-wrapper {
 		flex-grow: 1;
 		overflow: hidden;
+		position: relative;
 	}
 	iframe {
 		// flex-grow: 1;
@@ -89,5 +99,8 @@
 		max-width: 200%;
 		transform: scale( 0.5 );
 		transform-origin: top left;
+		position: absolute;
+		top: 0;
+		left: 0;
 	}
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,8 +1,8 @@
 @import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .themes__auto-loading-homepage-modal {
 	margin: 0 auto;
-	text-align: center;
 
 	h1 {
 		margin-bottom: 1em;
@@ -15,7 +15,7 @@
 
 		+ .dialog__action-buttons .button {
 			display: block;
-			margin: 0 auto 10px;
+			margin: 0 auto 1em;
 			width: 100%;
 		}
 	}
@@ -27,7 +27,7 @@
 }
 
 .themes__auto-loading-homepage-modal-homepage-hint {
-	margin-left: 20px;
+	margin-left: 1.5em;
 	font-size: $font-body-small;
 	font-style: italic;
 	margin-top: -5px;
@@ -44,14 +44,19 @@
 }
 
 .themes__theme-preview-items {
+	display: flex;
+	flex-direction: column;
 	margin: 0 0 1.5em;
 	max-width: 700px;
+
+	@include break-medium {
+		flex-direction: row;
+	}
 }
 
 .themes__theme-preview-item {
 	border: 1px solid var( --color-border-subtle );
 	border-radius: 2px;
-	margin: 0 0 1em;
 
 	@include break-medium {
 		width: 48%;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -42,7 +42,7 @@
 
 .themes__autoloading-homepage-option-description {
 	font-size: $font-body-small;
-	min-height: 80px;
+	min-height: 90px;
 
 	@include break-medium {
 		width: 70%;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -32,13 +32,14 @@
 }
 
 .themes__autoloading-homepage-option-description {
-	width: 50%;
+	font-size: $font-body-small;
+	width: 70%;
 }
 
 .themes__theme-preview-items {
 	display: flex;
 	flex-direction: column;
-	margin: 0 0 1.5em;
+	margin: 0 0 1em;
 	max-width: 700px;
 
 	@include break-medium {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -75,10 +75,20 @@
 		img,
 		.themes__iframe-wrapper {
 			display: block;
+			height: 100%;
+			max-height: 250px;
 		}
 
 		.form-label {
+			height: 100%;
+		}
+
+		.form-radio {
 			margin: 1em;
+		}
+
+		.form-radio__label {
+			margin: 1em 1em 1em 3em;
 		}
 
 		&:first-of-type {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -93,10 +93,10 @@
 		position: relative;
 	}
 	iframe {
-		height: 200%;
-		width: 200%;
-		max-width: 200%;
-		transform: scale( 0.5 );
+		height: 400%;
+		width: 400%;
+		max-width: 400%;
+		transform: scale( 0.25 );
 		transform-origin: top left;
 		position: absolute;
 		top: 0;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -93,7 +93,6 @@
 		position: relative;
 	}
 	iframe {
-		// flex-grow: 1;
 		height: 200%;
 		width: 200%;
 		max-width: 200%;
@@ -107,5 +106,5 @@
 
 .themes__iframe-wrapper .spinner {
 	position: relative;
-    top: 50%;
+	top: 50%;
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -51,21 +51,25 @@
 }
 
 .themes__theme-preview-item {
-	border: 1px solid var( --color-border-subtle );
-	border-radius: 2px;
-
 	img,
 	.themes__iframe-wrapper {
 		display: none;
 	}
 
 	@include break-medium {
+		border: 1px solid var( --color-border-subtle );
+		border-radius: 2px;
+		width: 48%;
+		margin-left: 2%;
+
 		img,
 		.themes__iframe-wrapper {
 			display: block;
 		}
-		width: 48%;
-		margin-left: 2%;
+
+		.form-label {
+			margin: 1em;
+		}
 
 		&:first-of-type {
 			margin-left: 0;
@@ -76,10 +80,6 @@
 	img {
 		max-width: 100%;
 		height: auto;
-	}
-
-	.form-label {
-		margin: 1em;
 	}
 }
 

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -104,3 +104,8 @@
 		left: 0;
 	}
 }
+
+.themes__iframe-wrapper .spinner {
+	position: relative;
+    top: 50%;
+}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -33,7 +33,10 @@
 
 .themes__autoloading-homepage-option-description {
 	font-size: $font-body-small;
-	width: 70%;
+
+	@include break-medium {
+		width: 70%;
+	}
 }
 
 .themes__theme-preview-items {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,7 +1,15 @@
+@import '@wordpress/base-styles/breakpoints';
+
 .themes__auto-loading-homepage-modal {
 	margin: 0 auto;
+	text-align: center;
 
-	@include breakpoint-deprecated( '<480px' ) {
+	h1 {
+		margin-bottom: 1em;
+		text-align: center;
+	}
+
+	@include break-mobile {
 		box-sizing: border-box;
 		max-width: 100%;
 
@@ -11,25 +19,56 @@
 			width: 100%;
 		}
 	}
+}
 
-	.themes__auto-loading-homepage-modal-close-icon {
-		float: right;
-		cursor: pointer;
+.themes__auto-loading-homepage-modal-close-icon {
+	cursor: pointer;
+	float: right;
+}
+
+.themes__auto-loading-homepage-modal-homepage-hint {
+	margin-left: 20px;
+	font-size: $font-body-small;
+	font-style: italic;
+	margin-top: -5px;
+}
+
+.themes__theme-preview-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+.themes__autoloading-homepage-option-description {
+	width: 50%;
+}
+
+.themes__theme-preview-items {
+	margin: 0 0 1.5em;
+	max-width: 700px;
+}
+
+.themes__theme-preview-item {
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 2px;
+	margin: 0 0 1em;
+
+	@include break-medium {
+		width: 48%;
+		margin-left: 2%;
+
+		&:first-of-type {
+			margin-left: 0;
+			margin-right: 2%;
+		}
 	}
 
-	.themes__theme-preview-item {
-		float: left;
-		width: 48%;
+	img {
+		max-width: 100%;
+		height: auto;
 	}
 
 	.form-label {
-		font-weight: 400;
-	}
-
-	.themes__auto-loading-homepage-modal-homepage-hint {
-		margin-left: 20px;
-		font-size: 0.875rem;
-		font-style: italic;
-		margin-top: -5px;
+		margin: 1em;
 	}
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -216,7 +216,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: true,
+		isomorphic: false,
 		title: 'Themes',
 	},
 	{

--- a/client/sections.js
+++ b/client/sections.js
@@ -216,7 +216,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: false,
+		isomorphic: true,
 		title: 'Themes',
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the preview modal displayed when a user attempts to activate a theme with the 'auto-loading-homepage' feature from the theme showcase.

![2021-06-22 17 11 05](https://user-images.githubusercontent.com/2124984/123000002-f719ca00-d37c-11eb-85cb-11d5aef3e50e.gif)

**Before**

<img width="511" alt="Screen Shot 2021-06-22 at 5 13 31 PM" src="https://user-images.githubusercontent.com/2124984/123000141-2defe000-d37d-11eb-8125-3930f3d26e8f.png">

**After**

<img width="782" alt="Screen Shot 2021-06-22 at 5 12 48 PM" src="https://user-images.githubusercontent.com/2124984/123000092-19134c80-d37d-11eb-9b26-68e48d1dc9e7.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / <img width="511" alt="Screen Shot 2021-06-22 at 5 13 31 PM" src="https://user-images.githubusercontent.com/2124984/123000141-2defe000-d37d-11eb-8125-3930f3d26e8f.png">" screenshots can also be very helpful when the change is visual.
-->


#### Testing instructions

* ~~Apply D63076-code to your sandbox, and make sure you have the API sandboxed.~~ Is now on production.
* Theme Showcase -> Click on three dots menu of a recommended theme -> Click activate -> See previews in modal
* Verify that the iframe on the left-hand preview can not be scrolled, clicked, or interacted with via keyboard.
* Verify that the iframe preview looks approximately the same size/zoom as the screenshot on the right.
* Verify that a loading spinner appears while the iframe preview is loading.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/52792
