### PR TITLE
Reskinned Domain Picker: Fix content shifts on medium-sized viewports

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -812,7 +812,6 @@ class DomainsStep extends React.Component {
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }
 				skipLabelText={ translate( 'Choose a domain later' ) }
-				align={ isReskinned ? 'left' : 'center' }
 				isWideLayout={ isReskinned }
 			/>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -812,6 +812,7 @@ class DomainsStep extends React.Component {
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }
 				skipLabelText={ translate( 'Choose a domain later' ) }
+				align={ isReskinned ? 'left' : 'center' }
 				isWideLayout={ isReskinned }
 			/>
 		);

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -54,6 +54,10 @@ body.is-section-signup.is-white-signup {
 	.domains__step-content {
 		display: flex;
 
+		@include break-small {
+			justify-content: center;
+		}
+
 		.search-component.is-open {
 			border: 1px solid #a7aaad;
 			border-radius: 4px; /* stylelint-disable-line */

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -54,10 +54,6 @@ body.is-section-signup.is-white-signup {
 	.domains__step-content {
 		display: flex;
 
-		@include break-small {
-			justify-content: center;
-		}
-
 		.search-component.is-open {
 			border: 1px solid #a7aaad;
 			border-radius: 4px; /* stylelint-disable-line */

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -142,7 +142,7 @@ body.is-section-signup.is-white-signup {
 			margin: 20px 20px 0;
 
 			@include break-large {
-				margin: 20px 0 0 20px;
+				margin: 0 0 0 20px;
 			}
 
 			@include break-wide {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -84,7 +84,7 @@ body.is-section-signup.is-white-signup {
 			}
 
 			@include break-wide {
-				width: 20vw;
+				width: 350px;
 			}
 		}
 
@@ -103,8 +103,6 @@ body.is-section-signup.is-white-signup {
 			@include break-large {
 				display: none;
 			}
-
-
 		}
 
 		.domains__domain-side-content {
@@ -118,7 +116,7 @@ body.is-section-signup.is-white-signup {
 				padding: 40px 0;
 			}
 
-			@include break-huge {
+			@include break-wide {
 				margin: 0 0 0 80px;
 			}
 		}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -128,15 +128,7 @@ body.is-section-signup.is-white-signup {
 		}
 
 		.register-domain-step {
-			width: 100vw;
-
-			@include break-large {
-				width: 62vw;
-			}
-
-			@include break-wide {
-				width: 48vw;
-			}
+			flex: 1;
 		}
 
 		.register-domain-step__search-card {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -83,7 +83,7 @@ body.is-section-signup.is-white-signup {
 				display: flex;
 			}
 
-			@include break-xlarge {
+			@include break-wide {
 				width: 20vw;
 			}
 		}
@@ -103,6 +103,8 @@ body.is-section-signup.is-white-signup {
 			@include break-large {
 				display: none;
 			}
+
+
 		}
 
 		.domains__domain-side-content {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -114,8 +114,12 @@ body.is-section-signup.is-white-signup {
 			margin: 0 20px;
 
 			@include break-large {
-				margin: 0 0 0 80px;
+				margin: 0 20px 0 40px;
 				padding: 40px 0;
+			}
+
+			@include break-huge {
+				margin: 0 0 0 80px;
 			}
 		}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -87,7 +87,7 @@ body.is-section-signup.is-white-signup {
 				display: flex;
 			}
 
-			@include break-wide {
+			@include break-xlarge {
 				width: 20vw;
 			}
 		}
@@ -107,8 +107,6 @@ body.is-section-signup.is-white-signup {
 			@include break-large {
 				display: none;
 			}
-
-
 		}
 
 		.domains__domain-side-content {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -806,11 +806,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 	.signup__step.is-domains {
 		.is-wide-layout {
-			max-width: 1200px;
-
-			@include break-huge {
-				max-width: 1280px;
-			}
+			max-width: 1280px;
 		}
 
 		.formatted-header__subtitle {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -811,10 +811,18 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 		.formatted-header__subtitle {
 			text-align: left;
+
+			@include break-large {
+				text-align: center;
+			}
 		}
 
 		.formatted-header__title {
 			text-align: left;
+
+			@include break-large {
+				text-align: center;
+			}
 		}
 	}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -811,18 +811,10 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 		.formatted-header__subtitle {
 			text-align: left;
-
-			@include break-large {
-				text-align: center;
-			}
 		}
 
 		.formatted-header__title {
 			text-align: left;
-
-			@include break-large {
-				text-align: center;
-			}
 		}
 	}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -807,6 +807,10 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-domains {
 		.is-wide-layout {
 			max-width: 1200px;
+
+			@include break-huge {
+				max-width: 1280px;
+			}
 		}
 
 		.formatted-header__subtitle {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* On medium-sized viewports, the content of the Domain step is centered.
* The content always take full width of the content area (max-width being set to 1280px)

### Testing instructions
1. Check out this branch.
2. `yarn && yarn start`
3. Navigate to `/start/domains?flags=signup/reskin`
4. Open dev tools and go through all breakpoints (set the viewport to responsive and resize the screen).
5. Ensure that:
- [ ] The page content is centered on medium-sized viewports.
- [ ] The side content blocks are not shrunken (i.e. condensed) on medium-sized viewports.

Fixes #53936
