### PR TITLE
ETK: Fix typo in font name

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/README.md
@@ -201,7 +201,7 @@ To white-label Global Styles:
 These are the fonts available via the font selector in the sidebar and for the themes to set as defaults:
 
 - Arvo
-- Bodoni Mona
+- Bodoni Moda
 - Cabin
 - Chivo
 - DM Sans

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -91,7 +91,7 @@ class Global_Styles {
 			'value' => self::SYSTEM_FONT,
 		),
 		'Arvo',
-		'Bodoni Mona',
+		'Bodoni Moda',
 		'Cabin',
 		'Chivo',
 		'Courier Prime',

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -204,8 +204,8 @@ class Global_Styles {
 							'base'     => 'Roboto',
 						),
 						array(
-							'label'    => 'Bodoni Mona / Overpass',
-							'headings' => 'Bodoni Mona',
+							'label'    => 'Bodoni Moda / Overpass',
+							'headings' => 'Bodoni Moda',
 							'base'     => 'Overpass',
 						),
 						array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bodoni Mona should be Bodoni Moda; this updates the font name introduced in #53417

**Before**

<img src="https://user-images.githubusercontent.com/4550351/122843978-fca6ee00-d343-11eb-8be2-239345350f3c.png" />

<img width="310" alt="Screen Shot 2021-06-22 at 11 57 08 AM" src="https://user-images.githubusercontent.com/2124984/122959143-0125d380-d351-11eb-8857-b82e21d8bf7e.png">

**After**

<img width="273" alt="Screen Shot 2021-06-22 at 11 55 02 AM" src="https://user-images.githubusercontent.com/2124984/122958409-d0459e80-d350-11eb-98bb-80384ee1b0ec.png">

<img width="281" alt="Screen Shot 2021-06-22 at 11 55 16 AM" src="https://user-images.githubusercontent.com/2124984/122958413-d0de3500-d350-11eb-81b5-d5d09adcbb25.png">

<img width="352" alt="Screen Shot 2021-06-22 at 11 55 43 AM" src="https://user-images.githubusercontent.com/2124984/122958458-da679d00-d350-11eb-94d0-10a0f9d67f59.png">


#### Testing instructions

* In your sandbox run this command from `~/public_html`: `install-plugin.sh etk fix/font-family-typo`
* Point the API to your sandbox: `public-api.wordpress.com`
* Activate a theme that supports Global Styles (eg. Blank Canvas)
* Edit a post/page in your site
* Click on the A icon on the top right to open Global Styles; the Bodoni Moda font should be listed in the dropdown and choosing it should display the font correctly on your site. It should look something like this:

<img width="352" alt="Screen Shot 2021-06-22 at 11 55 43 AM" src="https://user-images.githubusercontent.com/2124984/122958458-da679d00-d350-11eb-94d0-10a0f9d67f59.png">


Fixes #53876
