### PR TITLE
Auto-Loading Homepage confirmation modal updates

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -1,27 +1,131 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .themes__auto-loading-homepage-modal {
+	position: relative;
+
+	h1 {
+		margin-bottom: 1em;
+		text-align: center;
+	}
+}
+
+.themes__auto-loading-homepage-modal-close-icon {
+	cursor: pointer;
+	width: 16px;
+	height: 16px;
+	position: absolute;
+	top: 10px;
+	right: 10px;
+
+	@include break-medium {
+		width: 24px;
+		height: 24px;
+		right: 20px;
+		top: 20px;
+	}
+}
+
+.themes__auto-loading-homepage-modal-homepage-hint {
+	margin-left: 1.5em;
+	font-size: $font-body-small;
+	font-style: italic;
+	margin-top: -5px;
+}
+
+.themes__theme-preview-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	max-width: 700px;
+}
+
+.themes__autoloading-homepage-option-description {
+	font-size: $font-body-small;
 	min-height: 90px;
-	max-width: 400px;
-	margin: 0 auto;
 
-	@include breakpoint-deprecated( '<480px' ) {
-		box-sizing: border-box;
-		max-width: 100%;
+	@include break-medium {
+		width: 70%;
+	}
+}
 
-		+ .dialog__action-buttons .button {
+.themes__theme-preview-items {
+	display: flex;
+	flex-direction: column;
+	margin: 0 0 1em;
+	max-width: 700px;
+
+	@include break-medium {
+		flex-direction: row;
+	}
+}
+
+.themes__theme-preview-item {
+	img,
+	.themes__iframe-wrapper {
+		display: none;
+	}
+
+	@include break-medium {
+		border: 1px solid var( --color-border-subtle );
+		border-radius: 2px;
+		width: 48%;
+		margin-left: 2%;
+
+		img,
+		.themes__iframe-wrapper {
 			display: block;
-			margin: 0 auto 10px;
-			width: 100%;
+			height: 100%;
+			max-height: 235px;
+		}
+
+		.form-label {
+			height: 100%;
+		}
+
+		.form-radio {
+			margin: 1em;
+		}
+
+		.form-radio__label {
+			margin: 1em 1em 1em 3em;
+		}
+
+		&:first-of-type {
+			margin-left: 0;
+			margin-right: 2%;
 		}
 	}
 
-	.form-label {
-		font-weight: 400;
+	img {
+		max-width: 100%;
+		height: auto;
 	}
+}
 
-	.themes__auto-loading-homepage-modal-homepage-hint {
-		margin-left: 20px;
-		font-size: 0.875rem;
-		font-style: italic;
-		margin-top: -5px;
+.themes__theme-preview-item-iframe-container {
+	display: flex;
+	flex-direction: column;
+
+	.themes__iframe-wrapper {
+		flex-grow: 1;
+		overflow: hidden;
+		position: relative;
+		pointer-events: none;
 	}
+	iframe {
+		height: 357%;
+		width: 357%;
+		max-width: 357%;
+		transform: scale( 0.28 );
+		transform-origin: top left;
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
+}
+
+.themes__iframe-wrapper .spinner {
+	position: relative;
+	top: 50%;
 }


### PR DESCRIPTION
This PR re-applies the same changes that were originally submitted in https://github.com/Automattic/wp-calypso/pull/53796 but had to be reverted due to issues with deployment. It also removes the use of the `@wordpress/url` package which was causing the deployment issues. (See p1624469210216700-slack-C02DQP0FP for details).