### PR TITLE
Add Screen Switcher to Atomic sites only running Jetpack 9.9 and above

### DIFF
--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -12,8 +12,9 @@ import config from '@automattic/calypso-config';
  */
 import ScreenSwitcher, { DEFAULT_VIEW } from './screen-switcher';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import versionCompare from 'calypso/lib/version-compare';
 
 /**
  * Style dependencies
@@ -30,6 +31,9 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	const jetpackVersion = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'jetpack_version' )
+	);
 
 	const handleToggle = ( bool ) => {
 		if ( isBoolean( bool ) ) {
@@ -70,6 +74,11 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 
 	// Only visible on single-site screens of WordPress.com Simple and Atomic sites.
 	if ( ! wpAdminPath || ! siteId || ( isJetpack && ! isAtomic ) ) {
+		return null;
+	}
+
+	// Disable for Atomic sites that are running below Jetpack 9.9
+	if ( isAtomic && jetpackVersion && versionCompare( jetpackVersion, '9.9-alpha', '<' ) ) {
 		return null;
 	}
 

--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -95,7 +95,8 @@ $screen-options-icon-border-y: 7px;
 	}
 }
 
-.screen-switcher__button {
+.screen-switcher__button,
+a.screen-switcher__button {
 	cursor: pointer;
 	border-radius: 4px; /* stylelint-disable-line */
 	padding: 8px;

--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -104,7 +104,7 @@ a.screen-switcher__button {
 	border: 1px solid transparent;
 	display: inline-block;
 	font-size: $font-body-extra-small;
-	color: var( --color-text );
+	color: $gray-700;
 	line-height: normal;
 
 	// When the user sees this component they are going to be in Calypso

--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -104,7 +104,7 @@ a.screen-switcher__button {
 	border: 1px solid transparent;
 	display: inline-block;
 	font-size: $font-body-extra-small;
-	color: $gray-700;
+	color: var( --color-text );
 	line-height: normal;
 
 	// When the user sees this component they are going to be in Calypso

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -30,7 +30,6 @@ import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import { successNotice } from 'calypso/state/notices/actions';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import config from '@automattic/calypso-config';
 
 /**
@@ -97,7 +96,6 @@ const Home = ( {
 
 	return (
 		<Main wideLayout className="customer-home__main">
-			<ScreenOptionsTab wpAdminPath="index.php" />
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }

--- a/config/development.json
+++ b/config/development.json
@@ -173,6 +173,6 @@
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
-		"nav-unification/switcher": false
+		"nav-unification/switcher": true
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -116,7 +116,8 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"use-translation-chunks": true,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false
+		"wordpress-action-search": false,
+		"nav-unification/switcher": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -129,7 +129,8 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false
+		"wordpress-action-search": false,
+		"nav-unification/switcher": true
 	},
 	"rtl": false,
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,7 +133,8 @@
 		"woocommerce/extension-referrers": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false
+		"wordpress-action-search": false,
+		"nav-unification/switcher": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,7 +139,8 @@
 		"woocommerce/extension-referrers": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false
+		"wordpress-action-search": false,
+		"nav-unification/switcher": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables Screen Options in Calypso for Simple Sites
* Enables Screen Options in Calypso for Atomic sites **only when** they are running Jetpack 9.9 or above.
* Enables feature flag in all environments
* Removes Screen Options from My Home (pd2C0z-3q-p2#comment-146)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Calypso live generated below
* Screen Options should be visible on Simple sites
* Screen Options should not be visible on Atomic sites (as Jetpack 9.9 hasn't been released yet)
* Screen Options should not be visible on My Home

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/53981