### PR TITLE
State: Remove remaining user fetching from state middleware

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -9,14 +9,12 @@ import page from 'page';
  */
 import config from '@automattic/calypso-config';
 import {
-	JETPACK_DISCONNECT_RECEIVE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 	ROUTE_SET,
 	SELECTED_SITE_SET,
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 } from 'calypso/state/action-types';
-import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
 import { isFetchingAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -140,10 +138,6 @@ const handler = ( dispatch, action, getState ) => {
 
 				fetchAutomatedTransferStatusForSelectedSite( dispatch, getState );
 			}, 0 );
-			return;
-
-		case JETPACK_DISCONNECT_RECEIVE:
-			dispatch( fetchCurrentUser() );
 			return;
 	}
 };

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -33,7 +33,7 @@ import 'calypso/state/data-layer/wpcom/sites/homepage';
 
 /**
  * Returns a thunk that dispatches an action object to be used in signalling that a site has been
- * deleted. It also re-re-fetches the current user.
+ * deleted. It also re-fetches the current user.
  *
  * @param  {number} siteId  ID of deleted site
  * @returns {Function}        Action thunk

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -1,14 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	deleteSite,
-	receiveDeletedSite,
-	receiveSite,
-	receiveSites,
-	requestSites,
-	requestSite,
-} from '../actions';
+import { deleteSite, receiveSite, receiveSites, requestSites, requestSite } from '../actions';
 import {
 	SITE_RECEIVE,
 	SITE_REQUEST,
@@ -198,6 +191,12 @@ describe( 'actions', () => {
 				items: {},
 			},
 		} );
+		const dispatch = ( action ) => {
+			if ( typeof action === 'function' ) {
+				return action( dispatch, getState );
+			}
+			return spy( action );
+		};
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
@@ -214,10 +213,8 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch receive deleted site when request completes', async () => {
-			await deleteSite( 2916284 )( spy, getState );
-			const expected = receiveDeletedSite( 2916284 ).toString();
-			const received = spy.mock.calls[ 1 ].toString();
-			expect( received ).toEqual( expected );
+			await dispatch( deleteSite( 2916284 ) );
+			expect( spy ).toHaveBeenCalledWith( { type: 'SITE_DELETE_RECEIVE', siteId: 2916284 } );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the remaining user fetching from the state middleware and does some test cleanup.

This is a follow-up to #53817 and addresses the feedback by @jsnajdr in https://github.com/Automattic/wp-calypso/pull/53817#pullrequestreview-688264788.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Delete a WP.com simple site and verify that:
  * A request to `/me` is issued - see the network tab.
  * The site count in the "current site" area at the top of the "my-sites" sidebar reduces the count by 1 correctly.
* Disconnect a Jetpack site and go through the same 2 steps.
* Verify all tests pass.