### PR TITLE
Theme Showcase: Magic Search Welcome Bar: Add an advanced toggle (Redux)

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { intersection, difference, includes, flowRight as compose } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -57,6 +58,7 @@ class ThemesMagicSearchCard extends React.Component {
 			editedSearchElement: '',
 			cursorPosition: 0,
 			searchInput: this.props.search,
+			isWelcomeBarEnabled: false,
 		};
 	}
 
@@ -233,6 +235,18 @@ class ThemesMagicSearchCard extends React.Component {
 	};
 
 	insertTextInInput = ( text ) => {
+		// Used by the "Magic Welcome Bar".
+
+		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
+			// Add an extra leading space sometimes. If the user has "abcd" in
+			// their bar and they click to add "feature:", we want "abcd feature:",
+			// not "abcdfeature:".
+			const { searchInput, cursorPosition } = this.state;
+			if ( searchInput[ cursorPosition - 1 ] !== ' ' ) {
+				text = ' ' + text;
+			}
+		}
+
 		const updatedInput = this.insertTextAtCursor( text );
 		this.updateInput( updatedInput );
 	};
@@ -254,8 +268,15 @@ class ThemesMagicSearchCard extends React.Component {
 		this.focusOnInput();
 	};
 
+	handleWelcomeBarToggle = () => {
+		this.setState( ( prevState ) => ( {
+			isWelcomeBarEnabled: ! prevState.isWelcomeBarEnabled,
+		} ) );
+	};
+
 	render() {
 		const { translate, filters, showTierThemesControl } = this.props;
+		const { isWelcomeBarEnabled } = this.state;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
 
 		const tiers = [
@@ -302,6 +323,11 @@ class ThemesMagicSearchCard extends React.Component {
 		// Check if we want to render suggestions or welcome banner
 		const renderSuggestions = this.state.editedSearchElement !== '';
 
+		let isWelcomeBarVisible = ! renderSuggestions;
+		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
+			isWelcomeBarVisible = isWelcomeBarEnabled;
+		}
+
 		return (
 			<div className={ magicSearchClass }>
 				<StickyPanel>
@@ -329,9 +355,23 @@ class ThemesMagicSearchCard extends React.Component {
 								initialSelected={ this.props.tier }
 								options={ tiers }
 								onSelect={ this.props.select }
+								className={ classNames( {
+									'showcase-revamp': config.isEnabled( 'theme/showcase-revamp' ),
+								} ) }
 							/>
 						) }
-						{ config.isEnabled( 'theme/showcase-revamp' ) && <div>Revamp Enabled</div> }
+						{ config.isEnabled( 'theme/showcase-revamp' ) && (
+							<div>
+								<Button
+									onClick={ this.handleWelcomeBarToggle }
+									className="is-link themes-magic-search-card__advanced-toggle"
+								>
+									{ isWelcomeBarEnabled
+										? translate( 'Hide Advanced' )
+										: translate( 'Show Advanced' ) }
+								</Button>
+							</div>
+						) }
 					</div>
 				</StickyPanel>
 				<div role="presentation" onClick={ this.handleClickInside }>
@@ -343,7 +383,7 @@ class ThemesMagicSearchCard extends React.Component {
 							suggest={ this.suggest }
 						/>
 					) }
-					{ ! renderSuggestions && (
+					{ isWelcomeBarVisible && (
 						<MagicSearchWelcome
 							ref={ this.setSuggestionsRefs( 'welcome' ) }
 							taxonomies={ filtersKeys }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -64,6 +64,10 @@
 		.segmented-control__text {
 			min-width: inherit;
 		}
+
+		&.showcase-revamp {
+			padding: 11px 10px;
+		}
 	}
 
 	.more {
@@ -211,4 +215,11 @@
 
 .themes-magic-search-card__welcome-taxonomy-icon {
 	pointer-events: none;
+}
+
+.button.is-link.themes-magic-search-card__advanced-toggle {
+	font-size: 0.75rem;
+	margin-top: 3px;
+	margin-right: 10px;
+	white-space: nowrap;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the theme showcase, the "Magic Search Welcome Bar" will only appear after an advanced toggle is clicked

![2021-06-30_14-10](https://user-images.githubusercontent.com/937354/124018227-3fed0680-d9ad-11eb-9bbe-d59fe9bce83d.png)
^ **BEFORE** PR

![2021-06-30_14-09](https://user-images.githubusercontent.com/937354/124018282-4e3b2280-d9ad-11eb-8cc9-2e47c398f6e4.png)
^ **AFTER** PR

![2021-06-30_14-09_1](https://user-images.githubusercontent.com/937354/124018291-51361300-d9ad-11eb-9713-2709826f733d.png)
^ **AFTER** PR



#### Testing instructions

Testing both flag states:

* Start with flag enabled
  * `yarn && ENABLE_FEATURES=theme/showcase-revamp yarn start`
  * Changes should be visible
* Start with flag disabled
  * `yarn && yarn start`
  * Changes should not be visible

How to test:

* Visit Calypso. 
* Choose Appearance -> Themes in sthe sidebar
*  Click "Show All Themes"
* Use the newly revealed search
* On local dev, if you are sandboxing public api, you may not be able to load the page directly. Some workarounds are here: paYKcK-144-p2


https://github.com/Automattic/wp-calypso/issues/54077
