### PR TITLE
Show domain/email dates in the customer time zone

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -22,7 +22,7 @@ export function resolveDomainStatus(
 		case domainTypes.MAPPED:
 			if ( isExpiringSoon( domain, 30 ) ) {
 				const expiresMessage = translate( 'Expires in %(days)s', {
-					args: { days: moment.utc( domain.expiry ).fromNow( true ) },
+					args: { days: moment( domain.expiry ).fromNow( true ) },
 				} );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
@@ -111,7 +111,7 @@ export function resolveDomainStatus(
 
 			if ( isExpiringSoon( domain, 30 ) ) {
 				const expiresMessage = translate( 'Expires in %(days)s', {
-					args: { days: moment.utc( domain.expiry ).fromNow( true ) },
+					args: { days: moment( domain.expiry ).fromNow( true ) },
 				} );
 
 				if ( isExpiringSoon( domain, 5 ) ) {

--- a/client/my-sites/domains/domain-management/edit/card/notices/expiring-soon.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/notices/expiring-soon.jsx
@@ -37,7 +37,7 @@ function ExpiringSoon( props ) {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( expiry ).fromNow( true ),
+						days: moment( expiry ).fromNow( true ),
 						owner: domain.owner,
 					},
 				}
@@ -50,7 +50,7 @@ function ExpiringSoon( props ) {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( expiry ).fromNow( true ),
+						days: moment( expiry ).fromNow( true ),
 					},
 				}
 			);
@@ -65,7 +65,7 @@ function ExpiringSoon( props ) {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( expiry ).fromNow( true ),
+						days: moment( expiry ).fromNow( true ),
 					},
 				}
 			);
@@ -82,7 +82,7 @@ function ExpiringSoon( props ) {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( expiry ).fromNow( true ),
+						days: moment( expiry ).fromNow( true ),
 						owner: domain.owner,
 					},
 				}
@@ -95,7 +95,7 @@ function ExpiringSoon( props ) {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( expiry ).fromNow( true ),
+						days: moment( expiry ).fromNow( true ),
 					},
 				}
 			);

--- a/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
@@ -36,7 +36,7 @@ function DomainExpiryOrRenewal( { domain, isLoadingPurchase, moment, purchase, t
 	} else if ( domain.expired ) {
 		text = translate( 'Expired: %(expiry_date)s', {
 			args: {
-				expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	} else if (
@@ -49,26 +49,26 @@ function DomainExpiryOrRenewal( { domain, isLoadingPurchase, moment, purchase, t
 		if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
 			text = translate( 'Renews with your plan on %(renewal_date)s', {
 				args: {
-					renewal_date: moment.utc( domain.autoRenewalDate ).format( 'LL' ),
+					renewal_date: moment( domain.autoRenewalDate ).format( 'LL' ),
 				},
 			} );
 		} else {
 			text = translate( 'Renews: %(renewal_date)s', {
 				args: {
-					renewal_date: moment.utc( domain.autoRenewalDate ).format( 'LL' ),
+					renewal_date: moment( domain.autoRenewalDate ).format( 'LL' ),
 				},
 			} );
 		}
 	} else if ( domain.type === domainTypes.MAPPED && domain.bundledPlanSubscriptionId ) {
 		text = translate( 'Expires with your plan on %(expiry_date)s', {
 			args: {
-				expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	} else {
 		text = translate( 'Expires: %(expiry_date)s', {
 			args: {
-				expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+				expiry_date: moment( domain.expiry ).format( 'LL' ),
 			},
 		} );
 	}

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -85,7 +85,7 @@ class RegisteredDomainType extends React.Component {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( domain.renewableUntil ).fromNow( true ),
+						days: moment( domain.renewableUntil ).fromNow( true ),
 						redemptionCost: redemptionCost,
 					},
 				}
@@ -99,7 +99,7 @@ class RegisteredDomainType extends React.Component {
 						strong: <strong />,
 					},
 					args: {
-						days: moment.utc( domain.redeemableUntil ).fromNow( true ),
+						days: moment( domain.redeemableUntil ).fromNow( true ),
 						redemptionCost: redemptionCost,
 					},
 				}

--- a/client/my-sites/email/email-management/home/email-plan-subscription.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-subscription.jsx
@@ -85,7 +85,7 @@ class EmailPlanSubscription extends React.Component {
 		const hasSubscriptionExpired = this.hasSubscriptionExpired();
 		const translateArgs = {
 			args: {
-				expiryDate: moment.utc( purchase.expiryDate ).format( 'LL' ),
+				expiryDate: moment( purchase.expiryDate ).format( 'LL' ),
 			},
 			comment: 'Shows the expiry date of the email subscription',
 		};


### PR DESCRIPTION
Apparently we were using moment.utc to parse dates for domain expiration, renewal and etc. However this is wrong as it shows the date in UTC instead of the customer local time zone and that's creating a discrepancy with the expiration date we render in the purchases page.

#### Changes proposed in this Pull Request

* Replace moment.utc with moment so all the dates are rendered in the customer time zone

#### Testing instructions

* Make sure the expiry/renew dates are rendered correctly. This is best seen for the renewal dates as those also contain time while the expiration dates always end up at 00:00:00.
