### PR TITLE
[ETK/error-reporting] Activate sentry for a segment of users 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
 import apiFetch from '@wordpress/api-fetch';
 
-const shouldActivateSentry = window.dataFromPHP?.shouldActivateSentry === 'true';
+const shouldActivateSentry = window.A8C_FSE_ErrorReporting_Config?.shouldActivateSentry === 'true';
 /**
  * Errors that happened before this script had a chance to load
  * are captured in a global array. See `./index.php`.

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -3,13 +3,7 @@ import apiFetch from '@wordpress/api-fetch';
 import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
 
-const dataFromPHP = window.dataFromPHP;
-const shouldActivateSentry =
-	typeof dataFromPHP === 'object' && typeof dataFromPHP.shouldActivateSentry === 'string'
-		? dataFromPHP.shouldActivateSentry === 'true'
-		: false;
-
-console.debug( dataFromPHP );
+const shouldActivateSentry = window.dataFromPHP?.shouldActivateSentry === 'true';
 
 function activateSentry() {
 	console.debug( '[error-reporting] Activating Sentry!' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -6,6 +6,7 @@ import { Integrations } from '@sentry/tracing';
 const dataFromPHP = window.dataFromPHP;
 
 function activateSentry() {
+	console.debug( 'Activating Sentry!' );
 	Sentry.init( {
 		dsn: 'https://732ae01df1fe4974820b55d2c14028fa@o892859.ingest.sentry.io/5840079',
 		integrations: [ new Integrations.BrowserTracing() ],
@@ -19,6 +20,7 @@ function activateSentry() {
 
 // Activate the home-brew error-reporting
 function activateHomebrewErrorReporting() {
+	console.debug( 'Activating homebrew error-reporting!' );
 	/**
 	 * Errors that happened before this script had a chance to load
 	 * are captured in a global array. See `./index.php`.

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -4,9 +4,15 @@ import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
 
 const dataFromPHP = window.dataFromPHP;
+const shouldActivateSentry =
+	typeof dataFromPHP === 'object' && typeof dataFromPHP.shouldActivateSentry === 'string'
+		? dataFromPHP.shouldActivateSentry === 'true'
+		: false;
+
+console.debug( dataFromPHP );
 
 function activateSentry() {
-	console.debug( 'Activating Sentry!' );
+	console.debug( '[error-reporting] Activating Sentry!' );
 	Sentry.init( {
 		dsn: 'https://732ae01df1fe4974820b55d2c14028fa@o892859.ingest.sentry.io/5840079',
 		integrations: [ new Integrations.BrowserTracing() ],
@@ -20,7 +26,7 @@ function activateSentry() {
 
 // Activate the home-brew error-reporting
 function activateHomebrewErrorReporting() {
-	console.debug( 'Activating homebrew error-reporting!' );
+	console.debug( '[error-reporting] Activating homebrew error-reporting!' );
 	/**
 	 * Errors that happened before this script had a chance to load
 	 * are captured in a global array. See `./index.php`.
@@ -66,7 +72,7 @@ function activateHomebrewErrorReporting() {
 	Promise.allSettled( headErrors.map( reportError ) ).then( () => delete window._jsErr );
 }
 
-if ( dataFromPHP.activateSentry ) {
+if ( shouldActivateSentry ) {
 	activateSentry();
 } else {
 	activateHomebrewErrorReporting();

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -1,14 +1,13 @@
-import apiFetch from '@wordpress/api-fetch';
-
 import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
+import apiFetch from '@wordpress/api-fetch';
 
 const shouldActivateSentry = window.dataFromPHP?.shouldActivateSentry === 'true';
 
 function activateSentry() {
 	console.debug( '[error-reporting] Activating Sentry!' );
 	Sentry.init( {
-		dsn: 'https://732ae01df1fe4974820b55d2c14028fa@o892859.ingest.sentry.io/5840079',
+		dsn: 'https://658ae291b00242148af6b76494d4a49a@o248881.ingest.sentry.io/5876245',
 		integrations: [ new Integrations.BrowserTracing() ],
 
 		// Set tracesSampleRate to 1.0 to capture 100%

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
 import apiFetch from '@wordpress/api-fetch';
 
-const shouldActivateSentry = window.A8C_FSE_ErrorReporting_Config?.shouldActivateSentry === 'true';
+const shouldActivateSentry = window.A8C_ETK_ErrorReporting_Config?.shouldActivateSentry === 'true';
 /**
  * Errors that happened before this script had a chance to load
  * are captured in a global array. See `./index.php`.

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -11,7 +11,6 @@ const headErrors = window._jsErr || [];
 const headErrorHandler = window._headJsErrorHandler;
 
 function activateSentry() {
-	console.debug( '[error-reporting] Activating Sentry!' );
 	Sentry.init( {
 		dsn: 'https://658ae291b00242148af6b76494d4a49a@o248881.ingest.sentry.io/5876245',
 		integrations: [ new Integrations.BrowserTracing() ],
@@ -29,7 +28,6 @@ function activateSentry() {
 
 // Activate the home-brew error-reporting
 function activateHomebrewErrorReporting() {
-	console.debug( '[error-reporting] Activating homebrew error-reporting!' );
 	const reportError = ( { error } ) => {
 		// Sanitized error event objects do not include a nested error attribute. In
 		// that case, we return early to prevent a needless TypeError when defining

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -1,45 +1,71 @@
 import apiFetch from '@wordpress/api-fetch';
 
-/**
- * Errors that happened before this script had a chance to load
- * are captured in a global array. See `./index.php`.
- */
-const headErrors = window._jsErr || [];
-const headErrorHandler = window._headJsErrorHandler;
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
 
-const reportError = ( { error } ) => {
-	// Sanitized error event objects do not include a nested error attribute. In
-	// that case, we return early to prevent a needless TypeError when defining
-	// `data`, below. Also, sanitized errors don't include any useful information,
-	// so the sensible thing to do is to completely ignore them.
-	if ( ! error ) {
-		return;
-	}
+const dataFromPHP = window.dataFromPHP;
 
-	const data = {
-		message: error.message,
-		trace: error.stack,
-		url: document.location.href,
-		feature: 'wp-admin',
+function activateSentry() {
+	Sentry.init( {
+		dsn: 'https://732ae01df1fe4974820b55d2c14028fa@o892859.ingest.sentry.io/5840079',
+		integrations: [ new Integrations.BrowserTracing() ],
+
+		// Set tracesSampleRate to 1.0 to capture 100%
+		// of transactions for performance monitoring.
+		// We recommend adjusting this value in production
+		tracesSampleRate: 1.0,
+	} );
+}
+
+// Activate the home-brew error-reporting
+function activateHomebrewErrorReporting() {
+	/**
+	 * Errors that happened before this script had a chance to load
+	 * are captured in a global array. See `./index.php`.
+	 */
+	const headErrors = window._jsErr || [];
+	const headErrorHandler = window._headJsErrorHandler;
+
+	const reportError = ( { error } ) => {
+		// Sanitized error event objects do not include a nested error attribute. In
+		// that case, we return early to prevent a needless TypeError when defining
+		// `data`, below. Also, sanitized errors don't include any useful information,
+		// so the sensible thing to do is to completely ignore them.
+		if ( ! error ) {
+			return;
+		}
+
+		const data = {
+			message: error.message,
+			trace: error.stack,
+			url: document.location.href,
+			feature: 'wp-admin',
+		};
+
+		return (
+			apiFetch( {
+				global: true,
+				path: '/rest/v1.1/js-error',
+				method: 'POST',
+				data: { error: JSON.stringify( data ) },
+			} )
+				// eslint-disable-next-line no-console
+				.catch( () => console.error( 'Error: Unable to record the error in Logstash.' ) )
+		);
 	};
 
-	return (
-		apiFetch( {
-			global: true,
-			path: '/rest/v1.1/js-error',
-			method: 'POST',
-			data: { error: JSON.stringify( data ) },
-		} )
-			// eslint-disable-next-line no-console
-			.catch( () => console.error( 'Error: Unable to record the error in Logstash.' ) )
-	);
-};
+	window.addEventListener( 'error', reportError );
 
-window.addEventListener( 'error', reportError );
+	// Remove the head handler as it's not needed anymore after we set the main one above
+	window.removeEventListener( 'error', headErrorHandler );
+	delete window._headJsErrorHandler;
 
-// Remove the head handler as it's not needed anymore after we set the main one above
-window.removeEventListener( 'error', headErrorHandler );
-delete window._headJsErrorHandler;
+	// We still need to report the head errors, if any.
+	Promise.allSettled( headErrors.map( reportError ) ).then( () => delete window._jsErr );
+}
 
-// We still need to report the head errors, if any.
-Promise.allSettled( headErrors.map( reportError ) ).then( () => delete window._jsErr );
+if ( dataFromPHP.activateSentry ) {
+	activateSentry();
+} else {
+	activateHomebrewErrorReporting();
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -88,11 +88,12 @@ function is_atomic() {
  * Enqueue assets
  */
 function enqueue_script() {
-	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/error-reporting.asset.php';
-	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
-	$script_version      = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/error-reporting.js' );
-	$script_id           = 'a8c-fse-error-reporting-script';
-	$user_id             = get_current_user_id();
+	$asset_file             = include plugin_dir_path( __FILE__ ) . 'dist/error-reporting.asset.php';
+	$script_dependencies    = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
+	$script_version         = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/error-reporting.js' );
+	$script_id              = 'a8c-fse-error-reporting-script';
+	$user_id                = get_current_user_id();
+	$should_activate_sentry = ( user_is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry' ) ) || user_in_sentry_test_segment( $user_id );
 
 	wp_enqueue_script(
 		$script_id,
@@ -106,7 +107,7 @@ function enqueue_script() {
 		$script_id,
 		'dataFromPHP',
 		array(
-			'activateSentry' => ( user_is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry' ) ) || user_in_sentry_test_segment( $user_id ),
+			'shouldActivateSentry' => $should_activate_sentry ? 'true' : 'false',
 		)
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -61,21 +61,6 @@ function user_in_sentry_test_segment( $user_id ) {
 }
 
 /**
- * Returns whether or not the user is an automattician, but first verifies
- * if the function `is_automattician` exists in the current context. If not,
- * then we consider the user to not be an automattician. This guard is needed
- * because this function is not present in some envs, namely the testing env.
- *
- * @todo Remove once roll-out is complete
- *
- * @param int $user_id the user id.
- * @return bool
- */
-function user_is_automattician( $user_id ) {
-	return function_exists( __NAMESPACE__ . '\is_automattician' ) && is_automattician( $user_id );
-}
-
-/**
  * Returns whether or not the site loading ETK is in the WoA env.
  *
  * @return bool
@@ -97,8 +82,8 @@ function is_atomic() {
  * Used to check if the sticker is applied if user is A8C.
  */
 function should_activate_sentry( $user_id, $blog_id ) {
-	return ( user_is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry', $blog_id ) )
-		|| ( ! user_is_automattician( $user_id ) && user_in_sentry_test_segment( $user_id ) );
+	return ( is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry', $blog_id ) )
+		|| ( ! is_automattician( $user_id ) && user_in_sentry_test_segment( $user_id ) );
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -41,31 +41,38 @@ function add_crossorigin_to_script_els( $tag ) {
 }
 
 /**
- * Enqueue assets
+ * Temporary function to feature flag Sentry by segment. We'll be testing
+ * it on production (simple sites) for a while to see if it's feasible to
+ * activate it for all sites and perhaps get rid of our custom solution.
+ * If it works well, we'll activate for all simple sites and look into.
+ * activating it for WoA, too.
+ *
+ * @param int $user_id the user id.
+ * @return bool
  */
-function enqueue_script() {
-	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/error-reporting.asset.php';
-	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
-	$script_version      = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/error-reporting.js' );
+function user_in_sentry_test_segment( $user_id ) {
+	$current_segment = 10; // segment of existing users that will get this feature in %.
+	$user_segment    = $user_id % 100;
 
-	wp_enqueue_script(
-		'a8c-fse-error-reporting-script',
-		plugins_url( 'dist/error-reporting.js', __FILE__ ),
-		$script_dependencies,
-		$script_version,
-		true
-	);
+	// We get the last two digits of the user id and that will be used to decide in what
+	// segment the user is. i.e if current_segment is 10, then only ids that end in < 10
+	// will be considered part of the segment.
+	return $user_segment < $current_segment;
 }
 
 /**
- * Effectivelly activates the error reporting module by setting the necessary hooks.
+ * Returns whether or not the user is an automattician, but first verifies
+ * if the function `is_automattician` exists in the current context. If not,
+ * then we consider the user to not be an automattician. This guard is needed
+ * because this function is not present in some envs, namely the testing env.
+ *
+ * @todo Remove once roll-out is complete
+ *
+ * @param int $user_id the user id.
+ * @return bool
  */
-function activate_error_reporting() {
-	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler' );
-	add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_crossorigin_to_script_els', 99, 2 );
-	// We load as last as possible for perf reasons. The head handler will
-	// capture errors until the main handler is loaded.
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
+function user_is_automattician( $user_id ) {
+	return function_exists( 'is_automattician' ) && is_automattician( $user_id );
 }
 
 /**
@@ -77,8 +84,49 @@ function is_atomic() {
 	return defined( 'IS_ATOMIC' ) && IS_ATOMIC;
 }
 
+/**
+ * Enqueue assets
+ */
+function enqueue_script() {
+	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/error-reporting.asset.php';
+	$script_dependencies = isset( $asset_file['dependencies'] ) ? $asset_file['dependencies'] : array();
+	$script_version      = isset( $asset_file['version'] ) ? $asset_file['version'] : filemtime( plugin_dir_path( __FILE__ ) . 'dist/error-reporting.js' );
+	$script_id           = 'a8c-fse-error-reporting-script';
+	$user_id             = get_current_user_id();
+
+	wp_enqueue_script(
+		$script_id,
+		plugins_url( 'dist/error-reporting.js', __FILE__ ),
+		$script_dependencies,
+		$script_version,
+		true
+	);
+
+	wp_localize_script(
+		$script_id,
+		'dataFromPHP',
+		array(
+			'activateSentry' => ( user_is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry' ) ) || user_in_sentry_test_segment( $user_id ),
+		)
+	);
+}
+
+/**
+ * Setup the error reporting module by setting the necessary hooks. Whether or not we get the
+ * homebrew version or Sentry is decided inside the `enqueue_script` function, stored in a bool
+ * var, and passed over to the clientside script (index.js) which will then use this value to
+ * decide what tool to activate.
+ */
+function setup_error_reporting() {
+	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler' );
+	add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_crossorigin_to_script_els', 99, 2 );
+	// We load as last as possible for perf reasons. The head handler will
+	// capture errors until the main handler is loaded.
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
+}
+
 // We don't want to activate this module in AT just yet. See https://wp.me/p4TIVU-9DI#comment-10922.
 // @todo Remove once we have a version that works for WPCOM simple sites and WoA.
 if ( ! is_atomic() ) {
-	activate_error_reporting();
+	setup_error_reporting();
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -120,7 +120,7 @@ function enqueue_script() {
  * decide what tool to activate.
  */
 function setup_error_reporting() {
-	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler' );
+	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler', 0 );
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_crossorigin_to_script_els', 99, 2 );
 	// We load as last as possible for perf reasons. The head handler will
 	// capture errors until the main handler is loaded.

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -76,6 +76,7 @@ function user_in_sentry_test_segment( $user_id ) {
 function is_atomic() {
 	return defined( 'IS_ATOMIC' ) && IS_ATOMIC;
 }
+
 /**
  * Return whether Sentry should be activated for a given user.
  *
@@ -113,7 +114,7 @@ function enqueue_script() {
 
 	wp_localize_script(
 		$script_id,
-		'dataFromPHP',
+		'A8C_FSE_ErrorReporting_Config',
 		array(
 			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
 		)

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -51,7 +51,7 @@ function add_crossorigin_to_script_els( $tag ) {
  * @return bool
  */
 function user_in_sentry_test_segment( $user_id ) {
-	$current_segment = 10; // segment of existing users that will get this feature in %.
+	$current_segment = 1; // segment of existing users that will get this feature in %.
 	$user_segment    = $user_id % 100;
 
 	// We get the last two digits of the user id and that will be used to decide in what

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -114,7 +114,7 @@ function enqueue_script() {
 
 	wp_localize_script(
 		$script_id,
-		'A8C_FSE_ErrorReporting_Config',
+		'A8C_ETK_ErrorReporting_Config',
 		array(
 			'shouldActivateSentry' => should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
 		)

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -20,6 +20,14 @@ function head_error_handler() {
 			window._jsErr.push( errEvent );
 		}
 		window.addEventListener( 'error', window._headJsErrorHandler );
+		// Test code, will be removed later. Simulate several errors happening at about the same time.
+		let count = 0;
+		let intervalId;
+		intervalId = setInterval(() => {
+			count = count + 1;
+			if ( count >= 3 ) clearInterval( intervalId );
+			throw new Error( `Head error ${count} from the top-level document`);
+		}, 0 );
 	</script>
 	<?php
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -20,14 +20,6 @@ function head_error_handler() {
 			window._jsErr.push( errEvent );
 		}
 		window.addEventListener( 'error', window._headJsErrorHandler );
-		// Test code, will be removed later. Simulate several errors happening at about the same time.
-		let count = 0;
-		let intervalId;
-		intervalId = setInterval(() => {
-			count = count + 1;
-			if ( count >= 3 ) clearInterval( intervalId );
-			throw new Error( `Head error ${count} from the top-level document`);
-		}, 0 );
 	</script>
 	<?php
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/bootstrap.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/bootstrap.php
@@ -61,3 +61,24 @@ remove_filter( 'wp_die_handler', 'fail_if_died' );
 
 // Don't let deprecation notices cause tests to fail.
 PHPUnit\Framework\Error\Deprecated::$enabled = false;
+
+// Global function stubs that might be needed by all tests.
+
+/**
+ * Stub for the `is_automattician` function.
+ *
+ * This function is only used by the `class-errorreporting-activation-test.php`
+ * test at the moment. It needs to be defined here because for some reason it's
+ * not loaded by default globally in the test env,and since it's when the error
+ * reporting php module is loaded, and since all modules are loaded here for
+ * each test, defining it globally here is needed in order to not break the
+ * tests due to it being undefined.
+ *
+ * Check the `class-errorreporting-activation-test.php` test to make sense
+ * of the implementation here.
+ *
+ * @param int $user_id The user id.
+ */
+function is_automattician( $user_id ) {
+	return ( 8898 === $user_id || 8808 === $user_id );
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -2,15 +2,18 @@
 /**
  * Error Reporting Activation Test File.
  *
- * Unit tests Sentry/homebrew error reporting activation logic. This
- * test file should be ephemeral and will be removed once we decide
- * which solution to use.
+ * Unit-tests the Sentry/homebrew error reporting activation logic.
+ * This test file should be ephemeral and will be removed once we
+ * decide which solution to use.
  *
- * It's here to make it easier to test the the weakest link in the
- * logic chain in terms of complexity. The rest of the error reporting
- * module is easier to test manually and harder (and probably not worth
- * the time and effort) to write automate tests for. I think this provides
- * for a good pragmatic balance. -Marcelo.
+ * The rest of the error reporting module is easier to test manually,
+ * and harder (and probably not worth the time and effort) to write
+ * automated tests for. In fact, if we choose to use Sentry, then
+ * it'll pretty much only add a snippet (maybe with some additional
+ * conditional logic for WoA).
+ *
+ * I think this provides for a good pragmatic balance in giving
+ * us confidence. -Marcelo.
  *
  * @package full-site-editing-plugin
  */
@@ -112,7 +115,7 @@ class ErrorReporting_Activation_Test extends TestCase {
 	 * Tests that the `should_activate_sentry` function returns `false` for an a11n
 	 * user id if the current blog does not have the sticker applied.
 	 */
-	public function test_should_activate_sentry_false_if_a11n_without_sticker() {
+	public function test_should_activate_sentry_is_false_if_a11n_without_sticker() {
 		$this->assertFalse( should_activate_sentry( $this->a11n_user_id, $this->blog_without_sticker_id ) );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -22,14 +22,8 @@ namespace A8C\FSE\ErrorReporting;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * Stub for the is_automattician function
- *
- * @param int $user_id The user id.
- */
-function is_automattician( $user_id ) {
-	return ( 8898 === $user_id || 8808 === $user_id );
-}
+// Stub for the `is_automattician` function is in `bootstrap.php`.
+// See comments there for more info.
 
 /**
  * Stub for the has_blog_sticker function

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Error Reporting Activation Test File.
+ *
+ * Unit tests Sentry/homebrew error reporting activation logic. This
+ * test file should be ephemeral and will be removed once we decide
+ * which solution to use.
+ *
+ * It's here to make it easier to test the the weakest link in the
+ * logic chain in terms of complexity. The rest of the error reporting
+ * module is easier to test manually and harder (and probably not worth
+ * the time and effort) to write automate tests for. I think this provides
+ * for a good pragmatic balance. -Marcelo.
+ *
+ * @package full-site-editing-plugin
+ */
+
+namespace A8C\FSE\ErrorReporting;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Stub for the is_automattician function
+ *
+ * @param int $user_id The user id.
+ */
+function is_automattician( $user_id ) {
+	return ( 8898 === $user_id || 8808 === $user_id );
+}
+
+/**
+ * Stub for the has_blog_sticker function
+ *
+ * @param noop $sticker Not used.
+ * @param int  $blog_id The blog id.
+ */
+function has_blog_sticker( $sticker, $blog_id ) {
+	if ( 7731 === $blog_id ) {
+		return true;
+	}
+	if ( 7732 === $blog_id ) {
+		return false;
+	}
+}
+
+/**
+ * Class ErrorReporting_Activation_Test
+ */
+class ErrorReporting_Activation_Test extends TestCase {
+	/**
+	 * This should match the pct in `user_in_sentry_test_segment()` in
+	 * `../error-reporting/index.php`
+	 *
+	 * @var int $current_segment
+	 */
+	private $current_segment = 10;
+	/**
+	 * A dummy id that represents an a11n user. It's used in the `is_automattician`
+	 * stub defined above.
+	 *
+	 * @var int $a11n_user_id
+	 */
+	private $a11n_user_id = 8898;
+	/**
+	 * A dummy id that represents an a11n user that would fall in the segment.
+	 * It's used in the `is_automattician` stub defined above.
+	 *
+	 * @var int $a11n_user_id
+	 */
+	private $a11n_user_id_in_segment = 8808;
+	/**
+	 * A dummy id that represents a regular non-a11n user.
+	 *
+	 * @var int $a11n_user_id
+	 */
+	private $regular_user_id = 6600;
+	/**
+	 * A dummy id that represents an a11n user. It's used in the `is_automattician`
+	 * stub defined above.
+	 *
+	 * The sticker we're faking here is the `error-reporting-use-sentry`.
+	 * See: https://github.com/Automattic/wp-calypso/pull/54257.
+	 *
+	 * @var int $blog_with_sticker_id
+	 */
+	private $blog_with_sticker_id = 7731;
+
+	/**
+	 * A dummy id that represents an blog that has a sticker. It's used in the
+	 * `has_blog_sticker` defined above.
+	 *
+	 * @var int $blog_without_sticker_id
+	 */
+	private $blog_without_sticker_id = 7732;
+	/**
+	 * Represents a blog id we don't care about.Communicates that the id is not
+	 * really relevant in the given test context
+	 *
+	 * @var int $blog_noop_id
+	 */
+	private $blog_noop_id = 7733;
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `true` for an a11n
+	 * user id if the current blog has the sticker applied.
+	 */
+	public function test_should_activate_sentry_is_true_if_a11n_with_sticker() {
+		$this->assertTrue( should_activate_sentry( $this->a11n_user_id, $this->blog_with_sticker_id ) );
+	}
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `false` for an a11n
+	 * user id if the current blog does not have the sticker applied.
+	 */
+	public function test_should_activate_sentry_false_if_a11n_without_sticker() {
+		$this->assertFalse( should_activate_sentry( $this->a11n_user_id, $this->blog_without_sticker_id ) );
+	}
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `false` for an a11n
+	 * user that tested false for the sentry sticker but accidentally falls in the
+	 * test segment. A12s without the sticker that fall in the segment should not
+	 * have Sentry activated.
+	 */
+	public function test_should_activate_sentry_is_false_if_a11n_without_sticker_and_in_sentry_segment() {
+		$this->assertFalse( should_activate_sentry( $this->a11n_user_id_in_segment, $this->blog_without_sticker_id ) );
+	}
+
+	/**
+	 * Tests that the `should_activate_sentry` function returns `true` for the ids that fall
+	 * insidet the segment.
+	 */
+	public function test_should_activate_sentry_is_true_if_regular_user_in_sentry_segment() {
+		for ( $i = $this->regular_user_id; $i < $this->regular_user_id + $this->current_segment; $i++ ) {
+			$this->assertTrue( should_activate_sentry( $i, $this->blog_noop_id ) );
+		}
+	}
+	/**
+	 * Tests that the `should_activate_sentry` function returns `false` for the ids that fall outside
+	 * the test segment.
+	 */
+	public function test_should_activate_sentry_is_false_if_regular_user_outside_sentry_segment() {
+		for ( $i = $this->regular_user_id + $this->current_segment; $i <= $this->regular_user_id + 99; $i++ ) {
+			$this->assertFalse( should_activate_sentry( $i, $this->blog_noop_id ) );
+		}
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -50,7 +50,7 @@ class ErrorReporting_Activation_Test extends TestCase {
 	 *
 	 * @var int $current_segment
 	 */
-	private $current_segment = 10;
+	private $current_segment = 1;
 	/**
 	 * A dummy id that represents an a11n user. It's used in the `is_automattician`
 	 * stub defined above.

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit/class-errorreporting-activation-test.php
@@ -125,7 +125,7 @@ class ErrorReporting_Activation_Test extends TestCase {
 
 	/**
 	 * Tests that the `should_activate_sentry` function returns `true` for the ids that fall
-	 * insidet the segment.
+	 * inside the segment.
 	 */
 	public function test_should_activate_sentry_is_true_if_regular_user_in_sentry_segment() {
 		for ( $i = $this->regular_user_id; $i < $this->regular_user_id + $this->current_segment; $i++ ) {

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -103,6 +103,8 @@
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@automattic/typography": "^1.0.0",
 		"@babel/core": "^7.14.0",
+		"@sentry/browser": "^6.8.0",
+		"@sentry/tracing": "^6.8.0",
 		"@wordpress/a11y": "^2.15.3",
 		"@wordpress/api-fetch": "^4.0.0",
 		"@wordpress/base-styles": "^3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,69 @@
     lodash.merge "^4.4.0"
     postcss "^5.0.21"
 
+"@sentry/browser@^6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.8.0.tgz#023707cd2302f6818014e9a7e124856b2d064178"
+  integrity sha512-nxa71csHlG5sMHUxI4e4xxuCWtbCv/QbBfMsYw7ncJSfCKG3yNlCVh8NJ7NS0rZW/MJUT6S6+r93zw0HetNDOA==
+  dependencies:
+    "@sentry/core" "6.8.0"
+    "@sentry/types" "6.8.0"
+    "@sentry/utils" "6.8.0"
+    tslib "^1.9.3"
+
+"@sentry/core@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.8.0.tgz#bfac76844deee9126460c18dc6166015992efdc3"
+  integrity sha512-vJzWt/znEB+JqVwtwfjkRrAYRN+ep+l070Ti8GhJnvwU4IDtVlV3T/jVNrj6rl6UChcczaJQMxVxtG5x0crlAA==
+  dependencies:
+    "@sentry/hub" "6.8.0"
+    "@sentry/minimal" "6.8.0"
+    "@sentry/types" "6.8.0"
+    "@sentry/utils" "6.8.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.8.0.tgz#cb0f8509093919ed3c1ef98ef8cf63dc102a6524"
+  integrity sha512-hFrI2Ss1fTov7CH64FJpigqRxH7YvSnGeqxT9Jc1BL7nzW/vgCK+Oh2mOZbosTcrzoDv+lE8ViOnSN3w/fo+rg==
+  dependencies:
+    "@sentry/types" "6.8.0"
+    "@sentry/utils" "6.8.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.8.0.tgz#d6c3e4c96f231367aeb2b8a87a83b53d28e7c6db"
+  integrity sha512-MRxUKXiiYwKjp8mOQMpTpEuIby1Jh3zRTU0cmGZtfsZ38BC1JOle8xlwC4FdtOH+VvjSYnPBMya5lgNHNPUJDQ==
+  dependencies:
+    "@sentry/hub" "6.8.0"
+    "@sentry/types" "6.8.0"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.8.0.tgz#5baa4f2e66cd2e6851c213213017850f67e65f4b"
+  integrity sha512-3gDkQnmOuOjHz5rY7BOatLEUksANU3efR8wuBa2ujsPQvoLSLFuyZpRjPPsxuUHQOqAYIbSNAoDloXECvQeHjw==
+  dependencies:
+    "@sentry/hub" "6.8.0"
+    "@sentry/minimal" "6.8.0"
+    "@sentry/types" "6.8.0"
+    "@sentry/utils" "6.8.0"
+    tslib "^1.9.3"
+
+"@sentry/types@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.8.0.tgz#97fd531a0ed1e75e65b4a24b26509fb7c15eb7b8"
+  integrity sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA==
+
+"@sentry/utils@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.8.0.tgz#0ffafa5b69fe0cdeabad5c4a6cc68a426eaa6b37"
+  integrity sha512-OYlI2JNrcWKMdvYbWNdQwR4QBVv2V0y5wK0U6f53nArv6RsyO5TzwRu5rMVSIZofUUqjoE5hl27jqnR+vpUrsA==
+  dependencies:
+    "@sentry/types" "6.8.0"
+    tslib "^1.9.3"
+
 "@signal-noise/stylelint-scales@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@signal-noise/stylelint-scales/-/stylelint-scales-2.0.0.tgz#f81d31a75fd78f1883b9239f6ba8264bf56aa47a"
@@ -27655,6 +27718,11 @@ tslib@1.11.2, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
   integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27714,12 +27714,12 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.11.2, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
   integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
 
-tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## Changes proposed in this Pull Request

Load Sentry in the error-reporting ETK module that applies to wp-admin + Gutenberg, but only activate it for a segment of users (1% for now, using a simple modulus calc), and a12s' blogs that have the `error-reporting-use-sentry` sticker* applied. Keep activating our homebrew error-reporter for all other users.

*_Add the sticker with `wp --url=<your-wpcom-test-site-url> blog-stickers add --sticker=error-reporting-use-sentry --who=<your-wpcom-username>`. To remove just swap the `add` command with `remove`._

The goal is to experiment with Sentry and test its feasibility, while leaving our homebrew error-reporting active for all others. We're still using the same ETK module to do so (as it can make it easier to ship it to WoA later).

If everything goes well, we might deprecate our homebrew solution in favor of Sentry. More details: p9oQ9f-Ay-p2#comment-1075 and p9oQ9f-zY-p2#comment-1055 under the `Next` section 🤞🏻 

## Testing instructions

⚠️ Before testing any of the following scenarios, be sure to activate jsconcat in your WPCOM sandbox (apply this diff: D63665-code). This will start serving files from CDN domains (**i.e `s0.wp.com` -- be sure to sandbox this, too!**) which gets us closer to a production environment and allows us to test for CORS issues (for more details, see this systems-request: pMz3w-cCq-p2) ⚠️ 

### Happy-path: Sentry works when activated, verify it correctly captures JS errors on the editor page

1. Apply the `error-reporting-user-sentry` sticker to your sandboxed test blog (as an a11n, you can apply the `error-reporting-use-sentry` sticker to a blog (see command above) to instruct this module to activate Sentry);
2. Checkout this branch, `cd` to `apps/editing-toolkit`, and run `yarn dev --sync` to build and sync the custom ETK build to your sandbox;
2. You can then trigger an error manually [like this](https://github.com/Automattic/wp-calypso/pull/49485#issuecomment-828029870) from the editor page. Be sure to select the wp-admin iframe context (Gutenframe) if you're running the site through Calypso, or the error will be reported to the Calypso error reporter, instead!
3. Login to the A8C Sentry account and verify that the error has been captured in the `wpcom-gutenberg-wp-admin` project. Follow the instructions here: PCYsg-ldt-p2if you're not sure how to create your account and login).
4. Test "head" errors. These are errors that might happen before the error reporter (in this case, Sentry) has been loaded. In this case, it should be caught by and stored in a window-wise array, and then once the error reporting module is loaded - and after it activates Sentry  - it will then iterate through all of them and send them over the wire. There's currently some test code that will generate some exceptions for you. Verify that Sentry has 3 recent `Head error ${count} from the top-level document` errors shortly after you loaded the page.

### Additional scenarios

---

**UPDATE**: I [added](https://github.com/Automattic/wp-calypso/pull/54257/commits/05664a223a2d6bb04d4e2bb9044344373cc35f62) unit tests for the modulus segmentation/activation logic. See [here](https://github.com/Automattic/wp-calypso/pull/54257/commits/05664a223a2d6bb04d4e2bb9044344373cc35f62). I encourage to test these manually, too, since these are not integration tests, but we already have some further confidence in the core activation logic.

To run the tests:

`apps/editing-toolkit (try/sentry-for-a-segment-of-users●)$ yarn test:php`

@noahtallen Gave a good primer in this thread (slack): p1620858708150500-slack-C7YPUHBB2.

---

#### When loading a blog without the `error-reporting-use-sentry` applied as an a11n, the homebrew error is activated
1. Make sure your blog doesn't have the aforementioned sticker, remove it if necessary;
2. Checkout this branch, `cd` to `apps/editing-toolkit`, and run `yarn dev --sync` to build and sync the custom ETK build to your sandbox;
3. Load the editor and you should see `Activating homebrew error reporting!`, which means our version of error-reporting has been loaded instead _(`homebrew` here has nothing to do with the packaging tool, but is a way to refer to our own error-reporting solution, I'm trying to come up with a better term :))_

#### When loading a blog with the `error-reporting-use-sentry` applied as an a11n, Sentry is activated
1. Apply the `error-reporting-user-sentry` to your sandboxed test blog;
2. Checkout this branch, `cd` to `apps/editing-toolkit`, and run `yarn dev --sync` to build and sync the custom ETK build to your sandbox;
3. Load the editor and you should see `Activating Sentry!`
4. You can refer to the happy-path scenario above to further test Sentry and verify that it's capturing the errors.

#### Sentry is not activated for non-a12s:
1. In your sandbox, modify the `is_automattician` function to always return `false` (search for `function is_automattician` in opengrok to find where it's defined)
2. Checkout this branch, `cd` to `apps/editing-toolkit`, and run `yarn dev --sync` to build and sync the custom ETK build to your sandbox;
3. Load the editor and you should see `Activating homebrew error reporting!`, which means our version of error-reporting has been loaded instead.

#### Test the modulus segmentation logic works and that it loads the correct error reporter for each segment
1. Find out your user_id, you can output it using l( get_current_user_Id ) somewhere in the index.php for the error-reporting ETK module;
2. Let’s say your user_id is 7922883, this means you’d fall into the 84% segment. The default value in the test PR is `10`, so it should not load Sentry for you by default (it'd only load ids ending in 0-9). Try changing the `$current_segment` variable's value [here](https://github.com/Automattic/wp-calypso/blob/try/sentry-for-a-segment-of-users/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php#L54) to `84`, and then you should see `Activating Sentry` in the console.
3. Then change it to < 84 and you should see `Activating homebrew error reporting!` instead.

## Todo

- [ ] ~~Move the Sentry account data over to the config, in order to have different environments (staging, prod) - for now we'd probably only activate it on prod, though. See discussion: p1626280547282100/1625249660.115200-slack-C7YPUHBB2.~~

## Outstanding questions
- [ ] ~~Should we mutually activate each error reporting solution or would it make sense to activate both Sentry and our our error reporting at the same time?~~
- [x] What Sentry account to use? We can use the one I created using my A8C email (search for `Test Sentry account for WPCOM`  in the secret store) and move it to a Sentry-specific mailbox. This would require a systemsrequest to ask for the mailbox to be created.