### PR TITLE
build: Install devDependencies on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ ENV CONTAINER 'docker'
 ENV WEBPACK_OPTIONS '--progress=profile'
 ENV COMMIT_SHA $commit_sha
 ENV CALYPSO_ENV production
-ENV NODE_ENV production
 ENV WORKERS $workers
 ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true
@@ -63,6 +62,7 @@ RUN rm -fr /calypso/apps/editing-toolkit /calypso/apps/o2-blocks /calypso/apps/w
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
+ENV NODE_ENV production
 RUN yarn run build && rm -fr .cache
 
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,7 +11,6 @@ ENV PERSISTENT_CACHE=true
 ENV PROFILE=true
 ENV SKIP_TSC=true
 ENV NVM_DIR=/calypso/.nvm
-ENV NODE_ENV=production
 ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
@@ -31,7 +30,7 @@ RUN cd / \
 	# Prime yarn cache
 	&& yarn \
 	# Prime webpack caches
-	&& yarn build-client-both
+	&& NODE_ENV=production yarn build-client-both
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || yarn run build-client-both && yarn run build-languages-if-enabled",
 		"build-client-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || yarn run build-client-fallback",
 		"build-client-stats": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=true yarn run build-client-evergreen",
-		"build-packages": "{ [ \"$SKIP_TSC\" == \"true\" ] || tsc --build packages/tsconfig.json; } && lerna run prepare --stream",
+		"build-packages": "{ [ \"$SKIP_TSC\" = \"true\" ] || tsc --build packages/tsconfig.json; } && lerna run prepare --stream",
 		"build-languages": "yarn run translate && node bin/build-languages.js",
 		"build-languages-if-enabled": "node -e \"(process.env.BUILD_TRANSLATION_CHUNKS === 'true' || process.env.ENABLE_FEATURES === 'use-translation-chunks') && process.exit(1)\" || yarn run build-languages",
 		"calypso-doctor": "./node_modules/.bin/calypso-doctor",


### PR DESCRIPTION
#### Background

When `yarn` install dependencies, it looks at the value of `NODE_ENV` to decide whether to install devDependencies or not (https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-production-true-false).

This can cause problems as we need the devDependencies to bundle the app.

#### Changes proposed in this Pull Request

* Do not set `NODE_ENV` before running `yarn`

#### Testing instructions

N/A