### PR TITLE
Track Jetpack Connect flow with Jetpack GA Property

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -253,7 +253,14 @@ export function connect( context, next ) {
 		const product = getProductFromSlug( planSlug );
 		analyticsPageTitle = getJetpackProductDisplayName( product );
 	}
-	recordPageView( pathname, analyticsPageTitle || 'Jetpack Connect' );
+	recordPageView(
+		pathname,
+		analyticsPageTitle || 'Jetpack Connect',
+		{},
+		{
+			useJetpackGoogleAnalytics: true,
+		}
+	);
 
 	// Not clearing the plan here, because other flows can set the cookie before arriving here.
 	planSlug && storePlan( planSlug );
@@ -288,7 +295,14 @@ export function connect( context, next ) {
 }
 
 export function instructions( context, next ) {
-	recordPageView( 'jetpack/connect/instructions', 'Jetpack Manual Install Instructions' );
+	recordPageView(
+		'jetpack/connect/instructions',
+		'Jetpack Manual Install Instructions',
+		{},
+		{
+			useJetpackGoogleAnalytics: true,
+		}
+	);
 
 	const url = context.query.url;
 	if ( ! url ) {
@@ -299,7 +313,14 @@ export function instructions( context, next ) {
 }
 
 export function signupForm( context, next ) {
-	recordPageView( 'jetpack/connect/authorize', 'Jetpack Authorize' );
+	recordPageView(
+		'jetpack/connect/authorize',
+		'Jetpack Authorize',
+		{},
+		{
+			useJetpackGoogleAnalytics: true,
+		}
+	);
 
 	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
@@ -329,7 +350,14 @@ export function credsForm( context, next ) {
 }
 
 export function authorizeForm( context, next ) {
-	recordPageView( 'jetpack/connect/authorize', 'Jetpack Authorize' );
+	recordPageView(
+		'jetpack/connect/authorize',
+		'Jetpack Authorize',
+		{},
+		{
+			useJetpackGoogleAnalytics: true,
+		}
+	);
 
 	const { query } = context;
 	const transformedQuery = parseAuthorizationQuery( query );
@@ -347,7 +375,14 @@ export function sso( context, next ) {
 	const analyticsBasePath = '/jetpack/sso';
 	const analyticsPageTitle = 'Jetpack SSO';
 
-	recordPageView( analyticsBasePath, analyticsPageTitle );
+	recordPageView(
+		analyticsBasePath,
+		analyticsPageTitle,
+		{},
+		{
+			useJetpackGoogleAnalytics: true,
+		}
+	);
 
 	context.primary = (
 		<JetpackSsoForm

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -66,13 +66,24 @@ export function getGoogleAnalyticsDefaultConfig() {
  *
  * @param {string} urlPath The path of the current page
  * @param {string} pageTitle The title of the current page
+ * @param {bool} useJetpackGoogleAnalytics send the page view to Jetpack Google Analytics
  */
-export function fireGoogleAnalyticsPageView( urlPath, pageTitle ) {
-	window.gtag( 'config', TRACKING_IDS.wpcomGoogleAnalyticsGtag, {
-		...getGoogleAnalyticsDefaultConfig(),
-		page_path: urlPath,
-		page_title: pageTitle,
-	} );
+export function fireGoogleAnalyticsPageView(
+	urlPath,
+	pageTitle,
+	useJetpackGoogleAnalytics = false
+) {
+	window.gtag(
+		'config',
+		useJetpackGoogleAnalytics
+			? TRACKING_IDS.jetpackGoogleAnalyticsGtag
+			: TRACKING_IDS.wpcomGoogleAnalyticsGtag,
+		{
+			...getGoogleAnalyticsDefaultConfig(),
+			page_path: urlPath,
+			page_title: pageTitle,
+		}
+	);
 }
 
 /**

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -66,7 +66,7 @@ export function getGoogleAnalyticsDefaultConfig() {
  *
  * @param {string} urlPath The path of the current page
  * @param {string} pageTitle The title of the current page
- * @param {bool} useJetpackGoogleAnalytics send the page view to Jetpack Google Analytics
+ * @param {boolean} useJetpackGoogleAnalytics send the page view to Jetpack Google Analytics
  */
 export function fireGoogleAnalyticsPageView(
 	urlPath,

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -73,17 +73,18 @@ export function fireGoogleAnalyticsPageView(
 	pageTitle,
 	useJetpackGoogleAnalytics = false
 ) {
-	window.gtag(
-		'config',
-		useJetpackGoogleAnalytics
-			? TRACKING_IDS.jetpackGoogleAnalyticsGtag
-			: TRACKING_IDS.wpcomGoogleAnalyticsGtag,
-		{
+	window.gtag( 'config', TRACKING_IDS.wpcomGoogleAnalyticsGtag, {
+		...getGoogleAnalyticsDefaultConfig(),
+		page_path: urlPath,
+		page_title: pageTitle,
+	} );
+	if ( useJetpackGoogleAnalytics ) {
+		window.gtag( 'config', TRACKING_IDS.jetpackGoogleAnalyticsGtag, {
 			...getGoogleAnalyticsDefaultConfig(),
 			page_path: urlPath,
 			page_title: pageTitle,
-		}
-	);
+		} );
+	}
 }
 
 /**

--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -36,11 +36,20 @@ function initialize() {
 
 export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function recordPageView(
 	urlPath,
-	pageTitle
+	pageTitle,
+	useJetpackGoogleAnalytics = false
 ) {
-	gaDebug( 'Recording Page View ~ [URL: ' + urlPath + '] [Title: ' + pageTitle + ']' );
+	gaDebug(
+		'Recording Page View ~ [URL: ' +
+			urlPath +
+			'] [Title: ' +
+			pageTitle +
+			'] [useJetpackGoogleAnalytics: ' +
+			useJetpackGoogleAnalytics +
+			']'
+	);
 
-	fireGoogleAnalyticsPageView( urlPath, pageTitle );
+	fireGoogleAnalyticsPageView( urlPath, pageTitle, useJetpackGoogleAnalytics );
 } );
 
 /**

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -38,6 +38,7 @@ export class PageViewTracker extends React.Component {
 		selectedSiteId: PropTypes.number,
 		title: PropTypes.string.isRequired,
 		properties: PropTypes.object,
+		options: PropTypes.object,
 	};
 
 	state = {
@@ -91,9 +92,9 @@ export class PageViewTracker extends React.Component {
 	};
 
 	recordViewWithProperties() {
-		const { path, recorder = noop, title, properties } = this.props;
+		const { path, recorder = noop, title, properties, options } = this.props;
 
-		return recorder( path, title, 'default', properties );
+		return recorder( path, title, 'default', properties, options );
 	}
 
 	render() {

--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -13,13 +13,13 @@ import { processQueue } from './queue';
 import { referRecordPageView } from './refer';
 import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytics';
 
-export function recordPageView( urlPath, pageTitle, params = {} ) {
+export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) {
 	// Add delay to avoid stale `_dl` in recorded calypso_page_view event details.
 	// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript.
 	setTimeout( () => {
 		// Tracks, Google Analytics, Refer platform.
 		recordTracksPageViewWithPageParams( urlPath, params );
-		gaRecordPageView( urlPath, pageTitle );
+		gaRecordPageView( urlPath, pageTitle, options?.useJetpackGoogleAnalytics );
 		referRecordPageView();
 
 		// Retargeting.

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -648,7 +648,12 @@ export default function CompositeCheckout( {
 			<QueryPlans />
 			<QueryProducts />
 			<QueryContactDetailsCache />
-			<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
+			<PageViewTracker
+				path={ analyticsPath }
+				title="Checkout"
+				properties={ analyticsProps }
+				options={ { useJetpackGoogleAnalytics: isJetpackCheckout || isJetpackNotAtomic } }
+			/>
 			<CheckoutProvider
 				items={ items }
 				total={ total }

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -161,7 +161,12 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 
 	return (
 		<Main className="selector__main" wideLayout>
-			<PageViewTracker path={ viewTrackerPath } properties={ viewTrackerProps } title="Plans" />
+			<PageViewTracker
+				path={ viewTrackerPath }
+				properties={ viewTrackerProps }
+				title="Plans"
+				options={ { useJetpackGoogleAnalytics: true } }
+			/>
 
 			{ header }
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -165,7 +165,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 				path={ viewTrackerPath }
 				properties={ viewTrackerProps }
 				title="Plans"
-				options={ { useJetpackGoogleAnalytics: true } }
+				options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
 			/>
 
 			{ header }

--- a/client/state/analytics/actions/record.js
+++ b/client/state/analytics/actions/record.js
@@ -27,7 +27,7 @@ export const recordCustomFacebookConversionEvent = ( name, properties ) =>
 export const recordCustomAdWordsRemarketingEvent = ( properties ) =>
 	recordEvent( 'adwords', { properties } );
 
-export const recordPageView = ( url, title, service, properties = {} ) => ( {
+export const recordPageView = ( url, title, service, properties = {}, options = {} ) => ( {
 	type: ANALYTICS_PAGE_VIEW_RECORD,
 	meta: {
 		analytics: [
@@ -37,6 +37,7 @@ export const recordPageView = ( url, title, service, properties = {} ) => ( {
 					service,
 					url,
 					title,
+					options,
 					...properties,
 				},
 			},

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -27,7 +27,7 @@ const eventServices = {
 
 const pageViewServices = {
 	ga: ( { url, title } ) => gaRecordPageView( url, title ),
-	default: ( { url, title, ...params } ) => recordPageView( url, title, params ),
+	default: ( { url, title, options, ...params } ) => recordPageView( url, title, params, options ),
 };
 
 const loadTrackingTool = ( trackingTool ) => {

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -81,9 +81,14 @@ describe( 'middleware', () => {
 		test( 'should call pageView.record', () => {
 			dispatch( recordPageView( 'path', 'title', 'default', { name: 'value' } ) );
 
-			expect( pageviewRecordPageView ).toHaveBeenCalledWith( 'path', 'title', {
-				name: 'value',
-			} );
+			expect( pageviewRecordPageView ).toHaveBeenCalledWith(
+				'path',
+				'title',
+				{
+					name: 'value',
+				},
+				{}
+			);
 		} );
 
 		test( 'should call gaRecordEvent', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add options to `recordPageView`
* Allow override from Calypso Blue GA Property to Calypso Green/Jetpack.com GA Property
* Use these changes in the `jetpack/connect` flow and when checking out with a Jetpack Product


#### Testing instructions

##### Testing GA

To test Google Analytics you can either:
1. Use the [Tag Assistant Companion Chrome Plugin](https://chrome.google.com/webstore/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm) <img width="1008" alt="Screen Shot 2021-06-29 at 11 42 28 AM" src="https://user-images.githubusercontent.com/2810519/123850901-69376500-d8cf-11eb-88d6-cf1a5a04b9b7.png">

2. Set `localStorage.setItem( 'debug', 'calypso:analytics:ga' );` in the console, then verify you see `calypso:analytics:ga Recording Page View ~ [URL: /stats/day/:site] [Title: Stats > Day] [useJetpackGoogleAnalytics: false]` with `useJetpackGoogleAnalytics` true for a Jetpack GA page view and false for a Calypso standard GA page view
    

##### Instructions

1. Activate `ad-tracking` in `development.json`
2. Boot local branch
3. Navigate to `jetpack/connect`. Verify that GA Page Views are sent to the Jetpack Google Analytics Property `UA-52447-43` and Calypso dev property `UA-10673494-15`
4. Navigate to a jetpack site try to purchase a plan ( aka get to checkout with a Jetpack product
5. Verify that GA Page Views are sent to the Jetpack Google Analytics Property `UA-52447-43` and Calypso dev property `UA-10673494-15`
