### PR TITLE
Media Library: Move VideoPress shortcode and restyle for easier usability

### DIFF
--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -108,7 +108,7 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 		}
 
 		return (
-			<tr>
+			<tr className="detail-file-info__shortcode">
 				<th>{ this.props.translate( 'Shortcode' ) }</th>
 				<td>
 					<ClipboardButtonInput value={ '[wpvideo ' + videopressGuid + ']' } />
@@ -125,6 +125,7 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 		return (
 			<table className={ classes }>
 				<tbody>
+					{ this.renderVideoPressShortcode() }
 					<tr>
 						<th>{ this.props.translate( 'File Name' ) }</th>
 						<td title={ this.getItemValue( 'file' ) }>
@@ -138,7 +139,6 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 					{ this.renderFileSize() }
 					{ this.renderDimensions() }
 					{ this.renderDuration() }
-					{ this.renderVideoPressShortcode() }
 					<tr>
 						<th>{ this.props.translate( 'Upload Date' ) }</th>
 						<td>{ this.getItemValue( 'date' ) }</td>

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -166,6 +166,25 @@
 	display: block;
 	flex-basis: 50%;
 	width: 100%;
+
+	&.detail-file-info__shortcode {
+		flex-basis: 100%;
+
+		th {
+			color: inherit;
+			font-size: 14px;
+			width: 100%;
+			text-transform: none;
+		}
+
+		td {
+			width: 100%;
+
+			&::after {
+				display: none;
+			}
+		}
+	}
 }
 
 .editor-media-modal-detail__file-info th,


### PR DESCRIPTION
The VideoPress shortcode was crammed in with a grid of other metadata items, making it impossible to see the text of the shortcode. This PR moves it to the top of the grid, and makes it full width:

Before:

<img width="343" alt="Screen Shot 2021-06-24 at 3 18 03 PM" src="https://user-images.githubusercontent.com/789137/123334040-be562e00-d4ff-11eb-82f0-17566554404d.png">

After:

<img width="351" alt="Screen Shot 2021-06-24 at 3 17 33 PM" src="https://user-images.githubusercontent.com/789137/123334077-c6ae6900-d4ff-11eb-8a83-fc5618308a71.png">

#### Testing instructions
* Open the media library for a site that has videos.
* Click on a video to view its detail modal.
* Observe the new layout for the shortcode field. The copy button should still work as expected.
* Check on a small screen as well.

