### PR TITLE
wpcom-xhr-wrapper: Remove lib/user usage

### DIFF
--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -1,14 +1,16 @@
 /**
  * Internal dependencies
  */
+import { clearStore } from 'calypso/lib/user/store';
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
 		.default;
 
-	return xhr( params, function ( error, response, headers ) {
+	return xhr( params, async function ( error, response, headers ) {
 		if ( error && error.name === 'InvalidTokenError' ) {
+			await clearStore();
 			window.location.href = getLogoutUrl();
 		}
 

--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -1,18 +1,7 @@
 /**
- * External dependencies
- */
-import debugModule from 'debug';
-
-/**
  * Internal dependencies
  */
-import user from 'calypso/lib/user';
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
@@ -20,15 +9,7 @@ export default async function ( params, callback ) {
 
 	return xhr( params, function ( error, response, headers ) {
 		if ( error && error.name === 'InvalidTokenError' ) {
-			debug( 'Invalid token error detected, authorization probably revoked - logging out' );
-
-			const logoutUrl = getLogoutUrl( user().get() );
-			// Clear any data stored locally within the user data module or localStorage
-			user()
-				.clear()
-				.then( () => {
-					window.location.href = logoutUrl;
-				} );
+			window.location.href = getLogoutUrl();
 		}
 
 		callback( error, response, headers );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR includes a take 2 of the removal of `lib/user` from `wpcom-xhr-wrapper` in #53661, which was reverted in #53872 due to a redirect loop it was causing in Calypso Green / Jetpack Cloud.

This PR attempts the same cleanup, but preserves the logout URL logic. So we'll redirect to the logout URL instead of just refreshing the page.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Follow the test instructions in #53872 and verify they still work.