### PR TITLE
Redirect /me/concierge to /me/quickstart 

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -138,7 +138,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					<BusinessOnboarding
 						isWpcomPlan
 						onClick={ this.handleBusinessOnboardingClick }
-						link={ `/me/concierge/${ selectedSite.slug }/book` }
+						link={ `/me/quickstart/${ selectedSite.slug }/book` }
 					/>
 				) }
 				{ isWordadsInstantActivationEligible( selectedSite ) && (

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -602,7 +602,7 @@ class CancelPurchaseForm extends React.Component {
 		}
 		this.recordClickConciergeEvent();
 
-		return window.open( `/me/concierge/${ this.props.selectedSite.slug }/book` );
+		return window.open( `/me/quickstart/${ this.props.selectedSite.slug }/book` );
 	};
 
 	renderConciergeOffer = () => {

--- a/client/lib/analytics/test/utils.js
+++ b/client/lib/analytics/test/utils.js
@@ -38,7 +38,7 @@ describe( '#shouldReportOmitBlogId', () => {
 		expect( shouldReportOmitBlogId( '/tag' ) ).toBe( true );
 	} );
 	test( 'always returns false when :site is in the path', () => {
-		expect( shouldReportOmitBlogId( '/me/concierge/:site/book' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/me/quickstart/:site/book' ) ).toBe( false );
 		expect( shouldReportOmitBlogId( '/following/:site' ) ).toBe( false );
 	} );
 	test( 'always returns false when :site_id is in the path', () => {
@@ -46,10 +46,10 @@ describe( '#shouldReportOmitBlogId', () => {
 		expect( shouldReportOmitBlogId( '/sites/:site_id/external-media-upload' ) ).toBe( false );
 	} );
 	test( 'always returns false when :siteSlug is in the path', () => {
-		expect( shouldReportOmitBlogId( '/me/concierge/:siteSlug/:appointmentId/cancel' ) ).toBe(
+		expect( shouldReportOmitBlogId( '/me/quickstart/:siteSlug/:appointmentId/cancel' ) ).toBe(
 			false
 		);
-		expect( shouldReportOmitBlogId( '/me/concierge/:siteslug' ) ).toBe( false );
+		expect( shouldReportOmitBlogId( '/me/quickstart/:siteslug' ) ).toBe( false );
 	} );
 	test( 'always returns false when :siteId is in the path', () => {
 		expect( shouldReportOmitBlogId( '/jetpack/sso/:siteId?/:ssoNonce' ) ).toBe( false );

--- a/client/me/concierge/README.md
+++ b/client/me/concierge/README.md
@@ -6,11 +6,11 @@ rescheduling appointments.
 ## Supported routes
 
 ```js
-'/me/concierge'; // site selector step
-'/me/concierge/:siteSlug/book'; // booking concierge appointment wizard
-'/me/concierge/:siteSlug'; // redirects to calendar step for booking
-'/me/concierge/:siteSlug/:appointmentId/cancel'; // cancellation page for concierge appointment
-'/me/concierge/:siteSlug/:appointmentId/reschedule'; // rescheduling concierge appointments wizard
+'/me/quickstart'; // site selector step
+'/me/quickstart/:siteSlug/book'; // booking concierge appointment wizard
+'/me/quickstart/:siteSlug'; // redirects to calendar step for booking
+'/me/quickstart/:siteSlug/:appointmentId/cancel'; // cancellation page for concierge appointment
+'/me/quickstart/:siteSlug/:appointmentId/reschedule'; // rescheduling concierge appointments wizard
 ```
 
 ## Folder structure

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -58,7 +58,7 @@ class ConciergeCancel extends Component {
 		const { translate, siteSlug } = this.props;
 		return (
 			<>
-				<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
+				<HeaderCake backHref={ `/me/quickstart/${ siteSlug }/book` }>
 					{ translate( 'Reschedule or cancel' ) }
 				</HeaderCake>
 				<CompactCard>
@@ -91,7 +91,7 @@ class ConciergeCancel extends Component {
 					>
 						<Button
 							className="cancel__schedule-button"
-							href={ `/me/concierge/${ siteSlug }/book` }
+							href={ `/me/quickstart/${ siteSlug }/book` }
 							primary={ true }
 						>
 							{ translate( 'Schedule', {
@@ -128,7 +128,7 @@ class ConciergeCancel extends Component {
 							/>
 						) }
 
-						<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
+						<HeaderCake backHref={ `/me/quickstart/${ siteSlug }/book` }>
 							{ translate( 'Reschedule or cancel' ) }
 						</HeaderCake>
 						<Confirmation
@@ -143,7 +143,7 @@ class ConciergeCancel extends Component {
 									<Button
 										className="cancel__reschedule-button"
 										disabled={ disabledRescheduling }
-										href={ `/me/concierge/${ siteSlug }/${ appointmentId }/reschedule` }
+										href={ `/me/quickstart/${ siteSlug }/${ appointmentId }/reschedule` }
 									>
 										{ translate( 'Reschedule session' ) }
 									</Button>

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -26,7 +27,7 @@ import './style.scss';
 const book = ( context, next ) => {
 	context.primary = (
 		<ConciergeMain
-			analyticsPath="/me/concierge/:site/book"
+			analyticsPath="/me/quickstart/:site/book"
 			analyticsTitle="Concierge > Book"
 			skeleton={ BookSkeleton }
 			siteSlug={ context.params.siteSlug }
@@ -40,7 +41,7 @@ const book = ( context, next ) => {
 const cancel = ( context, next ) => {
 	context.primary = (
 		<ConciergeCancel
-			analyticsPath="/me/concierge/:site/:appointment/cancel"
+			analyticsPath="/me/quickstart/:site/:appointment/cancel"
 			analyticsTitle="Concierge > Cancel"
 			appointmentId={ context.params.appointmentId }
 			siteSlug={ context.params.siteSlug }
@@ -52,7 +53,7 @@ const cancel = ( context, next ) => {
 const reschedule = ( context, next ) => {
 	context.primary = (
 		<ConciergeMain
-			analyticsPath="/me/concierge/:site/:appointment/reschedule"
+			analyticsPath="/me/quickstart/:site/:appointment/reschedule"
 			analyticsTitle="Concierge > Reschedule"
 			appointmentId={ context.params.appointmentId }
 			skeleton={ RescheduleSkeleton }
@@ -74,9 +75,16 @@ const siteSelector = ( context, next ) => {
 	next();
 };
 
+const redirectToQuickStart = ( context, next ) => {
+	const newPath = context.path.replace( '/me/concierge/', '/me/quickstart/' );
+	page.redirect( newPath );
+	next();
+};
+
 export default {
 	book,
 	cancel,
 	reschedule,
 	siteSelector,
+	redirectToQuickStart,
 };

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -76,7 +76,7 @@ const siteSelector = ( context, next ) => {
 };
 
 const redirectToQuickStart = ( context, next ) => {
-	const newPath = context.path.replace( '/me/concierge/', '/me/quickstart/' );
+	const newPath = context.path.replace( '/me/concierge', '/me/quickstart' );
 	page.redirect( newPath );
 	next();
 };

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -12,26 +12,29 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
 
 const redirectToBooking = ( context ) => {
-	page.redirect( `/me/concierge/${ context.params.siteSlug }/book` );
+	page.redirect( `/me/quickstart/${ context.params.siteSlug }/book` );
 };
 
 export default () => {
-	page( '/me/concierge', controller.siteSelector, siteSelection, sites, makeLayout, clientRender );
+	page( '/me/concierge', controller.redirectToQuickStart, makeLayout, clientRender );
+	page( '/me/concierge/:siteSlug', redirectToBooking );
+	page( '/me/concierge/:siteSlug?/*', controller.redirectToQuickStart, makeLayout, clientRender );
+	page( '/me/quickstart', controller.siteSelector, siteSelection, sites, makeLayout, clientRender );
 
 	// redirect to booking page after site selection
-	page( '/me/concierge/:siteSlug', redirectToBooking );
+	page( '/me/quickstart/:siteSlug', redirectToBooking );
 
-	page( '/me/concierge/:siteSlug/book', controller.book, makeLayout, clientRender );
+	page( '/me/quickstart/:siteSlug/book', controller.book, makeLayout, clientRender );
 
 	page(
-		'/me/concierge/:siteSlug/:appointmentId/cancel',
+		'/me/quickstart/:siteSlug/:appointmentId/cancel',
 		controller.cancel,
 		makeLayout,
 		clientRender
 	);
 
 	page(
-		'/me/concierge/:siteSlug/:appointmentId/reschedule',
+		'/me/quickstart/:siteSlug/:appointmentId/reschedule',
 		controller.reschedule,
 		makeLayout,
 		clientRender

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -18,7 +18,7 @@ const redirectToBooking = ( context ) => {
 export default () => {
 	page( '/me/concierge', controller.redirectToQuickStart, makeLayout, clientRender );
 	page( '/me/concierge/:siteSlug', redirectToBooking );
-	page( '/me/concierge/:siteSlug?/*', controller.redirectToQuickStart, makeLayout, clientRender );
+	page( '/me/concierge/:siteSlug/*', controller.redirectToQuickStart, makeLayout, clientRender );
 	page( '/me/quickstart', controller.siteSelector, siteSelection, sites, makeLayout, clientRender );
 
 	// redirect to booking page after site selection

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -20,7 +20,7 @@ class ConfirmationStep extends Component {
 	handleClick = () => {
 		const { site } = this.props;
 
-		window.location.href = `/me/concierge/${ site.slug }/book`;
+		window.location.href = `/me/quickstart/${ site.slug }/book`;
 	};
 
 	render() {

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -97,7 +97,7 @@ class AppointmentInfo extends Component {
 
 					{ isAllowedToChangeAppointment && (
 						<FormFieldset>
-							<a href={ `/me/concierge/${ site.slug }/${ id }/cancel` } rel="noopener noreferrer">
+							<a href={ `/me/quickstart/${ site.slug }/${ id }/cancel` } rel="noopener noreferrer">
 								<FormButton isPrimary={ false } type="button">
 									{ translate( 'Reschedule or cancel' ) }
 								</FormButton>

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -72,7 +72,7 @@ class ConciergeBanner extends Component {
 					}
 				);
 				buttonText = translate( 'Session dashboard' );
-				buttonHref = '/me/concierge';
+				buttonHref = '/me/quickstart';
 				illustrationUrl = conciergeImage;
 				break;
 
@@ -87,7 +87,7 @@ class ConciergeBanner extends Component {
 					}
 				);
 				buttonText = translate( 'Schedule now' );
-				buttonHref = '/me/concierge';
+				buttonHref = '/me/quickstart';
 				illustrationUrl = conciergeImage;
 				break;
 
@@ -98,7 +98,7 @@ class ConciergeBanner extends Component {
 						'Quick Start Session is a one-on-one video session between the user and our support staff.',
 				} );
 				buttonText = translate( 'Schedule now' );
-				buttonHref = '/me/concierge';
+				buttonHref = '/me/quickstart';
 				illustrationUrl = conciergeImage;
 				break;
 

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -48,7 +48,7 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 						'your site and learn more about WordPress.com.'
 				) }
 				buttonText={ i18n.translate( 'Schedule a session' ) }
-				href={ `/me/concierge/${ selectedSite.slug }/book` }
+				href={ `/me/quickstart/${ selectedSite.slug }/book` }
 				onClick={ trackOnboardingButtonClick }
 			/>
 

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -365,7 +365,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		//Maybe record tracks event
 
-		window.location.href = '/me/concierge/' + selectedSite.slug + '/book';
+		window.location.href = '/me/quickstart/' + selectedSite.slug + '/book';
 	};
 
 	visitTitanWebmail = ( event ) => {

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -83,7 +83,7 @@ export default connect(
 					bumpStat( 'calypso_customer_home', 'view_quick_start_session_details' )
 				)
 			);
-			page( `/me/concierge/${ siteSlug }/book` );
+			page( `/me/quickstart/${ siteSlug }/book` );
 		},
 		reschedule: ( siteId, siteSlug, sessionId ) => ( dispatch ) => {
 			dispatch(
@@ -94,7 +94,7 @@ export default connect(
 					bumpStat( 'calypso_customer_home', 'reschedule_quick_start_session' )
 				)
 			);
-			page( `/me/concierge/${ siteSlug }/${ sessionId }/cancel` );
+			page( `/me/quickstart/${ siteSlug }/${ sessionId }/cancel` );
 		},
 	}
 )( QuickStart );

--- a/client/sections.js
+++ b/client/sections.js
@@ -41,7 +41,7 @@ const sections = [
 	},
 	{
 		name: 'concierge',
-		paths: [ '/me/concierge' ],
+		paths: [ '/me/concierge', '/me/quickstart' ],
 		module: 'calypso/me/concierge',
 		group: 'me',
 	},

--- a/packages/calypso-products/src/is-titan-mail.js
+++ b/packages/calypso-products/src/is-titan-mail.js
@@ -2,10 +2,6 @@ import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
 import { formatProduct } from './format-product';
 
 export function isTitanMail( product ) {
-	if ( ! product ) {
-		return false;
-	}
-
 	product = formatProduct( product );
 
 	return product.product_slug === TITAN_MAIL_MONTHLY_SLUG;

--- a/packages/calypso-products/src/is-titan-mail.js
+++ b/packages/calypso-products/src/is-titan-mail.js
@@ -2,6 +2,10 @@ import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
 import { formatProduct } from './format-product';
 
 export function isTitanMail( product ) {
+	if ( ! product ) {
+		return false;
+	}
+
 	product = formatProduct( product );
 
 	return product.product_slug === TITAN_MAIL_MONTHLY_SLUG;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the Quick Start session scheduler URL from /me/concierge to /me/quickstart
* Change the appointment booking, rescheduling, and canceling URLs to /me/quickstart counterparts
* For backwards compatibility, the /me/concierge links will still work but redirect to /me/quickstart

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a Quick Start session product and visit the scheduler at /me/quickstart. Verify that it opens the appointment scheduler correctly and that you are able to schedule an appointment.
* Visit /me/concierge and verify that you get redirected to /me/quickstart
* After booking an appointment, visit the session dashboard at /me/quickstart and click on the "Reschedule or cancel" button. Confirm that reschedule and cancel URLs go to the /me/quickstart version of the URL. Replace quickstart with concierge in those URLs and verify that they still work.
* Purchase an eCommerce plan and on the Thank You page, click on the schedule session link. Confirm that you're taken to /me/quickstart.
* Purchase a Quick Start product and then visit /me/purchases. You should see a banner at the top asking to schedule your session. Click on the banner CTA and confirm that you're taken to /me/quickstart.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 100-concierge-admin-gh and p8hWIX-3px-p2#comment-2367
