### PR TITLE
Adds loading state to the continue as user screen

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -44,9 +44,13 @@ async function validateUrl( redirectUrl ) {
 function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } ) {
 	const translate = useTranslate();
 	const [ validatedRedirectUrl, setValidatedRedirectUrl ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
 
 	useEffect( () => {
-		validateUrl( redirectUrlFromQuery ).then( setValidatedRedirectUrl );
+		validateUrl( redirectUrlFromQuery ).then( ( maybeValidatedUrl ) => {
+			setValidatedRedirectUrl( maybeValidatedUrl );
+			setIsLoading( false );
+		} );
 	}, [ redirectUrlFromQuery ] );
 
 	const userName = currentUser.display_name || currentUser.username;
@@ -58,7 +62,11 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 
 	return (
 		<div className="continue-as-user">
-			<a href={ validatedRedirectUrl || '/' } className="continue-as-user__gravatar-link">
+			<a
+				style={ { pointerEvents: isLoading ? 'none' : 'auto' } }
+				href={ validatedRedirectUrl || '/' }
+				className="continue-as-user__gravatar-link"
+			>
 				<Gravatar
 					user={ currentUser }
 					className="continue-as-user__gravatar"
@@ -67,7 +75,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 				/>
 				<div>{ userName }</div>
 			</a>
-			<Button primary href={ validatedRedirectUrl || '/' }>
+			<Button busy={ isLoading } primary href={ validatedRedirectUrl || '/' }>
 				{ translate( 'Continue' ) }
 			</Button>
 			<p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds loading state to the continue as user screen

#### Testing instructions

- Open a new incognito window with third-party cookies disabled.
- Go to https://wordpress.com and log in.
- In a new tab, go to a private/un-launched site.
- Open dev tools and set network throttling to "Slow 3G" or similar.
- The "Continue" button should be in a loading state till the request to `validate-redirect` completes.
- While the request completes, you should **not** be able to proceed by either clicking on the "Continue" button or clicking on the gravatar image.
- On completion of the request, you should be able to proceed by either clicking on the "Continue" button or clicking on the gravatar image.


Fixes #53698
