### PR TITLE
General Settings: Add Prompt For Changing Site Addresses

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -43,6 +43,7 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { launchSite } from 'calypso/state/sites/launch/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import { domainManagementChangeSiteAddress } from 'calypso/my-sites/domains/paths';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -190,6 +191,12 @@ export class SiteSettingsFormGeneral extends Component {
 								),
 							},
 						}
+					) }
+					&nbsp;
+					{ site.domain.endsWith( '.wordpress.com' ) && (
+						<a href={ domainManagementChangeSiteAddress( siteSlug, site.domain ) }>
+							{ translate( "You can also change your site's address in your Domain Settings." ) }
+						</a>
 					) }
 				</FormSettingExplanation>
 			);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -195,7 +195,7 @@ export class SiteSettingsFormGeneral extends Component {
 					&nbsp;
 					{ site.domain.endsWith( '.wordpress.com' ) && (
 						<a href={ domainManagementChangeSiteAddress( siteSlug, site.domain ) }>
-							{ translate( "You can also change your site's address in your Domain Settings." ) }
+							{ translate( 'You can change your site address in Domain Settings.' ) }
 						</a>
 					) }
 				</FormSettingExplanation>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a prompt displaying how users can change their Site Address in General Settings. 

I chose this language based on the "You can also modify the interface language in your profile." phrase below, but please feel free to let me know if it should be updated.

#### Testing instructions

Visit `/settings/general` and verify this link appears and works if you have a .wordpress.com site address.

<img width="815" alt="Screenshot 2021-06-21 at 09 58 55" src="https://user-images.githubusercontent.com/43215253/122735872-542b5800-d277-11eb-9059-86abd40a0b82.png">

cc @olaseni 

Fixes #53653