### PR TITLE
isTitanEmail: Check product is defined

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -483,7 +483,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
-		if ( isTitanMail( primaryPurchase ) ) {
+		if ( primaryPurchase && isTitanMail( primaryPurchase ) ) {
 			return (
 				<Button href={ emailManagementEdit( selectedSite.slug, primaryPurchase.meta ) }>
 					{ translate( 'Manage email' ) }

--- a/packages/calypso-products/src/is-titan-mail.js
+++ b/packages/calypso-products/src/is-titan-mail.js
@@ -5,6 +5,10 @@ import { formatProduct } from './format-product';
 import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
 
 export function isTitanMail( product ) {
+	if ( ! product ) {
+		return false;
+	}
+
 	product = formatProduct( product );
 
 	return product.product_slug === TITAN_MAIL_MONTHLY_SLUG;

--- a/packages/calypso-products/src/is-titan-mail.js
+++ b/packages/calypso-products/src/is-titan-mail.js
@@ -5,10 +5,6 @@ import { formatProduct } from './format-product';
 import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
 
 export function isTitanMail( product ) {
-	if ( ! product ) {
-		return false;
-	}
-
 	product = formatProduct( product );
 
 	return product.product_slug === TITAN_MAIL_MONTHLY_SLUG;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is to fix the bug reported by @JanaMW27 in p1624870231070900-slack-C01VA100LEA about Quick Start purchases showing a blank page after purchase completes.
* The fix is to check `product` is defined in the `isTitanMail()` check. 
* This bug is also seen while purchasing a traffic guide book from https://wordpress.com/marketing/ultimate-traffic-guide/

![tgcthf](https://user-images.githubusercontent.com/1269602/124123989-f5d95300-da88-11eb-9133-56a939483861.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a logged in account, head to /checkout/offer-quickstart-session.
* Click on the CTA to purchase a session.
* The purchase should complete successfully and the Thank You page should be shown. Without this PR, you would get a blank screen 
* Also try to complete a purchase of a traffic guide ebook from https://wordpress.com/marketing/ultimate-traffic-guide/, and confirm that you get a thank you page after successful completion of the purchase.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

