### PR TITLE
One click upsell: Validate contact information from stored card before showing

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -53,6 +53,10 @@ import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
+import {
+	isContactValidationResponseValid,
+	getTaxValidationResult,
+} from 'calypso/my-sites/checkout/composite-checkout/contact-validation';
 
 /**
  * Style dependencies
@@ -96,14 +100,59 @@ export class UpsellNudge extends React.Component {
 
 	state = {
 		showPurchaseModal: false,
+		isValidatingContactInfo: true,
+		isContactInfoValid: false,
 	};
 
 	componentDidMount() {
 		window.scrollTo( 0, 0 );
+		this.validateContactInfo();
 	}
+
+	componentDidUpdate() {
+		this.validateContactInfo();
+	}
+
+	validateContactInfo = () => {
+		if ( this.props.isLoading || ! this.state.isValidatingContactInfo ) {
+			return;
+		}
+		if ( this.props.cards.length === 0 ) {
+			this.setState( { isValidatingContactInfo: false, isContactInfoValid: false } );
+			return;
+		}
+		const storedCard = this.props.cards[ 0 ];
+		const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
+		const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
+
+		const validateContactDetails = async () => {
+			const contactInfo = {
+				postalCode: {
+					value: postalCode,
+					isTouched: true,
+					errors: [],
+					isRequired: true,
+				},
+				countryCode: {
+					value: countryCode,
+					isTouched: true,
+					errors: [],
+					isRequired: true,
+				},
+			};
+			const validationResult = await getTaxValidationResult( contactInfo );
+			return isContactValidationResponseValid( validationResult, contactInfo );
+		};
+
+		validateContactDetails().then( ( isValid ) => {
+			this.setState( { isValidatingContactInfo: false, isContactInfoValid: isValid } );
+		} );
+	};
 
 	render() {
 		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans, upsellType } = this.props;
+
+		const { isValidatingContactInfo } = this.state;
 
 		return (
 			<Main className={ upsellType }>
@@ -111,7 +160,7 @@ export class UpsellNudge extends React.Component {
 				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }
 				{ ! hasSitePlans && <QuerySitePlans siteId={ selectedSiteId } /> }
-				{ isLoading ? this.renderPlaceholders() : this.renderContent() }
+				{ isLoading || isValidatingContactInfo ? this.renderPlaceholders() : this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }
 			</Main>
@@ -302,6 +351,10 @@ export class UpsellNudge extends React.Component {
 
 		// stored cards should exist
 		if ( cards.length === 0 ) {
+			return false;
+		}
+
+		if ( ! this.state.isContactInfoValid ) {
 			return false;
 		}
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -52,7 +52,7 @@ export function PurchaseModal( {
 		cart,
 		siteId,
 		setStep,
-		storedCard: cards?.[ 0 ],
+		storedCard: cards[ 0 ],
 		onClose,
 	} );
 	const contentProps = {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -31,7 +31,7 @@ export function useSubmitTransaction( {
 }: {
 	cart: ResponseCart;
 	siteId: string | number;
-	storedCard: StoredCard;
+	storedCard: StoredCard | undefined;
 	setStep: SetStep;
 	onClose: OnClose;
 } ): SubmitTransactionFunction {
@@ -39,6 +39,9 @@ export function useSubmitTransaction( {
 	const reduxDispatch = useDispatch();
 
 	return useCallback( () => {
+		if ( ! storedCard ) {
+			throw new Error( 'No saved card found' );
+		}
 		const wpcomCart = translateResponseCartToWPCOMCart( cart );
 		const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
 		const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relatively recently we began requiring submitting a valid postal code and country code for all wpcom checkout transactions. Previously these fields were still submitted, but they were not required, nor were they validated.

In regular checkout, this is safe because we also validate these fields when checkout loads and when they change. If there is a problem, the user will see a clear notice well before they submit the transaction.

However, the one-click checkout modal post-checkout does not do any contact validation. Moreover, its postal code and country code come from data saved with the most recent stored card, and there is no way (apart from going to checkout) to see this data or edit it. When submitted, if the postal code is invalid, the user will receive a cryptic error with no obvious recourse.

This PR modifies the `UpsellNudge` component that displays the one click upsell so that it validates the postal code and country that the upsell would use when it loads. If the data is invalid, triggering the upsell will redirect to checkout instead of the one-click modal (just as it would if there were no saved cards or an unsupported product).

Fixes https://github.com/Automattic/wp-calypso/issues/54082

#### Testing instructions

To get the upsell to appear you'll need a Personal or Premium plan already purchased, and you'll need to have at least one stored card, then visit `/checkout/offer-quickstart-session/1234/example.com` where `example.com` is your site (the number is a receipt ID but doesn't really matter so you can just make it up).

Click "Yes, I want a WordPress Expert by my side!".

If your most recently saved credit card has a valid postal code and country, verify that you see the one-click upsell modal appear. 

If it does not, verify that you are immediately redirected to checkout.

You can view and edit your payment methods by visiting https://wordpress.com/me/purchases/payment-methods although you won't be able to see the postal code and country attached to each one in the UI. You can, however, use the network devtools of your web browser to look for the `/me/payment-methods` endpoint response, which will include the postal code and country as `meta`:

![postal_country_in_payment_methods_reply](https://user-images.githubusercontent.com/2036909/123702833-9fbea280-d831-11eb-905f-0ccdc56278a6.png)

#### Videos

##### Invalid postal code:

https://user-images.githubusercontent.com/2036909/123823780-7d796300-d8cb-11eb-9202-99289baa8018.mov

##### Valid postal code:

https://user-images.githubusercontent.com/2036909/123823812-823e1700-d8cb-11eb-9109-750d524d3ab4.mov

