### PR TITLE
My Home: Padding and hover style updates in the stats card

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -173,9 +173,11 @@ export const StatsV2 = ( {
 								</div>
 							) }
 						</div>
-						<a href={ `/stats/day/${ siteSlug }` } className="stats__all">
-							{ translate( 'See all stats' ) }
-						</a>
+						<div className="stats__all">
+							<a href={ `/stats/day/${ siteSlug }` } className="stats__all-link">
+								{ translate( 'See all stats' ) }
+							</a>
+						</div>
 					</>
 				) }
 			</Card>

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -29,6 +29,7 @@ import {
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import classnames from 'classnames';
 
 /**
  * Style dependencies
@@ -80,6 +81,7 @@ export const StatsV2 = ( {
 				),
 				4
 		  );
+	const renderChart = ! isSiteUnlaunched && ! isLoading && views > 0;
 
 	return (
 		<div className="stats">
@@ -90,7 +92,7 @@ export const StatsV2 = ( {
 				</>
 			) }
 			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-			<Card className="customer-home__card">
+			<Card className={ classnames( 'customer-home__card', { 'stats__with-chart': renderChart } ) }>
 				{ isSiteUnlaunched && (
 					<Chart data={ placeholderChartData } isPlaceholder>
 						<div>
@@ -135,7 +137,7 @@ export const StatsV2 = ( {
 						</div>
 					</div>
 				) }
-				{ ! isSiteUnlaunched && ! isLoading && views > 0 && (
+				{ renderChart && (
 					<>
 						<CardHeading>{ translate( 'Views' ) }</CardHeading>
 						<Chart data={ chartData } />

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,8 +1,10 @@
-.stats .card {
-	padding: 16px 16px 0;
-	@include breakpoint-deprecated( '>480px' ) {
-		box-shadow: none;
+.stats .card.customer-home__card {
+	box-shadow: none;
+	border-bottom: none;
+
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 16px 24px 0;
+		margin-bottom: 16px;
 	}
 }
 
@@ -86,7 +88,7 @@
 		border-top-right-radius: 3px; /* stylelint-disable-line scales/radii */
 	}
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-bottom: none;
 	}
 
@@ -133,7 +135,7 @@
 	border-top: none;
 	border-bottom-left-radius: 3px; /* stylelint-disable-line scales/radii */
 	border-bottom-right-radius: 3px; /* stylelint-disable-line scales/radii */
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border: 1px solid var( --color-neutral-5 );
 	}
 }

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,6 +1,7 @@
-.stats .card.customer-home__card {
+.stats .customer-home__card.stats__with-chart {
 	box-shadow: none;
 	border-bottom: none;
+	margin-bottom: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		padding: 16px 24px 0;
@@ -22,10 +23,7 @@
 
 	&.is-placeholder {
 		padding: 16px;
-		margin: 0 -16px -24px;
-		box-shadow: 0 0 0 1px var( --color-border-subtle );
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 3px;
+		margin: 0 -16px;
 		
 		@include breakpoint-deprecated( '>660px' ) {
 			padding: 16px 24px;

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,4 +1,5 @@
 .stats .card {
+	padding: 16px 16px 0;
 	@include breakpoint-deprecated( '>480px' ) {
 		box-shadow: none;
 		padding: 16px 24px 0;

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -38,6 +38,12 @@
 	}
 }
 
+.stats .card-heading {
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-left: -24px;
+	}
+}
+
 .stats .inline-support-link {
 	margin-left: 4px;
 }
@@ -65,21 +71,22 @@
 	width: 25%;
 	box-sizing: border-box;
 	text-align: center;
-	padding: 16px;
+	padding: 16px 24px;
 	display: flex;
 	flex-direction: column;
 
 	&:first-child {
-		padding-left: 24px;
+		border-top-left-radius: 3px; /* stylelint-disable-line scales/radii */
 	}
 
 	&:last-child {
 		padding-right: 24px;
 		border-right: 1px solid var( --color-neutral-5 );
+		border-top-right-radius: 3px; /* stylelint-disable-line scales/radii */
+	}
 
-		@include breakpoint-deprecated( '<480px' ) {
-			padding: 16px;
-		}
+	@include breakpoint-deprecated( '>480px' ) {
+		border-bottom: none;
 	}
 
 	@include breakpoint-deprecated( '1040px-1280px', '<960px' ) {
@@ -89,9 +96,21 @@
 		&:nth-child( 2 ) {
 			border-bottom: none;
 		}
-
 		&:nth-child( 2 ) {
+			border-top-right-radius: 3px; /* stylelint-disable-line scales/radii */
 			border-right: 1px solid var( --color-neutral-5 );
+		}
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		&:first-child, &:nth-child( 2 ), &:last-child {
+			border-radius: 0;
+		}
+	}
+
+	@include breakpoint-deprecated( '1040px-1280px' ) {
+		&:last-child {
+			border-top-right-radius: 0;
 		}
 	}
 }
@@ -110,8 +129,12 @@
 
 .stats__all {
     margin: 0 -24px;
-	border: 1px solid var( --color-neutral-5 );
 	border-top: none;
+	border-bottom-left-radius: 3px; /* stylelint-disable-line scales/radii */
+	border-bottom-right-radius: 3px; /* stylelint-disable-line scales/radii */
+	@include breakpoint-deprecated( '>480px' ) {
+		border: 1px solid var( --color-neutral-5 );
+	}
 }
 
 .stats__all-link {

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -22,11 +22,14 @@
 
 	&.is-placeholder {
 		padding: 16px;
-		margin: -16px;
-
-		@include breakpoint-deprecated( '>480px' ) {
+		margin: 0 -16px -24px;
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 3px;
+		
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 16px 24px;
-			margin: -16px -24px;
+			margin: -24px -24px 0;
 		}
 
 		.chart__y-axis-markers,

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,6 +1,7 @@
 .stats .card {
 	@include breakpoint-deprecated( '>480px' ) {
-		padding: 16px 24px;
+		box-shadow: none;
+		padding: 16px 24px 0;
 	}
 }
 
@@ -55,12 +56,12 @@
 .stats__data {
 	display: flex;
 	flex-wrap: wrap;
-	margin: 8px -24px 16px;
+	margin: 8px -24px 0;
 }
 
 .stats__data-item {
 	border: 1px solid var( --color-neutral-5 );
-	border-left: none;
+	border-right: none;
 	width: 25%;
 	box-sizing: border-box;
 	text-align: center;
@@ -74,7 +75,7 @@
 
 	&:last-child {
 		padding-right: 24px;
-		border-right: none;
+		border-right: 1px solid var( --color-neutral-5 );
 
 		@include breakpoint-deprecated( '<480px' ) {
 			padding: 16px;
@@ -90,7 +91,7 @@
 		}
 
 		&:nth-child( 2 ) {
-			border-right: none;
+			border-right: 1px solid var( --color-neutral-5 );
 		}
 	}
 }
@@ -108,5 +109,22 @@
 }
 
 .stats__all {
+    margin: 0 -24px;
+	border: 1px solid var( --color-neutral-5 );
+	border-top: none;
+}
+
+.stats__all-link {
+	display: block;
+    padding: 12px 24px;
 	font-size: $font-body-small;
+
+	&:hover {
+		background: var( --color-neutral-0 );
+	}
+
+	&:focus {
+		background: var( --color-primary );
+    	color: var( --color-text-inverted );
+	}
 }

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -10,7 +10,7 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
-		margin-bottom: 24px;
+		margin-bottom: 16px;
 	}
 
 	.task__text,


### PR DESCRIPTION
Update the style of the stats card to match the new my-home designs in https://github.com/Automattic/wp-calypso/issues/53213

I added hover and focus states to the "See all stats" link.
I also kept the font size at 14px to match the quick links which were set as 16px in the design but then changed to be 14px [ sorry I couldn't find a link to this discussion]

<img width="450" alt="Screen Shot 2021-06-25 at 2 16 50 PM" src="https://user-images.githubusercontent.com/22446385/123359455-1acd5200-d5c1-11eb-81e4-54bcf6402c8c.png">
<img width="553" alt="Screen Shot 2021-06-25 at 2 16 35 PM" src="https://user-images.githubusercontent.com/22446385/123359491-1d2fac00-d5c1-11eb-8f63-ac30ad14a16b.png">
