### PR TITLE
Disable security checklist menu flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -142,7 +142,7 @@
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"security/security-checkup": true,
+		"security/security-checkup": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,7 +104,7 @@
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"security/security-checkup": true,
+		"security/security-checkup": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,7 +110,7 @@
 		"republicize": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"security/security-checkup": true,
+		"security/security-checkup": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR disables the `security/security-checkup` feature flag that was enabled in the stage and wpcalypso environments in #43527, but then was never rolled out to production. The feature was mostly ready, but hit some state-related snags that stopped us from rolling it out. However, we didn't disable the flag as we should have.

We'll look to re-enable the feature once we have enough time to re-test the functionality and address the issues that were raised in our internal testing (ref: p7DVsv-8SR-p2).


#### Testing instructions

##### Testing the PR

* Open the live branch for this PR.
* Navigate to `/me/security` as a logged-in user.
* Verify that you see a tabbed layout with the Password tab selected. You should _not_ see a vertical menu with check and/or warning icons.

##### Testing in staging

* Navigate to `/me/security` as a logged-in user.
* Verify that you see a tabbed layout with the Password tab selected. You should _not_ see a vertical menu with check and/or warning icons.

Related to #43527