### PR TITLE
Tracking E2E Tests: Call dismiss notices at the right time

### DIFF
--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -200,13 +200,13 @@ export function createGeneralTests( { it, editorType, postType } ) {
 		await clearEventsStack( this.driver );
 
 		await editor.insertPattern( 'gallery', 'Heading and Three Images' );
+		await editor.dismissNotices();
 		// We need to save the eventsStack after each insertion to make sure we
 		// aren't running out of the E2E queue size.
 		const eventsStackGallery = await getEventsStack( this.driver );
 		if ( await editor.isBlockInserterOpen() ) {
 			await editor.closeBlockInserter();
 		}
-		await editor.dismissNotices();
 
 		const patternInsertedEvents = [ ...eventsStackGallery, ...eventsStackList ].filter(
 			( [ eventName ] ) => eventName === 'wpcom_pattern_inserted'

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -192,7 +192,7 @@ export function createGeneralTests( { it, editorType, postType } ) {
 		);
 	} );
 
-	it( 'Tracks "wpcom_pattern_inserted"', async function () {
+	it( 'Tracks "wpcom_pattern_inserted" through sidebar', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
 		await editor.insertPattern( 'list', 'List with Image' );
@@ -200,7 +200,7 @@ export function createGeneralTests( { it, editorType, postType } ) {
 		await clearEventsStack( this.driver );
 
 		await editor.insertPattern( 'gallery', 'Heading and Three Images' );
-		await editor.dismissNotices();
+
 		// We need to save the eventsStack after each insertion to make sure we
 		// aren't running out of the E2E queue size.
 		const eventsStackGallery = await getEventsStack( this.driver );
@@ -238,9 +238,11 @@ export function createGeneralTests( { it, editorType, postType } ) {
 			'list',
 			'"wpcom_pattern_inserted" editor tracking event pattern category property is incorrect'
 		);
+
+		await editor.dismissNotices();
 	} );
 
-	it( 'Tracks "wpcom_pattern_inserted"', async function () {
+	it( 'Tracks "wpcom_pattern_inserted" through quick inserter', async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
 		await editor.insertBlockOrPatternViaBlockAppender( 'List with Image' );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -659,8 +659,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				this.driver,
 				By.css( '.wp-block-template-part__selection-preview-item' )
 			);
-			await editor.dismissNotices();
 			await editor.waitForTemplatePartsToLoad();
+			await editor.dismissNotices();
 
 			const eventsStack = await getEventsStack( this.driver );
 			const blockInsertedEventFired = eventsStack.some(
@@ -698,8 +698,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				this.driver,
 				By.css( '.wp-block-template-part__selection-preview-item' )
 			);
-			await editor.dismissNotices();
 			await editor.waitForTemplatePartsToLoad();
+			await editor.dismissNotices();
 
 			// Let's find out the ID of the first child block of the template part
 			// and remove the block.

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -648,7 +648,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 			await editor.addBlock( 'Template Part' );
 			await clearEventsStack( this.driver );
-			await editor.dismissNotices();
 
 			await editor.runInCanvas( async () => {
 				await driverHelper.clickWhenClickable(
@@ -660,6 +659,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				this.driver,
 				By.css( '.wp-block-template-part__selection-preview-item' )
 			);
+			await editor.dismissNotices();
 			await editor.waitForTemplatePartsToLoad();
 
 			const eventsStack = await getEventsStack( this.driver );
@@ -685,7 +685,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			// so the insert event won't intefere with our asserts.
 			const blockId = await editor.addBlock( 'Template Part' );
 			await clearEventsStack( this.driver );
-			await editor.dismissNotices();
 
 			// Add a template part block and select an existing template part.
 			// Make sure the template part is loaded before moving on.
@@ -699,6 +698,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				this.driver,
 				By.css( '.wp-block-template-part__selection-preview-item' )
 			);
+			await editor.dismissNotices();
 			await editor.waitForTemplatePartsToLoad();
 
 			// Let's find out the ID of the first child block of the template part


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure notices are dismissed at the right time

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests are passing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
