### PR TITLE
Domains: Notify user when they are cancelling a domain that is used as for WPCOM email contact

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -133,7 +133,7 @@ class RemoveDomainDialog extends Component {
 
 				<p>
 					{ translate(
-						'Please visit your {{a}}Account Settings{{/a}} page to update your email address before proceeding.',
+						'You must visit your {{a}}Account Settings{{/a}} to update your email address before proceeding.',
 						{
 							components: { a: <a href="/me/account" /> },
 						}
@@ -173,7 +173,7 @@ class RemoveDomainDialog extends Component {
 				</FormFieldset>
 				<p>
 					{ translate(
-						'We will delete the domain name. Any services related to the domain will cease to function. Be sure you wish to proceed.'
+						'This domain name will be deleted. Any services related to it will cease to function. Are you sure you wish to proceed?'
 					) }
 				</p>
 			</Fragment>

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -181,9 +181,17 @@ class RemoveDomainDialog extends Component {
 	}
 
 	async isWpComEmailBasedOnDomain() {
+		this.setState( {
+			isCheckingEmail: true,
+		} );
+
 		const { purchase } = this.props;
 		const productName = getName( purchase );
 		const { email } = await wpcom.me().get();
+
+		this.setState( {
+			isCheckingEmail: false,
+		} );
 
 		return email.endsWith( productName );
 	}
@@ -239,7 +247,10 @@ class RemoveDomainDialog extends Component {
 			},
 			{
 				action: 'remove',
-				additionalClassNames: [ this.props.isRemoving ? 'is-busy' : '', 'is-scary' ],
+				additionalClassNames: [
+					this.props.isRemoving || this.state.isCheckingEmail ? 'is-busy' : '',
+					'is-scary',
+				],
 				label: translate( 'Delete this Domain' ),
 				onClick: this.nextStep,
 			},

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -266,6 +266,7 @@ class RemoveDomainDialog extends Component {
 				className="remove-domain-dialog__dialog"
 				isVisible={ this.props.isDialogVisible }
 				onClose={ this.close }
+				leaveTimeout={ 0 }
 			>
 				{ this.state.step === 1 && this.renderFirstStep( productName ) }
 				{ this.state.step === 2 && this.renderUpdateEmailStep( productName ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
It adds an extra verification step when cancelling a domain, checking whether the WPCOM email contact is based on it. Some smaller changes were also added, like changing the button's label, and adding more concise information on the steps.

#### First step 
##### Previous
![image](https://user-images.githubusercontent.com/18705930/124014917-809f4c80-d9ba-11eb-978d-f5ce31c393d4.png)

##### Current
![image](https://user-images.githubusercontent.com/18705930/124015063-a593bf80-d9ba-11eb-9d4d-21406a1ebd66.png)

#### Verification step
Checks if their wpcom account email uses the same domain. This step will be displayed until the email is updated:
![image](https://user-images.githubusercontent.com/18705930/124307937-e61c4600-db3e-11eb-8980-c2a9ca67fa55.png)

##### Deleting a domain without a WPCOM contact email based on it
https://user-images.githubusercontent.com/18705930/124304787-99cf0700-db3a-11eb-9f83-2b5c3f30144c.mov

##### Deleting a domain with a WPCOM contact email based on it:
https://user-images.githubusercontent.com/18705930/124304773-9471bc80-db3a-11eb-8cba-f8b944a5617a.mov




#### Final step
##### Previous
![image](https://user-images.githubusercontent.com/18705930/124015485-1e931700-d9bb-11eb-8354-f7261d157089.png)

##### Current
![image](https://user-images.githubusercontent.com/18705930/124308025-04824180-db3f-11eb-840b-1cd75c423058.png)

#### Testing instructions
 - Verify all tests pass.
 - Verify that the additional verification step is executed before prompting the cancelling confirmation.

Related to #19716.
