### PR TITLE
My Home: style the incomplete site setup tasks as empty circles

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -108,9 +108,10 @@
 
 	.nav-item__pending {
 		display: block;
+		box-sizing: border-box;
 		width: 8px;
 		height: 8px;
-		background-color: var( --color-neutral-20 );
+		border: 1px solid var( --studio-gray-10 );
 		// Using percentage because we're drawing a circle in CSS
 		// stylelint-disable-next-line declaration-property-unit-allowed-list
 		border-radius: 50%;
@@ -119,7 +120,8 @@
 	}
 
 	.nav-item.is-current .nav-item__pending {
-		background-color: var( --color-neutral-80 );
+		background-color: var( --studio-gray-80 );
+		border: none;
 	}
 
 	.nav-item__complete {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Suggested by @jeffgolenski in another PR https://github.com/Automattic/wp-calypso/pull/53972#issuecomment-868740548

* Change the style of unselected, incomplete tasks to a hollow bullet


https://user-images.githubusercontent.com/1500769/123564745-ae479280-d80e-11eb-8043-3be015a2ccef.mov



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should be testable using calypso.live
* Make sure the incomplete tasks are hollow, the complete tasks are ticks, and selected incomplete tasks are filled in bullets.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/53972#issuecomment-868740548
