### PR TITLE
Shopping Cart: Disable refetchOnWindowFocus for siteless/userless carts

### DIFF
--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -33,12 +33,17 @@ export default function CalypsoShoppingCartProvider( {
 } ): JSX.Element {
 	const selectedSite = useSelector( getSelectedSite );
 	const finalCartKey = cartKey === undefined ? getCartKey( { selectedSite } ) : cartKey;
+	const cartKeysThatDoNotAllowRefetch = [ 'no-site', 'no-user' ];
+	const refetchOnWindowFocus: boolean =
+		Boolean( selectedSite?.ID ) &&
+		Boolean( finalCartKey ) &&
+		! cartKeysThatDoNotAllowRefetch.includes( String( finalCartKey ) );
 
 	const options = useMemo(
 		() => ( {
-			refetchOnWindowFocus: !! finalCartKey,
+			refetchOnWindowFocus,
 		} ),
-		[ finalCartKey ]
+		[ refetchOnWindowFocus ]
 	);
 
 	// If cartKey is null, we pass that to ShoppingCartProvider because it is


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/53482 which added code to refetch the shopping cart whenever the window was refocused. That PR included code intended to disable this feature when there was no permanent cart, but it didn't properly take into account temporary cart conditions like siteless or registrationless carts. This PR attempts to fix that issue.

#### Testing instructions

##### To verify that the refresh is disabled

Merge these changes with https://github.com/Automattic/wp-calypso/pull/53894 and follow the testing instructions there until you see the checkout cart. Then open a new tab, wait about 2 minutes, and return to the checkout tab. Verify that the cart does not refresh.

##### To verify that the refresh still works:

- Add a product to your cart and visit checkout in a window or tab; let's call it "tab A".
- Open a second window or tab and load checkout there also; let's call this "tab B".
- In tab B, click to modify the cart in some way. The simplest option is to delete the item in the cart, but you could also change the tax location, change the product variant, or click an upsell.
- Return to tab A and verify that the cart now looks identical to tab B, with the change complete. (You may see the form briefly disable while it is updating, but it can be quite fast.)

NOTE: while you can use devtools to verify that the cart has reloaded, having (at least Chrome) devtools open interferes with the window focus event; changing _tabs_ will still trigger the refetch in this case, but not changing windows.