### PR TITLE
Emails: Update inline help for canceling plans & Google Workspace

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -95,7 +95,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Cancel my plan' ),
-		link: `/me/purchases/${ siteSlug }`,
+		link: `/me/purchases`,
 		synonyms: [ 'upgrade', 'business', 'professional', 'personal' ],
 		icon: 'plans',
 	},
@@ -112,7 +112,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 			},
 			comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
 		} ),
-		link: `/me/purchases/${ siteSlug }`,
+		link: `/me/purchases`,
 		synonyms: [ 'upgrade', 'business', 'professional', 'personal', 'google' ],
 		icon: 'plans',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Right now the links under the inline help are not working for canceling plan & canceling Google Workspace. This pull request addresses this issue.

#### Testing instructions

1. Go to inline help (blue question mark with blue circle shape)
2. Write **cancel** in the upper textbox
3. Check that the two links **"Cancel my plan"** and **"Cancel Google Workspace"** are redirecting to **/me/purchases**

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/122760774-c9a91f80-d29b-11eb-8d14-00ca55520690.png) | ![image](https://user-images.githubusercontent.com/5689927/122760255-340d9000-d29b-11eb-91b2-30fa148b889a.png)


Related to 1200182182542585-as-1199726263743921
