### PR TITLE
Theme Showcase: Keyed Suggestions appears less often

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -300,7 +300,9 @@ class ThemesMagicSearchCard extends React.Component {
 		} );
 
 		// Check if we want to render suggestions or welcome banner
-		const renderSuggestions = this.state.editedSearchElement !== '';
+		const renderSuggestions = this.state.editedSearchElement.match(
+			/(feature|layout|column|subject|style):/i
+		);
 
 		return (
 			<div className={ magicSearchClass }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In theme showcase, the "Keyed Suggestions" component appears less often. (Only when a search contains an uncompleted "feature:" like string).

![2021-06-28_15-06_1](https://user-images.githubusercontent.com/937354/123697504-9e39ae00-d822-11eb-9659-d658d688553f.png)
^ Search for "car" before

![2021-06-28_15-07](https://user-images.githubusercontent.com/937354/123697524-a265cb80-d822-11eb-859e-1b3dbb2cc7bf.png)
^ Search for "car" after

![2021-06-28_15-08](https://user-images.githubusercontent.com/937354/123697625-bd384000-d822-11eb-83d2-274c372e63a9.png)
^ Beginning a search with "feature:" after changes still displays the "Keyed Suggestions" component


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Calypso. 
* Choose Appearance -> Themes in sthe sidebar
*  Click "Show All Themes"
* Use the newly revealed search, try both regular searches and using the "Magic Welcome Bar" (aka, clicking on "Features" just below the search)
* On local dev, if you are sandboxing public api, you may not be able to load the page directly. Some workarounds are here: paYKcK-144-p2

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/issues/54077