### PR TITLE
Emails: Set every form field for each line when creating mailboxes

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -139,92 +139,86 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 			className={ classNames( 'gsuite-new-user-list__new-user', { 'show-labels': showLabels } ) }
 		>
 			<FormFieldset>
-				<div className="gsuite-new-user-list__new-user-section">
-					<div className="gsuite-new-user-list__new-user-name-container">
-						<LabelWrapper label={ translate( 'First name' ) } showLabel={ showLabels }>
-							<FormTextInput
-								autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-								placeholder={ translate( 'First name' ) }
-								value={ firstName }
-								maxLength={ 60 }
-								isError={ hasFirstNameError }
-								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-									onUserValueChange( 'firstName', event.target.value, mailBoxFieldTouched );
-								} }
-								onBlur={ () => {
-									setFirstNameFieldTouched( wasValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-							/>
-						</LabelWrapper>
+				<LabelWrapper label={ translate( 'First name' ) } showLabel={ showLabels }>
+					<FormTextInput
+						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+						placeholder={ translate( 'First name' ) }
+						value={ firstName }
+						maxLength={ 60 }
+						isError={ hasFirstNameError }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+							onUserValueChange( 'firstName', event.target.value, mailBoxFieldTouched );
+						} }
+						onBlur={ () => {
+							setFirstNameFieldTouched( wasValidated );
+						} }
+						onKeyUp={ onReturnKeyPress }
+					/>
+				</LabelWrapper>
 
-						{ hasFirstNameError && <FormInputValidation text={ firstNameError } isError /> }
+				{ hasFirstNameError && <FormInputValidation text={ firstNameError } isError /> }
+			</FormFieldset>
+
+			<FormFieldset>
+				<LabelWrapper label={ translate( 'Last name' ) } showLabel={ showLabels }>
+					<FormTextInput
+						placeholder={ translate( 'Last name' ) }
+						value={ lastName }
+						maxLength={ 60 }
+						isError={ hasLastNameError }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+							onUserValueChange( 'lastName', event.target.value );
+						} }
+						onBlur={ () => {
+							setLastNameFieldTouched( wasValidated );
+						} }
+						onKeyUp={ onReturnKeyPress }
+					/>
+				</LabelWrapper>
+
+				{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
+
+				{ showTrashButton && (
+					<Button
+						className="gsuite-new-user-list__new-user-remove-user-button"
+						onClick={ onUserRemove }
+					>
+						<Gridicon icon="trash" />
+						<span>{ translate( 'Remove user' ) }</span>
+					</Button>
+				) }
+			</FormFieldset>
+
+			<FormFieldset>
+				<div className="gsuite-new-user-list__new-user-email-container">
+					<div className="gsuite-new-user-list__new-user-email">
+						{ domains.length > 1 ? renderMultiDomain() : renderSingleDomain() }
 					</div>
 
-					<div className="gsuite-new-user-list__new-user-name-container">
-						<LabelWrapper label={ translate( 'Last name' ) } showLabel={ showLabels }>
-							<FormTextInput
-								placeholder={ translate( 'Last name' ) }
-								value={ lastName }
-								maxLength={ 60 }
-								isError={ hasLastNameError }
-								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-									onUserValueChange( 'lastName', event.target.value );
-								} }
-								onBlur={ () => {
-									setLastNameFieldTouched( wasValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-							/>
-						</LabelWrapper>
-
-						{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
-					</div>
-
-					{ showTrashButton && (
-						<Button
-							className="gsuite-new-user-list__new-user-remove-user-button"
-							onClick={ onUserRemove }
-						>
-							<Gridicon icon="trash" />
-							<span>{ translate( 'Remove user' ) }</span>
-						</Button>
-					) }
+					{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
 				</div>
 			</FormFieldset>
 
 			<FormFieldset>
-				<div className="gsuite-new-user-list__new-user-section">
-					<div className="gsuite-new-user-list__new-user-email-container">
-						<div className="gsuite-new-user-list__new-user-email">
-							{ domains.length > 1 ? renderMultiDomain() : renderSingleDomain() }
-						</div>
+					<LabelWrapper label={ translate( 'Password' ) } showLabel={ showLabels }>
+						<FormPasswordInput
+							autoCapitalize="off"
+							autoCorrect="off"
+							placeholder={ translate( 'Password' ) }
+							value={ password }
+							maxLength={ 100 }
+							isError={ hasPasswordError }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+								onUserValueChange( 'password', event.target.value );
+							} }
+							onBlur={ () => {
+								setPasswordFieldTouched( wasValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
+					</LabelWrapper>
 
-						{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
-					</div>
-
-					<div className="gsuite-new-user-list__new-user-password-container">
-						<LabelWrapper label={ translate( 'Password' ) } showLabel={ showLabels }>
-							<FormPasswordInput
-								autoCapitalize="off"
-								autoCorrect="off"
-								placeholder={ translate( 'Password' ) }
-								value={ password }
-								maxLength={ 100 }
-								isError={ hasPasswordError }
-								onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-									onUserValueChange( 'password', event.target.value );
-								} }
-								onBlur={ () => {
-									setPasswordFieldTouched( wasValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-							/>
-						</LabelWrapper>
-
-						{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
-					</div>
-				</div>
+					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
 			</FormFieldset>
 		</div>
 	);

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -200,25 +200,25 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 			</FormFieldset>
 
 			<FormFieldset>
-					<LabelWrapper label={ translate( 'Password' ) } showLabel={ showLabels }>
-						<FormPasswordInput
-							autoCapitalize="off"
-							autoCorrect="off"
-							placeholder={ translate( 'Password' ) }
-							value={ password }
-							maxLength={ 100 }
-							isError={ hasPasswordError }
-							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-								onUserValueChange( 'password', event.target.value );
-							} }
-							onBlur={ () => {
-								setPasswordFieldTouched( wasValidated );
-							} }
-							onKeyUp={ onReturnKeyPress }
-						/>
-					</LabelWrapper>
+				<LabelWrapper label={ translate( 'Password' ) } showLabel={ showLabels }>
+					<FormPasswordInput
+						autoCapitalize="off"
+						autoCorrect="off"
+						placeholder={ translate( 'Password' ) }
+						value={ password }
+						maxLength={ 100 }
+						isError={ hasPasswordError }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+							onUserValueChange( 'password', event.target.value );
+						} }
+						onBlur={ () => {
+							setPasswordFieldTouched( wasValidated );
+						} }
+						onKeyUp={ onReturnKeyPress }
+					/>
+				</LabelWrapper>
 
-					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+				{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
 			</FormFieldset>
 		</div>
 	);

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -53,7 +53,8 @@
 .gsuite-new-user-list__new-user {
 	.form-fieldset .form-label {
 		color: var( --color-text );
-		margin-bottom: 0;
+		margin-bottom: 1em;
+		margin-top: 0;
 
 		.form-text-input-with-affixes__suffix {
 			font-weight: normal;
@@ -106,7 +107,6 @@
 	}
 
 	@include breakpoint-deprecated( '>800px' ) {
-		flex-direction: row;
 
 		input[type='text'].form-text-input {
 			margin: 0;

--- a/client/my-sites/email/titan-add-mailboxes/titan-new-mailbox.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-new-mailbox.jsx
@@ -103,64 +103,59 @@ const TitanNewMailbox = ( {
 						</Button>
 					) }
 				</div>
+				<FormFieldset>
+					<FormLabel>
+						{ showLabels && translate( 'Email address' ) }
+						<FormTextInputWithAffixes
+							placeholder={ translate( 'Email' ) }
+							value={ mailbox }
+							isError={ hasMailboxError }
+							onChange={ ( event ) => {
+								onMailboxValueChange( 'mailbox', event.target.value.toLowerCase() );
+							} }
+							onBlur={ () => {
+								setMailboxFieldTouched( hasBeenValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+							suffix={ `@${ domain }` }
+						/>
+					</FormLabel>
+					{ hasMailboxError && <FormInputValidation text={ mailboxError } isError /> }
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						{ showLabels && translate( 'Password' ) }
+						<FormPasswordInput
+							autoCapitalize="off"
+							autoCorrect="off"
+							placeholder={ translate( 'Password' ) }
+							value={ password }
+							maxLength={ 100 }
+							isError={ hasPasswordError }
+							onChange={ ( event ) => {
+								onMailboxValueChange( 'password', event.target.value );
+							} }
+							onBlur={ () => {
+								setPasswordFieldTouched( hasBeenValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
+					</FormLabel>
+					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+				</FormFieldset>
 
-				<div className="titan-add-mailboxes__new-mailbox-email-and-password">
+				{ showIsAdminToggle && (
 					<FormFieldset>
-						<FormLabel>
-							{ showLabels && translate( 'Email address' ) }
-							<FormTextInputWithAffixes
-								placeholder={ translate( 'Email' ) }
-								value={ mailbox }
-								isError={ hasMailboxError }
-								onChange={ ( event ) => {
-									onMailboxValueChange( 'mailbox', event.target.value.toLowerCase() );
-								} }
-								onBlur={ () => {
-									setMailboxFieldTouched( hasBeenValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-								suffix={ `@${ domain }` }
-							/>
-						</FormLabel>
-						{ hasMailboxError && <FormInputValidation text={ mailboxError } isError /> }
+						<ToggleControl
+							checked={ isAdmin }
+							onChange={ ( newValue ) => {
+								onMailboxValueChange( 'isAdmin', newValue );
+							} }
+							help={ translate( 'Should this user have control panel access?' ) }
+							label={ translate( 'Is admin?' ) }
+						/>
 					</FormFieldset>
-					<FormFieldset>
-						<FormLabel>
-							{ showLabels && translate( 'Password' ) }
-							<FormPasswordInput
-								autoCapitalize="off"
-								autoCorrect="off"
-								placeholder={ translate( 'Password' ) }
-								value={ password }
-								maxLength={ 100 }
-								isError={ hasPasswordError }
-								onChange={ ( event ) => {
-									onMailboxValueChange( 'password', event.target.value );
-								} }
-								onBlur={ () => {
-									setPasswordFieldTouched( hasBeenValidated );
-								} }
-								onKeyUp={ onReturnKeyPress }
-							/>
-						</FormLabel>
-						{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
-					</FormFieldset>
-				</div>
-
-				<div className="titan-add-mailboxes__new-mailbox-password-and-is-admin">
-					{ showIsAdminToggle && (
-						<FormFieldset>
-							<ToggleControl
-								checked={ isAdmin }
-								onChange={ ( newValue ) => {
-									onMailboxValueChange( 'isAdmin', newValue );
-								} }
-								help={ translate( 'Should this user have control panel access?' ) }
-								label={ translate( 'Is admin?' ) }
-							/>
-						</FormFieldset>
-					) }
-				</div>
+				) }
 
 				<FormFieldset>
 					<FormLabel>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The changes in this Pull request are just changing how the forms add new email boxes (for Titan and Google). They should be now displayed in each field on one line.

These changes took into account the mobile browsers too.

#### Testing instructions

1. Go to Upgrades
2. Go to emails
3. Add a new Titan email
4. Compare the new form with the old form. Every field has to be one line long.

**Titan**
BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/124759567-0f1e4b80-df30-11eb-880a-c973dab188f5.png) | ![image](https://user-images.githubusercontent.com/5689927/124759471-f3b34080-df2f-11eb-8129-8d04d2af609f.png)

**Google Workspace**
1. Go to Upgrades
2. Go to emails
3. Add a new Google Workspace
4. Compare the new form with the old form. Every field has to be one line long.

**Google Workspace**
BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/124759971-8b189380-df30-11eb-90af-106de3042f7d.png) | ![image](https://user-images.githubusercontent.com/5689927/124760022-9a97dc80-df30-11eb-8a35-e043555f185b.png)
Related to {1200182182542585-as-1200414925548945}
