### PR TITLE
Revert "Shopping Cart: Move CalypsoShoppingCartProvider to top of render tree"

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -16,6 +16,7 @@ import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-ch
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import wp from 'calypso/lib/wp';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -81,20 +82,22 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			shouldCloseOnClickOutside={ false }
 			icon={ <Icon icon={ wordpress } size={ 36 } /> }
 		>
-			<StripeHookProvider
-				fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-				locale={ translate.locale }
-			>
-				<CompositeCheckout
-					redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
-					isInEditor
-					isFocusedLaunch={ isFocusedLaunch }
-					siteId={ site?.ID }
-					siteSlug={ site?.slug }
-					productAliasFromUrl={ commaSeparatedProductSlugs }
-					onAfterPaymentComplete={ handleAfterPaymentComplete }
-				/>
-			</StripeHookProvider>
+			<CalypsoShoppingCartProvider>
+				<StripeHookProvider
+					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
+					locale={ translate.locale }
+				>
+					<CompositeCheckout
+						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
+						isInEditor
+						isFocusedLaunch={ isFocusedLaunch }
+						siteId={ site?.ID }
+						siteSlug={ site?.slug }
+						productAliasFromUrl={ commaSeparatedProductSlugs }
+						onAfterPaymentComplete={ handleAfterPaymentComplete }
+					/>
+				</StripeHookProvider>
+			</CalypsoShoppingCartProvider>
 		</Modal>
 	) : null;
 };

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -23,6 +23,7 @@ import QueryContactDetailsCache from 'calypso/components/data/query-contact-deta
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 class DomainManagementData extends React.Component {
 	static propTypes = {
@@ -58,17 +59,20 @@ class DomainManagementData extends React.Component {
 				{ selectedSite && needsDomains && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 				{ selectedSite && needsPlans && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				{ needsProductsList && <QueryProductsList /> }
-				{ React.createElement( this.props.component, {
-					context: this.props.context,
-					domains: selectedSite ? this.props.domains : null,
-					hasSiteDomainsLoaded: this.props.hasSiteDomainsLoaded,
-					isRequestingSiteDomains: this.props.isRequestingSiteDomains,
-					products: this.props.products,
-					selectedDomainName: this.props.selectedDomainName,
-					selectedSite,
-					sitePlans: this.props.sitePlans,
-					user: this.props.currentUser,
-				} ) }
+
+				<CalypsoShoppingCartProvider>
+					{ React.createElement( this.props.component, {
+						context: this.props.context,
+						domains: selectedSite ? this.props.domains : null,
+						hasSiteDomainsLoaded: this.props.hasSiteDomainsLoaded,
+						isRequestingSiteDomains: this.props.isRequestingSiteDomains,
+						products: this.props.products,
+						selectedDomainName: this.props.selectedDomainName,
+						selectedSite,
+						sitePlans: this.props.sitePlans,
+						user: this.props.currentUser,
+					} ) }
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	}

--- a/client/components/upgrades/gsuite/README.md
+++ b/client/components/upgrades/gsuite/README.md
@@ -6,12 +6,19 @@ GSuiteUpgrade is a React component used to add G Suite email addresses to domain
 
 ```jsx
 import React from 'react';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import GSuiteUpgrade from 'calypso/components/upgrades/gsuite';
 import productsListFactory from 'calypso/lib/products-list';
 
 const productsList = productsListFactory();
 
-function MyComponent() {
-	return <GSuiteUpgrade domain={ domain } />;
+class MyComponent extends React.Component {
+	render() {
+		return (
+			<CalypsoShoppingCartProvider>
+				<GSuiteUpgrade domain={ domain } />;
+			</CalypsoShoppingCartProvider>
+		);
+	}
 }
 ```

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -16,7 +16,6 @@ import LayoutLoggedOut from 'calypso/layout/logged-out';
 import EmptyContent from 'calypso/components/empty-content';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import MomentProvider from 'calypso/components/localized-moment/provider';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { RouteProvider } from 'calypso/components/route';
 import { login } from 'calypso/lib/paths';
 import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
@@ -64,9 +63,7 @@ export const ProviderWrappedLayout = ( {
 			>
 				<QueryClientProvider client={ queryClient }>
 					<ReduxProvider store={ store }>
-						<CalypsoShoppingCartProvider>
-							<MomentProvider>{ layout }</MomentProvider>
-						</CalypsoShoppingCartProvider>
+						<MomentProvider>{ layout }</MomentProvider>
 					</ReduxProvider>
 				</QueryClientProvider>
 			</RouteProvider>

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -18,6 +18,7 @@ import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 
 export default function CheckoutSystemDecider( {
 	productAliasFromUrl,
@@ -90,29 +91,31 @@ export default function CheckoutSystemDecider( {
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
-				<StripeHookProvider
-					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-					locale={ locale }
-				>
-					<CompositeCheckout
-						siteSlug={ siteSlug }
-						siteId={ selectedSite?.ID }
-						productAliasFromUrl={ productAliasFromUrl }
-						purchaseId={ purchaseId }
-						couponCode={ couponCode }
-						redirectTo={ redirectTo }
-						feature={ selectedFeature }
-						plan={ plan }
-						isComingFromUpsell={ isComingFromUpsell }
-						infoMessage={ prepurchaseNotices }
-						isLoggedOutCart={ isLoggedOutCart }
-						isNoSiteCart={ isNoSiteCart }
-						isJetpackCheckout={ isJetpackCheckout }
-						jetpackSiteSlug={ jetpackSiteSlug }
-						jetpackPurchaseToken={ jetpackPurchaseToken }
-						isUserComingFromLoginForm={ isUserComingFromLoginForm }
-					/>
-				</StripeHookProvider>
+				<CalypsoShoppingCartProvider>
+					<StripeHookProvider
+						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
+						locale={ locale }
+					>
+						<CompositeCheckout
+							siteSlug={ siteSlug }
+							siteId={ selectedSite?.ID }
+							productAliasFromUrl={ productAliasFromUrl }
+							purchaseId={ purchaseId }
+							couponCode={ couponCode }
+							redirectTo={ redirectTo }
+							feature={ selectedFeature }
+							plan={ plan }
+							isComingFromUpsell={ isComingFromUpsell }
+							infoMessage={ prepurchaseNotices }
+							isLoggedOutCart={ isLoggedOutCart }
+							isNoSiteCart={ isNoSiteCart }
+							isJetpackCheckout={ isJetpackCheckout }
+							jetpackSiteSlug={ jetpackSiteSlug }
+							jetpackPurchaseToken={ jetpackPurchaseToken }
+							isUserComingFromLoginForm={ isUserComingFromLoginForm }
+						/>
+					</StripeHookProvider>
+				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
 		</>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -19,6 +19,7 @@ import {
 import { CALYPSO_PLANS_PAGE } from 'calypso/jetpack-connect/constants';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
@@ -258,12 +259,14 @@ export function upsellNudge( context, next ) {
 	setSectionMiddleware( { name: upsellType } )( context );
 
 	context.primary = (
-		<UpsellNudge
-			siteSlugParam={ site }
-			receiptId={ Number( receiptId ) }
-			upsellType={ upsellType }
-			upgradeItem={ upgradeItem }
-		/>
+		<CalypsoShoppingCartProvider>
+			<UpsellNudge
+				siteSlugParam={ site }
+				receiptId={ Number( receiptId ) }
+				upsellType={ upsellType }
+				upgradeItem={ upgradeItem }
+			/>
+		</CalypsoShoppingCartProvider>
 	);
 
 	next();

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,6 +22,7 @@ import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 /**
@@ -105,10 +106,12 @@ class CurrentSite extends Component {
 						/>
 					) }
 					{ selectedSite && isEnabled( 'current-site/stale-cart-notice' ) && (
-						<AsyncLoad
-							require="calypso/my-sites/current-site/stale-cart-items-notice"
-							placeholder={ null }
-						/>
+						<CalypsoShoppingCartProvider>
+							<AsyncLoad
+								require="calypso/my-sites/current-site/stale-cart-items-notice"
+								placeholder={ null }
+							/>
+						</CalypsoShoppingCartProvider>
 					) }
 					{ selectedSite && isEnabled( 'current-site/notice' ) && (
 						<AsyncLoad

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -38,6 +38,7 @@ import JetpackManageErrorPage from 'calypso/my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 const noop = () => {};
 const domainsAddHeader = ( context, next ) => {
@@ -72,7 +73,9 @@ const domainSearch = ( context, next ) => {
 		<Main wideLayout>
 			<PageViewTracker path="/domains/add/:site" title="Domain Search > Domain Registration" />
 			<DocumentHead title={ translate( 'Domain Search' ) } />
-			<DomainSearch basePath={ sectionify( context.path ) } context={ context } />
+			<CalypsoShoppingCartProvider>
+				<DomainSearch basePath={ sectionify( context.path ) } context={ context } />
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -86,7 +89,9 @@ const siteRedirect = ( context, next ) => {
 				title="Domain Search > Site Redirect"
 			/>
 			<DocumentHead title={ translate( 'Redirect a Site' ) } />
-			<SiteRedirect />
+			<CalypsoShoppingCartProvider>
+				<SiteRedirect />
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -97,7 +102,9 @@ const mapDomain = ( context, next ) => {
 		<Main wideLayout>
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
-			<MapDomain initialQuery={ context.query.initialQuery } />
+			<CalypsoShoppingCartProvider>
+				<MapDomain initialQuery={ context.query.initialQuery } />
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -114,11 +121,13 @@ const transferDomain = ( context, next ) => {
 				title="Domain Search > Domain Transfer"
 			/>
 			<DocumentHead title={ translate( 'Transfer a Domain' ) } />
-			<TransferDomain
-				basePath={ sectionify( context.path ) }
-				initialQuery={ context.query.initialQuery }
-				useStandardBack={ useStandardBack }
-			/>
+			<CalypsoShoppingCartProvider>
+				<TransferDomain
+					basePath={ sectionify( context.path ) }
+					initialQuery={ context.query.initialQuery }
+					useStandardBack={ useStandardBack }
+				/>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -140,11 +149,13 @@ const useYourDomain = ( context, next ) => {
 				title="Domain Search > Use Your Own Domain"
 			/>
 			<DocumentHead title={ translate( 'Use Your Own Domain' ) } />
-			<UseYourDomainStep
-				basePath={ sectionify( context.path ) }
-				initialQuery={ context.query.initialQuery }
-				goBack={ handleGoBack }
-			/>
+			<CalypsoShoppingCartProvider>
+				<UseYourDomainStep
+					basePath={ sectionify( context.path ) }
+					initialQuery={ context.query.initialQuery }
+					goBack={ handleGoBack }
+				/>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -164,13 +175,15 @@ const transferDomainPrecheck = ( context, next ) => {
 				path={ domainManagementTransferInPrecheck( ':site', ':domain' ) }
 				title="My Sites > Domains > Selected Domain"
 			/>
-			<div>
-				<TransferDomainStep
-					forcePrecheck={ true }
-					initialQuery={ domain }
-					goBack={ handleGoBack }
-				/>
-			</div>
+			<CalypsoShoppingCartProvider>
+				<div>
+					<TransferDomainStep
+						forcePrecheck={ true }
+						initialQuery={ domain }
+						goBack={ handleGoBack }
+					/>
+				</div>
+			</CalypsoShoppingCartProvider>
 		</Main>
 	);
 	next();
@@ -189,7 +202,9 @@ const googleAppsWithRegistration = ( context, next ) => {
 						args: { domain: context.params.registerDomain },
 					} ) }
 				/>
-				<GSuiteUpgrade domain={ context.params.registerDomain } />
+				<CalypsoShoppingCartProvider>
+					<GSuiteUpgrade domain={ context.params.registerDomain } />
+				</CalypsoShoppingCartProvider>
 			</Main>
 		);
 	}

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
@@ -18,10 +19,12 @@ import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan
 export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
 		pageContext.primary = (
-			<GSuiteAddUsers
-				productType={ pageContext.params.productType }
-				selectedDomainName={ pageContext.params.domain }
-			/>
+			<CalypsoShoppingCartProvider>
+				<GSuiteAddUsers
+					productType={ pageContext.params.productType }
+					selectedDomainName={ pageContext.params.domain }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 
 		next();
@@ -40,24 +43,32 @@ export default {
 
 	emailManagementManageTitanMailboxes( pageContext, next ) {
 		pageContext.primary = (
-			<TitanManageMailboxes
-				context={ pageContext.query.context }
-				selectedDomainName={ pageContext.params.domain }
-			/>
+			<CalypsoShoppingCartProvider>
+				<TitanManageMailboxes
+					context={ pageContext.query.context }
+					selectedDomainName={ pageContext.params.domain }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 
 		next();
 	},
 
 	emailManagementNewTitanAccount( pageContext, next ) {
-		pageContext.primary = <TitanAddMailboxes selectedDomainName={ pageContext.params.domain } />;
+		pageContext.primary = (
+			<CalypsoShoppingCartProvider>
+				<TitanAddMailboxes selectedDomainName={ pageContext.params.domain } />
+			</CalypsoShoppingCartProvider>
+		);
 
 		next();
 	},
 
 	emailManagementPurchaseNewEmailAccount( pageContext, next ) {
 		pageContext.primary = (
-			<EmailProvidersComparison selectedDomainName={ pageContext.params.domain } />
+			<CalypsoShoppingCartProvider>
+				<EmailProvidersComparison selectedDomainName={ pageContext.params.domain } />
+			</CalypsoShoppingCartProvider>
 		);
 
 		next();
@@ -82,7 +93,11 @@ export default {
 	},
 
 	emailManagement( pageContext, next ) {
-		pageContext.primary = <EmailManagementHome selectedDomainName={ pageContext.params.domain } />;
+		pageContext.primary = (
+			<CalypsoShoppingCartProvider>
+				<EmailManagementHome selectedDomainName={ pageContext.params.domain } />
+			</CalypsoShoppingCartProvider>
+		);
 
 		next();
 	},

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -80,6 +80,7 @@ import PlanFeaturesScroller from './scroller';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -1115,4 +1116,10 @@ const ConnectedPlanFeatures = connect(
 
 /* eslint-enable */
 
-export default ConnectedPlanFeatures;
+export default function PlanFeaturesWrapper( props ) {
+	return (
+		<CalypsoShoppingCartProvider>
+			<ConnectedPlanFeatures { ...props } />
+		</CalypsoShoppingCartProvider>
+	);
+}

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -20,6 +20,7 @@ import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -116,13 +117,15 @@ function CartToggleButton( {
 	};
 
 	return (
-		<PopoverCart
-			selectedSite={ site }
-			onToggle={ onToggle }
-			pinned={ isMobile() }
-			visible={ cartVisible }
-			path={ path }
-		/>
+		<CalypsoShoppingCartProvider>
+			<PopoverCart
+				selectedSite={ site }
+				onToggle={ onToggle }
+				pinned={ isMobile() }
+				visible={ cartVisible }
+				path={ path }
+			/>
+		</CalypsoShoppingCartProvider>
 	);
 }
 

--- a/client/my-sites/plugins/marketplace/marketplace-domain-upsell/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-domain-upsell/index.tsx
@@ -16,6 +16,7 @@ import type { DomainSuggestions } from '@automattic/data-stores';
 /**
  * Internal dependencies
  */
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
 	MARKETPLACE_FLOW_ID,
@@ -201,7 +202,9 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 export default function MarketplaceDomainUpsell(): JSX.Element {
 	return (
 		<ThemeProvider theme={ theme }>
-			<CalypsoWrappedMarketplaceDomainUpsell />
+			<CalypsoShoppingCartProvider>
+				<CalypsoWrappedMarketplaceDomainUpsell />
+			</CalypsoShoppingCartProvider>
 		</ThemeProvider>
 	);
 }

--- a/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
+++ b/client/my-sites/plugins/marketplace/marketplace-plugin-details/index.tsx
@@ -27,6 +27,7 @@ import {
 	getPlugin as getWporgPlugin,
 } from 'calypso/state/plugins/wporg/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import PurchaseArea from './purchase-area';
@@ -47,7 +48,7 @@ interface MarketplacePluginDetailsInterface {
 	marketplacePluginSlug: keyof PluginProductMappingInterface;
 }
 
-export default function MarketplacePluginDetails( {
+function MarketplacePluginDetails( {
 	marketplacePluginSlug,
 }: MarketplacePluginDetailsInterface ): JSX.Element {
 	const translate = useTranslate();
@@ -131,5 +132,15 @@ export default function MarketplacePluginDetails( {
 				'Loading...'
 			) }
 		</>
+	);
+}
+
+export default function MarketplacePluginDetailsWrapper(
+	props: MarketplacePluginDetailsInterface
+): JSX.Element {
+	return (
+		<CalypsoShoppingCartProvider>
+			<MarketplacePluginDetails { ...props }></MarketplacePluginDetails>
+		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -57,6 +57,7 @@ import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/selectors';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
 import { getExternalBackUrl } from './utils';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -519,46 +520,50 @@ class DomainsStep extends React.Component {
 			: null;
 
 		return (
-			<RegisterDomainStep
-				key="domainForm"
-				path={ this.props.path }
-				initialState={ initialState }
-				onAddDomain={ this.handleAddDomain }
-				products={ this.props.productsList }
-				basePath={ this.props.path }
-				promoTlds={ trueNamePromoTlds }
-				mapDomainUrl={ this.getMapDomainUrl() }
-				transferDomainUrl={ this.getTransferDomainUrl() }
-				useYourDomainUrl={ this.getUseYourDomainUrl() }
-				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
-				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerUnavailableOption={ ! this.props.isDomainOnly }
-				isDomainOnly={ this.props.isDomainOnly }
-				analyticsSection={ this.getAnalyticsSection() }
-				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
-				includeDotBlogSubdomain={ trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain() }
-				isSignupStep
-				isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
-				showExampleSuggestions={ showExampleSuggestions }
-				suggestion={ initialQuery }
-				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( {
-					isSignup: true,
-					isDomainOnly: this.props.isDomainOnly,
-				} ) }
-				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
-				selectedSite={ this.props.selectedSite }
-				showSkipButton={ this.props.showSkipButton }
-				vertical={ this.props.vertical }
-				onSkip={ this.handleSkip }
-				hideFreePlan={ this.handleSkip }
-				forceHideFreeDomainExplainerAndStrikeoutUi={
-					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-				}
-				isReskinned={ this.props.isReskinned }
-				reskinSideContent={ this.getSideContent() }
-			/>
+			<CalypsoShoppingCartProvider>
+				<RegisterDomainStep
+					key="domainForm"
+					path={ this.props.path }
+					initialState={ initialState }
+					onAddDomain={ this.handleAddDomain }
+					products={ this.props.productsList }
+					basePath={ this.props.path }
+					promoTlds={ trueNamePromoTlds }
+					mapDomainUrl={ this.getMapDomainUrl() }
+					transferDomainUrl={ this.getTransferDomainUrl() }
+					useYourDomainUrl={ this.getUseYourDomainUrl() }
+					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
+					onSave={ this.handleSave.bind( this, 'domainForm' ) }
+					offerUnavailableOption={ ! this.props.isDomainOnly }
+					isDomainOnly={ this.props.isDomainOnly }
+					analyticsSection={ this.getAnalyticsSection() }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
+					includeDotBlogSubdomain={
+						trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain()
+					}
+					isSignupStep
+					isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
+					showExampleSuggestions={ showExampleSuggestions }
+					suggestion={ initialQuery }
+					designType={ this.getDesignType() }
+					vendor={ getSuggestionsVendor( {
+						isSignup: true,
+						isDomainOnly: this.props.isDomainOnly,
+					} ) }
+					deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
+					selectedSite={ this.props.selectedSite }
+					showSkipButton={ this.props.showSkipButton }
+					vertical={ this.props.vertical }
+					onSkip={ this.handleSkip }
+					hideFreePlan={ this.handleSkip }
+					forceHideFreeDomainExplainerAndStrikeoutUi={
+						this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+					}
+					isReskinned={ this.props.isReskinned }
+					reskinSideContent={ this.getSideContent() }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 	};
 
@@ -569,17 +574,19 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="mappingForm">
-				<MapDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					initialState={ initialState }
-					path={ this.props.path }
-					onRegisterDomain={ this.handleAddDomain }
-					onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
-					onSave={ this.handleSave.bind( this, 'mappingForm' ) }
-					products={ this.props.productsList }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-				/>
+				<CalypsoShoppingCartProvider>
+					<MapDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						initialState={ initialState }
+						path={ this.props.path }
+						onRegisterDomain={ this.handleAddDomain }
+						onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
+						onSave={ this.handleSave.bind( this, 'mappingForm' ) }
+						products={ this.props.productsList }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};
@@ -593,18 +600,20 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="transferForm">
-				<TransferDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					basePath={ this.props.path }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					isSignupStep
-					mapDomainUrl={ this.getMapDomainUrl() }
-					onRegisterDomain={ this.handleAddDomain }
-					onTransferDomain={ this.handleAddTransfer }
-					onSave={ this.onTransferSave }
-					products={ this.props.productsList }
-				/>
+				<CalypsoShoppingCartProvider>
+					<TransferDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						onRegisterDomain={ this.handleAddDomain }
+						onTransferDomain={ this.handleAddTransfer }
+						onSave={ this.onTransferSave }
+						products={ this.props.productsList }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};
@@ -614,16 +623,18 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">
-				<UseYourDomainStep
-					analyticsSection={ this.getAnalyticsSection() }
-					basePath={ this.props.path }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					isSignupStep
-					mapDomainUrl={ this.getMapDomainUrl() }
-					transferDomainUrl={ this.getTransferDomainUrl() }
-					products={ this.props.productsList }
-				/>
+				<CalypsoShoppingCartProvider>
+					<UseYourDomainStep
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						transferDomainUrl={ this.getTransferDomainUrl() }
+						products={ this.props.productsList }
+					/>
+				</CalypsoShoppingCartProvider>
 			</div>
 		);
 	};


### PR DESCRIPTION
Reverts Automattic/wp-calypso#54261

Something is wrong. When I add a plan to the cart, the cart ends up empty.