### PR TITLE
WIP Add logmein e2e tests using playwright

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-logmein-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-logmein-spec.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { DataHelper, LoginFlow, MyHomePage } from '@automattic/calypso-e2e';
+
+describe( DataHelper.createSuiteTitle( 'Logmein' ), function () {
+	describe( 'Like an existing post', function () {
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( this.page, 'louisTestUser' );
+			await loginFlow.logIn();
+		} );
+
+		it( 'Visit site', async function () {
+			const visited = [];
+			this.page.on( 'request', ( request ) => {
+				const url = request.url();
+				if ( url.match( /^https:\/\/c3polikes\.blog/ ) ) {
+					visited.push( url );
+					const from = request.redirectedFrom();
+					if ( from ) {
+						visited.push( from.url() );
+					}
+				}
+			} );
+			// this.page.route( '**', ( route ) => {
+			// 	const url = route.request().url();
+			// 	if ( url.match( /c3polikes\.blog/ ) ) {
+			// 		visited.push( url );
+			// 		visited.push( request.redirectedFrom().url() );
+			// 	}
+			// 	route.continue();
+			// } );
+
+			const myHomePage = await MyHomePage.Expect( this.page );
+			await myHomePage.visitSite();
+
+			console.log( visited );
+		} );
+	} );
+} );


### PR DESCRIPTION
Todo:
- Add user with mapped domain
- Intercept and assert the logmein redirect flow is taking place
- Assert right click sets the updated url

#### Changes proposed in this Pull Request

Add e2e tests covering `logmein` introduced by #53443.

#### Testing instructions

Run with:
```
NODE_CONFIG_ENV=decrypted BROWSERSIZE=desktop ./node_modules/.bin/mocha --config .mocharc_playwright.yml specs/specs-playwright/wp-logmein-spec.js
```

Fixes #54110
