### PR TITLE
Domains: Add "update all domains' contact info" notice when updating account email

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -75,6 +75,10 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { clearStore } from 'calypso/lib/user/store';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import isRequestingAllDomains from 'calypso/state/selectors/is-requesting-all-domains';
+import { getFlatDomainsList } from 'calypso/state/sites/domains/selectors';
+import QueryAllDomains from 'calypso/components/data/query-all-domains';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
 
 export const noticeId = 'me-settings-notice';
 const noticeOptions = {
@@ -582,8 +586,12 @@ class Account extends React.Component {
 	}
 
 	hasCustomDomains() {
-		// TODO: Implement
-		return true;
+		if ( this.props.requestingFlatDomains ) {
+			return false;
+		}
+		return this.props.domainsList.some( ( domain ) => {
+			return domainTypes.REGISTERED === domain.type;
+		} );
 	}
 
 	renderUsernameValidation() {
@@ -997,6 +1005,7 @@ class Account extends React.Component {
 
 		return (
 			<Main wideLayout className="account">
+				<QueryAllDomains />
 				<QueryUserSettings />
 				<PageViewTracker path="/me/account" title="Me > Account Settings" />
 				<MeSidebarNavigation />
@@ -1144,6 +1153,8 @@ export default compose(
 			onboardingUrl: getOnboardingUrl( state ),
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 			linkDestination: getPreference( state, linkDestinationKey ),
+			requestingFlatDomains: isRequestingAllDomains( state ),
+			domainsList: getFlatDomainsList( state ),
 		} ),
 		{
 			bumpStat,

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -543,7 +543,7 @@ class Account extends React.Component {
 		}
 
 		let text = translate(
-			'Your e-mail change is pending. Please take a moment to check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change. Failure to confirm within 14 days will result in suspension of your domain name.',
+			'Your e-mail change is pending. Please take a moment to check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change.',
 			{
 				args: {
 					email: this.getUserSetting( 'new_user_email' ),
@@ -553,7 +553,7 @@ class Account extends React.Component {
 
 		if ( this.hasCustomDomains() ) {
 			text = translate(
-				'Your e-mail change is pending. Please take a moment to:{{br/}}1. Check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change. Failure to confirm within 14 days will result in suspension of your domain name.{{br/}}2. Update contact information on your domain names if necessary {{link}}here{{/link}}.',
+				'Your e-mail change is pending. Please take a moment to:{{br/}}1. Check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change.{{br/}}2. Update contact information on your domain names if necessary {{link}}here{{/link}}.',
 				{
 					args: {
 						email: this.getUserSetting( 'new_user_email' ),

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -536,52 +536,42 @@ class Account extends React.Component {
 
 	renderPendingEmailChange() {
 		const { translate } = this.props;
+		const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-email`;
 
 		if ( ! this.hasPendingEmailChange() ) {
 			return null;
 		}
 
+		let text = translate(
+			'Your e-mail change is pending. Please take a moment to check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change. Failure to confirm within 14 days will result in suspension of your domain name.',
+			{
+				args: {
+					email: this.getUserSetting( 'new_user_email' ),
+				},
+			}
+		);
+
+		if ( this.hasCustomDomains() ) {
+			text = translate(
+				'Your e-mail change is pending. Please take a moment to:{{br/}}1. Check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change. Failure to confirm within 14 days will result in suspension of your domain name.{{br/}}2. Update contact information on your domain names if necessary {{link}}here{{/link}}.',
+				{
+					args: {
+						email: this.getUserSetting( 'new_user_email' ),
+					},
+					components: {
+						br: <br />,
+						link: <a href={ editContactInfoInBulkUrl } />,
+					},
+				}
+			);
+		}
+
 		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate(
-					'There is a pending change of your email to %(email)s. Please check your inbox for a confirmation link.',
-					{
-						args: {
-							email: this.getUserSetting( 'new_user_email' ),
-						},
-					}
-				) }
-			>
+			<Notice showDismiss={ false } status="is-info" text={ text }>
 				<NoticeAction onClick={ () => this.props.cancelPendingEmailChange() }>
 					{ translate( 'Cancel' ) }
 				</NoticeAction>
 			</Notice>
-		);
-	}
-
-	renderUpdateEmailInBulkNotice() {
-		const { translate } = this.props;
-		const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-email`;
-
-		if ( ! this.hasPendingEmailChange() || ! this.hasCustomDomains() ) {
-			return null;
-		}
-
-		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate(
-					'You can also update the contact info for all of your domains to this e-mail address by clicking {{link}}here{{/link}}',
-					{
-						components: {
-							link: <a href={ editContactInfoInBulkUrl } />,
-						},
-					}
-				) }
-			></Notice>
 		);
 	}
 
@@ -807,7 +797,6 @@ class Account extends React.Component {
 						{ translate( 'Will not be publicly displayed' ) }
 					</FormSettingExplanation>
 					{ this.renderPendingEmailChange() }
-					{ this.renderUpdateEmailInBulkNotice() }
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -561,7 +561,7 @@ class Account extends React.Component {
 		const { translate } = this.props;
 		const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-info`;
 
-		if ( ! this.hasPendingEmailChange() ) {
+		if ( ! this.hasPendingEmailChange() || ! this.hasCustomDomains() ) {
 			return null;
 		}
 
@@ -579,6 +579,11 @@ class Account extends React.Component {
 				) }
 			></Notice>
 		);
+	}
+
+	hasCustomDomains() {
+		// TODO: Implement
+		return true;
 	}
 
 	renderUsernameValidation() {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -557,6 +557,30 @@ class Account extends React.Component {
 		);
 	}
 
+	renderUpdateEmailInBulkNotice() {
+		const { translate } = this.props;
+		const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-info`;
+
+		if ( ! this.hasPendingEmailChange() ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-info"
+				text={ translate(
+					'You can also update the contact info for all of your domains to this e-mail address by clicking {{link}}here{{/link}}',
+					{
+						components: {
+							link: <a href={ editContactInfoInBulkUrl } />,
+						},
+					}
+				) }
+			></Notice>
+		);
+	}
+
 	renderUsernameValidation() {
 		const { translate } = this.props;
 
@@ -766,10 +790,11 @@ class Account extends React.Component {
 						onChange={ this.updateEmailAddress }
 					/>
 					{ this.renderEmailValidation() }
-					{ this.renderPendingEmailChange() }
 					<FormSettingExplanation>
 						{ translate( 'Will not be publicly displayed' ) }
 					</FormSettingExplanation>
+					{ this.renderPendingEmailChange() }
+					{ this.renderUpdateEmailInBulkNotice() }
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -563,7 +563,7 @@ class Account extends React.Component {
 
 	renderUpdateEmailInBulkNotice() {
 		const { translate } = this.props;
-		const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-info`;
+		const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-email`;
 
 		if ( ! this.hasPendingEmailChange() || ! this.hasCustomDomains() ) {
 			return null;

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -543,7 +543,7 @@ class Account extends React.Component {
 		}
 
 		let text = translate(
-			'Your e-mail change is pending. Please take a moment to check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change.',
+			'Your email change is pending. Please take a moment to check %(email)s for an email with the subject "[WordPress.com] New Email Address" to confirm your change.',
 			{
 				args: {
 					email: this.getUserSetting( 'new_user_email' ),
@@ -553,7 +553,7 @@ class Account extends React.Component {
 
 		if ( this.hasCustomDomains() ) {
 			text = translate(
-				'Your e-mail change is pending. Please take a moment to:{{br/}}1. Check %(email)s for an e-mail with the subject "[WordPress.com] New Email Address" to confirm your change.{{br/}}2. Update contact information on your domain names if necessary {{link}}here{{/link}}.',
+				'Your email change is pending. Please take a moment to:{{br/}}1. Check %(email)s for an email with the subject "[WordPress.com] New Email Address" to confirm your change.{{br/}}2. Update contact information on your domain names if necessary {{link}}here{{/link}}.',
 				{
 					args: {
 						email: this.getUserSetting( 'new_user_email' ),


### PR DESCRIPTION
When updating their account's email information, users are now given a choice to access a page to update all their custom domains' email addresses at once. This is part of a larger project (pcYYhz-2M-p2) to improve user experience by updating both their WordPress.com email and registered domains emails together.

#### Changes proposed in this Pull Request

* Adds a notice when the user updates their WordPress.com's email address, prompting them to access a page to update all their domains' email addresses in bulk.
* Before:

<img width="1063" alt="Screen Shot 2021-06-17 at 16 42 20" src="https://user-images.githubusercontent.com/5324818/122462665-3c0fbc00-cf8b-11eb-80a8-5acdcfc87e4f.png">

* After:

<img width="1059" alt="Screen Shot 2021-06-23 at 19 26 50" src="https://user-images.githubusercontent.com/5324818/123175937-0110fb00-d459-11eb-8314-afd3b05e5ccc.png">

#### Testing instructions

You can try updating your account's email in your `/me/account` page either in the live build or in your local Calypso running this branch.

After updating your email, you should see the usual notice "There is a pending change of your email to `your.email@domain.com`..." and the new one below that, saying "You can also update the contact info for all of your domains...".

Note that the new notice should only appear for accounts that have at least one **registered custom domain**. It should not appear if the account only has mapped domains, for example.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Depends on #53481
