### PR TITLE
Janitorial: Remove more unused component state

### DIFF
--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -53,7 +53,6 @@ class CalendarButton extends Component {
 	state = { showPopover: false };
 
 	setDate = ( date ) => {
-		this.setState( { date } );
 		this.props.onDateChange( date );
 	};
 

--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -80,7 +80,6 @@ export class AppsBadge extends PureComponent {
 		const shouldLoadExternalImage = ! startsWith( localeSlug, 'en' );
 
 		this.state = {
-			shouldLoadExternalImage,
 			imageSrc: shouldLoadExternalImage
 				? APP_STORE_BADGE_URLS[ props.storeName ].src.replace( '{localeSlug}', localeSlug )
 				: APP_STORE_BADGE_URLS[ props.storeName ].defaultSrc,

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -50,7 +50,6 @@ class KeyringConnectButton extends Component {
 	};
 
 	state = {
-		isOpen: false, // The service is visually opened
 		isConnecting: false, // A pending connection is awaiting authorization
 		isRefreshing: false, // A pending refresh is awaiting completion
 		isAwaitingConnections: false, // Waiting for Keyring Connections request to finish

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -75,7 +75,7 @@ class PostPhoto extends React.Component {
 
 		const featuredImageStyle = {
 			backgroundImage: 'url(' + cssSafeUrl( imageUrl ) + ')',
-			backgroundSize: this.state.isExpanded ? 'contain' : 'cover',
+			backgroundSize: this.props.isExpanded ? 'contain' : 'cover',
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: 'center',
 		};

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -25,8 +25,6 @@ export default class ChartBar extends React.PureComponent {
 		max: Infinity,
 	};
 
-	state = { showPopover: false };
-
 	clickHandler = () => {
 		if ( typeof this.props.clickHandler === 'function' ) {
 			this.props.clickHandler( this.props.data );

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -79,7 +79,6 @@ class NavTabs extends Component {
 
 		const tabsClassName = classNames( 'section-nav-tabs', {
 			'is-dropdown': this.state.isDropdown,
-			'is-open': this.state.isDropdownOpen,
 			'has-siblings': this.props.hasSiblingControls,
 		} );
 

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -78,7 +78,6 @@ class Referrers extends Component {
 			: data;
 		return {
 			filteredSortedData: sortBySales( filteredData ),
-			unfilteredDataLength: data.length,
 		};
 	};
 
@@ -105,7 +104,7 @@ class Referrers extends Component {
 	};
 
 	setData( props, filter ) {
-		const { filteredSortedData, unfilteredDataLength } = this.getFilteredData( filter, props );
+		const { filteredSortedData } = this.getFilteredData( filter, props );
 		const { selectedReferrer, selectedReferrerIndex } = this.getSelectedReferrer(
 			filteredSortedData,
 			props
@@ -113,7 +112,6 @@ class Referrers extends Component {
 		this.setState( {
 			filter,
 			filteredSortedData,
-			unfilteredDataLength,
 			selectedReferrer,
 			selectedReferrerIndex,
 		} );

--- a/client/extensions/woocommerce/components/action-header/actions.js
+++ b/client/extensions/woocommerce/components/action-header/actions.js
@@ -54,7 +54,6 @@ class ActionButtons extends Component {
 		const buttonsClassName = classNames( {
 			'action-header__actions': true,
 			'is-dropdown': this.state.isDropdown,
-			'is-open': this.state.isDropdownOpen,
 		} );
 
 		return (

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -115,9 +115,7 @@ export class JetpackConnectMain extends Component {
 					onChange={ this.handleUrlChange }
 					onSubmit={ this.handleUrlSubmit }
 					isError={ status }
-					isFetching={
-						this.props.isCurrentUrlFetching || this.state.redirecting || this.state.waitingForSites
-					}
+					isFetching={ this.props.isCurrentUrlFetching || this.state.waitingForSites }
 					isInstall={ this.isInstall() }
 				/>
 			</Card>

--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -180,9 +180,7 @@ export class SearchPurchase extends Component {
 					onChange={ this.handleUrlChange }
 					onSubmit={ this.handleUrlSubmit }
 					isError={ status }
-					isFetching={
-						this.props.isCurrentUrlFetching || this.state.redirecting || this.state.waitingForSites
-					}
+					isFetching={ this.props.isCurrentUrlFetching || this.state.waitingForSites }
 					isInstall={ true }
 					isSearch={ isSearch }
 					candidateSites={ this.state.candidateSites }

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -27,10 +27,6 @@ class ConnectedApplicationItem extends React.Component {
 		isPlaceholder: false,
 	};
 
-	state = {
-		showDetail: false,
-	};
-
 	recordClickEvent = ( action, label = null ) => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action, label );
 	};

--- a/client/me/purchases/billing-history/billing-history-filters.jsx
+++ b/client/me/purchases/billing-history/billing-history-filters.jsx
@@ -22,7 +22,6 @@ import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-tr
 class BillingHistoryFilters extends React.Component {
 	state = {
 		activePopover: '',
-		searchValue: '',
 	};
 
 	preventEnterKeySubmission = ( event ) => {

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -51,9 +51,6 @@ class Security2faBackupCodes extends React.Component {
 
 	onRequestComplete = ( error, data ) => {
 		if ( error ) {
-			this.setState( {
-				lastError: this.props.translate( 'Unable to obtain backup codes. Please try again later.' ),
-			} );
 			return;
 		}
 

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -33,10 +33,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 		onDelete: PropTypes.func,
 	};
 
-	state = {
-		isInvalid: false,
-	};
-
 	render() {
 		const havePhone = ! isEmpty( this.props.storedPhone );
 
@@ -111,8 +107,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 
 			return;
 		}
-
-		this.setState( { isInvalid: null } );
 
 		this.props.onSave( {
 			countryCode: phoneNumber.countryData.code,

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -46,10 +46,6 @@ class Dns extends React.Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
-	state = {
-		addNew: true,
-	};
-
 	renderDnsTemplates() {
 		const selectedDomain = getSelectedDomain( this.props );
 

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -35,7 +35,6 @@ class SiteImporterSitePreview extends React.Component {
 	};
 
 	state = {
-		previewRetries: 0,
 		sitePreviewImage: '',
 		sitePreviewFailed: false,
 		loadingPreviewImage: true,

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -177,9 +177,7 @@ export class SearchPurchase extends Component {
 					onChange={ this.handleUrlChange }
 					onSubmit={ this.handleUrlSubmit }
 					isError={ status }
-					isFetching={
-						this.props.isCurrentUrlFetching || this.state.redirecting || this.state.waitingForSites
-					}
+					isFetching={ this.props.isCurrentUrlFetching || this.state.waitingForSites }
 					isInstall={ true }
 					isSearch={ isSearch }
 					candidateSites={ this.state.candidateSites }

--- a/client/my-sites/purchases/site-level-purchases-error-boundary.tsx
+++ b/client/my-sites/purchases/site-level-purchases-error-boundary.tsx
@@ -12,10 +12,10 @@ export default class SiteLevelPurchasesErrorBoundary extends React.Component< Si
 		super( props );
 	}
 
-	public state = { hasError: false, currentError: null };
+	public state = { hasError: false };
 
-	static getDerivedStateFromError( error: string ) {
-		return { currentError: error, hasError: true };
+	static getDerivedStateFromError() {
+		return { hasError: true };
 	}
 
 	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -40,7 +40,6 @@ const trackDeleteSiteOption = ( option ) => {
 class SiteTools extends Component {
 	state = {
 		showDialog: false,
-		showStartOverDialog: false,
 	};
 
 	componentDidUpdate( prevProps ) {

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -39,18 +39,6 @@ class StatsDatePicker extends Component {
 		isActivity: false,
 	};
 
-	state = {
-		isTooltipVisible: false,
-	};
-
-	showTooltip = () => {
-		this.setState( { isTooltipVisible: true } );
-	};
-
-	hideTooltip = () => {
-		this.setState( { isTooltipVisible: false } );
-	};
-
 	dateForSummarize() {
 		const { query, moment, translate } = this.props;
 		const localizedDate = moment();

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -97,7 +97,6 @@ class FollowingManage extends Component {
 
 	handleSearchClosed = () => {
 		this.scrollToTop();
-		this.setState( { showMoreResults: false } );
 		this.props.recordReaderTracksEvent( 'calypso_reader_following_manage_search_closed' );
 		recordAction( 'manage_feed_search_closed' );
 	};

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -66,10 +66,6 @@ class SearchStream extends React.Component {
 
 	getTitle = ( props = this.props ) => props.query || props.translate( 'Search' );
 
-	state = {
-		selected: SEARCH_TYPES.POSTS,
-	};
-
 	updateQuery = ( newValue ) => {
 		this.scrollToTop();
 		const trimmedValue = trim( newValue ).substring( 0, 1024 );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -132,7 +132,7 @@ class TagStream extends React.Component {
 		return (
 			<Stream
 				{ ...this.props }
-				listName={ this.state.title }
+				listName={ title }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
 				forcePlaceholders={ ! tag } // if tag has not loaded yet, then make everything a placeholder

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -21,10 +21,10 @@ export default class CheckoutErrorBoundary extends React.Component< CheckoutErro
 		super( props );
 	}
 
-	public state = { hasError: false, currentError: null };
+	public state = { hasError: false };
 
-	static getDerivedStateFromError( error: string ) {
-		return { currentError: error, hasError: true };
+	static getDerivedStateFromError() {
+		return { hasError: true };
 	}
 
 	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up more of the unused component state in Calypso (following a similar cleanup in #54208). There are even more instances here and there, but this is more than enough for a single PR 😉 

#### Testing instructions

Verify that the removed component state is not used.