### PR TITLE
Signup: use standard line height for domain suggestions

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -264,7 +264,7 @@ body.is-section-signup.is-white-signup {
 		margin-left: 0;
 		margin-top: 0;
 		margin-bottom: 10px;
-		
+
 		.badge {
 			border-radius: 4px; /* stylelint-disable-line */
 			font-size: 0.75rem;
@@ -288,7 +288,7 @@ body.is-section-signup.is-white-signup {
 		@include break-mobile {
 			margin: 0 20px;
 		}
-		
+
 		@include break-large {
 			margin: 0;
 		}
@@ -345,17 +345,13 @@ body.is-section-signup.is-white-signup {
 			background: none;
 			border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
 			border-top: 1px solid #fff; //This white border is to prevent jumpiness while showing borders on hover
-			
+
 			@include break-mobile {
 				padding-left: 5px;
 				padding-right: 5px;
 			}
 
 			.domain-registration-suggestion__domain-title {
-				@include break-xlarge {
-					line-height: 3rem;
-				}
-
 				.domain-registration-suggestion__domain-title-name {
 					color: var( --studio-gray-60 );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use normal line-height for domain suggestions even on larger screens

#### Testing instructions

* Go to /start on a large viewport (more than 1080px wide)
* Type a really long query so the search results are displayed on two lines 

#### Screenshots

* Before

<img width="800" alt="Screenshot 2021-06-29 at 16 34 56" src="https://user-images.githubusercontent.com/14192054/123807562-a19f6900-d8f8-11eb-8452-cb70ea666c12.png">

* After

<img width="800" alt="Screenshot 2021-06-29 at 16 35 24" src="https://user-images.githubusercontent.com/14192054/123807578-a5cb8680-d8f8-11eb-93c3-f339e6124f8a.png">


Related to https://github.com/Automattic/wp-calypso/issues/54010#issuecomment-869278840
