### PR TITLE
Jetpack Connect: Use Redux user fetching during auth

### DIFF
--- a/client/state/jetpack-connect/actions/authorize.js
+++ b/client/state/jetpack-connect/actions/authorize.js
@@ -7,8 +7,8 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import userFactory from 'calypso/lib/user';
 import wpcom from 'calypso/lib/wp';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { receiveSite } from 'calypso/state/sites/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'calypso/state/sites/constants';
@@ -67,23 +67,7 @@ export function authorize( queryObject ) {
 				} );
 
 				// Update the user now that we are fully connected.
-				const user = userFactory();
-				user.fetching = false;
-				user.fetch();
-
-				// @TODO: When user fetching is reduxified, let's get rid of this hack.
-				// Currently, we need it to make sure user has been refetched before we continue.
-				// Otherwise the user might see a confusing message that they have no sites.
-				// See p8oabR-j3-p2/#comment-2399 for more information.
-				return new Promise( ( resolve ) => {
-					const userFetched = setInterval( () => {
-						const loadedUser = user.get();
-						if ( loadedUser ) {
-							clearInterval( userFetched );
-							resolve( loadedUser );
-						}
-					}, 100 );
-				} );
+				return dispatch( fetchCurrentUser() );
 			} )
 			.then( () => {
 				// Site may not be accessible yet, so force fetch from wpcom


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates Jetpack Connect's `authorize` thunk to use Redux for fetching the user instead of `lib/user`.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Start with a user with more than 1 sites in the account.
* Spin up a [JN site](https://jurassic.ninja/create).
* Go to `/jetpack/connect` and input its URL.
* Verify auth completes successfully and works as it did before.
* Start with a user without any sites in their account.
* Spin up a [JN site](https://jurassic.ninja/create).
* Go to `/jetpack/connect` and input its URL.
* Verify auth completes successfully and works as it did before.