### PR TITLE
E2E: fix launch site free flow test

### DIFF
--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -78,6 +78,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	async skipSuggestion() {
 		// currently used in 'launch-site' and 'new-launch' signup flows
 		const skipSuggestion = By.css( '.domain-skip-suggestion > .button.domain-suggestion__action' );
+		await driverHelper.scrollIntoView( this.driver, skipSuggestion );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			skipSuggestion,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In order to avoid the overlapping elements, we need to scroll down before clicking Skip domain button.

#### Testing instructions

* `[WPCOM] Launch (mobile) @signup @parallel: Launch a free site >  Can launch a site` should pass

#### Screenshots
* **Before**

<img width="350" src="https://user-images.githubusercontent.com/14192054/123268473-ba79da00-d506-11eb-9fb1-64f85f28df65.png" />

* **After**

<img width="350" src="https://user-images.githubusercontent.com/14192054/123268503-c1a0e800-d506-11eb-982c-d342cde3a9c0.png" />


Related to p1624453841073100-slack-C1A1EKDGQ