### PR TITLE
Theme Showcase: Do away with "Show all themes" button, add tabs

### DIFF
--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -26,8 +26,8 @@ class RecommendedThemes extends React.Component {
 
 	componentDidUpdate( prevProps ) {
 		// Wait until rec themes to be loaded to scroll to search input if its in use.
-		const { isLoading, isShowcaseOpen, scrollToSearchInput, filter } = this.props;
-		if ( prevProps.isLoading !== isLoading && isLoading === false && isShowcaseOpen ) {
+		const { isLoading, scrollToSearchInput, filter } = this.props;
+		if ( prevProps.isLoading !== isLoading && isLoading === false ) {
 			scrollToSearchInput();
 		}
 		if ( prevProps.filter !== filter ) {

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 /**
  * Internal dependencies
@@ -43,9 +42,6 @@ class RecommendedThemes extends React.Component {
 	render() {
 		return (
 			<>
-				<h2>
-					<strong>{ translate( 'Recommended themes' ) }</strong>
-				</h2>
 				{ this.props.isLoading ? (
 					<Spinner size={ 100 } />
 				) : (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -285,7 +285,14 @@ class ThemeShowcase extends React.Component {
 						select={ this.onTierSelect }
 					/>
 					{ isLoggedIn && (
-						<SectionNav className="themes__section-nav">
+						<SectionNav
+							className="themes__section-nav"
+							selectedText={
+								'recommended' === this.state.tabFilter
+									? translate( 'Recommended' )
+									: translate( 'All Themes' )
+							}
+						>
 							<NavTabs>
 								<NavItem
 									onClick={ () => this.onFilterClick( 'recommended' ) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -74,7 +74,7 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.state = {
-			tabFilter: 'recommended',
+			tabFilter: this.props.loggedOutComponent ? 'all' : 'recommended',
 		};
 	}
 
@@ -304,7 +304,7 @@ class ThemeShowcase extends React.Component {
 					) }
 					{ this.props.upsellBanner }
 
-					{ 'recommended' === this.state.tabFilter && isLoggedIn && (
+					{ 'recommended' === this.state.tabFilter && (
 						<RecommendedThemes
 							upsellUrl={ this.props.upsellUrl }
 							search={ search }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -38,6 +38,10 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import RecommendedThemes from './recommended-themes';
 
 /**
  * Style dependencies
@@ -69,7 +73,9 @@ class ThemeShowcase extends React.Component {
 		super( props );
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
-		this.state = {};
+		this.state = {
+			tabFilter: 'recommended',
+		};
 	}
 
 	static propTypes = {
@@ -147,6 +153,7 @@ class ThemeShowcase extends React.Component {
 			// Strip filters and excess whitespace
 			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
+		this.setState( { tabFilter: 'all' } );
 		page( url );
 		this.scrollToSearchInput();
 	};
@@ -184,10 +191,16 @@ class ThemeShowcase extends React.Component {
 	};
 
 	onTierSelect = ( { value: tier } ) => {
+		this.setState( { tabFilter: 'all' } );
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
 		this.scrollToSearchInput();
+	};
+
+	onFilterClick = ( tabFilter ) => {
+		trackClick( 'section nav filter', tabFilter );
+		this.setState( { tabFilter } );
 	};
 
 	render() {
@@ -271,49 +284,111 @@ class ThemeShowcase extends React.Component {
 						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
+					<SectionNav className="themes__section-nav">
+						<NavTabs>
+							<NavItem
+								onClick={ () => this.onFilterClick( 'recommended' ) }
+								selected={ 'recommended' === this.state.tabFilter }
+							>
+								{ translate( 'Recommended' ) }
+							</NavItem>
+							<NavItem
+								onClick={ () => this.onFilterClick( 'all' ) }
+								selected={ 'all' === this.state.tabFilter }
+							>
+								{ translate( 'All Themes' ) }
+							</NavItem>
+						</NavTabs>
+					</SectionNav>
 					{ this.props.upsellBanner }
 
-					<ThemesSelection
-						upsellUrl={ this.props.upsellUrl }
-						search={ search }
-						tier={ this.props.tier }
-						filter={ filter }
-						vertical={ this.props.vertical }
-						siteId={ this.props.siteId }
-						listLabel={ this.props.listLabel }
-						defaultOption={ this.props.defaultOption }
-						secondaryOption={ this.props.secondaryOption }
-						placeholderCount={ this.props.placeholderCount }
-						getScreenshotUrl={ function ( theme ) {
-							if ( ! getScreenshotOption( theme ).getUrl ) {
-								return null;
-							}
+					{ 'recommended' === this.state.tabFilter && (
+						<RecommendedThemes
+							upsellUrl={ this.props.upsellUrl }
+							search={ search }
+							tier={ this.props.tier }
+							filter={ filter }
+							vertical={ this.props.vertical }
+							siteId={ this.props.siteId }
+							listLabel={ this.props.listLabel }
+							defaultOption={ this.props.defaultOption }
+							secondaryOption={ this.props.secondaryOption }
+							placeholderCount={ this.props.placeholderCount }
+							getScreenshotUrl={ function ( theme ) {
+								if ( ! getScreenshotOption( theme ).getUrl ) {
+									return null;
+								}
 
-							return localizeThemesPath(
-								getScreenshotOption( theme ).getUrl( theme ),
-								locale,
-								! isLoggedIn
-							);
-						} }
-						onScreenshotClick={ function ( themeId ) {
-							if ( ! getScreenshotOption( themeId ).action ) {
-								return;
-							}
-							getScreenshotOption( themeId ).action( themeId );
-						} }
-						getActionLabel={ function ( theme ) {
-							return getScreenshotOption( theme ).label;
-						} }
-						getOptions={ function ( theme ) {
-							return pickBy(
-								addTracking( options ),
-								( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-							);
-						} }
-						trackScrollPage={ this.props.trackScrollPage }
-						emptyContent={ this.props.emptyContent }
-						bookmarkRef={ this.bookmarkRef }
-					/>
+								return localizeThemesPath(
+									getScreenshotOption( theme ).getUrl( theme ),
+									locale,
+									! isLoggedIn
+								);
+							} }
+							onScreenshotClick={ function ( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
+									return;
+								}
+								getScreenshotOption( themeId ).action( themeId );
+							} }
+							getActionLabel={ function ( theme ) {
+								return getScreenshotOption( theme ).label;
+							} }
+							getOptions={ function ( theme ) {
+								return pickBy(
+									addTracking( options ),
+									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+								);
+							} }
+							trackScrollPage={ this.props.trackScrollPage }
+							emptyContent={ this.props.emptyContent }
+							scrollToSearchInput={ this.scrollToSearchInput }
+							bookmarkRef={ this.bookmarkRef }
+						/>
+					) }
+					{ 'all' === this.state.tabFilter && (
+						<ThemesSelection
+							upsellUrl={ this.props.upsellUrl }
+							search={ search }
+							tier={ this.props.tier }
+							filter={ filter }
+							vertical={ this.props.vertical }
+							siteId={ this.props.siteId }
+							listLabel={ this.props.listLabel }
+							defaultOption={ this.props.defaultOption }
+							secondaryOption={ this.props.secondaryOption }
+							placeholderCount={ this.props.placeholderCount }
+							getScreenshotUrl={ function ( theme ) {
+								if ( ! getScreenshotOption( theme ).getUrl ) {
+									return null;
+								}
+
+								return localizeThemesPath(
+									getScreenshotOption( theme ).getUrl( theme ),
+									locale,
+									! isLoggedIn
+								);
+							} }
+							onScreenshotClick={ function ( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
+									return;
+								}
+								getScreenshotOption( themeId ).action( themeId );
+							} }
+							getActionLabel={ function ( theme ) {
+								return getScreenshotOption( theme ).label;
+							} }
+							getOptions={ function ( theme ) {
+								return pickBy(
+									addTracking( options ),
+									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+								);
+							} }
+							trackScrollPage={ this.props.trackScrollPage }
+							emptyContent={ this.props.emptyContent }
+							bookmarkRef={ this.bookmarkRef }
+						/>
+					) }
 					<ThemePreview />
 					{ this.props.children }
 				</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -11,7 +11,6 @@ import { compact, pickBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import ThemesSelection from './themes-selection';
 import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -39,7 +38,6 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
-import RecommendedThemes from './recommended-themes';
 
 /**
  * Style dependencies
@@ -71,15 +69,7 @@ class ThemeShowcase extends React.Component {
 		super( props );
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
-		this.state = {
-			isShowcaseOpen: !! (
-				this.props.loggedOutComponent ||
-				this.props.search ||
-				this.props.filter ||
-				this.props.tier ||
-				this.props.hasShowcaseOpened
-			),
-		};
+		this.state = {};
 	}
 
 	static propTypes = {
@@ -143,12 +133,6 @@ class ThemeShowcase extends React.Component {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
 			this.scrollRef.current.scrollIntoView();
 		}
-	};
-
-	toggleShowcase = () => {
-		this.setState( { isShowcaseOpen: ! this.state.isShowcaseOpen } );
-		this.props.openThemesShowcase();
-		this.props.trackMoreThemesClick();
 	};
 
 	doSearch = ( searchBoxContent ) => {
@@ -259,8 +243,6 @@ class ThemeShowcase extends React.Component {
 
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
-		const { isShowcaseOpen } = this.state;
-		const isQueried = this.props.search || this.props.filter || this.props.tier;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -277,138 +259,63 @@ class ThemeShowcase extends React.Component {
 					/>
 				) }
 				<div className="themes__content">
-					{ ! this.props.loggedOutComponent && ! isQueried && (
-						<>
-							<RecommendedThemes
-								upsellUrl={ this.props.upsellUrl }
-								search={ search }
-								tier={ this.props.tier }
-								filter={ filter }
-								vertical={ this.props.vertical }
-								siteId={ this.props.siteId }
-								listLabel={ this.props.listLabel }
-								defaultOption={ this.props.defaultOption }
-								secondaryOption={ this.props.secondaryOption }
-								placeholderCount={ this.props.placeholderCount }
-								getScreenshotUrl={ function ( theme ) {
-									if ( ! getScreenshotOption( theme ).getUrl ) {
-										return null;
-									}
-
-									return localizeThemesPath(
-										getScreenshotOption( theme ).getUrl( theme ),
-										locale,
-										! isLoggedIn
-									);
-								} }
-								onScreenshotClick={ function ( themeId ) {
-									if ( ! getScreenshotOption( themeId ).action ) {
-										return;
-									}
-									getScreenshotOption( themeId ).action( themeId );
-								} }
-								getActionLabel={ function ( theme ) {
-									return getScreenshotOption( theme ).label;
-								} }
-								getOptions={ function ( theme ) {
-									return pickBy(
-										addTracking( options ),
-										( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-									);
-								} }
-								trackScrollPage={ this.props.trackScrollPage }
-								emptyContent={ this.props.emptyContent }
-								isShowcaseOpen={ isShowcaseOpen }
-								scrollToSearchInput={ this.scrollToSearchInput }
-								bookmarkRef={ this.bookmarkRef }
-							/>
-							<div className="theme-showcase__open-showcase-button-holder">
-								{ isShowcaseOpen ? (
-									<hr />
-								) : (
-									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
-										{ translate( 'Show all themes' ) }
-									</Button>
-								) }
-							</div>
-						</>
+					{ ! this.props.loggedOutComponent && showBanners && (
+						<UpworkBanner location={ 'theme-banner' } />
 					) }
-					<div
-						ref={ this.scrollRef }
-						className={
-							! isShowcaseOpen
-								? 'themes__hidden-content theme-showcase__all-themes'
-								: 'theme-showcase__all-themes'
-						}
-					>
-						{ ! this.props.loggedOutComponent && (
-							<>
-								<h2>
-									<strong>{ translate( 'Advanced Themes' ) }</strong>
-								</h2>
-								<p>
-									{ translate(
-										'These themes offer more power and flexibility, but can be harder to setup and customize.'
-									) }
-								</p>
-								{ showBanners && <UpworkBanner location={ 'theme-banner' } /> }
-							</>
-						) }
-						<QueryThemeFilters />
+					<QueryThemeFilters />
 
-						<ThemesSearchCard
-							onSearch={ this.doSearch }
-							search={ filterString + search }
-							tier={ tier }
-							showTierThemesControl={ ! isMultisite }
-							select={ this.onTierSelect }
-						/>
-						{ this.props.upsellBanner }
+					<ThemesSearchCard
+						onSearch={ this.doSearch }
+						search={ filterString + search }
+						tier={ tier }
+						showTierThemesControl={ ! isMultisite }
+						select={ this.onTierSelect }
+					/>
+					{ this.props.upsellBanner }
 
-						<ThemesSelection
-							upsellUrl={ this.props.upsellUrl }
-							search={ search }
-							tier={ this.props.tier }
-							filter={ filter }
-							vertical={ this.props.vertical }
-							siteId={ this.props.siteId }
-							listLabel={ this.props.listLabel }
-							defaultOption={ this.props.defaultOption }
-							secondaryOption={ this.props.secondaryOption }
-							placeholderCount={ this.props.placeholderCount }
-							getScreenshotUrl={ function ( theme ) {
-								if ( ! getScreenshotOption( theme ).getUrl ) {
-									return null;
-								}
+					<ThemesSelection
+						upsellUrl={ this.props.upsellUrl }
+						search={ search }
+						tier={ this.props.tier }
+						filter={ filter }
+						vertical={ this.props.vertical }
+						siteId={ this.props.siteId }
+						listLabel={ this.props.listLabel }
+						defaultOption={ this.props.defaultOption }
+						secondaryOption={ this.props.secondaryOption }
+						placeholderCount={ this.props.placeholderCount }
+						getScreenshotUrl={ function ( theme ) {
+							if ( ! getScreenshotOption( theme ).getUrl ) {
+								return null;
+							}
 
-								return localizeThemesPath(
-									getScreenshotOption( theme ).getUrl( theme ),
-									locale,
-									! isLoggedIn
-								);
-							} }
-							onScreenshotClick={ function ( themeId ) {
-								if ( ! getScreenshotOption( themeId ).action ) {
-									return;
-								}
-								getScreenshotOption( themeId ).action( themeId );
-							} }
-							getActionLabel={ function ( theme ) {
-								return getScreenshotOption( theme ).label;
-							} }
-							getOptions={ function ( theme ) {
-								return pickBy(
-									addTracking( options ),
-									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-								);
-							} }
-							trackScrollPage={ this.props.trackScrollPage }
-							emptyContent={ this.props.emptyContent }
-							bookmarkRef={ this.bookmarkRef }
-						/>
-						<ThemePreview />
-						{ this.props.children }
-					</div>
+							return localizeThemesPath(
+								getScreenshotOption( theme ).getUrl( theme ),
+								locale,
+								! isLoggedIn
+							);
+						} }
+						onScreenshotClick={ function ( themeId ) {
+							if ( ! getScreenshotOption( themeId ).action ) {
+								return;
+							}
+							getScreenshotOption( themeId ).action( themeId );
+						} }
+						getActionLabel={ function ( theme ) {
+							return getScreenshotOption( theme ).label;
+						} }
+						getOptions={ function ( theme ) {
+							return pickBy(
+								addTracking( options ),
+								( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+							);
+						} }
+						trackScrollPage={ this.props.trackScrollPage }
+						emptyContent={ this.props.emptyContent }
+						bookmarkRef={ this.bookmarkRef }
+					/>
+					<ThemePreview />
+					{ this.props.children }
 				</div>
 			</div>
 		);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -317,9 +317,7 @@ class ThemeShowcase extends React.Component {
 							</NavTabs>
 						</SectionNav>
 					) }
-					{ ! this.props.loggedOutComponent && showBanners && (
-						<UpworkBanner location={ 'theme-banner' } />
-					) }
+
 					{ this.props.upsellBanner }
 
 					{ 'recommended' === this.state.tabFilter && (
@@ -368,6 +366,9 @@ class ThemeShowcase extends React.Component {
 					) }
 					{ 'all' === this.state.tabFilter && (
 						<div className="theme-showcase__all-themes">
+							{ ! this.props.loggedOutComponent && showBanners && (
+								<UpworkBanner location={ 'theme-banner' } />
+							) }
 							<ThemesSelection
 								upsellUrl={ this.props.upsellUrl }
 								search={ search }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -356,47 +356,49 @@ class ThemeShowcase extends React.Component {
 						/>
 					) }
 					{ 'all' === this.state.tabFilter && (
-						<ThemesSelection
-							upsellUrl={ this.props.upsellUrl }
-							search={ search }
-							tier={ this.props.tier }
-							filter={ filter }
-							vertical={ this.props.vertical }
-							siteId={ this.props.siteId }
-							listLabel={ this.props.listLabel }
-							defaultOption={ this.props.defaultOption }
-							secondaryOption={ this.props.secondaryOption }
-							placeholderCount={ this.props.placeholderCount }
-							getScreenshotUrl={ function ( theme ) {
-								if ( ! getScreenshotOption( theme ).getUrl ) {
-									return null;
-								}
+						<div className="theme-showcase__all-themes">
+							<ThemesSelection
+								upsellUrl={ this.props.upsellUrl }
+								search={ search }
+								tier={ this.props.tier }
+								filter={ filter }
+								vertical={ this.props.vertical }
+								siteId={ this.props.siteId }
+								listLabel={ this.props.listLabel }
+								defaultOption={ this.props.defaultOption }
+								secondaryOption={ this.props.secondaryOption }
+								placeholderCount={ this.props.placeholderCount }
+								getScreenshotUrl={ function ( theme ) {
+									if ( ! getScreenshotOption( theme ).getUrl ) {
+										return null;
+									}
 
-								return localizeThemesPath(
-									getScreenshotOption( theme ).getUrl( theme ),
-									locale,
-									! isLoggedIn
-								);
-							} }
-							onScreenshotClick={ function ( themeId ) {
-								if ( ! getScreenshotOption( themeId ).action ) {
-									return;
-								}
-								getScreenshotOption( themeId ).action( themeId );
-							} }
-							getActionLabel={ function ( theme ) {
-								return getScreenshotOption( theme ).label;
-							} }
-							getOptions={ function ( theme ) {
-								return pickBy(
-									addTracking( options ),
-									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-								);
-							} }
-							trackScrollPage={ this.props.trackScrollPage }
-							emptyContent={ this.props.emptyContent }
-							bookmarkRef={ this.bookmarkRef }
-						/>
+									return localizeThemesPath(
+										getScreenshotOption( theme ).getUrl( theme ),
+										locale,
+										! isLoggedIn
+									);
+								} }
+								onScreenshotClick={ function ( themeId ) {
+									if ( ! getScreenshotOption( themeId ).action ) {
+										return;
+									}
+									getScreenshotOption( themeId ).action( themeId );
+								} }
+								getActionLabel={ function ( theme ) {
+									return getScreenshotOption( theme ).label;
+								} }
+								getOptions={ function ( theme ) {
+									return pickBy(
+										addTracking( options ),
+										( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+									);
+								} }
+								trackScrollPage={ this.props.trackScrollPage }
+								emptyContent={ this.props.emptyContent }
+								bookmarkRef={ this.bookmarkRef }
+							/>
+						</div>
 					) }
 					<ThemePreview />
 					{ this.props.children }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -191,7 +191,11 @@ class ThemeShowcase extends React.Component {
 	};
 
 	onTierSelect = ( { value: tier } ) => {
-		this.setState( { tabFilter: 'all' } );
+		// In this state: tabFilter = [ ##Recommended## | All(1) ]   tier = [ All(2) | Free | Premium ]
+		// Clicking "Free" or "Premium" forces tabFilter from "Recommended" to "All"
+		if ( tier !== '' && tier !== 'all' && this.state.tabFilter === 'recommended' ) {
+			this.setState( { tabFilter: 'all' } );
+		}
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
@@ -201,6 +205,14 @@ class ThemeShowcase extends React.Component {
 	onFilterClick = ( tabFilter ) => {
 		trackClick( 'section nav filter', tabFilter );
 		this.setState( { tabFilter } );
+
+		let callback = () => null;
+		// In this state: tabFilter = [ Recommended | ##All(1)## ]  tier = [ All(2) | Free | ##Premium## ]
+		// Clicking "Recommended" forces tier to be "all", since Recommend themes cannot filter on tier.
+		if ( 'recommended' === tabFilter && 'all' !== this.props.tier ) {
+			callback = () => this.onTierSelect( { value: 'all' } );
+		}
+		this.setState( { tabFilter }, callback );
 	};
 
 	render() {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -284,25 +284,27 @@ class ThemeShowcase extends React.Component {
 						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
-					<SectionNav className="themes__section-nav">
-						<NavTabs>
-							<NavItem
-								onClick={ () => this.onFilterClick( 'recommended' ) }
-								selected={ 'recommended' === this.state.tabFilter }
-							>
-								{ translate( 'Recommended' ) }
-							</NavItem>
-							<NavItem
-								onClick={ () => this.onFilterClick( 'all' ) }
-								selected={ 'all' === this.state.tabFilter }
-							>
-								{ translate( 'All Themes' ) }
-							</NavItem>
-						</NavTabs>
-					</SectionNav>
+					{ isLoggedIn && (
+						<SectionNav className="themes__section-nav">
+							<NavTabs>
+								<NavItem
+									onClick={ () => this.onFilterClick( 'recommended' ) }
+									selected={ 'recommended' === this.state.tabFilter }
+								>
+									{ translate( 'Recommended' ) }
+								</NavItem>
+								<NavItem
+									onClick={ () => this.onFilterClick( 'all' ) }
+									selected={ 'all' === this.state.tabFilter }
+								>
+									{ translate( 'All Themes' ) }
+								</NavItem>
+							</NavTabs>
+						</SectionNav>
+					) }
 					{ this.props.upsellBanner }
 
-					{ 'recommended' === this.state.tabFilter && (
+					{ 'recommended' === this.state.tabFilter && isLoggedIn && (
 						<RecommendedThemes
 							upsellUrl={ this.props.upsellUrl }
 							search={ search }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -284,11 +284,7 @@ class ThemeShowcase extends React.Component {
 					/>
 				) }
 				<div className="themes__content">
-					{ ! this.props.loggedOutComponent && showBanners && (
-						<UpworkBanner location={ 'theme-banner' } />
-					) }
 					<QueryThemeFilters />
-
 					<ThemesSearchCard
 						onSearch={ this.doSearch }
 						search={ filterString + search }
@@ -320,6 +316,9 @@ class ThemeShowcase extends React.Component {
 								</NavItem>
 							</NavTabs>
 						</SectionNav>
+					) }
+					{ ! this.props.loggedOutComponent && showBanners && (
+						<UpworkBanner location={ 'theme-banner' } />
 					) }
 					{ this.props.upsellBanner }
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -52,3 +52,7 @@
 .themes__hidden-content {
 	display: none;
 }
+
+.section-nav.themes__section-nav {
+	margin-top: 1px;
+}

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -353,6 +353,7 @@ class ThemesMagicSearchCard extends React.Component {
 						) }
 						{ isPremiumThemesEnabled && showTierThemesControl && (
 							<SimplifiedSegmentedControl
+								key={ this.props.tier }
 								initialSelected={ this.props.tier }
 								options={ tiers }
 								onSelect={ this.props.select }

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -33,7 +33,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async showOnlyThemesType( type ) {
-		await this.openShowcase();
 		await driverHelper.clickWhenClickable( this.driver, By.css( `a[data-e2e-value="${ type }"]` ) );
 		await this.waitUntilThemesLoaded();
 	}
@@ -107,13 +106,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.themes-magic-search-card__icon-close' )
-		);
-	}
-
-	async openShowcase() {
-		await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( `button[data-e2e-value="open-themes-button"]` )
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Put Recommended themes behind a new tab, and the rest of the showcase behind a tab called All Themes, with Recommended showing by default.

**Before**

![screencapture-wordpress-themes-caroauditsimple-wordpress-com-2021-06-29-12_30_40](https://user-images.githubusercontent.com/2124984/123834833-d9e18000-d8d5-11eb-96f4-08c80c4a6349.png)

**After**

![screencapture-calypso-localhost-3000-themes-calobeetesting44-wordpress-com-2021-07-07-12_58_48](https://user-images.githubusercontent.com/2124984/124800017-2b67bb80-df23-11eb-97f9-48be1c79928d.png)


#### Testing instructions

* Switch to this PR and navigate to `/themes/[site]`
* Add the flag query string to the URL to see everything behind the feature flag in addition to this PR: `?flags=theme/showcase-revamp`
* Note the lack of a "Show all themes" button at the bottom of the screen 🥳 
* You should be able to search, filter themes, etc. as expected
* You should see two new tabs, Recommended and All Themes, with Recommended selected by default; you should be able to switch between those selections
* When you search or filter, you'll be shifted to All Themes
* Check mobile devices for visual errors
* Tabs should not be present on the showcase when logged out; test when logged out to make sure everything works as expected, you can still search, filter, etc.
* Test on different site types with different plans (Jetpack, Premium, Business, Atomic, etc.) to make sure everything works as expected

Related to #54083 and #54076
