### PR TITLE
My Home: Move "Finish store setup" into Site setup checklist

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,5 +1,6 @@
 import { translate } from 'i18n-calypso';
 import React from 'react';
+import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -123,6 +124,19 @@ export const getTask = (
 					actionDispatchArgs: [ siteId, task.id ],
 				} ),
 				isSkippable: true,
+			};
+			break;
+		case CHECKLIST_KNOWN_TASKS.WOOCOMMERCE_SETUP:
+			taskData = {
+				timing: 7,
+				title: translate( 'Finish store setup' ),
+				description: translate(
+					"You're not ready to receive orders until you complete store setup."
+				),
+				actionText: translate( 'Finish store setup' ),
+				actionUrl: taskUrls?.woocommerce_setup,
+				illustration: earnSectionImage,
+				actionDisableOnComplete: false,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,6 +1,5 @@
 import { translate } from 'i18n-calypso';
 import React from 'react';
-import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -128,15 +127,15 @@ export const getTask = (
 			break;
 		case CHECKLIST_KNOWN_TASKS.WOOCOMMERCE_SETUP:
 			taskData = {
-				timing: 7,
+				timing: 2,
 				title: translate( 'Finish store setup' ),
 				description: translate(
-					"You're not ready to receive orders until you complete store setup."
+					'Add your store details, add products, configure shipping, so you can begin to collect orders!'
 				),
 				actionText: translate( 'Finish store setup' ),
 				actionUrl: taskUrls?.woocommerce_setup,
-				illustration: earnSectionImage,
 				actionDisableOnComplete: false,
+				isSkippable: true,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -127,7 +127,7 @@ export const getTask = (
 			break;
 		case CHECKLIST_KNOWN_TASKS.WOOCOMMERCE_SETUP:
 			taskData = {
-				timing: 2,
+				timing: 7,
 				title: translate( 'Finish store setup' ),
 				description: translate(
 					'Add your store details, add products, configure shipping, so you can begin to collect orders!'

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -44,12 +44,12 @@
 	.task__timing {
 		margin-bottom: 10px;
 		align-items: center;
-		color: var( --color-text-subtle );
 		font-size: $font-body-small;
 
 		.gridicon {
-			margin-right: 4px;
+			margin-right: 8px;
 			vertical-align: text-bottom;
+			color: var( --color-text-subtle );
 		}
 	}
 

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -15,6 +15,7 @@ export const CHECKLIST_KNOWN_TASKS = {
 	EMAIL_VERIFIED: 'email_verified',
 	BLOGNAME_SET: 'blogname_set',
 	MOBILE_APP_INSTALLED: 'mobile_app_installed',
+	WOOCOMMERCE_SETUP: 'woocommerce_setup',
 	SITE_LAUNCHED: 'site_launched',
 	FRONT_PAGE_UPDATED: 'front_page_updated',
 	SITE_MENU_UPDATED: 'site_menu_updated',

--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -10,6 +10,7 @@ import { getPostsForQuery } from 'calypso/state/posts/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getFrontPageEditorUrl from 'calypso/state/selectors/get-front-page-editor-url';
 import { createSelector } from '@automattic/state-utils';
+import { getSiteUrl } from 'calypso/state/sites/selectors';
 
 export const FIRST_TEN_SITE_POSTS_QUERY = { type: 'any', number: 10, order_by: 'ID', order: 'ASC' };
 
@@ -52,6 +53,7 @@ export default createSelector(
 			service_list_added: frontPageUrl,
 			staff_info_added: frontPageUrl,
 			product_list_added: frontPageUrl,
+			woocommerce_setup: getSiteUrl( state, siteId ) + '/wp-admin/admin.php?page=wc-admin',
 		};
 	},
 	( state, siteId ) => [ getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY ) ]


### PR DESCRIPTION
## Background

The new user experience for eCommerce plan customers is quite disjointed and there isn't a smooth connection between My Home and Woo Home.  pd2qGl-aS-p2. Aditionally the user doesn't have a "Launch" context set for them in either wpcom My Home or in Woo Home

One small improvement is to move the "Finish store setup" card to be within the My Home site setup checklist.  This gives the user context about the store setup being one part of their site.  The user is also able to see a launch context via the launch item in the checklist.

CURRENT  UI
![image](https://user-images.githubusercontent.com/5665959/126731826-92ca654f-719c-451d-9dab-1956bc22e0f8.png)


PROPOSED UI

![image](https://user-images.githubusercontent.com/5665959/126731142-41b63630-4406-46a1-81a1-a2ef42bf54f0.png)



## Changes proposed in this Pull Request


This PR renders the new "Finish store setup" checklist task added in D63486-code:
See discussion below for final design decisions.


#### Testing instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D63486-code for your sandbox
* Go to My Home
* Check your plan is `eCommerce` and yon don't complete the store setup before
* Verify `Finish store setup` showing in the  site setup checklist

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wc-calypso-bridge/issues/720