### PR TITLE
Playwright: add mobile support to pages used by `seo_preview` spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -11,13 +11,14 @@ import { Page } from 'playwright';
 
 const selectors = {
 	content: '#primary',
-	navtabsList: '.section-nav-tabs__list',
+	navTabs: 'div.section-nav-tabs',
+	navTabsDropdownOptions: '.select-dropdown__option',
 
 	// Traffic tab
 	websiteMetaTextArea: '#advanced_seo_front_page_description',
 	seoPreviewButton: '.seo-settings__preview-button',
 	seoPreviewPane: '.web-preview.is-seo',
-	seoPreviewPaneCloseButton: '.web-preview .web-preview__close',
+	seoPreviewPaneCloseButton: '.web-preview__close',
 };
 
 /**
@@ -32,16 +33,7 @@ export class MarketingPage extends BaseContainer {
 	 * @param {Page} page Underlying page on which the actions take place.
 	 */
 	constructor( page: Page ) {
-		super( page, selectors.content );
-	}
-
-	/**
-	 * Post-initialization steps when creating an instance of this object.
-	 *
-	 * @returns {Promise<void>} No return value.
-	 */
-	async _postInit(): Promise< void > {
-		await this.page.waitForSelector( selectors.navtabsList );
+		super( page );
 	}
 
 	/**
@@ -51,9 +43,18 @@ export class MarketingPage extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTabItem( name: string ): Promise< void > {
+		const navTabs = await this.page.waitForSelector( selectors.navTabs );
+		const isDropdown = await navTabs
+			.getAttribute( 'class' )
+			.then( ( value ) => value?.includes( 'is-dropdown' ) );
 		const sanitizedName = toTitleCase( [ name ] );
 
-		await this.page.click( `text=${ sanitizedName }` );
+		if ( isDropdown ) {
+			await navTabs.click();
+			await this.page.click( `${ selectors.navTabsDropdownOptions } >> text=${ name }` );
+		} else {
+			await this.page.click( `text=${ sanitizedName }` );
+		}
 	}
 
 	/* SEO Preview Methods */

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -12,7 +12,7 @@ import { Page } from 'playwright';
 const selectors = {
 	content: '#primary',
 	navTabs: 'div.section-nav-tabs',
-	navTabsDropdownOptions: '.select-dropdown__option',
+	navTabsDropdownOption: '.select-dropdown__option',
 
 	// Traffic tab
 	websiteMetaTextArea: '#advanced_seo_front_page_description',
@@ -51,7 +51,7 @@ export class MarketingPage extends BaseContainer {
 
 		if ( isDropdown ) {
 			await navTabs.click();
-			await this.page.click( `${ selectors.navTabsDropdownOptions } >> text=${ name }` );
+			await this.page.click( `${ selectors.navTabsDropdownOption } >> text=${ name }` );
 		} else {
 			await this.page.click( `text=${ sanitizedName }` );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements mobile viewport support for MarketingPage, used by the `seo_preview` spec.

#### Testing instructions

TeamCity
- ensure tests pass
- if muted tests are present, check if the mutes are caused by the `seo_preview` spec.

Related to #53803 