### PR TITLE
Emails: Fix refund windows and email support messages on checkout (Draft)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -6,6 +6,16 @@ import { useSelector } from 'react-redux';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 import {
+	isPlan,
+	isMonthly,
+	getYearlyPlanByMonthly,
+	getPlan,
+	isFreePlanProduct,
+	TERM_MONTHLY,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+} from '@automattic/calypso-products';
+import {
 	CheckoutCheckIcon,
 	CheckoutSummaryCard as CheckoutSummaryCardUnstyled,
 	FormStatus,
@@ -23,16 +33,6 @@ import {
 /**
  * Internal dependencies
  */
-import {
-	isPlan,
-	isMonthly,
-	getYearlyPlanByMonthly,
-	getPlan,
-	isFreePlanProduct,
-	TERM_MONTHLY,
-	TERM_ANNUALLY,
-	TERM_BIENNIALLY,
-} from '@automattic/calypso-products';
 import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import Gridicon from 'calypso/components/gridicon';

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -28,7 +28,7 @@ import {
 	isMonthly,
 	getYearlyPlanByMonthly,
 	getPlan,
-	isFreePlanProduct
+	isFreePlanProduct,
 } from '@automattic/calypso-products';
 import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -150,8 +150,8 @@ function CheckoutSummaryFeaturesList( props ) {
 	);
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const { hasMonthlyPlan = false } = props;
-	const isPaidSite = ! isFreePlanProduct( site.plan );
-	const sitePlan = getPlan( site.plan?.product_slug );
+	const isPaidSite = site ? ! isFreePlanProduct( site?.plan ) : false;
+	const sitePlan = site ? getPlan( site?.plan?.product_slug ) : null;
 
 	const showRefundText = responseCart.total_cost > 0;
 	let refundText = translate( 'Money back guarantee' );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -20,7 +20,7 @@ import {
 } from '@automattic/wpcom-checkout';
 
 /**
-/**const
+/**
  * Internal dependencies
  */
 import {
@@ -29,17 +29,15 @@ import {
 	getYearlyPlanByMonthly,
 	getPlan,
 	isFreePlanProduct,
+	TERM_MONTHLY,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
 } from '@automattic/calypso-products';
 import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import Gridicon from 'calypso/components/gridicon';
 import getPlanFeatures from '../lib/get-plan-features';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
-import {
-	TERM_MONTHLY,
-	TERM_ANNUALLY,
-	TERM_BIENNIALLY,
-} from '@automattic/calypso-products/src/constants';
 
 export default function WPCheckoutOrderSummary( {
 	siteId,
@@ -150,8 +148,8 @@ function CheckoutSummaryFeaturesList( props ) {
 	);
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const { hasMonthlyPlan = false } = props;
-	const isPaidSite = site ? ! isFreePlanProduct( site?.plan ) : false;
-	const sitePlan = site ? getPlan( site?.plan?.product_slug ) : null;
+	const isPaidSite = site ? ! isFreePlanProduct( site.plan ) : false;
+	const sitePlan = site?.plan?.product_slug ? getPlan( site.plan.product_slug ) : null;
 
 	const showRefundText = responseCart.total_cost > 0;
 	let refundText = translate( 'Money back guarantee' );
@@ -161,7 +159,7 @@ function CheckoutSummaryFeaturesList( props ) {
 		refundDays = 4;
 	} else if ( hasPlanInCart && ! hasDomainsInCart ) {
 		refundDays = hasMonthlyPlan ? 7 : 14;
-	} else if ( isPaidSite ) {
+	} else if ( isPaidSite && sitePlan ) {
 		if ( [ TERM_ANNUALLY, TERM_BIENNIALLY ].some( ( t ) => t === sitePlan.term ) ) {
 			refundDays = 14;
 		} else if ( sitePlan.term === TERM_MONTHLY ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This change fixes the refund windows as well as the unlimited email support message.
The problem was that in the shopping cart we don't have a plan, but we don't take into account the plan that the site is already using (this happens when we already have a site, and we want to buy an email plan)

#### Testing instructions

1. Have a paid site
2. Buy an email plan subscription (Google Workspace and Titan)
3. Check that it shows the following information:

```
Show 'Unlimited email support' instead of Email support'
Show '14-day money back guarantee' for Titan/Google Workspace with an annual subscription
Show '7-day money back guarantee' for Titan with a monthly subscription
Show '4-day money back guarantee' for Titan/Google Workspace if the user is purchasing a domain at the same time
```

This fix also adds the condition of a biennial subscription as a yearly subscription.

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/124443518-08e86d80-dd7e-11eb-9410-28d833351f1f.png) | ![image](https://user-images.githubusercontent.com/5689927/124443364-e6eeeb00-dd7d-11eb-953d-e7d2bdfeb5ab.png)

Related to {1200182182542585-as-1199573321451012}
