### PR TITLE
New Onboarding: remove Reynolds design

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -130,7 +130,7 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_alpha": false,
+			"is_alpha": true,
 			"features": []
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Set `is_alpha` flag to `true` for Reynolds design to remove it temporary from the design picker

#### Testing instructions
* Go to `/new`
* On `/new/design` there is no more Reynolds design

Related to p1625200500070300-slack-C9EJ7KSGH