### PR TITLE
Theme Showcase: Update placeholder text on theme search

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -276,7 +276,7 @@ class ThemesMagicSearchCard extends React.Component {
 				value={ this.state.searchInput }
 				ref={ this.setSearchInputRef }
 				placeholder={ translate(
-					"I'm creating a site for a: portfolio, magazine, business, wedding, blog, or…"
+					'Search by style or feature: portfolio, store, multiple menus, or…'
 				) }
 				analyticsGroup="Themes"
 				delaySearch={ true }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update placeholder text on theme search to make it clearer which searches are recommended
* Fixes #54170

**Before**

<img width="1353" alt="Screen Shot 2021-06-30 at 11 30 35 AM" src="https://user-images.githubusercontent.com/2124984/123989141-9864d980-d996-11eb-8765-770d43166907.png">

**After**

<img width="1354" alt="Screen Shot 2021-06-30 at 11 31 38 AM" src="https://user-images.githubusercontent.com/2124984/123989270-bd594c80-d996-11eb-81c5-9046a482ae82.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes` and click on "Show all themes"
* Note the placeholder text in the search bar has changed
* Make sure there are no spelling errors or typos :)
