### PR TITLE
Checkout email field: Fix "Invalid propType" console warning.

### DIFF
--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@automattic/composite-checkout';
+import { TranslateResult } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -46,7 +47,7 @@ export default function Field( {
 	placeholder?: string;
 	tabIndex?: number;
 	description?: string;
-	errorMessage?: string;
+	errorMessage?: TranslateResult;
 	autoComplete?: string;
 	disabled?: boolean;
 } ): JSX.Element {
@@ -111,7 +112,7 @@ Field.propTypes = {
 	placeholder: PropTypes.string,
 	tabIndex: PropTypes.string,
 	description: PropTypes.string,
-	errorMessage: PropTypes.string,
+	errorMessage: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 	autoComplete: PropTypes.string,
 	disabled: PropTypes.bool,
 };
@@ -252,7 +253,7 @@ function RenderedDescription( {
 }: {
 	description?: string;
 	isError?: boolean;
-	errorMessage?: string;
+	errorMessage?: TranslateResult;
 } ) {
 	if ( description || isError ) {
 		return <Description isError={ isError }>{ isError ? errorMessage : description }</Description>;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an "invalid prop-type" console warning on the email field in the site-only checkout flow.

- This changes the `errorMessage` propType to be: `PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] )`

.

<img width="842" alt="Screenshot on 2021-06-30 at 14-15-22" src="https://user-images.githubusercontent.com/11078128/124012426-25b42800-d9af-11eb-89bc-6ed654c1db12.png">




#### Testing instructions

First to see the "invalid prop-type" console warning:
1. Git checkout `trunk` branch and `yarn start`.
2. Go to: http://calypso.localhost:3000/checkout/jetpack/anysite.com/jetpack_backup_daily?unlinked=1&purchaseNonce=123456123  (this URL should load the site-only checkout page, whether you're logged-in or logged-out, shouldn't matter.)
3. In the email field, enter your existing WordPress.com email address. Enter Postal code and Country.
4. Open your browser console.
5. Click the "Continue" button and verify you see the "invalid prop-type" warning in the console.

Verify this PR fixes the console warning:

- Checkout this PR branch and `yarn start`.
- Complete steps 2 - 4 above.
- Click the "Continue" button and verify the "invalid prop-type" console warning is no longer occurring.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
