### PR TITLE
Help: Update Forums "Meta Information" Message

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -323,6 +323,7 @@ export class HelpContactForm extends React.PureComponent {
 	 */
 	analyseSiteData = () => {
 		const { userDeclaredUrl, userDeclaresUnableToSeeSite, errorData, siteData } = this.state;
+		const { helpSite } = this.props;
 
 		// "Unauthorized" means it's still a WP.com site - just a private one.
 		const isWpComConnectedSite =
@@ -330,6 +331,11 @@ export class HelpContactForm extends React.PureComponent {
 				siteData &&
 				siteData.ID &&
 				( ! siteData.jetpack || siteData.is_wpcom_atomic ) ) ||
+			( helpSite &&
+				! userDeclaresUnableToSeeSite &&
+				helpSite &&
+				helpSite.ID &&
+				( ! helpSite.jetpack || helpSite.is_wpcom_atomic ) ) ||
 			( userDeclaredUrl && errorData && errorData === 'unauthorized' );
 
 		// Returns true for self-hosted sites, irrespective of Jetpack connection status, and non-WordPress sites.
@@ -338,10 +344,12 @@ export class HelpContactForm extends React.PureComponent {
 			( userDeclaredUrl &&
 				errorData &&
 				( errorData === 'unknown_blog' || errorData === 'jetpack_error' ) ) ||
-			( this.props.helpSite && this.props.helpSite.jetpack && ! userDeclaresUnableToSeeSite );
+			( helpSite && helpSite.jetpack && ! userDeclaresUnableToSeeSite );
 
 		if ( isWpComConnectedSite ) {
-			return 'isWpComConnectedSite';
+			return userDeclaredUrl
+				? 'isWpComConnectedSiteNotLinkedToAccount'
+				: 'isWpComConnectedSiteLinkedToAccount';
 		}
 
 		if ( isNonWpComHostedSite ) {
@@ -422,6 +430,7 @@ export class HelpContactForm extends React.PureComponent {
 			site: this.props.helpSite,
 			helpSiteIsJetpack: analyseSiteData === 'isNonWpComHostedSiteWithJetpack',
 			helpSiteIsNotWpCom: analyseSiteData && analyseSiteData.startsWith( 'isNonWpComHosted' ),
+			helpSiteIsWpCom: analyseSiteData && analyseSiteData.startsWith( 'isWpComConnectedSite' ),
 			userDeclaredUrl: userDeclaresUnableToSeeSite && userDeclaredUrl,
 			userDeclaresNoSite,
 			userRequestsHidingUrl,
@@ -514,7 +523,7 @@ export class HelpContactForm extends React.PureComponent {
 		let actionLink;
 		let actionMessage;
 
-		if ( analyseSiteData === 'isWpComConnectedSite' ) {
+		if ( analyseSiteData === 'isWpComConnectedSiteNotLinkedToAccount' ) {
 			// The site is linked to WordPress.com but not appearing for the user, so they've probably lost access to the account which owns it.
 			noticeMessage = translate(
 				"%(siteName)s is linked to another WordPress.com account. If you're trying to access it, please follow our Account Recovery procedure.",

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -391,6 +391,7 @@ export class HelpContactForm extends React.PureComponent {
 			howCanWeHelp,
 			howYouFeel,
 			message,
+			siteCount,
 			userDeclaresUnableToSeeSite,
 			userDeclaredUrl,
 			userDeclaresNoSite,
@@ -434,6 +435,15 @@ export class HelpContactForm extends React.PureComponent {
 			userDeclaredUrl: userDeclaresUnableToSeeSite && userDeclaredUrl,
 			userDeclaresNoSite,
 			userRequestsHidingUrl,
+		} );
+
+		this.setState( {
+			message: '',
+			subject: '',
+			userDeclaresNoSite: false,
+			userDeclaresUnableToSeeSite: siteCount === 0,
+			userDeclaredUrl: '',
+			userRequestsHidingUrl: false,
 		} );
 	};
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -260,6 +260,7 @@ class HelpContact extends React.Component {
 		const {
 			helpSiteIsJetpack,
 			helpSiteIsNotWpCom,
+			helpSiteIsWpCom,
 			site,
 			subject,
 			message,
@@ -279,30 +280,32 @@ class HelpContact extends React.Component {
 		}
 
 		if ( site || userDeclaredUrl ) {
-			const siteUrl = userDeclaredUrl
-				? withoutHttp( userDeclaredUrl.trim() )
-				: withoutHttp( site.URL );
+			const siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
 
-			blogHelpMessage = translate( 'The site I need help with is %(siteUrl)s.', {
+			blogHelpMessage = translate( 'Site: %(siteUrl)s.', {
 				args: {
-					siteUrl: userRequestsHidingUrl
-						? translate( '[visible only to staff]' ) + ' help@' + siteUrl
-						: siteUrl,
+					siteUrl: userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl,
 				},
 			} );
 
+			if ( helpSiteIsWpCom ) {
+				blogHelpMessage += '\nWP.com: ' + translate( 'Yes' );
+			}
+
 			if ( helpSiteIsNotWpCom ) {
-				const jetpackMessage = helpSiteIsJetpack
-					? translate( 'It is not hosted by WordPress.com, but it is connected with Jetpack.' )
-					: translate( 'It is not hosted by WordPress.com or connected with Jetpack.' );
+				const jetpackMessage = helpSiteIsJetpack ? translate( 'Yes' ) : translate( 'Unknown' );
 
-				blogHelpMessage += ' ' + jetpackMessage;
-			}
-
-			if ( userDeclaredUrl ) {
 				blogHelpMessage +=
-					' ' + translate( 'This site is not linked to my WordPress.com account.' );
+					'\nWP.com: ' +
+					translate( 'Unknown' ) +
+					'\n' +
+					translate( 'Jetpack' ) +
+					': ' +
+					jetpackMessage;
 			}
+
+			const correctAccountMessage = userDeclaredUrl ? translate( 'Unknown' ) : translate( 'Yes' );
+			blogHelpMessage += '\nCorrect account: ' + correctAccountMessage;
 		}
 
 		const forumMessage = message + '\n\n' + blogHelpMessage;

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -256,10 +256,14 @@ class HelpContact extends React.Component {
 		this.clearSavedContactForm();
 	};
 
-	translateForForums = ( message ) => {
+	translateForForums = ( message, args ) => {
 		const { currentUserLocale, translate } = this.props;
 
-		return config( 'forum_locales' ).includes( currentUserLocale ) ? translate( message ) : message;
+		if ( config( 'forum_locales' ).includes( currentUserLocale ) ) {
+			return translate( message, args );
+		}
+
+		return args ? message.replace( '%s', args.args[ 0 ] ) : message;
 	};
 
 	submitSupportForumsTopic = ( contactForm ) => {
@@ -290,14 +294,12 @@ class HelpContact extends React.Component {
 		if ( site || userDeclaredUrl ) {
 			const siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
 
-			blogHelpMessage = this.translateForForums( 'Site: %(siteUrl)s.', {
-				args: {
-					siteUrl: userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl,
-				},
+			blogHelpMessage = this.translateForForums( 'Site: %s.', {
+				args: [ userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl ],
 			} );
 
 			if ( helpSiteIsWpCom ) {
-				blogHelpMessage += '\nWP.com: ' + this.translateForForums( 'Yes' );
+				blogHelpMessage += this.translateForForums( '\nWP.com: Yes' );
 			}
 
 			if ( helpSiteIsNotWpCom ) {
@@ -305,19 +307,18 @@ class HelpContact extends React.Component {
 					? this.translateForForums( 'Yes' )
 					: this.translateForForums( 'Unknown' );
 
-				blogHelpMessage +=
-					'\nWP.com: ' +
-					this.translateForForums( 'Unknown' ) +
-					'\n' +
-					this.translateForForums( 'Jetpack' ) +
-					': ' +
-					jetpackMessage;
+				blogHelpMessage += this.translateForForums( '\nWP.com: Unknown \nJetpack: %s.', {
+					args: [ jetpackMessage ],
+				} );
 			}
 
 			const correctAccountMessage = userDeclaredUrl
 				? this.translateForForums( 'Unknown' )
 				: this.translateForForums( 'Yes' );
-			blogHelpMessage += '\nCorrect account: ' + correctAccountMessage;
+
+			blogHelpMessage += this.translateForForums( '\nCorrect account: %s.', {
+				args: [ correctAccountMessage ],
+			} );
 		}
 
 		const forumMessage = message + '\n\n' + blogHelpMessage;

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -299,7 +299,7 @@ class HelpContact extends React.Component {
 			} );
 
 			if ( helpSiteIsWpCom ) {
-				blogHelpMessage += this.translateForForums( '\nWP.com: Yes' );
+				blogHelpMessage += '\n' + this.translateForForums( 'WP.com: Yes' );
 			}
 
 			if ( helpSiteIsNotWpCom ) {
@@ -307,7 +307,7 @@ class HelpContact extends React.Component {
 					? this.translateForForums( 'Yes' )
 					: this.translateForForums( 'Unknown' );
 
-				blogHelpMessage += this.translateForForums( '\nWP.com: Unknown \nJetpack: %s.', {
+				blogHelpMessage += '\n' + this.translateForForums( 'WP.com: Unknown \nJetpack: %s', {
 					args: [ jetpackMessage ],
 				} );
 			}
@@ -316,7 +316,7 @@ class HelpContact extends React.Component {
 				? this.translateForForums( 'Unknown' )
 				: this.translateForForums( 'Yes' );
 
-			blogHelpMessage += this.translateForForums( '\nCorrect account: %s.', {
+			blogHelpMessage += '\n' + this.translateForForums( 'Correct account: %s', {
 				args: [ correctAccountMessage ],
 			} );
 		}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -256,6 +256,12 @@ class HelpContact extends React.Component {
 		this.clearSavedContactForm();
 	};
 
+	translateForForums = ( message ) => {
+		const { currentUserLocale, translate } = this.props;
+
+		return config( 'forum_locales' ).includes( currentUserLocale ) ? translate( message ) : message;
+	};
+
 	submitSupportForumsTopic = ( contactForm ) => {
 		const {
 			helpSiteIsJetpack,
@@ -273,38 +279,44 @@ class HelpContact extends React.Component {
 		this.setState( { isSubmitting: true } );
 		this.recordCompactSubmit( 'forums' );
 
-		let blogHelpMessage = translate( "I don't have a site linked to this WordPress.com account" );
+		let blogHelpMessage = this.translateForForums(
+			"I don't have a site linked to this WordPress.com account"
+		);
 
 		if ( userDeclaresNoSite ) {
-			blogHelpMessage = translate( "I don't have a site with WordPress.com yet" );
+			blogHelpMessage = this.translateForForums( "I don't have a site with WordPress.com yet" );
 		}
 
 		if ( site || userDeclaredUrl ) {
 			const siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
 
-			blogHelpMessage = translate( 'Site: %(siteUrl)s.', {
+			blogHelpMessage = this.translateForForums( 'Site: %(siteUrl)s.', {
 				args: {
 					siteUrl: userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl,
 				},
 			} );
 
 			if ( helpSiteIsWpCom ) {
-				blogHelpMessage += '\nWP.com: ' + translate( 'Yes' );
+				blogHelpMessage += '\nWP.com: ' + this.translateForForums( 'Yes' );
 			}
 
 			if ( helpSiteIsNotWpCom ) {
-				const jetpackMessage = helpSiteIsJetpack ? translate( 'Yes' ) : translate( 'Unknown' );
+				const jetpackMessage = helpSiteIsJetpack
+					? this.translateForForums( 'Yes' )
+					: this.translateForForums( 'Unknown' );
 
 				blogHelpMessage +=
 					'\nWP.com: ' +
-					translate( 'Unknown' ) +
+					this.translateForForums( 'Unknown' ) +
 					'\n' +
-					translate( 'Jetpack' ) +
+					this.translateForForums( 'Jetpack' ) +
 					': ' +
 					jetpackMessage;
 			}
 
-			const correctAccountMessage = userDeclaredUrl ? translate( 'Unknown' ) : translate( 'Yes' );
+			const correctAccountMessage = userDeclaredUrl
+				? this.translateForForums( 'Unknown' )
+				: this.translateForForums( 'Yes' );
 			blogHelpMessage += '\nCorrect account: ' + correctAccountMessage;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This implements the changes outlined by @supernovia in https://github.com/Automattic/wp-calypso/pull/52979#issuecomment-866346708

I should note that there will probably need to be another change made to this file when the next Jetpack release is out, since then we can be more confident as to whether or not a piece of data is "Unknown". I'd recommend looking at the discussion in #52979 for greater context about this change.

#### Testing instructions

When submitting a Forums message through the Help form, verify that it follows a format identical to the one outlined in https://github.com/Automattic/wp-calypso/pull/52979#issuecomment-866346708. You can see this example here, though please note I've fixed the site URL error in this thread but I just didn't want to make a new one: https://wordpress.com/forums/topic/testing-proposed-forums-feature/

**Before:**
<img width="834" alt="Screenshot 2021-05-20 at 19 43 49" src="https://user-images.githubusercontent.com/43215253/119032131-bc9ac700-b9a3-11eb-904c-16a2c3f06399.png">

**After:**
<img width="849" alt="Screenshot 2021-06-26 at 12 17 05" src="https://user-images.githubusercontent.com/43215253/123511310-71499780-d678-11eb-9cdc-cc4198869639.png">

Also, the meta information should be in English when there is no Forums for the language which the user uses; this is based on their User Settings. See https://github.com/Automattic/wp-calypso/pull/52979#issuecomment-871550349 for the reasoning behind this.

cc @sixhours

Related to #52979
