### PR TITLE
Performance settings: Add link to Page Optimize settings

### DIFF
--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -10,16 +10,17 @@ import { ToggleControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Card, CompactCard } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SupportInfo from 'calypso/components/support-info';
+import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 
 class SpeedUpSiteSettings extends Component {
 	static propTypes = {
@@ -49,8 +50,10 @@ class SpeedUpSiteSettings extends Component {
 
 	render() {
 		const {
+			isPageOptimizeActive,
 			isRequestingSettings,
 			isSavingSettings,
+			pageOptimizeUrl,
 			photonModuleUnavailable,
 			selectedSiteId,
 			siteAcceleratorStatus,
@@ -122,6 +125,15 @@ class SpeedUpSiteSettings extends Component {
 						</FormFieldset>
 					) }
 				</Card>
+				{ isPageOptimizeActive && (
+					<div className="site-settings__page-optimize">
+						<CompactCard href={ pageOptimizeUrl }>
+							{ translate(
+								'Optimizes JS and CSS for faster page load and render in the browser.'
+							) }
+						</CompactCard>
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -146,5 +158,7 @@ export default connect( ( state ) => {
 		selectedSiteId,
 		siteAcceleratorStatus,
 		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
+		isPageOptimizeActive: isPluginActive( state, selectedSiteId, 'page-optimize' ),
+		pageOptimizeUrl: getSiteAdminUrl( state, selectedSiteId, 'admin.php?page=page-optimize' ),
 	};
 } )( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -128,9 +128,7 @@ class SpeedUpSiteSettings extends Component {
 				{ isPageOptimizeActive && (
 					<div className="site-settings__page-optimize">
 						<CompactCard href={ pageOptimizeUrl }>
-							{ translate(
-								'Optimizes JS and CSS for faster page load and render in the browser.'
-							) }
+							{ translate( 'Optimize JS and CSS for faster page load and render in the browser.' ) }
 						</CompactCard>
 					</div>
 				) }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -566,3 +566,8 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__cloudflare-spacer {
 	margin-bottom: 16px;
 }
+
+.site-settings__page-optimize {
+	margin-top: -16px;
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a link to the Performance settings page for configuring the Page Optimize plugin settings when the Page Optimize plugin is active (it's installed and active by default on all Atomic sites).

<img width="759" alt="Screen Shot 2021-06-18 at 16 02 20" src="https://user-images.githubusercontent.com/1233880/122573401-0f24dd00-d04f-11eb-945b-c398c260a7e2.png">

This helps with the effort of removing the current horizontal navigation bar (https://github.com/Automattic/wp-calypso/issues/53774, https://github.com/Automattic/jetpack/pull/20100), since we're planning to replace the "Settings > Performance" submenu that currently links to the Page Optimize settings with a submenu that links to the Calypso Performance settings.

#### Testing instructions

- Switch to an Atomic site.
- Go to Settings > General > Performance.
- Make sure there a is new link in the "Performance & speed" section that links to the Page Optimize settings page.
- Make sure the link only appears when the plugin is active.
