### PR TITLE
Cleanup tracking tests for mobile viewport.

### DIFF
--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -24,6 +24,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async expandDrawerItem( itemName ) {
+		await this.ensureSidebarMenuVisible();
 		const itemLocator = driverHelper.createTextLocator( By.css( '.sidebar__heading' ), itemName );
 		const itemElement = await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -24,7 +24,6 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async expandDrawerItem( itemName ) {
-		await this.ensureSidebarMenuVisible();
 		const itemLocator = driverHelper.createTextLocator( By.css( '.sidebar__heading' ), itemName );
 		const itemElement = await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -189,6 +189,26 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 		);
 	}
 
+	async closeGlobalStyles() {
+		if ( this.screenSize === 'mobile' ) {
+			const globalStylesCloseButtonLocator = By.css(
+				'button[aria-label="Close global styles sidebar"]'
+			);
+			return !! ( await driverHelper.clickIfPresent(
+				this.driver,
+				globalStylesCloseButtonLocator
+			) );
+		}
+
+		const pressedGlobalStylesButtonLocator = By.css(
+			'button[aria-label="Global Styles"][aria-expanded="true"]'
+		);
+		return !! ( await driverHelper.clickIfPresent(
+			this.driver,
+			pressedGlobalStylesButtonLocator
+		) );
+	}
+
 	async toggleGlobalStyles() {
 		if ( this.screenSize === 'mobile' ) {
 			const closed = await driverHelper.clickIfPresent(

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -176,6 +176,11 @@ export function createGeneralTests( { it, editorType, postType } ) {
 	it( `Block editor sidebar toggle should not trigger the "wpcom_block_editor_close_click" event`, async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
+		// The button that triggers the block editor sidebar is not available on mobile
+		if ( editor.screenSize === 'mobile' ) {
+			return this.skip();
+		}
+
 		// We open and close the sidebar to make sure we don't leave the sidebar
 		// open for the upcoming tests. We also make sure we don't trigger the
 		// on open and close actions.

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -203,8 +203,10 @@ export function createGeneralTests( { it, editorType, postType } ) {
 		await editor.insertPattern( 'list', 'List with Image' );
 		const eventsStackList = await getEventsStack( this.driver );
 		await clearEventsStack( this.driver );
+		await editor.dismissNotices();
 
 		await editor.insertPattern( 'gallery', 'Heading and Three Images' );
+		await editor.dismissNotices();
 
 		// We need to save the eventsStack after each insertion to make sure we
 		// aren't running out of the E2E queue size.
@@ -243,8 +245,6 @@ export function createGeneralTests( { it, editorType, postType } ) {
 			'list',
 			'"wpcom_pattern_inserted" editor tracking event pattern category property is incorrect'
 		);
-
-		await editor.dismissNotices();
 	} );
 
 	it( 'Tracks "wpcom_pattern_inserted" through quick inserter', async function () {

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -177,7 +177,7 @@ export function createGeneralTests( { it, editorType, postType } ) {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
 		// The button that triggers the block editor sidebar is not available on mobile
-		if ( editor.screenSize === 'mobile' ) {
+		if ( editor.screenSize === 'mobile' && editorType === 'post' ) {
 			return this.skip();
 		}
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -160,6 +160,11 @@ const deleteTemplateParts = async function ( driver ) {
 };
 
 const backToCalypso = async function ( driver ) {
+	if ( driverManager.currentScreenSize() === 'mobile' ) {
+		await driverHelper.clickWhenClickable( driver, By.css( '#wp-admin-bar-blog' ) );
+		return;
+	}
+
 	await driverHelper.clickWhenClickable(
 		driver,
 		driverHelper.createTextLocator( By.css( '.wp-menu-name' ), 'Plans' )

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -177,7 +177,7 @@ const deleteTemplateParts = async function ( driver ) {
 
 const backToCalypso = async function ( driver ) {
 	if ( driverManager.currentScreenSize() === 'mobile' ) {
-		await driverHelper.clickWhenClickable( driver, By.css( '#wp-admin-bar-blog' ) );
+		await driverHelper.clickWhenClickable( driver, By.css( '#wp-admin-bar-blog' ), 1000000000 );
 		return;
 	}
 
@@ -942,7 +942,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 			const isCalypsoSidebarAvailable = await driverHelper.isElementLocated(
 				this.driver,
-				By.css( '#content' )
+				By.css( '#wpcom' )
 			);
 			if ( ! isCalypsoSidebarAvailable ) {
 				await backToCalypso( this.driver );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -77,120 +77,45 @@ const changeGlobalStylesFirstColorPaletteItem = async ( driver, value, pickerOpe
 	await driverHelper.setWhenSettable( driver, By.css( '.components-color-picker input' ), value );
 };
 
-const exitSiteEditor = async function ( driver ) {
-	const isSiteEditorOpen = await driverHelper.isElementLocated(
-		driver,
-		By.css( '.edit-site-header' )
-	);
-	if ( ! isSiteEditorOpen ) {
-		return;
-	}
-
-	const editor = await SiteEditorComponent.Expect( driver );
-	const isNavigationSidebarOpen = await driverHelper.isElementLocated(
-		driver,
-		By.css( '.edit-site-navigation-panel.is-open' )
-	);
-	if ( ! isNavigationSidebarOpen ) {
-		await editor.toggleNavigationSidebar();
-	}
-
-	await driverHelper.waitUntilElementLocatedAndVisible(
-		driver,
-		By.css( '.components-navigation__back-button, .edit-site-navigation-panel__back-to-dashboard' )
-	);
-
-	await driver.wait(
-		async function () {
-			if (
-				await driverHelper.isElementNotLocated(
-					driver,
-					By.css( '.edit-site-navigation-panel__back-to-dashboard' )
-				)
-			) {
-				await driverHelper.clickWhenClickable(
-					driver,
-					By.css( '.components-navigation__back-button' )
-				);
-				return false;
-			}
-			return true;
-		},
-		config.get( 'explicitWaitMS' ),
-		'Could not reach the "Dashboard" button'
-	);
-
-	await driverHelper.clickWhenClickable(
-		driver,
-		By.css( '.edit-site-navigation-panel__back-to-dashboard' )
-	);
-};
-
-const deleteAll = async function ( driver ) {
-	// Make sure we have posts before trying to delete them
-	const noItemsRowLocator = By.css( '#the-list .no-items' );
-	const noItems = await driverHelper.isElementLocated( driver, noItemsRowLocator );
-	if ( noItems ) {
-		return;
-	}
-
-	const selectAllCheckboxLocator = By.css( '#cb-select-all-1' );
-	// We use the bottom bulk action dropdown and apply button because those are
-	// available on both mobile and desktop.
-	const bottomBulkActionDropdownLocator = By.css( '#bulk-action-selector-bottom' );
-	const bottomBulkActionApplyButtonLocator = By.css( '#doaction2' );
-	const createBottomBulkActionDropdownOptionLocator = ( value ) =>
-		By.css( `#bulk-action-selector-bottom option[value="${ value }"]` );
-	const trashedItemsLinkLocator = By.css( '.subsubsub .trash a' );
-
-	// Delete all posts
-	await driverHelper.clickWhenClickable( driver, selectAllCheckboxLocator );
-	await driverHelper.clickWhenClickable( driver, bottomBulkActionDropdownLocator );
-	await driverHelper.clickWhenClickable(
-		driver,
-		createBottomBulkActionDropdownOptionLocator( 'trash' )
-	);
-	await driverHelper.clickWhenClickable( driver, bottomBulkActionApplyButtonLocator );
-
-	// Empty trash
-	await driverHelper.clickWhenClickable( driver, trashedItemsLinkLocator );
-	await driverHelper.clickWhenClickable( driver, selectAllCheckboxLocator );
-	await driverHelper.clickWhenClickable( driver, bottomBulkActionDropdownLocator );
-	await driverHelper.clickWhenClickable(
-		driver,
-		createBottomBulkActionDropdownOptionLocator( 'delete' )
-	);
-	await driverHelper.clickWhenClickable( driver, bottomBulkActionApplyButtonLocator );
-};
-
 const deleteTemplates = async function ( driver ) {
-	const sidebar = await SidebarComponent.Expect( driver );
-	await sidebar.selectTemplates();
-	await deleteAll( driver );
+	await SiteEditorComponent.Expect( driver );
+
+	const getAndDeleteTemplates = async () => {
+		const templates = window.wp.data
+			.select( 'core' )
+			.getEntityRecords( 'postType', 'wp_template', {
+				per_page: -1,
+			} )
+			.filter( ( item ) => item.source === 'custom' );
+		for ( const template of templates ) {
+			await window.wp.data
+				.dispatch( 'core' )
+				.deleteEntityRecord( 'postType', 'wp_template', template.id );
+		}
+	};
+	await driver.executeScript( getAndDeleteTemplates );
 };
 
 const deleteTemplateParts = async function ( driver ) {
-	const sidebar = await SidebarComponent.Expect( driver );
-	await sidebar.selectTemplateParts();
-	await deleteAll( driver );
-};
-
-const backToCalypso = async function ( driver ) {
-	if ( driverManager.currentScreenSize() === 'mobile' ) {
-		await driverHelper.clickWhenClickable( driver, By.css( '#wp-admin-bar-blog' ) );
-		return;
-	}
-
-	await driverHelper.clickWhenClickable(
-		driver,
-		driverHelper.createTextLocator( By.css( '.wp-menu-name' ), 'Plans' )
-	);
+	await SiteEditorComponent.Expect( driver );
+	const getAndDeleteTemplateParts = async () => {
+		const templateParts = window.wp.data
+			.select( 'core' )
+			.getEntityRecords( 'postType', 'wp_template_part', {
+				per_page: -1,
+			} )
+			.filter( ( item ) => item.source === 'custom' );
+		for ( const templatePart of templateParts ) {
+			await window.wp.data
+				.dispatch( 'core' )
+				.deleteEntityRecord( 'postType', 'wp_template_part', templatePart.id );
+		}
+	};
+	await driver.executeScript( getAndDeleteTemplateParts );
 };
 
 const deleteTemplatesAndTemplateParts = async function ( driver ) {
 	await deleteTemplates( driver );
-	// At this point we are in wp-admin, go back to Calypso
-	await backToCalypso( driver );
 	await deleteTemplateParts( driver );
 };
 
@@ -480,11 +405,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			const loginFlow = new LoginFlow( this.driver, host === 'WPCOM' ? siteEditorUser : undefined );
 			await loginFlow.loginAndSelectMySite();
 
-			await deleteTemplatesAndTemplateParts( this.driver );
-
-			// At this point we are in wp-admin, go back to Calypso
-			await backToCalypso( this.driver );
-
 			const sidebar = await SidebarComponent.Expect( this.driver );
 			await sidebar.selectSiteEditor();
 
@@ -494,6 +414,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			const editor = await SiteEditorComponent.Expect( this.driver );
 			await editor.waitForTemplateToLoad();
 			await editor.waitForTemplatePartsToLoad();
+			await deleteTemplatesAndTemplateParts( this.driver );
 		} );
 
 		createGeneralTests( { it, editorType: 'site' } );
@@ -858,7 +779,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 						'Archive'
 					)
 				);
-				await editor.toggleNavigationSidebar();
 
 				const eventsStack = await getEventsStack( this.driver );
 				const editEvents = eventsStack.filter(
@@ -868,6 +788,15 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				const [ , editEventData ] = editEvents[ 0 ];
 				assert.strictEqual( editEventData.item_type, 'template' );
 				assert.strictEqual( editEventData.item_slug, 'archive' );
+
+				// Go back to index template and cleanup the new tempalte early to avoid parallel
+				// test conflicts as much as possible.
+				const templateMenuItemLocator = driverHelper.createTextLocator(
+					By.css( '.edit-site-navigation-panel__template-item-title' ),
+					'Index'
+				);
+				await driverHelper.clickWhenClickable( this.driver, templateMenuItemLocator );
+				await deleteTemplates( this.driver );
 			} );
 
 			it( 'should track "wpcom_block_editor_nav_sidebar_item_edit" when switching to a template part', async function () {
@@ -938,16 +867,6 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 		} );
 
 		after( async function () {
-			await exitSiteEditor( this.driver );
-
-			const isCalypsoSidebarAvailable = await driverHelper.isElementLocated(
-				this.driver,
-				By.css( '#wpcom' )
-			);
-			if ( ! isCalypsoSidebarAvailable ) {
-				await backToCalypso( this.driver );
-			}
-
 			await deleteTemplatesAndTemplateParts( this.driver );
 		} );
 	} );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -177,7 +177,7 @@ const deleteTemplateParts = async function ( driver ) {
 
 const backToCalypso = async function ( driver ) {
 	if ( driverManager.currentScreenSize() === 'mobile' ) {
-		await driverHelper.clickWhenClickable( driver, By.css( '#wp-admin-bar-blog' ), 1000000000 );
+		await driverHelper.clickWhenClickable( driver, By.css( '#wp-admin-bar-blog' ) );
 		return;
 	}
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -573,9 +573,19 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				const tabSelectedEvents = await getGlobalStylesTabSelectedEvents( this.driver );
 				assert.strictEqual( tabSelectedEvents.length, 0 );
 			} );
+
+			after( async function () {
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.closeGlobalStyles();
+			} );
 		} );
 
 		describe( 'Tracks "wpcom_block_editor_global_styles_update"', function () {
+			before( async function () {
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.toggleGlobalStyles();
+			} );
+
 			// Since these events are tracked via redux actions in updateEntityRecord and
 			// saveEditedEntityRecord, they are independent of UI.  If the desktop flow populates
 			// these events properly, the mobile flow will as well.  There is no added benefit to
@@ -616,9 +626,19 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				}
 				await testGlobalStylesColorPalette( this.driver, 'core/column' );
 			} );
+
+			after( async function () {
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.closeGlobalStyles();
+			} );
 		} );
 
 		describe( 'Tracks "wpcom_block_editor_global_styles_save"', function () {
+			before( async function () {
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.toggleGlobalStyles();
+			} );
+
 			// This test can be less intensive than our global styles update tests since they share
 			// the same code to build event structure from global styles objects.  So we mainly need
 			// to verify that the expected number of events are triggered.
@@ -645,6 +665,11 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				// Clean up by resetting to be safe.
 				await clickGlobalStylesResetButton( this.driver );
 				await saveGlobalStyles( this.driver );
+			} );
+
+			after( async function () {
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.closeGlobalStyles();
 			} );
 		} );
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -77,9 +77,9 @@ const changeGlobalStylesFirstColorPaletteItem = async ( driver, value, pickerOpe
 	await driverHelper.setWhenSettable( driver, By.css( '.components-color-picker input' ), value );
 };
 
-const deleteCustomEntities = async function ( driver, name ) {
+const deleteCustomEntities = async function ( driver, entityName ) {
 	await SiteEditorComponent.Expect( driver );
-	const getAndDeleteEntities = async () => {
+	const getAndDeleteEntities = async ( name ) => {
 		const entities = window.wp.data
 			.select( 'core' )
 			.getEntityRecords( 'postType', name, {
@@ -90,7 +90,7 @@ const deleteCustomEntities = async function ( driver, name ) {
 			await window.wp.data.dispatch( 'core' ).deleteEntityRecord( 'postType', name, entity.id );
 		}
 	};
-	await driver.executeScript( getAndDeleteEntities );
+	await driver.executeScript( getAndDeleteEntities, entityName );
 };
 
 const deleteTemplatesAndTemplateParts = async function ( driver ) {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -77,46 +77,25 @@ const changeGlobalStylesFirstColorPaletteItem = async ( driver, value, pickerOpe
 	await driverHelper.setWhenSettable( driver, By.css( '.components-color-picker input' ), value );
 };
 
-const deleteTemplates = async function ( driver ) {
+const deleteCustomEntities = async function ( driver, name ) {
 	await SiteEditorComponent.Expect( driver );
-
-	const getAndDeleteTemplates = async () => {
-		const templates = window.wp.data
+	const getAndDeleteEntities = async () => {
+		const entities = window.wp.data
 			.select( 'core' )
-			.getEntityRecords( 'postType', 'wp_template', {
+			.getEntityRecords( 'postType', name, {
 				per_page: -1,
 			} )
 			.filter( ( item ) => item.source === 'custom' );
-		for ( const template of templates ) {
-			await window.wp.data
-				.dispatch( 'core' )
-				.deleteEntityRecord( 'postType', 'wp_template', template.id );
+		for ( const entity of entities ) {
+			await window.wp.data.dispatch( 'core' ).deleteEntityRecord( 'postType', name, entity.id );
 		}
 	};
-	await driver.executeScript( getAndDeleteTemplates );
-};
-
-const deleteTemplateParts = async function ( driver ) {
-	await SiteEditorComponent.Expect( driver );
-	const getAndDeleteTemplateParts = async () => {
-		const templateParts = window.wp.data
-			.select( 'core' )
-			.getEntityRecords( 'postType', 'wp_template_part', {
-				per_page: -1,
-			} )
-			.filter( ( item ) => item.source === 'custom' );
-		for ( const templatePart of templateParts ) {
-			await window.wp.data
-				.dispatch( 'core' )
-				.deleteEntityRecord( 'postType', 'wp_template_part', templatePart.id );
-		}
-	};
-	await driver.executeScript( getAndDeleteTemplateParts );
+	await driver.executeScript( getAndDeleteEntities );
 };
 
 const deleteTemplatesAndTemplateParts = async function ( driver ) {
-	await deleteTemplates( driver );
-	await deleteTemplateParts( driver );
+	await deleteCustomEntities( driver, 'wp_template' );
+	await deleteCustomEntities( driver, 'wp_template_part' );
 };
 
 const clickBlockSettingsButton = async ( driver ) =>
@@ -796,7 +775,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 					'Index'
 				);
 				await driverHelper.clickWhenClickable( this.driver, templateMenuItemLocator );
-				await deleteTemplates( this.driver );
+				await deleteCustomEntities( this.driver, 'wp_template' );
 			} );
 
 			it( 'should track "wpcom_block_editor_nav_sidebar_item_edit" when switching to a template part', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -789,7 +789,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				assert.strictEqual( editEventData.item_type, 'template' );
 				assert.strictEqual( editEventData.item_slug, 'archive' );
 
-				// Go back to index template and cleanup the new tempalte early to avoid parallel
+				// Go back to index template and cleanup the new template early to avoid parallel
 				// test conflicts as much as possible.
 				const templateMenuItemLocator = driverHelper.createTextLocator(
 					By.css( '.edit-site-navigation-panel__template-item-title' ),

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -128,23 +128,39 @@ const exitSiteEditor = async function ( driver ) {
 
 const deleteAll = async function ( driver ) {
 	// Make sure we have posts before trying to delete them
-	const noItems = await driverHelper.isElementLocated( driver, By.css( '#the-list .no-items' ) );
+	const noItemsRowLocator = By.css( '#the-list .no-items' );
+	const noItems = await driverHelper.isElementLocated( driver, noItemsRowLocator );
 	if ( noItems ) {
 		return;
 	}
 
+	const selectAllCheckboxLocator = By.css( '#cb-select-all-1' );
+	// We use the bottom bulk action dropdown and apply button because those are
+	// available on both mobile and desktop.
+	const bottomBulkActionDropdownLocator = By.css( '#bulk-action-selector-bottom' );
+	const bottomBulkActionApplyButtonLocator = By.css( '#doaction2' );
+	const createBottomBulkActionDropdownOptionLocator = ( value ) =>
+		By.css( `#bulk-action-selector-bottom option[value="${ value }"]` );
+	const trashedItemsLinkLocator = By.css( '.subsubsub .trash a' );
+
 	// Delete all posts
-	await driverHelper.clickWhenClickable( driver, By.css( '#cb-select-all-1' ) );
-	await driverHelper.clickWhenClickable( driver, By.css( '#bulk-action-selector-top' ) );
+	await driverHelper.clickWhenClickable( driver, selectAllCheckboxLocator );
+	await driverHelper.clickWhenClickable( driver, bottomBulkActionDropdownLocator );
 	await driverHelper.clickWhenClickable(
 		driver,
-		By.css( '#bulk-action-selector-top option[value="trash"]' )
+		createBottomBulkActionDropdownOptionLocator( 'trash' )
 	);
-	await driverHelper.clickWhenClickable( driver, By.css( '#doaction' ) );
+	await driverHelper.clickWhenClickable( driver, bottomBulkActionApplyButtonLocator );
 
 	// Empty trash
-	await driverHelper.clickWhenClickable( driver, By.css( '.subsubsub .trash a' ) );
-	await driverHelper.clickWhenClickable( driver, By.css( '#delete_all' ) );
+	await driverHelper.clickWhenClickable( driver, trashedItemsLinkLocator );
+	await driverHelper.clickWhenClickable( driver, selectAllCheckboxLocator );
+	await driverHelper.clickWhenClickable( driver, bottomBulkActionDropdownLocator );
+	await driverHelper.clickWhenClickable(
+		driver,
+		createBottomBulkActionDropdownOptionLocator( 'delete' )
+	);
+	await driverHelper.clickWhenClickable( driver, bottomBulkActionApplyButtonLocator );
 };
 
 const deleteTemplates = async function ( driver ) {


### PR DESCRIPTION
Follow up to: https://github.com/Automattic/wp-calypso/pull/53971

### Changes proposed in this Pull Request

A newly-introduced tracking test is failing on the mobile viewport because the element that it tries o interact with to trigger the tracking event are missing or invisible. Some of it (or all) might be expected and perhaps the tests aren't taking the viewport into account (to be clarifying).

Here's the log of my investigation so far: p1625076387083600-slack-C7YPUHBB2

### Testing instructions

E2E tests should pass.