### PR TITLE
Add notice on wordads setting if site is private

### DIFF
--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -262,6 +262,17 @@ class AdsWrapper extends Component {
 		);
 	}
 
+	renderNoticeSiteIsPrivate() {
+		const { translate } = this.props;
+		return (
+			<Notice status="is-warning" showDismiss={ false }>
+				{ translate(
+					"No ads is displayed on your site becuase your site's privacy setting is set to private"
+				) }
+			</Notice>
+		);
+	}
+
 	render() {
 		const { site, translate } = this.props;
 		const jetpackPremium = site.jetpack && isEligbleJetpackPlan( site.plan );
@@ -287,6 +298,8 @@ class AdsWrapper extends Component {
 			component = this.renderEmptyContent();
 		} else if ( ! ( site.options.wordads || jetpackPremium ) ) {
 			component = null;
+		} else if ( site.options.wordads && site.is_private ) {
+			notice = this.renderNoticeSiteIsPrivate();
 		}
 
 		return (

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -263,11 +263,20 @@ class AdsWrapper extends Component {
 	}
 
 	renderNoticeSiteIsPrivate() {
-		const { translate } = this.props;
+		const { translate, siteSlug } = this.props;
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
 				{ translate(
-					"No ads is displayed on your site becuase your site's privacy setting is set to private"
+					"No ads are displayed on your site because your site's {{link}}privacy setting{{/link}} is set to private.",
+					{
+						components: {
+							link: (
+								<a
+									href={ `https://wordpress.com/settings/general/${ siteSlug }#site-privacy-settings` }
+								/>
+							),
+						},
+					}
 				) }
 			</Notice>
 		);

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -264,17 +264,14 @@ class AdsWrapper extends Component {
 
 	renderNoticeSiteIsPrivate() {
 		const { translate, siteSlug } = this.props;
+		const privacySettingPageLink = `https://wordpress.com/settings/general/${ siteSlug }#site-privacy-settings`;
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
 				{ translate(
 					"No ads are displayed on your site because your site's {{link}}privacy setting{{/link}} is set to private.",
 					{
 						components: {
-							link: (
-								<a
-									href={ `https://wordpress.com/settings/general/${ siteSlug }#site-privacy-settings` }
-								/>
-							),
+							link: <a href={ privacySettingPageLink } />,
 						},
 					}
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added notice if the site has WordAds enabled and visibility/privacy setting is set to private.

#### Testing instructions

1. Visit [https://wordpress.com/settings/general](https://wordpress.com/settings/general)
2. Select a site that has WordAds enabled.
3. Select private under the Privacy section and click on `Save settings`
4. Now go to WordAds dashboard. Tools > Earn > View ad dashboard
5. You should see a notice which tells the user ads are not being displayed because the site's privacy is set to private. 

![](https://d.pr/i/TrngFo+)

---

Fixes #45603 
