### PR TITLE
add border radius to quicklinks when collapsed

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -3,6 +3,8 @@
 
 .quick-links.foldable-card.card {
 	box-shadow: none;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 3px;
 	
 	&:not( .is-expanded ) {
 		box-shadow: 0 0 0 1px var( --color-border-subtle );

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -3,9 +3,11 @@
 
 .quick-links.foldable-card.card {
 	box-shadow: none;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 3px;
-	
+	@include breakpoint-deprecated( '>660px' ) {
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 3px;
+	}
+
 	&:not( .is-expanded ) {
 		box-shadow: 0 0 0 1px var( --color-border-subtle );
 	}


### PR DESCRIPTION
Tiny PR to add rounded corners to quick links card when collapsed.

resolves https://github.com/Automattic/wp-calypso/issues/54224

<img width="825" alt="Screen Shot 2021-07-02 at 3 23 03 PM" src="https://user-images.githubusercontent.com/22446385/124216051-6f387a80-db49-11eb-82ec-c324eda8096d.png">
