### PR TITLE
Signup: Enable reskin in all environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -154,6 +154,7 @@
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,
 		"memberships": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -107,6 +107,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"sign-in-with-apple": false,
+		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,
 		"memberships": true,

--- a/config/production.json
+++ b/config/production.json
@@ -119,6 +119,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,
 		"memberships": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -123,6 +123,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,6 +125,7 @@
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,

--- a/test/e2e/lib/flows/create-site-flow.js
+++ b/test/e2e/lib/flows/create-site-flow.js
@@ -28,11 +28,9 @@ export default class CreateSiteFlow {
 		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 		await pickAPlanPage.selectFreePlan();
 
-		const hoorayTitleLocator = driverHelper.createTextLocator(
-			By.css( '.signup-processing-screen__title' ),
-			/your site will be ready shortly/i
-		);
-		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, hoorayTitleLocator );
+		const hoorayScreenLocator = By.css( '.reskinned-processing-screen' );
+
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, hoorayScreenLocator );
 		/**
 		 * Let's give the create request enough time to finish. Sometimes it takes
 		 * way more than the default 20 seconds, and the cost of waiting a bit
@@ -40,7 +38,7 @@ export default class CreateSiteFlow {
 		 */
 		await driverHelper.waitUntilElementNotLocated(
 			this.driver,
-			hoorayTitleLocator,
+			hoorayScreenLocator,
 			config.get( 'explicitWaitMS' ) * 3
 		);
 


### PR DESCRIPTION
**Note**: merge this only when:
- [x] release is confirmed by Signup pod on the dedicated thread: p1624002830413600-slack-C01VA100LEA
- [x] all other issues from the [release milestone](https://github.com/Automattic/wp-calypso/milestone/355) are closed.

#### Changes proposed in this Pull Request

* Enable reskin in all environments for `onboarding` and `launch-site` signup flows.

#### Testing instructions

* Go to `/start` and experience the redesigned (white and airy) signup experience
* Go to `/start/launch-site?siteSlug={{SITE_URL}}` and experience the redesigned launch flow
* e2e tests should pass