### PR TITLE
Shopping Cart: Use middleware to sync cart with server

### DIFF
--- a/packages/shopping-cart/src/sync.ts
+++ b/packages/shopping-cart/src/sync.ts
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import type { Dispatch } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	convertResponseCartToRequestCart,
+	convertRawResponseCartToResponseCart,
+} from './cart-functions';
+import type {
+	RequestCart,
+	ResponseCart,
+	ShoppingCartState,
+	ShoppingCartAction,
+	ShoppingCartMiddleware,
+} from './types';
+
+const debug = debugFactory( 'shopping-cart:sync' );
+
+export function createCartSyncMiddleware(
+	setServerCart: ( cart: RequestCart ) => Promise< ResponseCart >
+): ShoppingCartMiddleware {
+	return function syncCartToServer(
+		action: ShoppingCartAction,
+		state: ShoppingCartState,
+		dispatch: Dispatch< ShoppingCartAction >
+	): void {
+		if ( action.type !== 'SYNC_CART_TO_SERVER' ) {
+			return;
+		}
+
+		if ( state.cacheStatus !== 'pending' ) {
+			debug(
+				`cache status (${ state.cacheStatus }) is not pending; not sending edited cart to server`
+			);
+			return;
+		}
+
+		const requestCart = convertResponseCartToRequestCart( state.responseCart );
+		debug( 'sending edited cart to server', requestCart );
+
+		setServerCart( requestCart )
+			.then( ( response ) => {
+				debug( 'update cart request complete', requestCart, '; updated cart is', response );
+				dispatch( {
+					type: 'RECEIVE_UPDATED_RESPONSE_CART',
+					updatedResponseCart: convertRawResponseCartToResponseCart( response ),
+				} );
+			} )
+			.catch( ( error ) => {
+				debug( 'error while setting cart', error );
+				dispatch( {
+					type: 'RAISE_ERROR',
+					error: 'SET_SERVER_CART_ERROR',
+					message: error.message,
+				} );
+			} );
+	};
+}

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { Dispatch } from 'react';
+
+/**
  * Internal dependencies
  */
 import type {
@@ -119,3 +124,11 @@ export type ShoppingCartState = {
 };
 
 export type CartValidCallback = ( cart: ResponseCart ) => void;
+
+export type DispatchAndWaitForValid = ( action: ShoppingCartAction ) => Promise< ResponseCart >;
+
+export type ShoppingCartMiddleware = (
+	action: ShoppingCartAction,
+	state: ShoppingCartState,
+	dispatch: Dispatch< ShoppingCartAction >
+) => void;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -87,6 +87,7 @@ export type CacheStatus = 'fresh' | 'fresh-pending' | 'valid' | 'invalid' | 'pen
 export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'rejected';
 
 export type ShoppingCartAction =
+	| { type: 'SYNC_CART_TO_SERVER' }
 	| { type: 'CLEAR_QUEUED_ACTIONS' }
 	| { type: 'REMOVE_CART_ITEM'; uuidToRemove: string }
 	| { type: 'CART_PRODUCTS_ADD'; products: RequestCartProduct[] }

--- a/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
+++ b/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
@@ -1,81 +1,28 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import debugFactory from 'debug';
+import type { Dispatch } from 'react';
 
 /**
  * Internal dependencies
  */
-import {
-	convertResponseCartToRequestCart,
-	convertRawResponseCartToResponseCart,
-} from './cart-functions';
-import type {
-	TempResponseCart,
-	RequestCart,
-	ResponseCart,
-	CacheStatus,
-	ShoppingCartAction,
-} from './types';
+import type { CacheStatus, ShoppingCartAction } from './types';
 
 const debug = debugFactory( 'shopping-cart:use-cart-update-and-revalidate' );
 
 export default function useCartUpdateAndRevalidate(
 	cacheStatus: CacheStatus,
-	responseCart: TempResponseCart,
-	setServerCart: ( arg0: RequestCart ) => Promise< ResponseCart >,
-	hookDispatch: ( arg0: ShoppingCartAction ) => void
+	dispatch: Dispatch< ShoppingCartAction >
 ): void {
-	const pendingResponseCart = useRef< TempResponseCart | undefined >();
-	const isMounted = useRef< boolean >( true );
-	useEffect( () => {
-		return () => {
-			isMounted.current = false;
-		};
-	}, [] );
-
 	useEffect( () => {
 		if ( cacheStatus !== 'invalid' ) {
 			return;
 		}
 
-		if ( pendingResponseCart.current && pendingResponseCart.current !== responseCart ) {
-			debug(
-				'a request is still pending; cancelling that request for a new one. pending request was:',
-				pendingResponseCart.current
-			);
-		}
-		pendingResponseCart.current = responseCart;
-
-		const requestCart = convertResponseCartToRequestCart( responseCart );
-		debug( 'sending edited cart to server', requestCart );
-
-		hookDispatch( { type: 'REQUEST_UPDATED_RESPONSE_CART' } );
-
-		setServerCart( requestCart )
-			.then( ( response ) => {
-				debug( 'update cart request complete', requestCart, '; updated cart is', response );
-				if ( responseCart !== pendingResponseCart.current ) {
-					debug( 'ignoring updated cart because there is a newer request pending' );
-					return;
-				}
-				isMounted.current &&
-					hookDispatch( {
-						type: 'RECEIVE_UPDATED_RESPONSE_CART',
-						updatedResponseCart: convertRawResponseCartToResponseCart( response ),
-					} );
-				pendingResponseCart.current = undefined;
-			} )
-			.catch( ( error ) => {
-				debug( 'error while setting cart', error );
-				isMounted.current &&
-					hookDispatch( {
-						type: 'RAISE_ERROR',
-						error: 'SET_SERVER_CART_ERROR',
-						message: error.message,
-					} );
-				pendingResponseCart.current = undefined;
-			} );
-	}, [ isMounted, setServerCart, cacheStatus, responseCart, hookDispatch ] );
+		debug( 'dispatching edited cart update request' );
+		dispatch( { type: 'REQUEST_UPDATED_RESPONSE_CART' } );
+		dispatch( { type: 'SYNC_CART_TO_SERVER' } );
+	}, [ cacheStatus, dispatch ] );
 }

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useReducer, useEffect, Dispatch } from 'react';
+import { useReducer, useEffect, Dispatch, useCallback, useRef } from 'react';
 import debugFactory from 'debug';
 
 /**
@@ -24,20 +24,27 @@ import type {
 	ShoppingCartAction,
 	CouponStatus,
 	CacheStatus,
+	ShoppingCartMiddleware,
 } from './types';
 import { getEmptyResponseCart } from './empty-carts';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-reducer' );
 const emptyResponseCart = getEmptyResponseCart();
 
-export default function useShoppingCartReducer(): [
-	ShoppingCartState,
-	Dispatch< ShoppingCartAction >
-] {
+export default function useShoppingCartReducer(
+	middleware: ShoppingCartMiddleware[]
+): [ ShoppingCartState, Dispatch< ShoppingCartAction > ] {
 	const [ hookState, hookDispatch ] = useReducer(
 		shoppingCartReducer,
 		getInitialShoppingCartState()
 	);
+
+	// We need a copy of the state so that dispatchWithMiddleware does not need
+	// hookState as a dependency. Otherwise, dispatchWithMiddleware will change
+	// on every render, which can cause problems for other hooks that depend on
+	// it.
+	const cachedState = useRef< ShoppingCartState >( hookState );
+	cachedState.current = hookState;
 
 	useEffect( () => {
 		if ( hookState.queuedActions.length > 0 && hookState.cacheStatus === 'valid' ) {
@@ -49,7 +56,21 @@ export default function useShoppingCartReducer(): [
 			debug( 'cart is loaded; queued actions complete' );
 		}
 	}, [ hookState.queuedActions, hookState.cacheStatus ] );
-	return [ hookState, hookDispatch ];
+
+	const dispatchWithMiddleware = useCallback(
+		( action: ShoppingCartAction ) => {
+			// We want to defer the middleware actions just like the dispatcher is deferred.
+			setTimeout( () => {
+				middleware.forEach( ( middlewareFn ) =>
+					middlewareFn( action, cachedState.current, hookDispatch )
+				);
+			} );
+			hookDispatch( action );
+		},
+		[ middleware ]
+	);
+
+	return [ hookState, dispatchWithMiddleware ];
 }
 
 const alwaysAllowedActions = [

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -22,6 +22,8 @@ import type {
 } from '../src/types';
 
 const planOne: ResponseCartProduct = {
+	time_added_to_cart: Date.now(),
+	current_quantity: 1,
 	product_name: 'WordPress.com Personal',
 	product_slug: 'personal-bundle',
 	currency: 'BRL',
@@ -54,6 +56,8 @@ const planOne: ResponseCartProduct = {
 };
 
 const planTwo: ResponseCartProduct = {
+	time_added_to_cart: Date.now(),
+	current_quantity: 1,
 	product_name: 'WordPress.com Business',
 	product_slug: 'business-bundle',
 	currency: 'BRL',

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -6,7 +6,14 @@ import '@automattic/calypso-polyfills';
  */
 import React, { useEffect, useRef } from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { screen, act, render, waitFor, fireEvent } from '@testing-library/react';
+import {
+	screen,
+	act,
+	render,
+	waitFor,
+	fireEvent,
+	waitForElementToBeRemoved,
+} from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -331,10 +338,8 @@ describe( 'useShoppingCart', () => {
 			);
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
 			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
-			await act( async () => {
-				fireEvent.click( screen.getByText( 'Click me' ) );
-			} );
-			expect( screen.queryByText( planOne.product_name ) ).not.toBeInTheDocument();
+			fireEvent.click( screen.getByText( 'Click me' ) );
+			await waitForElementToBeRemoved( () => screen.queryByText( planOne.product_name ) );
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -350,7 +355,9 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();
 			} );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 
@@ -379,10 +386,8 @@ describe( 'useShoppingCart', () => {
 			);
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
 			expect( screen.getByText( planOne.product_name ) ).toBeInTheDocument();
-			await act( async () => {
-				fireEvent.click( screen.getByText( 'Click me' ) );
-			} );
-			expect( screen.queryByText( planOne.product_name ) ).not.toBeInTheDocument();
+			fireEvent.click( screen.getByText( 'Click me' ) );
+			await waitForElementToBeRemoved( () => screen.queryByText( planOne.product_name ) );
 			expect( screen.getByText( planTwo.product_name ) ).toBeInTheDocument();
 		} );
 
@@ -410,7 +415,9 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();
 			} );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 
@@ -444,7 +451,7 @@ describe( 'useShoppingCart', () => {
 			await act( async () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 			} );
-			expect( screen.queryByText( planOne.product_slug ) ).not.toBeInTheDocument();
+			await waitForElementToBeRemoved( () => screen.queryByText( planOne.product_slug ) );
 			expect( screen.getByText( planTwo.product_slug ) ).toBeInTheDocument();
 		} );
 
@@ -460,7 +467,9 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();
 			} );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 
@@ -489,7 +498,9 @@ describe( 'useShoppingCart', () => {
 			await act( async () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 			} );
-			expect( screen.getByText( 'Coupon: ABCD' ) ).toBeInTheDocument();
+			await waitFor( () => {
+				expect( screen.getByText( 'Coupon: ABCD' ) ).toBeInTheDocument();
+			} );
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -504,7 +515,9 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();
 			} );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 
@@ -530,10 +543,8 @@ describe( 'useShoppingCart', () => {
 			);
 			await waitFor( () => screen.getByTestId( 'product-list' ) );
 			expect( screen.getByText( 'Coupon: ABCD' ) ).toBeInTheDocument();
-			await act( async () => {
-				fireEvent.click( screen.getByText( 'Click me' ) );
-			} );
-			expect( screen.queryByText( 'Coupon: ABCD' ) ).not.toBeInTheDocument();
+			fireEvent.click( screen.getByText( 'Click me' ) );
+			await waitForElementToBeRemoved( () => screen.queryByText( 'Coupon: ABCD' ) );
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -548,7 +559,9 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();
 			} );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 
@@ -582,7 +595,9 @@ describe( 'useShoppingCart', () => {
 			await act( async () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 			} );
-			expect( screen.getByText( locationText ) ).toBeInTheDocument();
+			await waitFor( async () => {
+				expect( screen.getByText( locationText ) ).toBeInTheDocument();
+			} );
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -597,7 +612,9 @@ describe( 'useShoppingCart', () => {
 				fireEvent.click( screen.getByText( 'Click me' ) );
 				expect( markUpdateComplete ).not.toHaveBeenCalled();
 			} );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the `ShoppingCartProvider` so that it uses a middleware function to send updated cart data to the server.

Previously, when the cart was modified by a consumer using a reducer action, a hook in the provider would notice that the cart data was in an `invalid` state and send a request to the server to update it. Just prior to sending the request, the hook would dispatch another action to "lock" the reducer so that any updates that came in before the server response returned would be queued. When the request returned from the server, a new reducer action would be dispatched to update the local cart, unlock it, and play any queued actions (which might possibly trigger another update).

This usually works fine, but there's a hidden race condition, discovered here: https://github.com/Automattic/wp-calypso/pull/54297#issuecomment-874347055

##### Before

If a second reducer action (ie: a second consumer request) is made just after the first one, the order of the queued dispatch actions will look like this:

1. FIRST_CHANGE
2. SECOND_CHANGE

The first action will be processed by the reducer, so now the dispatch queue looks like:

1. SECOND_CHANGE

The modified cart will be noticed by the hook, and now the dispatch queue is:

1. SECOND_CHANGE
2. LOCK_REDUCER

At this point, the hook will make the request to the server and wait for the response. While that's pending, the dispatch queue will continue to be processed. The second action will be run through the reducer and then the reducer will be locked. Do you see the problem?

Eventually, the server request will return and dispatch a new action to update the local cart. Updating the local cart will erase the changes made by the second action, and it will be silently lost.

We need a way to reliably lock the reducer _before_ the server request is made. Fortunately, we already have such a mechanism: the dispatch queue.

##### After

After this PR, here's how the same series of events will work. First, the initial actions are added to the dispatch queue:

1. FIRST_CHANGE
2. SECOND_CHANGE

The first action will be processed by the reducer, so now the dispatch queue looks like:

1. SECOND_CHANGE

The modified cart will be noticed by the hook, and now the dispatch queue is:

1. SECOND_CHANGE
2. LOCK_REDUCER
3. SYNC_CART

Next, the second action will be processed by the reducer, making the queue:

1. LOCK_REDUCER
2. SYNC_CART

At that point, the reducer will be locked, and then finally the server request will be made, successfully batching the first two requests.

#### Testing instructions

- Add a plan to the cart and visit checkout.
- Verify that checkout loads with the plan.
- Modify the plan term length by clicking "Edit" on the first step.
- Verify that there's a brief loading period when the cart is updated, but that the item changes as expected.
- Visit `/domains/add/example.com` for your site, and add a domain to the cart.
- Add email to the cart from the upsell you'll probably see.
- Verify that checkout loads with the plan, domain, and email.
- Try to add a random string as a coupon and verify that it doesn't work and that you get an error.
- Remove a product from your cart and verify that the item is removed.