### PR TITLE
E2E tests: Cleanup Site Editor Test

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -32,11 +32,6 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 		}
 		await this.driver.switchTo().defaultContent();
 		await driverHelper.waitUntilAbleToSwitchToFrame( this.driver, this.editoriFrameLocator );
-		await this.driver.sleep( 2000 );
-	}
-
-	async _postInit() {
-		await this.driver.sleep( 2000 );
 	}
 
 	async runInCanvas( fn ) {
@@ -148,7 +143,6 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 			By.css( '.components-menu-group' ),
 			this.explicitWaitMS / 5
 		);
-		await this.driver.sleep( 1000 );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -51,12 +51,12 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 	}
 
 	async waitForTemplateToLoad() {
-		await this.runInCanvas( () =>
-			driverHelper.waitUntilElementLocatedAndVisible(
+		await this.runInCanvas( async () => {
+			await driverHelper.waitUntilElementLocatedAndVisible(
 				this.driver,
 				By.css( '.edit-site-block-editor__block-list' )
-			)
-		);
+			);
+		} );
 	}
 
 	async openBlockInserterAndSearch( searchTerm ) {

--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -23,21 +23,21 @@ describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 
 	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
-		return await this.loginFlow.loginAndSelectMySite();
+		await this.loginFlow.loginAndSelectMySite();
 	} );
 
 	it( 'Can open site editor', async function () {
 		const sidebarComponent = await SidebarComponent.Expect( this.driver );
-		return await sidebarComponent.selectSiteEditor();
+		await sidebarComponent.selectSiteEditor();
 	} );
 
 	it( 'Site editor opens', async function () {
-		return await SiteEditorPage.Expect( this.driver );
+		await SiteEditorPage.Expect( this.driver );
 	} );
 
 	it( 'Template loads', async function () {
 		const editor = await SiteEditorComponent.Expect( this.driver );
-		return await editor.waitForTemplateToLoad();
+		await editor.waitForTemplateToLoad();
 	} );
 
 	it( 'Template parts load', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -42,10 +42,6 @@ describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 
 	it( 'Template parts load', async function () {
 		const editor = await SiteEditorComponent.Expect( this.driver );
-		return await editor.waitForTemplatePartsToLoad();
-	} );
-
-	after( async () => {
-		return await this.driver.switchTo().defaultContent();
+		await editor.waitForTemplatePartsToLoad();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove  unnecessary sleeps
* Remove `afterAll` hook
* Remove unnecessary returns

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure `test/e2e/specs/specs-wpcom/wp-site-editor-spec.js` test suite pass
* Make sure `test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js` test suite pass



Related to #
