### PR TITLE
Media Library: handle uploading video files by feature store

### DIFF
--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -26,7 +26,6 @@ import {
 	getKeyringConnections,
 } from 'calypso/state/sharing/keyring/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
@@ -228,7 +227,6 @@ export default connect(
 		needsKeyring: needsKeyring( state, source ),
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isJetpack: isJetpackSite( state, site?.ID ),
-		isAtomic: isAtomicSite( state, site?.ID ),
 		hasVideoUploadFeature: hasActiveSiteFeature( state, site.ID, 'videopress' ),
 		hasVideoUploadAvailableFeature: hasAvailableSiteFeature( state, site.ID, 'videopress' ),
 	} ),

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -227,8 +227,8 @@ export default connect(
 		needsKeyring: needsKeyring( state, source ),
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isJetpack: isJetpackSite( state, site?.ID ),
-		hasVideoUploadFeature: hasActiveSiteFeature( state, site.ID, 'videopress' ),
-		hasVideoUploadAvailableFeature: hasAvailableSiteFeature( state, site.ID, 'videopress' ),
+		hasVideoUploadFeature: hasActiveSiteFeature( state, site.ID, 'upload-video-files' ),
+		hasVideoUploadAvailableFeature: hasAvailableSiteFeature( state, site.ID, 'upload-video-files' ),
 	} ),
 	{
 		requestKeyringConnections,

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -19,7 +19,6 @@ import { filterItemsByMimePrefix } from 'calypso/lib/media/utils';
 import filterToMimePrefix from './filter-to-mime-prefix';
 import FilterBar from './filter-bar';
 import QueryPreferences from 'calypso/components/data/query-preferences';
-import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import searchUrl from 'calypso/lib/search-url';
 import {
 	isKeyringConnectionsFetching,
@@ -179,7 +178,6 @@ class MediaLibrary extends Component {
 		return (
 			<div className={ classes }>
 				<QueryPreferences />
-				<QuerySiteFeatures key="query-features" siteId={ this.props.site?.ID } />,
 				{ this.renderDropZone() }
 				<FilterBar
 					site={ this.props.site }

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -225,8 +225,12 @@ export default connect(
 		needsKeyring: needsKeyring( state, source ),
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isJetpack: isJetpackSite( state, site?.ID ),
-		hasVideoUploadFeature: hasActiveSiteFeature( state, site.ID, 'upload-video-files' ),
-		hasVideoUploadAvailableFeature: hasAvailableSiteFeature( state, site.ID, 'upload-video-files' ),
+		hasVideoUploadFeature: hasActiveSiteFeature( state, site?.ID, 'upload-video-files' ),
+		hasVideoUploadAvailableFeature: hasAvailableSiteFeature(
+			state,
+			site?.ID,
+			'upload-video-files'
+		),
 	} ),
 	{
 		requestKeyringConnections,

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -18,6 +18,9 @@ import { requestKeyringConnections as requestStub } from 'calypso/state/sharing/
 jest.mock( 'calypso/components/data/query-preferences', () =>
 	require( 'calypso/components/empty-component' )
 );
+jest.mock( 'calypso/components/data/query-site-features', () =>
+	require( 'calypso/components/empty-component' )
+);
 jest.mock( 'calypso/my-sites/media-library/content', () =>
 	require( 'calypso/components/empty-component' )
 );
@@ -49,11 +52,16 @@ describe( 'MediaLibrary', () => {
 		subscribe: () => false,
 	};
 
+	const site = {
+		ID: 123,
+	};
+
 	beforeEach( () => {
 		requestStub.resetHistory();
 	} );
 
-	const getItem = ( source ) => mount( <MediaLibrary store={ store } source={ source } /> );
+	const getItem = ( source ) =>
+		mount( <MediaLibrary site={ site } store={ store } source={ source } /> );
 
 	describe( 'keyring request', () => {
 		test( 'is issued when component mounted and viewing an external source', () => {

--- a/client/state/selectors/has-active-site-feature.js
+++ b/client/state/selectors/has-active-site-feature.js
@@ -7,6 +7,14 @@
  */
 import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 
+/**
+ * Check if the feature is active in the site.
+ *
+ * @param  {object}  state      Global state tree
+ * @param  {number}  siteId     The ID of the site we're querying
+ * @param  {string}  featureId  The dotcom feature to check.
+ * @returns {?object}           True if the feature is active. Otherwise, False.
+ */
 export default function hasActiveSiteFeature( state, siteId, featureId ) {
 	const siteFeatures = getSiteFeatures( state, siteId );
 

--- a/client/state/selectors/has-available-site-feature.js
+++ b/client/state/selectors/has-available-site-feature.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import getSiteFeatures from 'calypso/state/selectors/get-site-features';
+
+/**
+ * Check if the feature is available for the site.
+ *
+ * @param  {object}  state      Global state tree
+ * @param  {number}  siteId     The ID of the site we're querying
+ * @param  {string}  featureId  The dotcom feature to check.
+ * @returns {?Array|boolean}    Plasns array if the feature is available. Otherwise, False.
+ */
+export default function hasAvailableSiteFeature( state, siteId, featureId ) {
+	const siteFeatures = getSiteFeatures( state, siteId );
+
+	if ( ! siteFeatures?.available ) {
+		return false;
+	}
+
+	return siteFeatures.available[ featureId ] ?? false;
+}

--- a/client/state/selectors/test/has-active-site-feature.js
+++ b/client/state/selectors/test/has-active-site-feature.js
@@ -47,7 +47,7 @@ describe( 'selectors', () => {
 			expect( activeFeature ).to.eql( false );
 		} );
 
-		test( 'should return False when feature is no feature id', () => {
+		test( 'should return False when feature param is not defined', () => {
 			const active = [ 'feature_active_01', 'feature_active_02', 'feature_active_03' ];
 
 			const state = {

--- a/client/state/selectors/test/has-available-site-feature.js
+++ b/client/state/selectors/test/has-available-site-feature.js
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
+
+describe( 'selectors', () => {
+	describe( '#hasAvailableSiteFeature()', () => {
+		test( 'should return False when no site id', () => {
+			const available = {
+				'feature-available-01': [ 'plan-01', 'plan-02', 'plan-03' ],
+				'feature-available-02': [ 'plan-01' ],
+				'feature-available-03': [ 'plan-02' ],
+			};
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								available,
+							},
+						},
+					},
+				},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state );
+			expect( availableFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when site does not exist', () => {
+			const available = {
+				'feature-available-01': [ 'plan-01', 'plan-02', 'plan-03' ],
+				'feature-available-02': [ 'plan-01' ],
+				'feature-available-03': [ 'plan-02' ],
+			};
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								available,
+							},
+						},
+					},
+				},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state, 'unknown' );
+			expect( availableFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when feature is not populated', () => {
+			const state = {
+				sites: {},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state, 123001 );
+			expect( availableFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when available feature is not populated', () => {
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {},
+						},
+					},
+				},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state, 123001 );
+			expect( availableFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when feature id is not defined', () => {
+			const available = {
+				'feature-available-01': [ 'plan-01', 'plan-02', 'plan-03' ],
+				'feature-available-02': [ 'plan-01' ],
+				'feature-available-03': [ 'plan-02' ],
+			};
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								available,
+							},
+						},
+					},
+				},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state, 123001 );
+			expect( availableFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when feature is not defined in the available object', () => {
+			const available = {
+				'feature-available-01': [ 'plan-01', 'plan-02', 'plan-03' ],
+				'feature-available-02': [ 'plan-01' ],
+				'feature-available-03': [ 'plan-02' ],
+			};
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								available,
+							},
+						},
+					},
+				},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state, 123001, 'not-available-feature' );
+			expect( availableFeature ).to.eql( false );
+		} );
+
+		test( 'should return plans array when feature available', () => {
+			const available = {
+				'feature-available-01': [ 'plan-01', 'plan-02', 'plan-03' ],
+				'feature-available-02': [ 'plan-01' ],
+				'feature-available-03': [ 'plan-02' ],
+			};
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								available,
+							},
+						},
+					},
+				},
+			};
+
+			const availableFeature = hasAvailableSiteFeature( state, 123001, 'feature-available-01' );
+			expect( availableFeature ).to.eql( [ 'plan-01', 'plan-02', 'plan-03' ] );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It depends on D63248-code
* Follow up the PR https://github.com/Automattic/wp-calypso/pull/53144

This PR changes the way to check whether the site has the ability to upload video files, using the site features source.
For this purpose, I've added a new `hasAvailableSiteFeature()` selector (with tests 🎸 ).

#### Testing instructions

* Go to Media Library / video section in calypso: http://calypso.localhost:3000/media/videos/<testing-site>
* Confirm that the app allows/does not allow uploading video files depending on the site type and the site plan/products.

Reference

| site plan \ site type | Simple | Atomic | Jetpack |
|---|----|----|----|
| Free | 🍎 | 🍎 | 🍏 |
| Personal | 🍎 | 🍎 | 🍏  |
| Premium | 🍏 | 🍏 | 🍏 |
| Business | 🍏 | 🍏 | 🍏 |
| eCommerce | 🍏 | 🍏 | ✖️ |
| Security Daily |  ✖️| ✖️ | 🍏 |


### running tests

```
> yarn run test-client client/state/selectors/test/has-available-site-feature.js
```

```
$ TZ=UTC jest -c=test/client/jest.config.js client/state/selectors/test/has-available-site-feature.js
[ PASS ] client/state/selectors/test/has-available-site-feature.js

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.148 s
Ran all test suites matching /client\/state\/selectors\/test\/has-available-site-feature.js/i.
✨  Done in 3.73s.
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes https://github.com/Automattic/wp-calypso/issues/54162
