### PR TITLE
Add env var to enable persistent cache

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -7,6 +7,8 @@ ARG node_memory=8192
 WORKDIR /calypso
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
+ENV PERSISTENT_CACHE=true
+ENV PROFILE=true
 ENV NVM_DIR=/calypso/.nvm
 ENV NODE_ENV=production
 ENV CALYPSO_ENV=production

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -60,6 +60,8 @@ const defaultBrowserslistEnv = 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 const cachePath = path.resolve( '.cache', extraPath );
+const shouldUsePersistentCache = process.env.PERSISTENT_CACHE === 'true';
+const shouldProfile = process.env.PROFILE === 'true';
 
 function filterEntrypoints( entrypoints ) {
 	/* eslint-disable no-console */
@@ -202,17 +204,25 @@ const webpackConfig = {
 			TranspileConfig.loader( {
 				workerCount,
 				configFile: path.resolve( 'babel.config.js' ),
-				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
-				cacheIdentifier,
-				cacheCompression: false,
+				...( shouldUsePersistentCache
+					? {}
+					: {
+							cacheDirectory: path.resolve( cachePath, 'babel-client' ),
+							cacheIdentifier,
+							cacheCompression: false,
+					  } ),
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
 				workerCount,
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
-				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
-				cacheIdentifier,
-				cacheCompression: false,
+				...( shouldUsePersistentCache
+					? {}
+					: {
+							cacheDirectory: path.resolve( cachePath, 'babel-client' ),
+							cacheIdentifier,
+							cacheCompression: false,
+					  } ),
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
@@ -229,7 +239,11 @@ const webpackConfig = {
 					].filter( Boolean ),
 				},
 				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,
-				cacheDirectory: path.resolve( cachePath, 'css-loader' ),
+				...( shouldUsePersistentCache
+					? {}
+					: {
+							cacheDirectory: path.resolve( cachePath, 'css-loader' ),
+					  } ),
 			} ),
 			{
 				include: path.join( __dirname, 'sections.js' ),
@@ -368,8 +382,40 @@ const webpackConfig = {
 		 * Replace `lodash` with `lodash-es`
 		 */
 		new ExtensiveLodashReplacementPlugin(),
+
+		// Equivalent to the CLI flag --progress=profile
+		shouldProfile && new webpack.ProgressPlugin( { profile: true } ),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],
+
+	...( shouldUsePersistentCache
+		? {
+				cache: {
+					type: 'filesystem',
+					buildDependencies: {
+						config: [ __filename ],
+					},
+					cacheDirectory: path.resolve( cachePath, 'webpack' ),
+					profile: true,
+					version: [
+						// No need to add BROWSERSLIST, as it is already part of the cacheDirectory
+						shouldBuildChunksMap,
+						shouldMinify,
+						process.env.ENTRY_LIMIT,
+						process.env.SECTION_LIMIT,
+						process.env.SOURCEMAP,
+						process.env.NODE_ENV,
+						process.env.CALYPSO_ENV,
+					].join( '-' ),
+				},
+				snapshot: {
+					managedPaths: [
+						path.resolve( __dirname, '../node_modules' ),
+						path.resolve( __dirname, 'node_modules' ),
+					],
+				},
+		  }
+		: {} ),
 };
 
 module.exports = webpackConfig;


### PR DESCRIPTION
#### Background

Webpack 5 introduced a new [persistent cache](https://github.com/webpack/changelog-v5/blob/master/guides/persistent-caching.md) and at the same time [deprecated cache-loader](https://github.com/webpack-contrib/cache-loader).

We experimented with this cache in #49657, but after testing it we didn't find any real benefits and removed it (#49855). However, @mreishus found some improvements (#52884) and my local tests indicate it can speed up both production builds (`yarn build-client-evergreen`) and development builds (`yarn start`) by 8x and 3x respectively when the cache is hot. The impact when the cache is cold is rather small (~5% increase in build time).

#### Changes proposed in this Pull Request

This change re-enables the capacity to opt-in the new filesystem cache (#49657). This PR adds an env var `PERSISTENT_CACHE` used to opt-in the new caching system. Note this env var is not used for local development (yet) nor production builds. It is only enabled in the [Docker cache image](p4TIVU-9AM-p2), https://github.com/Automattic/wp-calypso/blob/trunk/Dockerfile.base#L1, so other builds can opt-in this new cache mechanism and find a cache in the filesystem already primed.

No build has opted-in yet, so this PR shouldn't have any effect in local or production builds.

In order to get more logs and verify the cache is being built (and eventually used), I also added the env var `PROFILE` to output profiling information during webpack builds and enabled it in the cache docker image.

#### Testing instructions

N/A