### PR TITLE
User: Remove unused `clear()`

### DIFF
--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import { EventEmitter } from 'events';
-import { Language } from '@automattic/languages';
 import { URL, JSONSerializable } from '../../types';
 
 type WPCOMError = { message: string };
@@ -30,8 +29,6 @@ export interface User extends EventEmitter {
 	fetch: () => Promise< void >;
 	handleFetchFailure: ( error: Error ) => void;
 	handleFetchSuccess: ( userdata: UserData ) => void;
-	getLanguage: () => Language | undefined;
-	clear: () => Promise< void > | void;
 	set: ( attributes: UserData ) => boolean;
 	verificationPollerCallback: ( signal?: true ) => void;
 	checkVerification: () => void;

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -174,18 +174,6 @@ User.prototype.handleFetchSuccess = function ( userData ) {
 	this.emit( 'change' );
 };
 
-/**
- * Clear any user data.
- */
-User.prototype.clear = async function () {
-	/**
-	 * Clear internal user data and empty localStorage cache
-	 * to discard any user reference that the application may hold
-	 */
-	this.data = false;
-	await clearStore();
-};
-
 User.prototype.set = function ( attributes ) {
 	let changed = false;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the unused `clear()` method from `lib/user` that is no longer used.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Verify the removed method is not used.