### PR TITLE
Site Editor: redirect to wp-admin when preferred to prevent infinite loops

### DIFF
--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
+import { shouldLoadGutenframe } from 'calypso/state/selectors/should-load-gutenframe';
 import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 
 /**
@@ -14,7 +14,7 @@ import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 export const getSiteEditorUrl = ( state, siteId ) => {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
-	if ( ! isEligibleForGutenframe( state, siteId ) ) {
+	if ( ! shouldLoadGutenframe( state, siteId ) ) {
 		return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Check for wp-admin preference in `getSiteEditorUrl` by calling `shouldLoadGutenframe`, which checks for it and also calls `isEligibleForGutenframe` internally.

#### Testing instructions

1. You… don't need to sandbox anything?!?
2. Build this PR locally
3. Turn on "Show wp-admin pages if available" in `/me/account`
4. Manually visit `calypso.localhost:3000/site-editor/YOUR_SITE_URL`. Without this PR, you should see it redirecting to itself infinitely. With this PR, it should redirect to `YOUR_SITE_URL/wp-admin/admin.php?page=gutenberg-edit-site` instead.

Fixes #52216 