### PR TITLE
route to site selection when going to /theme

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -100,3 +100,4 @@ export const redirectWithoutLocaleParamIfLoggedIn = () => {};
 export const render = () => {};
 export const ProviderWrappedLayout = () => null;
 export const notFound = () => null;
+export const selectSiteIfLoggedIn = () => null;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -27,6 +27,8 @@ import {
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
 import { render, hydrate } from './web-util.js';
+import { composeHandlers } from 'calypso/controller/shared';
+import { sites, siteSelection } from 'calypso/my-sites/controller';
 
 /**
  * Re-export
@@ -172,3 +174,16 @@ export const notFound = ( context, next ) => {
 
 	next();
 };
+
+export function selectSiteIfLoggedIn( context, next ) {
+	const state = context.store.getState();
+	if ( ! isUserLoggedIn( state ) ) {
+		next();
+		return;
+	}
+
+	// Logged in: Terminate the regular handler path by not calling next()
+	// and render the site selection screen, redirecting the user if they
+	// only have one site.
+	composeHandlers( siteSelection, sites, makeLayout, render )( context );
+}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -40,6 +40,12 @@
 		margin: 0;
 	}
 
+	.is-section-theme & {
+		.sites.main {
+			padding-top: 79px;
+		}
+	}
+
 	// This is needed to ensure the WebPreview component
 	// displays at full height.
 	.is-section-preview & {

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -5,6 +5,7 @@ import {
 	makeLayout,
 	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
+	selectSiteIfLoggedIn,
 } from 'calypso/controller';
 import { details, fetchThemeDetailsData } from './controller';
 import { createNavigation, siteSelection } from 'calypso/my-sites/controller';
@@ -32,7 +33,17 @@ export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
 	router(
-		`/${ langParam }/theme/:slug/:section(setup|support)?/:site_id?`,
+		`/${ langParam }/theme/:slug/:section(setup|support)?`,
+		redirectWithoutLocaleParamIfLoggedIn,
+		redirectToLoginIfSiteRequested,
+		selectSiteIfLoggedIn,
+		fetchThemeDetailsData,
+		details,
+		makeLayout
+	);
+
+	router(
+		`/${ langParam }/theme/:slug/:section(setup|support)?/:site_id`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectToLoginIfSiteRequested,
 		addNavigationIfLoggedIn,

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -11,6 +11,9 @@ import { details, fetchThemeDetailsData } from './controller';
 import { createNavigation, siteSelection } from 'calypso/my-sites/controller';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
+import { translate } from 'i18n-calypso';
+import React from 'react';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 
 function redirectToLoginIfSiteRequested( context, next ) {
 	if ( context.params.site_id ) {
@@ -29,6 +32,20 @@ function addNavigationIfLoggedIn( context, next ) {
 	next();
 }
 
+function setTitleAndSelectSiteIfLoggedIn( context, next ) {
+	const state = context.store.getState();
+	const theme = getCanonicalTheme( state, null, context.params.slug );
+	const themeName = theme.name;
+
+	context.getSiteSelectionHeaderText = () =>
+		translate( 'Select a site to see {{strong}}%(themeName)s{{/strong}} details', {
+			args: { themeName },
+			components: { strong: <strong /> },
+		} );
+
+	selectSiteIfLoggedIn( context, next );
+}
+
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
@@ -36,7 +53,7 @@ export default function ( router ) {
 		`/${ langParam }/theme/:slug/:section(setup|support)?`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectToLoginIfSiteRequested,
-		selectSiteIfLoggedIn,
+		setTitleAndSelectSiteIfLoggedIn,
 		fetchThemeDetailsData,
 		details,
 		makeLayout

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -38,7 +38,7 @@ function setTitleAndSelectSiteIfLoggedIn( context, next ) {
 	const themeName = theme.name;
 
 	context.getSiteSelectionHeaderText = () =>
-		translate( 'Select a site to see {{strong}}%(themeName)s{{/strong}} details', {
+		translate( 'Select a site to view {{strong}}%(themeName)s{{/strong}}', {
 			args: { themeName },
 			components: { strong: <strong /> },
 		} );

--- a/client/my-sites/themes/controller-logged-in.jsx
+++ b/client/my-sites/themes/controller-logged-in.jsx
@@ -11,11 +11,6 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { setBackPath } from 'calypso/state/themes/actions';
 import { getProps } from './controller';
-import { sites, siteSelection } from 'calypso/my-sites/controller';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { composeHandlers } from 'calypso/controller/shared';
-
 import SingleSiteComponent from './single-site';
 import Upload from './theme-upload';
 
@@ -52,17 +47,4 @@ export function upload( context, next ) {
 
 	context.primary = <Upload noticeType={ noticeType } />;
 	next();
-}
-
-export function selectSiteIfLoggedIn( context, next ) {
-	const state = context.store.getState();
-	if ( ! isUserLoggedIn( state ) ) {
-		next();
-		return;
-	}
-
-	// Logged in: Terminate the regular handler path by not calling next()
-	// and render the site selection screen, redirecting the user if they
-	// only have one site.
-	composeHandlers( siteSelection, sites, makeLayout, clientRender )( context );
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -6,10 +6,11 @@ import {
 	makeLayout,
 	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
+	selectSiteIfLoggedIn,
 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { loggedOut } from './controller';
-import { loggedIn, upload, selectSiteIfLoggedIn } from './controller-logged-in';
+import { loggedIn, upload } from './controller-logged-in';
 import { fetchAndValidateVerticalsAndFilters } from './validate-filters';
 
 export default function ( router ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a site selection screen if the user is logged in and navigates to `/theme/SLUG`

#### Testing instructions

* Check that going to `/theme/twentytwentyone` show the site selector screen. Like this:
![image](https://user-images.githubusercontent.com/375980/124285129-04287d00-db24-11eb-9856-6b918966f617.png)

* When you select a site verify that you see the theme selected and the site is the one you selected `/theme/twentytwentyone/[YOUR_SITE]`
* Check that when you click the Activate button both previews looks ok in the popup.

I moved the `selectSiteIfLoggedIn` middleware to a common place so it can be reused from `/theme` and `/themes`. It would be nice to check that the themes showcase did not change its behaviour.
* Go to `/themes`
* Verify you see the site picker screen
* Select a site
* Verify you see the theme showcase of your selected site

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53110
