### PR TITLE
Backup download: show file size

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -38,6 +38,7 @@ interface BackupProgress {
 	progress?: number;
 	rewindId: string;
 	url?: string;
+	bytesFormatted: string;
 }
 
 const BackupDownloadFlow: FunctionComponent< Props > = ( {
@@ -58,6 +59,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 
 	const downloadId = backupProgress?.downloadId;
 	const downloadUrl = backupProgress?.url;
+	const downloadSize = backupProgress?.bytesFormatted;
 	const downloadProgress =
 		backupProgress && backupProgress.progress !== undefined && ! isNaN( backupProgress.progress )
 			? backupProgress.progress
@@ -209,7 +211,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 				className="rewind-flow__primary-button"
 				onClick={ trackFileDownload }
 			>
-				{ translate( 'Download file' ) }
+				{ translate( 'Download file' ) } ({ downloadSize })
 			</Button>
 			<CheckYourEmail
 				message={ translate(

--- a/client/state/activity-log/backup/reducer.js
+++ b/client/state/activity-log/backup/reducer.js
@@ -39,6 +39,7 @@ export const backupProgress = keyedReducer( 'siteId', ( state = undefined, actio
 				startedAt: '',
 				downloadCount: 0,
 				validUntil: '',
+				bytesFormatted: '',
 				url: '',
 			};
 
@@ -53,6 +54,7 @@ export const backupProgress = keyedReducer( 'siteId', ( state = undefined, actio
 						startedAt: action.startedAt,
 						downloadCount: action.downloadCount,
 						validUntil: action.validUntil,
+						bytesFormatted: action.bytesFormatted,
 						url: action.url,
 				  };
 

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -25,6 +25,7 @@ const transformDownload = ( data ) =>
 	Object.assign(
 		{
 			downloadId: data.downloadId,
+			bytesFormatted: data.bytesFormatted,
 			rewindId: data.rewindId,
 			backupPoint: new Date( data.backupPoint * 1000 ),
 			startedAt: new Date( data.startedAt * 1000 ),

--- a/client/state/data-layer/wpcom/sites/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/downloads/index.js
@@ -71,6 +71,7 @@ const fromApi = ( data ) => ( {
 	rewindId: data.rewindId,
 	startedAt: data.startedAt,
 	downloadCount: +data.downloadCount,
+	bytesFormatted: data.bytesFormatted,
 	validUntil: data.validUntil,
 	url: data.url,
 	error: data.error,

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -35,6 +35,7 @@ export const download = {
 		startedAt: { type: 'integer' },
 		downloadCount: { type: 'integer' },
 		validUntil: { type: 'integer' },
+		bytesFormatted: { type: 'string' },
 	},
 	required: [ 'downloadId', 'rewindId', 'backupPoint', 'startedAt' ],
 };
@@ -49,6 +50,7 @@ export const rewind = {
 		started_at: { type: 'string' },
 		progress: { type: 'integer' },
 		reason: { type: 'string' },
+		bytesFormatted: { type: 'string' },
 		/**
 		 * Commenting these out temporarily because API is returning a null value for current_entry,
 		 * triggering a schema validation error. Once this is corrected on the backend (soon), we


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change will make us use a new "bytesFormatted" API response entry introduced by D63518 patch.
* The size of the backup download file will be render to let the user know how big the file is.

<img width="1088" alt="Screenshot 2021-06-30 at 17 51 33" src="https://user-images.githubusercontent.com/1929317/124001630-bea56c00-d9cc-11eb-971a-dc5893a29ed5.png">

#### Testing instructions

1. Please follow test instructions from D63518 patch.
1. Then start [your local instance of Calypso](https://github.com/Automattic/wp-calypso#getting-started) and visit http://calypso.localhost:3000/backup/macbretest.wpcomstaging.com/download/1624906075.02 (preferable the backup link for your test site and backup from the 1st point).
1. You should see the human-readable file size next to the "Download file" button