### PR TITLE
chore(renovate): Add a group for @testing-library packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,11 @@
 			"prPriority": 1
 		},
 		{
+			"groupName": "eslint packages",
+			"matchPackagePatterns": [ "^eslint" ],
+			"prPriority": 1
+		},
+		{
 			"groupName": "Testing library",
 			"matchPackagePrefixes": [ "@testing-library" ],
 			"prPriority": 1

--- a/renovate.json
+++ b/renovate.json
@@ -44,8 +44,8 @@
 			"prPriority": 1
 		},
 		{
-			"groupName": "eslint packages",
-			"matchPackagePatterns": [ "^eslint" ],
+			"groupName": "Testing library",
+			"matchPackagePrefixes": [ "@testing-library" ],
 			"prPriority": 1
 		}
 	],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a group for `@testing-library/*` packages so Renovate updates them in the same PR.

Relevant docs: https://docs.renovatebot.com/configuration-options/#matchpackagepatterns, https://docs.renovatebot.com/configuration-options/#packagerules

#### Testing instructions

N/A