### PR TITLE
My Home: "Add menu" task takes unverified users to the correct view in the customiser

### DIFF
--- a/client/state/selectors/get-menus-url.js
+++ b/client/state/selectors/get-menus-url.js
@@ -3,7 +3,6 @@
  */
 
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { getSiteAdminUrl, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 
 /**
@@ -20,12 +19,6 @@ export default function getMenusUrl( state, siteId ) {
 
 	if ( isJetpackSite( state, siteId ) ) {
 		return getSiteAdminUrl( state, siteId, 'customize.php' ) + '?autofocus[panel]=nav_menus';
-	}
-	// The Customizer's Menus panel shouldn't be available to users who haven't verified their
-	// email yet, so send them to the top-level Customizer where they will (maybe?) see that Menus
-	// are not available to them yet. See https://github.com/Automattic/wp-calypso/pull/13017
-	if ( ! isCurrentUserEmailVerified( state ) ) {
-		return '/customize/' + getSiteSlug( state, siteId );
 	}
 
 	return '/customize/menus/' + getSiteSlug( state, siteId );

--- a/client/state/selectors/test/get-menus-url.js
+++ b/client/state/selectors/test/get-menus-url.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { merge } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getMenusUrl from 'calypso/state/selectors/get-menus-url';
@@ -62,29 +57,8 @@ describe( 'getMenusUrl()', () => {
 		expect( url ).toBe( 'https://example.com/wp-admin/customize.php?autofocus[panel]=nav_menus' );
 	} );
 
-	test( 'should return URL of the Calypso customizer (top-level) for a user with unverified email', () => {
-		const userState = {
-			currentUser: {
-				user: {
-					email_verified: false,
-				},
-			},
-		};
-
-		const url = getMenusUrl( merge( state, userState ), 8765432 );
-		expect( url ).toBe( '/customize/example.wordpress.com' );
-	} );
-
 	test( "should return URL of the Calypso customizer's menu panel for a WP.com site", () => {
-		const userState = {
-			currentUser: {
-				user: {
-					email_verified: true,
-				},
-			},
-		};
-
-		const url = getMenusUrl( merge( state, userState ), 9876543 );
+		const url = getMenusUrl( state, 9876543 );
 		expect( url ).toBe( '/customize/menus/example2.wordpress.com' );
 	} );
 } );


### PR DESCRIPTION
There used to be a limitation where unverified users couldn't see the menu interface in the customiser. I don't know why, but it's mentioned in #13017 and looked like this:
![screen shot 2017-04-11 at 3 36 05 pm](https://cloud.githubusercontent.com/assets/349751/24933723/a71aa18c-1ecc-11e7-87e1-6a23fec1fde3.png)

That limitation no longer exists, but the code used by the "add menu" task for sending the user to the customiser.

#### Changes proposed in this Pull Request

* Allow unverified users to be taken to menu interface
* Remove unit test that would be testing a non-existent code branch

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test "add menu" task with unverified user, they should go to the correct customiser view
* Test "add menu" task with verified user, they should go to the correct customiser view
* Inspect other uses of the `getMenusUrl()` selector and satisify yourself that this change is appropriate everywhere it's used.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54151
