### PR TITLE
Disables loading alternate URLs for for support posts that have a blo…

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -6,6 +6,7 @@ export const RESULT_ARTICLE = 'article';
 export const RESULT_TOUR = 'tour';
 export const RESULT_VIDEO = 'video';
 export const RESULT_POST_ID = 'post_id';
+export const RESULT_BLOG_ID = 'blog_id';
 export const VIEW_CONTACT = 'contact';
 export const VIEW_RICH_RESULT = 'richresult';
 export const VIEW_FORUM = 'forums';

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -22,8 +22,8 @@ import QuerySupportArticleAlternates from 'calypso/components/data/query-support
 import { isDefaultLocale } from 'calypso/lib/i18n-utils';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
-import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
 import getInlineSupportArticlePostId from 'calypso/state/selectors/get-inline-support-article-post-id';
+import getInlineSupportArticleBlogId from 'calypso/state/selectors/get-inline-support-article-blog-id';
 import getInlineSupportArticleActionUrl from 'calypso/state/selectors/get-inline-support-article-action-url';
 import getInlineSupportArticleActionLabel from 'calypso/state/selectors/get-inline-support-article-action-label';
 import getInlineSupportArticleActionIsExternal from 'calypso/state/selectors/get-inline-support-article-action-is-external';
@@ -39,6 +39,7 @@ import {
  */
 import './style.scss';
 import './content.scss';
+import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
 
 const noop = () => {};
 
@@ -136,14 +137,21 @@ const getPostKey = memoize(
 
 const mapStateToProps = ( state ) => {
 	const postId = getInlineSupportArticlePostId( state );
+	const requestBlogId = getInlineSupportArticleBlogId( state );
+	const blogId = requestBlogId ?? SUPPORT_BLOG_ID;
 	const actionUrl = getInlineSupportArticleActionUrl( state );
 	const actionLabel = getInlineSupportArticleActionLabel( state );
 	const actionIsExternal = getInlineSupportArticleActionIsExternal( state );
 
-	let postKey = getPostKey( SUPPORT_BLOG_ID, postId );
+	let postKey = getPostKey( blogId, postId );
 	const locale = getCurrentLocaleSlug( state );
-	const shouldRequestAlternates =
+	let shouldRequestAlternates =
 		! isDefaultLocale( locale ) && shouldRequestSupportArticleAlternates( state, postKey );
+	// disable alternates for posts that have a blog ID set
+	if ( requestBlogId ) {
+		shouldRequestAlternates = false;
+	}
+
 	const isRequestingAlternates = isRequestingSupportArticleAlternates( state, postKey );
 	const supportArticleAlternates = getSupportArticleAlternatesForLocale( state, postKey, locale );
 

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -22,6 +22,7 @@ import QuerySupportArticleAlternates from 'calypso/components/data/query-support
 import { isDefaultLocale } from 'calypso/lib/i18n-utils';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
 import getInlineSupportArticlePostId from 'calypso/state/selectors/get-inline-support-article-post-id';
 import getInlineSupportArticleBlogId from 'calypso/state/selectors/get-inline-support-article-blog-id';
 import getInlineSupportArticleActionUrl from 'calypso/state/selectors/get-inline-support-article-action-url';
@@ -39,7 +40,6 @@ import {
  */
 import './style.scss';
 import './content.scss';
-import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
 
 const noop = () => {};
 

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -24,6 +24,7 @@ import {
 	RESULT_LINK,
 	RESULT_TOUR,
 	RESULT_TYPE,
+	RESULT_BLOG_ID,
 } from 'calypso/blocks/inline-help/constants';
 
 /**
@@ -69,8 +70,9 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 		trackResultView( result );
 
 		const resultPostId = get( result, RESULT_POST_ID );
+		const resultBlogId = get( result, RESULT_BLOG_ID );
 		const resultLink = getResultLink( result );
-		openDialog( { postId: resultPostId, actionUrl: resultLink } );
+		openDialog( { postId: resultPostId, actionUrl: resultLink, blogId: resultBlogId } );
 	};
 
 	return (

--- a/client/state/inline-support-article/actions.js
+++ b/client/state/inline-support-article/actions.js
@@ -16,6 +16,7 @@ import 'calypso/state/inline-support-article/init';
  * @param {string} options.postUrl     The URL of the support article
  * @param {string} options.actionLabel Label of the action
  * @param {string} options.actionUrl   URL of the action
+ * @param {number} options.blogId      The blog id of the support article
  *
  * @returns {object}		Action
  */
@@ -24,6 +25,7 @@ export function openSupportArticleDialog( {
 	postUrl = null,
 	actionLabel = null,
 	actionUrl = null,
+	blogId = null,
 } ) {
 	return {
 		type: SUPPORT_ARTICLE_DIALOG_OPEN,
@@ -31,6 +33,7 @@ export function openSupportArticleDialog( {
 		postUrl,
 		actionLabel,
 		actionUrl,
+		blogId,
 	};
 }
 

--- a/client/state/inline-support-article/reducer.js
+++ b/client/state/inline-support-article/reducer.js
@@ -15,12 +15,19 @@ export default withStorageKey(
 			postId: null,
 			postUrl: null,
 			isVisible: false,
+			blogId: null,
 		},
 		action
 	) => {
 		switch ( action.type ) {
 			case SUPPORT_ARTICLE_DIALOG_OPEN: {
-				const { postId, postUrl = null, actionLabel = null, actionUrl = null } = action;
+				const {
+					postId,
+					postUrl = null,
+					actionLabel = null,
+					actionUrl = null,
+					blogId = null,
+				} = action;
 
 				return {
 					postUrl,
@@ -28,6 +35,7 @@ export default withStorageKey(
 					isVisible: true,
 					actionLabel,
 					actionUrl,
+					blogId,
 				};
 			}
 			case SUPPORT_ARTICLE_DIALOG_CLOSE:

--- a/client/state/selectors/get-inline-support-article-blog-id.js
+++ b/client/state/selectors/get-inline-support-article-blog-id.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/inline-support-article/init';
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * @param {object} state Global app state
+ * @returns {object} ...
+ */
+export default ( state ) => get( state, 'inlineSupportArticle.blogId' );

--- a/client/state/selectors/get-inline-support-article-blog-id.js
+++ b/client/state/selectors/get-inline-support-article-blog-id.js
@@ -4,12 +4,7 @@
 import 'calypso/state/inline-support-article/init';
 
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * @param {object} state Global app state
  * @returns {object} ...
  */
-export default ( state ) => get( state, 'inlineSupportArticle.blogId' );
+export default ( state ) => state.inlineSupportArticle?.blogId;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The support document search used to only return English results.  In order to support our Mag-16 languages, if the user locale was not set to English a call was made to load alternates, in order to find the support page on the localised support website. 

The `help/search` endpoint has been updated to search the localised support blogs directly, so the returned results are not only from the English support website, causing the load alternates call to fail:


![](https://user-images.githubusercontent.com/36699353/122484667-4aada180-cf92-11eb-88f4-240ebc3d686e.gif)

 This diff disables the load alternates call for support posts that contain a blog ID. 

#### Testing instructions

1. Navigate to `/home`.
2. In the support section, click one of the default support links and make sure the dialog opens and the post is loaded correctly. 
3. In the support section, search for a support document. For example, search for the word "domains":
<img width="735" alt="image" src="https://user-images.githubusercontent.com/23708351/123320299-3c372b00-d53a-11eb-902e-ee835fac6f47.png">
Click one of the results and make sure the post is loaded correctly. 

4. Change your account language to one of the Mag-16 languages and repeat the above 2 steps, confirming that the post loads correctly.

![image](https://user-images.githubusercontent.com/23708351/123320550-92a46980-d53a-11eb-9ac1-9a8877afc25c.gif)


