### PR TITLE
Signup: add reskin styles without page refresh

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -230,7 +230,10 @@ class Signup extends React.Component {
 			this.updateShouldShowLoadingScreen( progress );
 		}
 
-		if ( ! isReskinnedFlow( flowName ) ) {
+		if ( isReskinnedFlow( flowName ) ) {
+			document.body.classList.add( 'is-white-signup' );
+			debug( 'In componentWillReceiveProps, addded is-white-signup class' );
+		} else {
 			document.body.classList.remove( 'is-white-signup' );
 			debug( 'In componentWillReceiveProps, removed is-white-signup class' );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add reskin styles when a user navigates to `/start` from Calypso without a full page refresh

#### Testing instructions

* Go to Calypso when logged-in
* Set language to non-EN
* Create a site from sidebar

Fixes https://github.com/Automattic/wp-calypso/issues/54012
