### PR TITLE
Gutenboarding: Use site ID instead of slug for fetching the cart in useOnSiteCreation

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -85,7 +85,7 @@ export default function useOnSiteCreation(): void {
 
 				const go = async () => {
 					if ( planProduct || domainProduct ) {
-						const cart: ResponseCart = await wpcom.getCart( newSite.site_slug );
+						const cart: ResponseCart = await wpcom.getCart( newSite.blogid );
 						await wpcom.setCart( newSite.blogid, {
 							...cart,
 							products: [ ...cart.products, planProduct, domainProduct ].filter( Boolean ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Gutenboarding does not use the `useShoppingCart` hook and instead manually interacts with the shopping-cart endpoint. It performs two operations: fetching the current cart and then saving a modified cart. For the first operation, it uses the site slug as the cart key, and for the second, it uses the site ID.

Using the site slug as the cart key can sometimes cause problems. This was noticed and fixed for `useShoppingCart` in https://github.com/Automattic/wp-calypso/pull/44410 but I only just noticed the same issue here.

This PR modifies Gutenboarding to use the site ID as the cart key for both shopping-cart operations.

#### Testing instructions

Create a new site using the gutenboarding flow with a paid plan. When you reach checkout, verify that the plan is in the cart and that no errors have occurred.