### PR TITLE
Domains: Update outdated domain mapping mentions

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -131,17 +131,17 @@ class DomainSearchResults extends React.Component {
 			) {
 				if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
 					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for free.{{/small}}',
 						{ args: { domain }, components }
 					);
 				} else if ( ! domainsWithPlansOnly ) {
 					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for %(cost)s.{{/small}}',
 						{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
 					);
 				} else {
 					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.{{/small}}',
 						{ args: { domain }, components }
 					);
 				}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -227,7 +227,8 @@ class DomainSearchResults extends React.Component {
 		);
 	}
 
-	handleAddMapping = () => {
+	handleAddMapping = ( event ) => {
+		event.preventDefault();
 		this.props.onAddMapping( this.props.lastDomainSearched );
 	};
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -136,8 +136,8 @@ class DomainSearchResults extends React.Component {
 					);
 				} else if ( ! domainsWithPlansOnly ) {
 					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for %(cost)s.{{/small}}',
-						{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.{{/small}}',
+						{ args: { domain }, components }
 					);
 				} else {
 					offer = translate(

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -223,7 +223,11 @@ class DomainSearchResults extends React.Component {
 
 	handleAddMapping = ( event ) => {
 		event.preventDefault();
-		this.props.onAddMapping( this.props.lastDomainSearched );
+		if ( this.props.isSignupStep ) {
+			this.props.onClickMapping( event, this.props.lastDomainSearched );
+		} else {
+			this.props.onAddMapping( this.props.lastDomainSearched );
+		}
 	};
 
 	renderPlaceholders() {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -224,7 +224,7 @@ class DomainSearchResults extends React.Component {
 	handleAddMapping = ( event ) => {
 		event.preventDefault();
 		if ( this.props.isSignupStep ) {
-			this.props.onClickMapping( event, this.props.lastDomainSearched );
+			this.props.onClickMapping( event );
 		} else {
 			this.props.onAddMapping( this.props.lastDomainSearched );
 		}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -75,7 +75,6 @@ class DomainSearchResults extends React.Component {
 	renderDomainAvailability() {
 		const {
 			availableDomain,
-			domainsWithPlansOnly,
 			lastDomainIsTransferrable,
 			lastDomainStatus,
 			lastDomainSearched,
@@ -132,11 +131,6 @@ class DomainSearchResults extends React.Component {
 				if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
 					offer = translate(
 						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for free.{{/small}}',
-						{ args: { domain }, components }
-					);
-				} else if ( ! domainsWithPlansOnly ) {
-					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.{{/small}}',
 						{ args: { domain }, components }
 					);
 				} else {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -556,8 +556,8 @@ class TransferDomainStep extends React.Component {
 
 							this.setState( {
 								notice: this.props.translate(
-									"This domain is available to be registered, but we don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}. " +
-										'If you register it elsewhere, you can {{a}}map it{{/a}} instead.',
+									'This domain appears to be available for registration, however we do not offer registrations or accept transfers for domains ending in {{strong}}.%(tld)s{{/strong}}. ' +
+										'If you register it elsewhere, you can {{a}}connect it{{/a}} to your WordPress.com site instead.',
 									{
 										args: { tld },
 										components: {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -92,7 +92,7 @@ class DomainSearch extends Component {
 	};
 
 	handleAddMapping = ( domain ) => {
-		page( this.getDomainMappingUrl( domain ) );
+		this.isMounted && page( this.getDomainMappingUrl( domain ) );
 	};
 
 	getDomainMappingUrl = ( domain ) => {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -92,15 +92,15 @@ class DomainSearch extends Component {
 	};
 
 	handleAddMapping = ( domain ) => {
-		page.redirect( this.getDomainMappingUrl( domain ) );
+		page( this.getDomainMappingUrl( domain ) );
 	};
 
 	getDomainMappingUrl = ( domain ) => {
-		let url = '/domains/add/mapping/';
+		let url = '/domains/add/mapping';
 
 		if ( this.props.selectedSiteSlug ) {
 			const query = stringify( { initialQuery: domain.trim() } );
-			url += `${ this.props.selectedSiteSlug }?${ query }`;
+			url += `/${ this.props.selectedSiteSlug }?${ query }`;
 		}
 
 		return url;

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -92,7 +92,7 @@ class DomainSearch extends Component {
 
 	handleAddMapping = ( domain ) => {
 		const mappingUrl = `/domains/add/mapping/${ this.props.selectedSiteSlug }?initialQuery=${ domain }`;
-		page( mappingUrl );
+		page.redirect( mappingUrl );
 	};
 
 	handleAddTransfer = ( domain ) => {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
+import { stringify } from 'qs';
 import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
@@ -91,8 +92,18 @@ class DomainSearch extends Component {
 	};
 
 	handleAddMapping = ( domain ) => {
-		const mappingUrl = `/domains/add/mapping/${ this.props.selectedSiteSlug }?initialQuery=${ domain }`;
-		page.redirect( mappingUrl );
+		page.redirect( this.getDomainMappingUrl( domain ) );
+	};
+
+	getDomainMappingUrl = ( domain ) => {
+		let url = '/domains/add/mapping/';
+
+		if ( this.props.selectedSiteSlug ) {
+			const query = stringify( { initialQuery: domain.trim() } );
+			url += `${ this.props.selectedSiteSlug }?${ query }`;
+		}
+
+		return url;
 	};
 
 	handleAddTransfer = ( domain ) => {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -8,7 +8,6 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
-import { stringify } from 'qs';
 import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
@@ -49,6 +48,7 @@ import EmailVerificationGate from 'calypso/components/email-verification/email-v
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
+import { domainMapping } from 'calypso/my-sites/domains/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 
 /**
@@ -92,18 +92,8 @@ class DomainSearch extends Component {
 	};
 
 	handleAddMapping = ( domain ) => {
-		this.isMounted && page( this.getDomainMappingUrl( domain ) );
-	};
-
-	getDomainMappingUrl = ( domain ) => {
-		let url = '/domains/add/mapping';
-
-		if ( this.props.selectedSiteSlug ) {
-			const query = stringify( { initialQuery: domain.trim() } );
-			url += `/${ this.props.selectedSiteSlug }?${ query }`;
-		}
-
-		return url;
+		const domainMappingUrl = domainMapping( this.props.selectedSiteSlug, domain );
+		this.isMounted && page( domainMappingUrl );
 	};
 
 	handleAddTransfer = ( domain ) => {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -24,7 +24,6 @@ import { canDomainAddGSuite, getProductType } from 'calypso/lib/gsuite';
 import {
 	hasPlan,
 	hasDomainInCart,
-	domainMapping,
 	domainTransfer,
 	domainRegistration,
 	updatePrivacyForDomain,
@@ -92,13 +91,8 @@ class DomainSearch extends Component {
 	};
 
 	handleAddMapping = ( domain ) => {
-		this.props.shoppingCartManager
-			.addProductsToCart( [
-				fillInSingleCartItemAttributes( domainMapping( { domain } ), this.props.productsList ),
-			] )
-			.then( () => {
-				this.isMounted && page( '/checkout/' + this.props.selectedSiteSlug );
-			} );
+		const mappingUrl = `/domains/add/mapping/${ this.props.selectedSiteSlug }?initialQuery=${ domain }`;
+		page( mappingUrl );
 	};
 
 	handleAddTransfer = ( domain ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates some copy where outdated domain mapping information was being displayed. Two places were updated:
- Domain search notices
- Inbound domain transfer

In these places, in some conditions, domain mapping was mentioned as a stand-alone product, which we don't offer anymore. These mentions were removed and improved. Both sign-up and existing site domain flows were updated. Also, the call to action links in these mentions were updated to take the user to the domain mapping flow instead of to the plan selection or checkout pages, hopefully making the flows a little clearer.

This update was prompted by issues reported in p2MSmN-8uJ-p2.

* * *

## Sign-up flow

#### Before

When trying to register a domain with an unsupported TLD:

<img width="955" alt="Screen Shot 2021-07-02 at 22 32 27" src="https://user-images.githubusercontent.com/5324818/124339712-b1cc7800-db86-11eb-92a3-e103adfc55e9.png">

After clicking the CTA, the user was taken to the plan selection screen:

<img width="1318" alt="Screen Shot 2021-07-02 at 22 32 46" src="https://user-images.githubusercontent.com/5324818/124339763-fa843100-db86-11eb-856d-e078c9558017.png">

### After

<img width="955" alt="Screen Shot 2021-07-02 at 22 46 27" src="https://user-images.githubusercontent.com/5324818/124339822-64043f80-db87-11eb-8b27-6180a69a254d.png">

When clicking the updated CTA, the user is now taken to the domain mapping page, which has more explanations about how mapping works:

<img width="746" alt="Screen Shot 2021-07-02 at 22 46 35" src="https://user-images.githubusercontent.com/5324818/124339826-6a92b700-db87-11eb-938f-f4136ec38e3c.png">

## Domain management flow

### Before

When trying to add a domain with an unsupported TLD to an existing site:

<img width="1061" alt="Screen Shot 2021-07-02 at 22 49 28" src="https://user-images.githubusercontent.com/5324818/124339889-c78e6d00-db87-11eb-9343-13144c31c9d3.png">

When clicking the CTA, the user was taken straight to the checkout page:

<img width="577" alt="Screen Shot 2021-07-02 at 22 35 02" src="https://user-images.githubusercontent.com/5324818/124339920-fa386580-db87-11eb-86f2-afbd310bb5d2.png">

### After

<img width="1062" alt="Screen Shot 2021-07-02 at 23 07 19" src="https://user-images.githubusercontent.com/5324818/124340268-53a19400-db8a-11eb-96a7-858f5b7eadaa.png">

When clicking the updated CTA, the user is taken to the mapping page:

<img width="1066" alt="Screen Shot 2021-07-02 at 22 51 57" src="https://user-images.githubusercontent.com/5324818/124339957-26ec7d00-db88-11eb-913d-a76b233ba814.png">

## Testing instructions

You can test with the live Calypso link or locally by running this branch in your environment.

Please test both the sign-up flow (access the `/start` URL) and the domains management flow (in Calypso - `Upgrades > Domains`).

Domain search:
* In the domains search bar, input a domain with a TLD we don't offer (e.g. `yourgroovydomain.eu`) and ensure the notice does not mention a price to connect a domain (as we do not offer stand-alone domain mappings anymore).
* Click the CTA link (`connect it`) and ensure it takes you to the domain mapping page

Inbound domain transfer:
* In the inbound domain transfer page, input a domain with a TLD we don't offer (e.g. `yourgroovydomain.eu`) and ensure the text is the updated one:

<img width="750" alt="Screen Shot 2021-07-02 at 23 03 57" src="https://user-images.githubusercontent.com/5324818/124340194-ceb67a80-db89-11eb-8660-59e784fbe3bd.png">

* Click on the CTA and ensure you are taken to the domain mapping page.

<img width="746" alt="Screen Shot 2021-07-02 at 23 04 35" src="https://user-images.githubusercontent.com/5324818/124340200-e4c43b00-db89-11eb-8bda-501edd8f1430.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
