### PR TITLE
G Suite: Remove former New G Suite Account route

### DIFF
--- a/client/lib/gsuite/constants.js
+++ b/client/lib/gsuite/constants.js
@@ -35,7 +35,6 @@ export const GOOGLE_WORKSPACE_PRODUCT_FAMILY = 'Google Workspace';
  * Defines product types to use as slugs in urls.
  *
  * @see emailManagementAddGSuiteUsers() in client/my-sites/email/paths.js
- * @see emailManagementNewGSuiteAccount() in client/my-sites/email/paths.js
  */
 export const GOOGLE_WORKSPACE_PRODUCT_TYPE = 'google-workspace';
 export const GSUITE_PRODUCT_TYPE = 'gsuite';

--- a/client/lib/gsuite/gsuite-product-type.js
+++ b/client/lib/gsuite/gsuite-product-type.js
@@ -28,7 +28,6 @@ export function getProductSlug( productType ) {
  * @param {string} productSlug - slug of the product
  * @returns {string} the corresponding product type
  * @see emailManagementAddGSuiteUsers() in client/my-sites/email/paths.js
- * @see emailManagementNewGSuiteAccount() in client/my-sites/email/paths.js
  */
 export function getProductType( productSlug ) {
 	if ( productSlug === GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -68,7 +68,6 @@ import {
 	emailManagementForwarding,
 	emailManagementManageTitanAccount,
 	emailManagementManageTitanMailboxes,
-	emailManagementNewGSuiteAccount,
 	emailManagementNewTitanAccount,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
@@ -192,7 +191,6 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		emailManagementForwarding,
 		emailManagementManageTitanAccount,
 		emailManagementManageTitanMailboxes,
-		emailManagementNewGSuiteAccount,
 		emailManagementNewTitanAccount,
 		emailManagementTitanControlPanelRedirect,
 	];
@@ -201,10 +199,6 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 	let domainManagementPaths = allPaths.map( ( pathFactory ) => {
 		if ( pathFactory === emailManagementAddGSuiteUsers ) {
 			return emailManagementAddGSuiteUsers( slug, slug, contextParams.productType );
-		}
-
-		if ( pathFactory === emailManagementNewGSuiteAccount ) {
-			return emailManagementNewGSuiteAccount( slug, slug, contextParams.productType );
 		}
 
 		return pathFactory( slug, slug );

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -32,20 +32,6 @@ export default {
 		next();
 	},
 
-	emailManagementNewGSuiteAccount( pageContext, next ) {
-		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<GSuiteAddUsers
-					isNewAccount
-					productType={ pageContext.params.productType }
-					selectedDomainName={ pageContext.params.domain }
-				/>
-			</CalypsoShoppingCartProvider>
-		);
-
-		next();
-	},
-
 	emailManagementManageTitanAccount( pageContext, next ) {
 		pageContext.primary = (
 			<TitanManagementIframe

--- a/client/my-sites/email/email-management/gsuite-user-item/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-user-item/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -69,7 +69,7 @@ function GSuiteUserItem( props ) {
 		const { siteSlug, user } = props;
 
 		return (
-			<Fragment>
+			<>
 				<Button compact={ true } onClick={ onFixClickHandler }>
 					{ translate( 'Finish Setup' ) }
 				</Button>
@@ -84,7 +84,7 @@ function GSuiteUserItem( props ) {
 						visible={ dialogVisible }
 					/>
 				) }
-			</Fragment>
+			</>
 		);
 	};
 

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -17,11 +17,7 @@ import { Button, Card } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
-import {
-	emailManagementAddGSuiteUsers,
-	emailManagementNewGSuiteAccount,
-	emailManagement,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
 import {
@@ -237,23 +233,14 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	render() {
-		const {
-			currentRoute,
-			isNewAccount,
-			productType,
-			translate,
-			selectedDomainName,
-			selectedSite,
-		} = this.props;
+		const { currentRoute, productType, translate, selectedDomainName, selectedSite } = this.props;
 
-		const analyticsPath = isNewAccount
-			? emailManagementNewGSuiteAccount( ':site', ':domain', ':productType', currentRoute )
-			: emailManagementAddGSuiteUsers(
-					':site',
-					selectedDomainName ? ':domain' : undefined,
-					':productType',
-					currentRoute
-			  );
+		const analyticsPath = emailManagementAddGSuiteUsers(
+			':site',
+			selectedDomainName ? ':domain' : undefined,
+			':productType',
+			currentRoute
+		);
 
 		const googleMailServiceFamily = getGoogleMailServiceFamily( getProductSlug( productType ) );
 
@@ -293,7 +280,6 @@ GSuiteAddUsers.propTypes = {
 	currentRoute: PropTypes.string,
 	domains: PropTypes.array.isRequired,
 	gsuiteUsers: PropTypes.array,
-	isNewAccount: PropTypes.bool,
 	isRequestingDomains: PropTypes.bool.isRequired,
 	productType: PropTypes.oneOf( [ GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE ] ),
 	selectedDomainName: PropTypes.string.isRequired,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
@@ -15,7 +15,6 @@ import { withShoppingCart } from '@automattic/shopping-cart';
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
 import { Button, Card } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
-import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import {
@@ -25,7 +24,6 @@ import {
 } from 'calypso/my-sites/email/paths';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
-import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
 import {
 	getEligibleGSuiteDomain,
 	getGoogleMailServiceFamily,
@@ -46,7 +44,6 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import SectionHeader from 'calypso/components/section-header';
-import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
@@ -72,12 +69,14 @@ class GSuiteAddUsers extends React.Component {
 	) {
 		if ( ! isRequestingDomains && 0 === users.length && userCanPurchaseGSuite ) {
 			const domainName = getEligibleGSuiteDomain( selectedDomainName, domains );
+
 			if ( '' !== domainName ) {
 				return {
 					users: newUsers( domainName ),
 				};
 			}
 		}
+
 		return null;
 	}
 
@@ -126,6 +125,7 @@ class GSuiteAddUsers extends React.Component {
 	recordClickEvent = ( eventName ) => {
 		const { recordTracksEvent, selectedDomainName } = this.props;
 		const { users } = this.state;
+
 		recordTracksEvent( eventName, {
 			domain_name: selectedDomainName,
 			user_count: users.length,
@@ -146,6 +146,7 @@ class GSuiteAddUsers extends React.Component {
 
 	componentDidMount() {
 		const { domains, isRequestingDomains, selectedDomainName } = this.props;
+
 		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
 		this.isMounted = true;
 	}
@@ -156,10 +157,13 @@ class GSuiteAddUsers extends React.Component {
 
 	shouldComponentUpdate( nextProps ) {
 		const { domains, isRequestingDomains, selectedDomainName } = nextProps;
+
 		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
+
 		if ( isRequestingDomains || ! domains.length ) {
 			return false;
 		}
+
 		return true;
 	}
 
@@ -183,9 +187,7 @@ class GSuiteAddUsers extends React.Component {
 	renderAddGSuite() {
 		const {
 			domains,
-			domainsWithForwards,
 			gsuiteUsers,
-			isNewAccount,
 			isRequestingDomains,
 			selectedDomainName,
 			translate,
@@ -197,21 +199,11 @@ class GSuiteAddUsers extends React.Component {
 		const selectedDomainInfo = getGSuiteSupportedDomains( domains ).filter(
 			( { domainName } ) => selectedDomainName === domainName
 		);
+
 		const canContinue = areAllUsersValid( users );
 
 		return (
-			<Fragment>
-				{ userCanPurchaseGSuite && isNewAccount && (
-					<Fragment>
-						<EmailExistingForwardsNotice
-							domainsWithForwards={ domainsWithForwards }
-							selectedDomainName={ selectedDomainName }
-						/>
-
-						<QueryEmailForwards domainName={ selectedDomainName } />
-					</Fragment>
-				) }
-
+			<>
 				<SectionHeader
 					label={ translate( 'Add New Mailboxes', {
 						comment: 'This refers to Google Workspace user accounts',
@@ -240,7 +232,7 @@ class GSuiteAddUsers extends React.Component {
 				) : (
 					<AddEmailAddressesCardPlaceholder />
 				) }
-			</Fragment>
+			</>
 		);
 	}
 
@@ -316,10 +308,10 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteId = get( selectedSite, 'ID', null );
 		const domains = getDomainsBySiteId( state, siteId );
+
 		return {
 			currentRoute: getCurrentRoute( state ),
 			domains,
-			domainsWithForwards: getDomainsWithForwards( state, domains ),
 			gsuiteUsers: getGSuiteUsers( state, siteId ),
 			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
 			productsList: getProductsList( state ),

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -52,24 +52,6 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
-			paths.emailManagementNewGSuiteAccount(
-				':site',
-				':domain',
-				productType,
-				paths.emailManagementAllSitesPrefix
-			),
-			paths.emailManagementNewGSuiteAccount( ':site', ':domain', productType ),
-		],
-		handlers: [
-			...commonHandlers,
-			controller.emailManagementNewGSuiteAccount,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	registerMultiPage( {
-		paths: [
 			paths.emailManagementManageTitanAccount(
 				':site',
 				':domain',

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -50,15 +50,6 @@ export function emailManagementAddGSuiteUsers(
 	return '/email/' + productType + '/add-users/' + siteName;
 }
 
-export function emailManagementNewGSuiteAccount(
-	siteName,
-	domainName,
-	productType,
-	relativeTo = null
-) {
-	return emailManagementEdit( siteName, domainName, productType + '/new', relativeTo );
-}
-
 export function emailManagementManageTitanAccount(
 	siteName,
 	domainName,

--- a/client/my-sites/email/titan-redirector/index.jsx
+++ b/client/my-sites/email/titan-redirector/index.jsx
@@ -91,10 +91,11 @@ class TitanRedirector extends Component {
 
 		if ( ! loaded || ! hasAllSitesLoaded ) {
 			return (
-				<React.Fragment>
+				<>
 					{ ! hasAllSitesLoaded && <QuerySites allSites={ true } /> }
+
 					<EmptyContent title={ translate( 'Redirecting…' ) } />
-				</React.Fragment>
+				</>
 			);
 		}
 


### PR DESCRIPTION
This pull request, which is a follow-up of https://github.com/Automattic/wp-calypso/pull/53463, removes a a route that is no longer used. The `Add New Mailboxes` page for Google Workspace was indeed used to create a new Google Workspace account (and add it to the shopping cart) in the past but this is performed in the `Email Comparison` page now. This pull request removes the warning about existing forwards shown on the `Add New Mailboxes` page for Google Workspace since this is also something that is handled by the `Email Comparison` page now. Finally, it updates the rare places where we would reference `Fragment` to use a simpler syntax.

#### Testing instructions

1. Run `git checkout remove/new-gsuite-account-route` and start your server, or open a [live branch](https://calypso.live/?branch=remove/new-gsuite-account-route)
2. Open the [`Emails` page](http://calypso.localhost:3000/email)
3. Assert that you can still add new Google Workspace accounts to the shopping cart
4. Assert that you can still add new Google Workspace (or G Suite) licenses to the shopping cart