### PR TITLE
Post Preview: Fix modal preview after React 17 upgrade.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -453,74 +453,81 @@ function handleUpdateImageBlocks( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handlePreview( calypsoPort ) {
-	$( '#editor' ).on( 'click', '.editor-post-preview', ( e ) => {
-		e.preventDefault();
-		e.stopPropagation();
-
-		const postUrl = select( 'core/editor' ).getCurrentPostAttribute( 'link' );
-		const previewChannel = new MessageChannel();
-
-		calypsoPort.postMessage(
-			{
-				action: 'previewPost',
-				payload: {
-					postUrl: postUrl,
-				},
-			},
-			[ previewChannel.port2 ]
-		);
-
-		const isAutosaveable = select( 'core/editor' ).isEditedPostAutosaveable();
-
-		// If we don't need to autosave the post before previewing, then we simply
-		// generate the preview.
-		if ( ! isAutosaveable ) {
-			sendPreviewData();
-			return;
-		}
-
-		// Request an autosave before generating the preview.
-		const postStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
-		const isDraft = [ 'draft', 'auto-draft' ].indexOf( postStatus ) !== -1;
-		if ( isDraft ) {
-			dispatch( 'core/editor' ).savePost( { isPreview: true } );
-		} else {
-			dispatch( 'core/editor' ).autosave( { isPreview: true } );
-		}
-		const unsubscribe = subscribe( () => {
-			const previewUrl = select( 'core/editor' ).getEditedPostPreviewLink();
-			if ( previewUrl ) {
-				unsubscribe();
-				sendPreviewData();
+	document.getElementById( 'editor' ).addEventListener(
+		'click',
+		( e ) => {
+			if ( ! e.target.classList.contains( 'editor-post-preview' ) ) {
+				return;
 			}
-		} );
+			e.preventDefault();
+			e.stopPropagation();
 
-		function sendPreviewData() {
-			const previewUrl = select( 'core/editor' ).getEditedPostPreviewLink();
+			const postUrl = select( 'core/editor' ).getCurrentPostAttribute( 'link' );
+			const previewChannel = new MessageChannel();
 
-			const featuredImageId = select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
-			const featuredImage = featuredImageId
-				? get( select( 'core' ).getMedia( featuredImageId ), 'source_url' )
-				: null;
+			calypsoPort.postMessage(
+				{
+					action: 'previewPost',
+					payload: {
+						postUrl: postUrl,
+					},
+				},
+				[ previewChannel.port2 ]
+			);
 
-			const authorId = select( 'core/editor' ).getCurrentPostAttribute( 'author' );
-			const author = find( select( 'core' ).getAuthors(), { id: authorId } );
-			const editedPost = {
-				title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
-				URL: select( 'core/editor' ).getEditedPostAttribute( 'link' ),
-				excerpt: select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
-				content: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
-				featured_image: featuredImage,
-				author: author,
-			};
+			const isAutosaveable = select( 'core/editor' ).isEditedPostAutosaveable();
 
-			previewChannel.port1.postMessage( {
-				previewUrl: previewUrl,
-				editedPost: editedPost,
+			// If we don't need to autosave the post before previewing, then we simply
+			// generate the preview.
+			if ( ! isAutosaveable ) {
+				sendPreviewData();
+				return;
+			}
+
+			// Request an autosave before generating the preview.
+			const postStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+			const isDraft = [ 'draft', 'auto-draft' ].indexOf( postStatus ) !== -1;
+			if ( isDraft ) {
+				dispatch( 'core/editor' ).savePost( { isPreview: true } );
+			} else {
+				dispatch( 'core/editor' ).autosave( { isPreview: true } );
+			}
+			const unsubscribe = subscribe( () => {
+				const previewUrl = select( 'core/editor' ).getEditedPostPreviewLink();
+				if ( previewUrl ) {
+					unsubscribe();
+					sendPreviewData();
+				}
 			} );
-			previewChannel.port1.close();
-		}
-	} );
+
+			function sendPreviewData() {
+				const previewUrl = select( 'core/editor' ).getEditedPostPreviewLink();
+
+				const featuredImageId = select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
+				const featuredImage = featuredImageId
+					? get( select( 'core' ).getMedia( featuredImageId ), 'source_url' )
+					: null;
+
+				const authorId = select( 'core/editor' ).getCurrentPostAttribute( 'author' );
+				const author = find( select( 'core' ).getAuthors(), { id: authorId } );
+				const editedPost = {
+					title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
+					URL: select( 'core/editor' ).getEditedPostAttribute( 'link' ),
+					excerpt: select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
+					content: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
+					featured_image: featuredImage,
+					author: author,
+				};
+
+				previewChannel.port1.postMessage( {
+					previewUrl: previewUrl,
+					editedPost: editedPost,
+				} );
+				previewChannel.port1.close();
+			}
+		},
+		{ capture: true }
+	);
 }
 
 /**


### PR DESCRIPTION
React 17 made some changes to how event delegation operates, which meant
that the event listener we registered to override the preview action
would no longer be fired.


#### Changes proposed in this Pull Request

This change updates the event listener to use the capture phase in the
event propagation, which fixes the problem.

#### Testing instructions

Details in PCYsg-l4k-p2

* Check out the change to your sandbox, and sandbox widgets.wp.com
* Load a post in the iframed version of the editor
* Click the preview link and check that you receive a model preview
  
Related to #54018

#### Notes

I think this is the solution, but I'm not sure if it's the correct behaviour. I thought we normally had a dropdown that allowed you to open the preview in a new tab. It might be that we need to update some other event listeners in this code.
