### PR TITLE
Reverting 8c1c259 and 35ee52006

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -9,15 +9,11 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { Dialog } from '@automattic/components';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
-import ExternalLink from 'calypso/components/external-link';
-import Gridicon from 'calypso/components/gridicon';
-import Spinner from 'calypso/components/spinner';
 import {
 	getCanonicalTheme,
 	hasActivatedTheme,
@@ -28,15 +24,11 @@ import {
 	getPreActivateThemeId,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
 import {
 	acceptAutoLoadingHomepageWarning,
 	hideAutoLoadingHomepageWarning,
 	activate as activateTheme,
 } from 'calypso/state/themes/actions';
-import { addQueryArgs } from '@wordpress/url';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { preventWidows } from 'calypso/lib/formatting';
 
 /**
  * Style dependencies
@@ -65,25 +57,10 @@ class AutoLoadingHomepageModal extends Component {
 		super( props );
 		this.state = {
 			homepageAction: 'keep_current_homepage',
+
 			// Used to reset state when dialog re-opens, see `getDerivedStateFromProps`
 			wasVisible: props.isVisible,
-			// Don't render the iframe on mobile; Doing it here prevents unnecessary data fetching vs. CSS.
-			isNarrow: isWithinBreakpoint( '<782px' ),
 		};
-	}
-
-	componentDidMount() {
-		// Change the isNarrow state when the size of the browser changes.
-		// (Putting this on an attribute instead of state because of react/no-did-mount-set-state)
-		this.unsubscribe = subscribeIsWithinBreakpoint( '<782px', ( isNarrow ) =>
-			this.setState( { isNarrow } )
-		);
-	}
-
-	componentWillUnmount() {
-		if ( typeof this.unsubscribe === 'function' ) {
-			this.unsubscribe();
-		}
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
@@ -142,7 +119,6 @@ class AutoLoadingHomepageModal extends Component {
 			isCurrentTheme,
 			isVisible = false,
 		} = this.props;
-		const { isNarrow } = this.state;
 
 		// Nothing to do when it's the current theme.
 		if ( isCurrentTheme ) {
@@ -163,18 +139,7 @@ class AutoLoadingHomepageModal extends Component {
 			return null;
 		}
 
-		const {
-			name: themeName,
-			id: themeId,
-			stylesheet,
-			screenshot: themeScreenshot,
-		} = this.props.theme;
-
-		const iframeSrcKeepHomepage = addQueryArgs( '//' + this.props.siteDomain, {
-			theme: stylesheet,
-			hide_banners: 'true',
-			preview_overlay: 'true',
-		} );
+		const { name: themeName, id: themeId } = this.props.theme;
 
 		return (
 			<Dialog
@@ -196,103 +161,39 @@ class AutoLoadingHomepageModal extends Component {
 				] }
 				onClose={ this.closeModalHandler( 'dismiss' ) }
 			>
-				<Gridicon
-					icon="cross"
-					className="themes__auto-loading-homepage-modal-close-icon"
-					onClick={ this.closeModalHandler( 'dismiss' ) }
-				/>
 				<TrackComponentView
 					eventName={ 'calypso_theme_autoloading_homepage_modal_view' }
 					eventProperties={ { theme: themeId } }
 				/>
-				<div className="themes__theme-preview-wrapper">
+				<div>
 					<h1>
-						{ translate( 'How would you like to use %(themeName)s?', {
+						{ translate( 'How would you like to use %(themeName)s on your site?', {
 							args: { themeName },
 						} ) }
 					</h1>
-					<div className="themes__theme-preview-items">
-						<div className="themes__theme-preview-item themes__theme-preview-item-iframe-container">
-							<FormLabel>
-								<div className="themes__iframe-wrapper">
-									<Spinner />
-									{ ! isNarrow && (
-										<iframe
-											scrolling="no"
-											loading="lazy"
-											title={ translate( 'Preview of current homepage with new theme applied' ) }
-											src={ iframeSrcKeepHomepage }
-										/>
-									) }
-								</div>
-								<FormRadio
-									value="keep_current_homepage"
-									checked={ 'keep_current_homepage' === this.state.homepageAction }
-									onChange={ this.handleHomepageAction }
-									label={ preventWidows(
-										translate( 'Switch theme, preserving my homepage content.' )
-									) }
-								/>
-							</FormLabel>
-						</div>
-						<div className="themes__theme-preview-item">
-							<FormLabel>
-								<img
-									src={ themeScreenshot }
-									alt={ translate( "Preview of new theme's default homepage" ) }
-								/>
-								<FormRadio
-									value="use_new_homepage"
-									checked={ 'use_new_homepage' === this.state.homepageAction }
-									onChange={ this.handleHomepageAction }
-									label={ preventWidows(
-										translate( 'Replace my homepage content with the %(themeName)s homepage.', {
-											args: { themeName },
-										} )
-									) }
-								/>
-							</FormLabel>
-						</div>
-					</div>
-					<div className="themes__autoloading-homepage-option-description">
-						{ this.state.homepageAction === 'keep_current_homepage' && (
-							<p>
-								{ preventWidows(
-									translate(
-										'Your new theme design will be applied without changing your homepage content.'
-									)
-								) }{ ' ' }
-								<ExternalLink
-									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-									icon
-									target="__blank"
-								>
-									{ translate( 'Learn more.' ) }
-								</ExternalLink>
-							</p>
-						) }
-						{ this.state.homepageAction === 'use_new_homepage' && (
-							<p>
-								<span
-									// eslint-disable-next-line react/no-danger
-									dangerouslySetInnerHTML={ {
-										__html: preventWidows(
-											translate(
-												'After activation, you can still access your old homepage content under Pages &rarr; Drafts.'
-											)
-										),
-									} }
-								/>{ ' ' }
-								<ExternalLink
-									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-									icon
-									target="__blank"
-								>
-									{ translate( 'Learn more.' ) }
-								</ExternalLink>
-							</p>
-						) }
-					</div>
+					<FormLabel>
+						<FormRadio
+							value="keep_current_homepage"
+							checked={ 'keep_current_homepage' === this.state.homepageAction }
+							onChange={ this.handleHomepageAction }
+							label={ translate( 'Switch to %(themeName)s without changing the homepage content.', {
+								args: { themeName },
+							} ) }
+						/>
+					</FormLabel>
+					<FormLabel>
+						<FormRadio
+							value="use_new_homepage"
+							checked={ 'use_new_homepage' === this.state.homepageAction }
+							onChange={ this.handleHomepageAction }
+							label={ translate(
+								'Replace the homepage content with the %(themeName)s demo content. The existing homepage will be saved as a draft under Pages → Drafts.',
+								{
+									args: { themeName },
+								}
+							) }
+						/>
+					</FormLabel>
 				</div>
 			</Dialog>
 		);
@@ -306,7 +207,6 @@ export default connect(
 
 		return {
 			siteId,
-			siteDomain: getSiteDomain( state, siteId ),
 			installingThemeId,
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,131 +1,27 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
-
 .themes__auto-loading-homepage-modal {
-	position: relative;
-
-	h1 {
-		margin-bottom: 1em;
-		text-align: center;
-	}
-}
-
-.themes__auto-loading-homepage-modal-close-icon {
-	cursor: pointer;
-	width: 16px;
-	height: 16px;
-	position: absolute;
-	top: 10px;
-	right: 10px;
-
-	@include break-medium {
-		width: 24px;
-		height: 24px;
-		right: 20px;
-		top: 20px;
-	}
-}
-
-.themes__auto-loading-homepage-modal-homepage-hint {
-	margin-left: 1.5em;
-	font-size: $font-body-small;
-	font-style: italic;
-	margin-top: -5px;
-}
-
-.themes__theme-preview-wrapper {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	max-width: 700px;
-}
-
-.themes__autoloading-homepage-option-description {
-	font-size: $font-body-small;
 	min-height: 90px;
+	max-width: 400px;
+	margin: 0 auto;
 
-	@include break-medium {
-		width: 70%;
-	}
-}
-
-.themes__theme-preview-items {
-	display: flex;
-	flex-direction: column;
-	margin: 0 0 1em;
-	max-width: 700px;
-
-	@include break-medium {
-		flex-direction: row;
-	}
-}
-
-.themes__theme-preview-item {
-	img,
-	.themes__iframe-wrapper {
-		display: none;
-	}
-
-	@include break-medium {
-		border: 1px solid var( --color-border-subtle );
-		border-radius: 2px;
-		width: 48%;
-		margin-left: 2%;
-
-		img,
-		.themes__iframe-wrapper {
-			display: block;
-			height: 100%;
-			max-height: 235px;
-		}
-
-		.form-label {
-			height: 100%;
-		}
-
-		.form-radio {
-			margin: 1em;
-		}
-
-		.form-radio__label {
-			margin: 1em 1em 1em 3em;
-		}
-
-		&:first-of-type {
-			margin-left: 0;
-			margin-right: 2%;
-		}
-	}
-
-	img {
+	@include breakpoint-deprecated( '<480px' ) {
+		box-sizing: border-box;
 		max-width: 100%;
-		height: auto;
-	}
-}
 
-.themes__theme-preview-item-iframe-container {
-	display: flex;
-	flex-direction: column;
-
-	.themes__iframe-wrapper {
-		flex-grow: 1;
-		overflow: hidden;
-		position: relative;
-		pointer-events: none;
+		+ .dialog__action-buttons .button {
+			display: block;
+			margin: 0 auto 10px;
+			width: 100%;
+		}
 	}
-	iframe {
-		height: 357%;
-		width: 357%;
-		max-width: 357%;
-		transform: scale( 0.28 );
-		transform-origin: top left;
-		position: absolute;
-		top: 0;
-		left: 0;
-	}
-}
 
-.themes__iframe-wrapper .spinner {
-	position: relative;
-	top: 50%;
+	.form-label {
+		font-weight: 400;
+	}
+
+	.themes__auto-loading-homepage-modal-homepage-hint {
+		margin-left: 20px;
+		font-size: 0.875rem;
+		font-style: italic;
+		margin-top: -5px;
+	}
 }

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -17,7 +17,7 @@
 	"dependencies": {
 		"@types/mocha": "^8.2.2",
 		"config": "^1.28.0",
-		"playwright": "1.11.0"
+		"playwright": "^1.12.0"
 	},
 	"devDependencies": {
 		"@types/config": "^0.0.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20731,10 +20731,10 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-playwright@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.11.0.tgz#0796cf08f4756e8187e01c705315d8e1fb48e25f"
-  integrity sha512-s3FQBRpu/pW/vZ/lFYhG/Q3WBUbT2rvMgrgy1PHDA7QtPN910C2rj9Ovd6A/m8yxuLnltd/OKqvlAGevWISHKw==
+playwright@^1.12.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.12.2.tgz#a484447177b061dd76247734fe65d77e3fb139fa"
+  integrity sha512-tSZGeILY70T4imhCMCsvzhoaDm9baosIG5fQncSWprpjVc/X4yYdBQCLBMvOi98H50hvu9fhgy2hpsgFKCsUaw==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -20748,7 +20748,7 @@ playwright@1.11.0:
     proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
     stack-utils "^2.0.3"
-    ws "^7.3.1"
+    ws "^7.4.6"
     yazl "^2.5.1"
 
 please-upgrade-node@^3.2.0:
@@ -28458,7 +28458,7 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.1.2, ws@^7.2.3, ws@^7.3.1, ws@^7.4.4:
+ws@^7.1.2, ws@^7.2.3, ws@^7.3.1, ws@^7.4.4, ws@^7.4.6:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.0.tgz#0033bafea031fb9df041b2026fc72a571ca44691"
   integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR reverts [8c1c259](https://github.com/Automattic/wp-calypso/commit/8c1c2592d623ce9d598065ad5ccd69c874049e9b) and [35ee52006](https://github.com/Automattic/wp-calypso/commit/35ee52006) to investigate deployment issues.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

