### PR TITLE
Components: Remove unneded check in QuerySites

### DIFF
--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -71,7 +71,7 @@ function QueryPrimaryAndRecent() {
 	useEffect( () => {
 		const siteIds = [ ...( primarySiteId ? [ primarySiteId ] : [] ), ...( recentSiteIds ?? [] ) ];
 
-		if ( siteIds && siteIds.length ) {
+		if ( siteIds.length ) {
 			dispatch( requestPrimaryAndRecent( siteIds ) );
 		}
 	}, [ dispatch, primarySiteId, recentSiteIds ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes an unnecessary check in `QuerySites` - `siteIds` will always be truth, as we're declaring it as an array. Checking for the array length will be enough. 

Initially introduced as we were refactoring `QuerySites` to hooks in #37555.

#### Testing instructions

Verify that querying all sites still works well