### PR TITLE
Theme Showcase: Add tabbed navigation, v2

### DIFF
--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 /**
  * Internal dependencies
@@ -43,9 +42,6 @@ class RecommendedThemes extends React.Component {
 	render() {
 		return (
 			<>
-				<h2>
-					<strong>{ translate( 'Recommended themes' ) }</strong>
-				</h2>
 				{ this.props.isLoading ? (
 					<Spinner size={ 100 } />
 				) : (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -38,6 +38,10 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import RecommendedThemes from './recommended-themes';
 
 /**
  * Style dependencies
@@ -70,6 +74,7 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.state = {
+			tabFilter: 'recommended',
 			page: 1,
 			showPreview: false,
 		};
@@ -193,6 +198,11 @@ class ThemeShowcase extends React.Component {
 		this.scrollToSearchInput();
 	};
 
+	onFilterClick = ( tabFilter ) => {
+		trackClick( 'section nav filter', tabFilter );
+		this.setState( { tabFilter } );
+	};
+
 	render() {
 		const {
 			currentThemeId,
@@ -274,49 +284,111 @@ class ThemeShowcase extends React.Component {
 						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
+					<SectionNav className="themes__section-nav">
+						<NavTabs>
+							<NavItem
+								onClick={ () => this.onFilterClick( 'recommended' ) }
+								selected={ 'recommended' === this.state.tabFilter }
+							>
+								{ translate( 'Recommended' ) }
+							</NavItem>
+							<NavItem
+								onClick={ () => this.onFilterClick( 'all' ) }
+								selected={ 'all' === this.state.tabFilter }
+							>
+								{ translate( 'All Themes' ) }
+							</NavItem>
+						</NavTabs>
+					</SectionNav>
 					{ this.props.upsellBanner }
 
-					<ThemesSelection
-						upsellUrl={ this.props.upsellUrl }
-						search={ search }
-						tier={ this.props.tier }
-						filter={ filter }
-						vertical={ this.props.vertical }
-						siteId={ this.props.siteId }
-						listLabel={ this.props.listLabel }
-						defaultOption={ this.props.defaultOption }
-						secondaryOption={ this.props.secondaryOption }
-						placeholderCount={ this.props.placeholderCount }
-						getScreenshotUrl={ function ( theme ) {
-							if ( ! getScreenshotOption( theme ).getUrl ) {
-								return null;
-							}
+					{ 'recommended' === this.state.tabFilter && (
+						<RecommendedThemes
+							upsellUrl={ this.props.upsellUrl }
+							search={ search }
+							tier={ this.props.tier }
+							filter={ filter }
+							vertical={ this.props.vertical }
+							siteId={ this.props.siteId }
+							listLabel={ this.props.listLabel }
+							defaultOption={ this.props.defaultOption }
+							secondaryOption={ this.props.secondaryOption }
+							placeholderCount={ this.props.placeholderCount }
+							getScreenshotUrl={ function ( theme ) {
+								if ( ! getScreenshotOption( theme ).getUrl ) {
+									return null;
+								}
 
-							return localizeThemesPath(
-								getScreenshotOption( theme ).getUrl( theme ),
-								locale,
-								! isLoggedIn
-							);
-						} }
-						onScreenshotClick={ function ( themeId ) {
-							if ( ! getScreenshotOption( themeId ).action ) {
-								return;
-							}
-							getScreenshotOption( themeId ).action( themeId );
-						} }
-						getActionLabel={ function ( theme ) {
-							return getScreenshotOption( theme ).label;
-						} }
-						getOptions={ function ( theme ) {
-							return pickBy(
-								addTracking( options ),
-								( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-							);
-						} }
-						trackScrollPage={ this.props.trackScrollPage }
-						emptyContent={ this.props.emptyContent }
-						bookmarkRef={ this.bookmarkRef }
-					/>
+								return localizeThemesPath(
+									getScreenshotOption( theme ).getUrl( theme ),
+									locale,
+									! isLoggedIn
+								);
+							} }
+							onScreenshotClick={ function ( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
+									return;
+								}
+								getScreenshotOption( themeId ).action( themeId );
+							} }
+							getActionLabel={ function ( theme ) {
+								return getScreenshotOption( theme ).label;
+							} }
+							getOptions={ function ( theme ) {
+								return pickBy(
+									addTracking( options ),
+									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+								);
+							} }
+							trackScrollPage={ this.props.trackScrollPage }
+							emptyContent={ this.props.emptyContent }
+							scrollToSearchInput={ this.scrollToSearchInput }
+							bookmarkRef={ this.bookmarkRef }
+						/>
+					) }
+					{ 'all' === this.state.tabFilter && (
+						<ThemesSelection
+							upsellUrl={ this.props.upsellUrl }
+							search={ search }
+							tier={ this.props.tier }
+							filter={ filter }
+							vertical={ this.props.vertical }
+							siteId={ this.props.siteId }
+							listLabel={ this.props.listLabel }
+							defaultOption={ this.props.defaultOption }
+							secondaryOption={ this.props.secondaryOption }
+							placeholderCount={ this.props.placeholderCount }
+							getScreenshotUrl={ function ( theme ) {
+								if ( ! getScreenshotOption( theme ).getUrl ) {
+									return null;
+								}
+
+								return localizeThemesPath(
+									getScreenshotOption( theme ).getUrl( theme ),
+									locale,
+									! isLoggedIn
+								);
+							} }
+							onScreenshotClick={ function ( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
+									return;
+								}
+								getScreenshotOption( themeId ).action( themeId );
+							} }
+							getActionLabel={ function ( theme ) {
+								return getScreenshotOption( theme ).label;
+							} }
+							getOptions={ function ( theme ) {
+								return pickBy(
+									addTracking( options ),
+									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+								);
+							} }
+							trackScrollPage={ this.props.trackScrollPage }
+							emptyContent={ this.props.emptyContent }
+							bookmarkRef={ this.bookmarkRef }
+						/>
+					) }
 					<ThemePreview />
 					{ this.props.children }
 				</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -11,7 +11,6 @@ import { compact, pickBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import ThemesSelection from './themes-selection';
 import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -39,7 +38,6 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
-import RecommendedThemes from './recommended-themes';
 
 /**
  * Style dependencies
@@ -74,13 +72,6 @@ class ThemeShowcase extends React.Component {
 		this.state = {
 			page: 1,
 			showPreview: false,
-			isShowcaseOpen: !! (
-				this.props.loggedOutComponent ||
-				this.props.search ||
-				this.props.filter ||
-				this.props.tier ||
-				this.props.hasShowcaseOpened
-			),
 		};
 	}
 
@@ -145,12 +136,6 @@ class ThemeShowcase extends React.Component {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
 			this.scrollRef.current.scrollIntoView();
 		}
-	};
-
-	toggleShowcase = () => {
-		this.setState( { isShowcaseOpen: ! this.state.isShowcaseOpen } );
-		this.props.openThemesShowcase();
-		this.props.trackMoreThemesClick();
 	};
 
 	doSearch = ( searchBoxContent ) => {
@@ -261,8 +246,6 @@ class ThemeShowcase extends React.Component {
 
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
-		const { isShowcaseOpen } = this.state;
-		const isQueried = this.props.search || this.props.filter || this.props.tier;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -279,138 +262,63 @@ class ThemeShowcase extends React.Component {
 					/>
 				) }
 				<div className="themes__content">
-					{ ! this.props.loggedOutComponent && ! isQueried && (
-						<>
-							<RecommendedThemes
-								upsellUrl={ this.props.upsellUrl }
-								search={ search }
-								tier={ this.props.tier }
-								filter={ filter }
-								vertical={ this.props.vertical }
-								siteId={ this.props.siteId }
-								listLabel={ this.props.listLabel }
-								defaultOption={ this.props.defaultOption }
-								secondaryOption={ this.props.secondaryOption }
-								placeholderCount={ this.props.placeholderCount }
-								getScreenshotUrl={ function ( theme ) {
-									if ( ! getScreenshotOption( theme ).getUrl ) {
-										return null;
-									}
-
-									return localizeThemesPath(
-										getScreenshotOption( theme ).getUrl( theme ),
-										locale,
-										! isLoggedIn
-									);
-								} }
-								onScreenshotClick={ function ( themeId ) {
-									if ( ! getScreenshotOption( themeId ).action ) {
-										return;
-									}
-									getScreenshotOption( themeId ).action( themeId );
-								} }
-								getActionLabel={ function ( theme ) {
-									return getScreenshotOption( theme ).label;
-								} }
-								getOptions={ function ( theme ) {
-									return pickBy(
-										addTracking( options ),
-										( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-									);
-								} }
-								trackScrollPage={ this.props.trackScrollPage }
-								emptyContent={ this.props.emptyContent }
-								isShowcaseOpen={ isShowcaseOpen }
-								scrollToSearchInput={ this.scrollToSearchInput }
-								bookmarkRef={ this.bookmarkRef }
-							/>
-							<div className="theme-showcase__open-showcase-button-holder">
-								{ isShowcaseOpen ? (
-									<hr />
-								) : (
-									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
-										{ translate( 'Show all themes' ) }
-									</Button>
-								) }
-							</div>
-						</>
+					{ ! this.props.loggedOutComponent && showBanners && (
+						<UpworkBanner location={ 'theme-banner' } />
 					) }
-					<div
-						ref={ this.scrollRef }
-						className={
-							! isShowcaseOpen
-								? 'themes__hidden-content theme-showcase__all-themes'
-								: 'theme-showcase__all-themes'
-						}
-					>
-						{ ! this.props.loggedOutComponent && (
-							<>
-								<h2>
-									<strong>{ translate( 'Advanced Themes' ) }</strong>
-								</h2>
-								<p>
-									{ translate(
-										'These themes offer more power and flexibility, but can be harder to setup and customize.'
-									) }
-								</p>
-								{ showBanners && <UpworkBanner location={ 'theme-banner' } /> }
-							</>
-						) }
-						<QueryThemeFilters />
+					<QueryThemeFilters />
 
-						<ThemesSearchCard
-							onSearch={ this.doSearch }
-							search={ filterString + search }
-							tier={ tier }
-							showTierThemesControl={ ! isMultisite }
-							select={ this.onTierSelect }
-						/>
-						{ this.props.upsellBanner }
+					<ThemesSearchCard
+						onSearch={ this.doSearch }
+						search={ filterString + search }
+						tier={ tier }
+						showTierThemesControl={ ! isMultisite }
+						select={ this.onTierSelect }
+					/>
+					{ this.props.upsellBanner }
 
-						<ThemesSelection
-							upsellUrl={ this.props.upsellUrl }
-							search={ search }
-							tier={ this.props.tier }
-							filter={ filter }
-							vertical={ this.props.vertical }
-							siteId={ this.props.siteId }
-							listLabel={ this.props.listLabel }
-							defaultOption={ this.props.defaultOption }
-							secondaryOption={ this.props.secondaryOption }
-							placeholderCount={ this.props.placeholderCount }
-							getScreenshotUrl={ function ( theme ) {
-								if ( ! getScreenshotOption( theme ).getUrl ) {
-									return null;
-								}
+					<ThemesSelection
+						upsellUrl={ this.props.upsellUrl }
+						search={ search }
+						tier={ this.props.tier }
+						filter={ filter }
+						vertical={ this.props.vertical }
+						siteId={ this.props.siteId }
+						listLabel={ this.props.listLabel }
+						defaultOption={ this.props.defaultOption }
+						secondaryOption={ this.props.secondaryOption }
+						placeholderCount={ this.props.placeholderCount }
+						getScreenshotUrl={ function ( theme ) {
+							if ( ! getScreenshotOption( theme ).getUrl ) {
+								return null;
+							}
 
-								return localizeThemesPath(
-									getScreenshotOption( theme ).getUrl( theme ),
-									locale,
-									! isLoggedIn
-								);
-							} }
-							onScreenshotClick={ function ( themeId ) {
-								if ( ! getScreenshotOption( themeId ).action ) {
-									return;
-								}
-								getScreenshotOption( themeId ).action( themeId );
-							} }
-							getActionLabel={ function ( theme ) {
-								return getScreenshotOption( theme ).label;
-							} }
-							getOptions={ function ( theme ) {
-								return pickBy(
-									addTracking( options ),
-									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-								);
-							} }
-							trackScrollPage={ this.props.trackScrollPage }
-							emptyContent={ this.props.emptyContent }
-							bookmarkRef={ this.bookmarkRef }
-						/>
-						<ThemePreview />
-						{ this.props.children }
-					</div>
+							return localizeThemesPath(
+								getScreenshotOption( theme ).getUrl( theme ),
+								locale,
+								! isLoggedIn
+							);
+						} }
+						onScreenshotClick={ function ( themeId ) {
+							if ( ! getScreenshotOption( themeId ).action ) {
+								return;
+							}
+							getScreenshotOption( themeId ).action( themeId );
+						} }
+						getActionLabel={ function ( theme ) {
+							return getScreenshotOption( theme ).label;
+						} }
+						getOptions={ function ( theme ) {
+							return pickBy(
+								addTracking( options ),
+								( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+							);
+						} }
+						trackScrollPage={ this.props.trackScrollPage }
+						emptyContent={ this.props.emptyContent }
+						bookmarkRef={ this.bookmarkRef }
+					/>
+					<ThemePreview />
+					{ this.props.children }
 				</div>
 			</div>
 		);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -155,6 +155,7 @@ class ThemeShowcase extends React.Component {
 			// Strip filters and excess whitespace
 			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
+		this.setState( { tabFilter: 'all' } );
 		page( url );
 		this.scrollToSearchInput();
 	};
@@ -192,6 +193,7 @@ class ThemeShowcase extends React.Component {
 	};
 
 	onTierSelect = ( { value: tier } ) => {
+		this.setState( { tabFilter: 'all' } );
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -52,3 +52,7 @@
 .themes__hidden-content {
 	display: none;
 }
+
+.section-nav.themes__section-nav {
+	margin-top: 1px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rather than relying on the filters, which seem to be broken-ish, this uses a simple state set to call up a different selection of themes depending on which tab is selected.
* This doesn't let folks search through the Recommended themes only. Searches still go through All Themes. 

**Before**

<img width="1371" alt="Screen Shot 2021-07-01 at 11 54 42 AM" src="https://user-images.githubusercontent.com/2124984/124154086-21494700-da63-11eb-8fe4-d6d8d1b46a9e.png">

**After**

<img width="1374" alt="Screen Shot 2021-07-01 at 11 57 04 AM" src="https://user-images.githubusercontent.com/2124984/124154432-7c7b3980-da63-11eb-8a05-1b8de15f75b5.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]`
* Note the addition of tabs under the search bar
* Clicking on All Themes should show the full showcase; clicking on Recommended shows just a subset of recommended themes
* Searching or filtering switches to All Themes to search among them

Related to #54083