### PR TITLE
Jetpack Cloud: update sidebar bottom items

### DIFF
--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -55,20 +55,21 @@ class JetpackCloudSidebar extends Component {
 				<SidebarFooter>
 					<SidebarMenu>
 						<SidebarItem
-							label={ translate( 'Get help', {
-								comment: 'Jetpack Cloud sidebar navigation item',
-							} ) }
-							link="https://jetpack.com/support"
-							materialIcon="help"
-							materialIconStyle="filled"
-							onNavigate={ this.onGetHelp }
-						/>
-						<SidebarItem
 							label={ translate( 'WP Admin', {
 								comment: 'Jetpack Cloud sidebar navigation item',
 							} ) }
 							link={ jetpackAdminUrl }
 							icon="my-sites"
+						/>
+						<SidebarItem
+							label={ translate( 'Get help', {
+								comment: 'Jetpack Cloud sidebar navigation item',
+							} ) }
+							link="https://jetpack.com/support"
+							className="sidebar__jetpack-cloud-item-has-border"
+							materialIcon="help"
+							materialIconStyle="filled"
+							onNavigate={ this.onGetHelp }
 						/>
 					</SidebarMenu>
 				</SidebarFooter>

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -64,7 +64,7 @@
 	.sidebar__footer {
 		margin-top: auto;
 
-		.sidebar__menu-link {
+		.sidebar__jetpack-cloud-item-has-border {
 			border-top: 1px solid var( --color-sidebar-border );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reorders the two bottom items in Calypso Green.
* Removes the top border on the first item.
* Props to @ederrengifo 

See more details on p6TEKc-55j-p2

#### Testing instructions

* Fire up this PR by running `yarn start-jetpack-cloud`.
* Go to `http://jetpack.cloud.localhost:3000/` and select any site.
* Ensure that you see the WP Admin link first (without top border), and Get Help second (with top border).

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/122580459-e51eeb00-d04d-11eb-931a-c403fa67c66f.png) | ![image](https://user-images.githubusercontent.com/390760/122580488-eb14cc00-d04d-11eb-9d5e-8b5c3be938a5.png)

