### PR TITLE
Launch: hide side explainer from reskin domain step on a paid plan

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -26,7 +26,6 @@ import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
-import { getStepModuleName } from 'calypso/signup/config/step-components';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl, isPlanSelectionAvailableLaterInFlow } from 'calypso/signup/utils';
 import {
@@ -49,6 +48,7 @@ import {
 	saveSignupStep,
 	submitSignupStep,
 } from 'calypso/state/signup/progress/actions';
+import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/selectors';
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -889,10 +889,8 @@ export default connect(
 			vertical: getVerticalForDomainSuggestions( state ),
 			selectedSite: getSelectedSite( state ),
 			sites: getSitesItems( state ),
-			isPlanSelectionAvailableLaterInFlow: isPlanSelectionAvailableLaterInFlow(
-				steps,
-				isPlanStepSkipped
-			),
+			isPlanSelectionAvailableLaterInFlow:
+				! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};
 	},

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -275,32 +275,14 @@ describe( 'utils', () => {
 		const defaultFlowSteps = [ 'user', 'domains', 'plans' ];
 
 		test( 'should return true when given flow contains "plans" step', () => {
-			const isPlanStepSkipped = false;
-			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow(
-				defaultFlowSteps,
-				isPlanStepSkipped
-			);
+			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow( defaultFlowSteps );
 
 			expect( isPlanSelectionAvailable ).toBe( true );
 		} );
 
 		test( 'should return false when given flow doesn`t contain "plans" step', () => {
 			const flowSteps = [ 'user', 'domains' ];
-			const isPlanStepSkipped = false;
-			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow(
-				flowSteps,
-				isPlanStepSkipped
-			);
-
-			expect( isPlanSelectionAvailable ).toBe( false );
-		} );
-
-		test( 'should return false when "plans" step was skipped', () => {
-			const isPlanStepSkipped = true;
-			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow(
-				defaultFlowSteps,
-				isPlanStepSkipped
-			);
+			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow( flowSteps );
 
 			expect( isPlanSelectionAvailable ).toBe( false );
 		} );

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -11,6 +11,7 @@ import {
 	getStepName,
 	getFlowName,
 	getFilteredSteps,
+	isPlanSelectionAvailableLaterInFlow,
 } from '../utils';
 
 jest.mock( 'calypso/signup/config/flows-pure', () => ( {
@@ -267,6 +268,41 @@ describe( 'utils', () => {
 			const canResume = canResumeFlow( 'onboarding', signupProgress );
 
 			expect( canResume ).toBe( false );
+		} );
+	} );
+
+	describe( 'isPlanSelectionAvailableLaterInFlow', () => {
+		const defaultFlowSteps = [ 'user', 'domains', 'plans' ];
+
+		test( 'should return true when given flow contains "plans" step', () => {
+			const isPlanStepSkipped = false;
+			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow(
+				defaultFlowSteps,
+				isPlanStepSkipped
+			);
+
+			expect( isPlanSelectionAvailable ).toBe( true );
+		} );
+
+		test( 'should return false when given flow doesn`t contain "plans" step', () => {
+			const flowSteps = [ 'user', 'domains' ];
+			const isPlanStepSkipped = false;
+			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow(
+				flowSteps,
+				isPlanStepSkipped
+			);
+
+			expect( isPlanSelectionAvailable ).toBe( false );
+		} );
+
+		test( 'should return false when "plans" step was skipped', () => {
+			const isPlanStepSkipped = true;
+			const isPlanSelectionAvailable = isPlanSelectionAvailableLaterInFlow(
+				defaultFlowSteps,
+				isPlanStepSkipped
+			);
+
+			expect( isPlanSelectionAvailable ).toBe( false );
 		} );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -177,7 +177,7 @@ export const isP2Flow = ( flowName ) => {
 
 // Derive if the "plans" step actually will be visible to the customer in a given flow after the domain step
 // i.e. Check "launch-site" flow while having a purchased paid plan
-export const isPlanSelectionAvailableLaterInFlow = ( flowSteps, isPlanStepSkipped ) => {
+export const isPlanSelectionAvailableLaterInFlow = ( flowSteps ) => {
 	/**
 	 * Caveat here even though "plans" step maybe available in a flow it might not be active
 	 * i.e. Check flow "domain"
@@ -191,5 +191,5 @@ export const isPlanSelectionAvailableLaterInFlow = ( flowSteps, isPlanStepSkippe
 	);
 	const isPlansStepExistsInFutureOfFlow = plansIndex > 0 && plansIndex > domainsIndex;
 
-	return isPlansStepExistsInFutureOfFlow && ! isPlanStepSkipped;
+	return isPlansStepExistsInFutureOfFlow;
 };

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -3,8 +3,8 @@ import { translate } from 'i18n-calypso';
 import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
-import steps from 'calypso/signup/config/steps-pure';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
+import steps from 'calypso/signup/config/steps-pure';
 
 const { defaultFlowName } = flows;
 
@@ -174,9 +174,15 @@ export const isReskinnedFlow = ( flowName ) => {
 
 export const isP2Flow = ( flowName ) => {
 	return flowName === 'p2' || flowName === 'p2-new';
+};
 
-// Derive if the "plans" step actually will be visible to the customer in a given flow after the domain step
-// i.e. Check "launch-site" flow while having a purchased paid plan
+/**
+ * Derive if the "plans" step actually will be visible to the customer in a given flow after the domain step
+ * i.e. Check "launch-site" flow while having a purchased paid plan
+ *
+ * @param  {object} flowSteps steps in the current flow
+ * @returns {boolean} true indicates that "plans" step will be one of the next steps in the flow
+ */
 export const isPlanSelectionAvailableLaterInFlow = ( flowSteps ) => {
 	/**
 	 * Caveat here even though "plans" step maybe available in a flow it might not be active

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -4,6 +4,8 @@ import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import steps from 'calypso/signup/config/steps-pure';
+import { getStepModuleName } from 'calypso/signup/config/step-components';
+
 const { defaultFlowName } = flows;
 
 function getDefaultFlowName() {
@@ -172,4 +174,22 @@ export const isReskinnedFlow = ( flowName ) => {
 
 export const isP2Flow = ( flowName ) => {
 	return flowName === 'p2' || flowName === 'p2-new';
+
+// Derive if the "plans" step actually will be visible to the customer in a given flow after the domain step
+// i.e. Check "launch-site" flow while having a purchased paid plan
+export const isPlanSelectionAvailableLaterInFlow = ( flowSteps, isPlanStepSkipped ) => {
+	/**
+	 * Caveat here even though "plans" step maybe available in a flow it might not be active
+	 * i.e. Check flow "domain"
+	 */
+
+	const plansIndex = flowSteps.findIndex(
+		( stepName ) => getStepModuleName( stepName ) === 'plans'
+	);
+	const domainsIndex = flowSteps.findIndex(
+		( stepName ) => getStepModuleName( stepName ) === 'domains'
+	);
+	const isPlansStepExistsInFutureOfFlow = plansIndex > 0 && plansIndex > domainsIndex;
+
+	return isPlansStepExistsInFutureOfFlow && ! isPlanStepSkipped;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide reskin side explainer promoting 'paid plan -> free domain' when there is no "Plans" step in the signup flow
* Extract `isPlanSelectionAvailableLaterInFlow` to utils and cover with unit tests

#### Testing instructions

* Create a site on `/start` with a free domain and a paid purchased plan
* Go to Site setup checklist in My Home and start the Launch flow
* On the Domains step (only step in this case), you shouldn't see the side explainer with paid plan promotion

#### Screenshots

* Before
<img width="700" alt="Screenshot 2021-06-29 at 15 32 45" src="https://user-images.githubusercontent.com/14192054/123802555-1c19ba00-d8f4-11eb-81f9-3ac1e3546cbc.png">

* After
<img width="700" alt="Screenshot 2021-06-29 at 15 32 07" src="https://user-images.githubusercontent.com/14192054/123801471-fe982080-d8f2-11eb-9814-0300dd6e141c.png">

Fixes https://github.com/Automattic/wp-calypso/issues/53974
