### PR TITLE
Remove pure:false flag from connect calls

### DIFF
--- a/apps/notifications/src/panel/templates/summary-in-list.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-list.jsx
@@ -11,10 +11,8 @@ import Gridicon from './gridicons';
 import noticon2gridicon from '../utils/noticon2gridicon';
 import actions from '../state/actions';
 import ImagePreloader from './image-loader';
-
 import { html } from '../indices-to-html';
-
-const { recordTracksEvent } = require( '../helpers/stats' );
+import { recordTracksEvent } from '../helpers/stats';
 
 export class SummaryInList extends React.Component {
 	handleClick = ( event ) => {
@@ -23,7 +21,7 @@ export class SummaryInList extends React.Component {
 
 		if ( event.metaKey || event.shiftKey ) {
 			window.open( this.props.note.url, '_blank' );
-		} else if ( this.props.currentNote == this.props.note.id ) {
+		} else if ( this.props.currentNote === this.props.note.id ) {
 			this.props.unselectNote();
 		} else {
 			recordTracksEvent( 'calypso_notification_note_open', {
@@ -70,4 +68,4 @@ const mapDispatchToProps = {
 	unselectNote: actions.ui.unselectNote,
 };
 
-export default connect( null, mapDispatchToProps, null, { pure: false } )( SummaryInList );
+export default connect( null, mapDispatchToProps )( SummaryInList );

--- a/apps/notifications/src/panel/templates/undo-list-item.jsx
+++ b/apps/notifications/src/panel/templates/undo-list-item.jsx
@@ -100,7 +100,7 @@ export class UndoListItem extends React.Component {
 		const updateSpamStatus = function ( error, data ) {
 			if ( error ) throw error;
 
-			if ( 'spam' != data.status ) {
+			if ( 'spam' !== data.status ) {
 				// TODO: Handle failure to set Spam status
 			}
 		};
@@ -212,6 +212,4 @@ const mapDispatchToProps = {
 	undoAction: actions.ui.undoAction,
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, null, { pure: false } )(
-	localize( UndoListItem )
-);
+export default connect( mapStateToProps, mapDispatchToProps )( localize( UndoListItem ) );

--- a/client/components/sorted-grid/label.jsx
+++ b/client/components/sorted-grid/label.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 
-const Label = ( { itemsCount, itemsPerRow, lastInRow, scale, text } ) => {
+const Label = ( { itemsCount, itemsPerRow, lastInRow, scale, text = '' } ) => {
 	const margin = ( ( 1 % scale ) / ( itemsPerRow - 1 ) ) * 100 || 0;
 	const style = {
 		marginRight: `${ lastInRow ? 0 : margin }%`,
@@ -29,10 +29,6 @@ Label.propTypes = {
 	lastInRow: PropTypes.bool,
 	scale: PropTypes.number.isRequired,
 	text: PropTypes.string,
-};
-
-Label.defaultProps = {
-	text: '',
 };
 
 export default Label;

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -201,7 +201,5 @@ export default connect(
 	{
 		successNotice,
 		recordGoogleEvent,
-	},
-	null,
-	{ pure: false }
+	}
 )( localize( Security2faDisable ) );

--- a/client/me/security-2fa-setup/index.jsx
+++ b/client/me/security-2fa-setup/index.jsx
@@ -96,6 +96,4 @@ class Security2faSetup extends Component {
 	}
 }
 
-export default connect( null, { successNotice }, null, { pure: false } )(
-	localize( Security2faSetup )
-);
+export default connect( null, { successNotice } )( localize( Security2faSetup ) );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -513,8 +513,6 @@ export default withMobileBreakpoint(
 			deleteKeyringConnection,
 			clearMediaErrors,
 			changeMediaSource,
-		},
-		null,
-		{ pure: false }
+		}
 	)( localize( MediaLibraryContent ) )
 );

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -264,7 +264,7 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 };
 
-const connectComponent = connect( mapStateToProps, mapDispatchToProps, null, { pure: false } );
+const connectComponent = connect( mapStateToProps, mapDispatchToProps );
 
 const getFormSettings = partialRight( pick, [ 'jetpack_cloudflare_analytics' ] );
 

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -121,7 +121,7 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 };
 
-const connectComponent = connect( mapStateToProps, mapDispatchToProps, null, { pure: false } );
+const connectComponent = connect( mapStateToProps, mapDispatchToProps );
 
 const getFormSettings = partialRight( pick, [ 'wga' ] );
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -670,33 +670,28 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	};
 };
 
-const connectComponent = connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const siteIsJetpack = isJetpackSite( state, siteId );
-		const selectedSite = getSelectedSite( state );
+const connectComponent = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteIsJetpack = isJetpackSite( state, siteId );
+	const selectedSite = getSelectedSite( state );
 
-		return {
-			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
-			isComingSoon: isSiteComingSoon( state, siteId ),
-			siteIsJetpack,
-			siteIsVip: isVipSite( state, siteId ),
-			siteSlug: getSelectedSiteSlug( state ),
-			selectedSite,
-			isPaidPlan: isCurrentPlanPaid( state, siteId ),
-			siteDomains: getDomainsBySiteId( state, siteId ),
-			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
-			isP2HubSite: isSiteP2Hub( state, siteId ),
-			isAtomicAndEditingToolkitDeactivated: isAtomicAndEditingToolkitPluginDeactivated(
-				state,
-				siteId
-			),
-		};
-	},
-	mapDispatchToProps,
-	null,
-	{ pure: false }
-);
+	return {
+		isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
+		isComingSoon: isSiteComingSoon( state, siteId ),
+		siteIsJetpack,
+		siteIsVip: isVipSite( state, siteId ),
+		siteSlug: getSelectedSiteSlug( state ),
+		selectedSite,
+		isPaidPlan: isCurrentPlanPaid( state, siteId ),
+		siteDomains: getDomainsBySiteId( state, siteId ),
+		isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
+		isP2HubSite: isSiteP2Hub( state, siteId ),
+		isAtomicAndEditingToolkitDeactivated: isAtomicAndEditingToolkitPluginDeactivated(
+			state,
+			siteId
+		),
+	};
+}, mapDispatchToProps );
 
 const getFormSettings = ( settings ) => {
 	const defaultSettings = {

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -217,9 +217,7 @@ const connectComponent = connect(
 			siteIsAutomatedTransfer,
 		};
 	},
-	{ requestPostTypes },
-	null,
-	{ pure: false }
+	{ requestPostTypes }
 );
 
 const getFormSettings = ( settings ) => {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -529,9 +529,4 @@ const mapDispatchToProps = {
 	),
 };
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps,
-	undefined,
-	{ pure: false } // defaults to true, but this component has internal state
-)( protectForm( localize( SeoForm ) ) );
+export default connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SeoForm ) ) );

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -397,7 +397,5 @@ export default connect(
 				path,
 			} ),
 		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
-	},
-	undefined,
-	{ pure: false } // defaults to true, but this component has internal state
+	}
 )( protectForm( localize( SiteVerification ) ) );

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
-import { flowRight } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -101,9 +100,7 @@ const connectComponent = connect(
 
 		return { data, siteSlug, siteId, isLoading };
 	},
-	{ recordGoogleEvent },
-	null,
-	{ pure: false }
+	{ recordGoogleEvent }
 );
 
-export default flowRight( connectComponent, localize )( StatsDownloadCsv );
+export default connectComponent( localize( StatsDownloadCsv ) );


### PR DESCRIPTION
We still have a few `connect()` calls that use the `{ pure: false }` option. Using this option is mostly a misunderstanding: it's _not_ needed when the component merely has local state. The option would be useful only if we wanted to rerender the component even if all props are still the same (in a `===` sense). But it's hard to come up with a reasonable example of such a component.