### PR TITLE
Adding account creation flows for Akismet and Gravitar.

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -8,7 +8,9 @@ import { get, includes, startsWith } from 'lodash';
  */
 import config from '@automattic/calypso-config';
 import {
+	isAkismetOAuth2Client,
 	isCrowdsignalOAuth2Client,
+	isGravatarOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
@@ -71,8 +73,26 @@ export function getSignupUrl(
 		signupUrl += '/' + signupFlow;
 	}
 
+	if ( isAkismetOAuth2Client( oauth2Client ) ) {
+		const oauth2Flow = 'wpcc';
+		const oauth2Params = new URLSearchParams( {
+			oauth2_client_id: oauth2Client.id,
+			oauth2_redirect: redirectTo,
+		} );
+		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
+	}
+
 	if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 		const oauth2Flow = 'crowdsignal';
+		const oauth2Params = new URLSearchParams( {
+			oauth2_client_id: oauth2Client.id,
+			oauth2_redirect: redirectTo,
+		} );
+		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
+	}
+
+	if ( isGravatarOAuth2Client( oauth2Client ) ) {
+		const oauth2Flow = 'wpcc';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -73,7 +73,7 @@ export function getSignupUrl(
 		signupUrl += '/' + signupFlow;
 	}
 
-	if ( isAkismetOAuth2Client( oauth2Client ) ) {
+	if ( isAkismetOAuth2Client( oauth2Client ) || isGravatarOAuth2Client( oauth2Client ) ) {
 		const oauth2Flow = 'wpcc';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
@@ -84,15 +84,6 @@ export function getSignupUrl(
 
 	if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 		const oauth2Flow = 'crowdsignal';
-		const oauth2Params = new URLSearchParams( {
-			oauth2_client_id: oauth2Client.id,
-			oauth2_redirect: redirectTo,
-		} );
-		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
-	}
-
-	if ( isGravatarOAuth2Client( oauth2Client ) ) {
-		const oauth2Flow = 'wpcc';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -4,8 +4,16 @@
 
 import { includes } from 'lodash';
 
+export const isAkismetOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client && oauth2Client.id === 973;
+};
+
 export const isCrowdsignalOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client && oauth2Client.id === 978;
+};
+
+export const isGravatarOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client && oauth2Client.id === 1854;
 };
 
 export const isWooOAuth2Client = ( oauth2Client ) => {

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -5,15 +5,15 @@
 import { includes } from 'lodash';
 
 export const isAkismetOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client && oauth2Client.id === 973;
+	return oauth2Client?.id === 973;
 };
 
 export const isCrowdsignalOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client && oauth2Client.id === 978;
+	return oauth2Client?.id === 978;
 };
 
 export const isGravatarOAuth2Client = ( oauth2Client ) => {
-	return oauth2Client && oauth2Client.id === 1854;
+	return oauth2Client?.id === 1854;
 };
 
 export const isWooOAuth2Client = ( oauth2Client ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The "Create an account" links on the Akismet and Gravatar login pages take users to the WPcom site creation flow, rather than the account creation flow.

This PR fixes that issue.

Here's a screenshot of the correct account creation page for Akismet:
<img width="536" alt="CleanShot 2021-06-30 at 13 09 52@2x" src="https://user-images.githubusercontent.com/35781181/124003198-a91c4c00-d9a4-11eb-8519-4e8a21ff0fea.png">

The Gravatar page is identical, except it says Gravatar instead of Akismet.

Context: /pbxNRc-p4-p2#comment-664
And Issue #611 on the Martech Github board.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso
* Open Gravatar.com and Akismet.com in an Incognito mode browser. Click the Sign In link and copy the path from that URL.
* open `calypso.localhost:3000/PATHNAME` in an Incognito browser.
* Click the "Create an account" link.
* Confirm that it takes you to the Account Creation page shown above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #28995
