### PR TITLE
Connections: Fix keyring user label when no ID

### DIFF
--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -239,6 +239,10 @@ class SharingConnection extends Component {
 
 const SharingConnectionKeyringUserLabel = localize(
 	( { siteId, keyringUserId, translate, userId } ) => {
+		if ( ! keyringUserId ) {
+			return null;
+		}
+
 		const fetchOptions = {
 			search: keyringUserId,
 			search_columns: [ 'ID' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the instance when we don't have a keyring user ID for a connection, but we try to guess the owner by it anyway. In that case, we should just bail and not try to look for the connection owner. 

See p9F6qB-78r-p2 for more details.

Fixes #54188.

#### Testing instructions

Verify connections in `/marketing/connections/:site` still work well when expanded.