### PR TITLE
Jetpack Cloud: Add landing page for users with no Jetpack sites

### DIFF
--- a/client/components/jetpack/no-jetpack-sites-message/index.tsx
+++ b/client/components/jetpack/no-jetpack-sites-message/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const NoJetpackSitesMessage = ( { siteSlug }: { siteSlug: string | undefined } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="no-jetpack-sites-message">
+			<h2 className="no-jetpack-sites-message__header">
+				{ translate( 'Jetpack features are already part of WordPress.com' ) }
+			</h2>
+			{ siteSlug && (
+				<p>
+					{ translate(
+						'Your site, %(siteSlug)s, already has the power of Jetpack built in. Its features can be found within your WordPress.com dashboard.',
+						{ args: { siteSlug } }
+					) }
+				</p>
+			) }
+			<p>
+				{ translate( 'This area is only for Jetpack customers with self-hosted WordPress sites.' ) }
+			</p>
+			<Button primary href="https://wordpress.com" rel="noopener noreferrer">
+				{ translate( 'Visit Dashboard' ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/components/jetpack/no-jetpack-sites-message/style.scss
+++ b/client/components/jetpack/no-jetpack-sites-message/style.scss
@@ -1,0 +1,12 @@
+.no-jetpack-sites-message {
+	margin: auto;
+	max-width: 720px;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		margin: 16px;
+	}
+}
+
+.no-jetpack-sites-message__header {
+	margin-bottom: 1.5rem;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a landing page for users who have no Jetpack sites.

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/42627630/123457983-1ea1aa00-d5aa-11eb-955c-70ea28203425.png">

#### Testing instructions
1. Acquire a user account with no Jetpack sites.
2. While logged in to that user account, visit `http://jetpack.cloud.localhost:3001/landing`.
3. Verify that you see a message indicating that you have no Jetpack sites, and that the button redirects you to WordPress.com.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1176558595787257