### PR TITLE
Playwright: add mobile support for interacting with WPCOM sidebar.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -11,6 +11,7 @@ import { Page } from 'playwright';
 const selectors = {
 	navbar: '.masterbar',
 	newPostButton: '.masterbar__item-new',
+	mySite: 'text=My Site',
 };
 /**
  * Component representing the navbar/masterbar at top of WPCOM.
@@ -27,13 +28,25 @@ export class NavbarComponent extends BaseContainer {
 		super( page, selectors.navbar );
 	}
 
+	async _click( selector: string ): Promise< void > {
+		const elementHandle = await this.page.waitForSelector( selector );
+		await elementHandle.waitForElementState( 'stable' );
+		await elementHandle.click();
+	}
+
 	/**
 	 * Locates and clicks on the new post button on the nav bar.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await this.page.waitForSelector( selectors.newPostButton );
-		await this.page.click( selectors.newPostButton, { timeout: 120000, clickCount: 10 } );
+		await this._click( selectors.newPostButton );
+	}
+
+	/**
+	 *
+	 */
+	async clickMySite(): Promise< void > {
+		await this._click( selectors.mySite );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -28,6 +28,11 @@ export class NavbarComponent extends BaseContainer {
 		super( page, selectors.navbar );
 	}
 
+	/**
+	 * Locates and clicks on the selector once the element is stable.
+	 *
+	 * @param {string} selector String selector.
+	 */
 	async _click( selector: string ): Promise< void > {
 		const elementHandle = await this.page.waitForSelector( selector );
 		await elementHandle.waitForElementState( 'stable' );
@@ -44,7 +49,9 @@ export class NavbarComponent extends BaseContainer {
 	}
 
 	/**
+	 * Clicks on `My Sites`.
 	 *
+	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMySite(): Promise< void > {
 		await this._click( selectors.mySite );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -11,7 +11,7 @@ import { Page } from 'playwright';
 const selectors = {
 	navbar: '.masterbar',
 	newPostButton: '.masterbar__item-new',
-	mySite: 'text=My Site',
+	mySiteButton: 'text=My Site',
 };
 /**
  * Component representing the navbar/masterbar at top of WPCOM.
@@ -35,7 +35,6 @@ export class NavbarComponent extends BaseContainer {
 	 */
 	async _click( selector: string ): Promise< void > {
 		const elementHandle = await this.page.waitForSelector( selector );
-		await elementHandle.waitForElementState( 'stable' );
 		await elementHandle.click();
 	}
 
@@ -49,11 +48,11 @@ export class NavbarComponent extends BaseContainer {
 	}
 
 	/**
-	 * Clicks on `My Sites`.
+	 * Clicks on `My Sites` on the top left of WPCOM dashboard.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	async clickMySite(): Promise< void > {
-		await this._click( selectors.mySite );
+	async clickMySites(): Promise< void > {
+		await this._click( selectors.mySiteButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -34,7 +34,7 @@ export class NavbarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await this.click( selectors.newPostButton );
+		await this.page.click( selectors.newPostButton );
 	}
 
 	/**
@@ -43,6 +43,6 @@ export class NavbarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMySites(): Promise< void > {
-		await this.click( selectors.mySiteButton );
+		await this.page.click( selectors.mySiteButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -29,22 +29,12 @@ export class NavbarComponent extends BaseContainer {
 	}
 
 	/**
-	 * Locates and clicks on the selector once the element is stable.
-	 *
-	 * @param {string} selector String selector.
-	 */
-	async _click( selector: string ): Promise< void > {
-		const elementHandle = await this.page.waitForSelector( selector );
-		await elementHandle.click();
-	}
-
-	/**
 	 * Locates and clicks on the new post button on the nav bar.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await this._click( selectors.newPostButton );
+		await this.click( selectors.newPostButton );
 	}
 
 	/**
@@ -53,6 +43,6 @@ export class NavbarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMySites(): Promise< void > {
-		await this._click( selectors.mySiteButton );
+		await this.click( selectors.mySiteButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -101,6 +101,9 @@ export class SidebarComponent extends BaseContainer {
 			selector = `${ selectors.subheading } >> text="${ subitem }"`;
 			await this._click( selector );
 		}
+
+		// Confirm the focus is now back to the content, not the sidebar.
+		await this.page.waitForSelector( `${ selectors.layout }.focus-content` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -78,7 +78,7 @@ export class SidebarComponent extends BaseContainer {
 		// If mobile, sidebar is hidden by default and focus is on the content.
 		// The sidebar must be first brought into view.
 		if ( viewportName === 'mobile' ) {
-			await this._openSidebar();
+			await this._openMobileSidebar();
 		}
 
 		if ( item ) {
@@ -111,7 +111,7 @@ export class SidebarComponent extends BaseContainer {
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	async _openSidebar(): Promise< void > {
+	async _openMobileSidebar(): Promise< void > {
 		const navbarComponent = await NavbarComponent.Expect( this.page );
 		await navbarComponent.clickMySites();
 		// `focus-sidebar` attribute is added once the sidebar is opened and focused in mobile view.

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencieds
- */
-import assert from 'assert';
-
-/**
  * Internal dependencies
  */
 import { BaseContainer } from '../base-container';
@@ -78,11 +73,11 @@ export class SidebarComponent extends BaseContainer {
 	 */
 	async gotoMenu( { item, subitem }: { item?: string; subitem?: string } ): Promise< void > {
 		let selector;
-		const viewport_name = getViewportName();
+		const viewportName = getViewportName();
 
 		// If mobile, sidebar is hidden by default and focus is on the content.
 		// The sidebar must be first brought into view.
-		if ( viewport_name === 'mobile' ) {
+		if ( viewportName === 'mobile' ) {
 			await this._openSidebar();
 		}
 
@@ -109,19 +104,16 @@ export class SidebarComponent extends BaseContainer {
 	}
 
 	/**
-	 * Opens the sidebar into view.
+	 * Opens the sidebar into view for mobile viewports.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async _openSidebar(): Promise< void > {
 		const navbarComponent = await NavbarComponent.Expect( this.page );
-		await navbarComponent.clickMySite();
-		// Layout specifies whether sidebar or main content is being focused at this time.
-		const elementHandle = await this.page.waitForSelector( selectors.layout );
-		await elementHandle.waitForElementState( 'stable' );
-		const classAttributes = ( await elementHandle.getAttribute( 'class' ) ) as string;
-		const isSidebarOpen = classAttributes.includes( 'focus-sidebar' );
-		assert.strictEqual( isSidebarOpen, true );
+		await navbarComponent.clickMySites();
+		// `focus-sidebar` attribute is added once the sidebar is opened and focused in mobile view.
+		const layoutElement = await this.page.waitForSelector( `${ selectors.layout }.focus-sidebar` );
+		await layoutElement.waitForElementState( 'stable' );
 	}
 
 	/**
@@ -133,7 +125,6 @@ export class SidebarComponent extends BaseContainer {
 	 *
 	 * @param {string} selector Any selector supported by Playwright.
 	 * @returns {Promise<void>} No return value.
-	 * @throws {assert.AssertionError} If on mobile the sidebar could not be toggled into view.
 	 */
 	async _click( selector: string ): Promise< void > {
 		// Wait for these promises in no particular order. We simply want to ensure the sidebar

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -4,11 +4,6 @@
 import { BaseContainer } from '../base-container';
 import { toTitleCase } from '../../data-helper';
 
-/**
- * Type dependencies
- */
-import { Page } from 'playwright';
-
 const selectors = {
 	content: '#primary',
 	navTabs: 'div.section-nav-tabs',
@@ -27,15 +22,6 @@ const selectors = {
  * @augments {BaseContainer}
  */
 export class MarketingPage extends BaseContainer {
-	/**
-	 * Constructs an instance of the MarketingPage object.
-	 *
-	 * @param {Page} page Underlying page on which the actions take place.
-	 */
-	constructor( page: Page ) {
-		super( page );
-	}
-
 	/**
 	 * Given a string, clicks on the tab matching the string at top of the page.
 	 *

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -11,13 +11,14 @@ import { Page } from 'playwright';
 
 const selectors = {
 	content: '#primary',
-	navtabsList: '.section-nav-tabs__list',
+	navTabs: 'div.section-nav-tabs',
+	navTabsDropdownOption: '.select-dropdown__option',
 
 	// Traffic tab
 	websiteMetaTextArea: '#advanced_seo_front_page_description',
 	seoPreviewButton: '.seo-settings__preview-button',
 	seoPreviewPane: '.web-preview.is-seo',
-	seoPreviewPaneCloseButton: '.web-preview .web-preview__close',
+	seoPreviewPaneCloseButton: '.web-preview__close',
 };
 
 /**
@@ -32,16 +33,7 @@ export class MarketingPage extends BaseContainer {
 	 * @param {Page} page Underlying page on which the actions take place.
 	 */
 	constructor( page: Page ) {
-		super( page, selectors.content );
-	}
-
-	/**
-	 * Post-initialization steps when creating an instance of this object.
-	 *
-	 * @returns {Promise<void>} No return value.
-	 */
-	async _postInit(): Promise< void > {
-		await this.page.waitForSelector( selectors.navtabsList );
+		super( page );
 	}
 
 	/**
@@ -51,9 +43,18 @@ export class MarketingPage extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTabItem( name: string ): Promise< void > {
+		const navTabs = await this.page.waitForSelector( selectors.navTabs );
+		const isDropdown = await navTabs
+			.getAttribute( 'class' )
+			.then( ( value ) => value?.includes( 'is-dropdown' ) );
 		const sanitizedName = toTitleCase( [ name ] );
 
-		await this.page.click( `text=${ sanitizedName }` );
+		if ( isDropdown ) {
+			await navTabs.click();
+			await this.page.click( `${ selectors.navTabsDropdownOption } >> text=${ name }` );
+		} else {
+			await this.page.click( `text=${ sanitizedName }` );
+		}
 	}
 
 	/* SEO Preview Methods */

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -13,7 +13,7 @@ describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
 
 	it( 'Navigate to Tools > Marketing page', async function () {
 		const sidebarComponent = await SidebarComponent.Expect( this.page );
-		await sidebarComponent.gotoMenu( { item: 'Tools' } );
+		await sidebarComponent.gotoMenu( { item: 'Tools', subitem: 'Marketing' } );
 	} );
 
 	it( 'Click on Traffic tab', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements ability for mobile viewports to interact with the WPCOM sidebar.

In previous iterations of the `SidebarComponent`, it assumed the sidebar was visible at all times - which is the case for `desktop` viewports, but not for `mobile`.

- add new methods to click the `My Sites` text on top left of WPCOM dashboard to toggle into view the sidebar.
- fix a critical logic error in `SidebarComponent.gotoMenu` that caused the selectors to be overwritten if both `item` and `subitem` were supplied.

#### Testing instructions

TeamCity
- ensure all tests pass.
