### PR TITLE
Add invisible jitm support

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -44,6 +44,8 @@ function renderTemplate( template, props ) {
 					placeholder={ null }
 				/>
 			);
+		case 'invisible':
+			return <>{ props.trackImpression && props.trackImpression() }</>;
 		default:
 			return (
 				<AsyncLoad
@@ -58,7 +60,7 @@ function renderTemplate( template, props ) {
 function getEventHandlers( props, dispatch ) {
 	const { jitm, currentSite, messagePath } = props;
 	const tracks = jitm.tracks || {};
-	const eventProps = { id: jitm.id, jitm: true };
+	const eventProps = { id: jitm.id, jitm: true, template: jitm?.template ?? 'default' };
 	const handlers = {};
 
 	if ( tracks.display ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds:

- a new template that simply fires an impression event
- the current jitm template being shown as an event-prop

This is similar to invisible jitm support in Jetpack, though more explicit, for use in A/B tests when you need exposure events.

#### Testing instructions

* Modify an existing jitm to be shown (D63149-code)
* No jitm will be shown, but tracks event will fire with the template set to `invisible`
* Modify the jitm to use the `'sidebar-banner'` template
* Now able to see the jitm and the tracks event fires with the template set to `sidebar-banner`

