### PR TITLE
Jetpack Scan: Allow multisites with Scan to have access to Scan UI

### DIFF
--- a/client/components/jetpack/scan-multisite-notice/index.tsx
+++ b/client/components/jetpack/scan-multisite-notice/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import { preventWidows } from 'calypso/lib/formatting';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const ScanMultisiteNotice: FunctionComponent = () => {
+	const multiSiteInfoLink = `https://jetpack.com/support/scan/#does-jetpack-scan-support-multisite`;
+	return (
+		<div className="scan-multisite-notice">
+			<div className="scan-multisite-notice__title">
+				{ preventWidows( translate( 'This site is a WordPress Multisite installation.' ) ) }
+			</div>
+			<p className="scan-multisite-notice__info">
+				{ preventWidows(
+					translate(
+						'Jetpack Scan for Multisite installations is not fully supported. ' +
+							'For more information {{ExternalLink}}visit our documentation page {{externalIcon/}}{{/ExternalLink}}.',
+						{
+							components: {
+								ExternalLink: (
+									<a href={ multiSiteInfoLink } target="_blank" rel="noopener noreferrer" />
+								),
+								externalIcon: <Gridicon icon="external" size={ 18 } />,
+							},
+						}
+					)
+				) }
+			</p>
+		</div>
+	);
+};
+
+export default ScanMultisiteNotice;

--- a/client/components/jetpack/scan-multisite-notice/style.scss
+++ b/client/components/jetpack/scan-multisite-notice/style.scss
@@ -1,0 +1,14 @@
+.scan-multisite-notice {
+	padding-top: 1.2rem;
+}
+
+.scan-multisite-notice__title {
+	font-size: 1rem;
+	font-weight: 600;
+	padding-bottom: 4px;
+}
+
+.scan-multisite-notice__info {
+	font-size: 0.875rem;
+	color: var( --studio-gray-40 );
+}

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { numberFormat, translate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 
@@ -13,6 +13,8 @@ import FixAllThreatsDialog from 'calypso/components/jetpack/fix-all-threats-dial
 import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import ThreatDialog from 'calypso/components/jetpack/threat-dialog';
 import ThreatItem from 'calypso/components/jetpack/threat-item';
+import ScanMultisiteNotice from 'calypso/components/jetpack/scan-multisite-notice';
+import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import { FixableThreat, Threat, ThreatAction } from 'calypso/components/jetpack/threat-item/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
@@ -62,6 +64,7 @@ const ScanError: React.FC< { site: Site } > = ( { site } ) => {
 };
 
 const ScanThreats = ( { error, site, threats }: Props ) => {
+	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, site.ID ) );
 	const {
 		updatingThreats,
 		selectedThreat,
@@ -138,6 +141,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 	return (
 		<>
 			<SecurityIcon icon="error" />
+			{ isMultiSite && <ScanMultisiteNotice /> }
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
 			<p>
 				{ translate(

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -21,9 +21,10 @@ import IsJetpackDisconnectedSwitch from 'calypso/components/jetpack/is-jetpack-d
 import ScanPlaceholder from 'calypso/components/jetpack/scan-placeholder';
 import ScanHistoryPlaceholder from 'calypso/components/jetpack/scan-history-placeholder';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isJetpackScanSlug } from '@automattic/calypso-products';
+import { isJetpackScanSlug, JETPACK_SCAN_PRODUCTS } from '@automattic/calypso-products';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
+import siteHasSubscription from 'calypso/state/selectors/site-has-subscription';
 
 export function showUpsellIfNoScan( context, next ) {
 	context.primary = scanUpsellSwitcher( <ScanPlaceholder />, context.primary );
@@ -78,7 +79,10 @@ export function showUnavailableForVaultPressSites( context, next ) {
 export function showUnavailableForMultisites( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	if ( isJetpackSiteMultiSite( state, siteId ) ) {
+	if (
+		isJetpackSiteMultiSite( state, siteId ) &&
+		! siteHasSubscription( state, siteId, JETPACK_SCAN_PRODUCTS )
+	) {
 		context.primary = isJetpackCloud() ? (
 			<ScanUpsellPage reason="multisite_not_supported" />
 		) : (

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -17,6 +17,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import ScanPlaceholder from 'calypso/components/jetpack/scan-placeholder';
 import ScanThreats from 'calypso/components/jetpack/scan-threats';
+import ScanMultisiteNotice from 'calypso/components/jetpack/scan-multisite-notice';
 import { Scan, Site } from 'calypso/my-sites/scan/types';
 import Gridicon from 'calypso/components/gridicon';
 import Main from 'calypso/components/main';
@@ -39,7 +40,6 @@ import ScanNavigation from './navigation';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
-import { preventWidows } from 'calypso/lib/formatting';
 
 /**
  * Type dependencies
@@ -77,33 +77,6 @@ class ScanPage extends Component< Props > {
 	state = {
 		showJetpackReviewPrompt: false,
 	};
-
-	renderMultisiteMessage() {
-		const multiSiteInfoLink = `https://jetpack.com/support/scan/#does-jetpack-scan-support-multisite`;
-		return (
-			<div className="scan__multisite-warning">
-				<div className="scan__multisite-warning-title">
-					{ preventWidows( translate( 'This site is a WordPress Multisite installation.' ) ) }
-				</div>
-				<p className="scan__multisite-warning-info">
-					{ preventWidows(
-						translate(
-							'Jetpack Scan for Multisite installations is not fully supported. ' +
-								'For more information {{ExternalLink}}visit our documentation page {{externalIcon/}}{{/ExternalLink}}.',
-							{
-								components: {
-									ExternalLink: (
-										<a href={ multiSiteInfoLink } target="_blank" rel="noopener noreferrer" />
-									),
-									externalIcon: <Gridicon icon="external" size={ 18 } />,
-								},
-							}
-						)
-					) }
-				</p>
-			</div>
-		);
-	}
 
 	renderProvisioning() {
 		return (
@@ -166,7 +139,7 @@ class ScanPage extends Component< Props > {
 		return (
 			<>
 				<SecurityIcon />
-				{ isMultiSite && this.renderMultisiteMessage() }
+				{ isMultiSite && <ScanMultisiteNotice /> }
 				{ this.renderHeader( translate( 'Don’t worry about a thing' ) ) }
 				<p>
 					{ translate(

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -125,6 +125,21 @@
 	margin-top: 8px;
 }
 
+.scan__content .scan__multisite-warning {
+	padding-top: 1.2rem;
+}
+
+.scan__content .scan__multisite-warning-title {
+	font-size: 1rem;
+	font-weight: 600;
+	padding-bottom: 4px;
+}
+
+.scan__content .scan__multisite-warning-info {
+	font-size: 0.875rem;
+	color: var( --studio-gray-40 );
+}
+
 /**
  * Jetpack.com specific styles
  */

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -7,7 +7,7 @@
 	}
 }
 
-.scan__content p {
+.scan__content > p {
 	font-size: $font-body;
 	margin-bottom: 16px;
 	line-height: 24px;
@@ -123,21 +123,6 @@
 
 .scan__wpcom-cta {
 	margin-top: 8px;
-}
-
-.scan__content .scan__multisite-warning {
-	padding-top: 1.2rem;
-}
-
-.scan__content .scan__multisite-warning-title {
-	font-size: 1rem;
-	font-weight: 600;
-	padding-bottom: 4px;
-}
-
-.scan__content .scan__multisite-warning-info {
-	font-size: 0.875rem;
-	color: var( --studio-gray-40 );
 }
 
 /**


### PR DESCRIPTION
Currently multisite sites are blocked from purchasing a Scan (and Backup) plan because multisite is not supported, however there is a set of multisite users that do already have a Scan (and/or Backup) plan from before we began restricting purchase or from users that purchased a plan but then converted to multisite afterwords.

These users/sites are getting wp.com notifications for vulnerabilities, but unable to see any additional information about them because when trying to view the Jetpack Scan dashboard in Calypso they are presented with a card that says, "WordPress multi-sites are not supported". (See image)
<img width="783" alt="Screenshot on 2021-06-21 at 11-15-16" src="https://user-images.githubusercontent.com/11078128/123271117-8387d200-d4ce-11eb-8279-cabae9763e36.png">


For multisite sites that already have a Scan plan, we want to allow access to the Scan UI so they can see the results of their scans, similar to what we have just recently done for Backup.  See PR: #53096

See original discussion: pbuNQi-1jg-p2

**This PR is on hold for a moment awaiting the outcome of a current ongoing discussion:** pbtFFM-Zr-p2

Requires patch: D63208-code

#### Changes proposed in this Pull Request

This PR makes the Scan UI available for multisite sites that already have a valid Jetpack Scan subscription. For these sites, a notice/message is displayed that says, "This site is a WordPress Multisite installation. Jetpack Scan for Multisite installations is not fully supported. For more information visit our documentation page."

#### Testing instructions

- Apply D63208-code to your sandbox and in your hosts file, point `public-api.wordpress.com` to your sandbox IP.
- checkout and run this PR (Calypso blue, `yarn start`);
- Create a Jurassic Ninja Multisite install
- In the wp-admin Jetpack dashboard, click "Connect" the site and complete the connection process.
- In Store Admin, add a Jetpack Security subscription to the JN site.
- Go to `http://calypso.localhost:3000/scan/:site`
- Verify you see the Jetpack Scan dashboard, as opposed to the "WordPress multi-sites are not supported" card. 
- In the Scan dashboard, below the icon, verify you see the multisite message/notice that says, "This site is a WordPress Multisite installation. Jetpack Scan for Multisite installations is not fully supported. For more information visit our documentation page".  (See screenshot)

**Testing multisite with scan threat(s) present:**

- TBD - In progress...


#### Screenshots
<img width="768" alt="Screenshot on 2021-06-21 at 10-52-28" src="https://user-images.githubusercontent.com/11078128/123270925-54716080-d4ce-11eb-9fa4-3318de5559b8.png">

<img width="766" alt="Screenshot on 2021-06-21 at 10-53-04" src="https://user-images.githubusercontent.com/11078128/123270947-589d7e00-d4ce-11eb-934e-9b1ce4cb2e7a.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Asana card: 1164141197617539-as-1200369879904042