### PR TITLE
Fixed chat window overflow on mobile device

### DIFF
--- a/client/components/happychat/composer.scss
+++ b/client/components/happychat/composer.scss
@@ -19,7 +19,7 @@
 		padding: 12px;
 		border: none;
 		background: transparent;
-		font-size: $font-body-small;
+		font-size: $font-body;
 		min-height: initial;
 		align-self: stretch;
 		resize: none;

--- a/client/components/happychat/composer.scss
+++ b/client/components/happychat/composer.scss
@@ -19,7 +19,6 @@
 		padding: 12px;
 		border: none;
 		background: transparent;
-		font-size: $font-body;
 		min-height: initial;
 		align-self: stretch;
 		resize: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updated font size of textarea inside happy chat window in Calypso to prevent chat window taking bigger width than actual screen size on mobile view. 

#### Testing instructions
Before starting testing please login into [hud-staging.happychat.io](hud-staging.happychat.io) in order to enable live chat support option. 

1. Open Wordpress.com in safari browser on mobile or simulator
2. Click on `?` on right bottom corner to contact support team
3. Select `Contact Us` option
4. Enter into live chat with support team. 
5. Make sure layout is not zoomed in when you focus on textarea for sending message to support team. 

Fixes: #40199 
