### PR TITLE
State: Drill down user ID to initial state

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -436,7 +436,7 @@ const boot = ( currentUser, registerRoutes ) => {
 		const initialState = getInitialState( initialReducer );
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		setStore( reduxStore );
-		onDisablePersistence( persistOnChange( reduxStore ) );
+		onDisablePersistence( persistOnChange( reduxStore, currentUser.get()?.ID ) );
 		setupLocale( currentUser.get(), reduxStore );
 		configureReduxStore( currentUser, reduxStore );
 		setupMiddlewares( currentUser, reduxStore );

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -8,6 +8,7 @@ import { Reducer, Store } from 'redux';
  */
 import { APPLY_STORED_STATE } from 'calypso/state/action-types';
 import { getStateFromCache } from 'calypso/state/initial-state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 const initializations = new Map< string, boolean >();
 const reducers = new Map< string, Reducer >();
@@ -34,7 +35,11 @@ function initializeState(
 	storageKey: string,
 	reducer: Reducer & OptionalStorageKey
 ) {
-	const storedState = getStateFromCache( reducer, storageKey );
+	const storedState = getStateFromCache(
+		reducer,
+		storageKey,
+		getCurrentUserId( store.getState() )
+	);
 
 	if ( storedState ) {
 		store.dispatch( { type: APPLY_STORED_STATE, storageKey, storedState } );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -13,7 +13,6 @@ import { useFakeTimers } from 'sinon';
  */
 import { withStorageKey } from '@automattic/state-utils';
 import * as browserStorage from 'calypso/lib/browser-storage';
-import userFactory from 'calypso/lib/user';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import { createReduxStore } from 'calypso/state';
 import signupReducer from 'calypso/state/signup/reducer';
@@ -38,11 +37,6 @@ const initialReducer = combineReducers( {
 	postTypes,
 } );
 
-jest.mock( 'calypso/lib/user', () => () => ( {
-	get: () => ( {
-		ID: 123456789,
-	} ),
-} ) );
 jest.mock( 'calypso/lib/user/support-user-interop', () => ( {
 	isSupportSession: jest.fn().mockReturnValue( false ),
 } ) );
@@ -79,7 +73,7 @@ describe( 'initial-state', () => {
 							.spyOn( browserStorage, 'getAllStoredItems' )
 							.mockResolvedValue( savedState );
 						await loadAllState();
-						state = getInitialState( initialReducer );
+						state = getInitialState( initialReducer, 123456789 );
 					} );
 
 					afterAll( () => {
@@ -144,7 +138,7 @@ describe( 'initial-state', () => {
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
 					await loadAllState();
-					state = getInitialState( initialReducer );
+					state = getInitialState( initialReducer, 123456789 );
 				} );
 
 				afterAll( () => {
@@ -207,7 +201,7 @@ describe( 'initial-state', () => {
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
 					await loadAllState();
-					state = getInitialState( initialReducer );
+					state = getInitialState( initialReducer, 123456789 );
 				} );
 
 				afterAll( () => {
@@ -262,7 +256,7 @@ describe( 'initial-state', () => {
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
 					await loadAllState();
-					state = getInitialState( initialReducer );
+					state = getInitialState( initialReducer, 123456789 );
 				} );
 
 				afterAll( () => {
@@ -292,13 +286,13 @@ describe( 'initial-state', () => {
 				let consoleErrorSpy;
 				let getStoredItemSpy;
 
-				const userId = userFactory().get().ID + 1;
+				const userId = 123456789 + 1;
 				const savedState = {
 					[ `redux-state-${ userId }` ]: {
 						// Create an invalid state by forcing the user ID
 						// stored in the state to differ from the current
 						// mocked user ID.
-						currentUser: { id: userFactory().get().ID + 1 },
+						currentUser: { id: userId },
 						postTypes: {
 							items: {
 								2916284: {
@@ -320,7 +314,7 @@ describe( 'initial-state', () => {
 						.spyOn( browserStorage, 'getAllStoredItems' )
 						.mockResolvedValue( savedState );
 					await loadAllState();
-					state = getInitialState( initialReducer );
+					state = getInitialState( initialReducer, 123456789 );
 				} );
 
 				afterAll( () => {
@@ -366,7 +360,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadAllState();
-				state = getStateFromCache( reader, 'reader' );
+				state = getStateFromCache( reader, 'reader', 123456789 );
 			} );
 
 			afterAll( () => {
@@ -458,7 +452,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadAllState();
-				state = getStateFromCache( reader, 'reader' );
+				state = getStateFromCache( reader, 'reader', 123456789 );
 			} );
 
 			afterAll( () => {
@@ -508,7 +502,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadAllState();
-				state = getStateFromCache( reader, 'reader' );
+				state = getStateFromCache( reader, 'reader', 123456789 );
 			} );
 
 			afterAll( () => {
@@ -630,7 +624,7 @@ describe( 'initial-state', () => {
 					.mockResolvedValue( storedState );
 
 				await loadAllState();
-				state = getStateFromCache( signupReducer, 'signup' );
+				state = getStateFromCache( signupReducer, 'signup', 123456789 );
 			} );
 
 			afterAll( () => {
@@ -691,7 +685,7 @@ describe( 'initial-state', () => {
 				.mockImplementation( ( value ) => Promise.resolve( value ) );
 
 			store = createReduxStore( initialState, reducer );
-			stopPersisting = persistOnChange( store );
+			stopPersisting = persistOnChange( store, 123456789 );
 		} );
 
 		afterEach( () => {
@@ -873,7 +867,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer );
+		const state = getInitialState( reducer, 123456789 );
 		const store = createReduxStore( state, reducer );
 
 		// verify that state from all storageKey's was loaded
@@ -900,7 +894,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer );
+		const state = getInitialState( reducer, 123456789 );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -934,7 +928,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer );
+		const state = getInitialState( reducer, 123456789 );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -970,7 +964,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer );
+		const state = getInitialState( reducer, 123456789 );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -1005,7 +999,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer );
+		const state = getInitialState( reducer, 123456789 );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the initial state to drill down the user ID to some functions that need the user ID, in order to decouple `lib/user` from the initial state.

This PR is motivated by https://github.com/Automattic/wp-calypso/pull/53669#discussion_r654387040

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Verify tests pass.
* Smoke test Calypso and verify persistence still works well.