### PR TITLE
Add Substack Importer UI

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -181,6 +181,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 			description: translate(
 				'An optional Substack Newsletter URL to import comments and author information.'
 			),
+			invalidDescription: translate(
+				'Enter a valid Substack Newsletter URL (https://newsletter.substack.com/).'
+			),
 		},
 		weight: 0,
 	};

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -137,6 +137,48 @@ function getConfig( { siteTitle = '' } = {} ) {
 		weight: 0,
 	};
 
+	importerConfig.substack = {
+		engine: 'substack',
+		key: 'importer-type-substack',
+		type: 'file',
+		title: 'Substack',
+		icon: 'substack',
+		description: translate(
+			'Import posts and images, podcasts and public comments from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+			{
+				args: {
+					importerName: 'Substack',
+					siteTitle,
+				},
+				components: {
+					b: <strong />,
+				},
+			}
+		),
+		uploadDescription: translate(
+			'A %(importerName)s export file is a ZIP file ' +
+				'containing a CSV file with all posts and individual HTML posts. ' +
+				'{{supportLink/}}',
+			{
+				args: {
+					importerName: 'Substack',
+				},
+				components: {
+					supportLink: (
+						<InlineSupportLink
+							supportPostId={ 87696 } // TODO: update
+							supportLink="https://wordpress.com/support/import/import-from-substack/"
+							showIcon={ false }
+						>
+							{ translate( 'Need help exporting your content?' ) }
+						</InlineSupportLink>
+					),
+				},
+			}
+		),
+		weight: 0,
+	};
+
 	importerConfig.squarespace = {
 		engine: 'squarespace',
 		key: 'importer-type-squarespace',

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -8,6 +8,7 @@ import { filter, orderBy, values } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from '@automattic/calypso-config';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 function getConfig( { siteTitle = '' } = {} ) {
@@ -181,9 +182,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 			description: translate(
 				'An optional Substack Newsletter URL to import comments and author information.'
 			),
-			invalidDescription: translate(
-				'Enter a valid Substack Newsletter URL (https://newsletter.substack.com/).'
-			),
+			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
+				args: { exampleUrl: 'https://newsletter.substack.com/' },
+			} ),
 			validate: ( urlInput ) => {
 				return /https:\/\/[\w-]+\.substack\.com/.test( urlInput );
 			},
@@ -270,11 +271,13 @@ function getConfig( { siteTitle = '' } = {} ) {
 }
 
 export function getImporters( params = {} ) {
-	const importers = orderBy(
-		values( getConfig( params ) ),
-		[ 'weight', 'title' ],
-		[ 'desc', 'asc' ]
-	);
+	const importerConfig = getConfig( params );
+
+	if ( ! config.isEnabled( 'importers/substack' ) ) {
+		delete importerConfig.substack;
+	}
+
+	const importers = orderBy( values( importerConfig ), [ 'weight', 'title' ], [ 'desc', 'asc' ] );
 
 	return importers;
 }

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -184,6 +184,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 			invalidDescription: translate(
 				'Enter a valid Substack Newsletter URL (https://newsletter.substack.com/).'
 			),
+			validate: ( urlInput ) => {
+				return /https:\/\/[\w-]+\.substack\.com/.test( urlInput );
+			},
 		},
 		weight: 0,
 	};

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -176,6 +176,12 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 			}
 		),
+		optionalUrl: {
+			title: translate( 'Substack Newsletter URL' ),
+			description: translate(
+				'An optional Substack Newsletter URL to import comments and author information.'
+			),
+		},
 		weight: 0,
 	};
 

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -186,7 +186,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				args: { exampleUrl: 'https://newsletter.substack.com/' },
 			} ),
 			validate: ( urlInput ) => {
-				return /https:\/\/[\w-]+\.substack\.com/.test( urlInput );
+				return /^https:\/\/[\w-]+\.substack\.com\/?$/.test( urlInput.trim() );
 			},
 		},
 		weight: 0,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1899,13 +1899,19 @@ Undocumented.prototype.uploadExportFile = function ( siteId, params ) {
 			error ? rejectPromise( error ) : resolve( data );
 		};
 
+		const formData = [
+			[ 'importStatus', JSON.stringify( params.importStatus ) ],
+			[ 'import', params.file ],
+		];
+
+		if ( params.url ) {
+			formData.push( [ 'url', params.url ] );
+		}
+
 		const req = this.wpcom.req.post(
 			{
 				path: `/sites/${ siteId }/imports/new`,
-				formData: [
-					[ 'importStatus', JSON.stringify( params.importStatus ) ],
-					[ 'import', params.file ],
-				],
+				formData,
 			},
 			resolver
 		);

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -89,6 +89,7 @@ class FileImporter extends React.PureComponent {
 			description,
 			overrideDestination,
 			uploadDescription,
+			optionalUrl,
 		} = this.props.importerData;
 		const { importerStatus, site } = this.props;
 		const { errorData, importerState } = importerStatus;
@@ -132,6 +133,7 @@ class FileImporter extends React.PureComponent {
 						description={ uploadDescription }
 						importerStatus={ importerStatus }
 						site={ site }
+						optionalUrl={ optionalUrl }
 					/>
 				) }
 			</Card>

--- a/client/my-sites/importer/importer-logo.jsx
+++ b/client/my-sites/importer/importer-logo.jsx
@@ -10,6 +10,7 @@ import { includes } from 'lodash';
  */
 import WixLogo from './logos/wix';
 import MediumLogo from './logos/medium';
+import SubstackLogo from './logos/substack';
 import SocialLogo from 'calypso/components/social-logo';
 
 /**
@@ -28,6 +29,10 @@ const ImporterLogo = ( { icon } ) => {
 
 	if ( 'medium' === icon ) {
 		return <MediumLogo />;
+	}
+
+	if ( 'substack' === icon ) {
+		return <SubstackLogo />;
 	}
 
 	return (

--- a/client/my-sites/importer/importer-logo.scss
+++ b/client/my-sites/importer/importer-logo.scss
@@ -30,6 +30,11 @@
 		background-color: var( --color-squarespace );
 	}
 
+	&.substack-logo {
+		padding: 8px;
+		background-color: var( --color-substack );
+	}
+
 	@include breakpoint-deprecated( '>960px' ) {
 		width: 56px;
 		height: 56px;

--- a/client/my-sites/importer/importer-substack.jsx
+++ b/client/my-sites/importer/importer-substack.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FileImporter from './file-importer';
+import importerConfig from 'calypso/lib/importer/importer-config';
+
+class ImporterSubstack extends React.PureComponent {
+	static displayName = 'ImporterSubstack';
+
+	static propTypes = {
+		site: PropTypes.shape( {
+			title: PropTypes.string.isRequired,
+		} ).isRequired,
+		siteTitle: PropTypes.string.isRequired,
+		importerStatus: PropTypes.shape( {
+			importerState: PropTypes.string.isRequired,
+			errorData: PropTypes.shape( {
+				type: PropTypes.string.isRequired,
+				description: PropTypes.string.isRequired,
+			} ),
+			statusMessage: PropTypes.string,
+		} ),
+	};
+
+	render() {
+		const importerData = importerConfig( {
+			siteTitle: this.props.siteTitle,
+		} ).substack;
+
+		return <FileImporter importerData={ importerData } { ...this.props } />;
+	}
+}
+
+export default localize( ImporterSubstack );

--- a/client/my-sites/importer/logos/substack.jsx
+++ b/client/my-sites/importer/logos/substack.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<svg
+		/*eslint-disable wpcalypso/jsx-classname-namespace */
+		className="substack-logo social-logo importer__service-icon"
+		role="img"
+		viewBox="0 0 24 24"
+		width="48"
+		height="48"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z" />
+	</svg>
+);

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -20,6 +20,7 @@ import WordPressImporter from 'calypso/my-sites/importer/importer-wordpress';
 import MediumImporter from 'calypso/my-sites/importer/importer-medium';
 import BloggerImporter from 'calypso/my-sites/importer/importer-blogger';
 import WixImporter from 'calypso/my-sites/importer/importer-wix';
+import SubstackImporter from 'calypso/my-sites/importer/importer-substack';
 import SquarespaceImporter from 'calypso/my-sites/importer/importer-squarespace';
 import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { getImporters, getImporterByKey } from 'calypso/lib/importer/importer-config';
@@ -60,6 +61,7 @@ import config from '@automattic/calypso-config';
 const importerComponents = {
 	blogger: BloggerImporter,
 	medium: MediumImporter,
+	substack: SubstackImporter,
 	squarespace: SquarespaceImporter,
 	wix: WixImporter,
 	wordpress: WordPressImporter,

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -52,6 +52,8 @@ class UploadingPane extends React.PureComponent {
 		optionalUrl: PropTypes.shape( {
 			title: PropTypes.string,
 			description: PropTypes.string,
+			invalidDescription: PropTypes.string,
+			validate: PropTypes.func,
 		} ),
 	};
 
@@ -166,7 +168,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	validateUrl = ( urlInput ) => {
-		return ! urlInput || urlInput === '' || /https:\/\/[\w-]+\.substack\.com/.test( urlInput );
+		return ! urlInput || urlInput === '' || this.props.optionalUrl.validate( urlInput );
 	};
 
 	setUrl = ( event ) => {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -164,6 +164,15 @@ class UploadingPane extends React.PureComponent {
 		this.props.startUpload( this.props.importerStatus, file );
 	};
 
+	validateUrl = ( urlInput ) => {
+		return ! urlInput || urlInput === '' || /https:\/\/[\w-]+\.substack\.com/.test( urlInput );
+	};
+
+	setUrl = ( event ) => {
+		const urlInput = event.target.value;
+		this.setState( { urlInput } );
+	};
+
 	render() {
 		const { importerStatus, site, isEnabled } = this.props;
 		const isReadyForImport = this.isReadyForImport();
@@ -209,12 +218,15 @@ class UploadingPane extends React.PureComponent {
 							<TextInput
 								label={ this.props.optionalUrl.title }
 								onChange={ this.setUrl }
-								onKeyPress={ this.validateOnEnter }
 								value={ this.state.urlInput }
 								placeholder="https://newsletter.substack.com"
 							/>
 						</FormLabel>
-						<FormSettingExplanation>{ this.props.optionalUrl.description }</FormSettingExplanation>
+						<FormSettingExplanation>
+							{ this.validateUrl( this.state.urlInput )
+								? this.props.optionalUrl.description
+								: this.props.optionalUrl.invalidDescription }
+						</FormSettingExplanation>
 					</div>
 				) }
 				<ImporterActionButtonContainer>
@@ -222,7 +234,9 @@ class UploadingPane extends React.PureComponent {
 						<ImporterActionButton
 							primary
 							onClick={ this.initiateFromUploadButton }
-							disabled={ ! this.state.fileToBeUploaded }
+							disabled={
+								! this.state.fileToBeUploaded || ! this.validateUrl( this.state.urlInput )
+							}
 						>
 							{ this.props.translate( 'Upload' ) }
 						</ImporterActionButton>

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -186,8 +186,8 @@ class UploadingPane extends React.PureComponent {
 		const hasEnteredUrl = this.state.urlInput && this.state.urlInput !== '';
 		const isValidUrl = this.validateUrl( this.state.urlInput );
 		const urlDescription = isValidUrl
-			? this.props.optionalUrl.description
-			: this.props.optionalUrl.invalidDescription;
+			? this.props?.optionalUrl?.description
+			: this.props?.optionalUrl?.invalidDescription;
 
 		return (
 			<div>

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -227,7 +227,7 @@ class UploadingPane extends React.PureComponent {
 								label={ this.props.optionalUrl.title }
 								onChange={ this.setUrl }
 								value={ this.state.urlInput }
-								placeholder="https://newsletter.substack.com"
+								placeholder="https://newsletter.substack.com/"
 							/>
 						</FormLabel>
 						{ hasEnteredUrl ? (

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -128,7 +128,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	initiateFromUploadButton = () => {
-		this.startUpload( this.state.fileToBeUploaded );
+		this.startUpload( this.state.fileToBeUploaded, this.state.urlInput );
 	};
 
 	setupUpload = ( file ) => {
@@ -160,8 +160,8 @@ class UploadingPane extends React.PureComponent {
 		}
 	};
 
-	startUpload = ( file ) => {
-		this.props.startUpload( this.props.importerStatus, file );
+	startUpload = ( file, url = undefined ) => {
+		this.props.startUpload( this.props.importerStatus, file, url );
 	};
 
 	validateUrl = ( urlInput ) => {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -164,7 +164,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	startUpload = ( file, url = undefined ) => {
-		this.props.startUpload( this.props.importerStatus, file, url );
+		this.props.startUpload( this.props.importerStatus, file, url ? url.trim() : undefined );
 	};
 
 	validateUrl = ( urlInput ) => {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -87,7 +87,7 @@ class UploadingPane extends React.PureComponent {
 			case appStates.READY_FOR_UPLOAD:
 			case appStates.UPLOAD_FAILURE:
 				if ( this.state.fileToBeUploaded ) {
-					return <p>{ this.props.translate( 'Click Upload to begin uploading the file' ) }</p>;
+					return <p>{ this.state?.fileToBeUploaded?.name?.substring?.( 0, 100 ) }</p>;
 				}
 				return <p>{ this.props.translate( 'Drag a file here, or click to upload a file' ) }</p>;
 			case appStates.UPLOAD_PROCESSING:

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -20,7 +20,11 @@ import {
 } from 'calypso/state/imports/uploads/selectors';
 import DropZone from 'calypso/components/drop-zone';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
+import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
+import TextInput from 'calypso/components/forms/form-text-input';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { ProgressBar } from '@automattic/components';
 
 /**
@@ -44,11 +48,20 @@ class UploadingPane extends React.PureComponent {
 			ID: PropTypes.number.isRequired,
 			single_user_site: PropTypes.bool.isRequired,
 		} ).isRequired,
+		optionalUrl: PropTypes.shape( {
+			title: PropTypes.string,
+			description: PropTypes.string,
+		} ),
 	};
 
-	static defaultProps = { description: null };
+	static defaultProps = { description: null, optionalUrl: null };
 
 	fileSelectorRef = React.createRef();
+
+	constructor( props ) {
+		super( props );
+		this.state = { urlInput: null };
+	}
 
 	componentDidUpdate( prevProps ) {
 		const { importerStatus } = this.props;
@@ -165,7 +178,27 @@ class UploadingPane extends React.PureComponent {
 					) }
 					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />
 				</div>
+				{ this.props.optionalUrl && (
+					<div className="importer__uploading-pane-url-input">
+						<FormLabel>
+							{ this.props.optionalUrl.title }
+							<TextInput
+								label={ this.props.optionalUrl.title }
+								onChange={ this.setUrl }
+								onKeyPress={ this.validateOnEnter }
+								value={ this.state.urlInput }
+								placeholder="https://newsletter.substack.com"
+							/>
+						</FormLabel>
+						<FormSettingExplanation>{ this.props.optionalUrl.description }</FormSettingExplanation>
+					</div>
+				) }
 				<ImporterActionButtonContainer>
+					{ this.props.optionalUrl && (
+						<ImporterActionButton primary>
+							{ this.props.translate( 'Upload' ) }
+						</ImporterActionButton>
+					) }
 					<ImporterCloseButton
 						importerStatus={ importerStatus }
 						site={ site }

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -25,6 +25,7 @@ import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-butto
 import TextInput from 'calypso/components/forms/form-text-input';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import { ProgressBar } from '@automattic/components';
 
 /**
@@ -180,6 +181,11 @@ class UploadingPane extends React.PureComponent {
 			'importer__upload-content',
 			this.props.importerStatus.importerState
 		);
+		const hasEnteredUrl = this.state.urlInput && this.state.urlInput !== '';
+		const isValidUrl = this.validateUrl( this.state.urlInput );
+		const urlDescription = isValidUrl
+			? this.props.optionalUrl.description
+			: this.props.optionalUrl.invalidDescription;
 
 		return (
 			<div>
@@ -222,11 +228,11 @@ class UploadingPane extends React.PureComponent {
 								placeholder="https://newsletter.substack.com"
 							/>
 						</FormLabel>
-						<FormSettingExplanation>
-							{ this.validateUrl( this.state.urlInput )
-								? this.props.optionalUrl.description
-								: this.props.optionalUrl.invalidDescription }
-						</FormSettingExplanation>
+						{ hasEnteredUrl ? (
+							<FormInputValidation isError={ ! isValidUrl }>{ urlDescription }</FormInputValidation>
+						) : (
+							<FormSettingExplanation>{ urlDescription }</FormSettingExplanation>
+						) }
 					</div>
 				) }
 				<ImporterActionButtonContainer>

--- a/client/state/imports/actions.js
+++ b/client/state/imports/actions.js
@@ -188,7 +188,7 @@ export const setUploadStartState = ( importerId, filenameOrUrl ) => ( {
 	importerId,
 } );
 
-export const startUpload = ( importerStatus, file ) => ( dispatch ) => {
+export const startUpload = ( importerStatus, file, url = undefined ) => ( dispatch ) => {
 	const {
 		importerId,
 		site: { ID: siteId },
@@ -200,6 +200,7 @@ export const startUpload = ( importerStatus, file ) => ( dispatch ) => {
 		.uploadExportFile( siteId, {
 			importStatus: toApi( importerStatus ),
 			file,
+			url,
 			onprogress: ( event ) => {
 				dispatch(
 					setUploadProgress( importerId, {

--- a/config/development.json
+++ b/config/development.json
@@ -75,6 +75,7 @@
 		"gutenboarding/long-previews": true,
 		"help": true,
 		"home/layout-dev": true,
+		"importers/substack": true,
 		"inline-help": true,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,

--- a/config/test.json
+++ b/config/test.json
@@ -48,6 +48,7 @@
 		"gutenboarding/landscape-preview": true,
 		"gutenboarding/long-previews": true,
 		"help": true,
+		"importers/substack": true,
 		"inline-help": true,
 		"ive/use-external-assignment": true,
 		"jetpack/concierge-sessions": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -58,6 +58,7 @@
 		"happychat": true,
 		"help": true,
 		"home/layout-dev": true,
+		"importers/substack": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -313,6 +313,7 @@
 	--color-reddit: #5f99cf;
 	--color-skype: #00aff0;
 	--color-stumbleupon: #eb4924;
+	--color-substack: #ff6719;
 	--color-squarespace: #222;
 	--color-telegram: #0088cc;
 	--color-tumblr: #35465c;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -312,6 +312,7 @@
 	--color-reddit: #5f99cf;
 	--color-skype: #00aff0;
 	--color-stumbleupon: #eb4924;
+	--color-substack: #ff6719;
 	--color-squarespace: #222;
 	--color-telegram: #0088cc;
 	--color-tumblr: #35465c;
@@ -658,6 +659,7 @@
 	--color-reddit: #5f99cf;
 	--color-skype: #00aff0;
 	--color-stumbleupon: #eb4924;
+	--color-substack: #ff6719;
 	--color-squarespace: #222;
 	--color-telegram: #0088cc;
 	--color-tumblr: #35465c;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Substack Importer UI to Calypso
* Adds a `url` key to the POST request sent to /importers/new for processing Substack entries from wpcom backend.

[Demo video here](https://user-images.githubusercontent.com/533/123935511-ec30ec00-d9b1-11eb-9c87-a9fbef444caf.mp4)

#### Code Changes Overview
1. A new Substack entry in importer-config that contains a new key `optionalUrl` that contains `title`, `description` and `invalidDescription` and a function `validate`.
2. A SubstackImporter that continues to use FileImporter.
3. Modifications in UploadingPane to display an optional URL field when the key `optionalUrl` is present.
4. Client-side validation of URL, including default, error & success states.
5. Modify the `startUpload` action and `wpcom` undocumented API to send across a `url` for `/imports/new`

#### Testing instructions

1. Go to Tools > Import and test any existing importer (Blogger for e.g.). Make sure the E2E flow works.
2. Now open Substack. The UI should be self-explanatory. The Upload button should be activated only if a valid file and a valid URL, or a valid file alone is present.
3. The Upload itself will throw an error as we haven't implemented the backend functionality, but examine the network request to ensure the url is passed correctly:
<img width="258" alt="CleanShot 2021-06-30 at 14 17 06@2x" src="https://user-images.githubusercontent.com/533/123938350-a7f31b00-d9b4-11eb-96fa-038dd5b46556.png">
4. Try to break this & code suggestions welcome! :)
