### PR TITLE
Signup: Do not create a cart item when skipping domain search result

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -329,7 +329,7 @@ class DomainSearchResults extends React.Component {
 			domainSkipSuggestion = (
 				<DomainSkipSuggestion
 					selectedSiteSlug={ this.props.selectedSite?.slug }
-					onButtonClick={ this.props.onSkip }
+					onButtonClick={ () => this.props.onSkip() }
 				/>
 			);
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

According to our endpoint error logs, signup is frequently requesting new shopping carts be created with invalid products (products missing a `product_id` are appearing with `context: "signup"`). 

This PR fixes one such error where the "Skip purchase" button in the domain flow tries to add a synthetic click event as a cart item. This bug was added in https://github.com/Automattic/wp-calypso/pull/47663

![skip-purchase](https://user-images.githubusercontent.com/2036909/122488845-57d78a00-cfac-11eb-965c-522dd277faba.png)


#### Testing instructions

- On an existing site without a plan or domain (it's ok if the site has already been launched), visit http://calypso.localhost:3000/start/launch-site/domains-launch?siteSlug=example.com with your site substituted at the end.
- Type a search string into the domain search field (this is necessary for some reason).
- Open your browser devtools and examine the Network tab looking for POST requests made to the `/me/shopping-cart` endpoint.
- Scroll down to the bottom and click "Skip Purchase" where it says "This is your current free site address".
- Verify that you reach the plan selection step.
- Verify that any `POST` network request to the `shopping-cart` endpoint does not include an invalid object in the `products` array. An invalid product is one without a `product_slug`. You may not see a `POST` at all, which is fine.

Example of an invalid product:

![bad-product](https://user-images.githubusercontent.com/2036909/122482384-746cc580-cf9e-11eb-8bfc-d542e4805b7b.png)
