### PR TITLE
Checkout: Update route definitions to use Redux current user

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -19,7 +19,7 @@ import {
 import { noop } from './utils';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
-import { noSite, siteSelection } from 'calypso/my-sites/controller';
+import { loggedInSiteSelection, noSite, siteSelection } from 'calypso/my-sites/controller';
 import { isEnabled } from '@automattic/calypso-config';
 import userFactory from 'calypso/lib/user';
 
@@ -29,17 +29,18 @@ export default function () {
 	const user = userFactory();
 	const isLoggedOut = ! user.get();
 
-	if ( isLoggedOut ) {
-		if ( isEnabled( 'jetpack/userless-checkout' ) ) {
-			page( '/checkout/jetpack/:siteSlug/:productSlug', checkout, makeLayout, clientRender );
-			page(
-				'/checkout/jetpack/thank-you/:site/:product',
-				jetpackCheckoutThankYou,
-				makeLayout,
-				clientRender
-			);
-		}
+	if ( isEnabled( 'jetpack/userless-checkout' ) ) {
+		page( '/checkout/jetpack/:siteSlug/:productSlug', checkout, makeLayout, clientRender );
+		page(
+			'/checkout/jetpack/thank-you/:site/:product',
+			loggedInSiteSelection,
+			jetpackCheckoutThankYou,
+			makeLayout,
+			clientRender
+		);
+	}
 
+	if ( isLoggedOut ) {
 		page( '/checkout/offer-quickstart-session', upsellNudge, makeLayout, clientRender );
 
 		page( '/checkout/no-site/:lang?', noSite, checkout, makeLayout, clientRender );
@@ -47,18 +48,6 @@ export default function () {
 		page( '/checkout*', redirectLoggedOut );
 
 		return;
-	}
-
-	// Handle logged-in user visiting Jetpack checkout
-	if ( isEnabled( 'jetpack/userless-checkout' ) ) {
-		page( '/checkout/jetpack/:siteSlug/:productSlug', checkout, makeLayout, clientRender );
-		page(
-			'/checkout/jetpack/thank-you/:site/:product',
-			siteSelection,
-			jetpackCheckoutThankYou,
-			makeLayout,
-			clientRender
-		);
 	}
 
 	// Show these paths only for logged in users

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -21,13 +21,9 @@ import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
 import { loggedInSiteSelection, noSite, siteSelection } from 'calypso/my-sites/controller';
 import { isEnabled } from '@automattic/calypso-config';
-import userFactory from 'calypso/lib/user';
 
 export default function () {
 	page( '/checkout*', recordSiftScienceUser );
-
-	const user = userFactory();
-	const isLoggedOut = ! user.get();
 
 	if ( isEnabled( 'jetpack/userless-checkout' ) ) {
 		page( '/checkout/jetpack/:siteSlug/:productSlug', checkout, makeLayout, clientRender );
@@ -40,19 +36,9 @@ export default function () {
 		);
 	}
 
-	if ( isLoggedOut ) {
-		page( '/checkout/offer-quickstart-session', upsellNudge, makeLayout, clientRender );
-
-		page( '/checkout/no-site/:lang?', noSite, checkout, makeLayout, clientRender );
-
-		page( '/checkout*', redirectLoggedOut );
-
-		return;
-	}
-
-	// Show these paths only for logged in users
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutPending,
 		makeLayout,
@@ -61,6 +47,7 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/no-site/:receiptId?',
+		redirectLoggedOut,
 		noSite,
 		checkoutThankYou,
 		makeLayout,
@@ -69,6 +56,7 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/:site/pending/:orderId',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutPending,
 		makeLayout,
@@ -77,6 +65,7 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,
 		makeLayout,
@@ -85,6 +74,7 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,
 		makeLayout,
@@ -93,16 +83,18 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,
 		makeLayout,
 		clientRender
 	);
 
-	page( '/checkout/no-site', noSite, checkout, makeLayout, clientRender );
+	page( '/checkout/no-site/:lang?', noSite, checkout, makeLayout, clientRender );
 
 	page(
 		'/checkout/features/:feature/:domain/:plan_name?',
+		redirectLoggedOut,
 		siteSelection,
 		checkout,
 		makeLayout,
@@ -115,6 +107,7 @@ export default function () {
 
 		page(
 			'/checkout/offer-support-session/:site?',
+			redirectLoggedOut,
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -123,6 +116,7 @@ export default function () {
 
 		page(
 			'/checkout/offer-support-session/:receiptId/:site',
+			redirectLoggedOut,
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -131,7 +125,7 @@ export default function () {
 
 		page(
 			'/checkout/offer-quickstart-session/:site?',
-			siteSelection,
+			loggedInSiteSelection,
 			upsellNudge,
 			makeLayout,
 			clientRender
@@ -139,6 +133,7 @@ export default function () {
 
 		page(
 			'/checkout/offer-quickstart-session/:receiptId/:site',
+			redirectLoggedOut,
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -148,6 +143,7 @@ export default function () {
 
 	page(
 		'/checkout/:domainOrProduct',
+		redirectLoggedOut,
 		siteSelection,
 		isEnabled( 'jetpack/redirect-legacy-plans' ) ? redirectJetpackLegacyPlans : noop,
 		checkout,
@@ -157,6 +153,7 @@ export default function () {
 
 	page(
 		'/checkout/:product/:domainOrProduct',
+		redirectLoggedOut,
 		siteSelection,
 		isEnabled( 'jetpack/redirect-legacy-plans' ) ? redirectJetpackLegacyPlans : noop,
 		checkout,
@@ -169,6 +166,7 @@ export default function () {
 
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',
+		redirectLoggedOut,
 		siteSelection,
 		checkout,
 		makeLayout,
@@ -177,6 +175,7 @@ export default function () {
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		gsuiteNudge,
 		makeLayout,
@@ -188,9 +187,12 @@ export default function () {
 
 	page(
 		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',
+		redirectLoggedOut,
 		siteSelection,
 		upsellNudge,
 		makeLayout,
 		clientRender
 	);
+
+	page( '/checkout*', redirectLoggedOut );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we're using `lib/user` when declaring the checkout routes, in order to differentiate between routes for logged-in users and routes for logged-out users. However, we've been getting rid of `lib/user` in favor of its Redux counterpart, so this PR moves this logic to relevant middleware. 

There are several specific details to talk through here:

1. Some routes exist for both kinds of users and are the same. We're just keeping one instance of those. One example is `/checkout/jetpack/:siteSlug/:productSlug`.
2. Some routes exist for both kinds of users, and are the same, with one difference: for logged-in users they include the site selection middleware. For those, we're merging them and using the `loggedInSiteSelection`, which triggers that middleware only for logged-in users. One example is `/checkout/jetpack/thank-you/:site/:product`. 
3. Some routes exist only for logged-in users. For all those, we're adding `redirectLoggedOut`, which will do a redirect to the login page, essentially preserving the current behavior for logged-out users.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

Go through all the checkout routes as both a logged-out and logged-in user, and verify all routes still work the same way. 