### PR TITLE
Screen options: Handle switches to WP Admin views

### DIFF
--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -10,7 +10,7 @@ import config from '@automattic/calypso-config';
 /**
  * Internal Dependencies
  */
-import ScreenSwitcher from './screen-switcher';
+import ScreenSwitcher, { DEFAULT_VIEW } from './screen-switcher';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -74,7 +74,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	}
 
 	const onSwitchView = ( view ) => {
-		if ( view === 'default' ) {
+		if ( view === DEFAULT_VIEW ) {
 			setIsOpen( false );
 		}
 	};

--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -4,12 +4,16 @@
 import React, { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
 import { useI18n } from '@wordpress/react-i18n';
+import { useSelector } from 'react-redux';
+import config from '@automattic/calypso-config';
 
 /**
  * Internal Dependencies
  */
-import config from '@automattic/calypso-config';
 import ScreenSwitcher from './screen-switcher';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 /**
  * Style dependencies
@@ -18,10 +22,14 @@ import './style.scss';
 
 const isBoolean = ( val ) => 'boolean' === typeof val;
 
-const ScreenOptionsTab = () => {
+const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	const ref = useRef( null );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const { __ } = useI18n();
+
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
 
 	const handleToggle = ( bool ) => {
 		if ( isBoolean( bool ) ) {
@@ -60,8 +68,19 @@ const ScreenOptionsTab = () => {
 		return null;
 	}
 
+	// Only visible on single-site screens of WordPress.com Simple and Atomic sites.
+	if ( ! wpAdminPath || ! siteId || ( isJetpack && ! isAtomic ) ) {
+		return null;
+	}
+
+	const onSwitchView = ( view ) => {
+		if ( view === 'default' ) {
+			setIsOpen( false );
+		}
+	};
+
 	return (
-		<div className="screen-options-tab" ref={ ref }>
+		<div className="screen-options-tab" ref={ ref } data-testid="screen-options-tab">
 			<button className="screen-options-tab__button" onClick={ handleToggle }>
 				<span className="screen-options-tab__label">{ __( 'Screen Options' ) }</span>
 				<span
@@ -74,7 +93,7 @@ const ScreenOptionsTab = () => {
 			{ isOpen && (
 				<div className="screen-options-tab__wrapper">
 					<div className="screen-options-tab__dropdown" data-testid="screen-options-dropdown">
-						<ScreenSwitcher />
+						<ScreenSwitcher onSwitch={ onSwitchView } wpAdminPath={ wpAdminPath } />
 					</div>
 				</div>
 			) }

--- a/client/components/screen-options-tab/screen-switcher.js
+++ b/client/components/screen-options-tab/screen-switcher.js
@@ -3,25 +3,48 @@
  */
 import React from 'react';
 import { useI18n } from '@wordpress/react-i18n';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { addQueryArgs } from 'calypso/lib/route';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const ScreenSwitcher = () => {
+const ScreenSwitcher = ( { onSwitch, wpAdminPath } ) => {
 	const { __ } = useI18n();
+
+	const siteId = useSelector( getSelectedSiteId );
+	let fullWpAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId, wpAdminPath ) );
+
+	// We indicate that the WP Admin view is preferred with the `preferred-view` query param. WP Admin will
+	// use that param to store the preference, so next times the user visits the page via the sidebar menu
+	// it will default to the WP Admin page.
+	fullWpAdminUrl = addQueryArgs( { 'preferred-view': 'wp-admin' }, fullWpAdminUrl );
 
 	return (
 		<div className="screen-switcher">
-			<button className="screen-switcher__button">
+			<button
+				className="screen-switcher__button"
+				onClick={ () => onSwitch && onSwitch( 'default' ) }
+			>
 				<strong>{ __( 'Default view' ) }</strong>
-				<p>{ __( 'Our WordPress.com redesign for a better experience.' ) }</p>
+				{ __( 'Our WordPress.com redesign for a better experience.' ) }
 			</button>
-			<button className="screen-switcher__button">
+			<a
+				className="screen-switcher__button"
+				onClick={ () => onSwitch && onSwitch( 'wp-admin' ) }
+				href={ fullWpAdminUrl }
+			>
 				<strong>{ __( 'Classic view' ) }</strong>
-				<p>{ __( 'The classic WP-Admin WordPress interface.' ) }</p>
-			</button>
+				{ __( 'The classic WP-Admin WordPress interface.' ) }
+			</a>
 		</div>
 	);
 };

--- a/client/components/screen-options-tab/screen-switcher.js
+++ b/client/components/screen-options-tab/screen-switcher.js
@@ -21,12 +21,12 @@ const ScreenSwitcher = ( { onSwitch, wpAdminPath } ) => {
 	const { __ } = useI18n();
 
 	const siteId = useSelector( getSelectedSiteId );
-	let fullWpAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId, wpAdminPath ) );
+	const wpAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId, wpAdminPath ) );
 
 	// We indicate that the WP Admin view is preferred with the `preferred-view` query param. WP Admin will
 	// use that param to store the preference, so next times the user visits the page via the sidebar menu
 	// it will default to the WP Admin page.
-	fullWpAdminUrl = addQueryArgs( { 'preferred-view': 'classic' }, fullWpAdminUrl );
+	const fullWpAdminUrl = addQueryArgs( { 'preferred-view': 'classic' }, wpAdminUrl );
 
 	return (
 		<div className="screen-switcher">

--- a/client/components/screen-options-tab/screen-switcher.js
+++ b/client/components/screen-options-tab/screen-switcher.js
@@ -26,7 +26,7 @@ const ScreenSwitcher = ( { onSwitch, wpAdminPath } ) => {
 	// We indicate that the WP Admin view is preferred with the `preferred-view` query param. WP Admin will
 	// use that param to store the preference, so next times the user visits the page via the sidebar menu
 	// it will default to the WP Admin page.
-	fullWpAdminUrl = addQueryArgs( { 'preferred-view': 'wp-admin' }, fullWpAdminUrl );
+	fullWpAdminUrl = addQueryArgs( { 'preferred-view': 'classic' }, fullWpAdminUrl );
 
 	return (
 		<div className="screen-switcher">
@@ -39,7 +39,7 @@ const ScreenSwitcher = ( { onSwitch, wpAdminPath } ) => {
 			</button>
 			<a
 				className="screen-switcher__button"
-				onClick={ () => onSwitch && onSwitch( 'wp-admin' ) }
+				onClick={ () => onSwitch && onSwitch( 'classic' ) }
 				href={ fullWpAdminUrl }
 			>
 				<strong>{ __( 'Classic view' ) }</strong>

--- a/client/components/screen-options-tab/screen-switcher.js
+++ b/client/components/screen-options-tab/screen-switcher.js
@@ -17,6 +17,9 @@ import { addQueryArgs } from 'calypso/lib/route';
  */
 import './style.scss';
 
+export const DEFAULT_VIEW = 'default';
+export const CLASSIC_VIEW = 'classic';
+
 const ScreenSwitcher = ( { onSwitch, wpAdminPath } ) => {
 	const { __ } = useI18n();
 
@@ -32,14 +35,14 @@ const ScreenSwitcher = ( { onSwitch, wpAdminPath } ) => {
 		<div className="screen-switcher">
 			<button
 				className="screen-switcher__button"
-				onClick={ () => onSwitch && onSwitch( 'default' ) }
+				onClick={ () => onSwitch && onSwitch( DEFAULT_VIEW ) }
 			>
 				<strong>{ __( 'Default view' ) }</strong>
 				{ __( 'Our WordPress.com redesign for a better experience.' ) }
 			</button>
 			<a
 				className="screen-switcher__button"
-				onClick={ () => onSwitch && onSwitch( 'classic' ) }
+				onClick={ () => onSwitch && onSwitch( CLASSIC_VIEW ) }
 				href={ fullWpAdminUrl }
 			>
 				<strong>{ __( 'Classic view' ) }</strong>

--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -88,7 +88,7 @@ $screen-options-icon-border-y: 7px;
 	// When the user isn't hover over one of the buttons let's highlight the first
 	// because it is the Calypso option and its safe to assume they're in Calypso
 	// if they are seeing this component.
-	.screen-switcher__button:first-of-type {
+	.screen-switcher__button:first-child {
 		> strong {
 			color: var( --color-accent );
 		}
@@ -101,33 +101,32 @@ $screen-options-icon-border-y: 7px;
 	padding: 8px;
 	text-align: left;
 	border: 1px solid transparent;
+	display: inline-block;
+	font-size: $font-body-extra-small;
+	color: var( --color-text );
+	line-height: normal;
+
+	// When the user sees this component they are going to be in Calypso
+	// so it's safe to assume the Calypso option is always going to be active.
+	&:first-child {
+		margin-bottom: 4px; /* stylelint-disable-line */
+		border-color: var( --color-accent );
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	strong {
+		display: block;
+		font-size: $default-font-size;
+		margin-bottom: 4px;
+	}
 
 	&:hover,
 	&:focus {
 		> strong {
 			color: var( --color-accent );
 		}
-	}
-
-	// When the user sees this component they are going to be in Calypso
-	// so it's safe to assume the Calypso option is always going to be active.
-	&:first-of-type {
-		margin-bottom: 4px; /* stylelint-disable-line */
-		border-color: var( --color-accent );
-	}
-
-	&:last-of-type {
-		margin-bottom: 0;
-	}
-
-	strong {
-		display: inline-block;
-		font-size: $default-font-size;
-		margin-bottom: 4px;
-	}
-
-	p {
-		font-size: $font-body-extra-small;
-		margin-bottom: 0;
 	}
 }

--- a/client/components/screen-options-tab/test/index.js
+++ b/client/components/screen-options-tab/test/index.js
@@ -6,22 +6,64 @@
  * External dependencies
  */
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import ScreenOptionsTab from '../index';
+import { render as rtlRender } from 'config/testing-library';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+
+const render = ( el, options ) => rtlRender( el, { ...options, reducers: { ui } } );
+
+const siteId = 1;
+const adminUrl = 'https://example.wordpress.com/wp-admin';
+
+const initialState = {
+	ui: { selectedSiteId: siteId },
+	sites: {
+		items: {
+			[ siteId ]: { options: { admin_url: adminUrl }, jetpack: false },
+		},
+	},
+};
 
 describe( 'ScreenOptionsTab', () => {
 	test( 'it renders correctly', () => {
-		render( <ScreenOptionsTab /> );
+		render( <ScreenOptionsTab wpAdminPath="index.php" />, { initialState } );
 
 		expect( screen.getByRole( 'button' ) ).toBeTruthy();
 	} );
 
+	test( 'does not render on all-sites screens', () => {
+		render( <ScreenOptionsTab wpAdminPath="index.php" />, {
+			initialState: {
+				...initialState,
+				ui: { selectedSiteId: null },
+			},
+		} );
+
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeNull();
+	} );
+
+	test( 'does not render on Jetpack sites', () => {
+		render( <ScreenOptionsTab wpAdminPath="index.php" />, {
+			initialState: {
+				...initialState,
+				sites: {
+					items: {
+						[ siteId ]: { options: { admin_url: adminUrl }, jetpack: true },
+					},
+				},
+			},
+		} );
+
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeNull();
+	} );
+
 	test( 'it toggles dropdown when clicked', () => {
-		render( <ScreenOptionsTab /> );
+		render( <ScreenOptionsTab wpAdminPath="index.php" />, { initialState } );
 
 		// We expect the dropdown to not be shown by default.
 		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).toBeNull();

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -71,7 +71,7 @@ export class CommentsManagement extends Component {
 
 		return (
 			<Main className="comments" wideLayout>
-				<ScreenOptionsTab />
+				<ScreenOptionsTab wpAdminPath="edit-comments.php" />
 				<PageViewTracker path={ analyticsPath } title="Comments" />
 				<DocumentHead title={ translate( 'Comments' ) } />
 				<SidebarNavigation />

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -97,7 +97,7 @@ const Home = ( {
 
 	return (
 		<Main wideLayout className="customer-home__main">
-			<ScreenOptionsTab />
+			<ScreenOptionsTab wpAdminPath="index.php" />
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -68,7 +68,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 
 	return (
 		<Main>
-			<ScreenOptionsTab />
+			<ScreenOptionsTab wpAdminPath="export.php" />
 			<DocumentHead title={ translate( 'Export' ) } />
 			<SidebarNavigation />
 			{ sectionContent }

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -274,7 +274,6 @@ class SectionImport extends Component {
 		if ( ! canImport ) {
 			return (
 				<Main>
-					<ScreenOptionsTab />
 					<SidebarNavigation />
 					<EmptyContent
 						title={ this.props.translate( 'You are not authorized to view this page' ) }
@@ -291,7 +290,7 @@ class SectionImport extends Component {
 
 		return (
 			<Main>
-				<ScreenOptionsTab />
+				<ScreenOptionsTab wpAdminPath="import.php" />
 				<DocumentHead title={ translate( 'Import Content' ) } />
 				<SidebarNavigation />
 				<FormattedHeader

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -366,7 +366,7 @@ class Media extends Component {
 
 		return (
 			<div ref={ this.containerRef } className="main main-column media" role="main">
-				<ScreenOptionsTab />
+				<ScreenOptionsTab wpAdminPath="upload.php" />
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<DocumentHead title={ translate( 'Media' ) } />

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -93,7 +93,7 @@ class PagesMain extends React.Component {
 
 		return (
 			<Main wideLayout classname="pages">
-				<ScreenOptionsTab />
+				<ScreenOptionsTab wpAdminPath="edit.php?post_type=page" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<DocumentHead title={ translate( 'Pages' ) } />
 				<SidebarNavigation />

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -76,7 +76,6 @@ class People extends React.Component {
 		if ( siteId && ! canViewPeople ) {
 			return (
 				<Main>
-					<ScreenOptionsTab />
 					<PageViewTracker
 						path={ `/people/${ filter }/:site` }
 						title={ `People > ${ titlecase( filter ) }` }
@@ -91,7 +90,7 @@ class People extends React.Component {
 		}
 		return (
 			<Main>
-				<ScreenOptionsTab />
+				<ScreenOptionsTab wpAdminPath="users.php" />
 				<PageViewTracker
 					path={ `/people/${ filter }/:site` }
 					title={ `People > ${ titlecase( filter ) }` }

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -77,7 +77,7 @@ class PostsMain extends React.Component {
 
 		return (
 			<Main wideLayout className="posts">
-				<ScreenOptionsTab />
+				<ScreenOptionsTab wpAdminPath="edit.php" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<DocumentHead title={ translate( 'Posts' ) } />
 				<SidebarNavigation />

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -31,7 +31,7 @@ import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 const SiteSettingsComponent = ( { siteId, translate } ) => {
 	return (
 		<Main className="site-settings">
-			<ScreenOptionsTab />
+			<ScreenOptionsTab wpAdminPath="options-general.php" />
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<QueryProductsList />
 			<QuerySitePurchases siteId={ siteId } />

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -21,7 +21,7 @@ import config from '@automattic/calypso-config';
 
 const SiteSettingsDiscussion = ( { site, translate } ) => (
 	<Main className="settings-discussion site-settings">
-		<ScreenOptionsTab />
+		<ScreenOptionsTab wpAdminPath="options-discussion.php" />
 		<DocumentHead title={ translate( 'Site Settings' ) } />
 		<JetpackDevModeNotice />
 		<SidebarNavigation />

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -21,7 +21,7 @@ import config from '@automattic/calypso-config';
 
 const SiteSettingsWriting = ( { site, translate } ) => (
 	<Main className="settings-writing site-settings">
-		<ScreenOptionsTab />
+		<ScreenOptionsTab wpAdminPath="options-writing.php" />
 		<DocumentHead title={ translate( 'Site Settings' ) } />
 		<JetpackDevModeNotice />
 		<SidebarNavigation />

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -30,8 +30,9 @@ const Taxonomies = ( { translate, labels, postType, site, taxonomy } ) => {
 	};
 
 	return (
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<div className="main main-column" role="main">
-			<ScreenOptionsTab />
+			<ScreenOptionsTab wpAdminPath={ `edit-tags.php?taxonomy=${ taxonomy }` } />
 			<DocumentHead
 				title={ translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) }
 			/>

--- a/client/my-sites/themes/themes-header.jsx
+++ b/client/my-sites/themes/themes-header.jsx
@@ -22,7 +22,7 @@ import './themes-header.scss';
 const ThemesHeader = () => {
 	return (
 		<div className="themes__header">
-			<ScreenOptionsTab />
+			<ScreenOptionsTab wpAdminPath="themes.php" />
 			<FormattedHeader
 				brandFont
 				className="themes__page-heading"

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -46,7 +46,7 @@ function Types( {
 
 	return (
 		<Main wideLayout>
-			<ScreenOptionsTab />
+			<ScreenOptionsTab wpAdminPath={ `edit.php?post_type=${ query.type }` } />
 			<DocumentHead title={ get( postType, 'label', '' ) } />
 			<PageViewTracker path={ siteId ? '/types/:site' : '/types' } title="Custom Post Type" />
 			<SidebarNavigation />


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/53708

#### Changes proposed in this Pull Request

Handles clicks on the new screen switcher component and redirect users to WP Admin when the Classic view is selected.

#### Testing instructions

- Use the Calypso live link below and append `?flags=nav-unification/switcher` to the end of the URL.
- Switch to a Simple or Atomic site.
- In the following screens, make sure that opening the Screen Options tab and clicking on "Classic view" redirects you to the equivalent WP Admin screen.
  - My Home
  - Posts > All posts
  - Posts > Categories
  - Posts > Tags
  - Media
  - Pages > All pages
  - Testimonials > All testimonials
  - Portfolio > All projects
  - Comments
  - Appearance > Themes
  - Users > All users
  - Tools > Import
  - Tools > Export
  - Settings > General
  - Settings > General > Writing
  - Settings > General > Discussion
- Make sure the WP Admin links include a `preferred-view=classic` param (which will be used in a future diff for storing the new preference).
- Switch to a Jetpack site.
- Make sure the quick switcher doesn't show up.


