### PR TITLE
Add feature flag: theme/showcase-revamp

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -331,6 +331,7 @@ class ThemesMagicSearchCard extends React.Component {
 								onSelect={ this.props.select }
 							/>
 						) }
+						{ config.isEnabled( 'theme/showcase-revamp' ) && <div>Revamp Enabled</div> }
 					</div>
 				</StickyPanel>
 				<div role="presentation" onClick={ this.handleClickInside }>

--- a/config/development.json
+++ b/config/development.json
@@ -154,6 +154,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
+		"theme/showcase-revamp": false,
 		"titan/iframe-control-panel": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,6 +103,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
+		"theme/showcase-revamp": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,6 +112,7 @@
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
+		"theme/showcase-revamp": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -115,6 +115,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
+		"theme/showcase-revamp": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
+		"theme/showcase-revamp": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -121,6 +121,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
+		"theme/showcase-revamp": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add feature flag: `theme/showcase-revamp`

#### Testing instructions

* Run normally
  * `yarn && yarn start`
* Run when flag is enabled
  * `yarn && ENABLE_FEATURES=theme/showcase-revamp yarn start`

Additional text should appear in the advanced theme search, but only when the flag is active. This is a placeholder that proves the flag is working and will be removed when we have more flag dependent behavior.

![2021-07-01_10-03](https://user-images.githubusercontent.com/937354/124146639-957bee80-da53-11eb-9ff8-b63e66283f33.png)
![2021-07-01_10-03_1](https://user-images.githubusercontent.com/937354/124146650-97de4880-da53-11eb-99a7-793402487861.png)

