### PR TITLE
Fix: Jetpack product card prices (currency code) not loading in some cases.

### DIFF
--- a/client/state/currency-code/reducer.js
+++ b/client/state/currency-code/reducer.js
@@ -5,6 +5,7 @@ import {
 	SITE_PLANS_FETCH_COMPLETED,
 	PLANS_RECEIVE,
 	PRODUCTS_LIST_RECEIVE,
+	SITE_PRODUCTS_FETCH_COMPLETED,
 } from 'calypso/state/action-types';
 import { withSchemaValidation } from 'calypso/state/utils';
 
@@ -20,6 +21,9 @@ function reducer( state = null, action ) {
 
 		case SITE_PLANS_FETCH_COMPLETED:
 			return action.plans[ 0 ]?.currencyCode ?? state;
+
+		case SITE_PRODUCTS_FETCH_COMPLETED:
+			return Object.values( action.products )[ 0 ]?.currency_code ?? state;
 	}
 
 	return state;

--- a/client/state/currency-code/test/reducer.js
+++ b/client/state/currency-code/test/reducer.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { PLANS_RECEIVE, SITE_PLANS_FETCH_COMPLETED } from 'calypso/state/action-types';
+import {
+	PLANS_RECEIVE,
+	SITE_PLANS_FETCH_COMPLETED,
+	SITE_PRODUCTS_FETCH_COMPLETED,
+} from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
 import currencyCode from '../reducer';
 
@@ -69,6 +73,30 @@ describe( '#currencyCode()', () => {
 					currencyCode: 'CAD',
 				},
 			],
+		} );
+		expect( state ).toBe( 'CAD' );
+	} );
+	test( 'should set currency code when site products fetch is completed', () => {
+		const state = currencyCode( undefined, {
+			type: SITE_PRODUCTS_FETCH_COMPLETED,
+			products: {
+				free_plan: {
+					product_name: 'WordPress.com Free',
+					currency_code: 'USD',
+				},
+			},
+		} );
+		expect( state ).toBe( 'USD' );
+	} );
+	test( 'should update currency code when site products fetch is completed', () => {
+		const state = currencyCode( 'USD', {
+			type: SITE_PRODUCTS_FETCH_COMPLETED,
+			products: {
+				free_plan: {
+					product_name: 'WordPress.com Free',
+					currency_code: 'CAD',
+				},
+			},
 		} );
 		expect( state ).toBe( 'CAD' );
 	} );


### PR DESCRIPTION
Initially a PR for this was created, reviewed, and ready to merge( https://github.com/Automattic/wp-calypso/pull/54090 ), but at the same time a different PR was merged (#48690) that moved the `currencyCode` reducer to a different location, so this PR is a re-creation of the original PR but for the `currencyCode` reducer in it's new location.

#### Changes proposed in this Pull Request

This PR fixes a bug where the Jetpack product card prices are not loading and they are stuck in a loading state in the UI.  This occurs only in one particular edge-case that I am aware of, which is during the jetpack connect flow when creating a new account with magic links. (See testing instructions below to see exactly how to reproduce it)

The reason prices aren't loading is because the user's `currency_code` value is coming back as `null`.

#### Implementation notes:

The `currency_code` is retrieved as a byproduct of either of these three fetch actions:

- `PRODUCTS_LIST_RECEIVE`
- `PLANS_RECEIVE`
- `SITE_PLANS_FETCH_COMPLETED`

([code reference here](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/currency-code/reducer.js#L13))

In this particular connection flow, none of the above three actions take place, therefore `currency_code` is coming back as `null`.

The fix was to add an additional fetch action, `SITE_PRODUCTS_FETCH_COMPLETED` because in this particular flow, this action is called and the `currency_code` can be retrieved from it.


#### Testing instructions

- Checkout this PR and start Calypso blue env (`yarn start`)

First, to reproduce and view the issue:

- Make sure you are logged-out of WordPress.com
- Create a JN site
- Go to https://wordpress.com/jetpack/connect and enter the JN site address, and click "Continue" button.
- On the log-in page, enter a new email address that is **not associated with an existing WordPress.com account**. (We'll be creating a new account here.) and click "Continue" button.
- Open your email account and open the "Create WordPress.com account" email that was sent to you. Click the button labeled, "Finish your Jetpack setup".
- Wait for the authorization process to finish...
- You should end up on the `wordpress.com/jetpack/connect/plans/:site?redirect=...` page.  You should see that the product prices are not loading and stuck in a loading state.
- You can refresh the page to confirm that the prices are still not loading.

Now to verify this PR fixes the issue:

- In the URL change the hostname from wordpress.com to calypso.localhost:3000 and press enter.
- Verify that all the prices in the product cards are now loading.

Run unit tests:

- `yarn test-client client/state/currency-code/test/reducer.js` 
- Verify all unit tests pass.

#### Testing steps screencast
![Screen Capture on 2021-06-28 at 15-57-29](https://user-images.githubusercontent.com/11078128/123696837-35eeca80-d82a-11eb-95a6-0ce4e845e2eb.gif)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Asana task # 1164141197617539-as-1200500830663033