### PR TITLE
Add translation context to the Extensions label in domain search filter

### DIFF
--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -231,7 +231,7 @@ export class DropdownFilters extends Component {
 				{ showTldFilter && (
 					<ValidationFieldset className="search-filters__tld-filters">
 						<FormLabel className="search-filters__label" htmlFor="search-filters-max-characters">
-							{ translate( 'Extensions' ) }:
+							{ translate( 'Extensions', { context: 'domain extension, like .com' } ) }:
 						</FormLabel>
 						<TokenField
 							isExpanded


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add context to 'Extensions' label in domains filter, so that it'd be possible to provide correct translations for it, instead of reusing the standard 'Extensions' which usually means 'Software Extensions'.

<img width="346" alt="Image 2021-07-01 at 3 31 21 PM" src="https://user-images.githubusercontent.com/7847633/124132894-93308900-da81-11eb-85fb-87ac3d8991d5.png">


#### Testing instructions

* Checkout the diff and `yarn start` or use Calypso.live and navigate to /start/domains
* Confirm that the page and filtering is working and the 'domains filter' button/popup displays 'Extensions:' label at the top (should be untranslated initially).

Fixes 283-gh-Automattic/i18n-issues