### PR TITLE
Launch: update reskinned processing screen

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -608,7 +608,12 @@ class Signup extends React.Component {
 			const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 			const hasPaidDomain = isDomainRegistration( domainItem );
 
-			return <ReskinnedProcessingScreen hasPaidDomain={ hasPaidDomain } />;
+			return (
+				<ReskinnedProcessingScreen
+					flowName={ this.props.flowName }
+					hasPaidDomain={ hasPaidDomain }
+				/>
+			);
 		}
 
 		return (

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -14,19 +14,19 @@ import './style.scss';
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
 
-/**
- * This component is cloned from the CreateSite component of Gutenboarding flow
- * to work with the onboarding signup flow.
- */
-export default function ReskinnedProcessingScreen( { hasPaidDomain } ) {
+// This component is cloned from the CreateSite component of Gutenboarding flow
+// to work with the onboarding signup flow.
+export default function ReskinnedProcessingScreen( { flowName, hasPaidDomain } ) {
 	const { __ } = useI18n();
 
 	const steps = React.useRef(
-		[
-			__( 'Building your site' ),
-			hasPaidDomain && __( 'Getting your domain' ),
-			__( 'Applying design' ),
-		].filter( Boolean )
+		flowName === 'launch-site'
+			? [ __( 'Your site will be live shortly.' ) ] // copy from 'packages/launch/src/focused-launch/success'
+			: [
+					__( 'Building your site' ),
+					hasPaidDomain && __( 'Getting your domain' ),
+					__( 'Applying design' ),
+			  ].filter( Boolean )
 	);
 	const totalSteps = steps.current.length;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add launch-specific processing message for `launch-site` reskinned flow.

#### Testing instructions

* Go to /start/launch-site?siteSlug={SITE_SLUG}&flags=signup/reskin
* Finish the flow to launch your site => you should see the 1-step processing screen illustrated below

#### Screenshots
<img width="816" alt="Screenshot 2021-06-21 at 12 59 41" src="https://user-images.githubusercontent.com/14192054/122749318-de82b480-d295-11eb-84f8-7207ab7de6db.png">

Fixes #53827
