### PR TITLE
Fixes Yoast Redirect URL After Plugin Install

### DIFF
--- a/client/state/sites/selectors/get-site-wordpress-seo-wizard-url.js
+++ b/client/state/sites/selectors/get-site-wordpress-seo-wizard-url.js
@@ -12,5 +12,5 @@ import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
  * @returns {?string}       Full URL to Yoast onboarding page in wp-admin
  */
 export default function getSiteWordPressSeoWizardUrl( state, siteId ) {
-	return getSiteAdminUrl( state, siteId, '/wp-admin/admin.php?page=wpseo_configurator' );
+	return getSiteAdminUrl( state, siteId, 'admin.php?page=wpseo_configurator' );
 }


### PR DESCRIPTION
#### Changes Proposed in This Pull Request

* Remove extra '/wp-admin/' from path.

#### Testing Instructions

1. Using a JetPack site, go to the Yoast plugin page.
2. Click on the Install button.
3. After 5 seconds your page should redirect to the Yoast setup page.

### Before

![yoast-plugin-redirect-404](https://user-images.githubusercontent.com/140841/124676973-2a804c80-de85-11eb-8d6e-838c74fd3298.gif)

### After

Should redirect to this page:
![yoast-setup-page](https://user-images.githubusercontent.com/140841/124677614-77b0ee00-de86-11eb-89a1-ae125ceafe7d.png)
