### PR TITLE
Domains: Hide postal code when unsupported

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -13,15 +13,17 @@ import { Input } from 'calypso/my-sites/domains/components/form';
 const noop = () => {};
 
 const EuAddressFieldset = ( props ) => {
-	const { getFieldProps, translate, contactDetailsErrors } = props;
+	const { getFieldProps, translate, contactDetailsErrors, arePostalCodesSupported } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields eu-address-fieldset">
-			<Input
-				label={ translate( 'Postal Code' ) }
-				{ ...getFieldProps( 'postal-code', {
-					customErrorMessage: contactDetailsErrors?.postalCode,
-				} ) }
-			/>
+			{ arePostalCodesSupported && (
+				<Input
+					label={ translate( 'Postal Code' ) }
+					{ ...getFieldProps( 'postal-code', {
+						customErrorMessage: contactDetailsErrors?.postalCode,
+					} ) }
+				/>
+			) }
 			<Input
 				label={ translate( 'City' ) }
 				{ ...getFieldProps( 'city', { customErrorMessage: contactDetailsErrors?.city } ) }

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -36,6 +36,7 @@ EuAddressFieldset.propTypes = {
 	getFieldProps: PropTypes.func,
 	translate: PropTypes.func,
 	contactDetailsErrors: PropTypes.object,
+	arePostalCodesSupported: PropTypes.bool,
 };
 
 EuAddressFieldset.defaultProps = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -41,6 +41,7 @@ EuAddressFieldset.propTypes = {
 
 EuAddressFieldset.defaultProps = {
 	getFieldProps: noop,
+	arePostalCodesSupported: true,
 };
 
 export default localize( EuAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -3,6 +3,7 @@
  *
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -19,6 +20,7 @@ import UsAddressFieldset from './us-address-fieldset';
 import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import { Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
+import { getCountryPostalCodeSupport } from 'calypso/state/countries/selectors';
 
 const noop = () => {};
 
@@ -94,5 +96,11 @@ export class RegionAddressFieldsets extends Component {
 		);
 	}
 }
+export default connect( ( state, props ) => {
+	const countryCode = props.countryCode;
+	const arePostalCodesSupported = getCountryPostalCodeSupport( state, countryCode );
 
-export default localize( RegionAddressFieldsets );
+	return {
+		arePostalCodesSupported,
+	};
+} )( localize( RegionAddressFieldsets ) );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -42,6 +42,7 @@ export class RegionAddressFieldsets extends Component {
 		getFieldProps: noop,
 		countryCode: 'US',
 		shouldAutoFocusAddressField: false,
+		arePostalCodesSupported: true,
 		hasCountryStates: false,
 	};
 

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -28,6 +28,7 @@ export class RegionAddressFieldsets extends Component {
 	static propTypes = {
 		getFieldProps: PropTypes.func,
 		translate: PropTypes.func,
+		arePostalCodesSupported: PropTypes.bool,
 		countryCode: PropTypes.string,
 		shouldAutoFocusAddressField: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -3,7 +3,6 @@
  *
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -20,7 +19,6 @@ import UsAddressFieldset from './us-address-fieldset';
 import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import { Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
-import { getCountryPostalCodeSupport } from 'calypso/state/countries/selectors';
 
 const noop = () => {};
 
@@ -97,11 +95,4 @@ export class RegionAddressFieldsets extends Component {
 		);
 	}
 }
-export default connect( ( state, props ) => {
-	const countryCode = props.countryCode;
-	const arePostalCodesSupported = getCountryPostalCodeSupport( state, countryCode );
-
-	return {
-		arePostalCodesSupported,
-	};
-} )( localize( RegionAddressFieldsets ) );
+export default localize( RegionAddressFieldsets );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -25,6 +25,11 @@ describe( 'EU Address Fieldset', () => {
 		translate: ( string ) => string,
 	};
 
+	const propsWithoutPostalCode = {
+		...defaultProps,
+		arePostalCodesSupported: false,
+	};
+
 	test( 'should render correctly with default props', () => {
 		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
 		expect( wrapper.find( '.eu-address-fieldset' ) ).to.have.length( 1 );
@@ -39,5 +44,11 @@ describe( 'EU Address Fieldset', () => {
 	test( 'should not render a state select components', () => {
 		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
 		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 0 );
+	} );
+
+	test( 'should render all expected input components but postal code', () => {
+		const wrapper = shallow( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -25,6 +25,11 @@ describe( 'UK Address Fieldset', () => {
 		translate: ( string ) => string,
 	};
 
+	const propsWithoutPostalCode = {
+		...defaultProps,
+		arePostalCodesSupported: false,
+	};
+
 	test( 'should render correctly with default props', () => {
 		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
 		expect( wrapper.find( '.uk-address-fieldset' ) ).to.have.length( 1 );
@@ -39,5 +44,11 @@ describe( 'UK Address Fieldset', () => {
 	test( 'should not render a state select components', () => {
 		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
 		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 0 );
+	} );
+
+	test( 'should render all expected input components but postal code', () => {
+		const wrapper = shallow( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -26,6 +26,11 @@ describe( 'US Address Fieldset', () => {
 		translate: ( string ) => string,
 	};
 
+	const propsWithoutPostalCode = {
+		...defaultProps,
+		arePostalCodesSupported: false,
+	};
+
 	test( 'should render correctly with default props', () => {
 		const wrapper = shallow( <UsAddressFieldset { ...defaultProps } /> );
 		expect( wrapper.find( '.us-address-fieldset' ) ).to.have.length( 1 );
@@ -36,5 +41,12 @@ describe( 'US Address Fieldset', () => {
 		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
 		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 1 );
 		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+	} );
+
+	test( 'should render all expected input components but postal code', () => {
+		const wrapper = shallow( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -36,6 +36,7 @@ UkAddressFieldset.propTypes = {
 	getFieldProps: PropTypes.func,
 	translate: PropTypes.func,
 	contactDetailsErrors: PropTypes.object,
+	arePostalCodesSupported: PropTypes.bool,
 };
 
 UkAddressFieldset.defaultProps = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -13,19 +13,21 @@ import { Input } from 'calypso/my-sites/domains/components/form';
 const noop = () => {};
 
 const UkAddressFieldset = ( props ) => {
-	const { getFieldProps, translate, contactDetailsErrors } = props;
+	const { getFieldProps, translate, contactDetailsErrors, arePostalCodesSupported } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields uk-address-fieldset">
 			<Input
 				label={ translate( 'City' ) }
 				{ ...getFieldProps( 'city', { customErrorMessage: contactDetailsErrors?.city } ) }
 			/>
-			<Input
-				label={ translate( 'Postal Code' ) }
-				{ ...getFieldProps( 'postal-code', {
-					customErrorMessage: contactDetailsErrors?.postalCode,
-				} ) }
-			/>
+			{ arePostalCodesSupported && (
+				<Input
+					label={ translate( 'Postal Code' ) }
+					{ ...getFieldProps( 'postal-code', {
+						customErrorMessage: contactDetailsErrors?.postalCode,
+					} ) }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -41,5 +41,6 @@ UkAddressFieldset.propTypes = {
 
 UkAddressFieldset.defaultProps = {
 	getFieldProps: noop,
+	arePostalCodesSupported: true,
 };
 export default localize( UkAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -59,6 +59,7 @@ UsAddressFieldset.propTypes = {
 UsAddressFieldset.defaultProps = {
 	countryCode: 'US',
 	getFieldProps: noop,
+	arePostalCodesSupported: true,
 };
 
 export default localize( UsAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -53,6 +53,7 @@ UsAddressFieldset.propTypes = {
 	getFieldProps: PropTypes.func,
 	translate: PropTypes.func,
 	contactDetailsErrors: PropTypes.object,
+	arePostalCodesSupported: PropTypes.bool,
 };
 
 UsAddressFieldset.defaultProps = {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -14,7 +14,13 @@ import { getStateLabelText, getPostCodeLabelText, STATE_SELECT_TEXT } from './ut
 const noop = () => {};
 
 const UsAddressFieldset = ( props ) => {
-	const { getFieldProps, translate, countryCode, contactDetailsErrors } = props;
+	const {
+		getFieldProps,
+		translate,
+		countryCode,
+		contactDetailsErrors,
+		arePostalCodesSupported,
+	} = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields us-address-fieldset">
 			<Input
@@ -30,12 +36,14 @@ const UsAddressFieldset = ( props ) => {
 					customErrorMessage: contactDetailsErrors?.state,
 				} ) }
 			/>
-			<Input
-				label={ getPostCodeLabelText( countryCode ) }
-				{ ...getFieldProps( 'postal-code', {
-					customErrorMessage: contactDetailsErrors?.postalCode,
-				} ) }
-			/>
+			{ arePostalCodesSupported && (
+				<Input
+					label={ getPostCodeLabelText( countryCode ) }
+					{ ...getFieldProps( 'postal-code', {
+						customErrorMessage: contactDetailsErrors?.postalCode,
+					} ) }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/domains/contact-details-form-fields/helper.js
+++ b/client/components/domains/contact-details-form-fields/helper.js
@@ -1,19 +1,15 @@
 /**
- * Internal dependencies
- */
-import 'calypso/state/countries/init';
-
-/**
  * Returns true if postal codes are supported on the specified country code,
  * or false otherwise.
  *
+ * @param {Array}  countries   Country list to check.
  * @param {string} countryCode Country code to check.
  * @returns {boolean}          Whether postal codes are supported in the country.
  */
 
-export function getCountryPostalCodeSupport( state, countryCode ) {
+export function getCountryPostalCodeSupport( countries, countryCode ) {
 	return (
-		state.countries.domains.find( ( country ) => country.code === countryCode.toUpperCase() )
-			?.has_postal_codes ?? false
+		countries.find( ( country ) => country.code === countryCode.toUpperCase() )?.has_postal_codes ??
+		false
 	);
 }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -434,6 +434,7 @@ export class ContactDetailsFormFields extends Component {
 
 				{ countryCode && (
 					<RegionAddressFieldsets
+						{ ...this.state.form }
 						getFieldProps={ this.getFieldProps }
 						countryCode={ countryCode }
 						hasCountryStates={ hasCountryStates }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -41,6 +41,7 @@ import './style.scss';
 import classNames from 'classnames';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { getCountryPostalCodeSupport } from './helper';
 
 const noop = () => {};
 
@@ -362,9 +363,13 @@ export class ContactDetailsFormFields extends Component {
 		return get( this.state.form, 'countryCode.value', '' );
 	}
 
+	getCountryPostalCodeSupport = ( countryCode ) =>
+		getCountryPostalCodeSupport( this.props.countriesList, countryCode );
+
 	renderContactDetailsFields() {
 		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
+		const arePostalCodesSupported = this.getCountryPostalCodeSupport( countryCode );
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
@@ -434,7 +439,7 @@ export class ContactDetailsFormFields extends Component {
 
 				{ countryCode && (
 					<RegionAddressFieldsets
-						{ ...this.state.form }
+						arePostalCodesSupported={ arePostalCodesSupported }
 						getFieldProps={ this.getFieldProps }
 						countryCode={ countryCode }
 						hasCountryStates={ hasCountryStates }

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -33,6 +33,7 @@ import { tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
  * Style dependencies
  */
 import './style.scss';
+import { getCountryPostalCodeSupport } from './helper';
 
 const debug = debugFactory( 'calypso:managed-contact-details-form-fields' );
 
@@ -296,6 +297,9 @@ export class ManagedContactDetailsFormFields extends Component {
 		);
 	}
 
+	getCountryPostalCodeSupport = ( countryCode ) =>
+		getCountryPostalCodeSupport( this.props.countriesList, countryCode );
+
 	renderContactDetailsFields() {
 		const { translate, hasCountryStates } = this.props;
 		const form = getFormFromContactDetails(
@@ -303,6 +307,7 @@ export class ManagedContactDetailsFormFields extends Component {
 			this.props.contactDetailsErrors
 		);
 		const countryCode = form.countryCode?.value ?? '';
+		const arePostalCodesSupported = this.getCountryPostalCodeSupport( countryCode );
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
@@ -324,6 +329,7 @@ export class ManagedContactDetailsFormFields extends Component {
 
 				{ countryCode && (
 					<RegionAddressFieldsets
+						arePostalCodesSupported={ arePostalCodesSupported }
 						getFieldProps={ this.getFieldProps }
 						countryCode={ countryCode }
 						hasCountryStates={ hasCountryStates }

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -157,6 +157,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       />
     </div>
     <RegionAddressFieldsets
+      arePostalCodesSupported={false}
       countryCode="IT"
       getFieldProps={[Function]}
       hasCountryStates={false}

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -157,10 +157,12 @@ describe( 'CompositeCheckout', () => {
 			{
 				code: 'US',
 				name: 'United States',
+				has_postal_codes: true,
 			},
 			{
 				code: 'AU',
 				name: 'Australia',
+				has_postal_codes: true,
 			},
 		];
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -160,6 +160,11 @@ describe( 'CompositeCheckout', () => {
 				has_postal_codes: true,
 			},
 			{
+				code: 'CW',
+				name: 'Curacao',
+				has_postal_codes: false,
+			},
+			{
 				code: 'AU',
 				name: 'Australia',
 				has_postal_codes: true,
@@ -478,6 +483,20 @@ describe( 'CompositeCheckout', () => {
 		expect( getByText( 'City' ) ).toBeInTheDocument();
 		expect( getByText( 'State' ) ).toBeInTheDocument();
 		expect( getByText( 'ZIP code' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a domain is in the cart', async () => {
+		let renderResult;
+		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		await act( async () => {
+			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const { getByText, queryByText, getByLabelText } = renderResult;
+		fireEvent.change( getByLabelText( 'Country' ), { target: { value: 'CW' } } );
+		expect( getByText( 'Country' ) ).toBeInTheDocument();
+		expect( getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( getByText( 'Email' ) ).toBeInTheDocument();
+		expect( queryByText( 'Postal code' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the checkout summary', async () => {

--- a/client/state/countries/selectors.js
+++ b/client/state/countries/selectors.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/countries/init';
+
+/**
+ * Returns true if postal codes are supported on the specified country code,
+ * or false otherwise.
+ *
+ * @param {string} countryCode Country code to check.
+ * @returns {boolean}          Whether postal codes are supported in the country.
+ */
+
+export function getCountryPostalCodeSupport( state, countryCode ) {
+	return (
+		state.countries.domains.find( ( country ) => country.code === countryCode.toUpperCase() )
+			?.has_postal_codes ?? false
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Follow up/related to https://github.com/Automattic/wp-calypso/pull/53522. This PR hides the postal code field and removes its value when the country doesn't support postal codes.

#### Screenshots

##### Country without postal code support
<img width="723" alt="country_without_postal_code_support" src="https://user-images.githubusercontent.com/18705930/124645284-a2d91480-de69-11eb-8c1c-d56905d54d00.png">

##### Country with postal code support
<img width="717" alt="country_with_postal_code_support" src="https://user-images.githubusercontent.com/18705930/124645278-9fde2400-de69-11eb-93f8-7dfca861ef40.png">

#### Preview
https://user-images.githubusercontent.com/18705930/124645263-9c4a9d00-de69-11eb-845d-2fdd4c7bf4e4.mov

#### Testing instructions
- Check that the tests are passing;
- Check that the postal code field is hidden when the country doesn't support postal codes.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

