### PR TITLE
Themes: auto-loading homepage confirmation modal: Add previews

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -194,6 +194,7 @@ class AutoLoadingHomepageModal extends Component {
 					<div className="themes__theme-preview-items">
 						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
 							<iframe
+								loading="lazy"
 								title={ translate( 'Preview of current homepage with new theme applied' ) }
 								src={ iframeSrcKeepHomepage }
 							/>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -232,8 +232,6 @@ class AutoLoadingHomepageModal extends Component {
 						Current issues:
 						<ul>
 							<li> Iframe doesn't block clicks </li>
-							<li> Iframe should be zoomed out? </li>
-							<li> Right side preview missing</li>
 						</ul>
 					</div>
 					<div className="themes__autoloading-homepage-option-description">

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -226,14 +226,6 @@ class AutoLoadingHomepageModal extends Component {
 							</FormLabel>
 						</div>
 					</div>
-					<div
-						style={ { backgroundColor: 'rgb( 252, 165, 165 )', padding: '4px', fontSize: '10px' } }
-					>
-						Current issues:
-						<ul>
-							<li> Iframe doesn't block clicks </li>
-						</ul>
-					</div>
 					<div className="themes__autoloading-homepage-option-description">
 						{ this.state.homepageAction === 'keep_current_homepage' && (
 							<p>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -26,11 +26,13 @@ import {
 	getPreActivateThemeId,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import {
 	acceptAutoLoadingHomepageWarning,
 	hideAutoLoadingHomepageWarning,
 	activate as activateTheme,
 } from 'calypso/state/themes/actions';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Style dependencies
@@ -141,7 +143,13 @@ class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const { name: themeName, id: themeId } = this.props.theme;
+		const { name: themeName, id: themeId, stylesheet } = this.props.theme;
+
+		// is HTTPS always appropriate?
+		const iframeSrcKeepHomepage = addQueryArgs( 'https://' + this.props.siteDomain, {
+			theme: stylesheet,
+			hide_banners: 'true',
+		} );
 
 		return (
 			<Dialog
@@ -179,8 +187,12 @@ class AutoLoadingHomepageModal extends Component {
 						} ) }
 					</h1>
 					<div className="themes__theme-preview-items">
-						<div className="themes__theme-preview-item">
-							<img src="https://placedog.net/500" alt="" />
+						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
+							<iframe
+								title={ translate( 'Preview of current homepage with new theme applied' ) }
+								src={ iframeSrcKeepHomepage }
+							/>
+							{ /* <img src="https://placedog.net/500" alt="" /> */ }
 							<FormLabel>
 								<FormRadio
 									value="keep_current_homepage"
@@ -203,6 +215,16 @@ class AutoLoadingHomepageModal extends Component {
 								/>
 							</FormLabel>
 						</div>
+					</div>
+					<div
+						style={ { backgroundColor: 'rgb( 252, 165, 165 )', padding: '4px', fontSize: '10px' } }
+					>
+						Current issues:
+						<ul>
+							<li> Iframe doesn't block clicks </li>
+							<li> Iframe should be zoomed out? </li>
+							<li> Right side preview missing</li>
+						</ul>
 					</div>
 					<div className="themes__autoloading-homepage-option-description">
 						{ this.state.homepageAction === 'keep_current_homepage' && (
@@ -252,6 +274,7 @@ export default connect(
 
 		return {
 			siteId,
+			siteDomain: getSiteDomain( state, siteId ),
 			installingThemeId,
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -143,7 +143,12 @@ class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const { name: themeName, id: themeId, stylesheet } = this.props.theme;
+		const {
+			name: themeName,
+			id: themeId,
+			stylesheet,
+			screenshot: themeScreenshot,
+		} = this.props.theme;
 
 		// is HTTPS always appropriate?
 		const iframeSrcKeepHomepage = addQueryArgs( 'https://' + this.props.siteDomain, {
@@ -192,7 +197,6 @@ class AutoLoadingHomepageModal extends Component {
 								title={ translate( 'Preview of current homepage with new theme applied' ) }
 								src={ iframeSrcKeepHomepage }
 							/>
-							{ /* <img src="https://placedog.net/500" alt="" /> */ }
 							<FormLabel>
 								<FormRadio
 									value="keep_current_homepage"
@@ -203,7 +207,7 @@ class AutoLoadingHomepageModal extends Component {
 							</FormLabel>
 						</div>
 						<div className="themes__theme-preview-item">
-							<img src="https://placedog.net/500" alt="" />
+							<img src={ themeScreenshot } alt="" />
 							<FormLabel>
 								<FormRadio
 									value="use_new_homepage"

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -208,7 +208,10 @@ class AutoLoadingHomepageModal extends Component {
 							</FormLabel>
 						</div>
 						<div className="themes__theme-preview-item">
-							<img src={ themeScreenshot } alt="" />
+							<img
+								src={ themeScreenshot }
+								alt={ translate( "Preview of new theme's default homepage" ) }
+							/>
 							<FormLabel>
 								<FormRadio
 									value="use_new_homepage"

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -193,11 +193,13 @@ class AutoLoadingHomepageModal extends Component {
 					</h1>
 					<div className="themes__theme-preview-items">
 						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
-							<iframe
-								loading="lazy"
-								title={ translate( 'Preview of current homepage with new theme applied' ) }
-								src={ iframeSrcKeepHomepage }
-							/>
+							<div className="themes__iframe-wrapper">
+								<iframe
+									loading="lazy"
+									title={ translate( 'Preview of current homepage with new theme applied' ) }
+									src={ iframeSrcKeepHomepage }
+								/>
+							</div>
 							<FormLabel>
 								<FormRadio
 									value="keep_current_homepage"

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -77,7 +77,17 @@
 .themes__theme-preview-item-iframe-container {
 	display: flex;
 	flex-direction: column;
-	iframe {
+
+	.themes__iframe-wrapper {
 		flex-grow: 1;
+		overflow: hidden;
+	}
+	iframe {
+		// flex-grow: 1;
+		height: 200%;
+		width: 200%;
+		max-width: 200%;
+		transform: scale( 0.5 );
+		transform-origin: top left;
 	}
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -73,3 +73,11 @@
 		margin: 1em;
 	}
 }
+
+.themes__theme-preview-item-iframe-container {
+	display: flex;
+	flex-direction: column;
+	iframe {
+		flex-grow: 1;
+	}
+}


### PR DESCRIPTION
## Note: This PR has a parent PR. It merges into that branch, not trunk! https://github.com/Automattic/wp-calypso/pull/53796

#### Changes proposed in this Pull Request

* Add previews to the theme switch modal

![2021-06-18_16-23](https://user-images.githubusercontent.com/937354/122617236-7e9bcc00-d051-11eb-9bef-15bf1d8957a6.png)



#### Testing instructions


* Theme Showcase -> Click on three dots menu of a recommended theme -> Click activate -> See previews in modal
* Block clicks from inside the iframe:
  * (Option 1) Apply D63076-code . You are still able to scroll the iframe.
  * (Option 2) Apply the diff in [this comment](https://github.com/Automattic/wp-calypso/pull/53823#issuecomment-864227840). You may no longer scroll the iframe. Perhaps the zoom should be adjusted, to show more of the homepage?
  * (Option 3) There may be another way to work this out, but I haven't find one yet. Open to ideas.



Related to https://github.com/Automattic/wp-calypso/issues/53674
