### PR TITLE
Apply new short term designs to my home page

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -37,10 +37,12 @@
 	display: flex;
 	align-items: center;
 	transition: all 0.1s;
-	padding: 8px 16px;
+	padding-top: 8px;
+	padding-bottom: 8px;
+	padding-left: 16px;
 	box-shadow: none;
 	@include breakpoint-deprecated( '>660px' ) {
-		padding: 8px 24px;
+		padding-left: 24px;
 	}
 
 	.quick-links__action-box-image {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -2,20 +2,18 @@
 @import '@wordpress/base-styles/mixins';
 
 .quick-links.foldable-card.card {
+	box-shadow: none;
+	
 	&:not( .is-expanded ) {
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
-	}
-
-	@include break-large {
-		box-shadow: none;
 	}
 
 	.foldable-card__header {
 		padding: 16px;
 		min-height: auto;
 
-		@include breakpoint-deprecated( '>480px' ) {
-			padding: 14px 24px;
+		@include breakpoint-deprecated( '>660px' ) {
+			padding: 16px 24px 14px;
 		}
 	}
 
@@ -39,9 +37,11 @@
 	display: flex;
 	align-items: center;
 	transition: all 0.1s;
-	padding-top: 8px;
-	padding-bottom: 8px;
+	padding: 8px 16px;
 	box-shadow: none;
+	@include breakpoint-deprecated( '>660px' ) {
+		padding: 8px 24px;
+	}
 
 	.quick-links__action-box-image {
 		display: flex;

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -1,4 +1,12 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .quick-links.foldable-card.card {
+
+	@include break-large {
+		box-shadow: none;
+	}
+
 	.foldable-card__header {
 		padding: 16px;
 		min-height: auto;
@@ -30,6 +38,7 @@
 	transition: all 0.1s;
 	padding-top: 12px;
 	padding-bottom: 12px;
+	box-shadow: none;
 
 	.quick-links__action-box-image {
 		display: flex;

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -2,7 +2,6 @@
 @import '@wordpress/base-styles/mixins';
 
 .quick-links.foldable-card.card {
-
 	@include break-large {
 		box-shadow: none;
 	}

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -12,7 +12,7 @@
 		min-height: auto;
 
 		@include breakpoint-deprecated( '>480px' ) {
-			padding: 16px 24px;
+			padding: 14px 24px;
 		}
 	}
 
@@ -36,8 +36,8 @@
 	display: flex;
 	align-items: center;
 	transition: all 0.1s;
-	padding-top: 12px;
-	padding-bottom: 12px;
+	padding-top: 8px;
+	padding-bottom: 8px;
 	box-shadow: none;
 
 	.quick-links__action-box-image {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -2,6 +2,10 @@
 @import '@wordpress/base-styles/mixins';
 
 .quick-links.foldable-card.card {
+	&:not( .is-expanded ) {
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+	}
+
 	@include break-large {
 		box-shadow: none;
 	}

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -37,7 +37,7 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 	};
 
 	return (
-		<Card className="go-mobile">
+		<Card className="go-mobile customer-home__card">
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
 					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -41,9 +41,6 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
 					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>
-					<h6 className="go-mobile__subheader customer-home__card-subheader">
-						{ translate( 'Make updates on the go.' ) }
-					</h6>
 				</div>
 				<div className="go-mobile__app-badges">
 					{ showIosBadge && (

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -41,6 +41,9 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
 					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>
+					<h6 className="go-mobile__subheader customer-home__card-subheader">
+						{ translate( 'Make updates on the go.' ) }
+					</h6>
 				</div>
 				<div className="go-mobile__app-badges">
 					{ showIosBadge && (

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -9,13 +9,9 @@
 	}
 }
 
-.go-mobile.card {
-	padding: 16px;
-
-	@include break-mobile {
-		padding: 16px 24px;
-	}
-
+.go-mobile.card.customer-home__card {
+	border-bottom: none;
+	
 	@include break-large {
 		box-shadow: none;
 	}

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -15,6 +15,10 @@
 	@include break-mobile {
 		padding: 16px 24px;
 	}
+
+	@include break-large {
+		box-shadow: none;
+	}
 }
 
 .go-mobile__app-badges {
@@ -26,18 +30,21 @@
 }
 
 .go-mobile__email-link {
-	padding-top: 20px;
+	padding-top: 8px;
 	color: var( --color-text-subtle );
 	display: none;
 
 	@include break-large() {
 		display: block;
 	}
+	@include break-xlarge {
+		padding-top: 18px;
+	}
 }
 
 .go-mobile__email-link-button {
 	display: block;
-	margin-top: 16px;
+	margin-top: 14px;
 }
 
 .go-mobile__row.has-2-cols {

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -77,7 +77,7 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 
 	return (
 		<>
-			<Card className="help-search">
+			<Card className="help-search customer-home__card">
 				<div className="help-search__inner">
 					<CardHeading>{ translate( 'Get help' ) }</CardHeading>
 					<div className="help-search__content">

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -11,9 +11,9 @@ $min_results_height: 180px;
 	}
 
 	.help-search__inner {
-		padding: 16px 16px 0;
+		padding: 0 16px;
 
-		@include break-mobile {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 16px 24px 0;
 		}
 	}
@@ -28,7 +28,10 @@ $min_results_height: 180px;
 	}
 
 	.help-search__footer {
-		margin-bottom: 12px;
+		margin-bottom: 30px;
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-bottom: 6px;
+		}
 	}
 
 	.help-search__cta {

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -31,7 +31,7 @@ const QuickStart = ( { nextSession, reschedule, siteId, siteSlug, viewDetails } 
 	return (
 		<>
 			{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
-			<Card className="quick-start next-session">
+			<Card className="quick-start next-session customer-home__card">
 				<HappinessEngineersTray />
 				<CardHeading>{ translate( 'Your scheduled Quick Start support session:' ) }</CardHeading>
 				<table>

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -89,8 +89,8 @@ export const StatsV2 = ( {
 					<QuerySiteStats siteId={ siteId } statType="statsTopPosts" query={ topPostsQuery } />
 				</>
 			) }
-
-			<Card>
+			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+			<Card className="customer-home__card">
 				{ isSiteUnlaunched && (
 					<Chart data={ placeholderChartData } isPlaceholder>
 						<div>

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -6,6 +6,7 @@
 
 .stats .chart {
 	margin: 0 -16px;
+	background: none;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 -24px;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -4,8 +4,18 @@
 
 .site-setup-list {
 	padding: 0;
+	box-shadow: none;
+	border-bottom: 1px solid var( --color-border-subtle );
+	margin-bottom: 30px;
+
 	@include display-grid;
 	@include grid-template-columns( 12, 24px, 1fr );
+
+	@include breakpoint-deprecated( '>660px' ) {
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		border-bottom: none;
+		margin-bottom: 16px;
+	}
 
 	@include breakpoint-deprecated( '<960px' ) {
 		display: block;
@@ -64,7 +74,7 @@
 		display: flex;
 		align-items: center;
 
-		@include break-mobile {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 16px 24px;
 		}
 	}
@@ -79,7 +89,7 @@
 		margin: 0;
 		color: var( --color-text );
 
-		@include break-mobile {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 16px 24px;
 		}
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -15,6 +15,8 @@
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
 		border-bottom: none;
 		margin-bottom: 16px;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 3px;
 	}
 
 	@include breakpoint-deprecated( '<960px' ) {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -3,7 +3,6 @@
 
 .task {
 	display: flex;
-	background: var( --color-surface );
 	box-shadow: 0 0 0 1px var( --color-border-subtle );
 	position: relative;
 	margin-bottom: 24px;

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -6,6 +6,8 @@
 	box-shadow: 0 0 0 1px var( --color-border-subtle );
 	position: relative;
 	margin-bottom: 24px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 3px;
 
 	.task__text,
 	.task__illustration {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -3,19 +3,23 @@
 
 .task {
 	display: flex;
-	box-shadow: 0 0 0 1px var( --color-border-subtle );
 	position: relative;
-	margin-bottom: 24px;
+	margin-bottom: 30px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 3px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		margin-bottom: 24px;
+	}
 
 	.task__text,
 	.task__illustration {
 		box-sizing: border-box;
-		padding: 24px 16px;
+		padding: 24px 24px 0;
 
-		@include break-mobile {
-			padding: 24px;
+		@include breakpoint-deprecated( '>660px' ) {
+			padding: 24px 16px;
 		}
 
 		@include breakpoint-deprecated( '>1040px' ) {

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -48,7 +48,7 @@ const LearnGrow = ( { cards, trackCards } ) => {
 
 	return (
 		<>
-			<Card className="learn-grow__content">
+			<Card className="learn-grow__content customer-home__card">
 				{ cards.map(
 					( card, index ) =>
 						cardComponents[ card ] &&

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/style.scss
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/style.scss
@@ -1,5 +1,6 @@
 .learn-grow__content .educational-content {
-	padding: 1.5rem 0;
+	margin: 0 -24px;
+	padding: 1.5rem 24px;
 	border-bottom: 1px solid var( --color-neutral-5 );
 
 	&:first-child {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -133,8 +133,6 @@ body.is-section-home {
 	}
 }
 
-
-/** Restyle sidebar on light themes **/
 .is-section-home.is-nav-unification .sidebar .sidebar__heading::after, .is-section-home.is-nav-unification .sidebar .sidebar__menu-link::after {
 	border-right-color: var( --studio-white );
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,7 +1,7 @@
 @import './grid-mixins.scss';
 
 body.is-section-home {
-	background: white;
+	background: var( --studio-white );;
 }
 
 .customer-home__heading {
@@ -74,7 +74,8 @@ body.is-section-home {
 }
 
 .customer-home__main .card {
-	border-radius: 2px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 3px;
 }
 
 .customer-home__main .card-heading {
@@ -109,4 +110,10 @@ body.is-section-home {
 	a:last-child .vertical-nav-item {
 		border-bottom: none;
 	}
+}
+
+
+/** Restyle sidebar on light themes **/
+.is-section-home.is-nav-unification .sidebar .sidebar__menu-link::after {
+	border-right-color: var( --studio-white );
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,5 +1,9 @@
 @import './grid-mixins.scss';
 
+body.is-section-home {
+	background: white;
+}
+
 .customer-home__heading {
 	display: flex;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -73,6 +73,10 @@ body.is-section-home {
 	}
 }
 
+.customer-home__main .card {
+	border-radius: 2px;
+}
+
 .customer-home__main .card-heading {
 	margin-bottom: 8px;
 }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -80,7 +80,7 @@ body.is-section-home {
 .customer-home__main .customer-home__card {
     padding: 0 16px 30px;
     margin-top: 0;
-    margin-bottom: 30px;
+    margin-bottom: 24px;
     border-bottom: 1px solid var( --color-border-subtle );
     box-shadow: none;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -54,8 +54,12 @@ body.is-section-home {
 	& > .card,
 	& > .foldable-card.card,
 	& > .foldable-card.card.is-expanded {
-		margin-bottom: 24px;
+		margin-bottom: 30px;
 		margin-top: 0;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-bottom: 16px;
+		}
 	}
 }
 
@@ -73,9 +77,26 @@ body.is-section-home {
 	}
 }
 
-.customer-home__main .card {
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 3px;
+.customer-home__main .customer-home__card {
+    padding: 0 16px 30px;
+    margin-top: 0;
+    margin-bottom: 30px;
+    border-bottom: 1px solid var( --color-border-subtle );
+    box-shadow: none;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 3px;
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		border-bottom: none;
+		padding: 16px 24px;
+		margin: 0 0 16px;
+	}
+
+	&.is-compact {
+		margin: 0 0 1px;
+    	padding: 16px 24px;
+	}
 }
 
 .customer-home__main .card-heading {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -114,6 +114,6 @@ body.is-section-home {
 
 
 /** Restyle sidebar on light themes **/
-.is-section-home.is-nav-unification .sidebar .sidebar__menu-link::after {
+.is-section-home.is-nav-unification .sidebar .sidebar__heading::after, .is-section-home.is-nav-unification .sidebar .sidebar__menu-link::after {
 	border-right-color: var( --studio-white );
 }


### PR DESCRIPTION
Re-creating PR for this branch after accidentally merging #53972 @roo2 

---

Apply design changes from https://github.com/Automattic/wp-calypso/issues/53212#issuecomment-866370338.

#### Changes 


Make page background white
Put a border radius on cards
Remove chevrons from quick links
Remove borders from between quick links
Reduce padding of quick links
Make 'hr's in the Learn/Grow section 100% width on mobile/tablet

Remove border from quick-links and app CTA cards on desktop
~~Remove  "Make updates on the go" App subtitle~~

#### Before Desktop:
<img width="500" alt="Screen Shot 2021-06-24 at 5 05 17 PM" src="https://user-images.githubusercontent.com/22446385/123205822-ab972580-d50e-11eb-9294-7a201be288c3.png">

#### Before Mobile learn/grow section:
<img width="496" alt="Screen Shot 2021-06-24 at 5 11 58 PM" src="https://user-images.githubusercontent.com/22446385/123206325-9a9ae400-d50f-11eb-9984-7cbb1470f93e.png">


#### After Desktop:
<img width="837" alt="Screen Shot 2021-06-24 at 5 05 28 PM" src="https://user-images.githubusercontent.com/22446385/123205849-b94cab00-d50e-11eb-8d50-8572a93a7a00.png">

#### After Mobile learn/grow section:
<img width="494" alt="Screen Shot 2021-06-24 at 5 12 06 PM" src="https://user-images.githubusercontent.com/22446385/123206182-61fb0a80-d50f-11eb-9b21-db418bdf561a.png">

