### PR TITLE
Don't show 'Create Site' option for domain-only site when unavailable

### DIFF
--- a/client/lib/domains/can-current-user-create-site-from-domain-only.js
+++ b/client/lib/domains/can-current-user-create-site-from-domain-only.js
@@ -1,0 +1,3 @@
+export function canCurrentUserCreateSiteFromDomainOnly( domain ) {
+	return !! domain?.currentUserCanCreateSiteFromDomainOnly;
+}

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -1,4 +1,5 @@
 export { canCurrentUserAddEmail } from './can-current-user-add-email';
+export { canCurrentUserCreateSiteFromDomainOnly } from './can-current-user-create-site-from-domain-only';
 export { canRedirect } from './can-redirect';
 export { checkAuthCode } from './check-auth-code';
 export { checkDomainAvailability } from './check-domain-availability';

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -20,6 +20,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
 
 /**
  * Style dependencies
@@ -42,6 +43,10 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 
 	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
 	const domainName = primaryDomain.name;
+	const canCreateSite = canCurrentUserCreateSiteFromDomainOnly( primaryDomain );
+	const createSiteUrl = `/start/site-selected/?siteSlug=${ encodeURIComponent(
+		slug
+	) }&siteId=${ encodeURIComponent( siteId ) }`;
 
 	const recordEmailClick = () => {
 		const tracksName = hasEmailWithUs
@@ -56,11 +61,12 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 		<div>
 			<EmptyContent
 				title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
-				line={ translate( 'Start a site now to unlock everything WordPress.com can offer.' ) }
-				action={ translate( 'Create site' ) }
-				actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent(
-					slug
-				) }&siteId=${ encodeURIComponent( siteId ) }` }
+				line={
+					canCreateSite &&
+					translate( 'Start a site now to unlock everything WordPress.com can offer.' )
+				}
+				action={ canCreateSite && translate( 'Create site' ) }
+				actionURL={ canCreateSite && createSiteUrl }
 				secondaryAction={ translate( 'Manage domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
 				illustration={ '/calypso/images/drake/drake-browser.svg' }

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -54,6 +54,9 @@ export const createSiteDomainObject = ( domain ) => {
 		contactInfoDisclosureAvailable: Boolean( domain.contact_info_disclosure_available ),
 		contactInfoDisclosed: Boolean( domain.contact_info_disclosed ),
 		currentUserCanAddEmail: Boolean( domain.current_user_can_add_email ),
+		currentUserCanCreateSiteFromDomainOnly: Boolean(
+			domain.current_user_can_create_site_from_domain_only
+		),
 		currentUserCanManage: Boolean( domain.current_user_can_manage ),
 		currentUserCannotAddEmailReason: assembleCurrentUserCannotAddEmailReason(
 			domain.current_user_cannot_add_email_reason

--- a/client/state/sites/domains/test/fixture/index.js
+++ b/client/state/sites/domains/test/fixture/index.js
@@ -32,6 +32,7 @@ export const DOMAIN_PRIMARY = {
 	contactInfoDisclosed: false,
 	contactInfoDisclosureAvailable: false,
 	currentUserCanAddEmail: true,
+	currentUserCanCreateSiteFromDomainOnly: false,
 	currentUserCanManage: true,
 	currentUserCannotAddEmailReason: null,
 	domain: 'retronevergiveup.me',
@@ -107,6 +108,7 @@ export const DOMAIN_NOT_PRIMARY = {
 	contactInfoDisclosed: false,
 	contactInfoDisclosureAvailable: false,
 	currentUserCanAddEmail: false,
+	currentUserCanCreateSiteFromDomainOnly: false,
 	currentUserCanManage: true,
 	currentUserCannotAddEmailReason: {
 		code: DOMAIN_EXPIRED_ERROR_CODE,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Certain user-restrictions may prevent a user from using the "Create site" option for domain-only sites. This PR will remove this option from the domain manage page for domain-only sites when the option is unavailable.

Depends on D63473-code

When the option is unavailable, the domain management page will show the following:

<img width="903" alt="Screen Shot 2021-06-29 at 2 23 35 PM" src="https://user-images.githubusercontent.com/1379730/123850657-48c7d480-d8e8-11eb-8b03-9062899f4300.png">

When the option is available, the domain management page should show the "Create site" option as usual:

<img width="903" alt="Screen Shot 2021-06-29 at 2 23 13 PM" src="https://user-images.githubusercontent.com/1379730/123850819-79a80980-d8e8-11eb-8618-af2a63357289.png">


#### Testing instructions

See the back-end patch for more information on how to configure a user/site to set this option for a test account.

When the option is set to be unavailable, make sure that the "Create site" button and "Start a site now to unlock everything WordPress.com can offer." text are not shown on the domain manage page for a domain-only site.

Make sure that both the button and the text are shown when the option is available.