### PR TITLE
Site-only Jetpack Checkout: allow logged-in users coming from the Pricing page

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -86,9 +86,12 @@ export function checkout( context, next ) {
 	const jetpackPurchaseToken = context.query.purchasetoken;
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
 	const isUserComingFromLoginForm = context.query?.flow === 'logged-out-checkout';
+	const isUserComingFromPlansPage = [ 'jetpack-plans', 'jetpack-connect-plans' ].includes(
+		context.query?.source
+	);
 	const isJetpackCheckout =
 		context.pathname.includes( '/checkout/jetpack' ) &&
-		( isLoggedOut || isUserComingFromLoginForm ) &&
+		( isLoggedOut || isUserComingFromLoginForm || isUserComingFromPlansPage ) &&
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const jetpackSiteSlug = context.params.siteSlug;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Open the site-only Jetpack Checkout to logged-in users who came from the Pricing page. Without this change, the checkout flow that starts on the Plans tab (located in wp-admin) doesn't work for logged-in users. In this case, users end up seeing the Site Selection page rather than the Checkout one.

#### Testing instructions

* Download this PR and start Calypso with `yarn start`.
* Open a window where you are logged in to WordPress.com.
* Create a JN site with Jetpack Beta enabled and make sure to use the Release Candidate version.
* Connect the site without connecting your WP.com user account. It might be easier to do it on a window where you are not logged in ( you can close this window after you connect the site ).
* Click on the Plans tab located at the Jetpack module ( wp-admin ) from the window where you're logged in.
* Once you're on the Pricing page, copy the link to check out of any Jetpack product and replace `wordpress.com` with `calypso.localhost:3000`.
* Paste the URL and verify that you see the checkout form.
* Complete the purchase.

Related to 1200152453830945-as-1200537443108669


#### Demo – before
![image](https://user-images.githubusercontent.com/3418513/124306937-119a3300-db35-11eb-85c5-bc3c7cec2b91.png)

#### Demo – after
![image](https://user-images.githubusercontent.com/3418513/124306959-1b239b00-db35-11eb-8176-df36f8986ef0.png)
