### PR TITLE
Signup: Add username input field to /start/account flow

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -466,6 +466,7 @@ export class UserStep extends Component {
 					}
 					horizontal={ isReskinned }
 					isReskinned={ isReskinned }
+					displayUsernameInput={ this.props.stepName === 'user' && ! this.props.isReskinned }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -444,7 +444,7 @@ export class UserStep extends Component {
 		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			isSocialSignupEnabled = true;
 		}
-		// debugger;
+
 		return (
 			<>
 				<SignupForm

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -444,7 +444,7 @@ export class UserStep extends Component {
 		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			isSocialSignupEnabled = true;
 		}
-
+		// debugger;
 		return (
 			<>
 				<SignupForm
@@ -466,7 +466,7 @@ export class UserStep extends Component {
 					}
 					horizontal={ isReskinned }
 					isReskinned={ isReskinned }
-					displayUsernameInput={ this.props.stepName === 'user' && ! this.props.isReskinned }
+					displayUsernameInput={ this.props.flowName === 'account' }
 				/>
 				<div id="g-recaptcha"></div>
 			</>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add the username input field to the `/start/account` user flow.

#### Technical changes
* `<SignupForm/>` - `displayUsernameInput` prop: Display the username input field when the current step is `user` and the reskinned flow isn't activated. 

### Testing instructions
1. check out this branch.
2. `yarn && yarn start`.
3. navigate to `/start/account`.
4. ensure that:
     - [ ] username input field is visible.
5. finish creating a site.
6. navigate to `/me`.
7. ensure that:
    - [ ] the provided username is visible.

#### Regression: Reskinned signup flow
1. check out this branch.
2. `yarn && yarn start`.
3. navigate to `/start/user?flags=signup/reskin`.
4. ensure that:
     - [ ] username input field is **not** visible.

Fixes #53751