### PR TITLE
Add/media share and rating

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -20,6 +20,10 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import TrackInputChanges from 'calypso/components/track-input-changes';
 import EditorMediaModalFieldset from '../fieldset';
 import { updateMedia } from 'calypso/state/media/thunks';
+import FormLabel from 'calypso/components/forms/form-label';
+import { FormCheckbox } from 'calypso/devdocs/design/playground-scope';
+import classnames from 'classnames';
+import FormRadio from 'calypso/components/forms/form-radio';
 
 class EditorMediaModalDetailFields extends Component {
 	static propTypes = {
@@ -82,14 +86,28 @@ class EditorMediaModalDetailFields extends Component {
 		this.props.onUpdate( this.props.item.ID, this.state.modifiedItem );
 	}
 
-	setFieldValue = ( { target } ) => {
+	setFieldByName = ( name, value ) => {
 		const modifiedItem = Object.assign(
 			{ ID: this.props.item.ID },
 			get( this.state, 'modifiedItem', {} ),
-			{ [ target.name ]: target.value }
+			{ [ name ]: value }
 		);
 
 		this.setState( { modifiedItem }, this.persistChange );
+	};
+
+	setFieldValue = ( { target } ) => {
+		this.setFieldByName( target.name, target.value );
+	};
+
+	handleRatingChange = ( { currentTarget } ) => {
+		this.setFieldByName( 'rating', currentTarget.value );
+	};
+
+	handleDisplayEmbed = () => {
+		const inputValue = 1 === this.getItemValue( 'display_embed' ) ? 0 : 1;
+
+		this.setFieldByName( 'display_embed', inputValue );
 	};
 
 	getItemValue( attribute ) {
@@ -128,6 +146,86 @@ class EditorMediaModalDetailFields extends Component {
 			</EditorMediaModalFieldset>
 		);
 	}
+
+	renderVideoPressShortcode = () => {
+		const videopressGuid = this.getItemValue( 'videopress_guid' );
+
+		if ( ! videopressGuid ) {
+			return;
+		}
+
+		return (
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Shortcode' ) }>
+				<ClipboardButtonInput value={ '[wpvideo ' + videopressGuid + ']' } />
+			</EditorMediaModalFieldset>
+		);
+	};
+
+	renderRating = () => {
+		const items = [
+			{
+				label: 'G',
+				value: 'G',
+			},
+			{
+				label: 'PG-13',
+				value: 'PG-13',
+			},
+			{
+				label: 'R',
+				value: 'R-17',
+			},
+			{
+				label: 'X',
+				value: 'X-18',
+			},
+		];
+		const rating = this.getItemValue( 'rating' );
+		if ( ! rating ) {
+			return;
+		}
+
+		return (
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Rating' ) }>
+				<div className={ classnames( 'form-radios-bar' ) } style={ { display: 'flex' } }>
+					{ items.map( ( item, i ) => (
+						<FormLabel key={ item.value + i } style={ { paddingRight: '15px' } }>
+							<FormRadio
+								checked={ rating === item.value }
+								onChange={ this.handleRatingChange }
+								{ ...item }
+							/>
+						</FormLabel>
+					) ) }
+				</div>
+			</EditorMediaModalFieldset>
+		);
+	};
+
+	renderShareEmbed = () => {
+		const share = this.getItemValue( 'display_embed' );
+		if ( share === undefined ) {
+			return;
+		}
+
+		return (
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Share' ) }>
+				<FormLabel>
+					<FormCheckbox
+						id="display_embed"
+						name="display_embed"
+						checked={ share === 1 }
+						onChange={ this.handleDisplayEmbed }
+					/>
+					<span>
+						{ this.props.translate(
+							'Display share menu and allow viewers to embed or download this video'
+						) }
+					</span>
+				</FormLabel>
+			</EditorMediaModalFieldset>
+		);
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -168,6 +266,10 @@ class EditorMediaModalDetailFields extends Component {
 				<EditorMediaModalFieldset className="detail__url-field" legend={ translate( 'URL' ) }>
 					<ClipboardButtonInput value={ url( this.props.item ) } />
 				</EditorMediaModalFieldset>
+
+				{ this.renderShareEmbed() }
+				{ this.renderRating() }
+				{ this.renderVideoPressShortcode() }
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -105,7 +105,7 @@ class EditorMediaModalDetailFields extends Component {
 	};
 
 	handleDisplayEmbed = () => {
-		const inputValue = 1 === this.getItemValue( 'display_embed' ) ? 0 : 1;
+		const inputValue = '1' === this.getItemValue( 'display_embed' ) ? '0' : '1';
 
 		this.setFieldByName( 'display_embed', inputValue );
 	};
@@ -214,7 +214,7 @@ class EditorMediaModalDetailFields extends Component {
 					<FormCheckbox
 						id="display_embed"
 						name="display_embed"
-						checked={ share === 1 }
+						checked={ share === '1' }
 						onChange={ this.handleDisplayEmbed }
 					/>
 					<span>

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -11,7 +11,6 @@ import classNames from 'classnames';
  */
 import { playtime } from 'calypso/lib/media/utils';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 
 class EditorMediaModalDetailFileInfo extends React.Component {
 	static displayName = 'EditorMediaModalDetailFileInfo';
@@ -100,23 +99,6 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 		);
 	};
 
-	renderVideoPressShortcode = () => {
-		const videopressGuid = this.getItemValue( 'videopress_guid' );
-
-		if ( ! videopressGuid ) {
-			return;
-		}
-
-		return (
-			<tr>
-				<th>{ this.props.translate( 'Shortcode' ) }</th>
-				<td>
-					<ClipboardButtonInput value={ '[wpvideo ' + videopressGuid + ']' } />
-				</td>
-			</tr>
-		);
-	};
-
 	render() {
 		const classes = classNames( 'editor-media-modal-detail__file-info', {
 			'is-loading': ! this.props.item,
@@ -138,7 +120,6 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 					{ this.renderFileSize() }
 					{ this.renderDimensions() }
 					{ this.renderDuration() }
-					{ this.renderVideoPressShortcode() }
 					<tr>
 						<th>{ this.props.translate( 'Upload Date' ) }</th>
 						<td>{ this.getItemValue( 'date' ) }</td>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the rating and share options from VideoPress to Calypso Edit Media modal.
* Moved the VideoPress shortcode input below the newly added rating and share options in order to have a similar structure as the section from WP-admin. 

#### Testing instructions
This must be tested with the changes included in the [following Jetpack PR](https://github.com/Automattic/jetpack/pull/20133). 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #51040
