### PR TITLE
ci(e2e): Migrate e2e-canary-i18n-nightly to TeamCity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -764,23 +764,4 @@ workflows:
           filters:
             branches:
               only: trunk
-
-  e2e-canary-i18n-nightly:
-    jobs:
-      - setup
-      - test-e2e-canary:
-          name: test-e2e-i18n-nightly
-          requires:
-            - setup
-          test-target: 'I18N'
-          test-flags: '-I'
-          filters:
-            branches:
-              only: trunk
-    triggers:
-      - schedule:
-          cron: '46 4 * * *'
-          filters:
-            branches:
-              only: trunk
 # vi: sts=2 ts=2 sw=2 et

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -447,6 +447,13 @@ private object I18NTests : BuildType({
 
 	params {
 		text(
+			name = "URL",
+			value = "https://wordpress.com",
+			label = "Test URL",
+			description = "URL to test against",
+			allowEmpty = false
+		)
+		text(
 			name = "LOCALES",
 			value = "en,es,pt-br,de,fr,he,ja,it,nl,ru,tr,id,zh-cn,zh-tw,ko,ar,sv",
 			label = "Locales to use",
@@ -474,6 +481,7 @@ private object I18NTests : BuildType({
 					cd test/e2e
 					mkdir temp
 
+					export URL=%URL%
 					export LIVEBRANCHES=false
 					export NODE_CONFIG_ENV=test
 					export TEST_VIDEO=true


### PR DESCRIPTION
#### Backgrond

I'm moving the  CircleCI job `e2e-canary-i18n-nightly` to a TeamCity equivalent.

This new build:
- Will run from `trunk` every 24h
- Will test the mag16 languages against `https://wordpress.com`
- Can be manually run for custom branches (useful when changing tests)
- URL is configurable in TeamCity UI
- List of languages is configurable in TeamCity UI
- WIll report status to slack channel `#i18n-bots`


#### Changes proposed in this Pull Request

* Add `URL` as a configurable property
* Drop workflow `e2e-canary-i18n-nightly` in CircleCI

#### Testing instructions

Verify E2E test pass for this branch
