### PR TITLE
Redirect Logged out users from Jetpack Product Connect to Site-less Checkout

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -383,12 +383,13 @@ export function redirectToLoginIfLoggedOut( context, next ) {
 	next();
 }
 
-export function redirectToSiteLessCheckoutIfLoggedOut( context, next ) {
-	const { type } = context.params;
-	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+export function redirectToSiteLessCheckout( context, next ) {
+	const { type, interval } = context.params;
 
-	if ( config.isEnabled( 'jetpack/siteless-checkout' ) && ! isLoggedIn ) {
-		page( addQueryArgs( context.query, `/checkout/jetpack/${ type }` ) );
+	const planSlug = getPlanSlugFromFlowType( type, interval );
+
+	if ( config.isEnabled( 'jetpack/siteless-checkout' ) ) {
+		page( addQueryArgs( context.query, `/checkout/jetpack/${ planSlug }` ) );
 		return;
 	}
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -68,6 +68,7 @@ import {
 	getJetpackProductDisplayName,
 } from '@automattic/calypso-products';
 import { externalRedirect } from 'calypso/lib/route/path';
+import { addQueryArgs } from 'calypso/lib/route';
 
 /**
  * Module variables
@@ -376,6 +377,18 @@ export function redirectToLoginIfLoggedOut( context, next ) {
 
 	if ( ! isLoggedIn ) {
 		page( login( { isJetpack: true, redirectTo: context.path } ) );
+		return;
+	}
+
+	next();
+}
+
+export function redirectToSiteLessCheckoutIfLoggedOut( context, next ) {
+	const { type } = context.params;
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
+	if ( config.isEnabled( 'jetpack/siteless-checkout' ) && ! isLoggedIn ) {
+		page( addQueryArgs( context.query, `/checkout/jetpack/${ type }` ) );
 		return;
 	}
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -38,6 +38,7 @@ export default function () {
 
 	page(
 		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?`,
+		controller.redirectToSiteLessCheckoutIfLoggedOut,
 		controller.loginBeforeJetpackSearch,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -38,7 +38,7 @@ export default function () {
 
 	page(
 		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?`,
-		controller.redirectToSiteLessCheckoutIfLoggedOut,
+		controller.redirectToSiteLessCheckout,
 		controller.loginBeforeJetpackSearch,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,

--- a/config/development.json
+++ b/config/development.json
@@ -91,6 +91,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
+		"jetpack/siteless-checkout": false,
 		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -62,6 +62,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
+		"jetpack/siteless-checkout": false,
 		"jetpack/userless-checkout": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,

--- a/config/production.json
+++ b/config/production.json
@@ -62,6 +62,7 @@
 		"jetpack/happychat": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
+		"jetpack/siteless-checkout": false,
 		"jetpack/userless-checkout": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,6 +63,7 @@
 		"jetpack/happychat": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
+		"jetpack/siteless-checkout": false,
 		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add redirect to `/jetpack/connect/[product]` path to simple checkout 

#### Testing instructions

1. Set `jetpack/siteless-checkout` to true in `development.json` and boot the branch
2. Navigate to various version of `calypso.localhost:3000/jetpack/connect/[product]`
   a. jetpack_backup_daily
   b. jetpack_security_daily
   c. jetpack_complete
   d.  personal
   e. /jetpack/connect/personal/monthly
   f. etc. 
3. Since the corresponding route does not exist you will end up at a login screen, but you can verify that the `redirect_to` param has become `/checkout/jetpack/[product]`
4. Test with some query args and verify that they are also preserved.
5. Revert `development.json` , reboot, test the same URL, and verify you are still brought to `jetpack/connect`

Related to 1200479326344990-as-1200505106233343