### PR TITLE
Revert "Signup: Use Redux for user fetching in signup actions"

### DIFF
--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { fetchCurrentUser } from 'calypso/state/current-user/actions';
+import user from 'calypso/lib/user';
+
+// State actions and selectors
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { requestSites } from 'calypso/state/sites/actions';
 
@@ -12,8 +14,7 @@ async function fetchSitesUntilSiteAppears( siteSlug, reduxStore ) {
 }
 
 export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
-	Promise.all( [
-		fetchSitesUntilSiteAppears( siteSlug, reduxStore ),
-		reduxStore.dispatch( fetchCurrentUser() ),
-	] ).then( onComplete );
+	Promise.all( [ fetchSitesUntilSiteAppears( siteSlug, reduxStore ), user().fetch() ] ).then(
+		onComplete
+	);
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#53782 because (we think) it sometimes causes the launch-site flow to hang.