### PR TITLE
Earn: Fix Broken Support Document Link on "Related Fees"

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -135,7 +135,7 @@ class MembershipsSection extends Component {
 										br: <br />,
 										a: (
 											<ExternalLink
-												href="https://wordpress.com/support/recurring-payments-button/#related-fees"
+												href="https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees"
 												icon={ true }
 											/>
 										),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the broken link to the support document on Related Fees located within the Earn section 

#### Testing instructions

This link appears on `/earn/payments/site` for sites that have Stripe connected, but it should be adequate to just check the links. I've also verified that the new link works in other languages, and it does.

Broken link: https://wordpress.com/support/recurring-payments-button/#related-fees
Updated link: https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees

cc @kwight 

Fixes #54157