### PR TITLE
Let WooCommerce mark it's own checklist as done

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce/index.jsx
@@ -25,7 +25,7 @@ export const SiteSetupListEcommerce = ( { siteUrl } ) => {
 			) }
 			actionText={ translate( 'Finish store setup' ) }
 			actionUrl={ `${ siteUrl }/wp-admin/admin.php?page=wc-admin` }
-			completeOnStart={ true }
+			completeOnStart={ false }
 			illustration={ earnSectionImage }
 			taskId={ TASK_SITE_SETUP_CHECKLIST_ECOMMERCE }
 			timing={ 7 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR leaves the WooCommerce Finish Setup card (that is on My Home) as incomplete until Woo says that it's done, instead of marking it as done as soon as the button to start it is pressed.

The WooCommerce checklist is a pretty important tool for new users with a new site, and it seems very appropriate to keep the link available until the user is finished with it. In addition, there are two different mechanisms to dismiss it manually, one in Calypso and one in WooCommerce,  so experienced users who don't find it useful will not be inconvenienced.


#### Testing Instructions:

The key thing to test is that hitting the "Finish store setup" does not  dismiss the task card, but the slightly tricky thing is the two different flags.

Being able to see and manipulate these flags makes it much easier to be confident the code is working as expected, so I've added instructions below to check & clear the two flags:

1. We have a calypso specific flag just for the card. Users can dismiss the card without dismissing the task list (because the task-list is super useful and the card is pretty in-your-face).

2. We have a WooCommerce flag for the task list itself, and we want the card to respect that flag (it doesn't make much sense to point people towards a task list they've dismissed, and the task list already has documentation and links to both hide and restore it).


You'll need a test site with an eCommerce plan in order to activate the "Finish store setup" card on your "My Home" page: https://wordpress.com/home/ {$TestWooCommerceSite}:

![My_Home_‹_julesauspremiumtest_—_WordPress_com](https://user-images.githubusercontent.com/5952255/122716512-aedfa680-d2ad-11eb-90c3-99baf67225bb.jpg)


Beyond that, we want to check that the two dismissal options still work as expected:

- [ ] Confirm that the "Finish store setup" card no longer appears after hiding the task list in WooCommerce using the "Hide this" button underneath the hamburger menu on `/wp-admin/admin.php?page=wc-admin`:
![Home_‹_WooCommerce_‹_julesauspremiumtest_—_WooCommerce](https://user-images.githubusercontent.com/5952255/122718987-f156b280-d2b0-11eb-9d27-a307af39284d.jpg)
- [ ] Restore the Setup Wizard by going to nearly any other WooCommerce page (`/wp-admin/admin.php?page=wc-addons` for example), explanding the "Help" tab, clicking on the "Setup wizard" option and then the "Setup wizard" button:
![WooCommerce_extensions_‹_julesauspremiumtest_—_WordPress](https://user-images.githubusercontent.com/5952255/122719705-ee0ff680-d2b1-11eb-8f5b-6ef7c0f3452e.jpg)
This should restore the task list itself on the WooCommerce Home page as well as the card on the calypso `/home/` page. 
- [ ] Dismiss the task through the "Hide this" button and confirm that the card disappears but the task list itself still appears on the woocommerce page. Any duration is fine, and any option can be cleared as described below.

#### Checking/Clearing the two flags

1. The first flag is on the Calypso side. This is the flag that we're removing in the PR, but it can still be added temporarily through the "Hide this" drop-down, or more likely has already been dismissed before this patch.

The easiest way to check/clear it is using the `/me/preferences/` api calls with https://developer.wordpress.com/docs/api/console/

To check for the flag, use `WP.COM API`, `v1.1`, `GET`, `/me/preferences/` and look for a `dismissible-card-home-task-site-setup-checklist-ecommerce-${blog_id}` key.

To Clear the flag, use `WP.COM API`, `v1.1`, `GET`, `/me/preferences/` and for a the `BODY/calypso_preferences` use that same key with the blog ID and assign it a value `null`:

![WordPress_com_Console_and_WordPress_Command_Line_Interface__wp-cli_](https://user-images.githubusercontent.com/5952255/122718022-c0c24900-d2af-11eb-9208-7505cb903d5d.jpg)

2. The other flag on the WooCommerce Side is the `woocommerce_task_list_hidden` option.

The most unambiguous way to check is to use the `/_cli` for your test site and
- query the value with  `wp option get woocommerce_task_list_hidden` 
- clear the value with `wp option update woocommerce_task_list_hidden no`
Note that "no" is the only value that will show the value.

Fixes #53686
