### PR TITLE
Customer Home: try wide width site selector

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -434,6 +434,7 @@ class SiteSelector extends Component {
 			'is-single': this.props.visibleSiteCount === 1,
 			'is-wide-layout': this.props.isWideLayout,
 			'is-grid': this.state.displayMode === 'grid',
+			'is-list': this.state.displayMode !== 'grid',
 			'is-hover-enabled': ! this.state.isKeyboardEngaged,
 		} );
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -82,7 +82,7 @@ class SiteSelector extends Component {
 	};
 
 	state = {
-		displayMode: this.props.isWideLayout ? 'grid' : 'list',
+		displayMode: 'list',
 		highlightedIndex: -1,
 		showSearch: false,
 		isKeyboardEngaged: false,
@@ -429,14 +429,18 @@ class SiteSelector extends Component {
 
 		const showDisplayToggle = this.props.isWideLayout;
 
-		const selectorClass = classNames( 'site-selector', 'sites-list', this.props.className, {
-			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
-			'is-single': this.props.visibleSiteCount === 1,
-			'is-wide-layout': this.props.isWideLayout,
-			'is-grid': this.state.displayMode === 'grid',
-			'is-list': this.state.displayMode !== 'grid',
-			'is-hover-enabled': ! this.state.isKeyboardEngaged,
-		} );
+		const selectorClass = classNames(
+			'site-selector',
+			'sites-list',
+			this.props.className,
+			'is-' + this.state.displayMode,
+			{
+				'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
+				'is-single': this.props.visibleSiteCount === 1,
+				'is-wide-layout': this.props.isWideLayout,
+				'is-hover-enabled': ! this.state.isKeyboardEngaged,
+			}
+		);
 
 		this.visibleSites = [];
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -27,6 +27,7 @@ import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
+import SegmentedControl from 'calypso/components/segmented-control';
 import SiteSelectorAddSite from './add-site';
 import searchSites from 'calypso/components/search-sites';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
@@ -44,6 +45,7 @@ const debug = debugFactory( 'calypso:site-selector' );
 class SiteSelector extends Component {
 	static propTypes = {
 		isPlaceholder: PropTypes.bool,
+		isWideLayout: PropTypes.bool,
 		sites: PropTypes.array,
 		siteBasePath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		showAddNewSite: PropTypes.bool,
@@ -70,6 +72,7 @@ class SiteSelector extends Component {
 		showAllSites: false,
 		siteBasePath: false,
 		indicator: false,
+		isWideLayout: false,
 		hideSelected: false,
 		selected: null,
 		onClose: noop,
@@ -79,6 +82,7 @@ class SiteSelector extends Component {
 	};
 
 	state = {
+		displayMode: this.props.isWideLayout ? 'grid' : 'list',
 		highlightedIndex: -1,
 		showSearch: false,
 		isKeyboardEngaged: false,
@@ -92,6 +96,10 @@ class SiteSelector extends Component {
 			showSearch: terms ? true : this.state.showSearch,
 			isKeyboardEngaged: true,
 		} );
+	};
+
+	onDisplayToggleClick = ( mode ) => {
+		this.setState( { displayMode: mode } );
 	};
 
 	componentDidUpdate( prevProps, prevState ) {
@@ -391,6 +399,25 @@ class SiteSelector extends Component {
 		);
 	}
 
+	renderDisplayToggle() {
+		return (
+			<SegmentedControl>
+				<SegmentedControl.Item
+					selected={ this.state.displayMode === 'grid' }
+					onClick={ () => this.onDisplayToggleClick( 'grid' ) }
+				>
+					{ this.props.translate( 'Grid' ) }
+				</SegmentedControl.Item>
+				<SegmentedControl.Item
+					selected={ this.state.displayMode === 'list' }
+					onClick={ () => this.onDisplayToggleClick( 'list' ) }
+				>
+					{ this.props.translate( 'List' ) }
+				</SegmentedControl.Item>
+			</SegmentedControl>
+		);
+	}
+
 	render() {
 		// Render an empty div.site-selector element as a placeholder. It's useful for lazy
 		// rendering of the selector in sidebar while keeping the on-appear animation work.
@@ -400,9 +427,13 @@ class SiteSelector extends Component {
 
 		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 
+		const showDisplayToggle = this.props.isWideLayout;
+
 		const selectorClass = classNames( 'site-selector', 'sites-list', this.props.className, {
 			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
 			'is-single': this.props.visibleSiteCount === 1,
+			'is-wide-layout': this.props.isWideLayout,
+			'is-grid': this.state.displayMode === 'grid',
 			'is-hover-enabled': ! this.state.isKeyboardEngaged,
 		} );
 
@@ -416,15 +447,18 @@ class SiteSelector extends Component {
 				onMouseMove={ this.onMouseMove }
 				onMouseLeave={ this.onMouseLeave }
 			>
-				<Search
-					onSearch={ this.onSearch }
-					delaySearch={ true }
-					// eslint-disable-next-line jsx-a11y/no-autofocus
-					autoFocus={ this.props.autoFocus }
-					disabled={ ! this.props.hasLoadedSites }
-					onSearchClose={ this.props.onClose }
-					onKeyDown={ this.onKeyDown }
-				/>
+				<div className="site-selector__search-filter">
+					<Search
+						onSearch={ this.onSearch }
+						delaySearch={ true }
+						// eslint-disable-next-line jsx-a11y/no-autofocus
+						autoFocus={ this.props.autoFocus }
+						disabled={ ! this.props.hasLoadedSites }
+						onSearchClose={ this.props.onClose }
+						onKeyDown={ this.onKeyDown }
+					/>
+					{ showDisplayToggle && this.renderDisplayToggle() }
+				</div>
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
 					{ this.renderAllSites() }
 					{ this.renderRecentSites( sites ) }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -24,7 +24,6 @@ import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-
 import getSites from 'calypso/state/selectors/get-sites';
 import getVisibleSites from 'calypso/state/selectors/get-visible-sites';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
-import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
@@ -33,6 +32,7 @@ import SiteSelectorAddSite from './add-site';
 import searchSites from 'calypso/components/search-sites';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { getUrlParts, getUrlFromParts, determineUrlType, format } from '@automattic/calypso-url';
+import { CompactCard } from '@automattic/components';
 
 /**
  * Style dependencies
@@ -311,23 +311,28 @@ class SiteSelector extends Component {
 	}
 
 	renderAllSites() {
-		if ( ! this.props.showAllSites || this.props.sitesFound || ! this.props.allSitesPath ) {
+		const { allSitesPath, showAllSites, sitesFound, translate } = this.props;
+
+		if ( ! showAllSites || sitesFound || ! allSitesPath ) {
 			return null;
 		}
 
 		this.visibleSites.push( ALL_SITES );
 
-		const isHighlighted = this.isHighlighted( ALL_SITES );
+		const classes = classNames( 'all-sites', {
+			'is-selected': this.isSelected( ALL_SITES ),
+		} );
 
 		return (
-			<AllSites
+			<CompactCard
+				className={ classes }
+				displayAsLink
 				key="selector-all-sites"
-				sites={ this.props.sites }
-				onSelect={ this.onAllSitesSelect }
+				onClick={ this.onAllSitesSelect }
 				onMouseEnter={ this.onAllSitesHover }
-				isHighlighted={ isHighlighted }
-				isSelected={ this.isSelected( ALL_SITES ) }
-			/>
+			>
+				{ translate( 'Manage All My Sites' ) }
+			</CompactCard>
 		);
 	}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -226,10 +226,6 @@ class SiteSelector extends Component {
 		}
 	};
 
-	onAllSitesSelect = ( event ) => {
-		this.onSiteSelect( event, ALL_SITES );
-	};
-
 	onSiteHover = ( event, siteId ) => {
 		if ( this.lastMouseHover !== siteId ) {
 			debug( `${ siteId } hovered` );
@@ -326,9 +322,8 @@ class SiteSelector extends Component {
 		return (
 			<CompactCard
 				className={ classes }
-				displayAsLink
+				href="/home"
 				key="selector-all-sites"
-				onClick={ this.onAllSitesSelect }
 				onMouseEnter={ this.onAllSitesHover }
 			>
 				{ translate( 'Manage All My Sites' ) }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -83,7 +83,7 @@ class SiteSelector extends Component {
 	};
 
 	state = {
-		displayMode: 'list',
+		displayMode: 'grid',
 		highlightedIndex: -1,
 		showSearch: false,
 		isKeyboardEngaged: false,

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 import classNames from 'classnames';
 import { filter, find, flow, get, includes, isEmpty } from 'lodash';
 import debugFactory from 'debug';
+import { Icon, grid, listView } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -405,14 +406,16 @@ class SiteSelector extends Component {
 				<SegmentedControl.Item
 					selected={ this.state.displayMode === 'grid' }
 					onClick={ () => this.onDisplayToggleClick( 'grid' ) }
+					title={ this.props.translate( 'Grid View' ) }
 				>
-					{ this.props.translate( 'Grid' ) }
+					<Icon icon={ grid } size={ 20 } />
 				</SegmentedControl.Item>
 				<SegmentedControl.Item
 					selected={ this.state.displayMode === 'list' }
 					onClick={ () => this.onDisplayToggleClick( 'list' ) }
+					title={ this.props.translate( 'List View' ) }
 				>
-					{ this.props.translate( 'List' ) }
+					<Icon icon={ listView } size={ 20 } />
 				</SegmentedControl.Item>
 			</SegmentedControl>
 		);

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -23,6 +23,22 @@
 	&.is-large .site-selector__sites {
 		border-top: 1px solid var( --color-neutral-10 );
 	}
+
+	.is-wide-layout & {
+		.site-selector__search-filter {
+			display: flex;
+			margin-right: 16px;
+
+			.search {
+				margin: 0 16px 0 0;
+				width: 80%;
+			}
+
+			.segmented-control {
+				width: 20%;
+			}
+		}
+	}
 }
 
 // Styles for Site elements within the Selector

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -45,7 +45,7 @@
 	}
 }
 
-.site-selector .all-sites.is-clickable {
+.site-selector .all-sites.is-card-link {
 	background: var( --color-sidebar-background );
 	box-shadow: none;
 	border-bottom: 1px solid var( --color-sidebar-border );

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -45,9 +45,38 @@
 	}
 }
 
+.site-selector .all-sites.is-clickable {
+	background: var( --color-sidebar-background );
+	box-shadow: none;
+	border-bottom: 1px solid var( --color-sidebar-border );
+	color: var( --color-sidebar-text );
+	font-size: $font-body-small;
+
+	.card__link-indicator {
+		color: var( --color-sidebar-text );
+	}
+
+	&:hover {
+		background: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-menu-hover-text );
+
+		.card__link-indicator {
+			color: var( --color-sidebar-menu-hover-text );
+		}
+	}
+
+	&.is-selected {
+		background-color: var( --color-sidebar-menu-selected-background );
+		color: var( --color-sidebar-menu-selected-text );
+
+		.card__link-indicator {
+			color: var( --color-sidebar-menu-selected-text );
+		}
+	}
+}
+
 // Styles for Site elements within the Selector
-.site-selector .site,
-.site-selector .all-sites {
+.site-selector .site {
 	font-size: $font-body-small;
 
 	// Highlight selected site
@@ -76,8 +105,7 @@
 
 .notouch .site-selector.is-hover-enabled .site:hover,
 .notouch .site-selector.is-hover-enabled .all-sites:hover
-.site-selector .site.is-highlighted,
-.site-selector .all-sites.is-highlighted {
+.site-selector .site.is-highlighted {
 	background-color: var( --color-neutral-5 );
 	cursor: pointer;
 
@@ -96,8 +124,7 @@
 // Highlight & hover effects
 .notouch .layout__secondary .site-selector.is-hover-enabled .site:hover,
 .notouch .layout__secondary .site-selector.is-hover-enabled .all-sites:hover
-.layout__secondary .site-selector .site.is-highlighted,
-.layout__secondary .site-selector .all-sites.is-highlighted {
+.layout__secondary .site-selector .site.is-highlighted {
 	background: var( --color-sidebar-menu-hover-background );
 
 	.site__badge {
@@ -216,10 +243,6 @@
 // Containers in the list of sites are larger
 .site-selector .site-action {
 	padding-top: 15px;
-}
-
-.site-selector .all-sites {
-	border-bottom: 1px solid var( --color-neutral-10 );
 }
 
 .site-selector__recent {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -30,12 +30,16 @@
 			margin-right: 16px;
 
 			.search {
+				height: 40px;
 				margin: 0 16px 0 0;
-				width: 80%;
 			}
 
 			.segmented-control {
-				width: 20%;
+				width: 100px;
+			}
+
+			.segmented-control__link {
+				line-height: 1;
 			}
 		}
 	}
@@ -126,6 +130,7 @@
 }
 
 .site-selector .search {
+	box-sizing: border-box;
 	margin: 8px;
 	height: 33px;
 	border: 1px solid var( --color-neutral-10 );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -323,6 +323,7 @@ function createSitesComponent( context ) {
 			getSiteSelectionHeaderText={ context.getSiteSelectionHeaderText }
 			fromSite={ context.query.site }
 			clearPageTitle={ context.clearPageTitle }
+			isWideLayout={ true }
 		/>
 	);
 }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -93,11 +93,9 @@ class CurrentSite extends Component {
 					) }
 
 					{ selectedSite ? (
-						<div>
-							<Site site={ selectedSite } homeLink={ true } />
-						</div>
+						<Site site={ selectedSite } homeLink={ true } />
 					) : (
-						<AllSites />
+						<AllSites href="/home" isSelected />
 					) }
 					{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 						<AsyncLoad

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -4,7 +4,7 @@ import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import home, { maybeRedirect } from './controller';
 
 export default function () {
-	page( '/home', siteSelection, sites, makeLayout, clientRender );
+	page( '/home', siteSelection, navigation, sites, makeLayout, clientRender );
 
 	page( '/home/:siteId', siteSelection, maybeRedirect, navigation, home, makeLayout, clientRender );
 }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -9,11 +9,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
-import Main from 'calypso/components/main';
-import SiteSelector from 'calypso/components/site-selector';
-import VisitSite from 'calypso/blocks/visit-site';
 import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import VisitSite from 'calypso/blocks/visit-site';
+import Main from 'calypso/components/main';
+import { Card } from '@automattic/components';
+import SiteSelector from 'calypso/components/site-selector';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
@@ -82,7 +84,7 @@ class Sites extends Component {
 		return path;
 	}
 
-	getHeaderText() {
+	getSubHeaderText() {
 		if ( this.props.getSiteSelectionHeaderText ) {
 			return this.props.getSiteSelectionHeaderText();
 		}
@@ -133,23 +135,39 @@ class Sites extends Component {
 				break;
 		}
 
-		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {
-			args: { path },
-			components: {
-				strong: <strong />,
-			},
-		} );
+		return translate(
+			'Select a site to open {{strong}}%(path)s{{/strong}}. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				args: { path },
+				components: {
+					strong: <strong />,
+					learnMoreLink: (
+						<InlineSupportLink
+							supportLink="https://wordpress.com/support/admin-bar/#switch-site"
+							supportPostId={ 20787 }
+							showIcon={ false }
+						/>
+					),
+				},
+			}
+		);
 	}
 
 	render() {
-		const { clearPageTitle, fromSite, siteBasePath, isWideLayout } = this.props;
+		const { clearPageTitle, fromSite, isWideLayout, siteBasePath, translate } = this.props;
 
 		return (
 			<>
 				{ clearPageTitle && <DocumentHead title="" /> }
 				<Main className={ isWideLayout ? 'sites is-wide-layout' : 'sites' }>
 					<div className="sites__select-header">
-						<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
+						<FormattedHeader
+							brandFont
+							className="sites__select-heading"
+							headerText={ translate( 'My Sites' ) }
+							subHeaderText={ this.getSubHeaderText() }
+							align="left"
+						/>
 						{ fromSite && <VisitSite siteSlug={ fromSite } /> }
 					</div>
 					<Card className="sites__select-wrapper">

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -153,7 +153,12 @@ class Sites extends Component {
 						{ fromSite && <VisitSite siteSlug={ fromSite } /> }
 					</div>
 					<Card className="sites__select-wrapper">
-						<SiteSelector filter={ this.filterSites } siteBasePath={ siteBasePath } groups />
+						<SiteSelector
+							filter={ this.filterSites }
+							siteBasePath={ siteBasePath }
+							groups
+							isWideLayout={ isWideLayout }
+						/>
 					</Card>
 				</Main>
 			</>

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -93,6 +93,23 @@ class Sites extends Component {
 
 		const { translate } = this.props;
 
+		if ( 'home' === path ) {
+			return translate(
+				'Select a site to edit and view its dashboard. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: (
+							<InlineSupportLink
+								supportLink="https://wordpress.com/support/admin-bar/#switch-site"
+								supportPostId={ 20787 }
+								showIcon={ false }
+							/>
+						),
+					},
+				}
+			);
+		}
+
 		// nicer wording for editor routes
 		const editorRouters = [ 'page', 'post', 'edit', 'block-editor' ];
 		if ( editorRouters.includes( path ) ) {
@@ -123,9 +140,6 @@ class Sites extends Component {
 				break;
 			case 'settings':
 				path = translate( 'Settings' );
-				break;
-			case 'home':
-				path = translate( 'My Home' );
 				break;
 			case 'hosting-config':
 				path = translate( 'Hosting Configuration' );

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -25,6 +25,7 @@ class Sites extends Component {
 	static propTypes = {
 		siteBasePath: PropTypes.string.isRequired,
 		clearPageTitle: PropTypes.bool,
+		isWideLayout: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -141,12 +142,12 @@ class Sites extends Component {
 	}
 
 	render() {
-		const { clearPageTitle, fromSite, siteBasePath } = this.props;
+		const { clearPageTitle, fromSite, siteBasePath, isWideLayout } = this.props;
 
 		return (
 			<>
 				{ clearPageTitle && <DocumentHead title="" /> }
-				<Main className="sites">
+				<Main className={ isWideLayout ? 'sites is-wide-layout' : 'sites' }>
 					<div className="sites__select-header">
 						<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
 						{ fromSite && <VisitSite siteSlug={ fromSite } /> }

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -60,51 +60,48 @@
 		box-shadow: none;
 	}
 
-	.site-selector .search {
-		height: 40px;
-		margin: 0 16px 0 0;
-	}
-
 	.site-selector.is-large .site-selector__sites {
 		border-top: none;
 		background: transparent;
 		margin-top: 16px;
 	}
 
-	.site {
-		background: var( --color-surface );
-		border: 1px solid var( --color-neutral-10 );
-		box-sizing: border-box;
-		float: left;
-		margin: 0 16px 16px 0;
-		padding: 8px;
-		width: calc( 25% - 16px );
-		height: 200px;
-	}
+	.is-grid {
+		.site {
+			background: var( --color-surface );
+			border: 1px solid var( --color-neutral-10 );
+			box-sizing: border-box;
+			float: left;
+			margin: 0 16px 16px 0;
+			padding: 8px;
+			width: calc( 25% - 16px );
+			height: 200px;
+		}
 
-	.site__content {
-		display: block;
-		padding: 8px !important;
-	}
+		.site__content {
+			display: block;
+			padding: 8px !important;
+		}
 
-	.site .site-icon {
-		flex: none;
-		width: 100% !important;
-		height: 80px !important;
-		margin: 0 auto 16px;
-	}
+		.site .site-icon {
+			flex: none;
+			width: 100% !important;
+			height: 80px !important;
+			margin: 0 auto 16px;
+		}
 
-	.site-icon__img {
-		top: -45%;
-	}
+		.site-icon__img {
+			top: -45%;
+		}
 
-	.site__info {
-		width: 100%;
-		flex: none;
-		position: relative;
-	}
+		.site__info {
+			width: 100%;
+			flex: none;
+			position: relative;
+		}
 
-	.site__title {
-		font-weight: 600;
+		.site__title {
+			font-weight: 600;
+		}
 	}
 }

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -32,15 +32,44 @@
 	}
 
 	.site-selector.is-large .site-selector__sites {
-		border-top: none;
 		background: transparent;
 		margin-top: 16px;
+	}
+
+	.site-selector.is-large.is-list .site-selector__sites {
+		margin-right: 16px;
+	}
+
+	.is-list {
+		.site {
+			background: var( --color-surface );
+			border: 1px solid var( --color-neutral-10 );
+			border-top: none;
+			box-sizing: border-box;
+			margin: 0;
+			padding: 8px;
+		}
+
+		.site .site-icon {
+			margin-right: 16px;
+			width: 60px !important;
+			height: 60px !important;
+		}
+
+		.site__title {
+			font-weight: 600;
+		}
+	}
+
+	.site-selector.is-large.is-grid .site-selector__sites {
+		border-top: none;
 	}
 
 	.is-grid {
 		.site {
 			background: var( --color-surface );
 			border: 1px solid var( --color-neutral-10 );
+			border-radius: 2px;
 			box-sizing: border-box;
 			float: left;
 			margin: 0 16px 16px 0;

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -6,35 +6,6 @@
 	}
 }
 
-.sites__select-header {
-	text-align: center;
-
-	.visit-site {
-		margin: -12px 0 24px;
-	}
-
-	.is-wide-layout & {
-		text-align: left;
-	}
-}
-
-.sites__select-heading {
-	font-size: $font-title-small;
-	font-weight: 400;
-	line-height: inherit;
-	margin-top: 16px;
-	margin-bottom: 24px;
-
-	strong {
-		text-transform: capitalize;
-	}
-
-	.is-wide-layout & {
-		font-family: 'Recoleta', 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
-		font-size: $font-title-medium;
-	}
-}
-
 .sites__select-wrapper.card {
 	padding: 0;
 

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -60,34 +60,51 @@
 		box-shadow: none;
 	}
 
+	.site-selector .search {
+		height: 40px;
+		margin: 0 16px 0 0;
+	}
+
 	.site-selector.is-large .site-selector__sites {
 		border-top: none;
 		background: transparent;
+		margin-top: 16px;
 	}
 
 	.site {
-		float: left;
-		width: 25%;
+		background: var( --color-surface );
+		border: 1px solid var( --color-neutral-10 );
 		box-sizing: border-box;
+		float: left;
+		margin: 0 16px 16px 0;
+		padding: 8px;
+		width: calc( 25% - 16px );
+		height: 200px;
 	}
 
 	.site__content {
-		background: var( --color-surface );
-		border: 1px solid var( --color-neutral-10 );
 		display: block;
-		height: 150px;
-		margin: 8px;
+		padding: 8px !important;
 	}
 
 	.site .site-icon {
 		flex: none;
-		width: 60px !important;
-		height: 60px !important;
-		margin: 0 auto;
+		width: 100% !important;
+		height: 80px !important;
+		margin: 0 auto 16px;
+	}
+
+	.site-icon__img {
+		top: -45%;
 	}
 
 	.site__info {
 		width: 100%;
 		flex: none;
+		position: relative;
+	}
+
+	.site__title {
+		font-weight: 600;
 	}
 }

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -53,3 +53,41 @@
 		padding-right: 0;
 	}
 }
+
+.is-wide-layout {
+	.sites__select-wrapper {
+		background: transparent;
+		box-shadow: none;
+	}
+
+	.site-selector.is-large .site-selector__sites {
+		border-top: none;
+		background: transparent;
+	}
+
+	.site {
+		float: left;
+		width: 25%;
+		box-sizing: border-box;
+	}
+
+	.site__content {
+		background: var( --color-surface );
+		border: 1px solid var( --color-neutral-10 );
+		display: block;
+		height: 150px;
+		margin: 8px;
+	}
+
+	.site .site-icon {
+		flex: none;
+		width: 60px !important;
+		height: 60px !important;
+		margin: 0 auto;
+	}
+
+	.site__info {
+		width: 100%;
+		flex: none;
+	}
+}

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -1,5 +1,9 @@
 .main.sites {
 	max-width: 320px;
+
+	&.is-wide-layout {
+		max-width: 1040px;
+	}
 }
 
 .sites__select-header {
@@ -7,6 +11,10 @@
 
 	.visit-site {
 		margin: -12px 0 24px;
+	}
+
+	.is-wide-layout & {
+		text-align: left;
 	}
 }
 
@@ -19,6 +27,11 @@
 
 	strong {
 		text-transform: capitalize;
+	}
+
+	.is-wide-layout & {
+		font-family: 'Recoleta', 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
+		font-size: $font-title-medium;
 	}
 }
 


### PR DESCRIPTION
**WIP - DO NOT MERGE**

The "all sites" version of Customer Home is a site selector without a sidebar. Since Customer Home is the default landing page for most users, this means that it's difficult for most users to access an "all sites" view for domains, posts, stats, etc. without first navigating to that section and then opening the all sites view… a self-fulfilling prophecy of users not using Calypso to manage multiple sites.

This PR introduces a wide layout for the site selector, as a pseudo "dashboard" for multiple site management. It also adds the All Sites navigation for Customer Home when a site isn't selected.

This is an MVP that could be quickly launched to help with #52789 while more involved fixes are explored. Additionally, since this uses the existing site selector (with nothing more than some custom styling), we could add any of the information available from the `/me/sites` endpoint (i.e. current plan, is Jetpack, etc.) with minimal effort.

**Before** | **After**
------------ | -------------
<img width="1552" alt="Screen Shot 2021-06-24 at 8 03 32 PM" src="https://user-images.githubusercontent.com/942359/123348863-60d5d780-d527-11eb-940c-c75672775875.png"> | <img width="1552" alt="Screen Shot 2021-06-24 at 8 03 41 PM" src="https://user-images.githubusercontent.com/942359/123348982-67fce580-d527-11eb-96e7-625fd8def112.png">

**To do:**
- [x] Adjust the styling to match the rest of Calypso (i.e. search height, fonts, hovers)
- [ ] Add mobile styling for the grid view
- [x] Maybe make the "Grid/List" toggle use icons
- [ ] Add a button at the end of the list to "Add a new site" 

**To test:**
- Visit Customer Home
- Click "Switch Site" in the sidebar
- Click "All my sites"
- verify that you see the wide-width site selector with the All Sites navigation
- verify that clicking a site takes you to the site's Customer Home