### PR TITLE
Checkout: Prevent plan upgrade variants which are term downgrades

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -79,10 +79,13 @@ export function useGetProductVariants(
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
+	debug( 'siteId', siteId );
 	const sitePlans: SitesPlansResult | null = useSelector( ( state ) =>
 		siteId ? getPlansBySiteId( state, siteId ) : null
 	);
+	debug( 'sitePlans', sitePlans );
 	const activePlan = sitePlans?.data?.find( ( plan ) => plan.currentPlan );
+	debug( 'activePlan', activePlan );
 
 	const variantProductSlugs = useVariantPlanProductSlugs( productSlug );
 	debug( 'variantProductSlugs', variantProductSlugs );

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -62,7 +62,7 @@ const Discount = styled.span`
 	}
 `;
 
-const DoNotPayThis = styled.span`
+const DoNotPayThis = styled.del`
 	text-decoration: line-through;
 	margin-right: 8px;
 

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -84,10 +84,12 @@ export function useGetProductVariants(
 		siteId ? getPlansBySiteId( state, siteId ) : null
 	);
 	debug( 'sitePlans', sitePlans );
-	const activePlan = sitePlans?.data?.find( ( plan ) => plan.currentPlan );
+	const activePlan: SitePlanData | undefined = sitePlans?.data?.find(
+		( plan ) => plan.currentPlan
+	);
 	debug( 'activePlan', activePlan );
 
-	const variantProductSlugs = useVariantPlanProductSlugs( productSlug );
+	const variantProductSlugs = useVariantPlanProductSlugs( productSlug, activePlan?.productSlug );
 	debug( 'variantProductSlugs', variantProductSlugs );
 
 	const productsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
@@ -204,8 +206,24 @@ function getVariantPlanProductSlugs( productSlug: string | undefined ): string[]
 	} );
 }
 
-function useVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
-	return useMemo( () => getVariantPlanProductSlugs( productSlug ), [ productSlug ] );
+function isVariantOfActivePlan(
+	activePlanSlug: string | undefined,
+	variantPlanSlug: string
+): boolean {
+	return getVariantPlanProductSlugs( activePlanSlug ).includes( variantPlanSlug );
+}
+
+function useVariantPlanProductSlugs(
+	productSlug: string | undefined,
+	activePlanSlug: string | undefined
+): string[] {
+	return useMemo(
+		() =>
+			getVariantPlanProductSlugs( productSlug ).filter(
+				( slug ) => ! isVariantOfActivePlan( activePlanSlug, slug )
+			),
+		[ productSlug, activePlanSlug ]
+	);
 }
 
 function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -10,6 +10,7 @@ import debugFactory from 'debug';
 import {
 	getTermDuration,
 	getPlan,
+	getBillingMonthsForTerm,
 	findPlansKeys,
 	GROUP_WPCOM,
 	GROUP_JETPACK,
@@ -163,18 +164,19 @@ function getLowestPriceTimesVariantInterval(
 			'There must be at least one variant to compare against when generating relative prices'
 		);
 	}
+
 	allVariants.sort( ( variantA, variantB ) => {
 		const variantAInterval = getTermDuration( variantA.plan.term );
 		const variantBInterval = getTermDuration( variantB.plan.term );
 		return variantAInterval - variantBInterval;
 	} );
 	const lowestVariant = allVariants[ 0 ];
-	const lowestVariantInterval = getTermDuration( lowestVariant.plan.term );
-	const variantInterval = getTermDuration( variant.plan.term );
-	const lowestVariantIntervalsInVariantInterval = Math.ceil(
-		variantInterval / lowestVariantInterval
-	);
-	return lowestVariant.priceFull * lowestVariantIntervalsInVariantInterval;
+
+	const monthsInVariant = getBillingMonthsForTerm( variant.plan.term );
+	const monthsInLowestVariant = getBillingMonthsForTerm( lowestVariant.plan.term );
+	const lowestVariantIntervalsInVariantTerm = Math.round( monthsInVariant / monthsInLowestVariant );
+
+	return lowestVariant.priceFull * lowestVariantIntervalsInVariantTerm;
 }
 
 function isVariantAllowed(

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -83,11 +83,9 @@ export function useGetProductVariants(
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
-	debug( 'siteId', siteId );
 	const sitePlans: SitesPlansResult | null = useSelector( ( state ) =>
 		siteId ? getPlansBySiteId( state, siteId ) : null
 	);
-	debug( 'sitePlans', sitePlans );
 	const activePlan: SitePlanData | undefined = sitePlans?.data?.find(
 		( plan ) => plan.currentPlan
 	);
@@ -99,13 +97,11 @@ export function useGetProductVariants(
 	const variantsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
 		return computeProductsWithPrices( state, siteId, variantProductSlugs, 0, {} );
 	} );
-	debug( 'variantsWithPrices', variantsWithPrices );
 
 	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );
 	const shouldFetchProducts = ! variantsWithPrices;
 
 	useEffect( () => {
-		debug( 'deciding whether to request product variant data' );
 		if ( shouldFetchProducts && ! haveFetchedProducts ) {
 			debug( 'dispatching request for product variant data' );
 			reduxDispatch( requestPlans() );
@@ -127,7 +123,6 @@ export function useGetProductVariants(
 	);
 
 	const filteredVariants = useMemo( () => {
-		debug( 'found unfiltered variants', variantsWithPrices );
 		return variantsWithPrices.filter( ( product ) =>
 			isVariantAllowed( product, activePlan?.interval )
 		);

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -37,9 +37,12 @@ export interface AvailableProductVariant {
 		product_id: number;
 		currency_code: string;
 	};
-	priceFullBeforeDiscount: number;
 	priceFull: number;
 	priceFinal: number;
+}
+
+export interface AvailableProductVariantAndCompared extends AvailableProductVariant {
+	priceFullBeforeDiscount: number;
 }
 
 export interface SitePlanData {
@@ -111,7 +114,7 @@ export function useGetProductVariants(
 	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
 
 	const getProductVariantFromAvailableVariant = useCallback(
-		( variant: AvailableProductVariant ): WPCOMProductVariant => {
+		( variant: AvailableProductVariantAndCompared ): WPCOMProductVariant => {
 			return {
 				variantLabel: getTermText( variant.plan.term, translate ),
 				variantDetails: <VariantPrice variant={ variant } />,
@@ -142,7 +145,7 @@ export function useGetProductVariants(
 
 function addComparativeDiscountsToVariants(
 	variants: AvailableProductVariant[]
-): AvailableProductVariant[] {
+): AvailableProductVariantAndCompared[] {
 	return variants.map( ( variant ) => {
 		return {
 			...variant,
@@ -199,7 +202,7 @@ function isVariantAllowed(
 	return false;
 }
 
-function VariantPrice( { variant }: { variant: AvailableProductVariant } ) {
+function VariantPrice( { variant }: { variant: AvailableProductVariantAndCompared } ) {
 	const currentPrice = variant.priceFinal || variant.priceFull;
 	const isDiscounted = currentPrice !== variant.priceFullBeforeDiscount;
 	return (
@@ -215,7 +218,7 @@ function VariantPrice( { variant }: { variant: AvailableProductVariant } ) {
 	);
 }
 
-function VariantPriceDiscount( { variant }: { variant: AvailableProductVariant } ) {
+function VariantPriceDiscount( { variant }: { variant: AvailableProductVariantAndCompared } ) {
 	const translate = useTranslate();
 	const discountPercentage = Math.round(
 		100 - ( variant.priceFinal / variant.priceFullBeforeDiscount ) * 100

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -185,7 +185,7 @@ function VariantPriceDiscount( { variant }: { variant: AvailableProductVariant }
 	);
 }
 
-function useVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
+function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
 	const chosenPlan = getPlan( productSlug );
 
 	if ( ! chosenPlan ) {
@@ -202,6 +202,10 @@ function useVariantPlanProductSlugs( productSlug: string | undefined ): string[]
 		group: chosenPlan.group,
 		type: chosenPlan.type,
 	} );
+}
+
+function useVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
+	return useMemo( () => getVariantPlanProductSlugs( productSlug ), [ productSlug ] );
 }
 
 function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -674,6 +674,19 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders the monthly variant without a discount percentage for a yearly plan when there is no current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: null,
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		const variantItem = screen.getByText( 'One month' ).closest( 'label' );
+		expect( within( variantItem ).queryByText( 'Save' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders the variant picker with yearly for a yearly plan when there is no current plan', async () => {
 		getPlansBySiteId.mockImplementation( () => ( {
 			data: null,
@@ -686,6 +699,19 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders the yearly variant with a discount percentage for a yearly plan when there is no current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: null,
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		const variantItem = screen.getByText( 'One year' ).closest( 'label' );
+		expect( within( variantItem ).getByText( /Save \d+%/ ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders the variant picker with two-years for a yearly plan when there is no current plan', async () => {
 		getPlansBySiteId.mockImplementation( () => ( {
 			data: null,
@@ -696,6 +722,19 @@ describe( 'CompositeCheckout', () => {
 		fireEvent.click( editOrderButton );
 
 		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the two-year variant with a discount percentage for a yearly plan when there is no current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: null,
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		const variantItem = screen.getByText( 'Two years' ).closest( 'label' );
+		expect( within( variantItem ).getByText( /Save \d+%/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the variant picker without monthly for a yearly plan when the current plan is yearly', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -267,68 +267,7 @@ describe( 'CompositeCheckout', () => {
 		const store = applyMiddleware( thunk )( createStore )( () => {
 			return {
 				plans: {
-					items: [
-						{
-							product_id: planWithoutDomain.product_id,
-							product_slug: planWithoutDomain.product_slug,
-							bill_period: 365,
-							product_type: 'bundle',
-							available: true,
-							price: '$48',
-							formatted_price: '$48',
-							raw_price: 48,
-						},
-						{
-							product_id: planWithoutDomainMonthly.product_id,
-							product_slug: planWithoutDomainMonthly.product_slug,
-							bill_period: 30,
-							product_type: 'bundle',
-							available: true,
-							price: '$7',
-							formatted_price: '$7',
-							raw_price: 7,
-						},
-						{
-							product_id: planWithoutDomainBiannual.product_id,
-							product_slug: planWithoutDomainBiannual.product_slug,
-							bill_period: 730,
-							product_type: 'bundle',
-							available: true,
-							price: '$84',
-							formatted_price: '$84',
-							raw_price: 84,
-						},
-						{
-							product_id: planLevel2.product_id,
-							product_slug: planLevel2.product_slug,
-							bill_period: 365,
-							product_type: 'bundle',
-							available: true,
-							price: '$300',
-							formatted_price: '$300',
-							raw_price: 300,
-						},
-						{
-							product_id: planLevel2Monthly.product_id,
-							product_slug: planLevel2Monthly.product_slug,
-							bill_period: 30,
-							product_type: 'bundle',
-							available: true,
-							price: '$33',
-							formatted_price: '$33',
-							raw_price: 33,
-						},
-						{
-							product_id: planLevel2Biannual.product_id,
-							product_slug: planLevel2Biannual.product_slug,
-							bill_period: 730,
-							product_type: 'bundle',
-							available: true,
-							price: '$499',
-							formatted_price: '$499',
-							raw_price: 499,
-						},
-					],
+					items: getPlansItemsState(),
 				},
 				sites: { items: {} },
 				siteSettings: { items: {} },
@@ -781,7 +720,27 @@ describe( 'CompositeCheckout', () => {
 			const variantItem = screen
 				.getByText( getVariantItemTextForInterval( expectedVariant ) )
 				.closest( 'label' );
-			expect( within( variantItem ).getByText( /Save \d+%/ ) ).toBeInTheDocument();
+			const lowestVariantItem = variantItem.closest( 'ul' ).querySelector( 'label:first-of-type' );
+			const lowestVariantSlug = lowestVariantItem.closest( 'div' ).querySelector( 'input' ).value;
+			const variantSlug = variantItem.closest( 'div' ).querySelector( 'input' ).value;
+
+			const variantData = getPlansItemsState().find(
+				( plan ) => plan.product_slug === variantSlug
+			);
+			const finalPrice = variantData.raw_price;
+			const variantInterval = variantData.bill_period;
+			const lowestVariantData = getPlansItemsState().find(
+				( plan ) => plan.product_slug === lowestVariantSlug
+			);
+			const lowestVariantPrice = lowestVariantData.raw_price;
+			const lowestVariantInterval = lowestVariantData.bill_period;
+			const intervalsInVariant = Math.round( variantInterval / lowestVariantInterval );
+			const priceBeforeDiscount = lowestVariantPrice * intervalsInVariant;
+
+			const discountPercentage = Math.round( 100 - ( finalPrice / priceBeforeDiscount ) * 100 );
+			expect(
+				within( variantItem ).getByText( `Save ${ discountPercentage }%` )
+			).toBeInTheDocument();
 		}
 	);
 
@@ -1463,4 +1422,69 @@ function getVariantItemTextForInterval( type ) {
 		default:
 			throw new Error( `Unknown plan type '${ type }'` );
 	}
+}
+
+function getPlansItemsState() {
+	return [
+		{
+			product_id: planWithoutDomain.product_id,
+			product_slug: planWithoutDomain.product_slug,
+			bill_period: 365,
+			product_type: 'bundle',
+			available: true,
+			price: '$48',
+			formatted_price: '$48',
+			raw_price: 48,
+		},
+		{
+			product_id: planWithoutDomainMonthly.product_id,
+			product_slug: planWithoutDomainMonthly.product_slug,
+			bill_period: 30,
+			product_type: 'bundle',
+			available: true,
+			price: '$7',
+			formatted_price: '$7',
+			raw_price: 7,
+		},
+		{
+			product_id: planWithoutDomainBiannual.product_id,
+			product_slug: planWithoutDomainBiannual.product_slug,
+			bill_period: 730,
+			product_type: 'bundle',
+			available: true,
+			price: '$84',
+			formatted_price: '$84',
+			raw_price: 84,
+		},
+		{
+			product_id: planLevel2.product_id,
+			product_slug: planLevel2.product_slug,
+			bill_period: 365,
+			product_type: 'bundle',
+			available: true,
+			price: '$300',
+			formatted_price: '$300',
+			raw_price: 300,
+		},
+		{
+			product_id: planLevel2Monthly.product_id,
+			product_slug: planLevel2Monthly.product_slug,
+			bill_period: 30,
+			product_type: 'bundle',
+			available: true,
+			price: '$33',
+			formatted_price: '$33',
+			raw_price: 33,
+		},
+		{
+			product_id: planLevel2Biannual.product_id,
+			product_slug: planLevel2Biannual.product_slug,
+			bill_period: 730,
+			product_type: 'bundle',
+			available: true,
+			price: '$499',
+			formatted_price: '$499',
+			raw_price: 499,
+		},
+	];
 }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -699,6 +699,18 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'does not render the variant picker for a renewal of the current plan', async () => {
+		const currentPlanRenewal = { ...planWithoutDomain, extra: { purchaseType: 'renewal' } };
+		const cartChanges = { products: [ currentPlanRenewal ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -203,15 +203,6 @@ const planLevel2Biannual = {
 };
 
 getPlanRawPrice.mockImplementation( () => 144 );
-getPlansBySiteId.mockImplementation( () => ( {
-	data: [
-		{
-			interval: 365,
-			productSlug: planWithoutDomain.product_slug,
-			currentPlan: true,
-		},
-	],
-} ) );
 
 const fetchStripeConfiguration = async () => {
 	return {
@@ -226,6 +217,16 @@ describe( 'CompositeCheckout', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 365,
+					productSlug: planWithoutDomain.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
 
@@ -686,6 +687,80 @@ describe( 'CompositeCheckout', () => {
 		fireEvent.click( editOrderButton );
 
 		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with monthly if there are variants when the current plan is monthly', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with yearly if there are variants when the current plan is monthly', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with two-years if there are variants when the current plan is monthly', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the variant picker if there are variants when the current plan is biannual', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 730,
+					productSlug: planWithoutDomainBiannual.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not render the variant picker if there are no variants after clicking into edit mode', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -662,6 +662,42 @@ describe( 'CompositeCheckout', () => {
 		expect( page.redirect ).not.toHaveBeenCalled();
 	} );
 
+	it( 'renders the variant picker with monthly for a yearly plan when there is no current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: null,
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with yearly for a yearly plan when there is no current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: null,
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with two-years for a yearly plan when there is no current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: null,
+		} ) );
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders the variant picker without monthly for a yearly plan when the current plan is yearly', async () => {
 		const cartChanges = { products: [ planLevel2 ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -28,8 +28,6 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
-jest.mock( 'calypso/state/plans/selectors' );
-import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
@@ -202,8 +200,6 @@ const planLevel2Biannual = {
 	item_subtotal_display: 'R$144',
 };
 
-getPlanRawPrice.mockImplementation( () => 144 );
-
 const fetchStripeConfiguration = async () => {
 	return {
 		public_key: 'abc123',
@@ -271,7 +267,68 @@ describe( 'CompositeCheckout', () => {
 		const store = applyMiddleware( thunk )( createStore )( () => {
 			return {
 				plans: {
-					items: [],
+					items: [
+						{
+							product_id: planWithoutDomain.product_id,
+							product_slug: planWithoutDomain.product_slug,
+							bill_period: 365,
+							product_type: 'bundle',
+							available: true,
+							price: '$48',
+							formatted_price: '$48',
+							raw_price: 48,
+						},
+						{
+							product_id: planWithoutDomainMonthly.product_id,
+							product_slug: planWithoutDomainMonthly.product_slug,
+							bill_period: 30,
+							product_type: 'bundle',
+							available: true,
+							price: '$7',
+							formatted_price: '$7',
+							raw_price: 7,
+						},
+						{
+							product_id: planWithoutDomainBiannual.product_id,
+							product_slug: planWithoutDomainBiannual.product_slug,
+							bill_period: 730,
+							product_type: 'bundle',
+							available: true,
+							price: '$84',
+							formatted_price: '$84',
+							raw_price: 84,
+						},
+						{
+							product_id: planLevel2.product_id,
+							product_slug: planLevel2.product_slug,
+							bill_period: 365,
+							product_type: 'bundle',
+							available: true,
+							price: '$300',
+							formatted_price: '$300',
+							raw_price: 300,
+						},
+						{
+							product_id: planLevel2Monthly.product_id,
+							product_slug: planLevel2Monthly.product_slug,
+							bill_period: 30,
+							product_type: 'bundle',
+							available: true,
+							price: '$33',
+							formatted_price: '$33',
+							raw_price: 33,
+						},
+						{
+							product_id: planLevel2Biannual.product_id,
+							product_slug: planLevel2Biannual.product_slug,
+							bill_period: 730,
+							product_type: 'bundle',
+							available: true,
+							price: '$499',
+							formatted_price: '$499',
+							raw_price: 499,
+						},
+					],
 				},
 				sites: { items: {} },
 				siteSettings: { items: {} },

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -786,6 +786,37 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'does not render the variant picker for a term change from annual to monthly of the current plan', async () => {
+		const cartChanges = { products: [ planWithoutDomainMonthly ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render the variant picker for a term change from monthly to annual of the current plan', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -661,14 +661,30 @@ describe( 'CompositeCheckout', () => {
 		expect( page.redirect ).not.toHaveBeenCalled();
 	} );
 
-	it( 'renders the variant picker if there are variants after clicking into edit mode', async () => {
+	it( 'renders the variant picker without monthly if there are variants when the current plan is yearly', async () => {
 		const cartChanges = { products: [ planLevel2 ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
 
-		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with yearly if there are variants when the current plan is yearly', async () => {
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
 		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with two-years if there are variants when the current plan is yearly', async () => {
+		const cartChanges = { products: [ planLevel2 ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
 		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -662,7 +662,7 @@ describe( 'CompositeCheckout', () => {
 		expect( page.redirect ).not.toHaveBeenCalled();
 	} );
 
-	it( 'renders the variant picker without monthly if there are variants when the current plan is yearly', async () => {
+	it( 'renders the variant picker without monthly for a yearly plan when the current plan is yearly', async () => {
 		const cartChanges = { products: [ planLevel2 ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
@@ -671,7 +671,7 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders the variant picker with yearly if there are variants when the current plan is yearly', async () => {
+	it( 'renders the variant picker with yearly for a yearly plan when the current plan is yearly', async () => {
 		const cartChanges = { products: [ planLevel2 ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
@@ -680,7 +680,7 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the variant picker with two-years if there are variants when the current plan is yearly', async () => {
+	it( 'renders the variant picker with two-years for a yearly plan when the current plan is yearly', async () => {
 		const cartChanges = { products: [ planLevel2 ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
@@ -689,7 +689,7 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the variant picker with monthly if there are variants when the current plan is monthly', async () => {
+	it( 'renders the variant picker with monthly for a yearly plan when the current plan is monthly', async () => {
 		getPlansBySiteId.mockImplementation( () => ( {
 			data: [
 				{
@@ -707,7 +707,7 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the variant picker with yearly if there are variants when the current plan is monthly', async () => {
+	it( 'renders the variant picker with yearly for a yearly plan when the current plan is monthly', async () => {
 		getPlansBySiteId.mockImplementation( () => ( {
 			data: [
 				{
@@ -725,7 +725,7 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the variant picker with two-years if there are variants when the current plan is monthly', async () => {
+	it( 'renders the variant picker with two-years for a yearly plan when the current plan is monthly', async () => {
 		getPlansBySiteId.mockImplementation( () => ( {
 			data: [
 				{
@@ -743,7 +743,61 @@ describe( 'CompositeCheckout', () => {
 		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
 	} );
 
-	it( 'does not render the variant picker if there are variants when the current plan is biannual', async () => {
+	it( 'renders the variant picker with monthly for a two-year plan when the current plan is monthly', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2Biannual ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with yearly for a two-year plan when the current plan is monthly', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2Biannual ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the variant picker with two-year for a two-year plan when the current plan is monthly', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: [
+				{
+					interval: 30,
+					productSlug: planWithoutDomainMonthly.product_slug,
+					currentPlan: true,
+				},
+			],
+		} ) );
+		const cartChanges = { products: [ planLevel2Biannual ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the variant picker for a yearly plan when the current plan is biannual', async () => {
 		getPlansBySiteId.mockImplementation( () => ( {
 			data: [
 				{

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -1,13 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	getPlan,
-	getMonthlyPlanByYearly,
-	getBillingMonthsForTerm,
-	GROUP_WPCOM,
-	TERM_MONTHLY,
-} from '@automattic/calypso-products';
+import { GROUP_WPCOM } from '@automattic/calypso-products';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import { getPlanPrice } from './get-plan-price';
 
@@ -35,7 +29,6 @@ export const computeFullAndMonthlyPricesForPlan = (
 	}
 
 	return {
-		priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
 		priceFull: getPlanPrice( state, siteId, planObject, false ),
 		priceFinal: Math.max(
 			getPlanPrice( state, siteId, planObject, false ) - credits - couponDiscount,
@@ -52,19 +45,8 @@ export const computeFullAndMonthlyPricesForPlan = (
  */
 function computePricesForWpComPlan( state, planObject ) {
 	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false ) || 0;
-	const isMonthly = planObject.term === TERM_MONTHLY;
-	const monthlyPlanObject = isMonthly
-		? planObject
-		: getPlan( getMonthlyPlanByYearly( planObject.getStoreSlug() ) );
-	const priceMonthly = monthlyPlanObject
-		? getPlanRawPrice( state, monthlyPlanObject.getProductId(), true ) || 0
-		: 0;
-	const priceFullBeforeDiscount = priceMonthly
-		? priceMonthly * getBillingMonthsForTerm( planObject.term )
-		: priceFull;
 
 	return {
-		priceFullBeforeDiscount,
 		priceFull,
 		priceFinal: priceFull,
 	};

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -134,7 +134,6 @@ describe( 'selectors', () => {
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
-				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceFinal: 120,
 			} );
@@ -143,7 +142,6 @@ describe( 'selectors', () => {
 		test( 'Should return proper priceFinal if couponDiscounts are provided', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, { def: 60 } ) ).toEqual( {
-				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceFinal: 60,
 			} );
@@ -180,7 +178,7 @@ describe( 'selectors', () => {
 			getPlan.mockImplementation( ( slug ) => testPlans[ slug ] );
 		} );
 
-		test( 'Should return list of shapes { priceFull, priceFullBeforeDiscount, plan, product, planSlug }', () => {
+		test( 'Should return list of shapes { priceFull, plan, product, planSlug }', () => {
 			const state = {
 				productsList: {
 					items: {
@@ -195,7 +193,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
-					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 120,
 				},
@@ -203,7 +200,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan2',
 					plan: testPlans.plan2,
 					product: state.productsList.items.plan2,
-					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceFinal: 240,
 				},
@@ -227,7 +223,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
-					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 60,
 				},
@@ -235,7 +230,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan2',
 					plan: testPlans.plan2,
 					product: state.productsList.items.plan2,
-					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceFinal: 120,
 				},
@@ -257,7 +251,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
-					priceFullBeforeDiscount: 150,
 					priceFinal: 120,
 					priceFull: 120,
 				},
@@ -278,7 +271,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
-					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 120,
 				},
@@ -311,7 +303,6 @@ describe( 'selectors', () => {
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
-					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceFinal: 120,
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR prevents the checkout plan variant picker from showing plan upgrades which are billing term downgrades because that sort of upgrade is not supported by our payments system. That is, it prevents upgrading from one plan to another plan that has a shorter renewal period. For example, while switching from a Yearly Personal plan to a Yearly Business plan is allowed, switching from a Yearly Personal plan to a Monthly Business plan is _not_ allowed.

To prevent some cases where you could end up switching variants and then not be able to return to your previously selected variant, this also disables the variant picker when the cart item is a variant of the active plan.

Finally, to prevent confusion about what the "Save X%" numbers mean in cases where the monthly price is not shown, this also modifies the discount percentage shown on each product variant, which is currently based on the monthly price for that variant, so that it now is based on the smallest displayed variant's price.

Fixes https://github.com/Automattic/wp-calypso/issues/52473

#### Screenshots

On a site that has an annual premium plan upgrading to a business plan, this is editing the order in checkout before this PR:

<img width="570" alt="Screen Shot 2021-07-08 at 7 52 46 PM" src="https://user-images.githubusercontent.com/2036909/125003848-23447480-e026-11eb-990d-5b50c6ee7a57.png">

And this is editing the same order in checkout after this PR:

<img width="571" alt="Screen Shot 2021-07-08 at 7 52 56 PM" src="https://user-images.githubusercontent.com/2036909/125003854-263f6500-e026-11eb-8a83-bc59e414bc70.png">

Here's editing the checkout order for a site with an (expiring) annual premium plan downgrading to monthly before this PR:

<img width="569" alt="Screen Shot 2021-07-08 at 8 03 48 PM" src="https://user-images.githubusercontent.com/2036909/125004555-c8ac1800-e027-11eb-9a55-98389019195f.png">

And here's editing that same order after this PR:

<img width="574" alt="Screen Shot 2021-07-08 at 8 03 56 PM" src="https://user-images.githubusercontent.com/2036909/125004566-cfd32600-e027-11eb-896e-5aad2db14705.png">


#### Testing instructions

Verify unchanged behavior for free plans:

- Using a site which has a free plan, add a paid plan (of any term length) to your cart and visit checkout.
- Click the "Edit" button at the top-right of the first step.
- Verify that you see a variation picker for the plan and that it includes the monthly, yearly, and two-year plan variants.

Verify that monthly plans can upgrade to any term:

- Next, using a site which has a paid _monthly_ plan, add a higher level _monthly_ plan to your cart and visit checkout (eg: if you have a Personal plan, add a Premium or Business plan).
- Click the "Edit" button at the top-right of the first step.
- Verify that you see a variation picker for the plan and that it includes the monthly, yearly, and two-year plan variants.

Verify that yearly plans cannot upgrade to a monthly term:

- Next, using a site which has a paid _yearly_ plan, add a higher level _yearly_ plan to your cart and visit checkout.
- Click the "Edit" button at the top-right of the first step.
- Verify that you see a variation picker for the plan and that it includes only the yearly and two-year plan variants.