### PR TITLE
Reinstate upgrade option for email forwards

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -279,7 +279,14 @@ const EmailPlan = ( props ) => {
 		);
 	}
 
-	const { domain, selectedSite, hasSubscription, purchase, isLoadingPurchase } = props;
+	const {
+		currentRoute,
+		domain,
+		selectedSite,
+		hasSubscription,
+		purchase,
+		isLoadingPurchase,
+	} = props;
 
 	// Ensure we check for email forwarding additions and removals
 	const shouldQueryEmailForwards = shouldCheckForEmailForwards( domain );
@@ -318,6 +325,12 @@ const EmailPlan = ( props ) => {
 			<div className="email-plan__actions">
 				<VerticalNav>
 					{ renderAddNewMailboxesOrRenewNavItem() }
+
+					<UpgradeNavItem
+						currentRoute={ currentRoute }
+						domain={ domain }
+						selectedSiteSlug={ selectedSite.slug }
+					/>
 
 					{ renderManageAllMailboxesNavItem() }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR reinstates the upgrade option for email forwards that was originally added in #53307, but unintentionally removed in #54133 when the component was refactored from a class component to a functional component

#### Testing instructions

* Open this branch locally or via the live branch
* Navigate to the email management page for a domain with email forwarding
* Verify that you see a button labeled "Upgrade to a hosted email"
* Confirm that clicking on the button takes you to the upgrade page added in #53307