### PR TITLE
Preferences: Add styling, for ease of use

### DIFF
--- a/client/lib/preferences-helper/array-preference.js
+++ b/client/lib/preferences-helper/array-preference.js
@@ -16,7 +16,7 @@ class ArrayPreference extends Component {
 		const { value } = this.props;
 
 		return (
-			<ul className="preferences-helper__array-preference">
+			<ul className="array-preference">
 				{ value.map( ( preference, index ) => (
 					<li key={ index }>{ JSON.stringify( preference ) }</li>
 				) ) }

--- a/client/lib/preferences-helper/array-preference.js
+++ b/client/lib/preferences-helper/array-preference.js
@@ -16,7 +16,7 @@ class ArrayPreference extends Component {
 		const { value } = this.props;
 
 		return (
-			<ul className="preferences-helper__list">
+			<ul className="preferences-helper__array-preference">
 				{ value.map( ( preference, index ) => (
 					<li key={ index }>{ JSON.stringify( preference ) }</li>
 				) ) }

--- a/client/lib/preferences-helper/boolean-preference.tsx
+++ b/client/lib/preferences-helper/boolean-preference.tsx
@@ -45,14 +45,14 @@ const BooleanPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__save-pref-button"
+						className="preferences-helper__preference-save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
 						{ 'save' }
 					</button>{ ' ' }
 					<button
-						className="preferences-helper__reset-pref-button"
+						className="preferences-helper__preference-reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>

--- a/client/lib/preferences-helper/boolean-preference.tsx
+++ b/client/lib/preferences-helper/boolean-preference.tsx
@@ -45,14 +45,14 @@ const BooleanPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__preference-save"
+						className="boolean-preference__save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
 						{ 'save' }
 					</button>{ ' ' }
 					<button
-						className="preferences-helper__preference-reset"
+						className="boolean-preference__reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>

--- a/client/lib/preferences-helper/number-preference.tsx
+++ b/client/lib/preferences-helper/number-preference.tsx
@@ -45,14 +45,14 @@ const NumberPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__preference-save"
+						className="number-preference__save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
 						{ 'save' }
 					</button>{ ' ' }
 					<button
-						className="preferences-helper__preference-reset"
+						className="number-preference__reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>

--- a/client/lib/preferences-helper/number-preference.tsx
+++ b/client/lib/preferences-helper/number-preference.tsx
@@ -45,14 +45,14 @@ const NumberPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__save-pref-button"
+						className="preferences-helper__preference-save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
 						{ 'save' }
 					</button>{ ' ' }
 					<button
-						className="preferences-helper__reset-pref-button"
+						className="preferences-helper__preference-reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>

--- a/client/lib/preferences-helper/object-preference.tsx
+++ b/client/lib/preferences-helper/object-preference.tsx
@@ -34,11 +34,11 @@ const ObjectPreference: FunctionComponent< Props > = ( { value } ) => {
 	};
 
 	return (
-		<ul className="preferences-helper__list">
+		<ul className="preferences-helper__object-preference">
 			{ value &&
 				Object.keys( value ).map( ( property ) => (
 					<li key={ property }>
-						<span>{ property }</span>
+						<span className="preferences-helper__object-preference-property">{ property }</span>
 						{ renderProperty( property, value[ property ] ) }
 					</li>
 				) ) }

--- a/client/lib/preferences-helper/object-preference.tsx
+++ b/client/lib/preferences-helper/object-preference.tsx
@@ -34,11 +34,11 @@ const ObjectPreference: FunctionComponent< Props > = ( { value } ) => {
 	};
 
 	return (
-		<ul className="preferences-helper__object-preference">
+		<ul className="object-preference">
 			{ value &&
 				Object.keys( value ).map( ( property ) => (
 					<li key={ property }>
-						<span className="preferences-helper__object-preference-property">{ property }</span>
+						<span className="object-preference__property">{ property }</span>
 						{ renderProperty( property, value[ property ] ) }
 					</li>
 				) ) }

--- a/client/lib/preferences-helper/preference-list.js
+++ b/client/lib/preferences-helper/preference-list.js
@@ -35,7 +35,7 @@ class PreferenceList extends Component {
 				<a href={ '/devdocs/client/state/preferences/README.md' }>{ translate( 'Preferences' ) }</a>
 				<Card className="preferences-helper__current-preferences">
 					{ sortedPreferenceItems.length > 0 ? (
-						<table className="preferences-helper__preferences-table">
+						<table className={ 'preferences-helper__preferences-table' }>
 							<thead>
 								<tr>
 									<th className="preferences-helper__header-unset">{ translate( 'Delete' ) }</th>

--- a/client/lib/preferences-helper/preference-list.js
+++ b/client/lib/preferences-helper/preference-list.js
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,31 +16,42 @@ import Preference from './preference';
 class PreferenceList extends Component {
 	render() {
 		const { preferences, translate } = this.props;
+
+		const sortedPreferenceItems = preferences
+			? Object.keys( preferences )
+					.sort()
+					.map( ( preferenceName ) => (
+						<Preference
+							key={ preferenceName }
+							name={ preferenceName }
+							value={ preferences[ preferenceName ] }
+						/>
+					) )
+			: [];
+
 		return (
-			<div>
+			<>
 				<QueryPreferences />
-				<a
-					href={ '/devdocs/client/state/preferences/README.md' }
-					title={ translate( 'Preferences' ) }
-				>
-					{ translate( 'Preferences' ) }
-				</a>
+				<a href={ '/devdocs/client/state/preferences/README.md' }>{ translate( 'Preferences' ) }</a>
 				<Card className="preferences-helper__current-preferences">
-					{ ! isEmpty( preferences ) ? (
-						Object.keys( preferences ).map( ( preferenceName ) => (
-							<Preference
-								key={ preferenceName }
-								name={ preferenceName }
-								value={ preferences[ preferenceName ] }
-							/>
-						) )
+					{ sortedPreferenceItems.length > 0 ? (
+						<table className="preferences-helper__preferences-table">
+							<thead>
+								<tr>
+									<th className="preferences-helper__header-unset">{ translate( 'Delete' ) }</th>
+									<th className="preferences-helper__header-name">{ translate( 'Name' ) }</th>
+									<th className="preferences-helper__header-value">{ translate( 'Value(s)' ) }</th>
+								</tr>
+							</thead>
+							<tbody>{ sortedPreferenceItems }</tbody>
+						</table>
 					) : (
-						<h5 className="preferences-helper__preference-header">
-							{ translate( 'No Preferences' ) }
+						<h5 className="preferences-helper__no-preferences">
+							{ translate( 'No preferences are currently set' ) }
 						</h5>
 					) }
 				</Card>
-			</div>
+			</>
 		);
 	}
 }

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -39,19 +39,20 @@ class Preference extends Component {
 		}
 
 		return (
-			<div>
-				<div className="preferences-helper__preference-header">
+			<tr>
+				<td className="preferences-helper__preference-unset">
 					<button
-						className="preferences-helper__unset"
 						onClick={ partial( unsetPreference, name, null ) }
 						title={ translate( 'Unset Preference' ) }
 					>
-						{ 'X' }
+						<span role="img" aria-label={ translate( 'Unset Preference' ) }>
+							&#10060;
+						</span>
 					</button>
-					<span>{ name }</span>
-				</div>
-				{ preferenceHandler }
-			</div>
+				</td>
+				<td className="preferences-helper__preference-name">{ name }</td>
+				<td className="preferences-helper__preference-value">{ preferenceHandler }</td>
+			</tr>
 		);
 	}
 }

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -40,7 +40,7 @@ class Preference extends Component {
 
 		return (
 			<tr>
-				<td className="preferences-helper__preference-unset">
+				<td className="preference__unset">
 					<button
 						onClick={ partial( unsetPreference, name, null ) }
 						title={ translate( 'Unset Preference' ) }
@@ -50,8 +50,8 @@ class Preference extends Component {
 						</span>
 					</button>
 				</td>
-				<td className="preferences-helper__preference-name">{ name }</td>
-				<td className="preferences-helper__preference-value">{ preferenceHandler }</td>
+				<td className="preference__name">{ name }</td>
+				<td className="preference__value">{ preferenceHandler }</td>
 			</tr>
 		);
 	}

--- a/client/lib/preferences-helper/string-preference.tsx
+++ b/client/lib/preferences-helper/string-preference.tsx
@@ -45,14 +45,14 @@ const StringPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__preference-save"
+						className="string-preference__save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
 						{ 'save' }
 					</button>{ ' ' }
 					<button
-						className="preferences-helper__preference-reset"
+						className="string-preference__reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>

--- a/client/lib/preferences-helper/string-preference.tsx
+++ b/client/lib/preferences-helper/string-preference.tsx
@@ -45,14 +45,14 @@ const StringPreference: FunctionComponent< Props > = ( { name, value } ) => {
 			{ value !== localValue && (
 				<>
 					<button
-						className="preferences-helper__save-pref-button"
+						className="preferences-helper__preference-save"
 						onClick={ savePreferenceChange }
 						disabled={ value === localValue }
 					>
 						{ 'save' }
 					</button>{ ' ' }
 					<button
-						className="preferences-helper__reset-pref-button"
+						className="preferences-helper__preference-reset"
 						onClick={ resetPreferenceChange }
 						disabled={ value === localValue }
 					>

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -41,12 +41,12 @@
 	overflow: hidden;
 }
 
-.preferences-helper__boolean-preference input {
+.preferences-helper__preferences-table .boolean-preference input {
 	margin: initial;
 }
 
-.preferences-helper__array-preference,
-.preferences-helper__object-preference {
+.preferences-helper__preferences-table .array-preference,
+.preferences-helper__preferences-table .object-preference {
 	margin: initial;
 	list-style: none;
 
@@ -55,21 +55,21 @@
 	}
 }
 
-.preferences-helper__object-preference li {
+.preferences-helper__preferences-table .object-preference li {
 	margin-bottom: 8px;
 }
 
-.preferences-helper__object-preference-property {
+.preferences-helper__preferences-table .object-preference__property {
 	display: block;
 	margin-bottom: 4px;
 	font-family: monospace;
 }
 
-.preferences-helper__array-preference {
+.preferences-helper__preferences-table .array-preference {
 	font-family: monospace;
 }
 
-.preferences-helper__preference-unset {
+.preferences-helper__preferences-table .preference__unset {
 	text-align: center;
 	color: var( --color-accent );
 
@@ -78,13 +78,15 @@
 	}
 }
 
-.preferences-helper__preference-name {
+.preferences-helper__preferences-table .preference__name {
 	text-align: right;
 	font-family: monospace;
 	font-weight: 600;
 }
 
-.preferences-helper__preference-save {
+.preferences-helper__preferences-table .boolean-preference__save,
+.preferences-helper__preferences-table .number-preference__save,
+.preferences-helper__preferences-table .string-preference__save {
 	margin: 0 4px;
 	padding: 4px 8px;
 
@@ -99,7 +101,9 @@
 	}
 }
 
-.preferences-helper__preference-reset {
+.preferences-helper__preferences-table .boolean-preference__reset,
+.preferences-helper__preferences-table .number-preference__reset,
+.preferences-helper__preferences-table .string-preference__reset {
 	margin: 0 4px;
 	padding: 4px 8px;
 
@@ -115,20 +119,21 @@
 	}
 }
 
-.number-preference input,
-.string-preference input {
+.preferences-helper__preferences-table .number-preference input,
+.preferences-helper__preferences-table .string-preference input {
 	margin: 4px 1rem 4px 0;
 }
 
-.boolean-preference input {
+.preferences-helper__preferences-table .boolean-preference input {
 	margin: 8px 1rem 8px 0;
 	appearance: checkbox;
 }
 
 .environment.is-prefs:hover .preferences-helper__current-preferences.card {
 	display: block;
+	max-width: 40vw;
 	max-height: 80vh;
-	overflow-y: scroll;
+	overflow: auto;
 	position: absolute;
 	bottom: 100%;
 	right: 0;

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -1,55 +1,128 @@
 .preferences-helper__current-preferences {
 	display: none;
+	line-height: initial;
+	text-transform: initial;
 }
 
-.preferences-helper__list {
-	margin: 5px 0 8px 20px;
+.preferences-helper__preferences-table {
+	border-collapse: collapse;
+	border-spacing: 1rem;
 
-	li {
-		font-weight: normal;
-		text-transform: initial;
-		margin-right: 5px;
+	th {
+		padding: 4px 8px;
+		border-bottom: 1px solid var( --color-neutral-50 );
+		text-transform: uppercase;
+	}
+
+	td {
+		padding: 12px 8px;
+		border-bottom: 1px solid var( --color-neutral-5 );
+	}
+
+	tr:last-child td {
+		border-bottom: none;
 	}
 }
 
-.preferences-helper__unset {
-	color: var( --color-accent );
-	cursor: pointer;
+.preferences-helper__header-unset {
+	text-align: center;
 }
 
-.preferences-helper__preference-header {
-	text-transform: initial;
-	margin-top: 5px;
+.preferences-helper__header-name {
+	text-align: right;
+}
+
+.preferences-helper__no-preferences {
+	text-align: center;
+
+	font-size: 1.5rem;
 	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
+}
+
+.preferences-helper__boolean-preference input {
+	margin: initial;
+}
+
+.preferences-helper__array-preference,
+.preferences-helper__object-preference {
+	margin: initial;
+	list-style: none;
+
+	li {
+		font-weight: normal;
+	}
+}
+
+.preferences-helper__object-preference li {
+	margin-bottom: 8px;
+}
+
+.preferences-helper__object-preference-property {
+	display: block;
+	margin-bottom: 4px;
+	font-family: monospace;
+}
+
+.preferences-helper__array-preference {
+	font-family: monospace;
+}
+
+.preferences-helper__preference-unset {
+	text-align: center;
+	color: var( --color-accent );
 
 	button {
-		display: inline;
-		margin-right: 5px;
+		cursor: pointer;
 	}
 }
 
-.preferences-helper__save-pref-button {
-	color: var( --color-accent );
+.preferences-helper__preference-name {
+	text-align: right;
+	font-family: monospace;
+	font-weight: 600;
+}
+
+.preferences-helper__preference-save {
+	margin: 0 4px;
+	padding: 4px 8px;
+
+	border-radius: 2px;
+	background-color: var( --color-accent );
+	color: var( --color-text-inverted );
+	font-weight: 600;
+
 	cursor: pointer;
 	&:disabled {
-		color: var( --color-neutral );
+		background-color: var( --color-neutral );
 	}
 }
 
-.preferences-helper__reset-pref-button {
+.preferences-helper__preference-reset {
+	margin: 0 4px;
+	padding: 4px 8px;
+
+	border-radius: 2px;
+	border: 1px solid var( --color-warning );
 	color: var( --color-warning );
+	font-weight: 600;
+
 	cursor: pointer;
+
 	&:disabled {
-		color: var( --color-neutral );
+		color: var( --color-text-subtle );
 	}
 }
 
-.boolean-preference {
-	input {
-		appearance: checkbox;
-	}
+.number-preference input,
+.string-preference input {
+	margin: 4px 1rem 4px 0;
+}
+
+.boolean-preference input {
+	margin: 8px 1rem 8px 0;
+	appearance: checkbox;
 }
 
 .environment.is-prefs:hover .preferences-helper__current-preferences.card {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-style and add translations to the Preferences helper to make it a little friendlier. 🙂
* Migrate from a `div`-based design to a `table`-based one, since preference data is naturally tabular.
* Render object and array-typed preference values in monospace font, since they often contain JSON.
* Make the "save" and "reset" buttons more obviously button-like, with padding/background/borders.
* Limit the `max-width` of the helper panel to 40% of the viewport width.
* Shorten CSS class names where possible, to make reading the code a little less awkward.

##### Implementation notes

* Translations might seem a little over-the-top for a development tool, but several calls to `translate` already existed in the Preferences helper before this PR. I'm not strongly committed to keeping my additions included, but I put them in mainly for consistency's sake.
* This new look takes up more screen real estate, but I don't have a good grasp on how much of a problem that could pose. If we need to shrink it, or even abandon this PR all together, I won't be offended.
* We may want to come back later and re-write this all to use `@wordpress/components`, but I thought this might be nice in the mean-time. 🙂 

#### Testing instructions

* In a local testing environment, start Calypso Blue.
* Open the Preferences Helper by going to the bottom right corner, hovering over the environment name, and then hovering over **PREFERENCES** in the menu that pops out.
* Verify that you're able to manage your user preferences just as in production: deleting should be possible for all items, and altering should be possible for all but the most complex data types. Be sure to test and compare the visibility and behavior of the "save" and "reset" buttons for preference types where they're applicable.

#### Reference captures (before / after)

<img height="300" alt="Screen Shot 2021-06-21 at 14 53 45" src="https://user-images.githubusercontent.com/670067/122819790-7f766d00-d2a0-11eb-9627-86bff218761e.png"> <img height="300" alt="Screen Shot 2021-06-21 at 14 53 02" src="https://user-images.githubusercontent.com/670067/123145101-174f9480-d422-11eb-8fa4-5ee76b7f7b52.png">