### PR TITLE
Theme Showcase: Add headers back in between lists of themes.

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -104,6 +104,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 							origin="wpcom"
 							defaultOption={ 'activate' }
 							secondaryOption={ 'tryandcustomize' }
+							noMarginBeforeHeader={ true }
 							search={ search }
 							tier={ tier }
 							filter={ filter }

--- a/client/my-sites/themes/themes-selection-header/index.jsx
+++ b/client/my-sites/themes/themes-selection-header/index.jsx
@@ -12,10 +12,12 @@ import { useTranslate } from 'i18n-calypso';
  */
 import './style.scss';
 
-const ThemesSelectionHeader = ( { label, source } ) => {
+const ThemesSelectionHeader = ( { label, noMarginBeforeHeader } ) => {
 	const translate = useTranslate();
 
-	const classes = classNames( 'themes__themes-selection-header', `source-${ source }` );
+	const classes = classNames( 'themes__themes-selection-header', {
+		'margin-before-header': ! noMarginBeforeHeader,
+	} );
 
 	return (
 		<div className={ classes }>

--- a/client/my-sites/themes/themes-selection-header/index.jsx
+++ b/client/my-sites/themes/themes-selection-header/index.jsx
@@ -8,25 +8,20 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 
 /**
- * Internal dependencies
- */
-import SectionHeader from 'calypso/components/section-header';
-
-/**
  * Style dependencies
  */
 import './style.scss';
 
-const ThemesSelectionHeader = ( { label, count } ) => {
+const ThemesSelectionHeader = ( { label, source } ) => {
 	const translate = useTranslate();
 
-	const selectionHeaderClassName = classNames( 'themes-selection-header', {
-		'is-placeholder': count === null,
-	} );
+	const classes = classNames( 'themes__themes-selection-header', `source-${ source }` );
 
 	return (
-		<div className={ selectionHeaderClassName }>
-			<SectionHeader label={ label || translate( 'WordPress.com themes' ) } count={ count } />
+		<div className={ classes }>
+			<h2>
+				<strong>{ label || translate( 'WordPress.com themes' ) }</strong>
+			</h2>
 		</div>
 	);
 };

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -1,3 +1,3 @@
-.themes__themes-selection-header {
+.themes__themes-selection-header.margin-before-header {
 	margin-top: 12px;
 }

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -1,7 +1,3 @@
 .themes__themes-selection-header {
 	margin-top: 12px;
 }
-
-.themes__themes-selection-header.source-wpcom {
-	margin-top: 0;
-}

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -1,34 +1,7 @@
-.themes-selection-header {
-	.section-header {
-		background-color: transparent;
-		border-color: transparent;
-		box-shadow: none;
-		padding: 24px 0 0;
-		margin-top: 12px;
-	}
+.themes__themes-selection-header {
+	margin-top: 12px;
+}
 
-	.section-header__label::before {
-		background-image: none;
-	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		.card {
-			padding-left: 15px;
-		}
-	}
-
-	@include breakpoint-deprecated( '<480px' ) {
-		.card {
-			padding-right: 15px;
-		}
-	}
-
-	&.is-placeholder {
-		.section-header__label-text,
-		.section-header__actions {
-			color: transparent;
-			background-color: var( --color-neutral-0 );
-			animation: loading-fade 1.6s ease-in-out infinite;
-		}
-	}
+.themes__themes-selection-header.source-wpcom {
+	margin-top: 0;
 }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -28,6 +28,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import config from '@automattic/calypso-config';
+import ThemesSelectionHeader from './themes-selection-header';
 
 /**
  * Style dependencies
@@ -157,11 +158,14 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, upsellUrl } = this.props;
+		const { source, query, upsellUrl, listLabel, themesCount } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
+				{ ! this.props.recommendedThemes && (
+					<ThemesSelectionHeader label={ listLabel } count={ themesCount } />
+				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }
 					themes={ this.props.recommendedThemes || this.props.themes }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -163,7 +163,7 @@ class ThemesSelection extends Component {
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
-				{ ! this.props.recommendedThemes && (
+				{ ! this.props.recommendedThemes && this.props.isLoggedIn && (
 					<ThemesSelectionHeader
 						label={ listLabel }
 						noMarginBeforeHeader={ noMarginBeforeHeader }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -158,13 +158,16 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, upsellUrl, listLabel } = this.props;
+		const { source, query, upsellUrl, listLabel, noMarginBeforeHeader } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
 				{ ! this.props.recommendedThemes && (
-					<ThemesSelectionHeader label={ listLabel } source={ source } />
+					<ThemesSelectionHeader
+						label={ listLabel }
+						noMarginBeforeHeader={ noMarginBeforeHeader }
+					/>
 				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -158,13 +158,13 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, upsellUrl, listLabel, themesCount } = this.props;
+		const { source, query, upsellUrl, listLabel } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
 				{ ! this.props.recommendedThemes && (
-					<ThemesSelectionHeader label={ listLabel } count={ themesCount } />
+					<ThemesSelectionHeader label={ listLabel } source={ source } />
 				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }


### PR DESCRIPTION
Theme Showcase: Add headers back in between lists of themes. These were removed in [39898](https://github.com/Automattic/wp-calypso/issues/39898) due to the theme counts not being accurate at the time. The theme counts seem to be working when I load them, but from the discussion in the issue above, it sounds like it used to be an intermittent issue and it could still return. I removed the counts so that I could move forward in confidence.

I thought the page [looked a little strange without the counts](https://user-images.githubusercontent.com/10274366/122608704-b2bfbe80-d04a-11eb-9da8-bc1015953d02.png), so I reformatted the headers to look like the "[Recommended Themes](https://user-images.githubusercontent.com/10274366/122608578-755b3100-d04a-11eb-9a8e-b12c37802a06.png)" header.


<img src='https://user-images.githubusercontent.com/10274366/122608375-1695b780-d04a-11eb-9b21-824ac4cfc7fd.png' width=400 />

<img src='https://user-images.githubusercontent.com/10274366/122608395-201f1f80-d04a-11eb-8874-a2c6f43284a6.png' width=400 />

#### Testing instructions

The theme showcase can be seen from atomic sites, simple sites or while logged out. View the theme showcase from all 3 contexts as well as using different screen sizes.

Try a simple site on the premium plan, which can see advanced themes.

Try an atomic site WITH an uploaded theme. And an atomic site WITHOUT an uploaded theme.

There isn't any business logic to test here, so it just needs to look OK.
