### PR TITLE
Reskinned Launch: Update UI/UX with small visual tweaks

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -130,6 +130,14 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
+		.plan-features__pricing {
+			.plan-price.is-discounted {
+				.plan-price__currency-symbol {
+					color: var( --color-text );
+				}
+			}
+		}
+
 		.plan-features__scroller-container {
 			.plan-features__scroll-button {
 				background: var( --color-text );

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -62,15 +62,17 @@ export default function ReskinnedProcessingScreen( { flowName, hasPaidDomain } )
 					'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
 				} }
 			/>
-			<p className="reskinned-processing-screen__progress-numbered-steps">
-				{
-					// translators: these are progress steps. Eg: step 1 of 4.
-					sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
-						currentStep: currentStep + 1,
-						totalSteps,
-					} )
-				}
-			</p>
+			{ totalSteps > 1 && (
+				<p className="reskinned-processing-screen__progress-numbered-steps">
+					{
+						// translators: these are progress steps. Eg: step 1 of 4.
+						sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+							currentStep: currentStep + 1,
+							totalSteps,
+						} )
+					}
+				</p>
+			) }
 		</div>
 	);
 }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -193,10 +193,14 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { hideFreePlan, subHeaderText, translate } = this.props;
+		const { flowName, hideFreePlan, subHeaderText, translate } = this.props;
 
 		if ( ! hideFreePlan ) {
 			if ( isDesktop() ) {
+				if ( flowName === 'launch-site' ) {
+					// TODO: return 'Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}.'
+				}
+
 				return translate(
 					"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
 					{
@@ -207,6 +211,9 @@ export class PlansStep extends Component {
 				);
 			}
 
+			if ( flowName === 'launch-site' ) {
+				// TODO: return 'Choose a plan or {{link}}continue with a free site{{/link}}.'
+			}
 			return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
 				components: {
 					link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -196,9 +196,50 @@ export class PlansStep extends Component {
 		const { flowName, hideFreePlan, subHeaderText, translate } = this.props;
 
 		if ( ! hideFreePlan ) {
+			if ( isDesktop() && flowName === 'launch-site' ) {
+				return translate(
+					"Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}.",
+					{
+						components: {
+							link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+						},
+					}
+				);
+			} else if ( isDesktop() ) {
+				return translate(
+					"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
+					{
+						components: {
+							link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+						},
+					}
+				);
+			} else if ( flowName === 'launch-site' ) {
+				return translate( 'Choose a plan or {{link}}continue with a free site{{/link}}.', {
+					components: {
+						link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+					},
+				} );
+			}
+
+			return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
+				components: {
+					link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+				},
+			} );
+		}
+
+		if ( ! hideFreePlan ) {
 			if ( isDesktop() ) {
 				if ( flowName === 'launch-site' ) {
-					// TODO: return 'Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}.'
+					return translate(
+						"Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}.",
+						{
+							components: {
+								link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+							},
+						}
+					);
 				}
 
 				return translate(
@@ -212,7 +253,11 @@ export class PlansStep extends Component {
 			}
 
 			if ( flowName === 'launch-site' ) {
-				// TODO: return 'Choose a plan or {{link}}continue with a free site{{/link}}.'
+				return translate( 'Choose a plan or {{link}}continue with a free site{{/link}}.', {
+					components: {
+						link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+					},
+				} );
 			}
 			return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
 				components: {

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -6,6 +6,7 @@ jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
  */
 import { shallow } from 'enzyme';
 import React from 'react';
+import { isDesktop } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -31,6 +32,13 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+
+jest.mock( '@automattic/viewport', () => {
+	return {
+		...jest.requireActual( '@automattic/viewport' ),
+		isDesktop: jest.fn(),
+	};
+} );
 
 const noop = () => {};
 const props = {
@@ -269,5 +277,51 @@ describe( 'isDotBlogDomainRegistration()', () => {
 				is_domain_registration: true,
 			} )
 		).toBe( false );
+	} );
+
+	describe( 'Subheader text', () => {
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		test( 'should return the correct subheader on desktop when free plan is visible & flowName = launch-site', () => {
+			isDesktop.mockImplementation( () => true );
+
+			const expected = `Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}.`;
+			const comp = shallow(
+				<PlansStep { ...props } flowName="launch-site" hideFreePlan={ false } />
+			);
+
+			expect( comp.find( 'step-wrapper' ).prop( 'subHeaderText' ) ).toEqual( expected );
+		} );
+
+		test( 'should return the correct subheader on desktop when free plan is visible', () => {
+			isDesktop.mockImplementation( () => true );
+
+			const expected = `Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.`;
+			const comp = shallow( <PlansStep { ...props } hideFreePlan={ false } /> );
+
+			expect( comp.find( 'step-wrapper' ).prop( 'subHeaderText' ) ).toEqual( expected );
+		} );
+
+		test( 'should return the correct subheader on non-desktop when free plan is visible & flow name = launch-site', () => {
+			isDesktop.mockImplementation( () => false );
+
+			const expected = `Choose a plan or {{link}}continue with a free site{{/link}}.`;
+			const comp = shallow(
+				<PlansStep { ...props } flowName="launch-site" hideFreePlan={ false } />
+			);
+
+			expect( comp.find( 'step-wrapper' ).prop( 'subHeaderText' ) ).toEqual( expected );
+		} );
+
+		test( 'should return the correct subheader on non-desktop when free plan is visible', () => {
+			isDesktop.mockImplementation( () => false );
+
+			const expected = `Choose a plan or {{link}}start with a free site{{/link}}.`;
+			const comp = shallow( <PlansStep { ...props } hideFreePlan={ false } /> );
+
+			expect( comp.find( 'step-wrapper' ).prop( 'subHeaderText' ) ).toEqual( expected );
+		} );
 	} );
 } );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -495,7 +495,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			color: $gray-100;
 			letter-spacing: 0.2px;
 			font-size: 2.25rem; /* stylelint-disable-line */
-			text-align: center;
+			text-align: left;
 			padding: 0 20px;
 
 			@include break-xlarge {
@@ -507,7 +507,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		.formatted-header__subtitle {
 			color: $gray-60;
 			font-size: 1rem;
-			text-align: center;
+			text-align: left;
 			padding: 0 20px;
 
 			@include break-xlarge {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Heading & Subheading are aligned to the left  (4a0c2316b798d37d24fe5d7be78adb42f5452565).
* Update discounted currency color (0bd3206dbcedb3e198fc89c81cf7d8f6ad19ae9a).
* Update launch page subheader text (16f91e25edfcb206f051d6f46ba4dd0e47a05d97).
* Hide "Step 1 of 1" copy from the Processing screen.

### For translators
See https://github.com/Automattic/wp-calypso/pull/53993#discussion_r660612306

> Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}.
> Choose a plan or {{link}}continue with a free site{{/link}}.

The user has 2 choices:
1. Select one of the plans in the overview or.
2. Continue with a free-tier plan and skip the plan selection.

<img width="1384" alt="Screenshot 2021-06-29 at 16 20 33" src="https://user-images.githubusercontent.com/12104589/123814401-f2619280-d8f5-11eb-8c4b-6a3e26e86668.png">

<img width="376" alt="Screenshot 2021-06-29 at 16 27 11" src="https://user-images.githubusercontent.com/12104589/123815558-e0ccba80-d8f6-11eb-858a-d8965d24b12e.png">

### Testing instructions
1. Check out this branch
2. `yarn && yarn start`
3. Navigate to `/start/launch-site/domains-launch?siteSlug={{SITE_SLUG}}`
4. Switch to a mobile viewport with dev tools. 
5. Ensure that:
    - [x] The title & subtitle are left-aligned
    - [x] The step counter shows **2** steps instead of 3.
6. Skip the domain purchase by picking the free domain.
7. Ensure that on the plans page:
    - [x] The subheader text is "Choose a plan or {{link}}continue with a free site{{/link}}".
8. Switch to a desktop viewport with dev tools.
9. Ensure that on the plans page:
    - [x] The subheader text is "Pick one that's right for you and unlock features that help you grow. Or {{link}}continue with a free site{{/link}}".
10. Continue to launch your site and ensure that:
     - [x] No step counter is displayed on the reskinned processing screen.

#### Testing the discounted currency color
For elaborate instructions on proxying to other countries, go to PCYsg-qMt-p2.

1. Proxy to India (BOM)
2. Navigate to `/start/launch-site/plans-launch?siteSlug={{SITE_SLUG}}&flags=signup/reskin`
3. Ensure that:
    - [ ] The discounted currency symbol is the same color as the price.




Fixes #53973, fixes #54118