### PR TITLE
ci(e2e): Fix types in mocha-debug-reporter

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -530,7 +530,7 @@ object RunAllUnitTests : BuildType({
 				export NODE_ENV="test"
 
 				# Run type checks
-				yarn tsc --build packages/tsconfig.json
+				yarn tsc --build packages/*/tsconfig.json
 				yarn tsc --build apps/editing-toolkit/tsconfig.json
 				yarn tsc --project client/landing/gutenboarding
 			"""

--- a/packages/mocha-debug-reporter/tsconfig.json
+++ b/packages/mocha-debug-reporter/tsconfig.json
@@ -4,7 +4,8 @@
 		"module": "CommonJS",
 		"declarationDir": "dist/types",
 		"outDir": "dist/cjs",
-		"rootDir": "src"
+		"rootDir": "src",
+		"types": [ "node" ]
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ]

--- a/packages/typography/tsconfig.json
+++ b/packages/typography/tsconfig.json
@@ -1,3 +1,0 @@
-{
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
-}

--- a/packages/webpack-config-flag-plugin/tsconfig.json
+++ b/packages/webpack-config-flag-plugin/tsconfig.json
@@ -1,3 +1,6 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
 }

--- a/packages/webpack-extensive-lodash-replacement-plugin/tsconfig.json
+++ b/packages/webpack-extensive-lodash-replacement-plugin/tsconfig.json
@@ -1,3 +1,6 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"compilerOptions": {
+		"types": ["node"]
+	}
 }

--- a/packages/webpack-inline-constant-exports-plugin/tsconfig.json
+++ b/packages/webpack-inline-constant-exports-plugin/tsconfig.json
@@ -1,3 +1,6 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"compilerOptions": {
+		"types": ["node"]
+	}
 }

--- a/packages/webpack-rtl-plugin/tsconfig.json
+++ b/packages/webpack-rtl-plugin/tsconfig.json
@@ -1,3 +1,6 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"compilerOptions": {
+		"types": ["node"]
+	}
 }

--- a/packages/wp-babel-makepot/tsconfig.json
+++ b/packages/wp-babel-makepot/tsconfig.json
@@ -1,3 +1,4 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"include": ["**/*.js", "package.json"]
 }


### PR DESCRIPTION
#### Background

In #54312 we changed the types visible to `tsc` to validate packages. I introduced a bug in the types for `packages/mocha-debug-reporter`, that prevents it from compiling:

```
16:35:46   $ tsc --build ./tsconfig.json
16:35:47   src/index.ts(5,16): error TS2307: Cannot find module 'fs' or its corresponding type declarations.
16:35:47   src/index.ts(6,18): error TS7016: Could not find a declaration file for module 'path'. '/home/teamcity-0/buildAgent/work/c4a9d5b38c1dacde/node_modules/path/path.js' implicitly has an 'any' type.
16:35:47     Try `npm i --save-dev @types/path` if it exists or add a new declaration (.d.ts) file containing `declare module 'path';`
16:35:47   src/index.ts(60,26): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
16:35:47   src/index.ts(62,34): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```


This wasn't detected in the PR because our type check job only typechecks packages listed in `packages/tsconfig.json`, and not all packages are there.

#### Changes proposed in this Pull Request

* Add missing `node` types to `mocha-debug-reporter`
* Refactor the typechecking job to test all `packages/*/tsconfig.json` projects.
* Add missing `node` types for the projects that were failing.

#### Testing instructions

N/A