### PR TITLE
Plans: Re-position CRM Free card next to Free card

### DIFF
--- a/client/components/jetpack/card/product-without-price/style.scss
+++ b/client/components/jetpack/card/product-without-price/style.scss
@@ -23,6 +23,12 @@
 		}
 	}
 
+	.product-without-price__title {
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-bottom: initial;
+		}
+	}
+
 	.product-without-price__button.button {
 		@include breakpoint-deprecated( '>660px' ) {
 			max-width: 210px;
@@ -72,7 +78,6 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: initial;
-		margin-bottom: initial;
 	}
 }
 

--- a/client/components/jetpack/card/product-without-price/style.scss
+++ b/client/components/jetpack/card/product-without-price/style.scss
@@ -15,17 +15,52 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 	}
-}
 
-.product-without-price--full-width
-.product-without-price__header {
-	@include breakpoint-deprecated( '>660px' ) {
+	.product-without-price__header {
+		@include breakpoint-deprecated( '>660px' ) {
+			flex: 1;
+			margin-inline-end: 32px;
+		}
+	}
+
+	.product-without-price__button.button {
+		@include breakpoint-deprecated( '>660px' ) {
+			max-width: 210px;
+		}
+
+		@include break-large {
+			margin-bottom: 0;
+		}
+	}
+
+	.product-without-price__features-list {
 		flex: 1;
-		margin-inline-end: 32px;
+
+		@include break-large {
+			align-self: center;
+
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			flex: 2 1;
+
+			margin-top: initial;
+			margin-bottom: -14px;
+
+			> li {
+				width: calc( 50% - 8px );
+				padding-inline-start: 8px;
+
+				margin-bottom: 14px;
+			}
+
+			> li:last-child {
+				margin-bottom: 14px;
+			}
+		}
 	}
 }
 
-.product-without-price--full-width
 .product-without-price__title {
 	color: var( --studio-gray-100 );
 	margin: 12px 0 20px;
@@ -41,14 +76,11 @@
 	}
 }
 
-.product-without-price--full-width
 .product-without-price__subheadline {
 	color: var( --studio-gray-60 );
-
 	font-size: inherit;
 }
 
-.product-without-price--full-width
 .product-without-price__button.button {
 	display: block;
 
@@ -60,23 +92,10 @@
 	border-radius: 4px;
 
 	font-size: 1rem;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		max-width: 210px;
-	}
-
-	@include break-large {
-		margin-bottom: 0;
-	}
 }
 
-.product-without-price--full-width
 .product-without-price__features-list {
-	margin: 28px 0 0;
-
 	color: var( --studio-gray-60 );
-
-	flex: 1;
 	margin: 0 16px 32px;
 
 	> li {
@@ -89,30 +108,6 @@
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
-		margin-top: 16px;
-		margin-bottom: 16px;
-	}
-
-	@include break-large {
-		align-self: center;
-
-		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
-		flex: 2 1;
-
-		margin-top: initial;
-		margin-bottom: -14px;
-
-		> li {
-			width: calc( 50% - 8px );
-			padding-inline-start: 8px;
-
-			margin-bottom: 14px;
-		}
-
-		> li:last-child {
-			margin-bottom: 14px;
-		}
+		margin: 16px;
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -68,7 +68,10 @@ export const EXTERNAL_PRODUCT_CRM_FREE: ( variation: Iterations ) => SelectorPro
 		args: { minPrice: '$0', maxPrice: '$17' },
 	} ),
 	iconSlug: 'jetpack_crm',
-	displayName: translate( 'CRM' ),
+	displayName:
+		variation === Iterations.ONLY_REALTIME_PRODUCTS
+			? translate( 'Jetpack CRM Free' )
+			: translate( 'CRM' ),
 	shortName: translate( 'CRM' ),
 	tagline: translate( 'Manage contacts effortlessly' ),
 	// Jetpack CRM isn't considered as a product like others for the time being (and therefore not

--- a/client/my-sites/plans/jetpack-plans/iterations.ts
+++ b/client/my-sites/plans/jetpack-plans/iterations.ts
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import { getUrlParts } from '@automattic/calypso-url';
+import { isEnabled } from '@automattic/calypso-config';
 
 /**
  * Iterations
  */
 
-export enum Iterations {}
+export enum Iterations {
+	ONLY_REALTIME_PRODUCTS = 'only-realtime-products',
+}
 
 const iterationNames: string[] = Object.values( Iterations );
 
@@ -43,7 +46,7 @@ const getCurrentCROIterationName = (): Iterations | null => {
 		}
 	}
 
-	return null;
+	return isEnabled( 'jetpack/only-realtime-products' ) ? Iterations.ONLY_REALTIME_PRODUCTS : null;
 };
 
 type IterationValueFunction< T > = ( key: Iterations | null ) => T | undefined;

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	PRODUCT_JETPACK_CRM_FREE,
+	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
+import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
+import ProductCardWithoutPrice from 'calypso/components/jetpack/card/product-without-price';
+import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
+
+/**
+ * Type dependencies
+ */
+import type { Duration, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type OwnProps = {
+	fullWidth?: boolean;
+	duration: Duration;
+	siteId: number | null;
+};
+
+const JetpackCrmFreeCard: React.FC< OwnProps > = ( { fullWidth, duration, siteId } ) => {
+	const slug =
+		duration === TERM_MONTHLY ? PRODUCT_JETPACK_CRM_FREE_MONTHLY : PRODUCT_JETPACK_CRM_FREE;
+	const product = slugToSelectorProduct( slug ) as SelectorProduct;
+
+	const dispatch = useDispatch();
+	const trackCallback = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_product_jpcrmfree_click', {
+					site_id: siteId ?? undefined,
+				} )
+			),
+		[ dispatch, siteId ]
+	);
+
+	const onButtonClick = useCallback( () => {
+		storePlan( slug );
+		trackCallback();
+	}, [ slug, trackCallback ] );
+
+	return (
+		<ProductCardWithoutPrice
+			fullWidth={ fullWidth }
+			className="jetpack-crm-free-card"
+			productSlug={ slug }
+			displayName={ product.displayName }
+			description={ product.description }
+			productFeatures={ product.features.items.map( ( i ) => i.text ) }
+			buttonLabel={ product.buttonLabel }
+			buttonHref={ product.externalUrl }
+			onButtonClick={ onButtonClick }
+		/>
+	);
+};
+
+export default JetpackCrmFreeCard;

--- a/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-crm-free-card/style.scss
@@ -1,0 +1,37 @@
+.jetpack-crm-free-card.product-without-price--full-width {
+	display: flex;
+	column-gap: 64px;
+	flex-wrap: wrap;
+
+    .product-without-price__header {
+        @include breakpoint-deprecated( '>660px' ) {
+            flex: 1 0 calc( 300px - 64px - 1px );
+            margin-inline-end: initial;
+        }
+    }
+
+    .product-without-price__features-list {
+        @include breakpoint-deprecated( '>660px' ) {
+            flex: 1 0 calc( 300px - 64px - 1px );
+            align-self: center;
+            margin: 0 0 0 16px;
+        }
+    
+        display: block;
+        margin: 0 16px 32px;
+    
+        & > li {
+            width: initial;
+    
+            &:last-child {
+                margin-block-end: initial;
+            }
+        }
+    }
+
+    .product-without-price__button.button {
+        @include breakpoint-deprecated( '>660px' ) {
+            max-width: 210px;
+        }
+    }
+}

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -43,13 +43,23 @@ const JetpackFreeCard: FC< JetpackFreeProps > = ( { fullWidth, siteId, urlQueryA
 		[ translate ]
 	);
 
+	const description = useMemo(
+		() =>
+			getForCurrentCROIteration( {
+				[ Iterations.ONLY_REALTIME_PRODUCTS ]: translate(
+					'Included for free with all products. Get started with Jetpack now at no cost.'
+				),
+			} ) ?? translate( 'Included for free with all products' ),
+		[ translate ]
+	);
+
 	return (
 		<ProductCardWithoutPrice
 			fullWidth={ fullWidth }
 			className="jetpack-free-card"
 			productSlug="free"
 			displayName={ translate( 'Jetpack Free' ) }
-			description={ translate( 'Included for free with all products' ) }
+			description={ description }
 			productFeatures={ features }
 			buttonHref={ buttonHref }
 			onButtonClick={ onButtonClick }

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -8,6 +8,7 @@ import React, { FC, useMemo } from 'react';
  * Internal dependencies
  */
 import ProductCardWithoutPrice from 'calypso/components/jetpack/card/product-without-price';
+import { getForCurrentCROIteration, Iterations } from '../iterations';
 import useJetpackFreeButtonProps from './use-jetpack-free-button-props';
 
 /**
@@ -23,14 +24,22 @@ const JetpackFreeCard: FC< JetpackFreeProps > = ( { fullWidth, siteId, urlQueryA
 	);
 
 	const features = useMemo(
-		() => [
-			translate( 'Site stats' ),
-			translate( 'Brute force attack protection' ),
-			translate( 'Content Delivery Network' ),
-			translate( 'Automated social media posting' ),
-			translate( 'Downtime monitoring' ),
-			translate( 'Activity Log' ),
-		],
+		() =>
+			getForCurrentCROIteration( {
+				[ Iterations.ONLY_REALTIME_PRODUCTS ]: [
+					translate( 'Site stats' ),
+					translate( 'Content Delivery Network' ),
+					translate( 'Downtime monitoring' ),
+					translate( 'Activity Log' ),
+				],
+			} ) ?? [
+				translate( 'Site stats' ),
+				translate( 'Brute force attack protection' ),
+				translate( 'Content Delivery Network' ),
+				translate( 'Automated social media posting' ),
+				translate( 'Downtime monitoring' ),
+				translate( 'Activity Log' ),
+			],
 		[ translate ]
 	);
 

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -15,8 +15,10 @@ import PlanUpgradeSection from '../plan-upgrade';
 import ProductCard from '../product-card';
 import { getProductPosition } from '../product-grid/products-order';
 import { getPlansToDisplay, getProductsToDisplay, isConnectionFlow } from './utils';
+import { getForCurrentCROIteration, Iterations } from '../iterations';
 import useGetPlansGridProducts from '../use-get-plans-grid-products';
 import JetpackFreeCard from '../jetpack-free-card';
+import JetpackCrmFreeCard from '../jetpack-crm-free-card';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	PLAN_JETPACK_SECURITY_DAILY,
@@ -147,6 +149,10 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	}, [ duration, availableProducts, purchasedProducts, includedInPlanProducts, currentPlanSlug ] );
 
 	const showFreeCard = useSelector( getShowFreeCard );
+	const showCrmFreeCard =
+		getForCurrentCROIteration( {
+			[ Iterations.ONLY_REALTIME_PRODUCTS ]: true,
+		} ) ?? false;
 
 	const bundleComparisonRef = useRef< null | HTMLElement >( null );
 	const scrollToComparison = () => {
@@ -169,7 +175,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		),
 		[ onDurationChange, duration ]
 	);
-
 
 	return (
 		<>
@@ -248,8 +253,19 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					) ) }
 				</ul>
 				<div className="product-grid__free">
+					{ showCrmFreeCard && (
+						<JetpackCrmFreeCard
+							fullWidth={ ! showFreeCard }
+							siteId={ siteId }
+							duration={ duration }
+						/>
+					) }
 					{ showFreeCard && (
-						<JetpackFreeCard fullWidth={ true } siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+						<JetpackFreeCard
+							fullWidth={ ! showCrmFreeCard }
+							siteId={ siteId }
+							urlQueryArgs={ urlQueryArgs }
+						/>
 					) }
 				</div>
 			</ProductGridSection>

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isEnabled } from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useMemo, useRef, useState, useEffect } from 'react';
@@ -171,11 +170,9 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		[ onDurationChange, duration ]
 	);
 
-	const onlyRealtimeProducts = isEnabled( 'jetpack/only-realtime-products' );
 
 	return (
 		<>
-			{ onlyRealtimeProducts && <h1>jetpack/only-realtime-products is enabled</h1> }
 			{ planRecommendation && (
 				<PlanUpgradeSection
 					planRecommendation={ planRecommendation }

--- a/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/products-order.ts
@@ -17,6 +17,11 @@ import {
 	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 } from '@automattic/calypso-products';
 
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
+
 /**
  * Type dependencies
  */
@@ -24,6 +29,21 @@ import type { JetpackPlanSlug, JetpackProductSlug } from '@automattic/calypso-pr
 
 const setProductsInPosition = ( slugs: string[], position: number ) =>
 	slugs.reduce( ( map, slug ) => ( { ...map, [ slug ]: position } ), {} );
+
+const ONLY_REALTIME_PRODUCT_POSITION_IN_GRID: Record< string, number > = {
+	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 1,
+	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: 1,
+	[ PLAN_JETPACK_SECURITY_DAILY ]: 10,
+	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: 10,
+	...setProductsInPosition( JETPACK_COMPLETE_PLANS, 20 ),
+	[ PLAN_JETPACK_SECURITY_REALTIME ]: 30,
+	[ PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: 30,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: 40,
+	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: 40,
+	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 50 ),
+	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 60 ),
+	...setProductsInPosition( JETPACK_SEARCH_PRODUCTS, 70 ),
+};
 
 const PRODUCT_POSITION_IN_GRID: Record< string, number > = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: 1,
@@ -42,4 +62,6 @@ const PRODUCT_POSITION_IN_GRID: Record< string, number > = {
 };
 
 export const getProductPosition = ( slug: JetpackPlanSlug | JetpackProductSlug ): number =>
-	PRODUCT_POSITION_IN_GRID[ slug ] ?? 100;
+	( getForCurrentCROIteration( {
+		[ Iterations.ONLY_REALTIME_PRODUCTS ]: ONLY_REALTIME_PRODUCT_POSITION_IN_GRID,
+	} ) ?? PRODUCT_POSITION_IN_GRID )[ slug ] ?? 100;

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -108,3 +108,33 @@
 .product-grid__more.is-detached {
 	margin-top: 48px;
 }
+
+
+/*
+ * From this point, rules only apply:
+ * - when the 'jetpack/only-realtime-products' feature flag is enabled
+ * - and the current active iteration is Iterations.ONLY_REALTIME_PRODUCTS
+ */
+.jetpack-plans__iteration--only-realtime-products {
+	.product-grid__plan-grid,
+	.product-grid__product-grid {
+		gap: 16px;
+	}
+
+	.product-grid__plan-grid:not( .is-wrapping ) {
+		gap: 16px 0;
+	}
+
+	.product-grid__free {
+		display: flex;
+		gap: 16px;
+		flex-wrap: wrap;
+
+		margin-block-start: 16px;
+
+		.product-without-price {
+			flex: 1 1 0;
+			min-width: 300px;
+		}
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -41,12 +41,12 @@
 
 	display: grid;
 	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
-	grid-gap: 24px 16px;
+	gap: 24px 16px;
 }
 
 .product-grid__plan-grid:not( .is-wrapping ) {
 	margin-top: 72px;
-	grid-gap: 24px 0;
+	gap: 24px 0;
 
 	// Considering there are 3 plans
 	> li {
@@ -78,7 +78,7 @@
 }
 
 .product-grid__free {
-	margin-top: 32px;
+	margin-block-start: 32px;
 }
 
 .product-grid__asterisk-items {

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -23,6 +24,7 @@ import ProductGrid from './product-grid';
 import buildCheckoutURL from './build-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getForCurrentCROIteration, Iterations } from './iterations';
 
 /**
  * Type dependencies
@@ -159,8 +161,12 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		setDuration( selectedDuration );
 	};
 
+	const iterationClassName = getForCurrentCROIteration(
+		( variation: Iterations | null ) => `jetpack-plans__iteration--${ variation ?? 'default' }`
+	);
+
 	return (
-		<Main className="selector__main" wideLayout>
+		<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
 			<PageViewTracker
 				path={ viewTrackerPath }
 				properties={ viewTrackerProps }

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -22,6 +22,10 @@ import {
 } from '@automattic/calypso-products';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
 import slugToSelectorProduct from './slug-to-selector-product';
 
 /**
@@ -55,7 +59,12 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 	}
 
 	// Include Jetpack CRM
+	const includeCrmFree =
+		getForCurrentCROIteration( {
+			[ Iterations.ONLY_REALTIME_PRODUCTS ]: false,
+		} ) ?? true;
 	if (
+		includeCrmFree &&
 		! ownedProducts.some( ( ownedProduct ) => JETPACK_CRM_FREE_PRODUCTS.includes( ownedProduct ) )
 	) {
 		availableProducts = [ ...availableProducts, ...JETPACK_CRM_FREE_PRODUCTS ];


### PR DESCRIPTION
Resolves `1200412004370260-as-1200532973279652`.

#### Changes proposed in this Pull Request

##### Feature/iteration flags

* Add a new iteration in `iterations.ts` called `ONLY_REALTIME_PRODUCTS`. When the `jetpack/only-realtime-products` feature flag is enabled, this becomes the iteration shown by default. It's still override-able by specifying `cloud-pricing-page=default` in the browser URL.
* Add an iteration-specific class name to the Plans/Pricing page (`selector.tsx`) to make iteration-specific styling a little easier.
* Remove the visibility test header for the `jetpack/only-realtime-products` feature flag, since it's no longer needed.

##### Jetpack Free

* Change the product description when the above iteration is enabled, to more closely match the length of the CRM Free card's description.
* Remove two bullet points from the Jetpack Free features list when the above iteration is enabled:
  * "Brute force attack protection"
  * "Automated social media posting"
* Make the Jetpack Free card full-width only when the CRM Free card is absent.

##### Jetpack CRM Free

* Change the product display name from "CRM" to "Jetpack CRM Free" when the above iteration is enabled.
* Remove Jetpack CRM Free from the regular (paid) product grid ordering when the above iteration is enabled.
* Create a new `JetpackCrmFreeCard` component, in the same pattern as `JetpackFreeCard`.
* When the above iteration is enabled, make the CRM Free card visible on the same row as the Jetpack Free card.

##### Miscellaneous / janitorial

* Make grid gaps all a uniform `16px` when the above iteration is enabled, per design mock-ups.
* Adjust `ProductWithoutPrice` styles to accommodate either one full-width card or two equal-width cards on the same row.
* Modernize some CSS properties in `product-grid/style.scss` to bring them into line with standard/make them more i18n-friendly.

#### Testing instructions

***NOTE:** For visual verification, consult the design mock-ups at `1a5ZL6xHHfOXdpXYQdiZuT-fi-732%3A31230`.*

##### Iteration not enabled (feature flag not set, or `?cloud-pricing-page=default`)

* Visit the Plans/Pricing page in any Calypso experience.
* Verify the page looks and behaves exactly as in production, for all the screen sizes and contexts you can think of. Some example permutations to try:
  * Jetpack Connect/Calypso Blue/Calypso Green
  * A site is selected/not selected
  * Small/medium/large screen widths

##### Iteration enabled (feature flag set, or `?cloud-pricing-page=only-realtime-products`)

* Visit the Plans/Pricing page in any Calypso experience.
* Verify the "CRM" card is no longer part of the same grid row as other paid products.
* Verify the "Jetpack CRM Free" card is now visible in the same grid section as Jetpack Free (whether or not the Jetpack Free card is visible).
* Verify that when you click the "Get CRM" button:
  * you're redirected to `https://jetpackcrm.com/pricing/...`; and
  * a Tracks event is recorded with the name `calypso_product_jpcrmfree_click` and your current site ID (if applicable) in the `site_id` property.

##### Iteration enabled; Jetpack Free card visible

* Visit the Plans/Pricing page in any Calypso experience where the Jetpack Free card is normally visible (e.g., Calypso Green with no site selected).
* Verify the Free and CRM Free cards appear side-by-side on the same row.
* Verify their call-to-action buttons line up vertically with each other.
* Verify that when you decrease the browser width, the cards eventually "stack" on top of each other like the other products in the grid.
* Verify that this stacking behavior happens at the same browser width as the other products on the page.

##### Iteration enabled; Jetpack Free card not visible

* Verify the Jetpack CRM Free card is visible and spans the entire width of the product grid.
* Verify that as you decrease the browser width, the card layout switches from horizontal to vertical, with the features list below instead of beside the product title and description.

#### Reference screenshots

##### Free card visible (before / after )

<img width="304" alt="image" src="https://user-images.githubusercontent.com/670067/124642819-e590f180-de55-11eb-8c17-a481a5a6f2bc.png"> <img width="304" alt="image" src="https://user-images.githubusercontent.com/670067/124642700-c1351500-de55-11eb-8ff5-5399b517551f.png">

<img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/124643101-3f91b700-de56-11eb-8636-bdfd41681663.png"> <img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/124643170-5cc68580-de56-11eb-8e8c-d98c0af2e4fb.png">

##### Free card not visible

<img width="247" alt="image" src="https://user-images.githubusercontent.com/670067/124643408-b038d380-de56-11eb-8773-f8d8c2396942.png">
<img width="650" alt="image" src="https://user-images.githubusercontent.com/670067/124643317-94353200-de56-11eb-822b-8011fc121e1a.png">