### PR TITLE
My Sites: Delete unused `jetpackModuleActive`

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,14 +13,7 @@ import { removeQueryArgs } from '@wordpress/url';
 import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { requestSite } from 'calypso/state/sites/actions';
-import {
-	getSite,
-	getSiteId,
-	getSiteAdminUrl,
-	getSiteSlug,
-	isJetpackModuleActive,
-	isJetpackSite,
-} from 'calypso/state/sites/selectors';
+import { getSite, getSiteId, getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -513,25 +506,6 @@ export function redirectToPrimary( context, primarySiteSlug ) {
 		redirectPath += `?${ context.querystring }`;
 	}
 	page.redirect( redirectPath );
-}
-
-export function jetpackModuleActive( moduleId, redirect ) {
-	return function ( context, next ) {
-		const { getState } = getStore( context );
-		const siteId = getSelectedSiteId( getState() );
-		const isJetpack = isJetpackSite( getState(), siteId );
-		const isModuleActive = isJetpackModuleActive( getState(), siteId, moduleId );
-
-		if ( ! isJetpack ) {
-			return next();
-		}
-
-		if ( isModuleActive || false === redirect ) {
-			next();
-		} else {
-			page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
-		}
-	};
 }
 
 export function navigation( context, next ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #53694, #53630, and #53632, the `jetpackModuleActive` method from the my-sites controller has been unused. This PR removes it completely.

#### Testing instructions

Verify the removed `jetpackModuleActive` is not in use anymore.