### PR TITLE
Update/add akismet marketing email category settings

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -161,8 +161,10 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack security and performance reports.' );
-		} else if ( 'akismet_reports' === category ) {
-			return this.props.translate( 'Tips for getting the most out of Akismet' );
+		} else if ( 'akismet_marketing' === category ) {
+			return this.props.translate(
+				'Relevant tips and new features to get the most out of Akismet'
+			);
 		}
 
 		return null;

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -120,6 +120,8 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Jetpack Newsletter' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack Reports' );
+		} else if ( 'akismet_marketing' === category ) {
+			return this.props.translate( 'Akismet Marketing' );
 		}
 
 		return category;
@@ -159,6 +161,8 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack security and performance reports.' );
+		} else if ( 'akismet_reports' === category ) {
+			return this.props.translate( 'Tips for getting the most out of Akismet' );
 		}
 
 		return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new email category "Akismet Marketing" to the unsubscribe logic. This is a new category that is being introduced to help further segment email campaigns and manage list subscriptions. The related patch can be found here: D63241-code.

Translators:
"Akismet Marketing"
"Relevant tips and new features to get the most out of Akismet"

#### Testing instructions

Check out this branch locally
Start your local install of Calypso with `yarn` and `yarn start`
Navigate to http://calypso.localhost:3000/mailing-lists/unsubscribe?category=akismet_marketing
You should see the relevant category name and description displayed
Note that you will see an unsubscribe error message until the related Phabricator patch is deployed

![Screen Shot 2021-06-25 at 12 06 50 PM](https://user-images.githubusercontent.com/18016357/123453867-eb611a00-d5ad-11eb-9ffc-a306dfe80afc.png)

This PR does not add a setting to /me/notifications/updates - it is difficult to reliably determine if a user has a site with Akismet enabled in order to show Akismet related settings conditionally here.
