### PR TITLE
My Home: Directly Link to Support Documentation

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -147,7 +147,7 @@ function HelpSearchResults( {
 			'is-selected': selectedResultIndex === resultIndex,
 		} );
 
-		const external = externalLinks && support_type === SUPPORT_TYPE_CONTEXTUAL_HELP;
+		const external = externalLinks && support_type !== SUPPORT_TYPE_ADMIN_SECTION;
 
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
@@ -168,16 +168,17 @@ function HelpSearchResults( {
 					<div className="inline-help__results-cell">
 						<a
 							href={ localizeUrl( link ) }
-							onClick={
-								external
-									? null
-									: ( event ) => {
-											event.preventDefault();
-											selectSearchResult( resultIndex );
-											onLinkClickHandler( event, result );
-									  }
-							}
-							target={ external ? '_blank' : '_self' }
+							onClick={ ( event ) => {
+								if ( ! external ) {
+									event.preventDefault();
+								}
+								selectSearchResult( resultIndex );
+								onLinkClickHandler( event, result );
+							} }
+							{ ...( external && {
+								target: '_blank',
+								rel: 'noreferrer',
+							} ) }
 						>
 							{ support_type === SUPPORT_TYPE_ADMIN_SECTION && (
 								<Gridicon icon={ icon } size={ 18 } />

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -51,6 +51,7 @@ const errorSpeak = debounceSpeak( { message: 'No search results found.' } );
 
 function HelpSearchResults( {
 	currentUserId,
+	externalLinks = false,
 	hasAPIResults = false,
 	hasPurchases,
 	isSearching = false,
@@ -146,6 +147,8 @@ function HelpSearchResults( {
 			'is-selected': selectedResultIndex === resultIndex,
 		} );
 
+		const external = externalLinks && support_type === SUPPORT_TYPE_CONTEXTUAL_HELP;
+
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
 		if (
@@ -165,11 +168,16 @@ function HelpSearchResults( {
 					<div className="inline-help__results-cell">
 						<a
 							href={ localizeUrl( link ) }
-							onClick={ ( event ) => {
-								event.preventDefault();
-								selectSearchResult( resultIndex );
-								onLinkClickHandler( event, result );
-							} }
+							onClick={
+								external
+									? null
+									: ( event ) => {
+											event.preventDefault();
+											selectSearchResult( resultIndex );
+											onLinkClickHandler( event, result );
+									  }
+							}
+							target={ external ? '_blank' : '_self' }
 						>
 							{ support_type === SUPPORT_TYPE_ADMIN_SECTION && (
 								<Gridicon icon={ icon } size={ 18 } />

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -40,7 +40,7 @@ const HelpSearch = ( { searchQuery, track } ) => {
 	const translate = useTranslate();
 
 	// trackResultView: Given a result, send an "_open" tracking event indicating that result is opened.
-	const trackResultView = ( event, result ) => {
+	const trackResultView = ( result ) => {
 		if ( ! result ) {
 			return;
 		}

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -41,7 +41,6 @@ const HelpSearch = ( { searchQuery, track } ) => {
 
 	// trackResultView: Given a result, send an "_open" tracking event indicating that result is opened.
 	const trackResultView = ( event, result ) => {
-		event.preventDefault();
 		if ( ! result ) {
 			return;
 		}

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -14,17 +14,14 @@ import CardHeading from 'calypso/components/card-heading';
 import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 import HelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import HelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
 import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
 import {
-	RESULT_POST_ID,
 	RESULT_ARTICLE,
 	RESULT_LINK,
 	RESULT_TOUR,
 	RESULT_TYPE,
-	RESULT_BLOG_ID,
 } from 'calypso/blocks/inline-help/constants';
 
 /**
@@ -39,7 +36,7 @@ const amendYouTubeLink = ( link = '' ) =>
 
 const getResultLink = ( result ) => amendYouTubeLink( get( result, RESULT_LINK ) );
 
-const HelpSearch = ( { searchQuery, openDialog, track } ) => {
+const HelpSearch = ( { searchQuery, track } ) => {
 	const translate = useTranslate();
 
 	// trackResultView: Given a result, send an "_open" tracking event indicating that result is opened.
@@ -69,10 +66,7 @@ const HelpSearch = ( { searchQuery, openDialog, track } ) => {
 
 		trackResultView( result );
 
-		const resultPostId = get( result, RESULT_POST_ID );
-		const resultBlogId = get( result, RESULT_BLOG_ID );
-		const resultLink = getResultLink( result );
-		openDialog( { postId: resultPostId, actionUrl: resultLink, blogId: resultBlogId } );
+		window.open( getResultLink( result ) );
 	};
 
 	return (
@@ -115,7 +109,6 @@ const mapStateToProps = ( state ) => ( {
 } );
 
 const mapDispatchToProps = {
-	openDialog: openSupportArticleDialog,
 	track: recordTracksEvent,
 };
 

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -40,7 +40,12 @@ const HelpSearch = ( { searchQuery, track } ) => {
 	const translate = useTranslate();
 
 	// trackResultView: Given a result, send an "_open" tracking event indicating that result is opened.
-	const trackResultView = ( result ) => {
+	const trackResultView = ( event, result ) => {
+		event.preventDefault();
+		if ( ! result ) {
+			return;
+		}
+
 		const resultLink = getResultLink( result );
 		const type = get( result, RESULT_TYPE, RESULT_ARTICLE );
 		const tour = get( result, RESULT_TOUR );
@@ -57,18 +62,6 @@ const HelpSearch = ( { searchQuery, track } ) => {
 		track( `calypso_inlinehelp_${ type }_open`, tracksData );
 	};
 
-	// openResultView: Given a result, open that result, and use trackResultView() to track it.
-	const openResultView = ( event, result ) => {
-		event.preventDefault();
-		if ( ! result ) {
-			return;
-		}
-
-		trackResultView( result );
-
-		window.open( getResultLink( result ) );
-	};
-
 	return (
 		<>
 			<Card className="help-search">
@@ -77,15 +70,16 @@ const HelpSearch = ( { searchQuery, track } ) => {
 					<div className="help-search__content">
 						<div className="help-search__search inline-help__search">
 							<HelpSearchCard
-								onSelect={ openResultView }
+								onSelect={ trackResultView }
 								query={ searchQuery }
 								location={ HELP_COMPONENT_LOCATION }
 								placeholder={ translate( 'Search support articles' ) }
 							/>
 							<HelpSearchResults
-								onSelect={ openResultView }
+								onSelect={ trackResultView }
 								searchQuery={ searchQuery }
 								placeholderLines={ 5 }
+								externalLinks
 							/>
 						</div>
 					</div>

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -40,7 +40,7 @@ const HelpSearch = ( { searchQuery, track } ) => {
 	const translate = useTranslate();
 
 	// trackResultView: Given a result, send an "_open" tracking event indicating that result is opened.
-	const trackResultView = ( result ) => {
+	const trackResultView = ( event, result ) => {
 		if ( ! result ) {
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Link directly to support document on the My Home section instead of relying on the `supportArticleDialog`

#### Testing instructions

Verify that these links make the support article appear directly in a new tab rather than displaying the Inline Help Dialog.

<img width="734" alt="Screenshot 2021-07-01 at 09 10 20" src="https://user-images.githubusercontent.com/43215253/124089856-35357e80-da4c-11eb-91f5-ed70ba9a92fb.png">

cc @p-jackson 

Related to #54150