### PR TITLE
Opt-in persistent cache for e2e images

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -5,6 +5,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.*
@@ -352,6 +353,10 @@ object BuildDockerImage : BuildType({
 	name = "Docker image"
 	description = "Build docker image containing Calypso"
 
+	params {
+		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)
+	}
+
 	vcs {
 		root(Settings.WpCalypso)
 		cleanCheckout = true
@@ -375,6 +380,19 @@ object BuildDockerImage : BuildType({
 			"""
 		}
 
+		script {
+			name = "Restore git mtime"
+			scriptContent = """
+				#!/usr/bin/env bash
+				sudo apt-get install -y git-restore-mtime
+				/usr/lib/git-core/git-restore-mtime --force --commit-time --skip-missing
+			"""
+			dockerImage = "%docker_image_e2e%"
+			dockerRunParameters = "-u %env.UID%"
+			dockerPull = true
+			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+		}
+
 		dockerCommand {
 			name = "Build docker image"
 			commandType = build {
@@ -393,6 +411,7 @@ object BuildDockerImage : BuildType({
 					--build-arg workers=16
 					--build-arg node_memory=32768
 					--build-arg use_cache=true
+					--build-arg base_image=%base_image%
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG use_cache=false
 ARG node_version=14.16.1
+ARG base_image=registry.a8c.com/calypso/base:latest
 
 ###################
 FROM node:${node_version}-buster as builder-cache-false
@@ -8,10 +9,11 @@ FROM node:${node_version}-buster as builder-cache-false
 ###################
 # This image contains a directory /calypso/.cache which includes caches
 # for yarn, terser, css-loader and babel.
-FROM registry.a8c.com/calypso/base:latest as builder-cache-true
+FROM ${base_image} as builder-cache-true
 
 ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
+ENV PERSISTENT_CACHE=true
 
 ###################
 FROM builder-cache-${use_cache} as builder
@@ -20,7 +22,7 @@ ARG commit_sha="(unknown)"
 ARG workers=4
 ARG node_memory=8192
 ENV CONTAINER 'docker'
-ENV WEBPACK_OPTIONS '--progress=profile'
+ENV PROFILE=true
 ENV COMMIT_SHA $commit_sha
 ENV CALYPSO_ENV production
 ENV WORKERS $workers
@@ -55,15 +57,14 @@ RUN bash /tmp/env-config.sh
 # dependencies which end up bloating the image.
 # /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
-RUN rm -fr /calypso/apps/editing-toolkit /calypso/apps/o2-blocks /calypso/apps/wpcom-block-editor /calypso/test /calypso/desktop \
-	&& yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile
 
 # Build the final layer
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
 ENV NODE_ENV production
-RUN yarn run build && rm -fr .cache
+RUN yarn run build
 
 
 ###################

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -408,6 +408,9 @@ const webpackConfig = {
 						process.env.CALYPSO_ENV,
 					].join( '-' ),
 				},
+				infrastructureLogging: {
+					debug: /webpack\.cache/,
+				},
 				snapshot: {
 					managedPaths: [
 						path.resolve( __dirname, '../node_modules' ),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -204,25 +204,17 @@ const webpackConfig = {
 			TranspileConfig.loader( {
 				workerCount,
 				configFile: path.resolve( 'babel.config.js' ),
-				...( shouldUsePersistentCache
-					? {}
-					: {
-							cacheDirectory: path.resolve( cachePath, 'babel-client' ),
-							cacheIdentifier,
-							cacheCompression: false,
-					  } ),
+				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
+				cacheIdentifier,
+				cacheCompression: false,
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
 				workerCount,
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
-				...( shouldUsePersistentCache
-					? {}
-					: {
-							cacheDirectory: path.resolve( cachePath, 'babel-client' ),
-							cacheIdentifier,
-							cacheCompression: false,
-					  } ),
+				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
+				cacheIdentifier,
+				cacheCompression: false,
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {


### PR DESCRIPTION
### Background

See #53867

### Changes proposed in this Pull Request

This PR includes a few changes needed to opt-in persistent cache for e2e images:

**Enable webpack persistent cache in e2e builds**

Adds `PERSISTENT_CACHE=true` env var to e2e builds. This does not affect production, only the images used to power `caypso.live` (used to run e2e tests).

**Make the base docker image configurable** 

This will allow us to experiment with images with different cache content to see the effect in the builds. It defaults to `registry.a8c.com/calypso/base:latest` (same value as before). 

**Added env var `PROFILE` to toggle webpack profiling**

Before we had `WEBPACK_OPTIONS='--progress=profile'` for the webapp and `PROFILE=true` for the Node.js app. This change uses `PROFILE=true` for both.

**Do not prune dependency tree when installing dependencies in production**

In an attempt to reduce the size of the docker image (and speed up its creation) we deleted some `package.json` that we know we don't need to install to bundle the app (eg: `apps/editing-toolkit`). Let's call that the "simplified tree".

This was preventing us to get value from the persistent cache: the cache is created with a "full tree", and when we tried to use it in a build that has a "simplified tree", webpack saw that the content of `node_modules` didn't match: the "full tree" will have more packages that got hoisted to the root `node_modules`. In that scenario webpack things the cache is not good and it won't use it.

This change will actually increase build time when we can't use the existing cache.

**Enable babel-cache even if the persistent cache is enabled**

This is an attempt to reduce the build time when the persistent cache can't be used. In theory it will make image generation slower (it has to generate and write babel cache and then webpack cache), but I wasn't able to find any meaningful difference. I'll keep an eye once merged.

**Added webpack cache logs**

It helps to diagnose when a cache was used and how long it took to serialize and deserialize.

#### Testing instructions

N/A
