### PR TITLE
Skip some tracking tests in mobile due to missing elements on the page

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -156,4 +156,33 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 			)
 		);
 	}
+
+	async toggleGlobalStyles() {
+		if ( this.screenSize === 'mobile' ) {
+			const closed = await driverHelper.clickIfPresent(
+				this.driver,
+				By.css( 'button[aria-label="Close global styles sidebar"]' )
+			);
+
+			if ( ! closed ) {
+				await driverHelper.clickIfPresent(
+					this.driver,
+					By.css( 'button[aria-label="More tools & options"]' )
+				);
+
+				await driverHelper.clickWhenClickable(
+					this.driver,
+					driverHelper.createTextLocator(
+						By.css( 'button[role="menuitemcheckbox"]' ),
+						'Global Styles'
+					)
+				);
+			}
+		} else {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( 'button[aria-label="Global Styles"]' )
+			);
+		}
+	}
 }

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -125,7 +125,7 @@ export function createGeneralTests( { it, editorType, postType } ) {
 	it( 'Tracks "wpcom_block_editor_undo_performed" event', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
-		// The undo button doesn't seem to be available on mobile
+		// The undo button is not available on mobile
 		if ( editor.screenSize === 'mobile' ) {
 			return this.skip();
 		}
@@ -150,7 +150,7 @@ export function createGeneralTests( { it, editorType, postType } ) {
 	it( 'Tracks "wpcom_block_editor_redo_performed" event', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
-		// The redo button doesn't seem to be available on mobile
+		// The redo button is not available on mobile
 		if ( editor.screenSize === 'mobile' ) {
 			return this.skip();
 		}
@@ -177,6 +177,7 @@ export function createGeneralTests( { it, editorType, postType } ) {
 		it( 'Tracks "wpcom_block_editor_details_open" event', async function () {
 			const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
+			// The details button is not available on mobile
 			if ( editor.screenSize === 'mobile' ) {
 				return this.skip();
 			}

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -105,6 +105,11 @@ export function createGeneralTests( { it, editorType, postType } ) {
 	it( 'Tracks "wpcom_block_editor_list_view_toggle" event', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
+		// The list view toggle button is not available on mobile
+		if ( editor.screenSize === 'mobile' ) {
+			return this.skip();
+		}
+
 		await editor.toggleListView(); // Open list view
 		await editor.toggleListView(); // Close list view
 
@@ -119,6 +124,11 @@ export function createGeneralTests( { it, editorType, postType } ) {
 
 	it( 'Tracks "wpcom_block_editor_undo_performed" event', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
+
+		// The undo button doesn't seem to be available on mobile
+		if ( editor.screenSize === 'mobile' ) {
+			return this.skip();
+		}
 
 		await editor.addBlock( 'Heading' );
 		await editor.addBlock( 'Columns' );
@@ -139,6 +149,11 @@ export function createGeneralTests( { it, editorType, postType } ) {
 
 	it( 'Tracks "wpcom_block_editor_redo_performed" event', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
+
+		// The redo button doesn't seem to be available on mobile
+		if ( editor.screenSize === 'mobile' ) {
+			return this.skip();
+		}
 
 		await editor.addBlock( 'Heading' );
 		await editor.addBlock( 'Columns' );
@@ -161,6 +176,10 @@ export function createGeneralTests( { it, editorType, postType } ) {
 	if ( editorType === 'post' ) {
 		it( 'Tracks "wpcom_block_editor_details_open" event', async function () {
 			const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
+
+			if ( editor.screenSize === 'mobile' ) {
+				return this.skip();
+			}
 
 			await editor.toggleDetails(); // Open details
 			await editor.toggleDetails(); // Close details

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -26,12 +26,6 @@ const host = dataHelper.getJetpackHost();
 
 const siteEditorUser = 'siteEditorSimpleSiteUser';
 
-const clickGlobalStylesButton = async ( driver ) =>
-	await driverHelper.clickWhenClickable(
-		driver,
-		By.css( '.edit-site-header__actions button[aria-label="Global Styles"]' )
-	);
-
 const clickBlockSettingsButton = async ( driver ) =>
 	await driverHelper.clickWhenClickable(
 		driver,
@@ -92,7 +86,9 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 		describe( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
 			it( 'when Global Styles sidebar is opened', async function () {
-				await clickGlobalStylesButton( this.driver );
+				const editor = await SiteEditorComponent.Expect( this.driver );
+
+				await editor.toggleGlobalStyles();
 
 				const eventsStack = await getEventsStack( this.driver );
 				const tabSelectedEvents = eventsStack.filter(
@@ -105,8 +101,10 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 
 			it( 'when Global Styles sidebar is closed', async function () {
+				const editor = await SiteEditorComponent.Expect( this.driver );
+
 				// Note the sidebar is already open here because of the previous test.
-				await clickGlobalStylesButton( this.driver );
+				await editor.toggleGlobalStyles();
 
 				const tabSelectedEvents = await getGlobalStylesTabSelectedEvents( this.driver );
 				assert.strictEqual( tabSelectedEvents.length, 1 );
@@ -116,7 +114,14 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 
 			it( `when Global Styles sidebar is closed by opening another sidebar (tab = ${ GLOBAL_STYLES_ROOT_TAB_NAME })`, async function () {
-				await clickGlobalStylesButton( this.driver );
+				const editor = await SiteEditorComponent.Expect( this.driver );
+
+				// It is not possible to open multiple sidebars on mobile.
+				if ( editor.screenSize === 'mobile' ) {
+					return this.skip();
+				}
+
+				await editor.toggleGlobalStyles();
 				await clickBlockSettingsButton( this.driver );
 
 				const tabSelectedEvents = await getGlobalStylesTabSelectedEvents( this.driver );
@@ -127,7 +132,14 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 
 			it( `when Global Styles sidebar is closed by opening another sidebar (tab = ${ GLOBAL_STYLES_BLOCK_TYPE_TAB_NAME })`, async function () {
-				await clickGlobalStylesButton( this.driver );
+				const editor = await SiteEditorComponent.Expect( this.driver );
+
+				// It is not possible to open multiple sidebars on mobile.
+				if ( editor.screenSize === 'mobile' ) {
+					return this.skip();
+				}
+
+				await editor.toggleGlobalStyles();
 				await clickGlobalStylesBlockTypeTab( this.driver );
 				await clickBlockSettingsButton( this.driver );
 
@@ -139,7 +151,9 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 
 			it( 'when tab is changed in Global Styles sidebar', async function () {
-				await clickGlobalStylesButton( this.driver );
+				const editor = await SiteEditorComponent.Expect( this.driver );
+
+				await editor.toggleGlobalStyles();
 				await clickGlobalStylesBlockTypeTab( this.driver );
 				await clickGlobalStylesRootTab( this.driver );
 
@@ -194,6 +208,11 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 		it( "Shouldn't track replaceInnerBlocks after undoing or redoing a template part edit", async function () {
 			const editor = await SiteEditorComponent.Expect( this.driver );
+
+			// This test relies on undo and redo which isn't available on mobile.
+			if ( editor.screenSize === 'mobile' ) {
+				return this.skip();
+			}
 
 			// Insert a template part block and clear the events stack
 			// so the insert event won't intefere with our asserts.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some newly-introduced tracking tests are failing on the mobile viewport because the elements that they try to interact with to trigger the tracking event are missing or invisible. Some of it (or all) might be expected and perhaps the tests aren't taking the viewport into account (to be clarifying).

#### Testing instructions

E2E tests should pass.
