### PR TITLE
Signup: re-add the username field and adjust tests

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -113,7 +113,7 @@ class SignupForm extends Component {
 
 	static defaultProps = {
 		displayNameInput: false,
-		displayUsernameInput: false,
+		displayUsernameInput: true,
 		flowName: '',
 		isSocialSignupEnabled: false,
 		showRecaptchaToS: false,

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -74,7 +74,7 @@ export async function waitUntilElementLocated( driver, locator, timeout ) {
  * @param {By|Function} locator The element's locator
  * @param {number} [timeout=explicitWaitMS] The timeout in milliseconds
  * @returns {Promise<WebElement>} A promise that will be resolved with true when the element becomes
- * unavaialble
+ * unavailable
  */
 export async function waitUntilElementNotLocated( driver, locator, timeout ) {
 	const locatorStr = getLocatorString( locator );

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -22,15 +22,7 @@ export default class AcceptInvitePage extends AsyncBaseContainer {
 		await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
 		await driverHelper.setWhenSettable( this.driver, By.css( '#password' ), password, true );
 		// set the username field if present.
-		// in this particular case, 50ms is enough.
-		// because we know the page is fully rendered if the password field above was settable
-		if (
-			await driverHelper.isElementEventuallyLocatedAndVisible(
-				this.driver,
-				By.css( '#username' ),
-				50
-			)
-		) {
+		if ( await driverHelper.isElementLocated( this.driver, By.css( '#username' ) ) ) {
 			await driverHelper.setWhenSettable( this.driver, By.css( '#username' ), username );
 		}
 		return await driverHelper.clickWhenClickable( this.driver, By.css( '.signup-form__submit' ) );

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -18,9 +18,17 @@ export default class AcceptInvitePage extends AsyncBaseContainer {
 		return await this.driver.findElement( By.css( '#email' ) ).getAttribute( 'value' );
 	}
 
-	async enterEmailAndPasswordAndSignUp( email, password ) {
+	async enterCredentialsAndSignUp( username, email, password ) {
 		await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
 		await driverHelper.setWhenSettable( this.driver, By.css( '#password' ), password, true );
+		// set the username field if present
+		if (
+			await driverHelper
+				.waitUntilElementLocatedAndVisible( this.driver, By.css( '#username' ), 50 )
+				.catch( () => false )
+		) {
+			await driverHelper.setWhenSettable( this.driver, By.css( '#username' ), username );
+		}
 		return await driverHelper.clickWhenClickable( this.driver, By.css( '.signup-form__submit' ) );
 	}
 

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -21,11 +21,15 @@ export default class AcceptInvitePage extends AsyncBaseContainer {
 	async enterCredentialsAndSignUp( username, email, password ) {
 		await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
 		await driverHelper.setWhenSettable( this.driver, By.css( '#password' ), password, true );
-		// set the username field if present
+		// set the username field if present.
+		// in this particular case, 50ms is enough.
+		// because we know the page is fully rendered if the password field above was settable
 		if (
-			await driverHelper
-				.waitUntilElementLocatedAndVisible( this.driver, By.css( '#username' ), 50 )
-				.catch( () => false )
+			await driverHelper.isElementEventuallyLocatedAndVisible(
+				this.driver,
+				By.css( '#username' ),
+				50
+			)
 		) {
 			await driverHelper.setWhenSettable( this.driver, By.css( '#username' ), username );
 		}

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -87,7 +87,11 @@ describe( `[${ host }] Invites - New user as Editor: (${ screenSize }) @parallel
 		assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 		assert( headerInviteText.includes( 'editor' ) );
 
-		await acceptInvitePage.enterEmailAndPasswordAndSignUp( newInviteEmailAddress, password );
+		await acceptInvitePage.enterCredentialsAndSignUp(
+			newUserName,
+			newInviteEmailAddress,
+			password
+		);
 		return await acceptInvitePage.waitUntilNotVisible();
 	} );
 

--- a/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
@@ -96,7 +96,11 @@ describe.skip( `[${ host }] Invites - New user as Viewer: (${ screenSize }) @par
 		assert.strictEqual( actualEmailAddress, newInviteEmailAddress );
 		assert( headerInviteText.includes( 'view' ) );
 
-		await acceptInvitePage.enterEmailAndPasswordAndSignUp( newInviteEmailAddress, password );
+		await acceptInvitePage.enterCredentialsAndSignUp(
+			newUserName,
+			newInviteEmailAddress,
+			password
+		);
 		removedViewerFlag = false;
 		return await acceptInvitePage.waitUntilNotVisible();
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This re-adds the username field in signup forms in all `/start` flows.

#### Testing instructions

1. In incognito, go to /start/user
2. Sign up with an empty username. A validation message should appear.
3. Type a valid username and it should go through.
4. The created account should have the same username you entered. 


Related to https://github.com/Automattic/wp-calypso/pull/53509
