### PR TITLE
Signup flows: add a name field to the flow object

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -3,11 +3,6 @@
  */
 import { translate } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import { addQueryArgs } from 'calypso/lib/route';
-
 const noop = () => {};
 
 export function generateFlows( {
@@ -17,9 +12,11 @@ export function generateFlows( {
 	getLaunchDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
+	getImportDestination = noop,
 } = {} ) {
-	const flows = {
-		account: {
+	const flows = [
+		{
+			name: 'account',
 			steps: [ 'user' ],
 			destination: '/',
 			description: 'Create an account without a blog.',
@@ -27,40 +24,40 @@ export function generateFlows( {
 			pageTitle: translate( 'Create an account' ),
 			showRecaptcha: true,
 		},
-
-		business: {
+		{
+			name: 'business',
 			steps: [ 'user', 'domains', 'plans-business' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
-
-		premium: {
+		{
+			name: 'premium',
 			steps: [ 'user', 'domains', 'plans-premium' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
-
-		personal: {
+		{
+			name: 'personal',
 			steps: [ 'user', 'domains', 'plans-personal' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
-
-		free: {
+		{
+			name: 'free',
 			steps: [ 'user', 'domains' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
-
-		'rebrand-cities': {
+		{
+			name: 'rebrand-cities',
 			steps: [ 'rebrand-cities-welcome', 'user' ],
 			destination: function ( dependencies ) {
 				return '/plans/select/business/' + dependencies.siteSlug;
@@ -68,16 +65,16 @@ export function generateFlows( {
 			description: 'Create an account for REBRAND cities partnership',
 			lastModified: '2019-06-17',
 		},
-
-		'with-theme': {
+		{
+			name: 'with-theme',
 			steps: [ 'domains-theme-preselected', 'plans', 'user' ],
 			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
-
-		'design-first': {
+		{
+			name: 'design-first',
 			steps: [
 				'template-first-themes',
 				'user',
@@ -91,15 +88,15 @@ export function generateFlows( {
 			description: 'Start with one of our template-first (Gutenberg) themes.',
 			lastModified: '2019-10-16',
 		},
-
-		main: {
+		{
+			name: 'main',
 			steps: [ 'user', 'about', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'The current best performing flow in AB tests',
 			lastModified: '2019-06-20',
 		},
-
-		'onboarding-with-preview': {
+		{
+			name: 'onboarding-with-preview',
 			steps: [
 				'user',
 				'site-type',
@@ -113,39 +110,39 @@ export function generateFlows( {
 			lastModified: '2020-03-03',
 			showRecaptcha: true,
 		},
-
-		onboarding: {
+		{
+			name: 'onboarding',
 			steps: [ 'user', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
 			showRecaptcha: true,
 		},
-
-		'onboarding-registrationless': {
+		{
+			name: 'onboarding-registrationless',
 			steps: [ 'domains', 'plans-new', 'user-new' ],
 			destination: getSignupDestination,
 			description: 'Checkout without user account or site. Read more https://wp.me/pau2Xa-1hW',
 			lastModified: '2020-06-26',
 			showRecaptcha: true,
 		},
-
-		desktop: {
+		{
+			name: 'desktop',
 			steps: [ 'user' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
 			lastModified: '2021-03-26',
 			showRecaptcha: true,
 		},
-
-		developer: {
+		{
+			name: 'developer',
 			steps: [ 'site', 'user' ],
 			destination: '/devdocs/welcome',
 			description: 'Signup flow for developers in developer environment',
 			lastModified: '2015-11-23',
 		},
-
-		'pressable-nux': {
+		{
+			name: 'pressable-nux',
 			steps: [ 'creds-permission', 'creds-confirm', 'creds-complete' ],
 			destination: '/stats',
 			description: 'Allow new Pressable users to grant permission to server credentials',
@@ -154,8 +151,8 @@ export function generateFlows( {
 			allowContinue: false,
 			hideFlowProgress: true,
 		},
-
-		'rewind-switch': {
+		{
+			name: 'rewind-switch',
 			steps: [ 'rewind-migrate', 'rewind-were-backing' ],
 			destination: '/activity-log',
 			description:
@@ -165,8 +162,8 @@ export function generateFlows( {
 			allowContinue: false,
 			hideFlowProgress: true,
 		},
-
-		'rewind-setup': {
+		{
+			name: 'rewind-setup',
 			steps: [ 'rewind-form-creds', 'rewind-were-backing' ],
 			destination: '/activity-log',
 			description: 'Allows users with Jetpack plan to setup credentials',
@@ -176,8 +173,8 @@ export function generateFlows( {
 			hideFlowProgress: true,
 			forceLogin: true,
 		},
-
-		'rewind-auto-config': {
+		{
+			name: 'rewind-auto-config',
 			steps: [ 'creds-permission', 'creds-confirm', 'rewind-were-backing' ],
 			destination: '/activity-log',
 			description:
@@ -187,249 +184,238 @@ export function generateFlows( {
 			allowContinue: false,
 			hideFlowProgress: true,
 		},
-
-		simple: {
+		{
+			name: 'simple',
 			steps: [ 'passwordless' ],
 			destination: '/',
 			description: 'A very simple signup flow',
 			lastModified: '2019-05-09',
 		},
-	};
-
-	flows[ 'clone-site' ] = {
-		steps: [
-			'clone-start',
-			'clone-destination',
-			'clone-credentials',
-			'clone-point',
-			'clone-ready',
-			'clone-cloning',
-		],
-		destination: '/activity-log',
-		description: 'Allow Jetpack users to clone a site via Rewind (alternate restore)',
-		lastModified: '2018-05-28',
-		disallowResume: true,
-		allowContinue: false,
-	};
-
-	// Important: For any changes done to the ecommerce flow,
-	// please copy the same changes to ecommerce-onboarding flow too
-	flows.ecommerce = {
-		steps: [ 'user', 'domains', 'plans-ecommerce-fulfilled' ],
-		destination: getSignupDestination,
-		description: 'Signup flow for creating an online store with an Atomic site',
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
-
-	flows[ 'ecommerce-onboarding' ] = {
-		steps: [ 'user', 'domains', 'plans-ecommerce' ],
-		destination: getSignupDestination,
-		description: 'Signup flow for creating an online store with an Atomic site',
-		lastModified: '2020-03-04',
-	};
-
-	flows[ 'ecommerce-design-first' ] = {
-		steps: [
-			'template-first-themes',
-			'user',
-			'site-type-with-theme',
-			'domains',
-			'plans-ecommerce',
-		],
-		destination: getSignupDestination,
-		description:
-			'Signup flow for creating an online store with an Atomic site, forked from the design-first flow',
-		lastModified: '2019-11-27',
-	};
-
-	flows[ 'ecommerce-monthly' ] = {
-		steps: [ 'user', 'domains', 'plans-ecommerce-monthly' ],
-		destination: getSignupDestination,
-		description: 'Signup flow for creating an online store with an Atomic site',
-		lastModified: '2021-02-02',
-		showRecaptcha: true,
-	};
-
-	flows.wpcc = {
-		steps: [ 'oauth2-user' ],
-		destination: getRedirectDestination,
-		description: 'WordPress.com Connect signup flow',
-		lastModified: '2017-08-24',
-		disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
-		showRecaptcha: true,
-	};
-
-	flows.p2 = {
-		steps: [ 'p2-site', 'p2-details', 'user' ],
-		destination: ( dependencies ) => `https://${ dependencies.siteSlug }?p2-site`,
-		description: 'P2 signup flow',
-		lastModified: '2020-09-01',
-		showRecaptcha: true,
-	};
-
-	flows.domain = {
-		steps: [
-			'domain-only',
-			'site-or-domain',
-			'site-picker',
-			'themes',
-			'plans-site-selected',
-			'user',
-		],
-		destination: getThankYouNoSiteDestination,
-		description: 'An experimental approach for WordPress.com/domains',
-		disallowResume: true,
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
-
-	flows[ 'add-domain' ] = {
-		steps: [
-			'select-domain',
-			'site-or-domain',
-			'site-picker',
-			'themes',
-			'plans-site-selected',
-			'user',
-		],
-		destination: getThankYouNoSiteDestination,
-		description: 'An approach to add a domain via the all domains view',
-		disallowResume: true,
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
-
-	flows[ 'site-selected' ] = {
-		steps: [ 'themes-site-selected', 'plans-site-selected' ],
-		destination: getSiteDestination,
-		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
-		description: 'A flow to test updating an existing site with `Signup`',
-		lastModified: '2017-01-19',
-	};
-
-	flows[ 'launch-site' ] = {
-		steps: [ 'domains-launch', 'plans-launch', 'launch' ],
-		destination: getLaunchDestination,
-		description: 'A flow to launch a private site.',
-		providesDependenciesInQuery: [ 'siteSlug' ],
-		lastModified: '2019-11-22',
-		pageTitle: translate( 'Launch your site' ),
-	};
-
-	const importSteps = [ 'domains', 'plans-import' ];
-
-	const importDestination = ( { importSiteEngine, importSiteUrl, siteSlug } ) =>
-		addQueryArgs(
-			{
-				engine: importSiteEngine || null,
-				'from-site': importSiteUrl ? encodeURIComponent( importSiteUrl ) : null,
-				signup: 1,
-			},
-			`/import/${ siteSlug }`
-		);
-
-	flows.import = {
-		steps: [ 'user', 'from-url', ...importSteps ],
-		destination: importDestination,
-		description: 'A flow to kick off an import during signup',
-		disallowResume: true,
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
-
-	flows[ 'import-onboarding' ] = {
+		{
+			name: 'clone-site',
+			steps: [
+				'clone-start',
+				'clone-destination',
+				'clone-credentials',
+				'clone-point',
+				'clone-ready',
+				'clone-cloning',
+			],
+			destination: '/activity-log',
+			description: 'Allow Jetpack users to clone a site via Rewind (alternate restore)',
+			lastModified: '2018-05-28',
+			disallowResume: true,
+			allowContinue: false,
+		},
+		// Important: For any changes done to the ecommerce flow,
+		// please copy the same changes to ecommerce-onboarding flow too
+		{
+			name: 'ecommerce',
+			steps: [ 'user', 'domains', 'plans-ecommerce-fulfilled' ],
+			destination: getSignupDestination,
+			description: 'Signup flow for creating an online store with an Atomic site',
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
+			name: 'ecommerce-onboarding',
+			steps: [ 'user', 'domains', 'plans-ecommerce' ],
+			destination: getSignupDestination,
+			description: 'Signup flow for creating an online store with an Atomic site',
+			lastModified: '2020-03-04',
+		},
+		{
+			name: 'ecommerce-design-first',
+			steps: [
+				'template-first-themes',
+				'user',
+				'site-type-with-theme',
+				'domains',
+				'plans-ecommerce',
+			],
+			destination: getSignupDestination,
+			description:
+				'Signup flow for creating an online store with an Atomic site, forked from the design-first flow',
+			lastModified: '2019-11-27',
+		},
+		{
+			name: 'ecommerce-monthly',
+			steps: [ 'user', 'domains', 'plans-ecommerce-monthly' ],
+			destination: getSignupDestination,
+			description: 'Signup flow for creating an online store with an Atomic site',
+			lastModified: '2021-02-02',
+			showRecaptcha: true,
+		},
+		{
+			name: 'wpcc',
+			steps: [ 'oauth2-user' ],
+			destination: getRedirectDestination,
+			description: 'WordPress.com Connect signup flow',
+			lastModified: '2017-08-24',
+			disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
+			showRecaptcha: true,
+		},
+		{
+			name: 'p2',
+			steps: [ 'p2-site', 'p2-details', 'user' ],
+			destination: ( dependencies ) => `https://${ dependencies.siteSlug }?p2-site`,
+			description: 'P2 signup flow',
+			lastModified: '2020-09-01',
+			showRecaptcha: true,
+		},
+		{
+			name: 'domain',
+			steps: [
+				'domain-only',
+				'site-or-domain',
+				'site-picker',
+				'themes',
+				'plans-site-selected',
+				'user',
+			],
+			destination: getThankYouNoSiteDestination,
+			description: 'An experimental approach for WordPress.com/domains',
+			disallowResume: true,
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
+			name: 'add-domain',
+			steps: [
+				'select-domain',
+				'site-or-domain',
+				'site-picker',
+				'themes',
+				'plans-site-selected',
+				'user',
+			],
+			destination: getThankYouNoSiteDestination,
+			description: 'An approach to add a domain via the all domains view',
+			disallowResume: true,
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
+			name: 'site-selected',
+			steps: [ 'themes-site-selected', 'plans-site-selected' ],
+			destination: getSiteDestination,
+			providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
+			description: 'A flow to test updating an existing site with `Signup`',
+			lastModified: '2017-01-19',
+		},
+		{
+			name: 'launch-site',
+			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
+			destination: getLaunchDestination,
+			description: 'A flow to launch a private site.',
+			providesDependenciesInQuery: [ 'siteSlug' ],
+			lastModified: '2019-11-22',
+			pageTitle: translate( 'Launch your site' ),
+		},
+		{
+			name: 'import',
+			steps: [ 'user', 'from-url', 'domains', 'plans-import' ],
+			destination: getImportDestination,
+			description: 'A flow to kick off an import during signup',
+			disallowResume: true,
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
 		// IMPORTANT: steps should match the onboarding flow through the `site-type` step to prevent issues
 		// when switching from the onboarding flow.
-		steps: [ 'user', 'site-type', 'import-url', 'import-preview', ...importSteps ],
-		destination: importDestination,
-		description: 'Import flow that can be used from the onboarding flow',
-		disallowResume: true,
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
+		{
+			name: 'import-onboarding',
+			steps: [ 'user', 'site-type', 'import-url', 'import-preview', 'domains', 'plans-import' ],
+			destination: getImportDestination,
+			description: 'Import flow that can be used from the onboarding flow',
+			disallowResume: true,
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
+			name: 'reader',
+			steps: [ 'reader-landing', 'user' ],
+			destination: '/',
+			description: 'Signup for an account and migrate email subs to the Reader.',
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
+			name: 'crowdsignal',
+			steps: [ 'oauth2-name' ],
+			destination: getRedirectDestination,
+			description: "Crowdsignal's custom WordPress.com Connect signup flow",
+			lastModified: '2018-11-14',
+			disallowResume: true,
+			autoContinue: true,
+			showRecaptcha: true,
+		},
+		{
+			name: 'plan-no-domain',
+			steps: [ 'user', 'site', 'plans' ],
+			destination: getSiteDestination,
+			description: 'Allow users to select a plan without a domain',
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
+			name: 'new-launch',
+			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
+			destination: getLaunchDestination,
+			description: 'Launch flow for a site created from /new',
+			lastModified: '2020-04-28',
+			pageTitle: translate( 'Launch your site' ),
+			providesDependenciesInQuery: [ 'siteSlug', 'source' ],
+		},
+		{
+			name: 'launch-only',
+			steps: [ 'launch' ],
+			destination: getLaunchDestination,
+			description:
+				'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain (e.g. via the launch banner in the site preview)',
+			lastModified: '2020-11-30',
+			pageTitle: translate( 'Launch your site' ),
+			providesDependenciesInQuery: [ 'siteSlug' ],
+		},
+		{
+			name: 'business-monthly',
+			steps: [ 'user', 'domains', 'plans-business-monthly' ],
+			destination: getSignupDestination,
+			description:
+				'Create an account and a blog and then add the business monthly plan to the users cart.',
+			lastModified: '2021-02-02',
+			showRecaptcha: true,
+		},
+		{
+			name: 'premium-monthly',
+			steps: [ 'user', 'domains', 'plans-premium-monthly' ],
+			destination: getSignupDestination,
+			description:
+				'Create an account and a blog and then add the premium monthly plan to the users cart.',
+			lastModified: '2021-02-02',
+			showRecaptcha: true,
+		},
+		{
+			name: 'personal-monthly',
+			steps: [ 'user', 'domains', 'plans-personal-monthly' ],
+			destination: getSignupDestination,
+			description:
+				'Create an account and a blog and then add the personal monthly plan to the users cart.',
+			lastModified: '2021-02-02',
+			showRecaptcha: true,
+		},
+		{
+			name: 'with-design-picker',
+			steps: [ 'user', 'domains', 'plans', 'design' ],
+			destination: getSignupDestination,
+			description: 'Default onboarding experience with design picker as the last step',
+			lastModified: '2021-03-29',
+			showRecaptcha: true,
+		},
+	];
 
-	flows.reader = {
-		steps: [ 'reader-landing', 'user' ],
-		destination: '/',
-		description: 'Signup for an account and migrate email subs to the Reader.',
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
-
-	flows.crowdsignal = {
-		steps: [ 'oauth2-name' ],
-		destination: getRedirectDestination,
-		description: "Crowdsignal's custom WordPress.com Connect signup flow",
-		lastModified: '2018-11-14',
-		disallowResume: true,
-		autoContinue: true,
-		showRecaptcha: true,
-	};
-
-	flows[ 'plan-no-domain' ] = {
-		steps: [ 'user', 'site', 'plans' ],
-		destination: getSiteDestination,
-		description: 'Allow users to select a plan without a domain',
-		lastModified: '2020-08-11',
-		showRecaptcha: true,
-	};
-
-	flows[ 'new-launch' ] = {
-		steps: [ 'domains-launch', 'plans-launch', 'launch' ],
-		destination: getLaunchDestination,
-		description: 'Launch flow for a site created from /new',
-		lastModified: '2020-04-28',
-		pageTitle: translate( 'Launch your site' ),
-		providesDependenciesInQuery: [ 'siteSlug', 'source' ],
-	};
-
-	flows[ 'launch-only' ] = {
-		steps: [ 'launch' ],
-		destination: getLaunchDestination,
-		description:
-			'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain (e.g. via the launch banner in the site preview)',
-		lastModified: '2020-11-30',
-		pageTitle: translate( 'Launch your site' ),
-		providesDependenciesInQuery: [ 'siteSlug' ],
-	};
-
-	flows[ 'business-monthly' ] = {
-		steps: [ 'user', 'domains', 'plans-business-monthly' ],
-		destination: getSignupDestination,
-		description:
-			'Create an account and a blog and then add the business monthly plan to the users cart.',
-		lastModified: '2021-02-02',
-		showRecaptcha: true,
-	};
-
-	flows[ 'premium-monthly' ] = {
-		steps: [ 'user', 'domains', 'plans-premium-monthly' ],
-		destination: getSignupDestination,
-		description:
-			'Create an account and a blog and then add the premium monthly plan to the users cart.',
-		lastModified: '2021-02-02',
-		showRecaptcha: true,
-	};
-
-	flows[ 'personal-monthly' ] = {
-		steps: [ 'user', 'domains', 'plans-personal-monthly' ],
-		destination: getSignupDestination,
-		description:
-			'Create an account and a blog and then add the personal monthly plan to the users cart.',
-		lastModified: '2021-02-02',
-		showRecaptcha: true,
-	};
-
-	flows[ 'with-design-picker' ] = {
-		steps: [ 'user', 'domains', 'plans', 'design' ],
-		destination: getSignupDestination,
-		description: 'Default onboarding experience with design picker as the last step',
-		lastModified: '2021-03-29',
-		showRecaptcha: true,
-	};
-
-	return flows;
+	// convert the array to an object keyed by `name`
+	return Object.fromEntries( flows.map( ( flow ) => [ flow.name, flow ] ) );
 }
 
 const flows = generateFlows();

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -94,6 +94,17 @@ function getEditorDestination( dependencies ) {
 	return `/page/${ dependencies.siteSlug }/home`;
 }
 
+function getImportDestination( { importSiteEngine, importSiteUrl, siteSlug } ) {
+	return addQueryArgs(
+		{
+			engine: importSiteEngine || null,
+			'from-site': importSiteUrl || null,
+			signup: 1,
+		},
+		`/import/${ siteSlug }`
+	);
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -102,6 +113,7 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 	getEditorDestination,
+	getImportDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {


### PR DESCRIPTION
Problem: after calling `flows.getFlow( name, isLoggedIn )`, the returned flow object doesn't include a `name` field. That prevents some refactorings where we'd like to replace flow name with the flow object:

From:
```js
getFirstInvalidStep( flowName, progress, isLoggedIn );
```
To:
```js
getFirstInvalidStep( flows.getFlow( flowName, isLoggedIn ), progress );
```
Note how this refactoring avoids proliferation of the `isLoggedIn` argument to every function that uses a flow, and how `getFirstInvalidStep` suddenly doesn't know the flow name.

Solution: include the `name` field on every flow object. The object that defines all the flows gets transformed from a key-value dictionary to an array, and the dictionary is then constructed with an equivalent of Lodash `keyBy( flows, 'name' )`.

See discussion in https://github.com/Automattic/wp-calypso/pull/53491#discussion_r647470229 for context.

Some additional changes that are worth pointing out:
- extracted the `getImportDestination` callback to be a parameter of the `generateFlows` function, just like all other `destination` callbacks are.
- inlined the `importSteps` array in the `import` and `import-onboarding` flows.

**How to test:**
There should be no behavior change, it's pure refactoring.