### PR TITLE
Plans: remove Plans navigation

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -16,7 +16,6 @@ import {
 } from '@automattic/calypso-products';
 import JetpackPluginUpdateWarning from 'calypso/blocks/jetpack-plugin-update-warning';
 import { preventWidows } from 'calypso/lib/formatting';
-import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Notice from 'calypso/components/notice';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -37,8 +36,12 @@ type StandardHeaderProps = {
 
 const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: StandardHeaderProps ) => (
 	<>
-		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
-		<PlansNavigation path={ '/plans' } />
+		<FormattedHeader
+			brandFont
+			headerText={ translate( 'Plans' ) }
+			subHeaderText={ translate( 'See and compare the features available on each Jetpack plan.' ) }
+			align="left"
+		/>
 		{ shouldShowPlanRecommendation && siteId && (
 			<JetpackPluginUpdateWarning
 				siteId={ siteId }
@@ -56,17 +59,14 @@ const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: Standard
 );
 
 const ConnectFlowPlansHeader = () => (
-	<>
-		<div className="jetpack-plans__heading">
-			<FormattedHeader
-				headerText={ translate( 'Explore our Jetpack plans' ) }
-				subHeaderText={ translate( "Now that you're set up, pick a plan that fits your needs." ) }
-				align="left"
-				brandFont
-			/>
-		</div>
-		<PlansNavigation path={ '/plans' } />
-	</>
+	<div className="jetpack-plans__heading">
+		<FormattedHeader
+			headerText={ translate( 'Explore our Jetpack plans' ) }
+			subHeaderText={ translate( "Now that you're set up, pick a plan that fits your needs." ) }
+			align="left"
+			brandFont
+		/>
+	</div>
 );
 
 const PlansHeader = ( { context, shouldShowPlanRecommendation }: HeaderProps ) => {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -22,7 +22,6 @@ import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
@@ -130,7 +129,6 @@ class Plans extends React.Component {
 								align="left"
 							/>
 							<div id="plans" className="plans plans__has-sidebar">
-								<PlansNavigation path={ this.props.context.path } />
 								{ isEnabled( 'p2/p2-plus' ) && isWPForTeamsSite ? (
 									<P2PlansMain
 										selectedPlan={ this.props.selectedPlan }

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -942,7 +942,7 @@ export class MySitesSidebar extends Component {
 					...urlParts,
 					protocol: urlParts.protocol || 'https:',
 					searchParams: new URLSearchParams( { page: 'jetpack' } ),
-					hash: '/my-plan',
+					hash: '/plans',
 				} ).href;
 			} catch ( error ) {
 				return null;

--- a/client/state/selectors/get-jetpack-wp-admin-url.js
+++ b/client/state/selectors/get-jetpack-wp-admin-url.js
@@ -17,7 +17,7 @@ export default function getJetpackWpAdminUrl( state ) {
 		? getUrlFromParts( {
 				...getUrlParts( adminUrl + 'admin.php' ),
 				search: '?page=jetpack',
-				hash: '/my-plan',
+				hash: '/plans',
 		  } ).href
 		: undefined;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove navigation inside the Plans page, simplifying the IA and doing without the My Plan view.
* See this thread for more details: p7DVsv-ago-p2#comment-36411
* Related Jetpack changes: https://github.com/Automattic/jetpack/pull/20141
* Will this need updated e2e tests? None that I could find.

#### Testing instructions

* Fire up this branch.
* Visit your Simple/Atomic/Jetpack site.
* Head to `Upgrades → Plans`. Depending whether you're seeing the changes above from the Jetpack branch, you might have to click into ”Plans”.
* Ensure you don't see a top navigation on the “Plans” page.

#### Screenshots - Simple site

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/122912144-ea32b180-d34f-11eb-801c-23b5c0d66f67.png) | ![image](https://user-images.githubusercontent.com/390760/122912083-de46ef80-d34f-11eb-8d51-f3ac424f89ad.png)

#### Screenshots - Atomic site

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/122911328-1994ee80-d34f-11eb-9b80-e64d8ea37916.png) | ![image](https://user-images.githubusercontent.com/390760/122912001-ca02f280-d34f-11eb-99dd-53c5bb1ae5f6.png)

#### Screenshots - Jetpack site

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/122912295-151d0580-d350-11eb-9766-db9277a63a8c.png) | ![image](https://user-images.githubusercontent.com/390760/122912269-0cc4ca80-d350-11eb-82cd-01f50b79de91.png)
