### PR TITLE
Logout: disable Redux persistence before clearing local storage

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -46,6 +46,7 @@ import initialReducer from 'calypso/state/reducer';
 import { getInitialState, persistOnChange, loadAllState } from 'calypso/state/initial-state';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import userFactory from 'calypso/lib/user';
+import { onDisablePersistence } from 'calypso/lib/user/store';
 import { isOutsideCalypso } from 'calypso/lib/url';
 import { getUrlParts } from '@automattic/calypso-url';
 import { setStore } from 'calypso/state/redux-store';
@@ -429,7 +430,7 @@ const boot = ( currentUser, registerRoutes ) => {
 		const initialState = getInitialState( initialReducer );
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		setStore( reduxStore );
-		persistOnChange( reduxStore );
+		onDisablePersistence( persistOnChange( reduxStore ) );
 		setupLocale( currentUser.get(), reduxStore );
 		configureReduxStore( currentUser, reduxStore );
 		setupMiddlewares( currentUser, reduxStore );

--- a/client/lib/user/store.js
+++ b/client/lib/user/store.js
@@ -23,3 +23,15 @@ export function getStoredUserId() {
 export function setStoredUserId( userId ) {
 	return store.set( 'wpcom_user_id', userId );
 }
+
+const disablePersistenceCallbacks = [];
+
+export function disablePersistence() {
+	for ( const callback of disablePersistenceCallbacks ) {
+		callback();
+	}
+}
+
+export function onDisablePersistence( callback ) {
+	disablePersistenceCallbacks.push( callback );
+}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -22,7 +22,7 @@ import { logoutUser } from 'calypso/state/logout/actions';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar-unified/utils';
-import { clearStore } from 'calypso/lib/user/store';
+import { clearStore, disablePersistence } from 'calypso/lib/user/store';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 
 /**
@@ -51,6 +51,7 @@ class MeSidebar extends React.Component {
 
 		try {
 			const { redirect_to } = await this.props.logoutUser( redirectTo );
+			disablePersistence();
 			await clearStore();
 			window.location.href = redirect_to || '/';
 		} catch {

--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -3,7 +3,12 @@
  */
 import wpcom from 'calypso/lib/wp';
 import userFactory from 'calypso/lib/user';
-import { clearStore, getStoredUserId, setStoredUserId } from 'calypso/lib/user/store';
+import {
+	clearStore,
+	disablePersistence,
+	getStoredUserId,
+	setStoredUserId,
+} from 'calypso/lib/user/store';
 import { CURRENT_USER_FETCH, CURRENT_USER_RECEIVE } from 'calypso/state/action-types';
 import { filterUserObject, getLogoutUrl } from 'calypso/lib/user/shared-utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -76,6 +81,7 @@ export function redirectToLogout( postLogoutRedirectUrl ) {
 		const logoutUrl = getLogoutUrl( userData, postLogoutRedirectUrl );
 
 		// Clear any data stored locally within the user data module or localStorage
+		disablePersistence();
 		await clearStore();
 
 		window.location.href = logoutUrl;

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -709,20 +709,6 @@ describe( 'initial-state', () => {
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		test( 'should not persist invalid state', () => {
-			// Create an invalid state by forcing the user ID stored in the
-			// state to differ from the current mocked user ID.
-			store.dispatch( {
-				type: 'foo',
-				data: 1,
-				userId: userFactory().get().ID + 1,
-			} );
-
-			clock.tick( SERIALIZE_THROTTLE );
-
-			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 0 );
-		} );
-
 		test( 'should persist state for changed state', () => {
 			store.dispatch( {
 				type: 'foo',

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -660,6 +660,7 @@ describe( 'initial-state', () => {
 		let store;
 		let clock;
 		let setStoredItemSpy;
+		let stopPersisting;
 
 		const dataReducer = withPersistence( ( state = null, { data } ) => {
 			if ( data && data !== state ) {
@@ -690,7 +691,7 @@ describe( 'initial-state', () => {
 				.mockImplementation( ( value ) => Promise.resolve( value ) );
 
 			store = createReduxStore( initialState, reducer );
-			persistOnChange( store, false );
+			stopPersisting = persistOnChange( store );
 		} );
 
 		afterEach( () => {
@@ -784,6 +785,24 @@ describe( 'initial-state', () => {
 				'redux-state-123456789',
 				expect.objectContaining( { data: 5 } )
 			);
+		} );
+
+		test( 'should not persist after calling the stop function', () => {
+			store.dispatch( {
+				type: 'foo',
+				data: 1,
+			} );
+			clock.tick( SERIALIZE_THROTTLE );
+			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 );
+
+			stopPersisting();
+
+			store.dispatch( {
+				type: 'foo',
+				data: 1,
+			} );
+			clock.tick( SERIALIZE_THROTTLE );
+			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 ); // no new call
 		} );
 	} );
 } );


### PR DESCRIPTION
When logging out, we clear the local storage so that there are no user data left behind. This PR disables Redux persistence (i.e., the throttled onchange callback and `window.onbeforeunload` callback) before clearing the store. Otherwise, that callback could save the current store from memory back into local storage right after it was cleared.

There was a `isValidReduxKeyAndState` function that attempted to do a damage control when such a state was saved: it checked the user IDs and prevented the state from being used if the IDs didn't match. In this PR I'm removing that function. It was added by @DavidRothstein in #25907 after a long discussion in #25626.

Disabling the Redux persistence is implemented by `persistOnChange` returning an unsubscribe callback and by saving that callback during boot. And then calling it before `clearStore` is called during logout.

**How to test:**
Verify that after logging out, your Redux state is no longer present in the `calypso/calypso_store` IndexedDB database. Before this patch, it was saved there despite `clearStore` being called on logout.