### PR TITLE
Add selectedDomain slug to domain suggestions query params

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -960,6 +960,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: this.props.vendor,
 			vertical: this.props.vertical,
+			site_slug: this.props?.selectedSite?.slug,
 			recommendation_context: get( this.props, 'selectedSite.name', '' )
 				.replace( ' ', ',' )
 				.toLocaleLowerCase(),


### PR DESCRIPTION
In certain cases we need to restrict domain suggestions for sites that are flagged. In order to do that we need to pass the selectedSite slug down to the domain suggestion endpoint. This PR does exactly that.

#### Changes proposed in this Pull Request

* Add selectedSite slug to the domain suggestions query params so that we can check if the current site is flagged

#### Testing instructions

* Test that when adding a domain to an existing site the `site_slug` param is passed down the the `domains/suggestion` REST API endpoint
* Also check the instructions in D61993-code 
