### PR TITLE
DO NOT MERGE: Revert "Theme Showcase: Enable the Theme Showcase feature flag on production"

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -154,7 +154,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
-		"theme/showcase-revamp": true,
+		"theme/showcase-revamp": false,
 		"titan/iframe-control-panel": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,7 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
-		"theme/showcase-revamp": true,
+		"theme/showcase-revamp": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,7 @@
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
-		"theme/showcase-revamp": true,
+		"theme/showcase-revamp": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -115,7 +115,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
-		"theme/showcase-revamp": true,
+		"theme/showcase-revamp": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
-		"theme/showcase-revamp": true,
+		"theme/showcase-revamp": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -121,7 +121,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
-		"theme/showcase-revamp": true,
+		"theme/showcase-revamp": false,
 		"tools/migrate": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
Reverts feature flag changes deployed in Automattic/wp-calypso#54254 in case something breaks.