### PR TITLE
State: Return promise in fetchCurrentUser

### DIFF
--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -65,6 +65,8 @@ export function fetchCurrentUser() {
 			.finally( () => {
 				fetchingUser = null;
 			} );
+
+		return fetchingUser;
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We recently introduced a `fetchCurrentUser` thunk, but as we were refactoring it to return the promise if one is currently in flight, we forgot to actually return it. This PR fixes that.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

None necessary. This should actually fix some e2e tests and bugs that we recently introduced.