### PR TITLE
Themes Magic Search Card: Only allow 'feature', 'columns', 'subject' filters

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -356,10 +356,16 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 }
 
+// Magic Search only allows "feature", "column", "subject" theme attributes to be searched
+// For simplicity and less user confusion.
+const allowSomeThemeFilters = ( { feature, column, subject } ) => ( { feature, column, subject } );
+const allowSomeAllValidFilters = ( filtersKeys ) =>
+	intersection( filtersKeys, [ 'feature', 'column', 'subject' ] );
+
 export default compose(
 	connect( ( state ) => ( {
-		filters: getThemeFilters( state ),
-		allValidFilters: Object.keys( getThemeFilterToTermTable( state ) ),
+		filters: allowSomeThemeFilters( getThemeFilters( state ) ),
+		allValidFilters: allowSomeAllValidFilters( Object.keys( getThemeFilterToTermTable( state ) ) ),
 	} ) ),
 	localize,
 	wrapWithClickOutside,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Themes Magic Search Card: Remove "layout", "style", from search filters, along with all other hidden filters like "color".

Before:
![2021-06-29_15-51](https://user-images.githubusercontent.com/937354/123865731-e70c6800-d8f1-11eb-8b42-f1041b1901d2.png)
^ BEFORE: 5 attributes in magic search welcome bar

![2021-06-29_15-52](https://user-images.githubusercontent.com/937354/123865851-04413680-d8f2-11eb-886e-c15d89e2e416.png)
^ BEFORE: Typing "pro" matches feature, style and subject

After:
![2021-06-29_15-52_1](https://user-images.githubusercontent.com/937354/123865920-17540680-d8f2-11eb-8d6e-697a483439c3.png)
^ AFTER: 3 attributes in magic search welcome bar

![2021-06-29_15-53](https://user-images.githubusercontent.com/937354/123865994-2d61c700-d8f2-11eb-8b7b-7fe28725c069.png)
^ AFTER: Typing "pro" matches feature and subject (style is no longer matched)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Calypso. 
* Choose Appearance -> Themes in sthe sidebar
*  Click "Show All Themes"
* Use the newly revealed search, type things in the bar and examine what keyed suggestions are or aren't returned
* On local dev, if you are sandboxing public api, you may not be able to load the page directly. Some workarounds are here: paYKcK-144-p2

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/issues/54077
