### PR TITLE
User: Move verification polling to a component

### DIFF
--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
  */
 
 import { successNotice } from 'calypso/state/notices/actions';
-import user from 'calypso/lib/user';
+import { sendVerificationSignal } from 'calypso/lib/user/verification-checker';
 
 /**
  * Page middleware
@@ -19,7 +19,7 @@ export default function emailVerification( context, next ) {
 	const showVerifiedNotice = '1' === context.query.verified;
 
 	if ( showVerifiedNotice ) {
-		user().signalVerification();
+		sendVerificationSignal();
 		setTimeout( () => {
 			const message = i18n.translate( 'Email confirmed!' );
 			const notice = successNotice( message, { duration: 10000 } );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -28,6 +28,7 @@ import {
 	getSidebarIsCollapsed,
 } from 'calypso/state/ui/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -298,6 +299,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (
 					<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				) }
+				<UserVerificationChecker />
 				{ config.isEnabled( 'layout/guided-tours' ) && (
 					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
 				) }

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -29,9 +29,6 @@ export interface User extends EventEmitter {
 	fetch: () => Promise< void >;
 	handleFetchFailure: ( error: Error ) => void;
 	handleFetchSuccess: ( userdata: UserData ) => void;
-	verificationPollerCallback: ( signal?: true ) => void;
-	checkVerification: () => void;
-	signalVerification: () => void;
 	dispatchToken: string;
 }
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -32,11 +32,6 @@ function User() {
 }
 
 /**
- * Constants
- */
-const VERIFICATION_POLL_INTERVAL = 15000;
-
-/**
  * Mixins
  */
 Emitter( User.prototype );
@@ -48,8 +43,6 @@ User.prototype.initialize = async function () {
 	debug( 'Initializing User' );
 	this.fetching = false;
 	this.data = false;
-
-	this.on( 'change', this.checkVerification.bind( this ) );
 
 	let skipBootstrap = false;
 
@@ -171,94 +164,6 @@ User.prototype.handleFetchSuccess = function ( userData ) {
 	this.data = userData;
 
 	this.emit( 'change' );
-};
-
-/**
- * Called every VERIFICATION_POLL_INTERVAL milliseconds
- * if the email is not verified.
- *
- * May also be called by a localStorage event, on which case
- * the `signal` parameter is set to true.
- *
- * @private
- */
-
-User.prototype.verificationPollerCallback = function ( signal ) {
-	// skip server poll if page is hidden or there are no listeners
-	// and this was not triggered by a localStorage signal
-	if ( ( document.hidden || this.listeners( 'verify' ).length === 0 ) && ! signal ) {
-		return;
-	}
-
-	debug( 'Verification: POLL' );
-
-	this.once( 'change', () => {
-		if ( this.get().email_verified ) {
-			// email is verified, stop polling
-			clearInterval( this.verificationPoller );
-			this.verificationPoller = null;
-			debug( 'Verification: VERIFIED' );
-			this.emit( 'verify' );
-		}
-	} );
-
-	this.fetch();
-};
-
-/**
- * Checks if the user email is verified, and starts polling
- * for verification if that's not the case.
- *
- * Also registers a listener to localStorage events.
- *
- * @private
- */
-
-User.prototype.checkVerification = function () {
-	if ( ! this.get() ) {
-		// not loaded, do nothing
-		return;
-	}
-
-	if ( this.get().email_verified ) {
-		// email already verified, do nothing
-		return;
-	}
-
-	if ( this.verificationPoller ) {
-		// already polling, do nothing
-		return;
-	}
-
-	this.verificationPoller = setInterval(
-		this.verificationPollerCallback.bind( this ),
-		VERIFICATION_POLL_INTERVAL
-	);
-
-	// wait for localStorage event (from other windows)
-	window.addEventListener( 'storage', ( e ) => {
-		if ( e.key === '__email_verified_signal__' && e.newValue ) {
-			debug( 'Verification: RECEIVED SIGNAL' );
-			window.localStorage.removeItem( '__email_verified_signal__' );
-			this.verificationPollerCallback( true );
-		}
-	} );
-};
-
-/**
- * Writes to local storage, signalling all other windows
- * that the user has been verified.
- *
- * This should be called from the verification successful
- * message, so that all the windows update instantaneously
- */
-
-User.prototype.signalVerification = function () {
-	if ( window.localStorage ) {
-		// use localStorage to signal to other browser windows that the user's email was verified
-		window.localStorage.setItem( '__email_verified_signal__', 1 );
-		debug( 'Verification: SENT SIGNAL' );
-	}
 };
 
 /**

--- a/client/lib/user/verification-checker.js
+++ b/client/lib/user/verification-checker.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
+
+const debug = debugFactory( 'calypso:user' );
+const storageKey = '__email_verified_signal__';
+
+export function sendVerificationSignal() {
+	if ( window.localStorage ) {
+		// use localStorage to signal to other browser windows that the user's email was verified
+		window.localStorage.setItem( storageKey, 1 );
+		debug( 'Verification: SENT SIGNAL' );
+	}
+}
+
+export default function UserVerificationChecker() {
+	const currentUser = useSelector( getCurrentUser );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( ! currentUser ) {
+			// not loaded, do nothing
+			return;
+		}
+
+		if ( currentUser.email_verified ) {
+			// email already verified, do nothing
+			return;
+		}
+
+		const postVerificationUserRefetch = ( e ) => {
+			if ( e.key === storageKey && e.newValue ) {
+				debug( 'Verification: RECEIVED SIGNAL' );
+				window.localStorage.removeItem( storageKey );
+				dispatch( fetchCurrentUser() );
+			}
+		};
+
+		// wait for localStorage event (from other windows)
+		window.addEventListener( 'storage', postVerificationUserRefetch );
+
+		return () => {
+			window.removeEventListener( 'storage', postVerificationUserRefetch );
+		};
+	}, [ currentUser, dispatch ] );
+
+	return null;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is an experiment to try moving the legacy user email verification polling to a functional component. By removing this from `lib/user`, very little logic remains in there to be refactored from and we're one step closer to removing `lib/user` completely.

Part of #24004 where we aim to reduxify `lib/user`.

#### Testing instructions

* Checkout this branch locally.
* Start with an unverified user (or ping me to help you how to "unverify" your user if that's easier).
* Go to `http://calypso.localhost:3000/people/new/:site` where `:site` is the primary site of your user.
* Open that same page in 2 separate tabs.
* In one of them, type `state.currentUser.user.email_verified` in the browser console. Verify it returns `false`.
* You should be seeing a notice at the top of the card, asking you to get your email verified before inviting other users.
* Click the button to send a verification email and close that tab. Keep the other one intact.
* Click the button in the email to verify your email. Once that's done, close that tab.
* In a new tab, open `http://calypso.localhost:3000/people/new/:site?verified=1` where `:site` is the primary site of your user. 
* You should get a success notice.
* Switch back to the other tab, **don't refresh it** and verify that a fresh network request to `/me` was done.
* Write `state.currentUser.user.email_verified` in its browser console. Verify it returns `true` now.