### PR TITLE
Playwright: add a slight delay to Playwright's curl request

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -801,6 +801,10 @@ object RunCalypsoPlaywrightE2eDesktopTests : BuildType({
 						continue
 					fi
 
+					// Wait some seconds to alleviate simulateneous traffic to the serving container
+					// to avoid incurring HTTP 304.
+					sleep 10
+
 					break
 				done
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add a slight delay at end of each `curl` request for Playwright containers due to issues with simultaneous requests possibly causing HTTP 304 to occur.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
