### PR TITLE
Moved back into sections.js the settings-* specific modules

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -22,11 +22,6 @@ import {
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
-import jetpackSettings from './settings-jetpack';
-import settingsPerformance from './settings-performance';
-import settingsWriting from './settings-writing';
-import settingsDiscussion from './settings-discussion';
-import settingsSecurity from './settings-security';
 
 export default function () {
 	page( '/settings', '/settings/general' );
@@ -41,12 +36,6 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-
-	jetpackSettings();
-	settingsPerformance();
-	settingsWriting();
-	settingsDiscussion();
-	settingsSecurity();
 
 	// Redirect settings pages for import and export now that they have their own sections.
 	page( '/settings/:importOrExport(import|export)/:subroute(.*)', ( context ) => {

--- a/client/sections.js
+++ b/client/sections.js
@@ -135,6 +135,36 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'settings-performance',
+		paths: [ '/settings/performance' ],
+		module: 'calypso/my-sites/site-settings/settings-performance',
+		group: 'sites',
+	},
+	{
+		name: 'settings-writing',
+		paths: [ '/settings/writing', '/settings/taxonomies', '/settings/podcasting' ],
+		module: 'calypso/my-sites/site-settings/settings-writing',
+		group: 'sites',
+	},
+	{
+		name: 'settings-discussion',
+		paths: [ '/settings/discussion' ],
+		module: 'calypso/my-sites/site-settings/settings-discussion',
+		group: 'sites',
+	},
+	{
+		name: 'settings-security',
+		paths: [ '/settings/security' ],
+		module: 'calypso/my-sites/site-settings/settings-security',
+		group: 'sites',
+	},
+	{
+		name: 'settings-jetpack',
+		paths: [ '/settings/jetpack' ],
+		module: 'calypso/my-sites/site-settings/settings-jetpack',
+		group: 'sites',
+	},
+	{
 		name: 'settings',
 		paths: [ '/settings' ],
 		module: 'calypso/my-sites/site-settings',


### PR DESCRIPTION
In the context of the [PR that fixes the mobile menu on several pages](https://github.com/Automattic/wp-calypso/pull/54203) in Calypso, we've moved the settings-* specific routes from [sections.js](https://github.com/Automattic/wp-calypso/pull/54203/files#diff-bbfd0752d7fc9a4e930a58d3f153a24662dd06baa00a529caf8b7715e9477003L138) to the [site-settings module](https://github.com/Automattic/wp-calypso/pull/54203/files#diff-4b5f4cbd9c73336c549a74f8f4497bacf9de3fdfe9860e44f62bfa366f8cc4e6R45) in order to avoid having route regex conflicts triggering multiple page() callbacks. 

When that happened, the sections-middle.js was called multiple times, triggering [activateSection](https://github.com/Automattic/wp-calypso/blob/trunk/client/sections-middleware.js#L98) multiple times, in which case, the navigation was first opened (as it should) and then un-toggling it immediately (preventing users to open up the navigation).

However, in the PR we also introduced a fix for a related issue that replaced the link with a button. By doing so, we can observe that the page callbacks are no longer triggering (as they should), and therefore, this change will also fix the original issue.

Therefore, to clean things up, and avoid the performance penalty by bundling the entire sections, I've added back the sections-* into sections.js since the original issue is no longer reproducing with the button change. 

#### Changes proposed in this Pull Request

* Move back into sections the settings routes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use Calypso live or checkout this branch on your local Calypso environment.
- Resize the browser size to a mobile resolution.
- Go to the following URLs and check that the menu opens and closes on the following sections:
- Settings > Discussion (Calypso)
- Settings > Performance (Calypso)
- Settings > Writing (Calypso)
- Settings > Jetpack (on Atomic)
- Posts > Tags (Calypso)
- Posts > Categories (Calypso)
- Make sure that https://wordpress.com/settings, https://wordpress.com/settings/jetpack, https://wordpress.com/settings/writing are pointing to the site selection component (where a user can select the site they want).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/54239
