### PR TITLE
State: Improve `fetchCurrentUser` thunk

### DIFF
--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -23,6 +23,12 @@ export function setCurrentUser( user ) {
 
 let fetchingUser = null;
 
+function setLegacyUserData( userData ) {
+	const user = userFactory();
+	user.data = userData;
+	user.emit( 'change' );
+}
+
 export function fetchCurrentUser() {
 	return ( dispatch ) => {
 		if ( fetchingUser ) {
@@ -50,11 +56,11 @@ export function fetchCurrentUser() {
 				dispatch( setCurrentUser( userData ) );
 
 				// @TODO: Remove this once `lib/user` has been fully reduxified
-				userFactory().data = userData;
+				setLegacyUserData( userData );
 			} )
 			.catch( () => {
 				// @TODO: Remove this once `lib/user` has been fully reduxified
-				userFactory().data = false;
+				setLegacyUserData( false );
 			} )
 			.finally( () => {
 				fetchingUser = null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR does a couple of improvements to the `fetchCurrentUser` thunk, as per @jsnajdr's comment [here](https://github.com/Automattic/wp-calypso/pull/53782#issuecomment-863897607):

> I see two issues with this patch and the other ones from the same series:
> - the `user().fetch()` method can detect that a fetch is already in progress and doesn't start a new one in that case. It returns the saved promise instead. `fetchCurrentUser` should do that, too.
> - the user info is now stored in two places -- `user.data` and Redux -- and they are not synced together. After `fetchCurrentUser` is done in this signup code, `user().get()` still has the old info.

We're essentially mirroring closer the `fetch()` from `lib/user` at this time. Eventually, we'll merge those together as @jsnajdr suggested in https://github.com/Automattic/wp-calypso/pull/53780#issuecomment-863935033

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Same as in #53780.