### PR TITLE
Signup: Try to use siteId for cartKey in addToCart

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -318,6 +318,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			callback,
 			reduxStore,
 			siteSlug,
+			siteId,
 			isFreeThemePreselected,
 			themeSlugWithRepo
 		);
@@ -339,7 +340,7 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 }
 
 export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxStore ) {
-	const { siteSlug } = dependencies;
+	const { siteSlug, siteId } = dependencies;
 	const { cartItem } = stepProvidedItems;
 	if ( isEmpty( cartItem ) ) {
 		// the user selected the free plan
@@ -351,7 +352,16 @@ export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxS
 	const providedDependencies = { cartItem };
 	const newCartItems = [ cartItem ].filter( ( item ) => item );
 
-	processItemCart( providedDependencies, newCartItems, callback, reduxStore, siteSlug, null, null );
+	processItemCart(
+		providedDependencies,
+		newCartItems,
+		callback,
+		reduxStore,
+		siteSlug,
+		siteId,
+		null,
+		null
+	);
 }
 
 export function addDomainToCart(
@@ -365,10 +375,20 @@ export function addDomainToCart(
 	const slug = siteSlug || dependencies.siteSlug;
 	const { domainItem, googleAppsCartItem } = stepProvidedItems;
 	const providedDependencies = stepProvidedDependencies || { domainItem };
+	const siteId = dependencies.siteId ?? stepProvidedDependencies?.siteId;
 
 	const newCartItems = [ domainItem, googleAppsCartItem ].filter( ( item ) => item );
 
-	processItemCart( providedDependencies, newCartItems, callback, reduxStore, slug, null, null );
+	processItemCart(
+		providedDependencies,
+		newCartItems,
+		callback,
+		reduxStore,
+		slug,
+		siteId,
+		null,
+		null
+	);
 }
 
 function processItemCart(
@@ -377,6 +397,7 @@ function processItemCart(
 	callback,
 	reduxStore,
 	siteSlug,
+	siteId,
 	isFreeThemePreselected,
 	themeSlugWithRepo
 ) {
@@ -387,7 +408,7 @@ function processItemCart(
 		);
 
 		if ( newCartItemsToAdd.length ) {
-			addToCart( siteSlug, newCartItemsToAdd, function ( cartError ) {
+			addToCart( siteId ?? siteSlug, newCartItemsToAdd, function ( cartError ) {
 				callback( cartError, providedDependencies );
 			} );
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Signup does not use the `useShoppingCart` hook and instead manually interacts with the shopping-cart endpoint. When it fetches the cart, it sometimes uses the site slug as the cart key.

Using the site slug as the cart key can sometimes cause problems. This was noticed and fixed for `useShoppingCart` in https://github.com/Automattic/wp-calypso/pull/44410 but I only just noticed the same issue here.

This PR modifies signup to use the site ID as the cart key (if present) for both shopping-cart operations. Hopefully I did this right; it's not 100% clear how to get the site ID from the signup architecture.

#### Testing instructions

- Visit `/home` for a site with no plan that has not yet launched (you can create a new site if necessary).
- Click the "Launch site" button on the home page.
- When you're presented with a list of domains, select a paid domain.
- When you're presented with a list of plan, select a paid plan.
- Verify that you end up in checkout with the domain and plan you selected.