### PR TITLE
Hide menubar on theme pages

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -55,14 +55,9 @@
 			padding-left: 24px;
 		}
 
-		.is-section-theme.has-no-sidebar &,
+		.is-section-theme &,
 		.is-section-themes.has-no-sidebar & {
 			padding: 0;
-			margin: 0;
-		}
-	
-		.is-section-theme & {
-			padding: 0 0 0 calc( var( --sidebar-width-max ) );
 			margin: 0;
 		}
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -34,14 +34,9 @@
 	}
 
 	// Themes sets it own padding/margin
-	.is-section-theme.has-no-sidebar &,
+	.is-section-theme &,
 	.is-section-themes.has-no-sidebar & {
 		padding: 0;
-		margin: 0;
-	}
-
-	.is-section-theme & {
-		padding: 0 0 0 calc( var( --sidebar-width-max ) );
 		margin: 0;
 	}
 

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -582,7 +582,7 @@ $font-size: rem( 14px );
 		}
 
 		&.is-sidebar-overflow {
-			.focus-content.is-section-theme {
+			.is-section-theme {
 				.layout__secondary {
 					transform: translateX( -100% );
 				}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -581,6 +581,14 @@ $font-size: rem( 14px );
 			}
 		}
 
+		&.is-sidebar-overflow {
+			.focus-content.is-section-theme {
+				.layout__secondary {
+					transform: translateX( -100% );
+				}
+			}
+		}
+
 		.sidebar__menu.is-togglable:not( .is-toggle-open ).hovered {
 			// .hovered is handled in client/layout/sidebar/expandable.jsx. Needed for repositioning and hover intent.
 			position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Undos the commit that made the menubar visible.

p1624480146060400-slack-C0202PMUXLJ

#### Testing instructions
Go to  https://wordpress.com/theme/twentytwentyone/[YOUR_SITE] and you should NOT see the menubar

Before:
![image](https://user-images.githubusercontent.com/375980/123263277-29d3d780-d4cf-11eb-92a5-18c7ba99eb9a.png)

After:
![image](https://user-images.githubusercontent.com/375980/123263583-86cf8d80-d4cf-11eb-8960-efe6e3868320.png)


Related to https://github.com/Automattic/wp-calypso/issues/53987