### PR TITLE
Playwright: migrate Theme switch preview spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -7,3 +7,4 @@ export * from './sidebar-component';
 export * from './support-component';
 export * from './support-article-component';
 export * from './post-likes-component';
+export * from './preview-component';

--- a/packages/calypso-e2e/src/lib/components/preview-component.ts
+++ b/packages/calypso-e2e/src/lib/components/preview-component.ts
@@ -10,9 +10,14 @@ import { Page } from 'playwright';
 
 const selectors = {
 	previewPane: '.web-preview',
-	activateButton: 'text=Activate'
+	activateButton: 'text=Activate',
 };
 
+/**
+ * Component representing the site published preview component.
+ *
+ * @augments {BaseContainer}
+ */
 export class PreviewComponent extends BaseContainer {
 	/**
 	 * Constructs an instance of the component.

--- a/packages/calypso-e2e/src/lib/components/preview-component.ts
+++ b/packages/calypso-e2e/src/lib/components/preview-component.ts
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	previewPane: '.web-preview',
+	activateButton: 'text=Activate'
+};
+
+export class PreviewComponent extends BaseContainer {
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		super( page, selectors.previewPane );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -7,3 +7,4 @@ export * from './gutenberg-editor-page';
 export * from './my-home-page';
 export * from './marketing-page';
 export * from './settings-page';
+export * from './themes-page';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -8,3 +8,4 @@ export * from './my-home-page';
 export * from './marketing-page';
 export * from './settings-page';
 export * from './themes-page';
+export * from './themes-detail-page';

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+import { PreviewComponent  } from '../components';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {
+	main: '.theme__sheet',
+	demoPane: '.theme__sheet-screenshot',
+};
+
+/**
+ * Component representing the Apperance > Themes page.
+ *
+ * @augments {BaseContainer}
+ */
+export class ThemesDetailPage extends BaseContainer {
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		super( page, selectors.main );
+	}
+
+	async preview(): Promise<void> {
+		await this.page.click( selectors.demoPane);
+		await PreviewComponent.Expect( this.page );
+	}
+
+
+}

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
-import { PreviewComponent  } from '../components';
+import { PreviewComponent } from '../components';
 
 /**
  * Type dependencies
@@ -29,10 +29,13 @@ export class ThemesDetailPage extends BaseContainer {
 		super( page, selectors.main );
 	}
 
-	async preview(): Promise<void> {
-		await this.page.click( selectors.demoPane);
+	/**
+	 * Launches the live preview of the theme.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async preview(): Promise< void > {
+		await this.page.click( selectors.demoPane );
 		await PreviewComponent.Expect( this.page );
 	}
-
-
 }

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { BaseContainer } from '../base-container';
+
+/**
+ * Type dependencies
+ */
+import { Page } from 'playwright';
+
+const selectors = {};
+
+/**
+ * Component representing the Apperance > Themes page.
+ *
+ * @augments {BaseContainer}
+ */
+export class ThemesPage extends BaseContainer {
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		super( page );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -43,28 +43,65 @@ export class ThemesPage extends BaseContainer {
 		super( page );
 	}
 
-	async _postInit(): Promise<void> {
-		await this.page.waitForSelector( selectors.spinner, {state: 'hidden'});
+	/**
+	 * Post initialization steps.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async _postInit(): Promise< void > {
+		await this.page.waitForSelector( selectors.spinner, { state: 'hidden' } );
 	}
 
-	async filterThemes( type: 'All' | 'Free' | 'Premium' ): Promise<void> {
+	/**
+	 * Filters the themes on page by clicking on the selector passed in as argument.
+	 *
+	 * @param {string} type Pre-defined types of themes.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async filterThemes( type: 'All' | 'Free' | 'Premium' ): Promise< void > {
 		await this.page.click( selectors.showAllThemesButton );
 		const searchToolbar = await this.page.waitForSelector( selectors.searchToolbar );
-		const button = await searchToolbar.waitForSelector( `a[data-e2e-value=${type.toLowerCase()}]` );
+		const button = await searchToolbar.waitForSelector(
+			`a[data-e2e-value=${ type.toLowerCase() }]`
+		);
 		await button.click();
-		await this.page.waitForSelector( selectors.placeholder, {state: 'hidden'});
-		const isSelected = await button.getAttribute('aria-checked');
+		// This will wait for all placeholder classes to return to hidden state.
+		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
+		// Verify that filter has been successfully applied.
+		const isSelected = await button.getAttribute( 'aria-checked' );
 		assert.strictEqual( isSelected, 'true' );
 	}
 
-	async search( keyword: string ):Promise<void> {
+	/**
+	 * Given a keyword, perform a search in the Themes toolbar.
+	 *
+	 * @param {string} keyword Theme name to search for. Can be a partial match.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async search( keyword: string ): Promise< void > {
 		const searchInput = await this.page.waitForSelector( selectors.searchInput );
 		await searchInput.fill( keyword );
-		await this.page.waitForSelector( selectors.placeholder, {state: 'hidden'});
+		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
 	}
 
-	async select( name: string): Promise<void> {
-		const selectedTheme = await this.page.waitForSelector(`${selectors.items}:has-text("${name}")`, {state: 'visible'});
+	/**
+	 * Select a theme by name.
+	 *
+	 * If the theme is not shown, this will throw an Error.
+	 *
+	 * @param {string} name Theme name to select.
+	 * @returns {Promise<void>} No return value.
+	 * @throws {Error} If theme is not shown on page.
+	 */
+	async select( name: string ): Promise< void > {
+		const selectedTheme = await this.page.waitForSelector(
+			`${ selectors.items }:has-text("${ name }")`,
+			{ state: 'visible' }
+		);
+
+		if ( ! selectedTheme ) {
+			throw new Error( `Requested theme ${ name } is not shown on page.` );
+		}
 		await selectedTheme.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import assert from 'assert';
+
+/**
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
@@ -8,7 +13,20 @@ import { BaseContainer } from '../base-container';
  */
 import { Page } from 'playwright';
 
-const selectors = {};
+const selectors = {
+	// Main themes listing
+	themes: '.themes__content',
+	items: '.card.theme',
+
+	// Transitions
+	spinner: '.themes__content > .spinner',
+	placeholder: '.themes-list .is-placeholder',
+
+	// Search
+	showAllThemesButton: 'text=Show all themes',
+	searchToolbar: '.themes-magic-search',
+	searchInput: '.themes-magic-search-card input.search__input',
+};
 
 /**
  * Component representing the Apperance > Themes page.
@@ -23,5 +41,30 @@ export class ThemesPage extends BaseContainer {
 	 */
 	constructor( page: Page ) {
 		super( page );
+	}
+
+	async _postInit(): Promise<void> {
+		await this.page.waitForSelector( selectors.spinner, {state: 'hidden'});
+	}
+
+	async filterThemes( type: 'All' | 'Free' | 'Premium' ): Promise<void> {
+		await this.page.click( selectors.showAllThemesButton );
+		const searchToolbar = await this.page.waitForSelector( selectors.searchToolbar );
+		const button = await searchToolbar.waitForSelector( `a[data-e2e-value=${type.toLowerCase()}]` );
+		await button.click();
+		await this.page.waitForSelector( selectors.placeholder, {state: 'hidden'});
+		const isSelected = await button.getAttribute('aria-checked');
+		assert.strictEqual( isSelected, 'true' );
+	}
+
+	async search( keyword: string ):Promise<void> {
+		const searchInput = await this.page.waitForSelector( selectors.searchInput );
+		await searchInput.fill( keyword );
+		await this.page.waitForSelector( selectors.placeholder, {state: 'hidden'});
+	}
+
+	async select( name: string): Promise<void> {
+		const selectedTheme = await this.page.waitForSelector(`${selectors.items}:has-text("${name}")`, {state: 'visible'});
+		await selectedTheme.click();
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-theme__switch-preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__switch-preview-spec.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { LoginFlow, SidebarComponent } from '@automattic/calypso-e2e';
+
+describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
+	let sidebarComponent;
+
+	it( 'Log In', async function () {
+		const loginFlow = new LoginFlow( this.page, user );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Navigate to Themes', async function () {
+		sidebarComponent = await SidebarComponent.Expect( this.page );
+		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-theme__switch-preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__switch-preview-spec.js
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { DataHelper, LoginFlow, SidebarComponent, ThemesPage, ThemesDetailPage } from '@automattic/calypso-e2e';
+import {
+	DataHelper,
+	LoginFlow,
+	SidebarComponent,
+	ThemesPage,
+	ThemesDetailPage,
+} from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
 	let sidebarComponent;
@@ -19,21 +25,21 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
 		await sidebarComponent.gotoMenu( { item: 'Appearance' } );
 	} );
 
-	it( 'Search for free theme', async function() {
+	it( 'Search for free theme', async function () {
 		themesPage = await ThemesPage.Expect( this.page );
 		await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
-	});
+	} );
 
-	it( 'Select Twenty Seventeen', async function() {
+	it( 'Select Twenty Seventeen', async function () {
 		await themesPage.select( themeName );
-	});
+	} );
 
-	it( 'See theme detail page', async function() {
+	it( 'See theme detail page', async function () {
 		themesDetailPage = await ThemesDetailPage.Expect( this.page );
-	})
+	} );
 
-	it( 'Preview theme', async function() {
+	it( 'Preview theme', async function () {
 		await themesDetailPage.preview();
-	})
+	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-theme__switch-preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__switch-preview-spec.js
@@ -1,18 +1,39 @@
 /**
  * External dependencies
  */
-import { LoginFlow, SidebarComponent } from '@automattic/calypso-e2e';
+import { DataHelper, LoginFlow, SidebarComponent, ThemesPage, ThemesDetailPage } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
 	let sidebarComponent;
+	let themesPage;
+	let themesDetailPage;
+	const themeName = 'Twenty Seventeen';
 
 	it( 'Log In', async function () {
-		const loginFlow = new LoginFlow( this.page, user );
+		const loginFlow = new LoginFlow( this.page );
 		await loginFlow.logIn();
 	} );
 
 	it( 'Navigate to Themes', async function () {
 		sidebarComponent = await SidebarComponent.Expect( this.page );
-		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
+		await sidebarComponent.gotoMenu( { item: 'Appearance' } );
 	} );
+
+	it( 'Search for free theme', async function() {
+		themesPage = await ThemesPage.Expect( this.page );
+		await themesPage.filterThemes( 'Free' );
+		await themesPage.search( themeName );
+	});
+
+	it( 'Select Twenty Seventeen', async function() {
+		await themesPage.select( themeName );
+	});
+
+	it( 'See theme detail page', async function() {
+		themesDetailPage = await ThemesDetailPage.Expect( this.page );
+	})
+
+	it( 'Preview theme', async function() {
+		await themesDetailPage.preview();
+	})
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates `wp-theme__switch-preview-spec.js` from Selenium to Playwright.

- create and implement `ThemesPage`, `ThemesDetailPage` and `PreviewComponent`.
- reorganize the test to explicitly search for the `Twenty Seventeen` theme.

#### Testing instructions

TeamCity
- ensure Playwright E2E task is passing.
- ensure code style and unit tests are passing.

Local
- pull branch
- transpile TypeScript
- run `mocha --config .mocharc_playwright.yml`

