### PR TITLE
Emails: Add header cake in emails comparison page

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -53,7 +53,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getTitanProductName } from 'calypso/lib/titan';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
-import { emailManagementForwarding } from 'calypso/my-sites/email/paths';
+import { emailManagementForwarding, emailManagement } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -471,8 +471,10 @@ class EmailProvidersComparison extends React.Component {
 		);
 	}
 
-	goBack = () => {
-		page( `/email/${ this.props.selectedSiteSlug }` );
+	handleBack = () => {
+		const { selectedSiteSlug } = this.props;
+
+		page( emailManagement( selectedSiteSlug ) );
 	};
 
 	renderHeaderSection() {
@@ -492,9 +494,7 @@ class EmailProvidersComparison extends React.Component {
 
 		return (
 			<>
-				<HeaderCake onClick={ this.goBack }>
-					{ translate( 'Emails' ) }
-				</HeaderCake>
+				<HeaderCake onClick={ this.handleBack }>{ translate( 'Add Email' ) }</HeaderCake>
 				<PromoCard
 					isPrimary
 					title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -70,6 +70,8 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
 import { withShoppingCart } from '@automattic/shopping-cart';
+import { Fragment } from '@wordpress/element';
+import HeaderCake from 'calypso/components/header-cake';
 
 /**
  * Style dependencies
@@ -470,6 +472,10 @@ class EmailProvidersComparison extends React.Component {
 		);
 	}
 
+	goBack = () => {
+		page( `/email/${ this.props.selectedSiteSlug }` );
+	};
+
 	renderHeaderSection() {
 		const { selectedDomainName, translate } = this.props;
 
@@ -486,20 +492,25 @@ class EmailProvidersComparison extends React.Component {
 		};
 
 		return (
-			<PromoCard
-				isPrimary
-				title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }
-				image={ image }
-				className="email-providers-comparison__action-panel"
-			>
-				<p>
-					{ translate(
-						'Pick one of our flexible options to connect your domain with email ' +
-							'and start getting emails @%(domainName)s today.',
-						translateArgs
-					) }
-				</p>
-			</PromoCard>
+			<Fragment>
+				<HeaderCake onClick={ this.goBack }>
+					<h1>{ translate( 'Emails' ) }</h1>
+				</HeaderCake>
+				<PromoCard
+					isPrimary
+					title={ translate( 'Get your own @%(domainName)s email address', translateArgs ) }
+					image={ image }
+					className="email-providers-comparison__action-panel"
+				>
+					<p>
+						{ translate(
+							'Pick one of our flexible options to connect your domain with email ' +
+								'and start getting emails @%(domainName)s today.',
+							translateArgs
+						) }
+					</p>
+				</PromoCard>
+			</Fragment>
 		);
 	}
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -70,7 +70,6 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { Fragment } from '@wordpress/element';
 import HeaderCake from 'calypso/components/header-cake';
 
 /**
@@ -492,9 +491,9 @@ class EmailProvidersComparison extends React.Component {
 		};
 
 		return (
-			<Fragment>
+			<>
 				<HeaderCake onClick={ this.goBack }>
-					<h1>{ translate( 'Emails' ) }</h1>
+					{ translate( 'Emails' ) }
 				</HeaderCake>
 				<PromoCard
 					isPrimary
@@ -510,7 +509,7 @@ class EmailProvidersComparison extends React.Component {
 						) }
 					</p>
 				</PromoCard>
-			</Fragment>
+			</>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Pull Request adds a header to go back to the previous page, adding the typical "Header Cake" react component to the top of the page.

#### Testing instructions

1. Go to [emails](https://wordpress.com/email/)
2. Add an email
3. Check that a header cake exists on top of the page
4. Click on back button

Expected result:
- User si redirected back to the previous page (https://wordpress.com/email/{siteSlug})

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/122554004-afbbd280-d038-11eb-807a-f57f0e6b8114.png) | ![image](https://user-images.githubusercontent.com/5689927/122553571-260c0500-d038-11eb-8789-c5b0b222bfed.png)

Related to 1200182182542585-as-1200467951588564
