### PR TITLE
Add support for Type dependencies as a valid header to satisfy the wpcalypso/import-docblock rule.

### DIFF
--- a/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const ERROR_MESSAGE = 'Missing external, internal, WordPress dependencies docblocks';
-const RX_DOCBLOCK = /\/\*\*\n \* ((Ex|In)ternal|WordPress) dependencies\s*\n \*\//i;
+const RX_DOCBLOCK = /\/\*\*\n \* ((Ex|In)ternal|WordPress|Type) dependencies\s*\n \*\//i;
 
 module.exports = {
 	meta: {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
@@ -9,7 +9,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Missing external, internal, WordPress dependencies docblocks';
+const ERROR_MESSAGE = 'Missing external, internal, WordPress, type dependencies docblocks';
 const RX_DOCBLOCK = /\/\*\*\n \* ((Ex|In)ternal|WordPress|Type) dependencies\s*\n \*\//i;
 
 module.exports = {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
@@ -15,7 +15,7 @@ const RX_DOCBLOCK = /\/\*\*\n \* ((Ex|In)ternal|WordPress|Type) dependencies\s*\
 module.exports = {
 	meta: {
 		docs: {
-			description: 'Enforce external, internal, WordPress dependencies docblocks',
+			description: 'Enforce external, internal, WordPress, type dependencies docblocks',
 			category: 'Stylistic Issues',
 		},
 	},

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/import-docblock.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/import-docblock.js
@@ -48,7 +48,7 @@ import eslint from 'eslint';`,
 			code: "import eslint from 'eslint';",
 			errors: [
 				{
-					message: 'Missing external, internal, WordPress dependencies docblocks',
+					message: 'Missing external, internal, WordPress, type dependencies docblocks',
 				},
 			],
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the `wpcalypso/import-docblock` rule to accept headers titled with `Type dependencies` as satisfying this rule.

An example of this file can would have been found in the [`packages/calypso-e2e/element-helper.ts`](https://github.com/Automattic/wp-calypso/pull/53724/files#diff-9c6de88091db68b4510f18ab00b505814c41bc10200edc4efe9ed90af4b26c54) file, where no imports other than types are necessary.

#### Testing instructions

TeamCity
- ensure unit tests pass