### PR TITLE
Converting current theme bar display to new, more clear design

### DIFF
--- a/client/my-sites/themes/current-theme/button.jsx
+++ b/client/my-sites/themes/current-theme/button.jsx
@@ -16,6 +16,7 @@ export default class extends React.Component {
 		icon: PropTypes.string.isRequired,
 		href: PropTypes.string,
 		onClick: PropTypes.func,
+		isPrimary: PropTypes.bool,
 	};
 
 	render() {
@@ -24,10 +25,12 @@ export default class extends React.Component {
 				role="button"
 				className={ classNames(
 					'current-theme__button',
-					'button',
+					'components-button',
 					'current-theme__' + this.props.name,
 					{
 						disabled: ! this.props.href,
+						'is-primary': this.props.isPrimary,
+						'is-secondary': ! this.props.isPrimary,
 					}
 				) }
 				onClick={ this.props.onClick.bind( null, this.props.name ) }

--- a/client/my-sites/themes/current-theme/button.jsx
+++ b/client/my-sites/themes/current-theme/button.jsx
@@ -22,9 +22,14 @@ export default class extends React.Component {
 		return (
 			<a
 				role="button"
-				className={ classNames( 'current-theme__button', 'current-theme__' + this.props.name, {
-					disabled: ! this.props.href,
-				} ) }
+				className={ classNames(
+					'current-theme__button',
+					'button',
+					'current-theme__' + this.props.name,
+					{
+						disabled: ! this.props.href,
+					}
+				) }
 				onClick={ this.props.onClick.bind( null, this.props.name ) }
 				href={ this.props.href }
 			>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -97,6 +97,7 @@ class CurrentTheme extends Component {
 								icon={ option.icon }
 								href={ currentThemeId && option.getUrl( currentThemeId ) }
 								onClick={ this.trackClick }
+								isPrimary={ option.label.toLowerCase() === 'customize' }
 							/>
 						) ) }
 					</div>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -12,8 +12,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
-import CurrentThemeButton from './button';
+import { Card, Button } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
 import { connectOptions } from '../theme-options';
 import { trackClick } from '../helpers';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -97,15 +97,22 @@ class CurrentTheme extends Component {
 					</div>
 					<div className={ classNames( 'current-theme__actions' ) }>
 						{ map( options, ( option, name ) => (
-							<CurrentThemeButton
+							<Button
+								className={ classNames(
+									'current-theme__button',
+									'components-button',
+									'current-theme__' + this.props.name
+								) }
+								primary={ option.label.toLowerCase() === 'customize' }
 								name={ name }
 								key={ name }
 								label={ option.label }
-								icon={ option.icon }
 								href={ currentThemeId && option.getUrl( currentThemeId ) }
 								onClick={ this.trackClick }
-								isPrimary={ option.label.toLowerCase() === 'customize' }
-							/>
+							>
+								{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
+								{ option.label }
+							</Button>
 						) ) }
 					</div>
 				</div>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -67,27 +67,32 @@ class CurrentTheme extends Component {
 				<QueryActiveTheme siteId={ siteId } />
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				<div className="current-theme__current">
-					{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
-					{ showScreenshot && (
-						<img src={ currentTheme.screenshot + '?w=150' } className="current-theme__img" alt="" />
-					) }
-					<div className="current-theme__description">
-						<span className="current-theme__name">{ text }</span>
-						<span className="current-theme__label">
-							{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
-						</span>
-						<p>
-							{ translate( 'This is the active theme on your site.' ) }{ ' ' }
-							<ExternalLink
-								href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-								icon
-								target="__blank"
-							>
-								{ translate( 'Learn more.' ) }
-							</ExternalLink>
-						</p>
+					<div className="current-theme__details">
+						{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
+						{ showScreenshot && (
+							<img
+								src={ currentTheme.screenshot + '?w=150' }
+								className="current-theme__img"
+								alt=""
+							/>
+						) }
+						<div className="current-theme__description">
+							<span className="current-theme__name">{ text }</span>
+							<span className="current-theme__label">
+								{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
+							</span>
+							<p>
+								{ translate( 'This is the active theme on your site.' ) }{ ' ' }
+								<ExternalLink
+									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
+									icon
+									target="__blank"
+								>
+									{ translate( 'Learn more.' ) }
+								</ExternalLink>
+							</p>
+						</div>
 					</div>
-
 					<div className={ classNames( 'current-theme__actions' ) }>
 						{ map( options, ( option, name ) => (
 							<CurrentThemeButton

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -19,6 +19,8 @@ import { trackClick } from '../helpers';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
+import ExternalLink from 'calypso/components/external-link';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Style dependencies
@@ -69,24 +71,35 @@ class CurrentTheme extends Component {
 					{ showScreenshot && (
 						<img src={ currentTheme.screenshot + '?w=150' } className="current-theme__img" alt="" />
 					) }
-					<span className="current-theme__label">{ translate( 'Current Theme' ) }</span>
-					<span className="current-theme__name">{ text }</span>
-				</div>
-				<div
-					className={ classNames( 'current-theme__actions', {
-						'two-buttons': Object.keys( options ).length === 2,
-					} ) }
-				>
-					{ map( options, ( option, name ) => (
-						<CurrentThemeButton
-							name={ name }
-							key={ name }
-							label={ option.label }
-							icon={ option.icon }
-							href={ currentThemeId && option.getUrl( currentThemeId ) }
-							onClick={ this.trackClick }
-						/>
-					) ) }
+					<div className="current-theme__description">
+						<span className="current-theme__name">{ text }</span>
+						<span className="current-theme__label">
+							{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
+						</span>
+						<p>
+							{ translate( 'This is the active theme on your site.' ) }{ ' ' }
+							<ExternalLink
+								href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
+								icon
+								target="__blank"
+							>
+								{ translate( 'Learn more.' ) }
+							</ExternalLink>
+						</p>
+					</div>
+
+					<div className={ classNames( 'current-theme__actions' ) }>
+						{ map( options, ( option, name ) => (
+							<CurrentThemeButton
+								name={ name }
+								key={ name }
+								label={ option.label }
+								icon={ option.icon }
+								href={ currentThemeId && option.getUrl( currentThemeId ) }
+								onClick={ this.trackClick }
+							/>
+						) ) }
+					</div>
 				</div>
 			</Card>
 		);

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -21,6 +21,7 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import ExternalLink from 'calypso/components/external-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import config from '@automattic/calypso-config';
 
 /**
  * Style dependencies
@@ -66,56 +67,59 @@ class CurrentTheme extends Component {
 			<Card className="current-theme">
 				<QueryActiveTheme siteId={ siteId } />
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
-				<div className="current-theme__current">
-					<div className="current-theme__details">
-						{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
-						{ showScreenshot && (
-							<img
-								src={ currentTheme.screenshot + '?w=150' }
-								className="current-theme__img"
-								alt=""
-							/>
-						) }
-						<div className="current-theme__description">
-							<div className="current-theme__title-wrapper">
-								<span className="current-theme__label">
-									{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
-								</span>
-								<span className="current-theme__name">{ text }</span>
+
+				{ config.isEnabled( 'theme/showcase-revamp' ) && (
+					<div className="current-theme__current">
+						<div className="current-theme__details">
+							{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
+							{ showScreenshot && (
+								<img
+									src={ currentTheme.screenshot + '?w=150' }
+									className="current-theme__img"
+									alt=""
+								/>
+							) }
+							<div className="current-theme__description">
+								<div className="current-theme__title-wrapper">
+									<span className="current-theme__label">
+										{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
+									</span>
+									<span className="current-theme__name">{ text }</span>
+								</div>
+								<p>
+									{ translate( 'This is the active theme on your site.' ) }{ ' ' }
+									<ExternalLink
+										href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
+										icon
+										target="__blank"
+									>
+										{ translate( 'Learn more.' ) }
+									</ExternalLink>
+								</p>
 							</div>
-							<p>
-								{ translate( 'This is the active theme on your site.' ) }{ ' ' }
-								<ExternalLink
-									href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-									icon
-									target="__blank"
+						</div>
+						<div className={ classNames( 'current-theme__actions' ) }>
+							{ map( options, ( option, name ) => (
+								<Button
+									className={ classNames(
+										'current-theme__button',
+										'components-button',
+										'current-theme__' + this.props.name
+									) }
+									primary={ option.label.toLowerCase() === 'customize' }
+									name={ name }
+									key={ name }
+									label={ option.label }
+									href={ currentThemeId && option.getUrl( currentThemeId ) }
+									onClick={ this.trackClick }
 								>
-									{ translate( 'Learn more.' ) }
-								</ExternalLink>
-							</p>
+									{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
+									{ option.label }
+								</Button>
+							) ) }
 						</div>
 					</div>
-					<div className={ classNames( 'current-theme__actions' ) }>
-						{ map( options, ( option, name ) => (
-							<Button
-								className={ classNames(
-									'current-theme__button',
-									'components-button',
-									'current-theme__' + this.props.name
-								) }
-								primary={ option.label.toLowerCase() === 'customize' }
-								name={ name }
-								key={ name }
-								label={ option.label }
-								href={ currentThemeId && option.getUrl( currentThemeId ) }
-								onClick={ this.trackClick }
-							>
-								{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
-								{ option.label }
-							</Button>
-						) ) }
-					</div>
-				</div>
+				) }
 			</Card>
 		);
 	}

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -104,54 +104,56 @@ class CurrentTheme extends Component {
 					)
 				}
 				{ config.isEnabled( 'theme/showcase-revamp' ) && (
-					<div className="current-theme__current">
-						<div className="current-theme__details">
-							{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
-							{ showScreenshot && (
-								<img
-									src={ currentTheme.screenshot + '?w=150' }
-									className="current-theme__img"
-									alt=""
-								/>
-							) }
-							<div className="current-theme__description">
-								<div className="current-theme__title-wrapper">
-									<span className="current-theme__label">
-										{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
-									</span>
-									<span className="current-theme__name">{ text }</span>
+					<div className="current-theme__post-revamp">
+						<div className="current-theme__current">
+							<div className="current-theme__details">
+								{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
+								{ showScreenshot && (
+									<img
+										src={ currentTheme.screenshot + '?w=150' }
+										className="current-theme__img"
+										alt=""
+									/>
+								) }
+								<div className="current-theme__description">
+									<div className="current-theme__title-wrapper">
+										<span className="current-theme__label">
+											{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
+										</span>
+										<span className="current-theme__name">{ text }</span>
+									</div>
+									<p>
+										{ translate( 'This is the active theme on your site.' ) }{ ' ' }
+										<ExternalLink
+											href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
+											icon
+											target="__blank"
+										>
+											{ translate( 'Learn more.' ) }
+										</ExternalLink>
+									</p>
 								</div>
-								<p>
-									{ translate( 'This is the active theme on your site.' ) }{ ' ' }
-									<ExternalLink
-										href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-										icon
-										target="__blank"
-									>
-										{ translate( 'Learn more.' ) }
-									</ExternalLink>
-								</p>
 							</div>
-						</div>
-						<div className={ classNames( 'current-theme__actions' ) }>
-							{ map( options, ( option, name ) => (
-								<Button
-									className={ classNames(
-										'current-theme__button',
-										'components-button',
-										'current-theme__' + this.props.name
-									) }
-									primary={ option.label.toLowerCase() === 'customize' }
-									name={ name }
-									key={ name }
-									label={ option.label }
-									href={ currentThemeId && option.getUrl( currentThemeId ) }
-									onClick={ this.trackClick }
-								>
-									{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
-									{ option.label }
-								</Button>
-							) ) }
+							<div className={ classNames( 'current-theme__actions' ) }>
+								{ map( options, ( option, name ) => (
+									<Button
+										className={ classNames(
+											'current-theme__button',
+											'components-button',
+											'current-theme__' + this.props.name
+										) }
+										primary={ option.label.toLowerCase() === 'customize' }
+										name={ name }
+										key={ name }
+										label={ option.label }
+										href={ currentThemeId && option.getUrl( currentThemeId ) }
+										onClick={ this.trackClick }
+									>
+										{ option.icon && <Gridicon icon={ option.icon } size={ 18 } /> }
+										{ option.label }
+									</Button>
+								) ) }
+							</div>
 						</div>
 					</div>
 				) }

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import { Card, Button } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
+import CurrentThemeButton from './button';
 import { connectOptions } from '../theme-options';
 import { trackClick } from '../helpers';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -67,7 +68,41 @@ class CurrentTheme extends Component {
 			<Card className="current-theme">
 				<QueryActiveTheme siteId={ siteId } />
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
-
+				{
+					// @TODO Remove this code as well as associated styles after feature flag deploy
+					! config.isEnabled( 'theme/showcase-revamp' ) && (
+						<div className="current-theme__pre-revamp">
+							<div className="current-theme__current">
+								{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
+								{ showScreenshot && (
+									<img
+										src={ currentTheme.screenshot + '?w=150' }
+										className="current-theme__img"
+										alt=""
+									/>
+								) }
+								<span className="current-theme__label">{ translate( 'Current Theme' ) }</span>
+								<span className="current-theme__name">{ text }</span>
+							</div>
+							<div
+								className={ classNames( 'current-theme__actions', {
+									'two-buttons': Object.keys( options ).length === 2,
+								} ) }
+							>
+								{ map( options, ( option, name ) => (
+									<CurrentThemeButton
+										name={ name }
+										key={ name }
+										label={ option.label }
+										icon={ option.icon }
+										href={ currentThemeId && option.getUrl( currentThemeId ) }
+										onClick={ this.trackClick }
+									/>
+								) ) }
+							</div>
+						</div>
+					)
+				}
 				{ config.isEnabled( 'theme/showcase-revamp' ) && (
 					<div className="current-theme__current">
 						<div className="current-theme__details">

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -77,10 +77,12 @@ class CurrentTheme extends Component {
 							/>
 						) }
 						<div className="current-theme__description">
-							<span className="current-theme__name">{ text }</span>
-							<span className="current-theme__label">
-								{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
-							</span>
+							<div className="current-theme__title-wrapper">
+								<span className="current-theme__label">
+									{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
+								</span>
+								<span className="current-theme__name">{ text }</span>
+							</div>
 							<p>
 								{ translate( 'This is the active theme on your site.' ) }{ ' ' }
 								<ExternalLink

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,4 +1,3 @@
-$current-theme-height: 112px;
 $current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme {
@@ -11,7 +10,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	flex-direction: column;
 
 	@include breakpoint-deprecated( '>960px' ) {
-		height: $current-theme-height;
+		min-height: 112px;
 		flex-direction: row;
 	}
 }
@@ -19,17 +18,19 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 .current-theme__details {
 	display: flex;
 	flex-direction: column;
+	font-size: $font-body-small;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		height: $current-theme-height;
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
+		font-size: $font-body;
 	}
 }
 
 .current-theme__img {
-	@include breakpoint-deprecated( '>960px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-right: $current-theme-border;
-		max-height: $current-theme-height;
+		max-width: 150px;
+		height: auto;
 	}
 }
 
@@ -39,8 +40,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	animation: loading-fade 1.6s ease-in-out infinite;
 	height: 100%;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		width: 75px;
+	@include breakpoint-deprecated( '>660px' ) {
+		width: 150px;
 	}
 }
 
@@ -53,7 +54,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	flex-direction: column;
 	align-items: flex-start;
 
-	@include breakpoint-deprecated( '>960px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row-reverse;
 		justify-content: flex-end;
 	}
@@ -71,7 +72,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	margin-left: 16px;
 	margin-bottom: 4px;
 
-	@include breakpoint-deprecated( '>960px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: auto;
 		margin-left: 8px;
 	}
@@ -84,8 +85,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	padding-left: 16px;
-	font-size: $font-title-small;
+	font-size: $font-body;
 	max-width: 100%;
+
+	@include breakpoint-deprecated( '>960px' ) {
+		font-size: $font-title-small;
+	}
 }
 
 .current-theme__placeholder {
@@ -96,7 +101,11 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme__description {
 	margin-top: 16px;
-	font-size: $font-body;
+	font-size: $font-body-small;
+
+	@include breakpoint-deprecated( '>960px' ) {
+		font-size: $font-body;
+	}
 }
 
 .current-theme__actions {
@@ -108,23 +117,27 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	justify-content: center;
 	flex-grow: 1;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		height: $current-theme-height;
-		padding-top: 0;
+	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-end;
 		justify-content: flex-end;
-		flex-grow: 1;
+	}
+
+	@include breakpoint-deprecated( '>960px' ) {
+		min-height: 112px;
+		padding-top: 0;
 	}
 }
 
 .current-theme__button {
 	margin-right: 10px;
-	margin-bottom: 20px;
+	margin-bottom: 16px;
 	font-weight: normal;
 	position: relative;
 
-	&:last-child {
-		margin-right: 20px;
+	@include breakpoint-deprecated( '>660px' ) {
+		&:last-child {
+			margin-right: 16px;
+		}
 	}
 }
 

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -5,142 +5,307 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	margin-bottom: 24px;
 }
 
-.current-theme__current {
-	display: flex;
-	flex-direction: column;
+.current-theme__pre-revamp {
+	$current-theme-height: 56px;
+	$current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 
-	@include breakpoint-deprecated( '>960px' ) {
-		min-height: 112px;
-		flex-direction: row;
+	.current-theme {
+		font-weight: 600;
+		padding: 0;
+		margin-bottom: 24px;
 	}
-}
 
-.current-theme__details {
-	display: flex;
-	flex-direction: column;
-	font-size: $font-body-small;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		flex-direction: row;
-		font-size: $font-body;
+	.current-theme__current {
+		@include breakpoint-deprecated( '>480px' ) {
+			width: 50%;
+			float: left;
+		}
+		height: $current-theme-height;
 	}
-}
 
-.current-theme__img {
-	@include breakpoint-deprecated( '>660px' ) {
+	.current-theme__img {
+		@include breakpoint-deprecated( '<480px' ) {
+			border-left: $current-theme-border;
+			float: right;
+		}
+		@include breakpoint-deprecated( '>480px' ) {
+			border-right: $current-theme-border;
+			float: left;
+		}
+		height: 100%;
+	}
+
+	.current-theme__img-placeholder {
+		@include breakpoint-deprecated( '<480px' ) {
+			float: right;
+		}
+		@include breakpoint-deprecated( '>480px' ) {
+			float: left;
+		}
+		width: 75px;
+		color: transparent;
+		background-color: var( --color-neutral-0 );
+		animation: loading-fade 1.6s ease-in-out infinite;
+		height: 100%;
+	}
+
+	.current-theme__label {
+		font-size: 0.875rem;
+		color: var( --color-neutral-light );
+		text-transform: uppercase;
+		padding-left: 15px;
+		padding-top: 10px;
+		margin-bottom: -2px;
+		display: inline-block;
+	}
+
+	.current-theme__name {
+		box-sizing: border-box;
+		padding-left: 15px;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		max-width: 100%;
+		display: block;
+	}
+
+	.current-theme__placeholder {
+		color: transparent;
+		background-color: var( --color-neutral-0 );
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+
+	.current-theme__actions {
+		height: $current-theme-height;
+		border-top: $current-theme-border;
+		box-sizing: border-box;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			width: 50%;
+			float: right;
+			border-top: none;
+			border-left: $current-theme-border;
+		}
+
+		&.two-buttons {
+			@include breakpoint-deprecated( '>480px' ) {
+				width: 33.3%;
+			}
+
+			.current-theme__button {
+				width: 50%;
+			}
+		}
+	}
+
+	.current-theme__button {
+		height: $current-theme-height;
+		box-sizing: border-box;
+		width: 33.33%;
+		float: left;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		margin: 0;
+		font-weight: normal;
+		/* transition: all 200ms ease-in-out; /* Unfortunately gradients don't transition (long-content-fade) */
+		position: relative;
+
+		&:link,
+		&:visited {
+			color: var( --color-neutral-70 );
+		}
+
+		&.disabled {
+			cursor: default;
+
+			span {
+				color: var( --color-neutral-light );
+			}
+		}
+
+		&:not( .disabled ):hover {
+			background: var( --color-primary-0 );
+			cursor: pointer;
+		}
+
+		&:not( .disabled ):active {
+			background: var( --color-primary-0 );
+		}
+
+		.accessible-focus &:focus {
+			z-index: z-index( 'root', '.accessible-focus .current-theme__button:focus' );
+			outline: solid 3px var( --color-primary-light );
+		}
+	}
+
+	.current-theme__button-label {
+		overflow: hidden;
+		white-space: nowrap;
+		max-width: 95%;
+
+		&::after {
+			@include long-content-fade( $size: 10% );
+		}
+
+		.current-theme__button:not( .disabled ):hover &::after {
+			@include long-content-fade( $color: var( --color-primary-0-rgb ), $size: 10% );
+		}
+	}
+
+	.current-theme__info {
+		border-left: $current-theme-border;
 		border-right: $current-theme-border;
-		max-height: 112px;
-		width: auto;
-	}
-}
 
-.current-theme__img-placeholder {
-	color: transparent;
-	background-color: var( --color-neutral-0 );
-	animation: loading-fade 1.6s ease-in-out infinite;
-	height: 100%;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		width: 150px;
-	}
-}
-
-.current-theme__description p {
-	padding: 16px;
-	margin-bottom: 0;
-}
-
-.current-theme__title-wrapper {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		flex-direction: row-reverse;
-		justify-content: flex-end;
-	}
-}
-
-.current-theme__label {
-	font-size: $font-body-extra-small;
-	color: var( --color-text-inverted );
-	display: inline-block;
-	background: var( --color-neutral-dark );
-	white-space: nowrap;
-	padding: 4px 12px;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 120px;
-	margin-left: 16px;
-	margin-bottom: 4px;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		margin-left: 8px;
-	}
-}
-
-.current-theme__name {
-	font-weight: 600;
-	box-sizing: border-box;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	padding-left: 16px;
-	font-size: $font-body;
-	max-width: 100%;
-
-	@include breakpoint-deprecated( '>960px' ) {
-		font-size: $font-title-small;
-	}
-}
-
-.current-theme__placeholder {
-	color: transparent;
-	background-color: var( --color-neutral-0 );
-	animation: loading-fade 1.6s ease-in-out infinite;
-}
-
-.current-theme__description {
-	margin-top: 16px;
-	font-size: $font-body-small;
-
-	@include breakpoint-deprecated( '>960px' ) {
-		font-size: $font-body;
-	}
-}
-
-.current-theme__actions {
-	border-top: $current-theme-border;
-	box-sizing: border-box;
-	padding-top: 16px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex-grow: 1;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		align-items: flex-end;
-		justify-content: flex-end;
-	}
-
-	@include breakpoint-deprecated( '>960px' ) {
-		min-height: 112px;
-		padding-top: 0;
-	}
-}
-
-.current-theme__button {
-	margin-right: 10px;
-	margin-bottom: 16px;
-	font-weight: normal;
-	position: relative;
-
-	@include breakpoint-deprecated( '>660px' ) {
 		&:last-child {
-			margin-right: 16px;
+			border-right: none;
 		}
 	}
 }
 
-.current-theme__button-label {
-	margin-left: 5px;
+.current-theme__post-revamp {
+	.current-theme__current {
+		display: flex;
+		flex-direction: column;
+
+		@include breakpoint-deprecated( '>960px' ) {
+			min-height: 112px;
+			flex-direction: row;
+		}
+	}
+
+	.current-theme__details {
+		display: flex;
+		flex-direction: column;
+		font-size: $font-body-small;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			flex-direction: row;
+			font-size: $font-body;
+		}
+	}
+
+	.current-theme__img {
+		@include breakpoint-deprecated( '>660px' ) {
+			border-right: $current-theme-border;
+			max-height: 112px;
+			width: auto;
+		}
+	}
+
+	.current-theme__img-placeholder {
+		color: transparent;
+		background-color: var( --color-neutral-0 );
+		animation: loading-fade 1.6s ease-in-out infinite;
+		height: 100%;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			width: 150px;
+		}
+	}
+
+	.current-theme__description p {
+		padding: 16px;
+		margin-bottom: 0;
+	}
+
+	.current-theme__title-wrapper {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			flex-direction: row-reverse;
+			justify-content: flex-end;
+		}
+	}
+
+	.current-theme__label {
+		font-size: $font-body-extra-small;
+		color: var( --color-text-inverted );
+		display: inline-block;
+		background: var( --color-neutral-dark );
+		white-space: nowrap;
+		padding: 4px 12px;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 120px;
+		margin-left: 16px;
+		margin-bottom: 4px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-left: 8px;
+		}
+	}
+
+	.current-theme__name {
+		font-weight: 600;
+		box-sizing: border-box;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		padding-left: 16px;
+		font-size: $font-body;
+		max-width: 100%;
+
+		@include breakpoint-deprecated( '>960px' ) {
+			font-size: $font-title-small;
+		}
+	}
+
+	.current-theme__placeholder {
+		color: transparent;
+		background-color: var( --color-neutral-0 );
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+
+	.current-theme__description {
+		margin-top: 16px;
+		font-size: $font-body-small;
+
+		@include breakpoint-deprecated( '>960px' ) {
+			font-size: $font-body;
+		}
+	}
+
+	.current-theme__actions {
+		border-top: $current-theme-border;
+		box-sizing: border-box;
+		padding-top: 16px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-grow: 1;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			align-items: flex-end;
+			justify-content: flex-end;
+		}
+
+		@include breakpoint-deprecated( '>960px' ) {
+			min-height: 112px;
+			padding-top: 0;
+		}
+	}
+
+	.current-theme__button {
+		margin-right: 10px;
+		margin-bottom: 16px;
+		font-weight: normal;
+		position: relative;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			&:last-child {
+				margin-right: 16px;
+			}
+		}
+
+		.gridicon {
+			top: 0;
+		}
+	}
+
+	.current-theme__button-label {
+		margin-left: 5px;
+	}
 }

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -293,6 +293,11 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		margin-bottom: 16px;
 		font-weight: normal;
 		position: relative;
+		border-width: 1px;
+
+		&:not( .is-primary ) {
+			outline: 1px solid var( --color-neutral-10 );
+		}
 
 		@include breakpoint-deprecated( '>660px' ) {
 			&:last-child {
@@ -302,6 +307,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 		.gridicon {
 			top: 0;
+			margin: 0 5px 0 0;
 		}
 	}
 

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -29,8 +29,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 .current-theme__img {
 	@include breakpoint-deprecated( '>660px' ) {
 		border-right: $current-theme-border;
-		max-width: 150px;
-		height: auto;
+		max-height: 112px;
+		width: auto;
 	}
 }
 
@@ -47,6 +47,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme__description p {
 	padding: 16px;
+	margin-bottom: 0;
 }
 
 .current-theme__title-wrapper {

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -45,19 +45,35 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 }
 
 .current-theme__description p {
-	padding: 15px;
+	padding: 16px;
+}
+
+.current-theme__title-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		flex-direction: row-reverse;
+		justify-content: flex-end;
+	}
 }
 
 .current-theme__label {
 	font-size: $font-body-extra-small;
 	color: var( --color-text-inverted );
+	display: inline-block;
 	background: var( --color-neutral-dark );
 	padding: 4px 12px;
-	position: relative;
-	top: -4px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 120px;
-	margin-left: 10px;
+	margin-left: 16px;
+	margin-bottom: 4px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-bottom: auto;
+		margin-left: 8px;
+	}
 }
 
 .current-theme__name {
@@ -66,7 +82,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	padding-left: 15px;
+	padding-left: 16px;
 	font-size: $font-title-small;
 	max-width: 100%;
 }
@@ -78,14 +94,14 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 }
 
 .current-theme__description {
-	margin-top: 15px;
+	margin-top: 16px;
 	font-size: $font-body;
 }
 
 .current-theme__actions {
 	border-top: $current-theme-border;
 	box-sizing: border-box;
-	padding-top: 15px;
+	padding-top: 16px;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -10,7 +10,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		height: $current-theme-height;
 		flex-direction: row;
 	}
@@ -20,14 +20,14 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		height: $current-theme-height;
 		flex-direction: row;
 	}
 }
 
 .current-theme__img {
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		border-right: $current-theme-border;
 		max-height: $current-theme-height;
 	}
@@ -39,7 +39,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	animation: loading-fade 1.6s ease-in-out infinite;
 	height: 100%;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 75px;
 	}
 }
@@ -53,7 +53,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	flex-direction: column;
 	align-items: flex-start;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row-reverse;
 		justify-content: flex-end;
 	}
@@ -64,13 +64,14 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	color: var( --color-text-inverted );
 	display: inline-block;
 	background: var( --color-neutral-dark );
+	white-space: nowrap;
 	padding: 4px 12px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 120px;
 	margin-left: 16px;
 	margin-bottom: 4px;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: auto;
 		margin-left: 8px;
 	}
@@ -107,7 +108,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	justify-content: center;
 	flex-grow: 1;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		height: $current-theme-height;
 		padding-top: 0;
 		align-items: flex-end;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -50,7 +50,7 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	padding-left: 15px;
-	font-size: 0.875rem;
+	font-size: 1rem;
 	max-width: 100%;
 }
 
@@ -62,7 +62,7 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 
 .current-theme__description {
 	margin-top: 15px;
-	font-size: 0.75rem;
+	font-size: 0.875rem;
 }
 
 .current-theme__actions {
@@ -75,40 +75,12 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 }
 
 .current-theme__button {
-	margin: 10px;
+	margin-right: 10px;
+	margin-bottom: 20px;
 	font-weight: normal;
 	position: relative;
 
-	&.disabled {
-		cursor: default;
-
-		span {
-			color: var( --color-neutral-light );
-		}
+	&:last-child {
+		margin-right: 20px;
 	}
-
-	&:not( .disabled ):hover {
-		background: var( --color-primary-0 );
-		cursor: pointer;
-	}
-
-	&:not( .disabled ):active {
-		background: var( --color-primary-0 );
-	}
-
-	.accessible-focus &:focus {
-		z-index: z-index( 'root', '.accessible-focus .current-theme__button:focus' );
-		outline: solid 3px var( --color-primary-light );
-	}
-}
-
-.current-theme__button-label {
-	overflow: hidden;
-	white-space: nowrap;
-	max-width: 95%;
-}
-
-.current-theme__customize {
-	color: var( --color-text-inverted );
-	background: var( --color-neutral-dark );
 }

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,39 +1,27 @@
-$current-theme-height: 56px;
+$current-theme-height: 112px;
 $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 
 .current-theme {
-	font-weight: 600;
 	padding: 0;
 	margin-bottom: 24px;
 }
 
 .current-theme__current {
-	@include breakpoint-deprecated( '>480px' ) {
-		width: 50%;
-		float: left;
-	}
 	height: $current-theme-height;
+	display: flex;
 }
 
 .current-theme__img {
 	@include breakpoint-deprecated( '<480px' ) {
 		border-left: $current-theme-border;
-		float: right;
 	}
 	@include breakpoint-deprecated( '>480px' ) {
 		border-right: $current-theme-border;
-		float: left;
 	}
 	height: 100%;
 }
 
 .current-theme__img-placeholder {
-	@include breakpoint-deprecated( '<480px' ) {
-		float: right;
-	}
-	@include breakpoint-deprecated( '>480px' ) {
-		float: left;
-	}
 	width: 75px;
 	color: transparent;
 	background-color: var( --color-neutral-0 );
@@ -41,24 +29,29 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	height: 100%;
 }
 
+.current-theme__description p {
+	padding: 15px;
+}
+
 .current-theme__label {
-	font-size: 0.8em;
-	color: var( --color-neutral-light );
-	text-transform: uppercase;
-	padding-left: 15px;
-	padding-top: 10px;
-	margin-bottom: -2px;
-	display: inline-block;
+	font-size: 0.75rem;
+	color: var( --color-text-inverted );
+	background: var( --color-neutral-dark );
+	padding: 4px 8px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 120px;
+	margin-left: 10px;
 }
 
 .current-theme__name {
+	font-weight: 600;
 	box-sizing: border-box;
-	padding-left: 15px;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	padding-left: 15px;
+	font-size: 0.875rem;
 	max-width: 100%;
-	display: block;
 }
 
 .current-theme__placeholder {
@@ -67,47 +60,24 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
+.current-theme__description {
+	margin-top: 15px;
+	font-size: 0.75rem;
+}
+
 .current-theme__actions {
 	height: $current-theme-height;
-	border-top: $current-theme-border;
 	box-sizing: border-box;
-
-	@include breakpoint-deprecated( '>480px' ) {
-		width: 50%;
-		float: right;
-		border-top: none;
-		border-left: $current-theme-border;
-	}
-
-	&.two-buttons {
-		@include breakpoint-deprecated( '>480px' ) {
-			width: 33.3%;
-		}
-
-		.current-theme__button {
-			width: 50%;
-		}
-	}
+	display: flex;
+	align-items: flex-end;
+	justify-content: flex-end;
+	flex-grow: 1;
 }
 
 .current-theme__button {
-	height: $current-theme-height;
-	box-sizing: border-box;
-	width: 33.33%;
-	float: left;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
-	margin: 0;
+	margin: 10px;
 	font-weight: normal;
-	/* transition: all 200ms ease-in-out; /* Unfortunately gradients don't transition (long-content-fade) */
 	position: relative;
-
-	&:link,
-	&:visited {
-		color: var( --color-neutral-70 );
-	}
 
 	&.disabled {
 		cursor: default;
@@ -136,21 +106,9 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	overflow: hidden;
 	white-space: nowrap;
 	max-width: 95%;
-
-	&::after {
-		@include long-content-fade( $size: 10% );
-	}
-
-	.current-theme__button:not( .disabled ):hover &::after {
-		@include long-content-fade( $color: var( --color-primary-0-rgb ), $size: 10% );
-	}
 }
 
-.current-theme__info {
-	border-left: $current-theme-border;
-	border-right: $current-theme-border;
-
-	&:last-child {
-		border-right: none;
-	}
+.current-theme__customize {
+	color: var( --color-text-inverted );
+	background: var( --color-neutral-dark );
 }

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -74,7 +74,6 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	margin-bottom: 4px;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		margin-bottom: auto;
 		margin-left: 8px;
 	}
 }

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,5 +1,5 @@
 $current-theme-height: 112px;
-$current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
+$current-theme-border: 1px solid var( --color-border-subtle );
 
 .current-theme {
 	padding: 0;
@@ -7,26 +7,41 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 }
 
 .current-theme__current {
-	height: $current-theme-height;
 	display: flex;
+	flex-direction: column;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		height: $current-theme-height;
+		flex-direction: row;
+	}
+}
+
+.current-theme__details {
+	display: flex;
+	flex-direction: column;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		height: $current-theme-height;
+		flex-direction: row;
+	}
 }
 
 .current-theme__img {
-	@include breakpoint-deprecated( '<480px' ) {
-		border-left: $current-theme-border;
-	}
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-right: $current-theme-border;
+		max-height: $current-theme-height;
 	}
-	height: 100%;
 }
 
 .current-theme__img-placeholder {
-	width: 75px;
 	color: transparent;
 	background-color: var( --color-neutral-0 );
 	animation: loading-fade 1.6s ease-in-out infinite;
 	height: 100%;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		width: 75px;
+	}
 }
 
 .current-theme__description p {
@@ -34,10 +49,12 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 }
 
 .current-theme__label {
-	font-size: 0.75rem;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-inverted );
 	background: var( --color-neutral-dark );
-	padding: 4px 8px;
+	padding: 4px 12px;
+	position: relative;
+	top: -4px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 120px;
 	margin-left: 10px;
@@ -50,7 +67,7 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	padding-left: 15px;
-	font-size: 1rem;
+	font-size: $font-title-small;
 	max-width: 100%;
 }
 
@@ -62,16 +79,25 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 
 .current-theme__description {
 	margin-top: 15px;
-	font-size: 0.875rem;
+	font-size: $font-body;
 }
 
 .current-theme__actions {
-	height: $current-theme-height;
+	border-top: $current-theme-border;
 	box-sizing: border-box;
+	padding-top: 15px;
 	display: flex;
-	align-items: flex-end;
-	justify-content: flex-end;
+	align-items: center;
+	justify-content: center;
 	flex-grow: 1;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		height: $current-theme-height;
+		padding-top: 0;
+		align-items: flex-end;
+		justify-content: flex-end;
+		flex-grow: 1;
+	}
 }
 
 .current-theme__button {
@@ -83,4 +109,8 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	&:last-child {
 		margin-right: 20px;
 	}
+}
+
+.current-theme__button-label {
+	margin-left: 5px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the "Current Theme" bar to the new design as described in https://github.com/Automattic/wp-calypso/issues/54075.

![image](https://user-images.githubusercontent.com/13437011/124662789-dd917b80-de6e-11eb-84fb-a06335610eca.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/themes/{SITE_URL}?flags=theme/showcase-revamp`
* Verify that the current theme banner displays as indicated above.
* Verify that previous (production) design does not display if feature flag is not enabled.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54075
