### PR TITLE
Code owners: add Ground control to monitor node version changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -127,3 +127,6 @@
 # E2E specs
 /test/e2e @WunderBart @scinos @Automattic/quality-squad
 /packages/calypso-e2e @worldomonation
+
+# Node updates
+/.nvmrc @Automattic/ground-control


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Ground Control aims to push Node version updates at the same time as Calypso updates their version.﻿Internal reference: p9dueE-39L-p2

#### Testing instructions

Not much to test here.
