### PR TITLE
Templates: Add a "needs triage" label to the issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "[Type] Bug"
+labels: "[Type] Bug, Needs triage"
 assignees: ''
 
 ---


### PR DESCRIPTION
Requested by @davipontesblog in p1624293216001100-slack-DK6KM9RUK