### PR TITLE
Shopping Cart: Move CalypsoShoppingCartProvider to top of render tree, take 2

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -16,7 +16,6 @@ import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-ch
 import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import wp from 'calypso/lib/wp';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -82,22 +81,20 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 			shouldCloseOnClickOutside={ false }
 			icon={ <Icon icon={ wordpress } size={ 36 } /> }
 		>
-			<CalypsoShoppingCartProvider>
-				<StripeHookProvider
-					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-					locale={ translate.locale }
-				>
-					<CompositeCheckout
-						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
-						isInEditor
-						isFocusedLaunch={ isFocusedLaunch }
-						siteId={ site?.ID }
-						siteSlug={ site?.slug }
-						productAliasFromUrl={ commaSeparatedProductSlugs }
-						onAfterPaymentComplete={ handleAfterPaymentComplete }
-					/>
-				</StripeHookProvider>
-			</CalypsoShoppingCartProvider>
+			<StripeHookProvider
+				fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
+				locale={ translate.locale }
+			>
+				<CompositeCheckout
+					redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
+					isInEditor
+					isFocusedLaunch={ isFocusedLaunch }
+					siteId={ site?.ID }
+					siteSlug={ site?.slug }
+					productAliasFromUrl={ commaSeparatedProductSlugs }
+					onAfterPaymentComplete={ handleAfterPaymentComplete }
+				/>
+			</StripeHookProvider>
 		</Modal>
 	) : null;
 };

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -23,7 +23,6 @@ import QueryContactDetailsCache from 'calypso/components/data/query-contact-deta
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 class DomainManagementData extends React.Component {
 	static propTypes = {
@@ -59,20 +58,17 @@ class DomainManagementData extends React.Component {
 				{ selectedSite && needsDomains && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 				{ selectedSite && needsPlans && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				{ needsProductsList && <QueryProductsList /> }
-
-				<CalypsoShoppingCartProvider>
-					{ React.createElement( this.props.component, {
-						context: this.props.context,
-						domains: selectedSite ? this.props.domains : null,
-						hasSiteDomainsLoaded: this.props.hasSiteDomainsLoaded,
-						isRequestingSiteDomains: this.props.isRequestingSiteDomains,
-						products: this.props.products,
-						selectedDomainName: this.props.selectedDomainName,
-						selectedSite,
-						sitePlans: this.props.sitePlans,
-						user: this.props.currentUser,
-					} ) }
-				</CalypsoShoppingCartProvider>
+				{ React.createElement( this.props.component, {
+					context: this.props.context,
+					domains: selectedSite ? this.props.domains : null,
+					hasSiteDomainsLoaded: this.props.hasSiteDomainsLoaded,
+					isRequestingSiteDomains: this.props.isRequestingSiteDomains,
+					products: this.props.products,
+					selectedDomainName: this.props.selectedDomainName,
+					selectedSite,
+					sitePlans: this.props.sitePlans,
+					user: this.props.currentUser,
+				} ) }
 			</div>
 		);
 	}

--- a/client/components/upgrades/gsuite/README.md
+++ b/client/components/upgrades/gsuite/README.md
@@ -6,19 +6,12 @@ GSuiteUpgrade is a React component used to add G Suite email addresses to domain
 
 ```jsx
 import React from 'react';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import GSuiteUpgrade from 'calypso/components/upgrades/gsuite';
 import productsListFactory from 'calypso/lib/products-list';
 
 const productsList = productsListFactory();
 
-class MyComponent extends React.Component {
-	render() {
-		return (
-			<CalypsoShoppingCartProvider>
-				<GSuiteUpgrade domain={ domain } />;
-			</CalypsoShoppingCartProvider>
-		);
-	}
+function MyComponent() {
+	return <GSuiteUpgrade domain={ domain } />;
 }
 ```

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -16,6 +16,7 @@ import LayoutLoggedOut from 'calypso/layout/logged-out';
 import EmptyContent from 'calypso/components/empty-content';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import MomentProvider from 'calypso/components/localized-moment/provider';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { RouteProvider } from 'calypso/components/route';
 import { login } from 'calypso/lib/paths';
 import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
@@ -63,7 +64,9 @@ export const ProviderWrappedLayout = ( {
 			>
 				<QueryClientProvider client={ queryClient }>
 					<ReduxProvider store={ store }>
-						<MomentProvider>{ layout }</MomentProvider>
+						<CalypsoShoppingCartProvider>
+							<MomentProvider>{ layout }</MomentProvider>
+						</CalypsoShoppingCartProvider>
 					</ReduxProvider>
 				</QueryClientProvider>
 			</RouteProvider>

--- a/client/my-sites/checkout/calypso-shopping-cart-messages.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-messages.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useShoppingCart } from '@automattic/shopping-cart';
+
+/**
+ * Internal Dependencies
+ */
+import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
+
+export function CalypsoShoppingCartMessages(): JSX.Element {
+	const { responseCart, isLoading } = useShoppingCart();
+	return <CartMessages cart={ responseCart } isLoadingCart={ isLoading } />;
+}

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -82,6 +82,7 @@ function CalypsoShoppingCartMessages() {
 	return (
 		<AsyncLoad
 			require="calypso/my-sites/checkout/cart/cart-messages"
+			placeholder={ null }
 			cart={ responseCart }
 			isLoadingCart={ isLoading }
 		/>

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -3,11 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import {
-	ShoppingCartProvider,
-	useShoppingCart,
-	getEmptyResponseCart,
-} from '@automattic/shopping-cart';
+import { ShoppingCartProvider, getEmptyResponseCart } from '@automattic/shopping-cart';
 import type { RequestCart } from '@automattic/shopping-cart';
 
 /**
@@ -71,20 +67,11 @@ export default function CalypsoShoppingCartProvider( {
 			setCart={ wpcomSetCart }
 			options={ options }
 		>
-			<CalypsoShoppingCartMessages />
+			<AsyncLoad
+				require="calypso/my-sites/checkout/calypso-shopping-cart-messages"
+				placeholder={ null }
+			/>
 			{ children }
 		</ShoppingCartProvider>
-	);
-}
-
-function CalypsoShoppingCartMessages() {
-	const { responseCart, isLoading } = useShoppingCart();
-	return (
-		<AsyncLoad
-			require="calypso/my-sites/checkout/cart/cart-messages"
-			placeholder={ null }
-			cart={ responseCart }
-			isLoadingCart={ isLoading }
-		/>
 	);
 }

--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -16,8 +16,8 @@ import type { RequestCart } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from './get-cart-key';
-import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import AsyncLoad from 'calypso/components/async-load';
 
 const wpcomGetCart = ( cartKey: string ) => wp.req.get( `/me/shopping-cart/${ cartKey }` );
 const wpcomSetCart = ( cartKey: string, cartData: RequestCart ) =>
@@ -79,5 +79,11 @@ export default function CalypsoShoppingCartProvider( {
 
 function CalypsoShoppingCartMessages() {
 	const { responseCart, isLoading } = useShoppingCart();
-	return <CartMessages cart={ responseCart } isLoadingCart={ isLoading } />;
+	return (
+		<AsyncLoad
+			require="calypso/my-sites/checkout/cart/cart-messages"
+			cart={ responseCart }
+			isLoadingCart={ isLoading }
+		/>
+	);
 }

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -18,7 +18,6 @@ import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/state/logstash/actions';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 
 export default function CheckoutSystemDecider( {
 	productAliasFromUrl,
@@ -91,31 +90,29 @@ export default function CheckoutSystemDecider( {
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
-				<CalypsoShoppingCartProvider>
-					<StripeHookProvider
-						fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
-						locale={ locale }
-					>
-						<CompositeCheckout
-							siteSlug={ siteSlug }
-							siteId={ selectedSite?.ID }
-							productAliasFromUrl={ productAliasFromUrl }
-							purchaseId={ purchaseId }
-							couponCode={ couponCode }
-							redirectTo={ redirectTo }
-							feature={ selectedFeature }
-							plan={ plan }
-							isComingFromUpsell={ isComingFromUpsell }
-							infoMessage={ prepurchaseNotices }
-							isLoggedOutCart={ isLoggedOutCart }
-							isNoSiteCart={ isNoSiteCart }
-							isJetpackCheckout={ isJetpackCheckout }
-							jetpackSiteSlug={ jetpackSiteSlug }
-							jetpackPurchaseToken={ jetpackPurchaseToken }
-							isUserComingFromLoginForm={ isUserComingFromLoginForm }
-						/>
-					</StripeHookProvider>
-				</CalypsoShoppingCartProvider>
+				<StripeHookProvider
+					fetchStripeConfiguration={ fetchStripeConfigurationWpcom }
+					locale={ locale }
+				>
+					<CompositeCheckout
+						siteSlug={ siteSlug }
+						siteId={ selectedSite?.ID }
+						productAliasFromUrl={ productAliasFromUrl }
+						purchaseId={ purchaseId }
+						couponCode={ couponCode }
+						redirectTo={ redirectTo }
+						feature={ selectedFeature }
+						plan={ plan }
+						isComingFromUpsell={ isComingFromUpsell }
+						infoMessage={ prepurchaseNotices }
+						isLoggedOutCart={ isLoggedOutCart }
+						isNoSiteCart={ isNoSiteCart }
+						isJetpackCheckout={ isJetpackCheckout }
+						jetpackSiteSlug={ jetpackSiteSlug }
+						jetpackPurchaseToken={ jetpackPurchaseToken }
+						isUserComingFromLoginForm={ isUserComingFromLoginForm }
+					/>
+				</StripeHookProvider>
 			</CheckoutErrorBoundary>
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
 		</>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -19,7 +19,6 @@ import {
 import { CALYPSO_PLANS_PAGE } from 'calypso/jetpack-connect/constants';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
@@ -259,14 +258,12 @@ export function upsellNudge( context, next ) {
 	setSectionMiddleware( { name: upsellType } )( context );
 
 	context.primary = (
-		<CalypsoShoppingCartProvider>
-			<UpsellNudge
-				siteSlugParam={ site }
-				receiptId={ Number( receiptId ) }
-				upsellType={ upsellType }
-				upgradeItem={ upgradeItem }
-			/>
-		</CalypsoShoppingCartProvider>
+		<UpsellNudge
+			siteSlugParam={ site }
+			receiptId={ Number( receiptId ) }
+			upsellType={ upsellType }
+			upgradeItem={ upgradeItem }
+		/>
 	);
 
 	next();

--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import type { SiteData } from 'calypso/state/ui/selectors/site-data';
 
 export default function getCartKey( {
 	selectedSite,

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,7 +22,6 @@ import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 /**
@@ -106,12 +105,10 @@ class CurrentSite extends Component {
 						/>
 					) }
 					{ selectedSite && isEnabled( 'current-site/stale-cart-notice' ) && (
-						<CalypsoShoppingCartProvider>
-							<AsyncLoad
-								require="calypso/my-sites/current-site/stale-cart-items-notice"
-								placeholder={ null }
-							/>
-						</CalypsoShoppingCartProvider>
+						<AsyncLoad
+							require="calypso/my-sites/current-site/stale-cart-items-notice"
+							placeholder={ null }
+						/>
 					) }
 					{ selectedSite && isEnabled( 'current-site/notice' ) && (
 						<AsyncLoad

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -38,7 +38,6 @@ import JetpackManageErrorPage from 'calypso/my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 const noop = () => {};
 const domainsAddHeader = ( context, next ) => {
@@ -73,9 +72,7 @@ const domainSearch = ( context, next ) => {
 		<Main wideLayout>
 			<PageViewTracker path="/domains/add/:site" title="Domain Search > Domain Registration" />
 			<DocumentHead title={ translate( 'Domain Search' ) } />
-			<CalypsoShoppingCartProvider>
-				<DomainSearch basePath={ sectionify( context.path ) } context={ context } />
-			</CalypsoShoppingCartProvider>
+			<DomainSearch basePath={ sectionify( context.path ) } context={ context } />
 		</Main>
 	);
 	next();
@@ -89,9 +86,7 @@ const siteRedirect = ( context, next ) => {
 				title="Domain Search > Site Redirect"
 			/>
 			<DocumentHead title={ translate( 'Redirect a Site' ) } />
-			<CalypsoShoppingCartProvider>
-				<SiteRedirect />
-			</CalypsoShoppingCartProvider>
+			<SiteRedirect />
 		</Main>
 	);
 	next();
@@ -102,9 +97,7 @@ const mapDomain = ( context, next ) => {
 		<Main wideLayout>
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
-			<CalypsoShoppingCartProvider>
-				<MapDomain initialQuery={ context.query.initialQuery } />
-			</CalypsoShoppingCartProvider>
+			<MapDomain initialQuery={ context.query.initialQuery } />
 		</Main>
 	);
 	next();
@@ -121,13 +114,11 @@ const transferDomain = ( context, next ) => {
 				title="Domain Search > Domain Transfer"
 			/>
 			<DocumentHead title={ translate( 'Transfer a Domain' ) } />
-			<CalypsoShoppingCartProvider>
-				<TransferDomain
-					basePath={ sectionify( context.path ) }
-					initialQuery={ context.query.initialQuery }
-					useStandardBack={ useStandardBack }
-				/>
-			</CalypsoShoppingCartProvider>
+			<TransferDomain
+				basePath={ sectionify( context.path ) }
+				initialQuery={ context.query.initialQuery }
+				useStandardBack={ useStandardBack }
+			/>
 		</Main>
 	);
 	next();
@@ -149,13 +140,11 @@ const useYourDomain = ( context, next ) => {
 				title="Domain Search > Use Your Own Domain"
 			/>
 			<DocumentHead title={ translate( 'Use Your Own Domain' ) } />
-			<CalypsoShoppingCartProvider>
-				<UseYourDomainStep
-					basePath={ sectionify( context.path ) }
-					initialQuery={ context.query.initialQuery }
-					goBack={ handleGoBack }
-				/>
-			</CalypsoShoppingCartProvider>
+			<UseYourDomainStep
+				basePath={ sectionify( context.path ) }
+				initialQuery={ context.query.initialQuery }
+				goBack={ handleGoBack }
+			/>
 		</Main>
 	);
 	next();
@@ -175,15 +164,13 @@ const transferDomainPrecheck = ( context, next ) => {
 				path={ domainManagementTransferInPrecheck( ':site', ':domain' ) }
 				title="My Sites > Domains > Selected Domain"
 			/>
-			<CalypsoShoppingCartProvider>
-				<div>
-					<TransferDomainStep
-						forcePrecheck={ true }
-						initialQuery={ domain }
-						goBack={ handleGoBack }
-					/>
-				</div>
-			</CalypsoShoppingCartProvider>
+			<div>
+				<TransferDomainStep
+					forcePrecheck={ true }
+					initialQuery={ domain }
+					goBack={ handleGoBack }
+				/>
+			</div>
 		</Main>
 	);
 	next();
@@ -202,9 +189,7 @@ const googleAppsWithRegistration = ( context, next ) => {
 						args: { domain: context.params.registerDomain },
 					} ) }
 				/>
-				<CalypsoShoppingCartProvider>
-					<GSuiteUpgrade domain={ context.params.registerDomain } />
-				</CalypsoShoppingCartProvider>
+				<GSuiteUpgrade domain={ context.params.registerDomain } />
 			</Main>
 		);
 	}

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailForwarding from 'calypso/my-sites/email/email-forwarding';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
@@ -19,12 +18,10 @@ import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan
 export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
 		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<GSuiteAddUsers
-					productType={ pageContext.params.productType }
-					selectedDomainName={ pageContext.params.domain }
-				/>
-			</CalypsoShoppingCartProvider>
+			<GSuiteAddUsers
+				productType={ pageContext.params.productType }
+				selectedDomainName={ pageContext.params.domain }
+			/>
 		);
 
 		next();
@@ -43,32 +40,24 @@ export default {
 
 	emailManagementManageTitanMailboxes( pageContext, next ) {
 		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<TitanManageMailboxes
-					context={ pageContext.query.context }
-					selectedDomainName={ pageContext.params.domain }
-				/>
-			</CalypsoShoppingCartProvider>
+			<TitanManageMailboxes
+				context={ pageContext.query.context }
+				selectedDomainName={ pageContext.params.domain }
+			/>
 		);
 
 		next();
 	},
 
 	emailManagementNewTitanAccount( pageContext, next ) {
-		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<TitanAddMailboxes selectedDomainName={ pageContext.params.domain } />
-			</CalypsoShoppingCartProvider>
-		);
+		pageContext.primary = <TitanAddMailboxes selectedDomainName={ pageContext.params.domain } />;
 
 		next();
 	},
 
 	emailManagementPurchaseNewEmailAccount( pageContext, next ) {
 		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<EmailProvidersComparison selectedDomainName={ pageContext.params.domain } />
-			</CalypsoShoppingCartProvider>
+			<EmailProvidersComparison selectedDomainName={ pageContext.params.domain } />
 		);
 
 		next();
@@ -93,11 +82,7 @@ export default {
 	},
 
 	emailManagement( pageContext, next ) {
-		pageContext.primary = (
-			<CalypsoShoppingCartProvider>
-				<EmailManagementHome selectedDomainName={ pageContext.params.domain } />
-			</CalypsoShoppingCartProvider>
-		);
+		pageContext.primary = <EmailManagementHome selectedDomainName={ pageContext.params.domain } />;
 
 		next();
 	},

--- a/client/my-sites/marketplace/marketplace-domain-upsell/index.tsx
+++ b/client/my-sites/marketplace/marketplace-domain-upsell/index.tsx
@@ -16,7 +16,6 @@ import type { DomainSuggestions } from '@automattic/data-stores';
 /**
  * Internal dependencies
  */
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
 	MARKETPLACE_FLOW_ID,
@@ -202,9 +201,7 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 export default function MarketplaceDomainUpsell(): JSX.Element {
 	return (
 		<ThemeProvider theme={ theme }>
-			<CalypsoShoppingCartProvider>
-				<CalypsoWrappedMarketplaceDomainUpsell />
-			</CalypsoShoppingCartProvider>
+			<CalypsoWrappedMarketplaceDomainUpsell />
 		</ThemeProvider>
 	);
 }

--- a/client/my-sites/marketplace/marketplace-plugin-details/index.tsx
+++ b/client/my-sites/marketplace/marketplace-plugin-details/index.tsx
@@ -27,7 +27,6 @@ import {
 	getPlugin as getWporgPlugin,
 } from 'calypso/state/plugins/wporg/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import PurchaseArea from './purchase-area';
@@ -48,7 +47,7 @@ interface MarketplacePluginDetailsInterface {
 	marketplacePluginSlug: keyof PluginProductMappingInterface;
 }
 
-function MarketplacePluginDetails( {
+export default function MarketplacePluginDetails( {
 	marketplacePluginSlug,
 }: MarketplacePluginDetailsInterface ): JSX.Element {
 	const translate = useTranslate();
@@ -137,15 +136,5 @@ function MarketplacePluginDetails( {
 				'Loading...'
 			) }
 		</>
-	);
-}
-
-export default function MarketplacePluginDetailsWrapper(
-	props: MarketplacePluginDetailsInterface
-): JSX.Element {
-	return (
-		<CalypsoShoppingCartProvider>
-			<MarketplacePluginDetails { ...props }></MarketplacePluginDetails>
-		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -80,7 +80,6 @@ import PlanFeaturesScroller from './scroller';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 /**
  * Style dependencies
@@ -1116,10 +1115,4 @@ const ConnectedPlanFeatures = connect(
 
 /* eslint-enable */
 
-export default function PlanFeaturesWrapper( props ) {
-	return (
-		<CalypsoShoppingCartProvider>
-			<ConnectedPlanFeatures { ...props } />
-		</CalypsoShoppingCartProvider>
-	);
-}
+export default ConnectedPlanFeatures;

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -20,7 +20,6 @@ import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -117,15 +116,13 @@ function CartToggleButton( {
 	};
 
 	return (
-		<CalypsoShoppingCartProvider>
-			<PopoverCart
-				selectedSite={ site }
-				onToggle={ onToggle }
-				pinned={ isMobile() }
-				visible={ cartVisible }
-				path={ path }
-			/>
-		</CalypsoShoppingCartProvider>
+		<PopoverCart
+			selectedSite={ site }
+			onToggle={ onToggle }
+			pinned={ isMobile() }
+			visible={ cartVisible }
+			path={ path }
+		/>
 	);
 }
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -57,7 +57,6 @@ import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/selectors';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
 import { getExternalBackUrl } from './utils';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -520,50 +519,46 @@ class DomainsStep extends React.Component {
 			: null;
 
 		return (
-			<CalypsoShoppingCartProvider>
-				<RegisterDomainStep
-					key="domainForm"
-					path={ this.props.path }
-					initialState={ initialState }
-					onAddDomain={ this.handleAddDomain }
-					products={ this.props.productsList }
-					basePath={ this.props.path }
-					promoTlds={ trueNamePromoTlds }
-					mapDomainUrl={ this.getMapDomainUrl() }
-					transferDomainUrl={ this.getTransferDomainUrl() }
-					useYourDomainUrl={ this.getUseYourDomainUrl() }
-					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
-					onSave={ this.handleSave.bind( this, 'domainForm' ) }
-					offerUnavailableOption={ ! this.props.isDomainOnly }
-					isDomainOnly={ this.props.isDomainOnly }
-					analyticsSection={ this.getAnalyticsSection() }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
-					includeDotBlogSubdomain={
-						trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain()
-					}
-					isSignupStep
-					isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
-					showExampleSuggestions={ showExampleSuggestions }
-					suggestion={ initialQuery }
-					designType={ this.getDesignType() }
-					vendor={ getSuggestionsVendor( {
-						isSignup: true,
-						isDomainOnly: this.props.isDomainOnly,
-					} ) }
-					deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
-					selectedSite={ this.props.selectedSite }
-					showSkipButton={ this.props.showSkipButton }
-					vertical={ this.props.vertical }
-					onSkip={ this.handleSkip }
-					hideFreePlan={ this.handleSkip }
-					forceHideFreeDomainExplainerAndStrikeoutUi={
-						this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-					}
-					isReskinned={ this.props.isReskinned }
-					reskinSideContent={ this.getSideContent() }
-				/>
-			</CalypsoShoppingCartProvider>
+			<RegisterDomainStep
+				key="domainForm"
+				path={ this.props.path }
+				initialState={ initialState }
+				onAddDomain={ this.handleAddDomain }
+				products={ this.props.productsList }
+				basePath={ this.props.path }
+				promoTlds={ trueNamePromoTlds }
+				mapDomainUrl={ this.getMapDomainUrl() }
+				transferDomainUrl={ this.getTransferDomainUrl() }
+				useYourDomainUrl={ this.getUseYourDomainUrl() }
+				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
+				onSave={ this.handleSave.bind( this, 'domainForm' ) }
+				offerUnavailableOption={ ! this.props.isDomainOnly }
+				isDomainOnly={ this.props.isDomainOnly }
+				analyticsSection={ this.getAnalyticsSection() }
+				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+				includeWordPressDotCom={ trueNamePromoTlds ? false : includeWordPressDotCom }
+				includeDotBlogSubdomain={ trueNamePromoTlds ? false : this.shouldIncludeDotBlogSubdomain() }
+				isSignupStep
+				isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableInFlow }
+				showExampleSuggestions={ showExampleSuggestions }
+				suggestion={ initialQuery }
+				designType={ this.getDesignType() }
+				vendor={ getSuggestionsVendor( {
+					isSignup: true,
+					isDomainOnly: this.props.isDomainOnly,
+				} ) }
+				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
+				selectedSite={ this.props.selectedSite }
+				showSkipButton={ this.props.showSkipButton }
+				vertical={ this.props.vertical }
+				onSkip={ this.handleSkip }
+				hideFreePlan={ this.handleSkip }
+				forceHideFreeDomainExplainerAndStrikeoutUi={
+					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+				}
+				isReskinned={ this.props.isReskinned }
+				reskinSideContent={ this.getSideContent() }
+			/>
 		);
 	};
 
@@ -574,19 +569,17 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="mappingForm">
-				<CalypsoShoppingCartProvider>
-					<MapDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						initialState={ initialState }
-						path={ this.props.path }
-						onRegisterDomain={ this.handleAddDomain }
-						onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
-						onSave={ this.handleSave.bind( this, 'mappingForm' ) }
-						products={ this.props.productsList }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-					/>
-				</CalypsoShoppingCartProvider>
+				<MapDomainStep
+					analyticsSection={ this.getAnalyticsSection() }
+					initialState={ initialState }
+					path={ this.props.path }
+					onRegisterDomain={ this.handleAddDomain }
+					onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
+					onSave={ this.handleSave.bind( this, 'mappingForm' ) }
+					products={ this.props.productsList }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+				/>
 			</div>
 		);
 	};
@@ -600,20 +593,18 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="transferForm">
-				<CalypsoShoppingCartProvider>
-					<TransferDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						basePath={ this.props.path }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
-						onRegisterDomain={ this.handleAddDomain }
-						onTransferDomain={ this.handleAddTransfer }
-						onSave={ this.onTransferSave }
-						products={ this.props.productsList }
-					/>
-				</CalypsoShoppingCartProvider>
+				<TransferDomainStep
+					analyticsSection={ this.getAnalyticsSection() }
+					basePath={ this.props.path }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					isSignupStep
+					mapDomainUrl={ this.getMapDomainUrl() }
+					onRegisterDomain={ this.handleAddDomain }
+					onTransferDomain={ this.handleAddTransfer }
+					onSave={ this.onTransferSave }
+					products={ this.props.productsList }
+				/>
 			</div>
 		);
 	};
@@ -623,18 +614,16 @@ class DomainsStep extends React.Component {
 
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">
-				<CalypsoShoppingCartProvider>
-					<UseYourDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						basePath={ this.props.path }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
-						transferDomainUrl={ this.getTransferDomainUrl() }
-						products={ this.props.productsList }
-					/>
-				</CalypsoShoppingCartProvider>
+				<UseYourDomainStep
+					analyticsSection={ this.getAnalyticsSection() }
+					basePath={ this.props.path }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					isSignupStep
+					mapDomainUrl={ this.getMapDomainUrl() }
+					transferDomainUrl={ this.getTransferDomainUrl() }
+					products={ this.props.productsList }
+				/>
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the second attempt on https://github.com/Automattic/wp-calypso/pull/54261 which had to be reverted in https://github.com/Automattic/wp-calypso/pull/54297 due to a race condition (not caused by this PR but this PR exposed it) which should be now fixed by https://github.com/Automattic/wp-calypso/pull/54300 I've updated the testing instructions in this version of the PR to cover the case fixed by the race condition.

This moves the `CalypsoShoppingCartProvider` to the top of the web render tree, which should make it much easier for components in calypso to utilize the shopping cart without needing to create their own provider. Since the provider fetches the shopping cart endpoint, this will reduce the number of shopping cart API calls, especially on pages where there are more than one sibling components that need access to the cart.

#### Testing instructions

The main thing to do here is to make sure that shopping cart operations in calypso still work without any errors. Here's some examples:

- Add a plan to your cart and visit checkout, eg: by visiting `/plans/example.com` and clicking a plan's upgrade button.
- Without completing the purchase, visit the domain search page and verify that the popover cart is visible with a dot to let you know there's an item in the cart, eg: by visiting `/domains/add/example.com`
- Add a domain to your cart.
- Add a Google email subscription to your cart.
- Delete all the items from the cart in checkout.
- Using a site without a paid plan, visit the post editor and try to add a premium content block.

The other thing to verify is that there are no problems in cases where the cart should not be available, notably signup. You can do this by creating a new site and verifying that there are no errors.