### PR TITLE
Support removing mailboxes for Professional Email

### DIFF
--- a/client/data/emails/use-emails-query.js
+++ b/client/data/emails/use-emails-query.js
@@ -8,7 +8,9 @@ import { useQuery } from 'react-query';
  */
 import wpcom from 'calypso/lib/wp';
 
-const getCacheKey = ( siteId, domain ) => [ 'emailAccounts', siteId, domain ];
+export const queryKeyPrefix = 'emailAccounts';
+
+const getCacheKey = ( siteId, domain ) => [ queryKeyPrefix, siteId, domain ];
 
 /**
  * Get the associated emails given a Site Identificator

--- a/client/data/emails/use-emails-query.js
+++ b/client/data/emails/use-emails-query.js
@@ -8,9 +8,7 @@ import { useQuery } from 'react-query';
  */
 import wpcom from 'calypso/lib/wp';
 
-export const queryKeyPrefix = 'emailAccounts';
-
-const getCacheKey = ( siteId, domain ) => [ queryKeyPrefix, siteId, domain ];
+export const getCacheKey = ( siteId, domain ) => [ 'emailAccounts', siteId, domain ];
 
 /**
  * Get the associated emails given a Site Identificator

--- a/client/data/emails/use-remove-titan-mailbox-mutation.js
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.js
@@ -12,6 +12,7 @@ import { getCacheKey } from './use-emails-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import wp from 'calypso/lib/wp';
 
+const invalidationDelayTimeout = 5000;
 const noop = () => {};
 
 const getNumberOfMailboxes = ( queryClient, queryKey ) => {
@@ -58,14 +59,14 @@ export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutation
 		queryClient.invalidateQueries( queryKey ).then( () => {
 			const numberOfMailboxes = getNumberOfMailboxes( queryClient, queryKey );
 
-			// Determine if we need to schedule another invalidation since the removal job is not synchronous
+			// Determine if we already have updated data, since the removal job is not synchronous
 			if ( numberOfMailboxes < context.previousNumberOfMailboxes ) {
 				return;
 			}
 
 			setTimeout( () => {
 				queryClient.invalidateQueries( queryKey );
-			}, 10000 );
+			}, invalidationDelayTimeout );
 		} );
 	};
 

--- a/client/data/emails/use-remove-titan-mailbox-mutation.js
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.js
@@ -3,11 +3,13 @@
  */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { queryKeyPrefix } from './use-emails-query';
+import { getCacheKey } from './use-emails-query';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import wp from 'calypso/lib/wp';
 
 const noop = () => {};
@@ -21,19 +23,50 @@ const noop = () => {};
  * @returns {{ data, error, isLoading: boolean, removeTitanMailbox: Function, ...}} Returns various parameters piped from `useMutation`
  */
 export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutationOptions = null ) {
-	mutationOptions = mutationOptions ?? {};
-
-	const suppliedOnSettled = mutationOptions.onSettled ?? noop;
-
 	const queryClient = useQueryClient();
 
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	const queryKey = getCacheKey( selectedSiteId, domainName );
+
+	mutationOptions = mutationOptions ?? {};
+
+	// Collect the supplied callback
+	const suppliedOnSettled = mutationOptions.onSettled ?? noop;
+
+	// Setup optimistic updates before the mutation by excluding the mailbox we intend to delete from the cached query data.
+	// This can provide for a good UX.
+	mutationOptions.onMutate = async () => {
+		await queryClient.cancelQueries( queryKey );
+
+		const previousData = queryClient.getQueryData( queryKey );
+
+		queryClient.setQueryData( queryKey, ( data ) => {
+			if ( data?.accounts?.[ 0 ].emails?.length > 0 ) {
+				data.accounts[ 0 ].emails = data.accounts[ 0 ].emails.filter(
+					( mailbox ) => mailbox.mailbox !== mailboxName
+				);
+			}
+			return data;
+		} );
+
+		// Snapshot the query data before the mutation. This snapshot is provided in context to the status callbacks
+		return { previousData };
+	};
+
+	// This is called for both success and error statuses.
+	// Invoke any supplied `onSettled` callbacks here. This is so we can do things like invalidate queries and
+	// rollback optimistic updates if the mutation fails
 	mutationOptions.onSettled = ( data, error, variables, context ) => {
 		suppliedOnSettled?.( data, error, variables, context );
 
-		queryClient.invalidateQueries( {
-			predicate: ( { queryKey: [ prefix, , domain ] = [] } ) =>
-				prefix === queryKeyPrefix && domain === domainName,
-		} );
+		// Always invalidate attendant queries
+		queryClient.invalidateQueries( queryKey );
+
+		if ( error ) {
+			// If the mutation failed to succeed, "rollback" the optimistic update
+			queryClient.setQueryData( queryKey, context.previousData );
+		}
 	};
 
 	const mutation = useMutation(
@@ -50,9 +83,11 @@ export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutation
 
 	const { mutate } = mutation;
 
+	// Memoize the `mutate` method into a callback
 	const removeTitanMailbox = useCallback( () => {
 		mutate( {} );
 	}, [ mutate ] );
 
+	// Bundle the callback to make it easy for downstream clients to invoke it
 	return { removeTitanMailbox, ...mutation };
 }

--- a/client/data/emails/use-remove-titan-mailbox-mutation.js
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import { queryKeyPrefix } from './use-emails-query';
+import wp from 'calypso/lib/wp';
+
+const noop = () => {};
+
+/**
+ * Deletes a mailbox from a Professional Email (Titan) account
+ *
+ * @param {string} domainName The domain name of the mailbox
+ * @param {string} mailboxName The mailbox name
+ * @param {object} mutationOptions Mutation options passed on to `useMutation`
+ * @returns {{ data, error, isLoading: boolean, removeTitanMailbox: Function, ...}} Returns various parameters piped from `useMutation`
+ */
+export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutationOptions = null ) {
+	mutationOptions = mutationOptions ?? {};
+
+	const suppliedOnSettled = mutationOptions.onSettled ?? noop;
+
+	const queryClient = useQueryClient();
+
+	mutationOptions.onSettled = ( data, error, variables, context ) => {
+		suppliedOnSettled?.( data, error, variables, context );
+
+		queryClient.invalidateQueries( {
+			predicate: ( { queryKey: [ prefix, , domain ] = [] } ) =>
+				prefix === queryKeyPrefix && domain === domainName,
+		} );
+	};
+
+	const mutation = useMutation(
+		() =>
+			wp.req.get( {
+				path: `/emails/titan/${ encodeURIComponent( domainName ) }/mailbox/${ encodeURIComponent(
+					mailboxName
+				) }`,
+				method: 'DELETE',
+				apiNamespace: 'wpcom/v2',
+			} ),
+		mutationOptions
+	);
+
+	const { mutate } = mutation;
+
+	const removeTitanMailbox = useCallback( () => {
+		mutate( {} );
+	}, [ mutate ] );
+
+	return { removeTitanMailbox, ...mutation };
+}

--- a/client/lib/emails/get-email-address.js
+++ b/client/lib/emails/get-email-address.js
@@ -1,0 +1,15 @@
+/**
+ * Construct an email address from the mailbox object.
+ *
+ * @param {Object} Mailbox The mailbox object.
+ * @param {string} Mailbox.mailbox The mailbox name/username for the mailbox.
+ * @param {string} Mailbox.domain The domain for the mailbox.
+ * @returns {string} Returns the email address formed from the mailbox object.
+ */
+export function getEmailAddress( { mailbox, domain } ) {
+	if ( mailbox && domain ) {
+		return `${ mailbox }@${ domain }`;
+	}
+
+	return '';
+}

--- a/client/lib/emails/index.js
+++ b/client/lib/emails/index.js
@@ -1,3 +1,4 @@
+export { getEmailAddress } from './get-email-address';
 export { getEmailForwardAddress } from './get-email-forward-address';
 export { hasGoogleAccountTOSWarning } from './has-google-account-t-o-s-warning';
 export { hasPaidEmailWithUs } from './has-paid-email-with-us';

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -724,18 +724,6 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function (
 	return result.then?.( camelCaseKeys );
 };
 
-Undocumented.prototype.getEmailAccountsForSiteAndDomain = function ( siteId, domain, fn ) {
-	return this.wpcom.req.get(
-		{
-			path: `/sites/${ encodeURIComponent( siteId ) }/emails/accounts/${ encodeURIComponent(
-				domain
-			) }/mailboxes`,
-			apiNamespace: 'wpcom/v2',
-		},
-		fn
-	);
-};
-
 /**
  * Retrieves the Titan order provisioning URL for a domain.
  *

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -203,6 +203,8 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 
 	const emailAddress = getEmailAddress( mailbox );
 
+	const noticeDuration = 7000;
+
 	const errorMessage = errorNotice(
 		translate(
 			'There was an error removing {{strong}}%(emailAddress)s{{/strong}} from your account',
@@ -214,7 +216,7 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 				},
 			}
 		),
-		{ duration: 7000 }
+		{ duration: noticeDuration }
 	);
 
 	const successMessage = successNotice(
@@ -225,7 +227,7 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 				strong: <strong />,
 			},
 		} ),
-		{ duration: 5000 }
+		{ duration: noticeDuration }
 	);
 
 	const { removeTitanMailbox } = useRemoveTitanMailboxMutation( mailbox.domain, mailbox.mailbox, {
@@ -332,8 +334,8 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 			{ domainHasTitanMailWithUs && (
 				<RemoveTitanMailboxConfirmationDialog
 					mailbox={ mailbox }
-					visible={ removeTitanMailboxDialogVisible }
 					setVisible={ setRemoveTitanMailboxDialogVisible }
+					visible={ removeTitanMailboxDialogVisible }
 				/>
 			) }
 			<EllipsisMenu position="bottom" className="email-mailbox-action-menu__main">

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
@@ -10,8 +10,11 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Dialog } from '@automattic/components';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import {
+	getEmailAddress,
 	getEmailForwardAddress,
 	hasGoogleAccountTOSWarning,
 	isEmailUserAdmin,
@@ -46,6 +49,7 @@ import { removeEmailForward } from 'calypso/state/email-forwarding/actions';
 import titanCalendarIcon from 'calypso/assets/images/email-providers/titan/services/flat/calendar.svg';
 import titanContactsIcon from 'calypso/assets/images/email-providers/titan/services/flat/contacts.svg';
 import titanMailIcon from 'calypso/assets/images/email-providers/titan/services/flat/mail.svg';
+import { useRemoveTitanMailboxMutation } from 'calypso/data/emails/use-remove-titan-mailbox-mutation';
 
 const removeEmailForwardMailbox = ( { dispatch, mailbox } ) => {
 	recordTracksEvent( 'calypso_email_management_email_forwarding_delete_click', {
@@ -61,11 +65,14 @@ const removeEmailForwardMailbox = ( { dispatch, mailbox } ) => {
  * Returns the available menu items for Titan Emails
  *
  * @param {Object} titanMenuParams The argument for this function.
- * @param {string} titanMenuParams.email The email address of the Titan account
- * @param {Function} titanMenuParams.translate The translate function
+ * @param {Function} titanMenuParams.showRemoveMailboxDialog The function that removes modal dialogs for confirming mailbox removals
+ * @param {Object} titanMenuParams.mailbox The mailbox object.
+ * @param {Function} titanMenuParams.translate The translate function.
  * @returns Array of menu items
  */
-const getTitanMenuItems = ( { email, translate } ) => {
+const getTitanMenuItems = ( { showRemoveMailboxDialog, mailbox, translate } ) => {
+	const email = getEmailAddress( mailbox );
+
 	return [
 		{
 			href: getTitanEmailUrl( email ),
@@ -91,6 +98,20 @@ const getTitanMenuItems = ( { email, translate } ) => {
 				comment: 'View the Contacts application for Titan',
 			} ),
 		},
+		{
+			isInternalLink: true,
+			materialIcon: 'delete',
+			onClick: () => {
+				showRemoveMailboxDialog?.();
+
+				recordTracksEvent( 'calypso_email_management_titan_remove_mailbox_click', {
+					domain_name: mailbox.domain,
+					mailbox: mailbox.mailbox,
+				} );
+			},
+			key: `remove_mailbox:${ mailbox.mailbox }`,
+			title: translate( 'Remove mailbox' ),
+		},
 	];
 };
 
@@ -99,15 +120,16 @@ const getTitanMenuItems = ( { email, translate } ) => {
  *
  * @param {Object} gSuiteMenuParams Parameter for this function.
  * @param {Object} gSuiteMenuParams.account The account the current mailbox is linked to.
- * @param {string} gSuiteMenuParams.email The full email address for the current mailbox.
  * @param {Object} gSuiteMenuParams.mailbox The mailbox object.
  * @param {Function} gSuiteMenuParams.translate The translate function.
  * @returns {Array|null} Returns an array of menu items or null if no items should be shown.
  */
-const getGSuiteMenuItems = ( { account, email, mailbox, translate } ) => {
+const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 	if ( hasGoogleAccountTOSWarning( account ) ) {
 		return null;
 	}
+
+	const email = getEmailAddress( mailbox );
 
 	return [
 		{
@@ -175,19 +197,117 @@ const getEmailForwardMenuItems = ( { dispatch, mailbox, translate } ) => {
 	];
 };
 
+const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const emailAddress = getEmailAddress( mailbox );
+
+	const errorMessage = errorNotice(
+		translate(
+			'There was an error removing {{strong}}%(emailAddress)s{{/strong}} from your account',
+			{
+				comment: '%(emailAddress)s is the email address associated to the mailbox being deleted',
+				args: { emailAddress },
+				components: {
+					strong: <strong />,
+				},
+			}
+		),
+		{ duration: 7000 }
+	);
+
+	const successMessage = successNotice(
+		translate( '{{strong}}%(emailAddress)s{{/strong}} has been removed from your account', {
+			comment: '%(emailAddress)s is the email address associated to the mailbox being deleted',
+			args: { emailAddress },
+			components: {
+				strong: <strong />,
+			},
+		} ),
+		{ duration: 5000 }
+	);
+
+	const { removeTitanMailbox } = useRemoveTitanMailboxMutation( mailbox.domain, mailbox.mailbox, {
+		onSettled: ( data ) => {
+			if ( data?.status === 202 ) {
+				dispatch( successMessage );
+				return;
+			}
+			dispatch( errorMessage );
+		},
+	} );
+
+	const onClose = ( action ) => {
+		setVisible( false );
+
+		if ( 'remove' === action ) {
+			removeTitanMailbox();
+
+			recordTracksEvent( 'calypso_email_management_titan_remove_mailbox_execute', {
+				domain_name: mailbox.domain,
+				mailbox: mailbox.mailbox,
+			} );
+		}
+	};
+
+	const buttons = [
+		{ action: 'cancel', label: translate( 'Cancel' ) },
+		{ action: 'remove', label: translate( 'Confirm' ), isPrimary: true },
+	];
+
+	return (
+		<Dialog
+			className="email-mailbox-action-menu__remove-titan-mailbox-dialog"
+			isVisible={ visible }
+			buttons={ buttons }
+			onClose={ onClose }
+		>
+			<div>
+				<h3> { translate( 'Remove mailbox' ) } </h3>
+				<p>
+					{ translate(
+						'Are you sure you want to remove {{strong}}%(emailAddress)s{{/strong}}? All your data will be deleted!',
+						{
+							comment:
+								'%(emailAddress)s is the email address associated to the mailbox being deleted',
+							args: { emailAddress },
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</p>
+			</div>
+		</Dialog>
+	);
+};
+
+RemoveTitanMailboxConfirmationDialog.propTypes = {
+	mailbox: PropTypes.object.isRequired,
+	visible: PropTypes.bool.isRequired,
+	setVisible: PropTypes.func.isRequired,
+};
+
 const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const email = `${ mailbox.mailbox }@${ mailbox.domain }`;
+	const [ removeTitanMailboxDialogVisible, setRemoveTitanMailboxDialogVisible ] = useState( false );
+
+	const domainHasTitanMailWithUs = hasTitanMailWithUs( domain );
 
 	const getMenuItems = () => {
-		if ( hasTitanMailWithUs( domain ) ) {
-			return getTitanMenuItems( { email, translate } );
+		if ( domainHasTitanMailWithUs ) {
+			return getTitanMenuItems( {
+				showRemoveMailboxDialog: () => setRemoveTitanMailboxDialogVisible( true ),
+				mailbox,
+				translate,
+			} );
 		}
 
 		if ( hasGSuiteWithUs( domain ) ) {
-			return getGSuiteMenuItems( { account, email, mailbox, translate } );
+			return getGSuiteMenuItems( { account, mailbox, translate } );
 		}
 
 		if ( hasEmailForwards( domain ) ) {
@@ -208,32 +328,41 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	}
 
 	return (
-		<EllipsisMenu position="bottom" className="email-mailbox-action-menu__main">
-			{ menuItems.map(
-				( {
-					href,
-					image,
-					imageAltText,
-					isInternalLink = false,
-					key,
-					materialIcon,
-					onClick,
-					title,
-				} ) => (
-					<PopoverMenuItem
-						key={ href || key }
-						className="email-mailbox-action-menu__menu-item"
-						isExternalLink={ ! isInternalLink }
-						href={ href }
-						onClick={ onClick }
-					>
-						{ image && <img src={ image } alt={ imageAltText } /> }
-						{ materialIcon && <MaterialIcon icon={ materialIcon } /> }
-						{ title }
-					</PopoverMenuItem>
-				)
+		<>
+			{ domainHasTitanMailWithUs && (
+				<RemoveTitanMailboxConfirmationDialog
+					mailbox={ mailbox }
+					visible={ removeTitanMailboxDialogVisible }
+					setVisible={ setRemoveTitanMailboxDialogVisible }
+				/>
 			) }
-		</EllipsisMenu>
+			<EllipsisMenu position="bottom" className="email-mailbox-action-menu__main">
+				{ menuItems.map(
+					( {
+						href,
+						image,
+						imageAltText,
+						isInternalLink = false,
+						key,
+						materialIcon,
+						onClick,
+						title,
+					} ) => (
+						<PopoverMenuItem
+							key={ href || key }
+							className="email-mailbox-action-menu__menu-item"
+							isExternalLink={ ! isInternalLink }
+							href={ href }
+							onClick={ onClick }
+						>
+							{ image && <img src={ image } alt={ imageAltText } /> }
+							{ materialIcon && <MaterialIcon icon={ materialIcon } /> }
+							{ title }
+						</PopoverMenuItem>
+					)
+				) }
+			</EllipsisMenu>
+		</>
 	);
 };
 

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -219,14 +219,19 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 		{ duration: noticeDuration }
 	);
 
+	// The mailboxes are not removed immediately, but rather scheduled. An async job takes care of the deletion. Then
+	// we also wait for the deletion event to come through from Titan since we really only read the local tables.
 	const successMessage = successNotice(
-		translate( '{{strong}}%(emailAddress)s{{/strong}} has been removed from your account', {
-			comment: '%(emailAddress)s is the email address associated to the mailbox being deleted',
-			args: { emailAddress },
-			components: {
-				strong: <strong />,
-			},
-		} ),
+		translate(
+			'{{strong}}%(emailAddress)s{{/strong}} has been scheduled for removal from your account',
+			{
+				comment: '%(emailAddress)s is the email address associated to the mailbox being deleted',
+				args: { emailAddress },
+				components: {
+					strong: <strong />,
+				},
+			}
+		),
 		{ duration: noticeDuration }
 	);
 

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -70,7 +70,7 @@ const removeEmailForwardMailbox = ( { dispatch, mailbox } ) => {
  * @param {Function} titanMenuParams.translate The translate function.
  * @returns Array of menu items
  */
-const getTitanMenuItems = ( { showRemoveMailboxDialog, mailbox, translate } ) => {
+const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) => {
 	const email = getEmailAddress( mailbox );
 
 	return [
@@ -209,7 +209,7 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 		translate(
 			'There was an error removing {{strong}}%(emailAddress)s{{/strong}} from your account',
 			{
-				comment: '%(emailAddress)s is the email address associated to the mailbox being deleted',
+				comment: '%(emailAddress)s is the email address for the mailbox being deleted',
 				args: { emailAddress },
 				components: {
 					strong: <strong />,
@@ -225,7 +225,7 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 		translate(
 			'{{strong}}%(emailAddress)s{{/strong}} has been scheduled for removal from your account',
 			{
-				comment: '%(emailAddress)s is the email address associated to the mailbox being deleted',
+				comment: '%(emailAddress)s is the email address for the mailbox being deleted',
 				args: { emailAddress },
 				components: {
 					strong: <strong />,
@@ -274,10 +274,9 @@ const RemoveTitanMailboxConfirmationDialog = ( { mailbox, visible, setVisible } 
 				<h3> { translate( 'Remove mailbox' ) } </h3>
 				<p>
 					{ translate(
-						'Are you sure you want to remove {{strong}}%(emailAddress)s{{/strong}}? All your data will be deleted!',
+						'Are you sure you want to remove {{strong}}%(emailAddress)s{{/strong}}? All your emails, calendar events, and contacts will be deleted!',
 						{
-							comment:
-								'%(emailAddress)s is the email address associated to the mailbox being deleted',
+							comment: '%(emailAddress)s is the email address for the mailbox being deleted',
 							args: { emailAddress },
 							components: {
 								strong: <strong />,

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -53,7 +53,6 @@ import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/cons
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
-import { ReactQueryDevtools } from 'react-query/devtools';
 
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
@@ -325,8 +324,6 @@ const EmailPlan = ( props ) => {
 					{ renderViewBillingAndPaymentSettingsNavItem() }
 				</VerticalNav>
 			</div>
-
-			<ReactQueryDevtools initialIsOpen={ false } />
 		</>
 	);
 };

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -53,6 +53,7 @@ import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/cons
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
@@ -324,6 +325,8 @@ const EmailPlan = ( props ) => {
 					{ renderViewBillingAndPaymentSettingsNavItem() }
 				</VerticalNav>
 			</div>
+
+			<ReactQueryDevtools initialIsOpen={ false } />
 		</>
 	);
 };

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -213,6 +213,14 @@
 	}
 }
 
+.email-mailbox-action-menu__remove-titan-mailbox-dialog {
+	h3 {
+		font-size: $font-title-medium;
+		margin-bottom: 10px;
+		font-weight: 600;
+	}
+}
+
 .popover__menu-item.email-mailbox-action-menu__menu-item {
 	align-items: center;
 	display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a routine to derive email addresses from the mailbox object
* Writes a method signature for the delete mailbox API 
* Adds a "Delete Mailbox" menu item to remove Professional Email mailbox items
* Wires up the menu item to invoke the delete mailbox API when clicked
* Displays success/error messaging upon response from the API

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via the [live branch](https://calypso.live/?branch=add/remove-mailbox-button-for-professional-email).
* Add multiple Professional Email mailboxes for a domain you own.
* Navigate to the email plan page for said domain.
* To observe track events consult the FG Guide at PCYsg-cae-p2
* For each of the mailboxes, open the action/kebab menu for the email.
* Verify that an option exists in the menu to "Remove Mailbox".
* Click on the "Remove Mailbox" option.
* Verify that we triggered a `calypso_email_management_titan_remove_mailbox_click` Tracks event.
* Verify that a confirmation dialog is shown to you
* Verify that you see a success notice appear.
* Verify that the page is updated and no longer shows the removed mailbox.
* Verify that when the last mailbox is removed the email plan page displays "No mailboxes"

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshot

<img width="1140" alt="Screenshot 2021-06-26 at 12 39 52 AM" src="https://user-images.githubusercontent.com/277661/123494287-319e9380-d617-11eb-869d-e1028e4a9efa.png">

