### PR TITLE
Jetpack Cloud: Unify pricing and plans routes

### DIFF
--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -3,8 +3,7 @@
  */
 import { jetpackPricingContext } from './controller';
 import config from '@automattic/calypso-config';
-import userFactory from 'calypso/lib/user';
-import { siteSelection } from 'calypso/my-sites/controller';
+import { loggedInSiteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 
 /**
@@ -13,22 +12,11 @@ import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import './style.scss';
 
 export default function (): void {
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
-
 	jetpackPlans( `/:locale/pricing`, jetpackPricingContext );
 
-	if ( isLoggedOut ) {
-		jetpackPlans( `/pricing`, jetpackPricingContext );
+	jetpackPlans( `/pricing`, loggedInSiteSelection, jetpackPricingContext );
 
-		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-			jetpackPlans( `/plans`, jetpackPricingContext );
-		}
-	} else {
-		jetpackPlans( `/pricing`, siteSelection, jetpackPricingContext );
-
-		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-			jetpackPlans( `/plans/:site?`, siteSelection, jetpackPricingContext );
-		}
+	if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
+		jetpackPlans( `/plans/:site?`, loggedInSiteSelection, jetpackPricingContext );
 	}
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -43,7 +43,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
@@ -491,6 +491,14 @@ export function siteSelection( context, next ) {
 				}
 			} );
 	}
+}
+
+export function loggedInSiteSelection( context, next ) {
+	if ( isUserLoggedIn( context.store.getState() ) ) {
+		siteSelection( context, next );
+		return;
+	}
+	next();
 }
 
 export function recordNoSitesPageView( context, siteFragment, title ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, in the Jetpack Cloud pricing section, we declare the same routes twice for logged-in users and once for logged-out users. However, that relies on `lib/user` for retrieving the user without relying on the Redux store. It is also unnecessary - the route definitions are the same, with the exception that site selection middleware is executed only for logged-in users.

This PR introduces a `loggedInSiteSelection` middleware that will trigger site selection only for logged-in users. Furthermore, it updates the pricing and plans routes to use that, and unifies them to remove the need for declaring them twice.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Spin up Jetpack Cloud locally or use `calypso.live`.
* Verify `/pricing`, `/plans`, and `/plans/:site` work the same way for logged-in and logged-out users as they did before.

