### PR TITLE
Remove font size redundant CSS for plans title

### DIFF
--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -15,11 +15,6 @@
 		margin-bottom: 15px;
 	}
 
-	.formatted-header__title {
-		font-family: 'Recoleta';
-		font-size: 3rem;
-	}
-
 	.step-wrapper {
 		&.is-wide-layout {
 			max-width: 1200px;
@@ -53,4 +48,3 @@
 	line-height: inherit;
 	text-decoration: underline;
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This removes some apparently-redundant CSS that was added in https://github.com/Automattic/wp-calypso/pull/52358 to stylize the plans step. When I say redundant, I mean two things:
	* It creates undesired behavior in blue sign up, so it can be removed.
	* It recreates the default behavior in white sign up, so it can be removed.

But a review from @niranjan-uma-shankar would be appreciated for sure.

#### Testing instructions

- Follow steps in https://github.com/Automattic/wp-calypso/issues/54112 and see they're not reproducible.
- Check the white sign up in `/start/` and make sure the title formatting is consistent between the domain and the plan steps.

Fixes #54112