### PR TITLE
Remove Lodash from state/preferences

### DIFF
--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { withStorageKey } from '@automattic/state-utils';
@@ -41,8 +36,8 @@ export const localValues = ( state = {}, action ) => {
 			return { ...state, [ key ]: value };
 		}
 		case PREFERENCES_SAVE_SUCCESS: {
-			const { key } = action;
-			return omit( state, key );
+			const { [ action.key ]: removed, ...rest } = state;
+			return rest;
 		}
 	}
 

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get, find, has } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { DEFAULT_PREFERENCE_VALUES } from './constants';
@@ -22,18 +17,16 @@ export const isFetchingPreferences = ( state ) => !! state.preferences.fetching;
  * @returns {*}            Preference value
  */
 export function getPreference( state, key ) {
-	return get(
-		find(
-			[
-				state.preferences?.localValues,
-				state.preferences?.remoteValues,
-				DEFAULT_PREFERENCE_VALUES,
-			],
-			( source ) => has( source, key )
-		),
-		key,
-		null
-	);
+	for ( const source of [
+		state.preferences?.localValues,
+		state.preferences?.remoteValues,
+		DEFAULT_PREFERENCE_VALUES,
+	] ) {
+		if ( source && source.hasOwnProperty( key ) ) {
+			return source[ key ] ?? null;
+		}
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
Removes Lodash from `state/preferences` selectors and reducer.

**How to test:**
Verify that unit tests pass.