### PR TITLE
Add siteless checkout thank you page (and post-checkout redirect).

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -19,21 +19,19 @@ import {
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import { cleanUrl } from 'calypso/jetpack-connect/utils.js';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Main from 'calypso/components/main';
 
 interface Props {
 	productSlug: string | 'no_product';
-	zendeskTicketId: string | undefined;
 }
 
-const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
-	productSlug,
-	zendeskTicketId,
-} ) => {
+const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( { productSlug } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const userEmail = useSelector( getCurrentUserEmail );
 
 	const hasProductInfo = productSlug !== 'no_product';
 
@@ -49,7 +47,7 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 		'https://jetpack.com/support/getting-started-with-jetpack/';
 
 	// TODO: Get the correct link to schedule 15min Happiness support session. This link is not correct.
-	const happinessAppointmentLink = `/schedule-happiness-appointment?ticketId=${ zendeskTicketId }`;
+	const happinessAppointmentLink = `/schedule-happiness-appointment?user=${ userEmail }`;
 
 	const [ siteInput, setSiteInput ] = useState( '' );
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -54,7 +54,8 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 	const [ siteInput, setSiteInput ] = useState( '' );
 
 	const onUrlChange = useCallback( ( e ) => {
-		setSiteInput( e.target.value );
+		const siteUrl = e.target.value;
+		setSiteInput( siteUrl );
 	}, [] );
 
 	const onUrlSubmit = useCallback( () => {
@@ -89,9 +90,9 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
 					</h1>
 					<p>
-						{ translate( 'Here’s how to get started with Jetpack.' ) }
+						{ translate( "Here's how to get started with Jetpack." ) }
 						<br />
-						{ translate( ' We’ve also sent you an email with these instructions.' ) }
+						{ translate( "We've also sent you an email with these instructions." ) }
 					</p>
 					<div className="jetpack-checkout-siteless-thank-you__step">
 						<div className="jetpack-checkout-siteless-thank-you__step-number">1</div>
@@ -132,7 +133,13 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 							<div className="jetpack-checkout-siteless-thank-you__step-number">2</div>
 							<div className="jetpack-checkout-siteless-thank-you__step-content">
 								<h2>{ translate( 'Let us know your website address' ) }</h2>
-								<p>
+								<p
+									className={
+										isProductListFetching
+											? 'jetpack-checkout-siteless-thank-you__product-info-loading'
+											: 'jetpack-checkout-siteless-thank-you__product-info'
+									}
+								>
 									{ translate( 'What site will you be adding %(productName)s to?', {
 										args: {
 											productName,
@@ -173,7 +180,7 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 						<h2>{ translate( 'Do you need help?' ) }</h2>
 						<p>
 							{ translate(
-								'If you prefer to setup Jetpack with the help of out Happiness Engineers, {{a}}schedule a 15 min call now{{/a}}.',
+								'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 min call now{{/a}}.',
 								{
 									components: {
 										a: (

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -1,0 +1,204 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, useState, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { Card } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormButton from 'calypso/components/forms/form-button';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import QueryProducts from 'calypso/components/data/query-products-list';
+import {
+	isProductsListFetching as getIsProductListFetching,
+	getProductName,
+} from 'calypso/state/products-list/selectors';
+import { cleanUrl } from 'calypso/jetpack-connect/utils.js';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import Main from 'calypso/components/main';
+
+interface Props {
+	productSlug: string | 'no_product';
+	zendeskTicketId: string | undefined;
+}
+
+const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
+	productSlug,
+	zendeskTicketId,
+} ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const hasProductInfo = productSlug !== 'no_product';
+
+	const productName = useSelector( ( state ) =>
+		hasProductInfo ? getProductName( state, productSlug ) : null
+	) as string | null;
+
+	const isProductListFetching = useSelector( ( state ) =>
+		getIsProductListFetching( state )
+	) as boolean;
+
+	const jetpackInstallInstructionsLink =
+		'https://jetpack.com/support/getting-started-with-jetpack/';
+
+	// TODO: Get the correct link to schedule 15min Happiness support session. This link is not correct.
+	const happinessAppointmentLink = `/schedule-happiness-appointment?ticketId=${ zendeskTicketId }`;
+
+	const [ siteInput, setSiteInput ] = useState( '' );
+
+	const onUrlChange = useCallback( ( e ) => {
+		setSiteInput( e.target.value );
+	}, [] );
+
+	const onUrlSubmit = useCallback( () => {
+		const siteUrl = cleanUrl( siteInput );
+		if ( siteUrl ) {
+			dispatch(
+				recordTracksEvent( 'calypso_siteless_checkout_submit_website_address', {
+					zendeskTicketId,
+					productSlug,
+					siteUrl,
+				} )
+			);
+			// TODO: dispatch a request to WPCOM with the `siteUrl` and the ZendDesk ticket ID to some endpoint to
+			// append the `siteUrl` to the ZendDesk ticket.
+			// On successful response redirect to schedule 15min Happiness support page? (Calendly?)
+		}
+	}, [ siteInput, dispatch, productSlug, zendeskTicketId ] );
+
+	return (
+		<Main fullWidthLayout className="jetpack-checkout-siteless-thank-you">
+			<PageViewTracker
+				path="/checkout/jetpack/thank-you/no-site/:product"
+				title="Checkout > Jetpack Siteless Thank You"
+				properties={ { product_slug: productSlug } }
+			/>
+			<Card className="jetpack-checkout-siteless-thank-you__card">
+				<div className="jetpack-checkout-siteless-thank-you__card-main">
+					<JetpackLogo full size={ 45 } />
+					{ hasProductInfo && <QueryProducts type="jetpack" /> }
+					<h1 className="jetpack-checkout-siteless-thank-you__main-message">
+						{ translate( 'Thank you for your purchase!' ) }{ ' ' }
+						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+					</h1>
+					<p>
+						{ translate( 'Here’s how to get started with Jetpack.' ) }
+						<br />
+						{ translate( ' We’ve also sent you an email with these instructions.' ) }
+					</p>
+					<div className="jetpack-checkout-siteless-thank-you__step">
+						<div className="jetpack-checkout-siteless-thank-you__step-number">1</div>
+						<div className="jetpack-checkout-siteless-thank-you__step-content">
+							<h2>{ translate( 'Install Jetpack' ) }</h2>
+							<p>
+								{ translate(
+									'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													className="jetpack-checkout-siteless-thank-you__link"
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ () =>
+														dispatch(
+															recordTracksEvent(
+																'calypso_siteless_checkout_install_instructions_link_clicked',
+																{
+																	zendeskTicketId,
+																	productSlug,
+																}
+															)
+														)
+													}
+													href={ jetpackInstallInstructionsLink }
+												/>
+											),
+										},
+									}
+								) }
+							</p>
+						</div>
+					</div>
+					{ hasProductInfo && ( isProductListFetching || productName ) && (
+						<div className="jetpack-checkout-siteless-thank-you__step">
+							<div className="jetpack-checkout-siteless-thank-you__step-number">2</div>
+							<div className="jetpack-checkout-siteless-thank-you__step-content">
+								<h2>{ translate( 'Let us know your website address' ) }</h2>
+								<p>
+									{ translate( 'What site will you be adding %(productName)s to?', {
+										args: {
+											productName,
+										},
+									} ) }
+									<br />
+									{ translate( 'Knowing this will allow us to jumpstart the activation process.' ) }
+								</p>
+								<FormLabel
+									className="jetpack-checkout-siteless-thank-you__form-label"
+									htmlFor="website-address-input"
+								>
+									Your website address:
+								</FormLabel>
+								<div className="jetpack-checkout-siteless-thank-you__form-group" role="group">
+									<FormTextInput
+										className="jetpack-checkout-siteless-thank-you__form-input"
+										autoCapitalize="off"
+										value={ siteInput }
+										placeholder="https://yourjetpack.blog"
+										onChange={ onUrlChange }
+										autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+									/>
+									<FormButton
+										className="jetpack-checkout-siteless-thank-you__form-submit"
+										disabled={ ! siteInput }
+										onClick={ onUrlSubmit }
+									>
+										{ translate( 'Continue' ) }
+									</FormButton>
+								</div>
+							</div>
+						</div>
+					) }
+				</div>
+				<div className="jetpack-checkout-siteless-thank-you__card-footer">
+					<div>
+						<h2>{ translate( 'Do you need help?' ) }</h2>
+						<p>
+							{ translate(
+								'If you prefer to setup Jetpack with the help of out Happiness Engineers, {{a}}schedule a 15 min call now{{/a}}.',
+								{
+									components: {
+										a: (
+											<a
+												className="jetpack-checkout-siteless-thank-you__link"
+												onClick={ () =>
+													dispatch(
+														recordTracksEvent( 'calypso_siteless_checkout_happiness_link_clicked', {
+															zendeskTicketId,
+															productSlug,
+														} )
+													)
+												}
+												href={ happinessAppointmentLink }
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+					</div>
+				</div>
+			</Card>
+		</Main>
+	);
+};
+
+export default JetpackCheckoutSitelessThankYou;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -63,16 +63,15 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 		if ( siteUrl ) {
 			dispatch(
 				recordTracksEvent( 'calypso_siteless_checkout_submit_website_address', {
-					zendeskTicketId,
-					productSlug,
-					siteUrl,
+					product_slug: productSlug,
+					site_url: siteUrl,
 				} )
 			);
-			// TODO: dispatch a request to WPCOM with the `siteUrl` and the ZendDesk ticket ID to some endpoint to
+			// TODO: dispatch a post request to WPCOM with the `siteUrl` and the users email address to some endpoint to
 			// append the `siteUrl` to the ZendDesk ticket.
 			// On successful response redirect to schedule 15min Happiness support page? (Calendly?)
 		}
-	}, [ siteInput, dispatch, productSlug, zendeskTicketId ] );
+	}, [ siteInput, dispatch, productSlug ] );
 
 	return (
 		<Main fullWidthLayout className="jetpack-checkout-siteless-thank-you">
@@ -113,8 +112,7 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 															recordTracksEvent(
 																'calypso_siteless_checkout_install_instructions_link_clicked',
 																{
-																	zendeskTicketId,
-																	productSlug,
+																	product_slug: productSlug,
 																}
 															)
 														)
@@ -189,8 +187,7 @@ const JetpackCheckoutSitelessThankYou: FunctionComponent< Props > = ( {
 												onClick={ () =>
 													dispatch(
 														recordTracksEvent( 'calypso_siteless_checkout_happiness_link_clicked', {
-															zendeskTicketId,
-															productSlug,
+															product_slug: productSlug,
 														} )
 													)
 												}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -676,8 +676,7 @@
 }
 
 .jetpack-checkout-siteless-thank-you {
-	.jetpack-checkout-siteless-thank-you__card,
-	.jetpack-checkout-siteless-thank-you__card-loading {
+	.jetpack-checkout-siteless-thank-you__card {
 		display: flex;
 		flex-direction: column;
 		padding: 0;
@@ -810,10 +809,13 @@
 			}
 		}
 
-		.jetpack-checkout-siteless-thank-you__sub-message-loading,
 		.jetpack-checkout-siteless-thank-you__sub-message {
 			font-size: 1.5rem;
 			margin-bottom: 64px;
+		}
+
+		.jetpack-checkout-siteless-thank-you__product-info-loading {
+			@include placeholder( --color-neutral-30 );
 		}
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -675,6 +675,149 @@
 	}
 }
 
+.jetpack-checkout-siteless-thank-you {
+	.jetpack-checkout-siteless-thank-you__card,
+	.jetpack-checkout-siteless-thank-you__card-loading {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+		box-shadow: 0 0 40px 0 #00000014;
+
+		width: 100%;
+		max-width: none;
+
+		@include break-medium {
+			flex-direction: row;
+			width: auto;
+			max-width: 1200px;
+		}
+
+		.jetpack-logo {
+			margin-bottom: 25px;
+		}
+
+		h1 {
+			font-size: 3rem;
+			line-height: 3.25rem;
+			padding-bottom: 24px;
+			+ p {
+				font-size: 1.5rem;
+				line-height: 2rem;
+			}
+		}
+		h2 {
+			font-size: 1.5rem;
+			font-weight: 700;
+			line-height: 1.75rem;
+			padding-bottom: 16px;
+		}
+
+		a.jetpack-checkout-siteless-thank-you__link {
+			text-decoration: underline;
+			color: var( --color-studio-black );
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		> div {
+			box-sizing: border-box;
+			padding: 15px 26px 26px;
+			@include break-mobile {
+				padding: 30px 76px 55px;
+			}
+		}
+		.jetpack-checkout-siteless-thank-you__card-main {
+			max-width: 744px;
+		}
+
+		.jetpack-checkout-siteless-thank-you__step {
+			display: flex;
+			align-items: flex-start;
+			.jetpack-checkout-siteless-thank-you__step-number {
+				color: white;
+				background-color: var( --studio-jetpack-green-50 );
+				text-align: center;
+				border-radius: 50%;
+				font-size: 1.25rem;
+				width: 1.8rem;
+				height: 1.8rem;
+			}
+			.jetpack-checkout-siteless-thank-you__step-content {
+				flex: 1;
+				padding: 0 10px 0 16px;
+			}
+		}
+
+		.jetpack-checkout-siteless-thank-you__form-group {
+			display: flex;
+			flex-direction: column;
+			padding-bottom: 1.5em;
+			@include break-mobile {
+				display: flex;
+				flex-direction: row;
+				justify-content: space-between;
+			}
+
+			.jetpack-checkout-siteless-thank-you__form-input {
+				margin-bottom: 16px;
+				@include break-mobile {
+					flex: 1;
+					margin-right: 16px;
+					margin-bottom: 0;
+				}
+			}
+			.button.jetpack-checkout-siteless-thank-you__form-submit {
+				margin: 0;
+				&.is-primary {
+					background-color: var( --studio-jetpack-green-50 );
+					border-color: var( --studio-jetpack-green-50 );
+					&:hover {
+						background-color: var( --studio-jetpack-green-60 );
+						border-color: var( --studio-jetpack-green-60 );
+					}
+					&[disabled] {
+						color: var( --color-neutral-20 );
+						background-color: var( --color-surface );
+						border-color: var( --color-neutral-5 );
+					}
+				}
+				@include break-mobile {
+					align-self: flex-end;
+					justify-self: flex-end;
+				}
+			}
+		}
+
+		.jetpack-checkout-siteless-thank-you__card-footer {
+			display: flex;
+			align-items: flex-end;
+
+			background-color: var( --color-neutral-5 );
+			> div {
+				max-width: 456px;
+			}
+		}
+		// TODO min width
+		// TODO primary button color
+		.jetpack-checkout-siteless-thank-you__main-message {
+			font-size: 2.25rem;
+			font-weight: 700;
+			margin-bottom: 24px;
+
+			@include break-mobile {
+				font-size: 3rem;
+			}
+		}
+
+		.jetpack-checkout-siteless-thank-you__sub-message-loading,
+		.jetpack-checkout-siteless-thank-you__sub-message {
+			font-size: 1.5rem;
+			margin-bottom: 64px;
+		}
+	}
+}
+
 .jetpack-checkout-thank-you {
 	.jetpack-checkout-thank-you__card,
 	.jetpack-checkout-thank-you__card-loading {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -797,8 +797,7 @@
 				max-width: 456px;
 			}
 		}
-		// TODO min width
-		// TODO primary button color
+
 		.jetpack-checkout-siteless-thank-you__main-message {
 			font-size: 2.25rem;
 			font-weight: 700;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -141,11 +141,7 @@ export default function getThankYouPageUrl( {
 		// extract a product from the cart, in siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug;
 
-		// TODO: Get the Zendesk ticket ID & pass it along with the thankYouPageUrl (`ticketId` query param).
-		// Just using the `pendingOrReceiptId` value for now as an example.
-		return `/checkout/jetpack/thank-you/no-site/${
-			productSlug ?? 'no_product'
-		}?ticketId=${ pendingOrReceiptId }`;
+		return `/checkout/jetpack/thank-you/no-site/${ productSlug ?? 'no_product' }`;
 	}
 
 	const fallbackUrl = getFallbackDestination( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -125,14 +125,27 @@ export default function getThankYouPageUrl( {
 	const pendingOrReceiptId = getPendingOrReceiptId( receiptId, orderId, purchaseId );
 	debug( 'pendingOrReceiptId is', pendingOrReceiptId );
 
-	// jetpack userless checkout uses a special thank you page
+	// jetpack userless & siteless checkout uses a special thank you page
 	if ( isJetpackCheckout ) {
-		debug( 'redirecting to userless jetpack thank you' );
+		if ( siteSlug ) {
+			debug( 'redirecting to userless jetpack thank you' );
 
-		// extract a product from the cart, in userless checkout there should only be one
+			// extract a product from the cart, in userless checkout there should only be one
+			const productSlug = cart?.products[ 0 ]?.product_slug;
+
+			return `/checkout/jetpack/thank-you/${ siteSlug }/${ productSlug ?? 'no_product' }`;
+		}
+		// siteless checkout
+		debug( 'redirecting to siteless jetpack thank you' );
+
+		// extract a product from the cart, in siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug;
 
-		return `/checkout/jetpack/thank-you/${ siteSlug }/${ productSlug ?? 'no_product' }`;
+		// TODO: Get the Zendesk ticket ID & pass it along with the thankYouPageUrl (`ticketId` query param).
+		// Just using the `pendingOrReceiptId` value for now as an example.
+		return `/checkout/jetpack/thank-you/no-site/${
+			productSlug ?? 'no_product'
+		}?ticketId=${ pendingOrReceiptId }`;
 	}
 
 	const fallbackUrl = getFallbackDestination( {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -947,4 +947,24 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/jetpack/thank-you/foo.bar/no_product' );
 	} );
+
+	it( 'redirects to the jetpack "siteless" checkout thank you when jetpack checkout arg is set, but siteSlug is undefined.', () => {
+		const cart = {
+			products: [
+				{
+					product_slug: 'jetpack_backup_daily',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: undefined,
+			cart,
+			isJetpackCheckout: true,
+			receiptId: 123456789,
+		} );
+		expect( url ).toBe(
+			'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?ticketId=123456789'
+		);
+	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -961,10 +961,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: undefined,
 			cart,
 			isJetpackCheckout: true,
-			receiptId: 123456789,
 		} );
-		expect( url ).toBe(
-			'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?ticketId=123456789'
-		);
+		expect( url ).toBe( '/checkout/jetpack/thank-you/no-site/jetpack_backup_daily' );
 	} );
 } );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -285,10 +285,7 @@ export function jetpackCheckoutThankYou( context, next ) {
 	const isSitelessCheckoutFlow = context.path.includes( '/checkout/jetpack/thank-you/no-site' );
 
 	context.primary = isSitelessCheckoutFlow ? (
-		<JetpackCheckoutSitelessThankYou
-			productSlug={ context.params.product }
-			zendeskTicketId={ context.query?.ticketId }
-		/>
+		<JetpackCheckoutSitelessThankYou productSlug={ context.params.product } />
 	) : (
 		<JetpackCheckoutThankYou
 			site={ context.params.site }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -23,6 +23,7 @@ import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
+import JetpackCheckoutSitelessThankYou from './checkout-thank-you/jetpack-checkout-siteless-thank-you';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
@@ -281,8 +282,14 @@ export function redirectToSupportSession( context ) {
 
 export function jetpackCheckoutThankYou( context, next ) {
 	const isUserlessCheckoutFlow = context.path.includes( '/checkout/jetpack' );
+	const isSitelessCheckoutFlow = context.path.includes( '/checkout/jetpack/thank-you/no-site' );
 
-	context.primary = (
+	context.primary = isSitelessCheckoutFlow ? (
+		<JetpackCheckoutSitelessThankYou
+			productSlug={ context.params.product }
+			zendeskTicketId={ context.query?.ticketId }
+		/>
+	) : (
 		<JetpackCheckoutThankYou
 			site={ context.params.site }
 			productSlug={ context.params.product }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -25,6 +25,17 @@ import { isEnabled } from '@automattic/calypso-config';
 export default function () {
 	page( '/checkout*', recordSiftScienceUser );
 
+	if ( isEnabled( 'jetpack/siteless-checkout' ) ) {
+		page( '/checkout/jetpack/:productSlug', noSite, checkoutSiteless, makeLayout, clientRender );
+		page(
+			'/checkout/jetpack/thank-you/no-site/:product',
+			noSite,
+			jetpackCheckoutThankYou,
+			makeLayout,
+			clientRender
+		);
+	}
+
 	if ( isEnabled( 'jetpack/userless-checkout' ) ) {
 		page( '/checkout/jetpack/:siteSlug/:productSlug', checkout, makeLayout, clientRender );
 		page(
@@ -34,10 +45,6 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
-	}
-
-	if ( isEnabled( 'jetpack/siteless-checkout' ) ) {
-		page( '/checkout/jetpack/:productSlug', noSite, checkoutSiteless, makeLayout, clientRender );
 	}
 
 	page(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new route & controller for the siteless thank-you page.
* Sets the post-checkout redirect (the Thank You page url) to: `/checkout/jetpack/thank-you/no-site/:product?ticketId=321312`
* Adds  new `JetpackSitelessCheckoutThankYou` component & scss styles for rendering the post checkout thank-you page (for _siteless_ purchases).

Still TODO:
- On submitting the website address input, we still need to dispatch a post request to WPCOM with the site address and the and the user email address to some endpoint so we can append the site address(url) to the ZendDesk ticket (which will be created on the wpcom backend after purchase is completed).
- On successful response(of above request), we need to redirect to a "schedule 15min Happiness support" page. (Calendly?)
- Figure out/create the correct link (Calendly link?) for the "schedule a 15 min call now" link. (currently the link is incorrect and not working correctly)
- Figure out how to pass the Zendesk ticket ID (created on the wpcom backend after transaction completed) back to the Calypso checkout thank-you page.

Asana task: 1200479326344990-as-1200481482484418

#### Testing instructions

1. Patch your WPCOM sandbox with D63168-code. (we need this to be able to complete the _site-less_ checkout)
2. Add `define( 'USE_STORE_SANDBOX', true );` to `wp-content/mu-plugins/0-sandbox.php`
3. Sandbox `public-api.wordpress.com`.
4. Download this PR.
5. Edit the `config/development.json` file and enable the `jetpack/siteless-checkout` feature flag.
6. Start Calypso with `yarn start`. You need to do this since this PR introduces a new feature flag.
7. Visit http://calypso.localhost:3000/checkout/jetpack/jetpack_scan on a window where you are **not** logged-in to WordPress.com.
8. Complete checkout (using an email address that is **not** already associated with a WordPress.com account).
9. Make sure you are redirected to the siteless Thank You page. ( `http://calypso.localhost:3000/checkout/jetpack/thank-you/no-site/jetpack_scan`).
10. Verify the Thank You page looks like the screenshot below and like the figma design link, located in the Asana task(link above).
11. Open the browser console and enter: `localStorage.debug='calypso:analytics*'`
12. Reload the page and check the Tracks events:
    - Verify the Page View event is firing on page load.
    - Verify the `calypso_siteless_checkout_install_instructions_link_clicked` event fires when clicking the, "instructions we put together here" link. Verify the `product_slug` property  and value. Verify that the link opens `https://jetpack.com/support/getting-started-with-jetpack/` in a new tab.
    - Verify the `calypso_siteless_checkout_happiness_link_clicked` event fires when clicking the "schedule a 15 min call now" link. Verify the `product_slug` property and value.
13. Verify the "Continue" button is disabled until something is entered into the input field.
14. In the Website address field, enter a site address and click "Continue" button.  Verify the `calypso_siteless_checkout_submit_website_address` event fires. Verify `product_slug`, and `site_url` properties and values.

**Run unit test:**
`yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`
Verify all tests pass.

#### Screenshot

<img width="1491" alt="Screenshot on 2021-07-02 at 09-34-23" src="https://user-images.githubusercontent.com/11078128/124304774-3345eb00-db32-11eb-932f-a2de4c5a3e50.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
