### PR TITLE
Playwright: add ability to generate a test post and refactor existing tests

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -3,6 +3,7 @@
  */
 import { NavbarComponent, SidebarComponent } from '../components';
 import { GutenbergEditorPage } from '../pages';
+import { randomPhrase } from '../../data-helper';
 
 /**
  * Type dependencies
@@ -34,5 +35,22 @@ export class NewPostFlow {
 		const navbarComponent = await NavbarComponent.Expect( this.page );
 		await navbarComponent.clickNewPost();
 		await GutenbergEditorPage.Expect( this.page );
+	}
+
+	/**
+	 * Starts and publishes a new post from the navbar/masterbar button.
+	 *
+	 * @returns {Promise<string>} URL to the published post.
+	 */
+	async getNewTestPost(): Promise< string > {
+		await this.newPostFromNavbar();
+		const gutenbergEditorPage = await GutenbergEditorPage.Expect( this.page );
+		// Not too concerned with variation here so reuse the same phrase for title
+		// and text.
+		const phrase = randomPhrase();
+		await gutenbergEditorPage.enterTitle( phrase );
+		await gutenbergEditorPage.enterText( phrase );
+		// Return the URL of the post.
+		return await gutenbergEditorPage.publish( { getUrl: true } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -220,7 +220,6 @@ export class GutenbergEditorPage extends BaseContainer {
 	 * @returns {Promise<string>} URl of the published entry.
 	 */
 	async _getPublishedURL(): Promise< string > {
-		console.log( 'get publish url hit!' );
 		const title = await this.getTitle();
 		return await this.frame.$eval(
 			`${ selectors.publishPanel } :text("${ title }")`,

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -9,8 +9,6 @@ import { BaseContainer } from '../../base-container';
 import { Page, Frame } from 'playwright';
 
 const selectors = {
-	page: '#main',
-
 	// Like Widget
 	likeWidget: 'iframe.post-likes-widget',
 	likeButton: 'a.like',
@@ -33,7 +31,7 @@ export class PublishedPostPage extends BaseContainer {
 	 * @param {Page} page Underlying page on which interactions take place.
 	 */
 	constructor( page: Page ) {
-		super( page, selectors.page );
+		super( page );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-likes__logged-out-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__logged-out-spec.js
@@ -27,8 +27,13 @@ describe( DataHelper.createSuiteTitle( 'Likes (Logged Out)' ), function () {
 			await loginFlow.logIn();
 			const newPostFlow = new NewPostFlow( this.page );
 			postUrl = await newPostFlow.getNewTestPost();
-			// Clear the cookies for user.
-			await BrowserManager.clearCookies( this.page );
+			// Shut down the BrowserContext that generated the post as
+			// the logged in state appears to be 'sticky' on WPCOM.
+			// Clearing the cache does not appear to reset this state, nor
+			// does the explicit action of logging out.
+			await this.page.context().close();
+			// Generate a new BrowserContext and Page object to be used for testing.
+			this.page = await BrowserManager.start();
 		} );
 
 		it( 'Visit post', async function () {

--- a/test/e2e/specs/specs-playwright/wp-likes__logged-out-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__logged-out-spec.js
@@ -5,8 +5,8 @@ import {
 	DataHelper,
 	BrowserManager,
 	LoginFlow,
+	NewPostFlow,
 	PublishedPostPage,
-	PublishedPostsListPage,
 } from '@automattic/calypso-e2e';
 
 /**
@@ -18,27 +18,30 @@ describe( DataHelper.createSuiteTitle( 'Likes (Logged Out)' ), function () {
 	describe( 'Like an existing post as logged out user', function () {
 		let loginFlow;
 		let publishedPostPage;
-		let publishedPostsListPage;
-		let url;
+		let postUrl;
 
-		it( 'Set up', async function () {
-			url = DataHelper.getAccountSiteURL( user );
+		before( 'Set up', async function () {
+			// Log In, write then publish a new post and save the post URL.
+			// This is done as the default user.
+			loginFlow = new LoginFlow( this.page );
+			await loginFlow.logIn();
+			const newPostFlow = new NewPostFlow( this.page );
+			postUrl = await newPostFlow.getNewTestPost();
+			// Clear the cookies for user.
 			await BrowserManager.clearCookies( this.page );
 		} );
 
-		it( 'Visit site', async function () {
+		it( 'Visit post', async function () {
 			// This is a raw call to the underlying page as it does not warrant creating
 			// an entire flow or page for this one action.
-			await this.page.goto( url );
-		} );
-
-		it( 'Click on first post', async function () {
-			publishedPostsListPage = await PublishedPostsListPage.Expect( this.page, user );
-			await publishedPostsListPage.visitPost( 1 );
+			await this.page.goto( postUrl );
 		} );
 
 		it( 'Like post', async function () {
+			// Upon navigation conclusion, the published post should be on screen.
 			publishedPostPage = await PublishedPostPage.Expect( this.page );
+
+			// Prepare to execute a new log in flow as the specified user.
 			loginFlow = new LoginFlow( this.page, user );
 
 			// Clicking the Like button will bring up a new popup, so

--- a/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
@@ -6,8 +6,6 @@ import {
 	LoginFlow,
 	NewPostFlow,
 	GutenbergEditorPage,
-	MyHomePage,
-	PublishedPostsListPage,
 	PublishedPostPage,
 } from '@automattic/calypso-e2e';
 
@@ -18,7 +16,9 @@ const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 
 describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
-	describe( 'Like a new post', function () {
+	let postUrl;
+
+	describe( 'Create and like a new post', function () {
 		let publishedPostPage;
 		let gutenbergEditorPage;
 
@@ -43,7 +43,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 
 		it( 'Publish and visit post', async function () {
-			await gutenbergEditorPage.publish( { visit: true } );
+			postUrl = await gutenbergEditorPage.publish( { visit: true, getUrl: true } );
 		} );
 
 		it( 'Like post', async function () {
@@ -56,22 +56,17 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 	} );
 
-	describe( 'Like an existing post', function () {
+	describe( 'Like an existing post as non-author', function () {
 		let publishedPostPage;
 
 		it( 'Log in', async function () {
-			const loginFlow = new LoginFlow( this.page, 'gutenbergSimpleSiteUser' );
+			const loginFlow = new LoginFlow( this.page );
 			await loginFlow.logIn();
 		} );
 
-		it( 'Visit site', async function () {
-			const myHomePage = await MyHomePage.Expect( this.page );
-			await myHomePage.visitSite();
-		} );
-
-		it( 'Click on first post', async function () {
-			const publishedPostsListPage = await PublishedPostsListPage.Expect( this.page );
-			await publishedPostsListPage.visitPost( 1 );
+		it( 'Visit post', async function () {
+			// Raw call to the Page object.
+			await this.page.goto( postUrl );
 		} );
 
 		it( 'Like post', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes a refactor of how some of the `Likes` tests are laid out.

Previously, many of the tests under `Likes` banner would seek to open an existing post and perform some interactions there. This caused non-determinism when the post that happened to have been selected was a password-protected post, for example. In this case, the tests would fail unexpectedly.

Changes are proposed for all tests in the `Like` banner that requires a post to first create a test post. This process is tedious and has been encapsulated in a new flow under `NewPostFlow.getNewTestPost`.

## Detailed changes

NewPostFlow
- create a new method to create and return the URL of a test post.

GutenbergEditorPage
- new parameter added to `publish` method to specify if post URL is to be returned to the caller.

wp-likes logged out spec
- refactored test to call the newly implemented NewPostFlow method to generate a test post.
- overall made the test more deterministic and less reliant on chance.

wp-likes post spec
- refactored test to try liking the post as multiple users.

#### Testing instructions

TeamCity
- ensure tests pass
- ensure no muted steps from `wp-likes__logged-out-spec`.

Local
- pull changes
- transpile
- `mocha --config .mocharc_playwright.yml`


