### PR TITLE
Signup: Remove separator on signup form for logged in users

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -987,7 +987,7 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.horizontal && (
+				{ this.props.horizontal && ! this.userCreationComplete() && (
 					<div className="signup-form__separator">
 						<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes https://github.com/Automattic/wp-calypso/issues/53942

#### Testing instructions

Make sure https://github.com/Automattic/wp-calypso/issues/53942 isn't reproducible.

