### PR TITLE
Abstract hooks so they don't depend on mocha internals

### DIFF
--- a/test/e2e/lib/hooks/browser/browser-logs.js
+++ b/test/e2e/lib/hooks/browser/browser-logs.js
@@ -2,29 +2,17 @@
  * External dependencies
  */
 import fs from 'fs/promises';
+import path from 'path';
 import { logging } from 'selenium-webdriver';
 
-/**
- * Internal dependencies
- */
-import { generatePath } from '../../test-utils';
-
-export const saveBrowserLogs = async ( driver ) => {
-	try {
-		await Promise.allSettled(
-			[
-				[ () => driver.manage().logs().get( logging.Type.BROWSER ), 'console.log' ],
-				[ () => driver.manage().logs().get( logging.Type.PERFORMANCE ), 'performance.log' ],
-			].map( async ( [ logsPromise, file ] ) => {
-				const logs = await logsPromise();
-				return fs.writeFile( generatePath( file ), JSON.stringify( logs, null, 2 ) );
-			} )
-		);
-	} catch ( err ) {
-		console.warn(
-			'Got an error trying to save logs from the browser. This IS NOT causing the test to break, is just a warning'
-		);
-		console.warn( 'Original error:' );
-		console.warn( err );
-	}
+export const saveBrowserLogs = async ( { tempDir, driver } ) => {
+	return await Promise.allSettled(
+		[
+			[ () => driver.manage().logs().get( logging.Type.BROWSER ), 'console.log' ],
+			[ () => driver.manage().logs().get( logging.Type.PERFORMANCE ), 'performance.log' ],
+		].map( async ( [ logsPromise, file ] ) => {
+			const logs = await logsPromise();
+			return await fs.writeFile( path.join( tempDir, file ), JSON.stringify( logs, null, 2 ) );
+		} )
+	);
 };

--- a/test/e2e/lib/hooks/browser/browser.js
+++ b/test/e2e/lib/hooks/browser/browser.js
@@ -3,7 +3,7 @@
  */
 import { quitBrowser, startBrowser, ensureNotLoggedIn } from '../../driver-manager';
 
-export const closeBrowser = async function ( driver ) {
+export const closeBrowser = async function ( { driver } ) {
 	await quitBrowser( driver );
 };
 

--- a/test/e2e/lib/hooks/browser/index.js
+++ b/test/e2e/lib/hooks/browser/index.js
@@ -12,11 +12,11 @@ export const buildHooks = () => {
 			driver = await createBrowser();
 			return driver;
 		},
-		saveBrowserLogs: function () {
-			return saveBrowserLogs( driver );
+		saveBrowserLogs: function ( options ) {
+			if ( driver ) return saveBrowserLogs( { ...options, driver } );
 		},
 		closeBrowser: function () {
-			return closeBrowser( driver );
+			if ( driver ) return closeBrowser( { driver } );
 		},
 	};
 };

--- a/test/e2e/lib/hooks/mocha.js
+++ b/test/e2e/lib/hooks/mocha.js
@@ -14,7 +14,9 @@ import { buildHooks as buildBrowserHooks } from './browser';
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
 export const mochaHooks = async () => {
-	const tempDir = await mkdtemp( path.resolve( __dirname, '../../test-' ) );
+	const tempDir =
+		process.env.TEMP_ASSET_PATH || ( await mkdtemp( path.resolve( __dirname, '../../test-' ) ) );
+
 	let driver;
 	const hooks = {
 		afterAll: [],

--- a/test/e2e/lib/hooks/mocha.js
+++ b/test/e2e/lib/hooks/mocha.js
@@ -2,28 +2,70 @@
  * External dependencies
  */
 import config from 'config';
+import path from 'path';
+import { mkdtemp } from 'fs/promises';
 
 /**
  * Internal dependencies
  */
-import { buildHooks as buildVideoHooks } from './video';
+import { buildHooks as buildVideoHooks, isVideoEnabled } from './video';
 import { buildHooks as buildBrowserHooks } from './browser';
 
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 
-export const mochaHooks = () => {
-	const videoHooks = buildVideoHooks();
+export const mochaHooks = async () => {
+	const tempDir = await mkdtemp( path.resolve( __dirname, '../../test-' ) );
+	let driver;
+	const hooks = {
+		afterAll: [],
+		beforeAll: [],
+		afterEach: [],
+	};
+
+	if ( isVideoEnabled() ) {
+		const {
+			startFramebuffer,
+			stopFramebuffer,
+			takeScreenshot,
+			startVideoRecording,
+			saveVideoRecording,
+			stopVideoRecording,
+		} = buildVideoHooks();
+
+		hooks.beforeAll.push( async function () {
+			await startFramebuffer();
+			await startVideoRecording( { tempDir } );
+		} );
+
+		hooks.afterEach.push( async function () {
+			if ( this.currentTest && this.currentTest.state === 'failed' ) {
+				await takeScreenshot( {
+					tempDir,
+					testName: this.currentTest.title,
+					driver,
+				} );
+				await saveVideoRecording( { tempDir, testName: this.currentTest.title } );
+			}
+		} );
+
+		hooks.afterAll.push( async function () {
+			await stopFramebuffer();
+			await stopVideoRecording();
+		} );
+	}
+
 	const browserHooks = buildBrowserHooks();
 
-	const createBrowserHook = async function () {
+	hooks.beforeAll.push( async function createBrowserHook() {
 		this.timeout( startBrowserTimeoutMS );
-		const driver = await browserHooks.createBrowser();
+		driver = await browserHooks.createBrowser();
 		this.driver = driver;
-	};
+	} );
 
-	return {
-		afterAll: [ ...videoHooks.afterAll, browserHooks.saveBrowserLogs, browserHooks.closeBrowser ],
-		beforeAll: [ ...videoHooks.beforeAll, createBrowserHook ],
-		afterEach: [ ...videoHooks.afterEach ],
-	};
+	hooks.afterAll.push( async function () {
+		await browserHooks.saveBrowserLogs( { tempDir } );
+		await browserHooks.closeBrowser();
+	} );
+
+	return hooks;
 };

--- a/test/e2e/lib/hooks/video/framebuffer.js
+++ b/test/e2e/lib/hooks/video/framebuffer.js
@@ -5,7 +5,7 @@ import { spawn } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { accessSync } from 'fs';
 import path from 'path';
-import { generatePath, getTestNameWithTime } from '../../test-utils';
+import { getTestNameWithTime } from '../../test-utils';
 
 export const getFreeDisplay = () => {
 	// eslint-disable-next-line no-constant-condition
@@ -25,52 +25,36 @@ export const buildHooks = ( displayNum ) => {
 	let xvfb;
 
 	const startFramebuffer = async () => {
-		xvfb = spawn( 'Xvfb', [
-			'-ac',
-			`:${ displayNum }`,
-			'-screen',
-			'0',
-			'1440x1000x24',
-			'+extension',
-			'RANDR',
-		] );
+		return new Promise( ( resolve, reject ) => {
+			xvfb = spawn( 'Xvfb', [
+				'-ac',
+				`:${ displayNum }`,
+				'-screen',
+				'0',
+				'1440x1000x24',
+				'+extension',
+				'RANDR',
+			] );
+			xvfb.on( 'error', reject );
+			// If there is no error in 100ms, assume the process spawned successfully
+			// TODO Node 15+ has a better way to do this (https://nodejs.org/api/child_process.html#child_process_event_spawn)
+			setTimeout( resolve, 100 );
+		} );
 	};
 
 	const stopFramebuffer = async () => {
-		try {
-			if ( ! xvfb ) return;
-
-			xvfb.kill();
-		} catch ( err ) {
-			console.warn(
-				'Got an error trying to stop the framebuffer. This IS NOT causing the test to break, is just a warning'
-			);
-			console.warn( 'Original error:' );
-			console.warn( err );
-		}
+		xvfb.kill();
 	};
 
-	async function takeScreenshot() {
-		if ( ! this.currentTest || this.currentTest.state !== 'failed' ) {
-			return;
-		}
-
-		try {
-			const fileName = generatePath(
-				`screenshots/${ getTestNameWithTime( this.currentTest ) }.png`
-			);
-			await mkdir( path.dirname( fileName ), { recursive: true } );
-
-			const driver = this.driver;
-			const screenshotData = await driver.takeScreenshot();
-			await writeFile( fileName, screenshotData, { encoding: 'base64' } );
-		} catch ( err ) {
-			console.warn(
-				'Got an error trying to save a screenshot from the browser. This IS NOT causing the test to break, is just a warning'
-			);
-			console.warn( 'Original error:' );
-			console.warn( err );
-		}
+	async function takeScreenshot( { tempDir, testName, driver } ) {
+		const fileName = path.join(
+			tempDir,
+			'screenshots',
+			`${ getTestNameWithTime( testName ) }.png`
+		);
+		await mkdir( path.dirname( fileName ), { recursive: true } );
+		const screenshotData = await driver.takeScreenshot();
+		await writeFile( fileName, screenshotData, { encoding: 'base64' } );
 	}
 
 	return { startFramebuffer, stopFramebuffer, takeScreenshot };

--- a/test/e2e/lib/hooks/video/index.js
+++ b/test/e2e/lib/hooks/video/index.js
@@ -17,13 +17,6 @@ export const isVideoEnabled = () => {
 };
 
 export const buildHooks = () => {
-	if ( ! isVideoEnabled() ) {
-		return {
-			afterAll: [],
-			beforeAll: [],
-			afterEach: [],
-		};
-	}
 	const displayNum = getFreeDisplay();
 
 	const { startFramebuffer, stopFramebuffer, takeScreenshot } = buildFramebufferHooks( displayNum );
@@ -31,13 +24,15 @@ export const buildHooks = () => {
 		displayNum
 	);
 
-	// Used by driver-manager and video hooks
+	// Used by driver-manager
 	global.displayNum = displayNum;
 
-	// startVideoRecording must come after startFramebuffer, as it depends on the framebuffer being up
 	return {
-		afterAll: [ stopFramebuffer, stopVideoRecording ],
-		beforeAll: [ startFramebuffer, startVideoRecording ],
-		afterEach: [ takeScreenshot, saveVideoRecording ],
+		startFramebuffer,
+		stopFramebuffer,
+		takeScreenshot,
+		startVideoRecording,
+		saveVideoRecording,
+		stopVideoRecording,
 	};
 };

--- a/test/e2e/lib/hooks/video/video-recorder.js
+++ b/test/e2e/lib/hooks/video/video-recorder.js
@@ -6,7 +6,7 @@ import { rename, mkdir, unlink } from 'fs/promises';
 import { createWriteStream } from 'fs';
 import { spawn } from 'child_process';
 import ffmpeg from 'ffmpeg-static';
-import { generatePath, getTestNameWithTime } from '../../test-utils';
+import { getTestNameWithTime } from '../../test-utils';
 
 const kill = ( proc ) =>
 	new Promise( ( resolve ) => {
@@ -18,13 +18,12 @@ export const buildHooks = ( displayNum ) => {
 	let file;
 	let ffVideo;
 
-	const startVideoRecording = async () => {
-		console.log( `Start video recording on port :${ displayNum }}` );
+	const startVideoRecording = async ( { tempDir } ) => {
 		const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
-		file = generatePath( `screenshots/${ displayNum }-${ dateTime }.mpg` );
+		file = path.join( tempDir, `screenshots/${ displayNum }-${ dateTime }.mpg` );
 		await mkdir( path.dirname( file ), { recursive: true } );
 
-		const logging = createWriteStream( generatePath( 'ffmpeg.log' ), { flags: 'a' } );
+		const logging = createWriteStream( path.join( tempDir, 'ffmpeg.log' ), { flags: 'a' } );
 		ffVideo = spawn( ffmpeg.path, [
 			'-f',
 			'x11grab',
@@ -44,40 +43,17 @@ export const buildHooks = ( displayNum ) => {
 		ffVideo.stderr.pipe( logging );
 	};
 
-	async function saveVideoRecording() {
-		if ( ! this.currentTest || this.currentTest.state !== 'failed' ) {
-			return;
-		}
-
-		try {
-			const newFile = generatePath(
-				`screenshots/${ getTestNameWithTime( this.currentTest ) }.mpg`
-			);
-			await mkdir( path.dirname( newFile ), { recursive: true } );
-			await kill( ffVideo );
-			await rename( file, newFile );
-		} catch ( err ) {
-			console.warn(
-				'Got an error trying to save the recorded video. This IS NOT causing the test to break, is just a warning'
-			);
-			console.warn( 'Original error:' );
-			console.warn( err );
-		}
+	async function saveVideoRecording( { tempDir, testName } ) {
+		const newFile = path.join( tempDir, `screenshots/${ getTestNameWithTime( testName ) }.mpg` );
+		await mkdir( path.dirname( newFile ), { recursive: true } );
+		await kill( ffVideo );
+		await rename( file, newFile );
 	}
 
 	const stopVideoRecording = async () => {
 		if ( ! ffVideo || ffVideo.killed ) return;
-
-		try {
-			await kill( ffVideo );
-			await unlink( file );
-		} catch ( err ) {
-			console.warn(
-				'Got an error trying to clean up the recorded video. This IS NOT causing the test to break, is just a warning'
-			);
-			console.warn( 'Original error:' );
-			console.warn( err );
-		}
+		await kill( ffVideo );
+		await unlink( file );
 	};
 
 	return { startVideoRecording, saveVideoRecording, stopVideoRecording };

--- a/test/e2e/lib/test-utils.js
+++ b/test/e2e/lib/test-utils.js
@@ -7,8 +7,8 @@ const BASE_PATH = process.env.TEMP_ASSET_PATH || path.join( __dirname, '..' );
 
 export const generatePath = ( name ) => path.join( BASE_PATH, name );
 
-export const getTestNameWithTime = ( test ) => {
-	const currentTestName = test.title.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
+export const getTestNameWithTime = ( testName ) => {
+	const currentTestName = testName.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
 	const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
 	return `${ currentTestName }-${ dateTime }`;
 };


### PR DESCRIPTION
#### Background

Our Mocha hooks depend on some Mocha internals that make them hard to reuse in Jest. Namely:

- Expect current test to live in `this.currentTest`
- Expect `this.driver`
- Expect `process.env.TEMP_ASSET_PATH` to point to a temporary unique dir (set by Magellan).

#### Changes proposed in this Pull Request

* Abstract the functions inside `test/e2e/lib/hooks/video/` and `test/e2e/lib/hooks/browser` to work on arguments and don't expect any `this` or env var.
* Create wrappers for those hooks that need it in `test/e2e/lib/hooks/mocha.js`, reading the values from `this`/`process.env` as required and passing them to the real hooks.

In the future, we'll also have a `test/e2e/lib/hooks/jest.js` that reuses the same hooks but pulls the required data (current test, temporary dir) from somewhere else.

#### Testing instructions

Validate all tests pass