### PR TITLE
Site Switcher: Prevent search field zooming in ios

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -131,10 +131,6 @@
 		}
 	}
 
-	.search__input[type='search'] {
-		font-size: $font-body-small;
-	}
-
 	.search__open-icon,
 	.search__close-icon {
 		color: var( --color-neutral-light );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Font sizes less than 16px cause iOS to zoom when the field is focused. This change means that the site selector field will use a 16px font size rather than a 14px font size

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This occurs in sidebar switcher and in the full screen switcher

To test the sidebar
1. Access calypso in iOS
2. Use the site switcher 
3. Focus the search for site

What I expected to happen

Page not get zoomed in
What actually happened


To test the full screen site-switcher:
    Go to https://wordpress.com/home
    Click on Search

What I expected to happen

Page not get zoomed in
What actually happened

Page got zoomed in

Before | After
-------|------ 
![image](https://user-images.githubusercontent.com/93301/123959660-55126700-d9a6-11eb-9ac1-d7828d10ef05.png)|![image](https://user-images.githubusercontent.com/93301/123959875-91de5e00-d9a6-11eb-8ff6-d571183457e0.png)





<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #54155
