### PR TITLE
Add e2e test for 'from_template_selector' tracks prop.

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
@@ -40,10 +40,16 @@ describe( `[${ host }] Calypso Gutenberg Page Editor Tracking: (${ screenSize })
 			await wpAdminSidebar.selectNewPage();
 
 			const editor = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
-			await editor.initEditor( { dismissPageTemplateLocator: false } );
+			await editor.initEditor( { dismissPageTemplateLocator: true } );
 		} );
 
 		it( 'Tracks "from_template_selector" property for "wpcom_block_inserted"', async function () {
+			// Reload for page layout selector.
+			await this.driver.navigate().refresh();
+			await driverHelper.dismissAlertIfPresent( this.driver );
+			const editor = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
+			await editor.initEditor();
+
 			await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( '.page-pattern-modal .pattern-selector-item__label' )

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
+import assert from 'assert';
 import config from 'config';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -12,8 +14,9 @@ import GutenbergEditorComponent from '../../lib/gutenberg/gutenberg-editor-compo
 import WPAdminSidebar from '../../lib/pages/wp-admin/wp-admin-sidebar';
 
 import * as driverManager from '../../lib/driver-manager.js';
+import * as driverHelper from '../../lib/driver-helper.js';
 import * as dataHelper from '../../lib/data-helper.js';
-import { clearEventsStack } from '../../lib/gutenberg/tracking/utils.js';
+import { clearEventsStack, getEventsStack } from '../../lib/gutenberg/tracking/utils.js';
 import { createGeneralTests } from '../../lib/gutenberg/tracking/general-tests.js';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
@@ -37,7 +40,23 @@ describe( `[${ host }] Calypso Gutenberg Page Editor Tracking: (${ screenSize })
 			await wpAdminSidebar.selectNewPage();
 
 			const editor = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
-			await editor.initEditor( { dismissPageTemplateLocator: true } );
+			await editor.initEditor( { dismissPageTemplateLocator: false } );
+		} );
+
+		it( 'Tracks "from_template_selector" property for "wpcom_block_inserted"', async function () {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.page-pattern-modal .pattern-selector-item__label' )
+			);
+
+			const insertedEvents = await getEventsStack( this.driver ).filter(
+				( event ) => event[ 0 ] === 'wpcom_block_inserted'
+			);
+
+			assert(
+				insertedEvents.filter( ( event ) => event[ 1 ].from_template_selector === true ).length ===
+					insertedEvents.length
+			);
 		} );
 
 		createGeneralTests( { it, editorType: 'post', postType: 'page' } );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
@@ -46,7 +46,7 @@ describe( `[${ host }] Calypso Gutenberg Page Editor Tracking: (${ screenSize })
 				By.css( '.page-pattern-modal .pattern-selector-item__label' )
 			);
 
-			const insertedEvents = await getEventsStack( this.driver ).filter(
+			const insertedEvents = ( await getEventsStack( this.driver ) ).filter(
 				( event ) => event[ 0 ] === 'wpcom_block_inserted'
 			);
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
@@ -38,18 +38,9 @@ describe( `[${ host }] Calypso Gutenberg Page Editor Tracking: (${ screenSize })
 
 			const wpAdminSidebar = await WPAdminSidebar.Expect( this.driver );
 			await wpAdminSidebar.selectNewPage();
-
-			const editor = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
-			await editor.initEditor( { dismissPageTemplateLocator: true } );
 		} );
 
 		it( 'Tracks "from_template_selector" property for "wpcom_block_inserted"', async function () {
-			// Reload for page layout selector.
-			await this.driver.navigate().refresh();
-			await driverHelper.dismissAlertIfPresent( this.driver );
-			const editor = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
-			await editor.initEditor();
-
 			await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( '.page-pattern-modal .pattern-selector-item__label' )
@@ -63,6 +54,12 @@ describe( `[${ host }] Calypso Gutenberg Page Editor Tracking: (${ screenSize })
 				insertedEvents.filter( ( event ) => event[ 1 ].from_template_selector === true ).length ===
 					insertedEvents.length
 			);
+
+			// Reset for following tests.
+			await this.driver.navigate().refresh();
+			await driverHelper.dismissAlertIfPresent( this.driver );
+			const editor = await GutenbergEditorComponent.Expect( this.driver, 'wp-admin' );
+			await editor.initEditor( { dismissPageTemplateLocator: true } );
 		} );
 
 		createGeneralTests( { it, editorType: 'post', postType: 'page' } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following up on a bug fix for the `from_template_selector` tracking property being broken (https://github.com/Automattic/wp-calypso/pull/53640).  Here, we add a simple e2e test to verify the property is populated on `wpcom_block_inserted` events when adding a page layout.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Run e2e tests for `wp-calypso-gutenberg-page-editor-tracking-spec` and verify they pass as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53410
