### PR TITLE
Jetpack Checkout without site for logged-in and logged-out users

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -721,14 +721,15 @@ function getAnalyticsPath(
 	} else if ( selectedFeature && ! plan ) {
 		analyticsPath = '/checkout/features/:feature/:site';
 		analyticsProps = { feature: selectedFeature, site: selectedSiteSlug };
-	} else if ( product && ! purchaseId ) {
-		analyticsPath = isJetpackCheckout
-			? '/checkout/jetpack/:site/:product'
-			: '/checkout/:site/:product';
+	} else if ( product && selectedSiteSlug && ! purchaseId ) {
+		analyticsPath = '/checkout/:site/:product';
 		analyticsProps = { product, site: selectedSiteSlug, checkoutFlow };
 	} else if ( selectedSiteSlug ) {
 		analyticsPath = '/checkout/:site';
 		analyticsProps = { site: selectedSiteSlug };
+	} else if ( product && ! selectedSiteSlug ) {
+		analyticsPath = '/checkout/:product';
+		analyticsProps = { product, checkoutFlow };
 	} else {
 		analyticsPath = '/checkout/no-site';
 	}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -723,13 +723,13 @@ function getAnalyticsPath(
 		analyticsProps = { feature: selectedFeature, site: selectedSiteSlug };
 	} else if ( product && selectedSiteSlug && ! purchaseId ) {
 		analyticsPath = '/checkout/:site/:product';
-		analyticsProps = { product, site: selectedSiteSlug, checkoutFlow };
+		analyticsProps = { product, site: selectedSiteSlug, checkout_flow: checkoutFlow };
 	} else if ( selectedSiteSlug ) {
 		analyticsPath = '/checkout/:site';
 		analyticsProps = { site: selectedSiteSlug };
 	} else if ( product && ! selectedSiteSlug ) {
 		analyticsPath = '/checkout/:product';
-		analyticsProps = { product, checkoutFlow };
+		analyticsProps = { product, checkout_flow: checkoutFlow };
 	} else {
 		analyticsPath = '/checkout/no-site';
 	}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -732,6 +732,11 @@ function getAnalyticsPath(
 	} else {
 		analyticsPath = '/checkout/no-site';
 	}
+
+	if ( isJetpackCheckout ) {
+		analyticsPath = analyticsPath.replace( 'checkout', 'checkout/jetpack' );
+	}
+
 	return { analyticsPath, analyticsProps };
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -18,9 +18,13 @@ export default async function submitWpcomTransaction(
 	transactionOptions: PaymentProcessorOptions
 ): Promise< WPCOMTransactionEndpointResponse > {
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || payload.cart.is_jetpack_checkout ) {
-		const createAccountOptions = payload.cart.is_jetpack_checkout
+		const isJetpackCheckout = payload.cart.is_jetpack_checkout;
+
+		const createAccountOptions = isJetpackCheckout
 			? { signupFlowName: 'jetpack-userless-checkout' }
 			: { signupFlowName: 'onboarding-registrationless' };
+
+		const isSitelessJetpackCheckout = isJetpackCheckout && ! transactionOptions.siteId;
 
 		return createAccount( createAccountOptions ).then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;
@@ -34,10 +38,9 @@ export default async function submitWpcomTransaction(
 					...payload.cart,
 					blog_id: siteId || '0',
 					cart_key: siteId || 'no-site',
-					create_new_blog: false,
+					create_new_blog: isSitelessJetpackCheckout,
 				},
 			};
-
 			return wp.undocumented().transactions( newPayload );
 		} );
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -26,7 +26,7 @@ export default async function submitWpcomTransaction(
 			: { signupFlowName: 'onboarding-registrationless' };
 
 		const isSitelessJetpackCheckout =
-			isEnabled( 'jetpack/siteless-checkout' ) && isJetpackCheckout && ! transactionOptions.siteId;
+			isEnabled( 'jetpack/siteless-checkout' ) && isJetpackCheckout && payload.cart.blog_id === '0';
 
 		return createAccount( createAccountOptions ).then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isEnabled } from '@automattic/calypso-config';
 import type {
 	WPCOMTransactionEndpointRequestPayload,
 	WPCOMTransactionEndpointResponse,
@@ -24,7 +25,8 @@ export default async function submitWpcomTransaction(
 			? { signupFlowName: 'jetpack-userless-checkout' }
 			: { signupFlowName: 'onboarding-registrationless' };
 
-		const isSitelessJetpackCheckout = isJetpackCheckout && ! transactionOptions.siteId;
+		const isSitelessJetpackCheckout =
+			isEnabled( 'jetpack/siteless-checkout' ) && isJetpackCheckout && ! transactionOptions.siteId;
 
 		return createAccount( createAccountOptions ).then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -123,9 +123,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 		blog_id: siteId || '0',
 		cart_key: siteId || 'no-site',
 		create_new_blog: siteId ? false : true,
-		is_jetpack_checkout: responseCart.products.some(
-			( product ) => product.extra.isJetpackCheckout
-		),
+		is_jetpack_checkout: false,
 		coupon: responseCart.coupon || '',
 		currency: responseCart.currency,
 		temporary: false,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { getTotalLineItemFromCart, tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
 import type { LineItem } from '@automattic/composite-checkout';
@@ -103,10 +104,21 @@ export function createTransactionEndpointCartFromResponseCart( {
 	responseCart: ResponseCart;
 } ): WPCOMTransactionEndpointCart {
 	if ( responseCart.products.some( ( product ) => product.extra.isJetpackCheckout ) ) {
+		const isUserLess = responseCart.cart_key === 'no-user';
+		const isSiteLess = responseCart.blog_id === 0;
+
+		// At this point, cart_key will be 'no-user' | blog_id | 'no-site', in that order.
+		const cartKey = isUserLess ? responseCart.cart_key : responseCart.blog_id || 'no-site';
+		const isSiteLessJetpackCheckout = isEnabled( 'jetpack/siteless-checkout' ) && isSiteLess;
+
+		// A cart with the 'no-user' key, in the context of a Jetpack checkout flow, means that
+		// a WP.com account will be created before submitting the transaction (see submitWpcomTransaction).
+		// Once the WP.com account is created, the cart key is replaced with the blog ID and sent to the
+		// /transactions endpoint. If there is no blog ID, a temporary blog is created on the backend side.
 		return {
 			blog_id: responseCart.blog_id.toString(),
-			cart_key: responseCart.blog_id.toString(),
-			create_new_blog: false,
+			cart_key: cartKey.toString(),
+			create_new_blog: isSiteLessJetpackCheckout,
 			is_jetpack_checkout: true,
 			coupon: responseCart.coupon || '',
 			currency: responseCart.currency,

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -44,6 +44,34 @@ import { TRUENAME_COUPONS } from 'calypso/lib/domains';
 
 const debug = debugFactory( 'calypso:checkout-controller' );
 
+export function checkoutSiteless( context, next ) {
+	const state = context.store.getState();
+	const isLoggedOut = ! isUserLoggedIn( state );
+	const { productSlug: product } = context.params;
+
+	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+
+	setSectionMiddleware( { name: 'checkout' } )( context );
+
+	// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
+	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
+
+	context.primary = (
+		<CheckoutSystemDecider
+			productAliasFromUrl={ product }
+			couponCode={ couponCode }
+			isComingFromUpsell={ !! context.query.upgrade }
+			redirectTo={ context.query.redirect_to }
+			isLoggedOutCart={ isLoggedOut }
+			isNoSiteCart={ true }
+			isJetpackCheckout={ true }
+		/>
+	);
+
+	next();
+}
+
 export function checkout( context, next ) {
 	const { feature, plan, purchaseId } = context.params;
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -9,6 +9,7 @@ import page from 'page';
 import {
 	checkout,
 	checkoutPending,
+	checkoutSiteless,
 	checkoutThankYou,
 	upsellNudge,
 	redirectToSupportSession,
@@ -33,6 +34,10 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
+	}
+
+	if ( isEnabled( 'jetpack/siteless-checkout' ) ) {
+		page( '/checkout/jetpack/:productSlug', noSite, checkoutSiteless, makeLayout, clientRender );
 	}
 
 	page(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for checkouts without a site in context under `/checkout/jetpack/:product`.
* Make the checkout page work for logged-in users and logged-out users.

#### Testing instructions

* Patch your WPCOM sandbox with D63168-code.
* Sandbox `public-api.wordpress.com`.
* Download this PR.
* Edit the `config/development.json` file and enabled the `jetpack/siteless-checkout` feature flag.
* Start Calypso with `yarn start`. You need to do this since this PR introduces a new feature flag.
* Visit `http://calypso.localhost:3000/checkout/jetpack/:product` on a window where you are logged in to WordPress.com, replacing `:product` with a valid Jetpack product slug such as `jetpack_scan`.
* Make sure you can checkout.
* Complete checkout.
* Make sure you are redirected to the Thank You page.

Related to 1200479326344990-as-1200481482484380

#### Demo

![image](https://user-images.githubusercontent.com/3418513/122953734-db96cb00-d34c-11eb-9203-401bdf36cc40.png)