### PR TITLE
Apply new short term designs to my home page

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -1,4 +1,12 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .quick-links.foldable-card.card {
+
+	@include break-large {
+		box-shadow: none;
+	}
+
 	.foldable-card__header {
 		padding: 16px;
 		min-height: auto;
@@ -30,6 +38,7 @@
 	transition: all 0.1s;
 	padding-top: 12px;
 	padding-bottom: 12px;
+	box-shadow: none;
 
 	.quick-links__action-box-image {
 		display: flex;

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -2,7 +2,6 @@
 @import '@wordpress/base-styles/mixins';
 
 .quick-links.foldable-card.card {
-
 	@include break-large {
 		box-shadow: none;
 	}

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -12,7 +12,7 @@
 		min-height: auto;
 
 		@include breakpoint-deprecated( '>480px' ) {
-			padding: 16px 24px;
+			padding: 14px 24px;
 		}
 	}
 
@@ -36,8 +36,8 @@
 	display: flex;
 	align-items: center;
 	transition: all 0.1s;
-	padding-top: 12px;
-	padding-bottom: 12px;
+	padding-top: 8px;
+	padding-bottom: 8px;
 	box-shadow: none;
 
 	.quick-links__action-box-image {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -2,6 +2,10 @@
 @import '@wordpress/base-styles/mixins';
 
 .quick-links.foldable-card.card {
+	&:not( .is-expanded ) {
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+	}
+
 	@include break-large {
 		box-shadow: none;
 	}

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -41,9 +41,6 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
 					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>
-					<h6 className="go-mobile__subheader customer-home__card-subheader">
-						{ translate( 'Make updates on the go.' ) }
-					</h6>
 				</div>
 				<div className="go-mobile__app-badges">
 					{ showIosBadge && (

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -41,6 +41,9 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
 					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>
+					<h6 className="go-mobile__subheader customer-home__card-subheader">
+						{ translate( 'Make updates on the go.' ) }
+					</h6>
 				</div>
 				<div className="go-mobile__app-badges">
 					{ showIosBadge && (

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -15,6 +15,10 @@
 	@include break-mobile {
 		padding: 16px 24px;
 	}
+
+	@include break-large {
+		box-shadow: none;
+	}
 }
 
 .go-mobile__app-badges {
@@ -26,18 +30,21 @@
 }
 
 .go-mobile__email-link {
-	padding-top: 20px;
+	padding-top: 8px;
 	color: var( --color-text-subtle );
 	display: none;
 
 	@include break-large() {
 		display: block;
 	}
+	@include break-xlarge {
+		padding-top: 18px;
+	}
 }
 
 .go-mobile__email-link-button {
 	display: block;
-	margin-top: 16px;
+	margin-top: 14px;
 }
 
 .go-mobile__row.has-2-cols {

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/style.scss
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/style.scss
@@ -1,5 +1,6 @@
 .learn-grow__content .educational-content {
-	padding: 1.5rem 0;
+	margin: 0 -24px;
+	padding: 1.5rem 24px;
 	border-bottom: 1px solid var( --color-neutral-5 );
 
 	&:first-child {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,5 +1,9 @@
 @import './grid-mixins.scss';
 
+body.is-section-home {
+	background: white;
+}
+
 .customer-home__heading {
 	display: flex;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -73,6 +73,10 @@ body.is-section-home {
 	}
 }
 
+.customer-home__main .card {
+	border-radius: 2px;
+}
+
 .customer-home__main .card-heading {
 	margin-bottom: 8px;
 }


### PR DESCRIPTION
Apply design changes from https://github.com/Automattic/wp-calypso/issues/53212#issuecomment-866370338.

#### Changes 


Make page background white
Put a border radius on cards
Remove chevrons from quick links
Remove borders from between quick links
Reduce padding of quick links
Make 'hr's in the Learn/Grow section 100% width on mobile/tablet

Remove border from quick-links and app CTA cards on desktop
~~Remove  "Make updates on the go" App subtitle~~

#### Before Desktop:
<img width="500" alt="Screen Shot 2021-06-24 at 5 05 17 PM" src="https://user-images.githubusercontent.com/22446385/123205822-ab972580-d50e-11eb-9294-7a201be288c3.png">

#### Before Mobile learn/grow section:
<img width="496" alt="Screen Shot 2021-06-24 at 5 11 58 PM" src="https://user-images.githubusercontent.com/22446385/123206325-9a9ae400-d50f-11eb-9984-7cbb1470f93e.png">


#### After Desktop:
<img width="837" alt="Screen Shot 2021-06-24 at 5 05 28 PM" src="https://user-images.githubusercontent.com/22446385/123205849-b94cab00-d50e-11eb-8d50-8572a93a7a00.png">

#### After Mobile learn/grow section:
<img width="494" alt="Screen Shot 2021-06-24 at 5 12 06 PM" src="https://user-images.githubusercontent.com/22446385/123206182-61fb0a80-d50f-11eb-9b21-db418bdf561a.png">

