### PR TITLE
Remove wildcard for settings path in favour of more strict Settings G…

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -166,7 +166,7 @@ const sections = [
 	},
 	{
 		name: 'settings',
-		paths: [ '/settings' ],
+		paths: [ '/settings-general' ],
 		module: 'calypso/my-sites/site-settings',
 		group: 'sites',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The generic path `/settings/` was renamed to `/settings-general/`. This change was needed because this generic path conflicted with the specific paths like `settings/writing`, and triggering the sections-middleware twice on mobile. Because of this, the menu on mobile was toggled and immediately untoggled.

#### Testing instructions
- Use Calypso live or checkout this branch on your local Calypso environment.
- Resize the browser size to a mobile resolution.
- Go to the following URLs and check that the menu opens and closes on the following sections:
- Settings > Discussion  (Calypso)
- Settings > Performance  (Calypso)
- Settings > Writing  (Calypso)
- Settings > Jetpack (on Atomic)
- Posts > Tags (Calypso)
- Posts > Categories (Calypso)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


