### PR TITLE
State: Remove user fetching from state middleware

### DIFF
--- a/client/state/jetpack/connection/actions.js
+++ b/client/state/jetpack/connection/actions.js
@@ -14,6 +14,7 @@ import {
 	JETPACK_USER_CONNECTION_DATA_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import wp from 'calypso/lib/wp';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 
 import 'calypso/state/data-layer/wpcom/jetpack/connection/owner';
 import 'calypso/state/jetpack/init';
@@ -90,10 +91,11 @@ export const disconnect = ( siteId ) => ( dispatch ) =>
 				siteId,
 				status: response,
 			} );
+			dispatch( fetchCurrentUser() );
 		} );
 
 /**
- * Change the jetpack master user.
+ * Change the jetpack connection owner.
  *
  * @param {number} siteId the site ID
  * @param {number} newOwnerWporgId the wporg user ID of the new owner

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -13,7 +13,6 @@ import {
 	NOTIFICATIONS_PANEL_TOGGLE,
 	ROUTE_SET,
 	SELECTED_SITE_SET,
-	SITE_DELETE_RECEIVE,
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 } from 'calypso/state/action-types';
@@ -143,7 +142,6 @@ const handler = ( dispatch, action, getState ) => {
 			}, 0 );
 			return;
 
-		case SITE_DELETE_RECEIVE:
 		case JETPACK_DISCONNECT_RECEIVE:
 			dispatch( fetchCurrentUser() );
 			return;

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -10,6 +10,7 @@ import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import config from '@automattic/calypso-config';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import {
@@ -31,16 +32,19 @@ import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'calypso/state/sites/c
 import 'calypso/state/data-layer/wpcom/sites/homepage';
 
 /**
- * Returns an action object to be used in signalling that a site has been
- * deleted.
+ * Returns a thunk that dispatches an action object to be used in signalling that a site has been
+ * deleted. It also re-re-fetches the current user.
  *
  * @param  {number} siteId  ID of deleted site
- * @returns {object}         Action object
+ * @returns {Function}        Action thunk
  */
 export function receiveDeletedSite( siteId ) {
-	return {
-		type: SITE_DELETE_RECEIVE,
-		siteId,
+	return ( dispatch ) => {
+		dispatch( {
+			type: SITE_DELETE_RECEIVE,
+			siteId,
+		} );
+		dispatch( fetchCurrentUser() );
 	};
 }
 

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -215,7 +215,9 @@ describe( 'actions', () => {
 
 		test( 'should dispatch receive deleted site when request completes', async () => {
 			await deleteSite( 2916284 )( spy, getState );
-			expect( spy ).toHaveBeenCalledWith( receiveDeletedSite( 2916284 ) );
+			const expected = receiveDeletedSite( 2916284 ).toString();
+			const received = spy.mock.calls[ 1 ].toString();
+			expect( received ).toEqual( expected );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/53784#discussion_r654300002 and removes user fetching from the state middleware, moving it into the corresponding actions and converting them to thunks as needed.

Related to #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Delete a WP.com simple site and verify that:
  * A request to `/me` is issued - see the network tab.
  * The site count in the "current site" area at the top of the "my-sites" sidebar reduces the count by 1 correctly.
* Disconnect a Jetpack site and go through the same 2 steps.
* Verify all tests pass.