### PR TITLE
Gutenberg Editor Tracking: Track list view block select

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -20,6 +20,7 @@ import {
 	wpcomTemplatePartReplaceBubble,
 } from './wpcom-template-part-replace';
 import wpcomTemplatePartChooseExisting from './wpcom-template-part-choose-existing';
+import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -60,6 +61,7 @@ const EVENTS_MAPPING = [
 	wpcomTemplatePartReplaceCapture(),
 	wpcomTemplatePartReplaceBubble(),
 	wpcomTemplatePartChooseExisting(),
+	wpcomBlockEditorListViewSelect(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
@@ -29,7 +29,7 @@ export default () => ( {
 
 		const currentBlock = getSelectedBlock();
 		tracksRecordEvent( 'wpcom_block_editor_list_view_select', {
-			block_name: currentBlock.block_name,
+			block_name: currentBlock.name,
 		} );
 	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_list_view_select`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-block-editor-list-view-select',
+	selector: '[aria-label="Block navigation structure"] [role="row"]:not(.is-selected) button',
+	type: 'click',
+	capture: true,
+	handler: async () => {
+		const { getSelectedBlock } = select( 'core/block-editor' );
+
+		const blockBefore = getSelectedBlock();
+		// Wait until the selected block changes.
+		while ( blockBefore?.clientId === getSelectedBlock()?.clientId ) {
+			await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+		}
+
+		const currentBlock = getSelectedBlock();
+		tracksRecordEvent( 'wpcom_block_editor_list_view_select', {
+			block_name: currentBlock.block_name,
+		} );
+	},
+} );

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -130,7 +130,6 @@ export function createGeneralTests( { it, editorType, postType } ) {
 			return this.skip();
 		}
 
-		await editor.addBlock( 'Columns' );
 		await editor.addBlock( 'Heading' );
 		await editor.addBlock( 'Image' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Track blocks selected using the list view. Triggers `wpcom_block_editor_list_view_select` with a `block_name` property which indicates what block has been selected.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Open post editor
* Make sure you have some blocks
* Open list view
* Select a block and make sure the `wpcom_block_editor_list_view_select` event is triggered with the selected block's internal name. Eg. selecting a Paragraph `block_name: 'core/paragraph'`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
