### PR TITLE
Checkout: Only allow masterbar close to go to relative redirect_to

### DIFF
--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -39,9 +40,22 @@ class CheckoutMasterbar extends React.Component {
 
 		try {
 			const searchParams = new URLSearchParams( window.location.search );
-			searchParams.has( 'signup' ) && clearSignupDestinationCookie();
+
+			if ( searchParams.has( 'signup' ) ) {
+				clearSignupDestinationCookie();
+			}
+
+			// Some places that open checkout (eg: purchase page renewals) return the
+			// user there after checkout by putting the previous page's path in the
+			// `redirect_to` query param. When leaving checkout via the close button,
+			// we probably want to return to that location also.
 			if ( searchParams.has( 'redirect_to' ) ) {
-				closeUrl = searchParams.get( 'redirect_to' );
+				const redirectPath = searchParams.get( 'redirect_to' );
+				// Only allow redirecting to relative paths.
+				if ( redirectPath.startsWith( '/' ) ) {
+					page( redirectPath );
+					return;
+				}
 			}
 		} catch ( error ) {
 			// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -83,6 +83,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 		( state ) => siteId && canCurrentUser( state, siteId, 'manage_options' )
 	);
 	const translate = useTranslate();
+	const postCheckoutUrl = window.location.pathname + window.location.search;
 	return (
 		<PromoCard
 			title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
@@ -110,7 +111,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 					<Button
 						className="backup__wpcom-cta backup__wpcom-realtime-cta"
 						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
-							redirect_to: window.location.href,
+							redirect_to: postCheckoutUrl,
 						} ) }
 						onClick={ onUpgradeClick }
 						primary
@@ -120,7 +121,7 @@ const BackupUpsellBody: FunctionComponent = () => {
 					<Button
 						className="backup__wpcom-cta backup__wpcom-daily-cta"
 						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
-							redirect_to: window.location.href,
+							redirect_to: postCheckoutUrl,
 						} ) }
 						onClick={ onUpgradeClick }
 					>

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -90,6 +90,7 @@ const ScanUpsellBody: FunctionComponent = () => {
 		( state ) => siteId && canCurrentUser( state, siteId, 'manage_options' )
 	);
 	const translate = useTranslate();
+	const postCheckoutUrl = window.location.pathname + window.location.search;
 
 	return (
 		<PromoCard
@@ -118,7 +119,7 @@ const ScanUpsellBody: FunctionComponent = () => {
 						text: translate( 'Get daily scanning' ),
 						action: {
 							url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
-								redirect_to: window.location.href,
+								redirect_to: postCheckoutUrl,
 							} ),
 							onClick: onUpgradeClick,
 							selfTarget: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some places that open checkout (eg: renewals triggered from a purchase page) return the user to that location after checkout by putting the previous page's path in the `redirect_to` query param. When leaving checkout via the masterbar close button, we probably want to return to that location also, so https://github.com/Automattic/wp-calypso/pull/49440 makes that button use the `redirect_to` query param if one is present.

However, this is risky because any URL could be appended to that query param and the masterbar close button would happily send you there. This could be used by Phishing attacks, amongst other things.

This OR updates the close button on the Masterbar in checkout so that it will only redirect to the `redirect_to` query param URL if that URL is relative to calypso.

Props to @tyxla for [noticing this issue](https://github.com/Automattic/wp-calypso/commit/f393dd3051b3f25341cfb635d43b138459d22539#r53059967).

![checkout-master-bar-close-button](https://user-images.githubusercontent.com/2036909/124515799-511f8400-ddae-11eb-8082-cbb59a9ef4e8.png)


#### Testing instructions

- Add a new plan to your cart and visit checkout.
- Click the close button in the masterbar and verify that you return to the plans page.
- Visit the purchase page for an already-purchased product and click one of the "Renew now" links.
- Click the close button in the masterbar and verify that you return to the purchase page.
