### PR TITLE
Jetpack Cloud: update sidebar navigation colors

### DIFF
--- a/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+++ b/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
@@ -65,18 +65,21 @@
 	--color-masterbar-item-hover-background: var( --studio-gray-60 );
 	--color-masterbar-item-active-background: var( --studio-gray-40 );
 
-	--color-sidebar-background: var( --studio-gray-0 );
-	--color-sidebar-background-rgb: var( --studio-gray-0-rgb );
+	--color-sidebar-background: var( --studio-white );
+	--color-sidebar-background-rgb: var( --studio-white-rgb );
 	--color-sidebar-border: var( --studio-gray-5 );
 	--color-sidebar-text: var( --studio-gray-60 );
-	--color-sidebar-text-alternative: var( --studio-gray-70 );
+	--color-sidebar-text-rgb: var( --studio-gray-60-rgb );
+	--color-sidebar-text-alternative: var( --studio-gray-60 );
 	--color-sidebar-gridicon-fill: var( --studio-gray-60 );
-	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-10 );
-	--color-sidebar-menu-selected-background-rgb: var( --studio-jetpack-green-10-rgb );
-	--color-sidebar-menu-selected-text: var( --studio-jetpack-green-50 );
-	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
-	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
-	--color-sidebar-menu-hover-text: var( --studio-gray-70 );
+	--color-sidebar-menu-selected-text: var( --studio-gray-90 );
+	--color-sidebar-menu-selected-text-rgb: var( --studio-gray-90-rgb );
+	--color-sidebar-menu-selected-background: var( --studio-gray-0 );
+	--color-sidebar-menu-selected-background-rgb: var( --studio-gray-0-rgb );
+	--color-sidebar-menu-selected-gridicon-fill: var( --studio-jetpack-green-50 );
+	--color-sidebar-menu-hover-text: var( --studio-gray-90 );
+	--color-sidebar-menu-hover-background: var( --studio-gray-0 );
+	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-0-rgb );
 
 	--color-threat-found: var( --studio-red-50 );
 	--color-threat-fixed: var( --studio-jetpack-green-40 );

--- a/client/components/jetpack/portal-nav/style.scss
+++ b/client/components/jetpack/portal-nav/style.scss
@@ -21,5 +21,9 @@
 
 	.section-nav-tab__link {
 		padding: 14px 16px 11px;
+
+		&:hover {
+			background-color: var( --studio-gray-0 );
+		}
 	}
 }

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -3,22 +3,73 @@
 // Menu links
 .sidebar__jetpack-cloud {
 
-	.current-site__switch-sites .button.is-borderless .dashicons-before {
-		top: 15px;
+	.site__home {
+		background-color: var( --color-sidebar-menu-hover-text );
+
+		svg {
+			fill: var( --color-sidebar-background );
+		}
+		
+	}
+
+	.current-site__switch-sites .button.is-borderless {
+		border-radius: 0;
+
+		&:hover {
+			background-color: var( --color-sidebar-menu-hover-background );
+		}
+
+		 .dashicons-before {
+			top: 15px;
+		}
+	}
+
+	.selected {
+
+		.sidebar__menu-link {
+			background-color: var( --color-sidebar-menu-selected-background );
+		}
+
+		.sidebar__menu-link-text {
+			color: var( --color-sidebar-menu-hover-text );
+		}
+
+		.sidebar__menu-icon {
+			fill: var( --color-sidebar-menu-selected-gridicon-fill );
+		}
+
+		&:hover {
+			.sidebar__menu-icon {
+				fill: var( --color-sidebar-menu-selected-gridicon-fill );
+			}
+		}
 	}
 
 	.sidebar__menu-link {
 		padding-top: 14px;
 		padding-bottom: 14px;
 
+		&:hover {
+			background-color: var( --color-sidebar-menu-hover-background );
+
+			.sidebar__menu-link-text {
+				color: var( --color-sidebar-menu-hover-text );
+			}
+		}
+
 		.selected &,
 		.selected &:hover {
-			background-color: rgba( var( --color-sidebar-menu-selected-background-rgb ), 0.12 );
+			background-color: var( --color-sidebar-menu-hover-background );
 		}
+	}
+
+	.sidebar__menu-icon {
+		fill: var( --color-sidebar-gridicon-fill );
 	}
 
 	.sidebar__menu-link-text {
 		line-height: 1.2em;
+		color: var( --color-sidebar-text );
 
 		@include breakpoint-deprecated( '<960px' ) {
 			white-space: nowrap;
@@ -37,7 +88,7 @@
 
 		&.is-toggle-open {
 			.sidebar__heading {
-				background-color: var( --studio-white );
+				background-color: var( --color-sidebar-background );
 			}
 		}
 	}

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -57,6 +57,14 @@
 			}
 		}
 
+		&:active {
+			background-color: rgba ( var ( --color-sidebar-menu-selected-text-rgb ), 0.075);
+
+			.sidebar__menu-icon {
+				fill: var( --color-sidebar-menu-selected-gridicon-fill );
+			}
+		}
+
 		.selected &,
 		.selected &:hover {
 			background-color: var( --color-sidebar-menu-hover-background );

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -56,6 +56,10 @@
 				color: var( --color-sidebar-menu-hover-text );
 			}
 		}
+		
+		html.accessible-focus &:focus {
+			box-shadow: inset 0 0 0 2px var( --color-primary-light );
+		}
 
 		&:active {
 			background-color: rgba ( var ( --color-sidebar-menu-selected-text-rgb ), 0.075);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -116,13 +116,14 @@
 	--color-sidebar-text-rgb: var( --studio-gray-60-rgb );
 	--color-sidebar-text-alternative: var( --studio-gray-60 );
 	--color-sidebar-gridicon-fill: var( --studio-gray-60 );
-	--color-sidebar-menu-selected-text: var( --studio-jetpack-green-50 );
-	--color-sidebar-menu-selected-text-rgb: var( --studio-jetpack-green-50-rgb );
-	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-5 );
-	--color-sidebar-menu-selected-background-rgb: var( --studio-jetpack-green-5-rgb );
+	--color-sidebar-menu-selected-text: var( --studio-gray-90 );
+	--color-sidebar-menu-selected-text-rgb: var( --studio-gray-90-rgb );
+	--color-sidebar-menu-selected-background: var( --studio-gray-0 );
+	--color-sidebar-menu-selected-background-rgb: var( --studio-gray-0-rgb );
+	--color-sidebar-menu-selected-gridicon-fill: var( --studio-jetpack-green-50 );
 	--color-sidebar-menu-hover-text: var( --studio-gray-90 );
-	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
-	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
+	--color-sidebar-menu-hover-background: var( --studio-gray-0 );
+	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-0-rgb );
 
 	--color-scary-0: var( --studio-red-0 );
 	--color-scary-5: var( --studio-red-5 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update colors and overrides used in the sidebar `style.scss `file
- Update color variables in `jetpack-cloud theme` and `calypso-color-scheme-jetpack-cloud` files
- Adjust the color for the background of tabs in portal nav `style.scss `file
- Thank you @keoshi for the guidance!

More details in p6TEKc-55n

#### Testing instructions

- Fire up this PR by running yarn start-jetpack-cloud.
- Go to http://jetpack.cloud.localhost:3000/ and select any site.
- Check the sidebar for regular users 
- Check the header tabs for partner users (change to `const show = true;` in [this](https://github.com/Automattic/wp-calypso/blob/9ff7ac4ddd50c07b3d61b39afa7aaefe6d279014/client/components/jetpack/portal-nav/index.tsx#L42) file)

#### Screenshots

Before | After
--|--
<img width="1570" alt="Screen Shot 2021-06-25 at 11 14 40" src="https://user-images.githubusercontent.com/10525007/123454946-bb624880-d5a6-11eb-9738-8cd26a1ca899.png"> | <img width="1570" alt="Screen Shot 2021-06-25 at 11 14 58" src="https://user-images.githubusercontent.com/10525007/123454969-c4531a00-d5a6-11eb-82d5-6e0f5d4544fb.png">
