### PR TITLE
Boot: Pass user ID when retrieving initial state

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -433,7 +433,7 @@ const boot = ( currentUser, registerRoutes ) => {
 	saveOauthFlags();
 	utils();
 	loadAllState().then( () => {
-		const initialState = getInitialState( initialReducer );
+		const initialState = getInitialState( initialReducer, currentUser.get()?.ID );
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		setStore( reduxStore );
 		onDisablePersistence( persistOnChange( reduxStore, currentUser.get()?.ID ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #53888 we updated the mechanism for passing the current user to the Calypso app boot. As part of that, we are now passing down the current user ID to the initial state and persistence mechanisms, where it's used as part of the redux storage key. However, in #53888 we forgot to pass the current user ID to the `getInitialState()` function, and that essentially broke the persistence of the root state tree, which still includes some essential persisted trees (for example, `sites`, which is one of the biggest trees we persist). 

#### Testing instructions

* Checkout this branch and run it locally.
* Make sure you're logged into WP.com.
* Clear all your local application state for Calypso (except for cookies).
* Navigate through Calypso a bit - reader, my sites, etc.
* If you decided to test it on `calypso.live`, add `?debug` to the URL, so the global `state` var will be available.
* Make sure that when you type `state.sites.items` it returns all your sites.
* Close the tab and open a new one.
* Quickly type `state.sites.items` and verify the sites are still there.
* Alternatively, add a `console.log( storedState );` just below [this line](https://github.com/Automattic/wp-calypso/blob/fix/initial-state-current-id/client/state/initial-state.js#L185) and verify the object contains all your sites in `sites.items`.

#### Context

Discovered by @scinos as he saw a performance regression since #53888 was merged.