### PR TITLE
Check we have a valid blog id on is_theme_supported

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -127,7 +127,7 @@ function is_site_eligible_for_full_site_editing() {
  * @return bool True if current theme supports FSE, false otherwise.
  */
 function is_theme_supported() {
-	if ( 0 === get_current_blog_id() ) {
+	if ( is_multisite() && 0 === get_current_blog_id() ) {
 		// get_theme_slug will always return false.
 		return false;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -127,6 +127,10 @@ function is_site_eligible_for_full_site_editing() {
  * @return bool True if current theme supports FSE, false otherwise.
  */
 function is_theme_supported() {
+	if ( 0 === get_current_blog_id() ) {
+		// get_theme_slug will always return false.
+		return false;
+	}
 	// Use un-normalized theme slug because get_theme requires the full string.
 	$theme = wp_get_theme( get_theme_slug() );
 	return ! $theme->errors() && in_array( 'full-site-editing', $theme->tags, true );


### PR DESCRIPTION
Calling get_option when `get_current_blog_id()` is `0` produces lots of PHP warnings on HyperDB

#### Changes proposed in this Pull Request

* Add a check for `get_current_blog() !== 0` on multisite WP

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
