### PR TITLE
`withUpdateUser`: simplify success & error notices

### DIFF
--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -19,7 +19,7 @@ function useUpdateUserMutation( siteId, queryOptions = {} ) {
 			onSuccess( ...args ) {
 				const [ { login } ] = args;
 				queryClient.invalidateQueries( getCacheKey( siteId, login ) );
-				queryOptions?.onSuccess( ...args );
+				queryOptions.onSuccess?.( ...args );
 			},
 		}
 	);

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -10,13 +10,16 @@ import { useMutation, useQueryClient } from 'react-query';
 import wp from 'calypso/lib/wp';
 import { getCacheKey } from './use-user-query';
 
-function useUpdateUserMutation( siteId ) {
+function useUpdateUserMutation( siteId, queryOptions = {} ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
 		( { userId, variables } ) => wp.req.post( `/sites/${ siteId }/users/${ userId }`, variables ),
 		{
-			onSuccess( { login } ) {
+			...queryOptions,
+			onSuccess( ...args ) {
+				const [ { login } ] = args;
 				queryClient.invalidateQueries( getCacheKey( siteId, login ) );
+				queryOptions?.onSuccess( ...args );
 			},
 		}
 	);

--- a/client/my-sites/people/edit-team-member-form/with-update-user.js
+++ b/client/my-sites/people/edit-team-member-form/with-update-user.js
@@ -11,13 +11,12 @@ import useUpdateUserMutation from 'calypso/data/users/use-update-user-mutation';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useTranslate } from 'i18n-calypso';
 
-const useSuccessNotice = ( isSuccess, user ) => {
-	const showNotice = React.useRef();
+const withUpdateUser = ( Component ) => ( props ) => {
+	const { siteId, user } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-
-	React.useEffect( () => {
-		showNotice.current = () => {
+	const { updateUser, isLoading } = useUpdateUserMutation( siteId, {
+		onSuccess() {
 			dispatch(
 				successNotice(
 					translate( 'Successfully updated @%(user)s', {
@@ -27,21 +26,8 @@ const useSuccessNotice = ( isSuccess, user ) => {
 					{ id: 'update-user-notice' }
 				)
 			);
-		};
-	}, [ dispatch, translate, user.login ] );
-
-	React.useEffect( () => {
-		isSuccess && showNotice.current();
-	}, [ isSuccess ] );
-};
-
-const useErrorNotice = ( isError, user ) => {
-	const showNotice = React.useRef();
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	React.useEffect( () => {
-		showNotice.current = () => {
+		},
+		onError() {
 			dispatch(
 				errorNotice(
 					translate( 'There was an error updating @%(user)s', {
@@ -51,20 +37,8 @@ const useErrorNotice = ( isError, user ) => {
 					{ id: 'update-user-notice' }
 				)
 			);
-		};
-	}, [ dispatch, translate, user.login ] );
-
-	React.useEffect( () => {
-		isError && showNotice.current();
-	}, [ isError ] );
-};
-
-const withUpdateUser = ( Component ) => ( props ) => {
-	const { siteId, user } = props;
-	const { updateUser, isSuccess, isError, isLoading } = useUpdateUserMutation( siteId );
-
-	useSuccessNotice( isSuccess, user );
-	useErrorNotice( isError, user );
+		},
+	} );
 
 	return <Component { ...props } updateUser={ updateUser } isUpdating={ isLoading } />;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sibling PR to #54447

* `withUpdateUser`: use a simpler approach to dispatch success and error notices

#### Testing instructions

Try the following steps for a simple site, an AT site and a Jetpack site because the fields you can change differ on the type of the site.

* Go to `people/team/` and choose on of the people on your team which isn't you
* Attempt to change the role and/or other attributes of that user
* Hit _Save changes_
* Are the changes persisted successfully and shown locally (e.g. role changes)?

Follow-up to #50992
