### PR TITLE
Signup: align step counter with the number of interactive steps

### DIFF
--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -42,6 +42,7 @@ You can add a new step to Modular Signup from `/client/signup/config/steps-pure.
 - (optional) `providesDependencies` is an array that lets the signup framework know what dependencies the step is expected to provide. If the step does not provide all of these, or if it provides more than it says, an error will be thrown (unless `optionalDependencies` is used, see below).
 - (optional) `optionalDependencies` is an array that lists which of the items in `providesDependencies` are optional. If one of these values is missing when a step is submitted there'll be no error.
 - (optional) `delayApiRequestUntilComplete` is a boolean that, when true, causes the step's `apiRequestFunction` to be called only after the user has submitted every step in the signup flow. This is useful for steps that the user should be able to go back and change at any point in signup.
+- (optional) `props` is an object with some custom properties that may be specific to a certain step. 
 
 You will also need to define which React component implements your step in `/client/signup/config/step-components.js`. Make sure to require the component as an internal dependency in `step-components.js`.
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -639,6 +639,9 @@ export function generateSteps( {
 			apiRequestFunction: launchSiteApi,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'isPreLaunch' ],
+			props: {
+				nonInteractive: true,
+			},
 		},
 
 		passwordless: {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -598,8 +598,10 @@ class Signup extends React.Component {
 		return flows.getFlow( flowName, this.props.isLoggedIn ).steps.indexOf( stepName );
 	}
 
-	getFlowLength() {
-		return flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps.length;
+	getInteractiveStepsCount() {
+		const flowStepsSlugs = flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps;
+		const flowSteps = flowStepsSlugs.filter( ( step ) => ! steps[ step ].props.nonInteractive );
+		return flowSteps.length;
 	}
 
 	renderProcessingScreen( isReskinned ) {
@@ -738,7 +740,7 @@ class Signup extends React.Component {
 				{ ! isWPForTeamsFlow( this.props.flowName ) && (
 					<SignupHeader
 						positionInFlow={ this.getPositionInFlow() }
-						flowLength={ this.getFlowLength() }
+						flowLength={ this.getInteractiveStepsCount() }
 						flowName={ this.props.flowName }
 						showProgressIndicator={ showProgressIndicator }
 						shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -601,7 +601,7 @@ class Signup extends React.Component {
 
 	getInteractiveStepsCount() {
 		const flowStepsSlugs = flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps;
-		const flowSteps = flowStepsSlugs.filter( ( step ) => ! steps[ step ].props.nonInteractive );
+		const flowSteps = flowStepsSlugs.filter( ( step ) => ! steps[ step ].props?.nonInteractive );
 		return flowSteps.length;
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -89,6 +89,7 @@ import SiteMockups from './site-mockup';
 import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 
 /**
  * Style dependencies
@@ -739,12 +740,17 @@ class Signup extends React.Component {
 				<DocumentHead title={ this.props.pageTitle } />
 				{ ! isWPForTeamsFlow( this.props.flowName ) && (
 					<SignupHeader
-						positionInFlow={ this.getPositionInFlow() }
-						flowLength={ this.getInteractiveStepsCount() }
-						flowName={ this.props.flowName }
-						showProgressIndicator={ showProgressIndicator }
 						shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
 						isReskinned={ isReskinned }
+						rightComponent={
+							showProgressIndicator && (
+								<FlowProgressIndicator
+									positionInFlow={ this.getPositionInFlow() }
+									flowLength={ this.getInteractiveStepsCount() }
+									flowName={ this.props.flowName }
+								/>
+							)
+						}
 					/>
 				) }
 				<div className="signup__steps">{ this.renderCurrentStep( isReskinned ) }</div>

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -11,7 +11,6 @@ import classnames from 'classnames';
  */
 
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 
 /**
  * Style dependencies
@@ -21,17 +20,13 @@ import './style.scss';
 
 export default class SignupHeader extends Component {
 	static propTypes = {
-		flowLength: PropTypes.number,
-		positionInFlow: PropTypes.number,
-		flowName: PropTypes.string,
-		showProgressIndicator: PropTypes.bool,
 		shouldShowLoadingScreen: PropTypes.bool,
 		isReskinned: PropTypes.bool,
+		rightComponent: PropTypes.node,
 	};
 
 	render() {
-		const logoClasses = classnames( {
-			'wordpress-logo': true,
+		const logoClasses = classnames( 'wordpress-logo', {
 			'is-large': this.props.shouldShowLoadingScreen && ! this.props.isReskinned,
 		} );
 
@@ -46,13 +41,7 @@ export default class SignupHeader extends Component {
 				{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }
 				<div className="signup-header__right">
-					{ ! this.props.shouldShowLoadingScreen && this.props.showProgressIndicator && (
-						<FlowProgressIndicator
-							positionInFlow={ this.props.positionInFlow }
-							flowLength={ this.props.flowLength }
-							flowName={ this.props.flowName }
-						/>
-					) }
+					{ ! this.props.shouldShowLoadingScreen && this.props.rightComponent }
 				</div>
 			</div>
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Step counter (top-right) displayed during signup and launch flows should ignore the non-interactive steps like processing.

**Technical changes:**
* Introduce the prop `nonIteractive` for the steps config and use it for `launch` step
* Render FlowProgressIndicator in signup/main
* Cleanup SignupHeader to be a wrapper component

### Testing instructions

* For an existing free site, start the launch flow
* You should see 1 of 2 steps in top-right 

Fixes part of https://github.com/Automattic/wp-calypso/issues/53973 
> The step counter aligns with the actual number of steps.
