### PR TITLE
One click upsell: Handle explicit payment processor errors

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -3,7 +3,8 @@
  */
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { useProcessPayment } from '@automattic/composite-checkout';
+import { useProcessPayment, PaymentProcessorResponseType } from '@automattic/composite-checkout';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
@@ -53,7 +54,17 @@ export function useSubmitTransaction( {
 			postalCode,
 			siteId: siteId ? String( siteId ) : undefined,
 		} )
-			.then( () => {
+			.then( ( response: PaymentProcessorResponse ) => {
+				if ( response.type === PaymentProcessorResponseType.ERROR ) {
+					recordTracksEvent( 'calypso_oneclick_upsell_payment_error', {
+						error_code: response.payload,
+						reason: response.payload,
+					} );
+					reduxDispatch( errorNotice( response.payload ) );
+					onClose();
+					return;
+				}
+
 				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
 			} )
 			.catch( ( error ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/51460 we modified the saved card payment processor so that it would return an explicit error with the resolved Promise if the transaction failed instead of throwing. This allowed us to differentiate between "expected" transaction errors (when an endpoint returns a message that the user needs to see) and "unexpected" errors (when some JavaScript code has a bug and throws an error that the developers need to see).

However, the one-click upsell still expects errors to be thrown:

https://github.com/Automattic/wp-calypso/blob/8bbf750434c6e182dc47fc284a2cec1870330ede/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts#L59-L66

As a result, if the transaction endpoint returns an error, the Promise will resolve successfully, but nothing will happen.

This PR modifies the one-click upsell so that it looks for errors inside its success handler also.

Fixes https://github.com/Automattic/wp-calypso/issues/54081

#### Testing instructions

First apply D63405-code to break the transactions endpoint and sandbox the REST API.

To get the modal to appear you'll need a Personal or Premium plan already purchased, and you'll need to have at least one stored card, then visit `/checkout/offer-quickstart-session/1234/example.com` where `example.com` is your site (the number is a receipt ID but doesn't really matter so you can just make it up).

<img width="493" alt="Screen Shot 2021-06-28 at 1 36 44 PM" src="https://user-images.githubusercontent.com/2036909/123679926-12ba2000-d816-11eb-93cc-551abf7deca0.png">

Click "Yes, I want a WordPress Expert by my side!" then click the "Pay" button in the modal. Verify that the modal disappears and that a notice is displayed that reports the error.

<img width="337" alt="Screen Shot 2021-06-28 at 3 30 04 PM" src="https://user-images.githubusercontent.com/2036909/123693174-be1ea100-d825-11eb-9710-2338e9d2d0cf.png">
