### PR TITLE
My Home: Align horizontal padding of text for primary cards on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 @import '../../../grid-mixins.scss';
 
 .site-setup-list {
@@ -24,12 +26,18 @@
 		}
 
 		.site-setup-list__task {
-			padding: 0 24px 16px;
+			padding: 0 16px 16px;
 			border-bottom: 1px solid var( --color-border-subtle );
 			transition: all 0.1s;
+
+			@include break-mobile {
+				padding: 0 24px 16px;
+			}
+
 			&:last-child {
 				border-bottom: none;
 			}
+
 			.task__text {
 				padding: 0;
 			}
@@ -51,21 +59,29 @@
 	}
 
 	.card-heading {
-		padding: 16px 24px;
+		padding: 16px;
 		border-bottom: 1px solid var( --color-border-subtle );
 		display: flex;
 		align-items: center;
+
+		@include break-mobile {
+			padding: 16px 24px;
+		}
 	}
 
 	button.nav-item {
 		display: flex;
 		align-items: center;
-		padding: 16px 24px;
+		padding: 16px;
 		transition: all 0.1s;
 		cursor: pointer;
 		width: 100%;
 		margin: 0;
 		color: var( --color-text );
+
+		@include break-mobile {
+			padding: 16px 24px;
+		}
 
 		&:hover {
 			background-color: var( --color-neutral-0 );

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -18,7 +18,7 @@
 		}
 
 		@include breakpoint-deprecated( '>1040px' ) {
-			padding: 32px;
+			padding: 32px 24px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses a bug pointed out here: https://github.com/Automattic/wp-calypso/pull/53619#discussion_r654142166

The primary card at the top of My Home (usually a "task" that's promoting some feature, but also the site setup card) has 32px padding for widths > 1040. However the rest of My Home uses padding of 32px. This PR makes all of these primary task cards line up.

* Reduce padding on larger screens for the "task" cards
* Adjust padding off site setup menu tasks so they align properly on small screens

These screenshots are from after the change:
<img width="376" alt="storesetup" src="https://user-images.githubusercontent.com/1500769/123042971-b6d54d00-d44b-11eb-9a2d-961f055892d6.png">
<img width="376" alt="sitesetup" src="https://user-images.githubusercontent.com/1500769/123042989-bc329780-d44b-11eb-8fe4-3dfc4076ce90.png">
<img width="805" alt="largerpromocard" src="https://user-images.githubusercontent.com/1500769/123043002-c18fe200-d44b-11eb-9c40-d13a5af28a42.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Everything should be testable with calypso.live
* Test My Home at various screen widths and check that the left edge of the text always stacks up nicely, as shown by the pink line in the screenshots above
* To quickly view a specific view use a url like `/home/{{ site url }}?dev=true&home=VIEW_SITE_SETUP_ECOMMERCE`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53178
