### PR TITLE
End Jetpack pricing page discount experiment

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -11,7 +11,6 @@ import { Button, ProductIcon } from '@automattic/components';
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
-import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import JetpackProductCardTimeFrame from './time-frame';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -87,11 +86,6 @@ const DisplayPrice = ( {
 	hideSavingLabel,
 } ) => {
 	const translate = useTranslate();
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_jetpack_yearly_total_discount'
-	);
-	const withTreatmentVariation =
-		experimentAssignment?.variationName === 'treatment' && billingTerm === TERM_ANNUALLY;
 
 	if ( isDeprecated ) {
 		return (
@@ -158,29 +152,32 @@ const DisplayPrice = ( {
 	const couponDiscountedPrice = parseFloat(
 		( ( discountedPrice ?? originalPrice ) * FRESHPACK_PERCENTAGE ).toFixed( 2 )
 	);
-	const discountElt = withTreatmentVariation
-		? translate( '* Save %(percent)d%% for the first year', {
-				args: {
-					percent: ( ( originalPrice - couponDiscountedPrice ) / originalPrice ) * 100,
-				},
-				comment: 'Asterisk clause describing the displayed price adjustment',
-		  } )
-		: translate( '* You Save %(percent)d%%', {
-				args: {
-					percent: INTRO_PRICING_DISCOUNT_PERCENTAGE,
-				},
-				comment: 'Asterisk clause describing the displayed price adjustment',
-		  } );
+	const discountElt =
+		billingTerm === TERM_ANNUALLY
+			? translate( '* Save %(percent)d%% for the first year', {
+					args: {
+						percent: ( ( originalPrice - couponDiscountedPrice ) / originalPrice ) * 100,
+					},
+					comment: 'Asterisk clause describing the displayed price adjustment',
+			  } )
+			: translate( '* You Save %(percent)d%%', {
+					args: {
+						percent: INTRO_PRICING_DISCOUNT_PERCENTAGE,
+					},
+					comment: 'Asterisk clause describing the displayed price adjustment',
+			  } );
 
 	return (
 		<div className="jetpack-product-card__price">
-			{ currencyCode && originalPrice && ! isLoadingExperimentAssignment ? (
+			{ currencyCode && originalPrice ? (
 				<>
 					{ displayFrom && <span className="jetpack-product-card__price-from">from</span> }
 					<PlanPrice
 						original
 						className="jetpack-product-card__original-price"
-						rawPrice={ ( withTreatmentVariation ? originalPrice : couponOriginalPrice ) as number }
+						rawPrice={
+							( billingTerm === TERM_ANNUALLY ? originalPrice : couponOriginalPrice ) as number
+						}
 						currencyCode={ currencyCode }
 					/>
 					<PlanPrice


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR ends the discount experiment that was started by #53151. It removes the experiment related code and keeps the treatment variation.

### Testing instructions

- Download the PR and run Calypso or cloud
- Visit the plans/pricing page
- Select the monthly term
- Check that the page looks and behaves as it does in production
- Select the yearly term
- Check that the struck-through price is the same as with the monthly term
- Check that the final price is the same as in production
- Check that the discount percentage reflects the actual discount from the struck-through price to the original price

### Screenshots

#### Monthly
<img width="1043" alt="Screen Shot 2021-06-29 at 1 56 38 PM" src="https://user-images.githubusercontent.com/1620183/123847358-83c80900-d8e4-11eb-8641-fd015f442558.png">


#### Yearly
<img width="1041" alt="Screen Shot 2021-06-29 at 1 56 44 PM" src="https://user-images.githubusercontent.com/1620183/123847375-875b9000-d8e4-11eb-8559-6351b2710bfc.png">
