### PR TITLE
Fixed the navigation not opening on mobile for the Calypso settings pages

### DIFF
--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import TranslatableString from 'calypso/components/translatable/proptype';
@@ -25,6 +25,7 @@ class MasterbarItem extends Component {
 		icon: '',
 		onClick: noop,
 		hasUnseen: false,
+		url: '',
 	};
 
 	_preloaded = false;
@@ -36,29 +37,42 @@ class MasterbarItem extends Component {
 		}
 	};
 
+	renderChildren() {
+		return (
+			<Fragment>
+				{ this.props.hasUnseen && (
+					<span className="masterbar__item-bubble" aria-label="You have unseen content" />
+				) }
+				{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
+				<span className="masterbar__item-content">{ this.props.children }</span>
+			</Fragment>
+		);
+	}
+
 	render() {
 		const itemClasses = classNames( 'masterbar__item', this.props.className, {
 			'is-active': this.props.isActive,
 			'has-unseen': this.props.hasUnseen,
 		} );
 
-		return (
-			<a
-				data-tip-target={ this.props.tipTarget }
-				href={ this.props.url }
-				onClick={ this.props.onClick }
-				title={ this.props.tooltip }
-				className={ itemClasses }
-				onTouchStart={ this.preload }
-				onMouseEnter={ this.preload }
-			>
-				{ this.props.hasUnseen && (
-					<span className="masterbar__item-bubble" aria-label="You have unseen content" />
-				) }
-				{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
-				<span className="masterbar__item-content">{ this.props.children }</span>
-			</a>
-		);
+		const attributes = {
+			'data-tip-target': this.props.tipTarget,
+			onClick: this.props.onClick,
+			title: this.props.tooltip,
+			className: itemClasses,
+			onTouchStart: this.preload,
+			onMouseEnter: this.preload,
+		};
+
+		if ( this.props.url ) {
+			return (
+				<a { ...attributes } href={ this.props.url }>
+					{ this.renderChildren() }
+				</a>
+			);
+		}
+
+		return <button { ...attributes }>{ this.renderChildren() }</button>;
 	}
 }
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -25,7 +25,7 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
-import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -94,6 +94,7 @@ class MasterbarLoggedIn extends React.Component {
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
 		this.handleLayoutFocus( 'sites' );
+		this.props.activateNextLayoutFocus();
 
 		/**
 		 * Site Migration: Reset a failed migration when clicking on My Sites
@@ -349,5 +350,5 @@ export default connect(
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		};
 	},
-	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta }
+	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta, activateNextLayoutFocus }
 )( localize( MasterbarLoggedIn ) );

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -22,6 +22,11 @@ import {
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
+import jetpackSettings from './settings-jetpack';
+import settingsPerformance from './settings-performance';
+import settingsWriting from './settings-writing';
+import settingsDiscussion from './settings-discussion';
+import settingsSecurity from './settings-security';
 
 export default function () {
 	page( '/settings', '/settings/general' );
@@ -36,6 +41,12 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	jetpackSettings();
+	settingsPerformance();
+	settingsWriting();
+	settingsDiscussion();
+	settingsSecurity();
 
 	// Redirect settings pages for import and export now that they have their own sections.
 	page( '/settings/:importOrExport(import|export)/:subroute(.*)', ( context ) => {

--- a/client/sections.js
+++ b/client/sections.js
@@ -135,36 +135,6 @@ const sections = [
 		group: 'sites',
 	},
 	{
-		name: 'settings-performance',
-		paths: [ '/settings/performance' ],
-		module: 'calypso/my-sites/site-settings/settings-performance',
-		group: 'sites',
-	},
-	{
-		name: 'settings-writing',
-		paths: [ '/settings/writing', '/settings/taxonomies', '/settings/podcasting' ],
-		module: 'calypso/my-sites/site-settings/settings-writing',
-		group: 'sites',
-	},
-	{
-		name: 'settings-discussion',
-		paths: [ '/settings/discussion' ],
-		module: 'calypso/my-sites/site-settings/settings-discussion',
-		group: 'sites',
-	},
-	{
-		name: 'settings-security',
-		paths: [ '/settings/security' ],
-		module: 'calypso/my-sites/site-settings/settings-security',
-		group: 'sites',
-	},
-	{
-		name: 'settings-jetpack',
-		paths: [ '/settings/jetpack' ],
-		module: 'calypso/my-sites/site-settings/settings-jetpack',
-		group: 'sites',
-	},
-	{
 		name: 'settings',
 		paths: [ '/settings' ],
 		module: 'calypso/my-sites/site-settings',

--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -39,7 +39,7 @@ export default class NavBarComponent extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, profileLocator );
 	}
 	async clickMySites() {
-		const mySitesLocator = By.css( 'header.masterbar a.masterbar__item' );
+		const mySitesLocator = By.css( '[data-tip-target="my-sites"]' );
 		await driverHelper.clickWhenClickable( this.driver, mySitesLocator );
 	}
 	async hasUnreadNotifications() {

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -200,7 +200,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		const isOpen = await driverHelper.isElementLocated( this.driver, openSidebarLocator );
 
 		if ( ! isOpen ) {
-			const mySitesButtonLocator = By.css( 'a[data-tip-target="my-sites"]' );
+			const mySitesButtonLocator = By.css( '[data-tip-target="my-sites"]' );
 			await driverHelper.clickWhenClickable( this.driver, mySitesButtonLocator );
 			await driverHelper.waitUntilElementStopsMoving( this.driver, openSidebarLocator );
 		}


### PR DESCRIPTION
Fixes the issue on mobile devices that prevents the users to open the navigation menu on several pages.

#### Changes proposed in this Pull Request

* Moved the `settings/*` paths from `sections.js` into the site-settings module.
* Changed the My Sites element to a button/a dynamically depending on whether it gets a URL or not.


#### Testing instructions
- Use Calypso live or checkout this branch on your local Calypso environment.
- Resize the browser size to a mobile resolution.
- Go to the following URLs and check that the menu opens and closes on the following sections:
- Settings > Discussion  (Calypso)
- Settings > Performance  (Calypso)
- Settings > Writing  (Calypso)
- Settings > Jetpack (on Atomic)
- Posts > Tags (Calypso)
- Posts > Categories (Calypso)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/54068
