### PR TITLE
Boot: Try independent user initialization

### DIFF
--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -81,12 +81,9 @@ function renderDevHelpers( reduxStore ) {
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
 
-	if ( currentUser.get() ) {
+	if ( currentUser ) {
 		// Set current user in Redux store
-		reduxStore.dispatch( setCurrentUser( currentUser.get() ) );
-		currentUser.on( 'change', () => {
-			reduxStore.dispatch( setCurrentUser( currentUser.get() ) );
-		} );
+		reduxStore.dispatch( setCurrentUser( currentUser ) );
 	}
 
 	if ( config.isEnabled( 'network-connection' ) ) {
@@ -105,7 +102,7 @@ const setRouteMiddleware = ( reduxStore ) => {
 };
 
 const setAnalyticsMiddleware = ( currentUser, reduxStore ) => {
-	initializeAnalytics( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
+	initializeAnalytics( currentUser ? currentUser : undefined, getSuperProps( reduxStore ) );
 };
 
 export function setupMiddlewares( currentUser, reduxStore ) {

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -16,7 +16,7 @@ import page from 'page';
 import createStore from './store';
 import { setupMiddlewares, configureReduxStore } from './common';
 import initLoginSection from 'calypso/login';
-import userFactory from 'calypso/lib/user';
+import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { setupLocale } from 'calypso/boot/locale';
 import { setStore } from 'calypso/state/redux-store';
 
@@ -35,7 +35,7 @@ const boot = ( currentUser ) => {
 
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
-	setupLocale( currentUser.get(), store );
+	setupLocale( currentUser, store );
 
 	page( '*', ( context, next ) => {
 		context.store = store;
@@ -51,7 +51,7 @@ const boot = ( currentUser ) => {
 	page.start( { decodeURLComponents: false } );
 };
 
-window.AppBoot = () => {
-	const user = userFactory();
-	user.initialize().then( () => boot( user ) );
+window.AppBoot = async () => {
+	const user = await initializeCurrentUser();
+	boot( user );
 };

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -6,8 +6,15 @@ import config from '@automattic/calypso-config';
 /**
  * Internal dependencies
  */
+import wpcom from 'calypso/lib/wp';
 import { decodeEntities } from 'calypso/lib/formatting/decode-entities';
 import { getLanguage } from 'calypso/lib/i18n-utils/utils';
+import {
+	isSupportUserSession,
+	isSupportNextSession,
+	supportUserBoot,
+	supportNextBoot,
+} from 'calypso/lib/user/support-user-interop';
 import { withoutHttp } from 'calypso/lib/url';
 
 function getSiteSlug( url ) {
@@ -102,4 +109,51 @@ export function getLogoutUrl( userData, redirect ) {
 	}
 
 	return url;
+}
+
+export function rawCurrentUserFetch() {
+	return wpcom.me().get( {
+		meta: 'flags',
+	} );
+}
+
+export async function initializeCurrentUser() {
+	let skipBootstrap = false;
+
+	if ( isSupportUserSession() ) {
+		// boot the support session and skip the user bootstrap: the server sent the unwanted
+		// user info there (me) instead of the target SU user.
+		supportUserBoot();
+		skipBootstrap = true;
+	}
+
+	if ( isSupportNextSession() ) {
+		// boot the support session and proceed with user bootstrap (unlike the SupportUserSession,
+		// the initial GET request includes the right cookies and header and returns a server-generated
+		// page with the right window.currentUser value)
+		supportNextBoot();
+	}
+
+	if ( ! skipBootstrap && config.isEnabled( 'wpcom-user-bootstrap' ) ) {
+		if ( window.currentUser ) {
+			return window.currentUser;
+		}
+		return;
+	}
+
+	let userData;
+	try {
+		userData = await rawCurrentUserFetch();
+	} catch ( error ) {
+		if ( error.error !== 'authorization_required' ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to fetch the user from /me endpoint:', error );
+		}
+	}
+
+	if ( ! userData ) {
+		return false;
+	}
+
+	return filterUserObject( userData );
 }

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -138,7 +138,7 @@ export async function initializeCurrentUser() {
 		if ( window.currentUser ) {
 			return window.currentUser;
 		}
-		return;
+		return false;
 	}
 
 	let userData;

--- a/client/state/current-user/actions.js
+++ b/client/state/current-user/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'calypso/lib/wp';
 import userFactory from 'calypso/lib/user';
 import {
 	clearStore,
@@ -14,7 +13,7 @@ import {
 	CURRENT_USER_RECEIVE,
 	CURRENT_USER_SET_EMAIL_VERIFIED,
 } from 'calypso/state/action-types';
-import { filterUserObject, getLogoutUrl } from 'calypso/lib/user/shared-utils';
+import { filterUserObject, getLogoutUrl, rawCurrentUserFetch } from 'calypso/lib/user/shared-utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 /**
@@ -48,11 +47,7 @@ export function fetchCurrentUser() {
 			type: CURRENT_USER_FETCH,
 		} );
 
-		fetchingUser = wpcom
-			.me()
-			.get( {
-				meta: 'flags',
-			} )
+		fetchingUser = rawCurrentUserFetch()
 			.then( async ( user ) => {
 				const userData = filterUserObject( user );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is an attempt to move user initialization to an independent helper function. To make the way for that, we're abstracting the user fetching to a separate helper, too, and use that for fetching in Redux, too. 

Part of #24004 where we aim to reduxify `lib/user`. This is the last step to unlock removing the legacy `lib/user` event emitter instance.

#### Testing instructions

* Logged in user loads correctly - with and without a clean Redux store.
* Logging in and logging out works correctly.
* Support sessions still work well.
* Accepting an invitation for a site still works well.
* Saving the user profile works as it did before.
* Deleting a WP.com site and disconnecting a Jetpack site still works well.
* Verify Calypso with bootstrapped user still works (see PCYsg-5YE-p2 for instructions)
* Smoke test Calypso and look out for anything suspicious.