### PR TITLE
Playwright: make Gutenberg publish and visit post steps more reliable.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -30,7 +30,6 @@ const selectors = {
 	publishPanel: '.editor-post-publish-panel',
 	publishButton:
 		'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button',
-	publishSpinner: '.components-spinner',
 	viewPostButton: 'text=View Post',
 };
 
@@ -177,7 +176,6 @@ export class GutenbergEditorPage extends BaseContainer {
 		await this.frame.click( selectors.publishPanelToggle );
 		await this.frame.waitForSelector( selectors.publishPanel );
 		await this.frame.click( selectors.publishButton );
-		await this.frame.waitForSelector( selectors.publishSpinner, { state: 'hidden' } );
 
 		if ( visit ) {
 			await this._visitPublishedEntryFromPublishPane();

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -188,8 +188,10 @@ export class GutenbergEditorPage extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async _visitPublishedEntryFromPublishPane(): Promise< void > {
-		const viewPostButton = await this.frame.waitForSelector( selectors.viewPostButton );
-		await Promise.all( [ this.page.waitForNavigation(), viewPostButton.click() ] );
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.frame.click( selectors.viewPostButton ),
+		] );
 		await this.page.waitForLoadState( 'networkidle' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -30,6 +30,7 @@ const selectors = {
 	publishPanel: '.editor-post-publish-panel',
 	publishButton:
 		'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button',
+	publishSpinner: '.components-spinner',
 	viewPostButton: 'text=View Post',
 };
 
@@ -176,7 +177,7 @@ export class GutenbergEditorPage extends BaseContainer {
 		await this.frame.click( selectors.publishPanelToggle );
 		await this.frame.waitForSelector( selectors.publishPanel );
 		await this.frame.click( selectors.publishButton );
-		await this.frame.waitForSelector( selectors.viewPostButton );
+		await this.frame.waitForSelector( selectors.publishSpinner, { state: 'hidden' } );
 
 		if ( visit ) {
 			await this._visitPublishedEntryFromPublishPane();
@@ -189,10 +190,8 @@ export class GutenbergEditorPage extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async _visitPublishedEntryFromPublishPane(): Promise< void > {
-		await Promise.all( [
-			this.frame.click( selectors.viewPostButton ),
-			this.page.waitForNavigation(),
-			this.page.waitForLoadState( 'networkidle' ),
-		] );
+		const viewPostButton = await this.frame.waitForSelector( selectors.viewPostButton );
+		await Promise.all( [ this.page.waitForNavigation(), viewPostButton.click() ] );
+		await this.page.waitForLoadState( 'networkidle' );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR revisits how GutenbergEditorPage.publish is implemented with the goal of making the process more reliable.

In some instances, test cases have failed due to the promises in `Promise.all` resolving prematurely for one reason or another. This causes the Playwright engine to believe it has clicked on the link to navigate to the published post when in fact it has not.

- add an explicit wait for the `spinner` to disappear.
- move the promise for `waitForLoadState` out from `Promise.all`.


#### Testing instructions

TeamCity:
- ensure Playwright E2E tests pass.
- inspect the Playwright E2E task to ensure that any tests involving publish and visit post are not flaking out (including being muted).


