### PR TITLE
Themes: Remove unnecessary spacing on auto-loading homepage confirmation modal.

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -234,10 +234,12 @@ class AutoLoadingHomepageModal extends Component {
 						</div>
 						<div className="themes__theme-preview-item">
 							<FormLabel>
-								<img
-									src={ themeScreenshot }
-									alt={ translate( "Preview of new theme's default homepage" ) }
-								/>
+								<div className="themes__theme-preview-image-wrapper">
+									<img
+										src={ themeScreenshot }
+										alt={ translate( "Preview of new theme's default homepage" ) }
+									/>
+								</div>
 								<FormRadio
 									value="use_new_homepage"
 									checked={ 'use_new_homepage' === this.state.homepageAction }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -99,7 +99,7 @@
 	}
 
 	img {
-		max-width: 100%;
+		width: 100%;
 		height: auto;
 	}
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -74,10 +74,16 @@
 		margin-left: 2%;
 
 		img,
-		.themes__iframe-wrapper {
+		.themes__iframe-wrapper,
+		.themes__theme-preview-image-wrapper {
 			display: block;
 			height: 100%;
+		}
+
+		.themes__iframe-wrapper,
+		.themes__theme-preview-image-wrapper {
 			max-height: 235px;
+			overflow: hidden;
 		}
 
 		.form-label {

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -46,6 +46,7 @@
 
 	@include break-medium {
 		width: 70%;
+		min-height: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The auto-loading homepage confirmation modal on the theme showcase has a min-height on its description paragraph in mobile to prevent controls jumping around when changing the selected radio button (which changes the text).
* This is not necessary on desktop and in fact adds extra spacing that looks weird, so this update removes it from medium-breakpoint screens and above.
* This PR also fixes an issue which was preventing demo homepage preview images from completely filling their container.

Before:
![CleanShot 2021-06-23 at 15 18 12@2x](https://user-images.githubusercontent.com/13437011/123162506-4c65e200-d436-11eb-8c93-0f81dc3d8997.png)

After:
![CleanShot 2021-06-23 at 15 16 42@2x](https://user-images.githubusercontent.com/13437011/123162590-669fc000-d436-11eb-8203-79c452a6784b.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Theme Showcase -> Click on three dots menu of a recommended theme (Ideally TwentyTwentyOne since it has a colored background) -> Click activate
* Verify that the modal popup does not have unnecessary space between description paragraph and buttons.
* Verify that right-hand preview image fills whole container.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1624477808051100-slack-C0202PMUXLJ