### PR TITLE
StatsDownloadCsv: remove old unused dataList prop

### DIFF
--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -29,7 +29,6 @@ class StatsDownloadCsv extends Component {
 		siteSlug: PropTypes.string,
 		path: PropTypes.string.isRequired,
 		period: PropTypes.object.isRequired,
-		dataList: PropTypes.object,
 		data: PropTypes.array,
 		query: PropTypes.object,
 		statType: PropTypes.string,
@@ -94,20 +93,11 @@ class StatsDownloadCsv extends Component {
 
 const connectComponent = connect(
 	( state, ownProps ) => {
-		const { dataList, statType, query } = ownProps;
+		const { statType, query } = ownProps;
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSiteSlug( state, siteId );
-		let data;
-		let isLoading;
-
-		// TODO: When `stats-list` is no longer, this can be removed
-		if ( dataList ) {
-			data = dataList.csvData();
-			isLoading = dataList.isLoading();
-		} else {
-			data = getSiteStatsCSVData( state, siteId, statType, query );
-			isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query );
-		}
+		const data = getSiteStatsCSVData( state, siteId, statType, query );
+		const isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query );
 
 		return { data, siteSlug, siteId, isLoading };
 	},

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -24,7 +24,6 @@ class StatsTabs extends React.Component {
 	static propTypes = {
 		activeKey: PropTypes.string,
 		activeIndex: PropTypes.string,
-		dataList: PropTypes.object,
 		selectedTab: PropTypes.string,
 		switchTab: PropTypes.func,
 		tabs: PropTypes.array,


### PR DESCRIPTION
Removes a `dataList` prop that is a remnant of Stats Reduxification that was finished years ago (see #10510 for example). Noticed this prop when working on #53940.

**How to test:**
Verify that `dataList` doesn't appear anywhere in the codebase.