### PR TITLE
Signup: Show domain search query reset button for reskin

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -182,15 +182,13 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.search-filters__dropdown-filters {
-		border: none;
+		height: 48px;
 
 		&.search-filters__dropdown-filters--is-open {
 			box-shadow: none;
 		}
 
 		.button {
-			flex-direction: row;
-
 			&:hover,
 			&:focus {
 				box-shadow: none;
@@ -198,7 +196,6 @@ body.is-section-signup.is-white-signup {
 
 			.search-filters__dropdown-filters-button-text {
 				color: var( --color-neutral-60 );
-				padding-left: 6px;
 			}
 		}
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -166,9 +166,6 @@ body.is-section-signup.is-white-signup {
 		.search-component__open-icon {
 			transform: scaleX( -1 );
 		}
-		.search-component__close-icon {
-			display: none;
-		}
 
 		.search-component__icon-search {
 			fill: #a7aaad;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -167,6 +167,10 @@ body.is-section-signup.is-white-signup {
 			transform: scaleX( -1 );
 		}
 
+		.search-component__icon-navigation.components-button:focus:not( :disabled ) {
+			box-shadow: 0 0 0 1px var( --color-neutral-60 );
+		}
+
 		.search-component__icon-search {
 			fill: #a7aaad;
 			margin: 8px 6px 8px 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Show the (x) close icon button on the right of the domain search input
* Align filters button as it is in production (icon on top of label)

#### Testing instructions
* Go to `/start/domains?flags=signup/reskin`
* Enter a domain search query => the buttons should appear
* Clicking the button should reset the search query

#### Screenshot
<img width="948" alt="Screenshot 2021-06-19 at 10 01 46" src="https://user-images.githubusercontent.com/14192054/122634195-6c6b6d80-d0e5-11eb-98ad-b450afa13e45.png">

Fixes https://github.com/Automattic/wp-calypso/issues/53807