### PR TITLE
Fix/Media library grid visually broken on mobile

### DIFF
--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -22,7 +22,7 @@ class SortedGrid extends PureComponent {
 		getItemGroup: PropTypes.func.isRequired,
 		items: PropTypes.array,
 		itemsPerRow: PropTypes.number.isRequired,
-		isMobile: PropTypes.bool,
+		scale: PropTypes.number.isRequired,
 	};
 
 	getItems() {
@@ -58,7 +58,7 @@ class SortedGrid extends PureComponent {
 								itemsCount={ count }
 								itemsPerRow={ this.props.itemsPerRow }
 								lastInRow={ last( keys( row.groups ) ) === group }
-								isMobile={ this.props.isMobile }
+								scale={ this.props.scale }
 							/>
 						)
 					);
@@ -82,7 +82,7 @@ class SortedGrid extends PureComponent {
 			'getItemGroup',
 			'items',
 			'renderItem',
-			'isMobile'
+			'scale'
 		);
 
 		return <InfiniteList items={ this.getItems() } renderItem={ this.renderItem } { ...props } />;

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -22,6 +22,7 @@ class SortedGrid extends PureComponent {
 		getItemGroup: PropTypes.func.isRequired,
 		items: PropTypes.array,
 		itemsPerRow: PropTypes.number.isRequired,
+		isMobile: PropTypes.bool,
 	};
 
 	getItems() {
@@ -57,6 +58,7 @@ class SortedGrid extends PureComponent {
 								itemsCount={ count }
 								itemsPerRow={ this.props.itemsPerRow }
 								lastInRow={ last( keys( row.groups ) ) === group }
+								isMobile={ this.props.isMobile }
 							/>
 						)
 					);
@@ -74,7 +76,14 @@ class SortedGrid extends PureComponent {
 	};
 
 	render() {
-		const props = omit( this.props, 'getGroupLabel', 'getItemGroup', 'items', 'renderItem' );
+		const props = omit(
+			this.props,
+			'getGroupLabel',
+			'getItemGroup',
+			'items',
+			'renderItem',
+			'isMobile'
+		);
 
 		return <InfiniteList items={ this.getItems() } renderItem={ this.renderItem } { ...props } />;
 	}

--- a/client/components/sorted-grid/label.jsx
+++ b/client/components/sorted-grid/label.jsx
@@ -4,12 +4,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { getMediaScalePreference } from 'calypso/state/preferences/selectors';
 
 const Label = ( { itemsCount, itemsPerRow, lastInRow, scale, text } ) => {
 	const margin = ( ( 1 % scale ) / ( itemsPerRow - 1 ) ) * 100 || 0;
@@ -31,20 +29,10 @@ Label.propTypes = {
 	lastInRow: PropTypes.bool,
 	scale: PropTypes.number.isRequired,
 	text: PropTypes.string,
-	isMobile: PropTypes.bool,
 };
 
 Label.defaultProps = {
 	text: '',
 };
 
-const connectComponent = connect(
-	( state, { isMobile } ) => ( {
-		scale: getMediaScalePreference( state, 'mediaScale', isMobile ),
-	} ),
-	null,
-	null,
-	{ pure: false }
-);
-
-export default connectComponent( Label );
+export default Label;

--- a/client/components/sorted-grid/label.jsx
+++ b/client/components/sorted-grid/label.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getPreference } from 'calypso/state/preferences/selectors';
+import { getMediaScalePreference } from 'calypso/state/preferences/selectors';
 
 const Label = ( { itemsCount, itemsPerRow, lastInRow, scale, text } ) => {
 	const margin = ( ( 1 % scale ) / ( itemsPerRow - 1 ) ) * 100 || 0;
@@ -31,6 +31,7 @@ Label.propTypes = {
 	lastInRow: PropTypes.bool,
 	scale: PropTypes.number.isRequired,
 	text: PropTypes.string,
+	isMobile: PropTypes.bool,
 };
 
 Label.defaultProps = {
@@ -38,8 +39,8 @@ Label.defaultProps = {
 };
 
 const connectComponent = connect(
-	( state ) => ( {
-		scale: getPreference( state, 'mediaScale' ),
+	( state, { isMobile } ) => ( {
+		scale: getMediaScalePreference( state, 'mediaScale', isMobile ),
 	} ),
 	null,
 	null,

--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -204,3 +204,4 @@ export const MEDIA_IMAGE_RESIZER = 'MEDIA_IMAGE_RESIZER';
  * @type {Array}
  */
 export const SCALE_CHOICES = [ 0.077, 0.115, 0.157, 0.24, 0.323 ];
+export const SCALE_TOUCH_GRID = 0.323;

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import page from 'page';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -63,12 +64,14 @@ export class MediaLibraryContent extends React.Component {
 		onMediaScaleChange: PropTypes.func,
 		postId: PropTypes.number,
 		isConnected: PropTypes.bool,
+		isMobile: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		mediaValidationErrors: Object.freeze( {} ),
 		onAddMedia: noop,
 		source: '',
+		isMobile: isMobile(),
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -364,6 +367,7 @@ export class MediaLibraryContent extends React.Component {
 				<MediaLibraryList
 					key="list-loading"
 					filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
+					isMobile={ this.props.isMobile }
 				/>
 			);
 		}
@@ -398,6 +402,7 @@ export class MediaLibraryContent extends React.Component {
 					thumbnailType={ this.getThumbnailType() }
 					single={ this.props.single }
 					scrollable={ this.props.scrollable }
+					isMobile={ this.props.isMobile }
 				/>
 			</MediaListData>
 		);
@@ -421,6 +426,7 @@ export class MediaLibraryContent extends React.Component {
 					sticky={ ! this.props.scrollable }
 					hasAttribution={ 'pexels' === this.props.source }
 					hasRefreshButton={ 'pexels' !== this.props.source }
+					isMobile={ this.props.isMobile }
 				/>
 			);
 		}
@@ -437,6 +443,7 @@ export class MediaLibraryContent extends React.Component {
 					onViewDetails={ this.props.onViewDetails }
 					onDeleteItem={ this.props.onDeleteItem }
 					sticky={ ! this.props.scrollable }
+					isMobile={ this.props.isMobile }
 				/>
 			);
 		}

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import page from 'page';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isMobile } from '@automattic/viewport';
+import { withMobileBreakpoint } from '@automattic/viewport-react';
 
 /**
  * Internal dependencies
@@ -64,14 +64,13 @@ export class MediaLibraryContent extends React.Component {
 		onMediaScaleChange: PropTypes.func,
 		postId: PropTypes.number,
 		isConnected: PropTypes.bool,
-		isMobile: PropTypes.bool,
+		isBreakpointActive: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		mediaValidationErrors: Object.freeze( {} ),
 		onAddMedia: noop,
 		source: '',
-		isMobile: isMobile(),
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -367,7 +366,7 @@ export class MediaLibraryContent extends React.Component {
 				<MediaLibraryList
 					key="list-loading"
 					filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
-					isMobile={ this.props.isMobile }
+					isMobile={ this.props.isBreakpointActive }
 				/>
 			);
 		}
@@ -402,7 +401,7 @@ export class MediaLibraryContent extends React.Component {
 					thumbnailType={ this.getThumbnailType() }
 					single={ this.props.single }
 					scrollable={ this.props.scrollable }
-					isMobile={ this.props.isMobile }
+					isMobile={ this.props.isBreakpointActive }
 				/>
 			</MediaListData>
 		);
@@ -426,7 +425,7 @@ export class MediaLibraryContent extends React.Component {
 					sticky={ ! this.props.scrollable }
 					hasAttribution={ 'pexels' === this.props.source }
 					hasRefreshButton={ 'pexels' !== this.props.source }
-					isMobile={ this.props.isMobile }
+					isMobile={ this.props.isBreakpointActive }
 				/>
 			);
 		}
@@ -443,7 +442,7 @@ export class MediaLibraryContent extends React.Component {
 					onViewDetails={ this.props.onViewDetails }
 					onDeleteItem={ this.props.onDeleteItem }
 					sticky={ ! this.props.scrollable }
-					isMobile={ this.props.isMobile }
+					isMobile={ this.props.isBreakpointActive }
 				/>
 			);
 		}
@@ -494,4 +493,4 @@ export default connect(
 	},
 	null,
 	{ pure: false }
-)( localize( MediaLibraryContent ) );
+)( localize( withMobileBreakpoint( MediaLibraryContent ) ) );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -24,6 +24,7 @@ import {
 	ValidationErrors as MediaValidationErrors,
 	MEDIA_IMAGE_RESIZER,
 	MEDIA_IMAGE_THUMBNAIL,
+	SCALE_TOUCH_GRID,
 } from 'calypso/lib/media/constants';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -40,6 +41,7 @@ import { deleteKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
 import { clearMediaErrors, changeMediaSource } from 'calypso/state/media/actions';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { getPreference } from 'calypso/state/preferences/selectors';
 
 /**
  * Style dependencies
@@ -48,6 +50,23 @@ import './content.scss';
 
 const noop = () => {};
 const first = ( arr ) => arr[ 0 ];
+
+function getMediaScalePreference( state, isMobile ) {
+	const mediaScale = getPreference( state, 'mediaScale' );
+
+	// On mobile viewport, return the media scale value of 0.323 (3 columns per row)
+	// regardless of stored preference value, if it's not 1.
+	if ( isMobile && mediaScale !== 1 ) {
+		return SCALE_TOUCH_GRID;
+	}
+	// On non-mobile viewport, return the media scale value of 0.323 if the stored
+	// preference value is greater than 0.323.
+	if ( ! isMobile && mediaScale > SCALE_TOUCH_GRID ) {
+		return SCALE_TOUCH_GRID;
+	}
+
+	return mediaScale;
+}
 
 export class MediaLibraryContent extends React.Component {
 	static propTypes = {
@@ -65,6 +84,7 @@ export class MediaLibraryContent extends React.Component {
 		postId: PropTypes.number,
 		isConnected: PropTypes.bool,
 		isBreakpointActive: PropTypes.bool,
+		mediaScale: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -366,7 +386,7 @@ export class MediaLibraryContent extends React.Component {
 				<MediaLibraryList
 					key="list-loading"
 					filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
-					isMobile={ this.props.isBreakpointActive }
+					mediaScale={ this.props.mediaScale }
 				/>
 			);
 		}
@@ -401,7 +421,7 @@ export class MediaLibraryContent extends React.Component {
 					thumbnailType={ this.getThumbnailType() }
 					single={ this.props.single }
 					scrollable={ this.props.scrollable }
-					isMobile={ this.props.isBreakpointActive }
+					mediaScale={ this.props.mediaScale }
 				/>
 			</MediaListData>
 		);
@@ -425,7 +445,7 @@ export class MediaLibraryContent extends React.Component {
 					sticky={ ! this.props.scrollable }
 					hasAttribution={ 'pexels' === this.props.source }
 					hasRefreshButton={ 'pexels' !== this.props.source }
-					isMobile={ this.props.isBreakpointActive }
+					mediaScale={ this.props.mediaScale }
 				/>
 			);
 		}
@@ -442,7 +462,7 @@ export class MediaLibraryContent extends React.Component {
 					onViewDetails={ this.props.onViewDetails }
 					onDeleteItem={ this.props.onDeleteItem }
 					sticky={ ! this.props.scrollable }
-					isMobile={ this.props.isBreakpointActive }
+					mediaScale={ this.props.mediaScale }
 				/>
 			);
 		}
@@ -465,32 +485,35 @@ export class MediaLibraryContent extends React.Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const guidedTourState = getGuidedTourState( state );
-		const mediaValidationErrorTypes = values( ownProps.mediaValidationErrors ).map( first );
-		const shouldPauseGuidedTour =
-			! isEmpty( guidedTourState.tour ) && 0 < size( mediaValidationErrorTypes );
-		const googleConnection = getKeyringConnectionsByName( state, 'google_photos' );
+export default withMobileBreakpoint(
+	connect(
+		( state, ownProps ) => {
+			const guidedTourState = getGuidedTourState( state );
+			const mediaValidationErrorTypes = values( ownProps.mediaValidationErrors ).map( first );
+			const shouldPauseGuidedTour =
+				! isEmpty( guidedTourState.tour ) && 0 < size( mediaValidationErrorTypes );
+			const googleConnection = getKeyringConnectionsByName( state, 'google_photos' );
 
-		return {
-			siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
-			isRequesting: isKeyringConnectionsFetching( state ),
-			displayUploadMediaButton: canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
-			mediaValidationErrorTypes,
-			shouldPauseGuidedTour,
-			googleConnection: googleConnection.length === 1 ? googleConnection[ 0 ] : null, // There can be only one
-			selectedItems: getMediaLibrarySelectedItems( state, ownProps.site?.ID ),
-		};
-	},
-	{
-		toggleGuidedTour: ( shouldPause ) => ( dispatch ) => {
-			dispatch( shouldPause ? pauseGuidedTour() : resumeGuidedTour() );
+			return {
+				siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
+				isRequesting: isKeyringConnectionsFetching( state ),
+				displayUploadMediaButton: canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
+				mediaValidationErrorTypes,
+				shouldPauseGuidedTour,
+				googleConnection: googleConnection.length === 1 ? googleConnection[ 0 ] : null, // There can be only one
+				selectedItems: getMediaLibrarySelectedItems( state, ownProps.site?.ID ),
+				mediaScale: getMediaScalePreference( state, ownProps.isBreakpointActive ),
+			};
 		},
-		deleteKeyringConnection,
-		clearMediaErrors,
-		changeMediaSource,
-	},
-	null,
-	{ pure: false }
-)( localize( withMobileBreakpoint( MediaLibraryContent ) ) );
+		{
+			toggleGuidedTour: ( shouldPause ) => ( dispatch ) => {
+				dispatch( shouldPause ? pauseGuidedTour() : resumeGuidedTour() );
+			},
+			deleteKeyringConnection,
+			clearMediaErrors,
+			changeMediaSource,
+		},
+		null,
+		{ pure: false }
+	)( localize( MediaLibraryContent ) )
+);

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -132,7 +132,7 @@ class MediaLibraryExternalHeader extends React.Component {
 
 				{ canCopy && this.renderCopyButton() }
 
-				<MediaLibraryScale onChange={ onMediaScaleChange } />
+				<MediaLibraryScale onChange={ onMediaScaleChange } isMobile={ this.props.isMobile } />
 			</Card>
 		);
 	}

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -32,6 +32,7 @@ class MediaLibraryExternalHeader extends React.Component {
 		hasAttribution: PropTypes.bool,
 		hasRefreshButton: PropTypes.bool,
 		isFetchingNextPage: PropTypes.bool,
+		mediaScale: PropTypes.number,
 	};
 
 	constructor( props ) {
@@ -132,7 +133,7 @@ class MediaLibraryExternalHeader extends React.Component {
 
 				{ canCopy && this.renderCopyButton() }
 
-				<MediaLibraryScale onChange={ onMediaScaleChange } isMobile={ this.props.isMobile } />
+				<MediaLibraryScale onChange={ onMediaScaleChange } mediaScale={ this.props.mediaScale } />
 			</Card>
 		);
 	}

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -32,7 +32,7 @@ class MediaLibraryHeader extends React.Component {
 		onMediaScaleChange: PropTypes.func,
 		onAddMedia: PropTypes.func,
 		sticky: PropTypes.bool,
-		isMobile: PropTypes.bool,
+		mediaScale: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -141,7 +141,7 @@ class MediaLibraryHeader extends React.Component {
 				/>
 				<MediaLibraryScale
 					onChange={ this.props.onMediaScaleChange }
-					isMobile={ this.props.isMobile }
+					mediaScale={ this.props.mediaScale }
 				/>
 			</Card>
 		);

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -32,6 +32,7 @@ class MediaLibraryHeader extends React.Component {
 		onMediaScaleChange: PropTypes.func,
 		onAddMedia: PropTypes.func,
 		sticky: PropTypes.bool,
+		isMobile: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -138,7 +139,10 @@ class MediaLibraryHeader extends React.Component {
 					onDelete={ this.props.onDeleteItem }
 					site={ this.props.site }
 				/>
-				<MediaLibraryScale onChange={ this.props.onMediaScaleChange } />
+				<MediaLibraryScale
+					onChange={ this.props.onMediaScaleChange }
+					isMobile={ this.props.isMobile }
+				/>
 			</Card>
 		);
 

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -19,7 +19,7 @@ import ListNoContent from './list-no-content';
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import SortedGrid from 'calypso/components/sorted-grid';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { getPreference } from 'calypso/state/preferences/selectors';
+import { getMediaScalePreference } from 'calypso/state/preferences/selectors';
 import { selectMediaItems } from 'calypso/state/media/actions';
 import isFetchingNextPage from 'calypso/state/selectors/is-fetching-next-page';
 
@@ -44,6 +44,7 @@ export class MediaLibraryList extends React.Component {
 		mediaOnFetchNextPage: PropTypes.func,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
+		isMobile: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -254,14 +255,15 @@ export class MediaLibraryList extends React.Component {
 				renderItem={ this.renderItem }
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 				className="media-library__list"
+				isMobile={ this.props.isMobile }
 			/>
 		);
 	}
 }
 
 export default connect(
-	( state, { site } ) => ( {
-		mediaScale: getPreference( state, 'mediaScale' ),
+	( state, { site, isMobile } ) => ( {
+		mediaScale: getMediaScalePreference( state, 'mediaScale', isMobile ),
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isFetchingNextPage: isFetchingNextPage( state, site?.ID ),
 	} ),

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -19,7 +19,6 @@ import ListNoContent from './list-no-content';
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import SortedGrid from 'calypso/components/sorted-grid';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { getMediaScalePreference } from 'calypso/state/preferences/selectors';
 import { selectMediaItems } from 'calypso/state/media/actions';
 import isFetchingNextPage from 'calypso/state/selectors/is-fetching-next-page';
 
@@ -44,7 +43,6 @@ export class MediaLibraryList extends React.Component {
 		mediaOnFetchNextPage: PropTypes.func,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
-		isMobile: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -255,15 +253,14 @@ export class MediaLibraryList extends React.Component {
 				renderItem={ this.renderItem }
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 				className="media-library__list"
-				isMobile={ this.props.isMobile }
+				scale={ this.props.mediaScale }
 			/>
 		);
 	}
 }
 
 export default connect(
-	( state, { site, isMobile } ) => ( {
-		mediaScale: getMediaScalePreference( state, 'mediaScale', isMobile ),
+	( state, { site } ) => ( {
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isFetchingNextPage: isFetchingNextPage( state, site?.ID ),
 	} ),

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -15,8 +15,7 @@ import Gridicon from 'calypso/components/gridicon';
 import FormRange from 'calypso/components/forms/range';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { setPreference, savePreference } from 'calypso/state/preferences/actions';
-import { getMediaScalePreference } from 'calypso/state/preferences/selectors';
-import { SCALE_CHOICES } from 'calypso/lib/media/constants';
+import { SCALE_CHOICES, SCALE_TOUCH_GRID } from 'calypso/lib/media/constants';
 
 /**
  * Constants
@@ -34,7 +33,6 @@ const SLIDER_STEPS = 100;
  *
  * @type {number}
  */
-const SCALE_TOUCH_GRID = 0.323;
 
 class MediaLibraryScale extends Component {
 	static propTypes = {
@@ -42,7 +40,6 @@ class MediaLibraryScale extends Component {
 		onChange: PropTypes.func,
 		setMediaScalePreference: PropTypes.func,
 		saveMediaScalePreference: PropTypes.func,
-		isMobile: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -70,7 +67,7 @@ class MediaLibraryScale extends Component {
 	}
 
 	setScale( value ) {
-		if ( value === this.props.scale ) {
+		if ( value === this.props.mediaScale ) {
 			return;
 		}
 
@@ -95,7 +92,7 @@ class MediaLibraryScale extends Component {
 			return this.state.sliderPosition;
 		}
 
-		const { scale } = this.props;
+		const scale = this.props.mediaScale;
 
 		// Map the media scale index back to a slider position as follows:
 		// index 0 -> position 0
@@ -109,7 +106,8 @@ class MediaLibraryScale extends Component {
 	}
 
 	render() {
-		const { translate, scale } = this.props;
+		const { translate } = this.props;
+		const scale = this.props.mediaScale;
 
 		return (
 			<div className="media-library__scale">
@@ -144,12 +142,7 @@ class MediaLibraryScale extends Component {
 	}
 }
 
-export default connect(
-	( state, { isMobile } ) => ( {
-		scale: getMediaScalePreference( state, 'mediaScale', isMobile ),
-	} ),
-	{
-		setMediaScalePreference: partial( setPreference, 'mediaScale' ),
-		saveMediaScalePreference: partial( savePreference, 'mediaScale' ),
-	}
-)( localize( MediaLibraryScale ) );
+export default connect( null, {
+	setMediaScalePreference: partial( setPreference, 'mediaScale' ),
+	saveMediaScalePreference: partial( savePreference, 'mediaScale' ),
+} )( localize( MediaLibraryScale ) );

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -15,7 +15,7 @@ import Gridicon from 'calypso/components/gridicon';
 import FormRange from 'calypso/components/forms/range';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { setPreference, savePreference } from 'calypso/state/preferences/actions';
-import { getPreference } from 'calypso/state/preferences/selectors';
+import { getMediaScalePreference } from 'calypso/state/preferences/selectors';
 import { SCALE_CHOICES } from 'calypso/lib/media/constants';
 
 /**
@@ -34,7 +34,7 @@ const SLIDER_STEPS = 100;
  *
  * @type {number}
  */
-const SCALE_TOUCH_GRID = 0.32;
+const SCALE_TOUCH_GRID = 0.323;
 
 class MediaLibraryScale extends Component {
 	static propTypes = {
@@ -42,6 +42,7 @@ class MediaLibraryScale extends Component {
 		onChange: PropTypes.func,
 		setMediaScalePreference: PropTypes.func,
 		saveMediaScalePreference: PropTypes.func,
+		isMobile: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -144,8 +145,8 @@ class MediaLibraryScale extends Component {
 }
 
 export default connect(
-	( state ) => ( {
-		scale: getPreference( state, 'mediaScale' ),
+	( state, { isMobile } ) => ( {
+		scale: getMediaScalePreference( state, 'mediaScale', isMobile ),
 	} ),
 	{
 		setMediaScalePreference: partial( setPreference, 'mediaScale' ),

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -39,18 +39,7 @@ export function getPreference( state, key ) {
 }
 
 export function getMediaScalePreference( state, key, isMobile ) {
-	const mediaScale = get(
-		find(
-			[
-				state.preferences?.localValues,
-				state.preferences?.remoteValues,
-				DEFAULT_PREFERENCE_VALUES,
-			],
-			( source ) => has( source, key )
-		),
-		key,
-		null
-	);
+	const mediaScale = getPreference( state, key );
 
 	// On mobile viewport, return the media scale value of 0.323 (3 columns per row)
 	// regardless of stored preference value, if it's not 1.

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -8,8 +8,6 @@ import { get, find, has } from 'lodash';
  */
 import { DEFAULT_PREFERENCE_VALUES } from './constants';
 
-import { SCALE_TOUCH_GRID } from 'calypso/lib/media/constants';
-
 import 'calypso/state/preferences/init';
 
 export const isFetchingPreferences = ( state ) => !! state.preferences.fetching;
@@ -38,22 +36,6 @@ export function getPreference( state, key ) {
 	);
 }
 
-export function getMediaScalePreference( state, key, isMobile ) {
-	const mediaScale = getPreference( state, key );
-
-	// On mobile viewport, return the media scale value of 0.323 (3 columns per row)
-	// regardless of stored preference value, if it's not 1.
-	if ( isMobile && mediaScale !== 1 ) {
-		return SCALE_TOUCH_GRID;
-	}
-	// On non-mobile viewport, return the media scale value of 0.323 if the stored
-	// preference value is greater than 0.323.
-	if ( ! isMobile && mediaScale > SCALE_TOUCH_GRID ) {
-		return SCALE_TOUCH_GRID;
-	}
-
-	return mediaScale;
-}
 /**
  * Returns the a key value store of all current remote preferences. The keys
  * of the object are each preference key and the values are the preference

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -36,6 +36,26 @@ export function getPreference( state, key ) {
 	);
 }
 
+export function getMediaScalePreference( state, key, isMobile ) {
+	const SCALE_TOUCH_GRID = 0.323;
+	const mediaScale = get(
+		find(
+			[
+				state.preferences?.localValues,
+				state.preferences?.remoteValues,
+				DEFAULT_PREFERENCE_VALUES,
+			],
+			( source ) => has( source, key )
+		),
+		key,
+		null
+	);
+
+	if ( ( isMobile && mediaScale !== 1 ) || ( ! isMobile && mediaScale > SCALE_TOUCH_GRID ) ) {
+		return SCALE_TOUCH_GRID;
+	}
+	return mediaScale;
+}
 /**
  * Returns the a key value store of all current remote preferences. The keys
  * of the object are each preference key and the values are the preference

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -8,6 +8,8 @@ import { get, find, has } from 'lodash';
  */
 import { DEFAULT_PREFERENCE_VALUES } from './constants';
 
+import { SCALE_TOUCH_GRID } from 'calypso/lib/media/constants';
+
 import 'calypso/state/preferences/init';
 
 export const isFetchingPreferences = ( state ) => !! state.preferences.fetching;
@@ -37,7 +39,6 @@ export function getPreference( state, key ) {
 }
 
 export function getMediaScalePreference( state, key, isMobile ) {
-	const SCALE_TOUCH_GRID = 0.323;
 	const mediaScale = get(
 		find(
 			[
@@ -60,7 +61,7 @@ export function getMediaScalePreference( state, key, isMobile ) {
 	// preference value is greater than 0.323.
 	if ( ! isMobile && mediaScale > SCALE_TOUCH_GRID ) {
 		return SCALE_TOUCH_GRID;
-}
+	}
 
 	return mediaScale;
 }

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -51,9 +51,17 @@ export function getMediaScalePreference( state, key, isMobile ) {
 		null
 	);
 
-	if ( ( isMobile && mediaScale !== 1 ) || ( ! isMobile && mediaScale > SCALE_TOUCH_GRID ) ) {
+	// On mobile viewport, return the media scale value of 0.323 (3 columns per row)
+	// regardless of stored preference value, if it's not 1.
+	if ( isMobile && mediaScale !== 1 ) {
 		return SCALE_TOUCH_GRID;
 	}
+	// On non-mobile viewport, return the media scale value of 0.323 if the stored
+	// preference value is greater than 0.323.
+	if ( ! isMobile && mediaScale > SCALE_TOUCH_GRID ) {
+		return SCALE_TOUCH_GRID;
+}
+
 	return mediaScale;
 }
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render only 3 or 1 media library list items per row on mobile viewport, regardless of the scale slider position.
* Limit the maximum media scale value to 0.323 when the scale slider is visible.  

#### Testing instructions

Please view http://calypso.localhost:3000/media/:domain on mobile width. The page should render 3 items per row on mobile viewport. You should be able to switch from 3 items per row to 1 item per row with the segmented control buttons. When you switch to a larger viewport (window screen width greater than 480) when the page was displaying 1 item per row on mobile viewport, the media scale value is set back to 0.323. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before
![image](https://user-images.githubusercontent.com/50002894/122453901-b8e56a80-cf78-11eb-87b8-d3642499a8d0.png)

![image](https://user-images.githubusercontent.com/50002894/122454190-1c6f9800-cf79-11eb-951b-99574082bde2.png)

* After
![image](https://user-images.githubusercontent.com/50002894/122454714-addf0a00-cf79-11eb-8fe0-eb4ea20fb232.png)

![image](https://user-images.githubusercontent.com/50002894/122454848-c5b68e00-cf79-11eb-8333-f555dae110ee.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #48227
Related to #8295
