### PR TITLE
Theme Showcase: Do away with "Show all themes" button, add tabs, take 2

### DIFF
--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -26,8 +26,8 @@ class RecommendedThemes extends React.Component {
 
 	componentDidUpdate( prevProps ) {
 		// Wait until rec themes to be loaded to scroll to search input if its in use.
-		const { isLoading, isShowcaseOpen, scrollToSearchInput, filter } = this.props;
-		if ( prevProps.isLoading !== isLoading && isLoading === false && isShowcaseOpen ) {
+		const { isLoading, scrollToSearchInput, filter } = this.props;
+		if ( prevProps.isLoading !== isLoading && isLoading === false ) {
 			scrollToSearchInput();
 		}
 		if ( prevProps.filter !== filter ) {

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -41,10 +41,7 @@ class RecommendedThemes extends React.Component {
 	render() {
 		return (
 			<>
-				<ConnectedThemesSelection
-					{ ...this.props }
-					listLabel={ translate( 'Recommended themes' ) }
-				/>
+				<ConnectedThemesSelection { ...this.props } />
 			</>
 		);
 	}

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 /**
  * Internal dependencies
@@ -43,9 +42,6 @@ class RecommendedThemes extends React.Component {
 	render() {
 		return (
 			<>
-				<h2>
-					<strong>{ translate( 'Recommended themes' ) }</strong>
-				</h2>
 				{ this.props.isLoading ? (
 					<Spinner size={ 100 } />
 				) : (

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -12,8 +12,6 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
-import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import { isPartnerPurchase } from 'calypso/lib/purchases';
 import { connectOptions } from './theme-options';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -93,11 +91,10 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				{ ...props }
 				siteId={ siteId }
 				emptyContent={ showWpcomThemesList ? <div /> : null }
+				isJetpackSite={ true }
 			>
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<ThanksModal source={ 'list' } />
-				<AutoLoadingHomepageModal source={ 'list' } />
 				{ showWpcomThemesList && (
 					<div>
 						<ConnectedThemesSelection

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -19,8 +19,6 @@ import {
 	FEATURE_UNLIMITED_PREMIUM_THEMES,
 	PLAN_JETPACK_SECURITY_REALTIME,
 } from '@automattic/calypso-products';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import ThemesSelection from './themes-selection';
 import { addTracking } from './helpers';
@@ -93,8 +91,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				emptyContent={ showWpcomThemesList ? <div /> : null }
 				isJetpackSite={ true }
 			>
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				{ showWpcomThemesList && (
 					<div>
 						<ConnectedThemesSelection

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -11,8 +11,6 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
-import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import { connectOptions } from './theme-options';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from '@automattic/calypso-products';
@@ -84,8 +82,6 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 			>
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<ThanksModal source={ 'list' } />
-				<AutoLoadingHomepageModal source={ 'list' } />
 			</ThemeShowcase>
 		</Main>
 	);

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -15,8 +15,6 @@ import { connectOptions } from './theme-options';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { hasFeature, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -79,10 +77,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 				upsellUrl={ upsellUrl }
 				upsellBanner={ bannerLocationBelowSearch ? upsellBanner : null }
 				siteId={ siteId }
-			>
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-			</ThemeShowcase>
+			/>
 		</Main>
 	);
 } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -17,9 +17,11 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { addTracking, trackClick, localizeThemesPath } from './helpers';
 import DocumentHead from 'calypso/components/data/document-head';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
+import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
+import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import config from '@automattic/calypso-config';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { openThemesShowcase } from 'calypso/state/themes/themes-ui/actions';
@@ -93,6 +95,7 @@ class ThemeShowcase extends React.Component {
 		upsellBanner: PropTypes.any,
 		trackMoreThemesClick: PropTypes.func,
 		loggedOutComponent: PropTypes.bool,
+		isJetpackSite: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -230,6 +233,7 @@ class ThemeShowcase extends React.Component {
 			filterString,
 			isMultisite,
 			locale,
+			isJetpackSite,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -410,9 +414,11 @@ class ThemeShowcase extends React.Component {
 								emptyContent={ this.props.emptyContent }
 								bookmarkRef={ this.bookmarkRef }
 							/>
-							{ this.props.isJetpack && this.props.children }
+							{ isJetpackSite && this.props.children }
 						</div>
 					) }
+					<ThanksModal source={ 'list' } />
+					<AutoLoadingHomepageModal source={ 'list' } />
 					<ThemePreview />
 				</div>
 			</div>
@@ -431,7 +437,6 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	filterToTermTable: getThemeFilterToTermTable( state ),
 	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
 	themesBookmark: getThemesBookmark( state ),
-	isJetpack: isJetpackSite( state, siteId ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -17,7 +17,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { addTracking, trackClick, localizeThemesPath } from './helpers';
 import DocumentHead from 'calypso/components/data/document-head';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from '@automattic/calypso-config';
@@ -410,10 +410,10 @@ class ThemeShowcase extends React.Component {
 								emptyContent={ this.props.emptyContent }
 								bookmarkRef={ this.bookmarkRef }
 							/>
+							{ this.props.isJetpack && this.props.children }
 						</div>
 					) }
 					<ThemePreview />
-					{ this.props.children }
 				</div>
 			</div>
 		);
@@ -431,6 +431,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	filterToTermTable: getThemeFilterToTermTable( state ),
 	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
 	themesBookmark: getThemesBookmark( state ),
+	isJetpack: isJetpackSite( state, siteId ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -25,12 +25,7 @@ import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homep
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import config from '@automattic/calypso-config';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { openThemesShowcase } from 'calypso/state/themes/themes-ui/actions';
-import {
-	getThemesBookmark,
-	hasShowcaseOpened as hasShowcaseOpenedSelector,
-} from 'calypso/state/themes/themes-ui/selectors';
+import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import ThemesSearchCard from './themes-magic-search-card';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import {
@@ -78,7 +73,10 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.state = {
-			tabFilter: this.props.loggedOutComponent ? 'all' : 'recommended',
+			tabFilter:
+				this.props.loggedOutComponent || this.props.search || this.props.filter || this.props.tier
+					? 'all'
+					: 'recommended',
 		};
 	}
 
@@ -109,11 +107,7 @@ class ThemeShowcase extends React.Component {
 	};
 
 	componentDidMount() {
-		const { search, filter, tier, hasShowcaseOpened, themesBookmark } = this.props;
-		// Open showcase on state if we open here with query override.
-		if ( ( search || filter || tier ) && ! hasShowcaseOpened ) {
-			this.props.openThemesShowcase();
-		}
+		const { themesBookmark } = this.props;
 		// Scroll to bookmark if applicable.
 		if ( themesBookmark ) {
 			// Timeout to move this to the end of the event queue or it won't work here.
@@ -438,13 +432,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
-	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
 	themesBookmark: getThemesBookmark( state ),
 } );
 
-const mapDispatchToProps = {
-	trackMoreThemesClick: () => recordTracksEvent( 'calypso_themeshowcase_more_themes_clicked' ),
-	openThemesShowcase: () => openThemesShowcase(),
-};
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( ThemeShowcase ) );
+export default connect( mapStateToProps, null )( localize( ThemeShowcase ) );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -285,7 +285,14 @@ class ThemeShowcase extends React.Component {
 						select={ this.onTierSelect }
 					/>
 					{ isLoggedIn && (
-						<SectionNav className="themes__section-nav">
+						<SectionNav
+							className="themes__section-nav"
+							selectedText={
+								'recommended' === this.state.tabFilter
+									? translate( 'Recommended' )
+									: translate( 'All Themes' )
+							}
+						>
 							<NavTabs>
 								<NavItem
 									onClick={ () => this.onFilterClick( 'recommended' ) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -74,7 +74,7 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.state = {
-			tabFilter: 'recommended',
+			tabFilter: this.props.loggedOutComponent ? 'all' : 'recommended',
 		};
 	}
 
@@ -304,7 +304,7 @@ class ThemeShowcase extends React.Component {
 					) }
 					{ this.props.upsellBanner }
 
-					{ 'recommended' === this.state.tabFilter && isLoggedIn && (
+					{ 'recommended' === this.state.tabFilter && (
 						<RecommendedThemes
 							upsellUrl={ this.props.upsellUrl }
 							search={ search }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -38,6 +38,10 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import RecommendedThemes from './recommended-themes';
 
 /**
  * Style dependencies
@@ -69,7 +73,9 @@ class ThemeShowcase extends React.Component {
 		super( props );
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
-		this.state = {};
+		this.state = {
+			tabFilter: 'recommended',
+		};
 	}
 
 	static propTypes = {
@@ -147,6 +153,7 @@ class ThemeShowcase extends React.Component {
 			// Strip filters and excess whitespace
 			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
+		this.setState( { tabFilter: 'all' } );
 		page( url );
 		this.scrollToSearchInput();
 	};
@@ -184,10 +191,16 @@ class ThemeShowcase extends React.Component {
 	};
 
 	onTierSelect = ( { value: tier } ) => {
+		this.setState( { tabFilter: 'all' } );
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
 		this.scrollToSearchInput();
+	};
+
+	onFilterClick = ( tabFilter ) => {
+		trackClick( 'section nav filter', tabFilter );
+		this.setState( { tabFilter } );
 	};
 
 	render() {
@@ -271,49 +284,111 @@ class ThemeShowcase extends React.Component {
 						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
+					<SectionNav className="themes__section-nav">
+						<NavTabs>
+							<NavItem
+								onClick={ () => this.onFilterClick( 'recommended' ) }
+								selected={ 'recommended' === this.state.tabFilter }
+							>
+								{ translate( 'Recommended' ) }
+							</NavItem>
+							<NavItem
+								onClick={ () => this.onFilterClick( 'all' ) }
+								selected={ 'all' === this.state.tabFilter }
+							>
+								{ translate( 'All Themes' ) }
+							</NavItem>
+						</NavTabs>
+					</SectionNav>
 					{ this.props.upsellBanner }
 
-					<ThemesSelection
-						upsellUrl={ this.props.upsellUrl }
-						search={ search }
-						tier={ this.props.tier }
-						filter={ filter }
-						vertical={ this.props.vertical }
-						siteId={ this.props.siteId }
-						listLabel={ this.props.listLabel }
-						defaultOption={ this.props.defaultOption }
-						secondaryOption={ this.props.secondaryOption }
-						placeholderCount={ this.props.placeholderCount }
-						getScreenshotUrl={ function ( theme ) {
-							if ( ! getScreenshotOption( theme ).getUrl ) {
-								return null;
-							}
+					{ 'recommended' === this.state.tabFilter && (
+						<RecommendedThemes
+							upsellUrl={ this.props.upsellUrl }
+							search={ search }
+							tier={ this.props.tier }
+							filter={ filter }
+							vertical={ this.props.vertical }
+							siteId={ this.props.siteId }
+							listLabel={ this.props.listLabel }
+							defaultOption={ this.props.defaultOption }
+							secondaryOption={ this.props.secondaryOption }
+							placeholderCount={ this.props.placeholderCount }
+							getScreenshotUrl={ function ( theme ) {
+								if ( ! getScreenshotOption( theme ).getUrl ) {
+									return null;
+								}
 
-							return localizeThemesPath(
-								getScreenshotOption( theme ).getUrl( theme ),
-								locale,
-								! isLoggedIn
-							);
-						} }
-						onScreenshotClick={ function ( themeId ) {
-							if ( ! getScreenshotOption( themeId ).action ) {
-								return;
-							}
-							getScreenshotOption( themeId ).action( themeId );
-						} }
-						getActionLabel={ function ( theme ) {
-							return getScreenshotOption( theme ).label;
-						} }
-						getOptions={ function ( theme ) {
-							return pickBy(
-								addTracking( options ),
-								( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-							);
-						} }
-						trackScrollPage={ this.props.trackScrollPage }
-						emptyContent={ this.props.emptyContent }
-						bookmarkRef={ this.bookmarkRef }
-					/>
+								return localizeThemesPath(
+									getScreenshotOption( theme ).getUrl( theme ),
+									locale,
+									! isLoggedIn
+								);
+							} }
+							onScreenshotClick={ function ( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
+									return;
+								}
+								getScreenshotOption( themeId ).action( themeId );
+							} }
+							getActionLabel={ function ( theme ) {
+								return getScreenshotOption( theme ).label;
+							} }
+							getOptions={ function ( theme ) {
+								return pickBy(
+									addTracking( options ),
+									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+								);
+							} }
+							trackScrollPage={ this.props.trackScrollPage }
+							emptyContent={ this.props.emptyContent }
+							scrollToSearchInput={ this.scrollToSearchInput }
+							bookmarkRef={ this.bookmarkRef }
+						/>
+					) }
+					{ 'all' === this.state.tabFilter && (
+						<ThemesSelection
+							upsellUrl={ this.props.upsellUrl }
+							search={ search }
+							tier={ this.props.tier }
+							filter={ filter }
+							vertical={ this.props.vertical }
+							siteId={ this.props.siteId }
+							listLabel={ this.props.listLabel }
+							defaultOption={ this.props.defaultOption }
+							secondaryOption={ this.props.secondaryOption }
+							placeholderCount={ this.props.placeholderCount }
+							getScreenshotUrl={ function ( theme ) {
+								if ( ! getScreenshotOption( theme ).getUrl ) {
+									return null;
+								}
+
+								return localizeThemesPath(
+									getScreenshotOption( theme ).getUrl( theme ),
+									locale,
+									! isLoggedIn
+								);
+							} }
+							onScreenshotClick={ function ( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
+									return;
+								}
+								getScreenshotOption( themeId ).action( themeId );
+							} }
+							getActionLabel={ function ( theme ) {
+								return getScreenshotOption( theme ).label;
+							} }
+							getOptions={ function ( theme ) {
+								return pickBy(
+									addTracking( options ),
+									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+								);
+							} }
+							trackScrollPage={ this.props.trackScrollPage }
+							emptyContent={ this.props.emptyContent }
+							bookmarkRef={ this.bookmarkRef }
+						/>
+					) }
 					<ThemePreview />
 					{ this.props.children }
 				</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -11,7 +11,6 @@ import { compact, pickBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import ThemesSelection from './themes-selection';
 import SubMasterbarNav from 'calypso/components/sub-masterbar-nav';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -39,7 +38,6 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
-import RecommendedThemes from './recommended-themes';
 
 /**
  * Style dependencies
@@ -71,15 +69,7 @@ class ThemeShowcase extends React.Component {
 		super( props );
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
-		this.state = {
-			isShowcaseOpen: !! (
-				this.props.loggedOutComponent ||
-				this.props.search ||
-				this.props.filter ||
-				this.props.tier ||
-				this.props.hasShowcaseOpened
-			),
-		};
+		this.state = {};
 	}
 
 	static propTypes = {
@@ -143,12 +133,6 @@ class ThemeShowcase extends React.Component {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
 			this.scrollRef.current.scrollIntoView();
 		}
-	};
-
-	toggleShowcase = () => {
-		this.setState( { isShowcaseOpen: ! this.state.isShowcaseOpen } );
-		this.props.openThemesShowcase();
-		this.props.trackMoreThemesClick();
 	};
 
 	doSearch = ( searchBoxContent ) => {
@@ -259,8 +243,6 @@ class ThemeShowcase extends React.Component {
 
 		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
-		const { isShowcaseOpen } = this.state;
-		const isQueried = this.props.search || this.props.filter || this.props.tier;
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -277,138 +259,63 @@ class ThemeShowcase extends React.Component {
 					/>
 				) }
 				<div className="themes__content">
-					{ ! this.props.loggedOutComponent && ! isQueried && (
-						<>
-							<RecommendedThemes
-								upsellUrl={ this.props.upsellUrl }
-								search={ search }
-								tier={ this.props.tier }
-								filter={ filter }
-								vertical={ this.props.vertical }
-								siteId={ this.props.siteId }
-								listLabel={ this.props.listLabel }
-								defaultOption={ this.props.defaultOption }
-								secondaryOption={ this.props.secondaryOption }
-								placeholderCount={ this.props.placeholderCount }
-								getScreenshotUrl={ function ( theme ) {
-									if ( ! getScreenshotOption( theme ).getUrl ) {
-										return null;
-									}
-
-									return localizeThemesPath(
-										getScreenshotOption( theme ).getUrl( theme ),
-										locale,
-										! isLoggedIn
-									);
-								} }
-								onScreenshotClick={ function ( themeId ) {
-									if ( ! getScreenshotOption( themeId ).action ) {
-										return;
-									}
-									getScreenshotOption( themeId ).action( themeId );
-								} }
-								getActionLabel={ function ( theme ) {
-									return getScreenshotOption( theme ).label;
-								} }
-								getOptions={ function ( theme ) {
-									return pickBy(
-										addTracking( options ),
-										( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-									);
-								} }
-								trackScrollPage={ this.props.trackScrollPage }
-								emptyContent={ this.props.emptyContent }
-								isShowcaseOpen={ isShowcaseOpen }
-								scrollToSearchInput={ this.scrollToSearchInput }
-								bookmarkRef={ this.bookmarkRef }
-							/>
-							<div className="theme-showcase__open-showcase-button-holder">
-								{ isShowcaseOpen ? (
-									<hr />
-								) : (
-									<Button onClick={ this.toggleShowcase } data-e2e-value="open-themes-button">
-										{ translate( 'Show all themes' ) }
-									</Button>
-								) }
-							</div>
-						</>
+					{ ! this.props.loggedOutComponent && showBanners && (
+						<UpworkBanner location={ 'theme-banner' } />
 					) }
-					<div
-						ref={ this.scrollRef }
-						className={
-							! isShowcaseOpen
-								? 'themes__hidden-content theme-showcase__all-themes'
-								: 'theme-showcase__all-themes'
-						}
-					>
-						{ ! this.props.loggedOutComponent && (
-							<>
-								<h2>
-									<strong>{ translate( 'Advanced Themes' ) }</strong>
-								</h2>
-								<p>
-									{ translate(
-										'These themes offer more power and flexibility, but can be harder to setup and customize.'
-									) }
-								</p>
-								{ showBanners && <UpworkBanner location={ 'theme-banner' } /> }
-							</>
-						) }
-						<QueryThemeFilters />
+					<QueryThemeFilters />
 
-						<ThemesSearchCard
-							onSearch={ this.doSearch }
-							search={ filterString + search }
-							tier={ tier }
-							showTierThemesControl={ ! isMultisite }
-							select={ this.onTierSelect }
-						/>
-						{ this.props.upsellBanner }
+					<ThemesSearchCard
+						onSearch={ this.doSearch }
+						search={ filterString + search }
+						tier={ tier }
+						showTierThemesControl={ ! isMultisite }
+						select={ this.onTierSelect }
+					/>
+					{ this.props.upsellBanner }
 
-						<ThemesSelection
-							upsellUrl={ this.props.upsellUrl }
-							search={ search }
-							tier={ this.props.tier }
-							filter={ filter }
-							vertical={ this.props.vertical }
-							siteId={ this.props.siteId }
-							listLabel={ this.props.listLabel }
-							defaultOption={ this.props.defaultOption }
-							secondaryOption={ this.props.secondaryOption }
-							placeholderCount={ this.props.placeholderCount }
-							getScreenshotUrl={ function ( theme ) {
-								if ( ! getScreenshotOption( theme ).getUrl ) {
-									return null;
-								}
+					<ThemesSelection
+						upsellUrl={ this.props.upsellUrl }
+						search={ search }
+						tier={ this.props.tier }
+						filter={ filter }
+						vertical={ this.props.vertical }
+						siteId={ this.props.siteId }
+						listLabel={ this.props.listLabel }
+						defaultOption={ this.props.defaultOption }
+						secondaryOption={ this.props.secondaryOption }
+						placeholderCount={ this.props.placeholderCount }
+						getScreenshotUrl={ function ( theme ) {
+							if ( ! getScreenshotOption( theme ).getUrl ) {
+								return null;
+							}
 
-								return localizeThemesPath(
-									getScreenshotOption( theme ).getUrl( theme ),
-									locale,
-									! isLoggedIn
-								);
-							} }
-							onScreenshotClick={ function ( themeId ) {
-								if ( ! getScreenshotOption( themeId ).action ) {
-									return;
-								}
-								getScreenshotOption( themeId ).action( themeId );
-							} }
-							getActionLabel={ function ( theme ) {
-								return getScreenshotOption( theme ).label;
-							} }
-							getOptions={ function ( theme ) {
-								return pickBy(
-									addTracking( options ),
-									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-								);
-							} }
-							trackScrollPage={ this.props.trackScrollPage }
-							emptyContent={ this.props.emptyContent }
-							bookmarkRef={ this.bookmarkRef }
-						/>
-						<ThemePreview />
-						{ this.props.children }
-					</div>
+							return localizeThemesPath(
+								getScreenshotOption( theme ).getUrl( theme ),
+								locale,
+								! isLoggedIn
+							);
+						} }
+						onScreenshotClick={ function ( themeId ) {
+							if ( ! getScreenshotOption( themeId ).action ) {
+								return;
+							}
+							getScreenshotOption( themeId ).action( themeId );
+						} }
+						getActionLabel={ function ( theme ) {
+							return getScreenshotOption( theme ).label;
+						} }
+						getOptions={ function ( theme ) {
+							return pickBy(
+								addTracking( options ),
+								( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+							);
+						} }
+						trackScrollPage={ this.props.trackScrollPage }
+						emptyContent={ this.props.emptyContent }
+						bookmarkRef={ this.bookmarkRef }
+					/>
+					<ThemePreview />
+					{ this.props.children }
 				</div>
 			</div>
 		);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -317,9 +317,7 @@ class ThemeShowcase extends React.Component {
 							</NavTabs>
 						</SectionNav>
 					) }
-					{ ! this.props.loggedOutComponent && showBanners && (
-						<UpworkBanner location={ 'theme-banner' } />
-					) }
+
 					{ this.props.upsellBanner }
 
 					{ 'recommended' === this.state.tabFilter && (
@@ -368,6 +366,9 @@ class ThemeShowcase extends React.Component {
 					) }
 					{ 'all' === this.state.tabFilter && (
 						<div className="theme-showcase__all-themes">
+							{ ! this.props.loggedOutComponent && showBanners && (
+								<UpworkBanner location={ 'theme-banner' } />
+							) }
 							<ThemesSelection
 								upsellUrl={ this.props.upsellUrl }
 								search={ search }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -356,47 +356,49 @@ class ThemeShowcase extends React.Component {
 						/>
 					) }
 					{ 'all' === this.state.tabFilter && (
-						<ThemesSelection
-							upsellUrl={ this.props.upsellUrl }
-							search={ search }
-							tier={ this.props.tier }
-							filter={ filter }
-							vertical={ this.props.vertical }
-							siteId={ this.props.siteId }
-							listLabel={ this.props.listLabel }
-							defaultOption={ this.props.defaultOption }
-							secondaryOption={ this.props.secondaryOption }
-							placeholderCount={ this.props.placeholderCount }
-							getScreenshotUrl={ function ( theme ) {
-								if ( ! getScreenshotOption( theme ).getUrl ) {
-									return null;
-								}
+						<div className="theme-showcase__all-themes">
+							<ThemesSelection
+								upsellUrl={ this.props.upsellUrl }
+								search={ search }
+								tier={ this.props.tier }
+								filter={ filter }
+								vertical={ this.props.vertical }
+								siteId={ this.props.siteId }
+								listLabel={ this.props.listLabel }
+								defaultOption={ this.props.defaultOption }
+								secondaryOption={ this.props.secondaryOption }
+								placeholderCount={ this.props.placeholderCount }
+								getScreenshotUrl={ function ( theme ) {
+									if ( ! getScreenshotOption( theme ).getUrl ) {
+										return null;
+									}
 
-								return localizeThemesPath(
-									getScreenshotOption( theme ).getUrl( theme ),
-									locale,
-									! isLoggedIn
-								);
-							} }
-							onScreenshotClick={ function ( themeId ) {
-								if ( ! getScreenshotOption( themeId ).action ) {
-									return;
-								}
-								getScreenshotOption( themeId ).action( themeId );
-							} }
-							getActionLabel={ function ( theme ) {
-								return getScreenshotOption( theme ).label;
-							} }
-							getOptions={ function ( theme ) {
-								return pickBy(
-									addTracking( options ),
-									( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-								);
-							} }
-							trackScrollPage={ this.props.trackScrollPage }
-							emptyContent={ this.props.emptyContent }
-							bookmarkRef={ this.bookmarkRef }
-						/>
+									return localizeThemesPath(
+										getScreenshotOption( theme ).getUrl( theme ),
+										locale,
+										! isLoggedIn
+									);
+								} }
+								onScreenshotClick={ function ( themeId ) {
+									if ( ! getScreenshotOption( themeId ).action ) {
+										return;
+									}
+									getScreenshotOption( themeId ).action( themeId );
+								} }
+								getActionLabel={ function ( theme ) {
+									return getScreenshotOption( theme ).label;
+								} }
+								getOptions={ function ( theme ) {
+									return pickBy(
+										addTracking( options ),
+										( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+									);
+								} }
+								trackScrollPage={ this.props.trackScrollPage }
+								emptyContent={ this.props.emptyContent }
+								bookmarkRef={ this.bookmarkRef }
+							/>
+						</div>
 					) }
 					<ThemePreview />
 					{ this.props.children }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -191,7 +191,11 @@ class ThemeShowcase extends React.Component {
 	};
 
 	onTierSelect = ( { value: tier } ) => {
-		this.setState( { tabFilter: 'all' } );
+		// In this state: tabFilter = [ ##Recommended## | All(1) ]   tier = [ All(2) | Free | Premium ]
+		// Clicking "Free" or "Premium" forces tabFilter from "Recommended" to "All"
+		if ( tier !== '' && tier !== 'all' && this.state.tabFilter === 'recommended' ) {
+			this.setState( { tabFilter: 'all' } );
+		}
 		trackClick( 'search bar filter', tier );
 		const url = this.constructUrl( { tier } );
 		page( url );
@@ -201,6 +205,14 @@ class ThemeShowcase extends React.Component {
 	onFilterClick = ( tabFilter ) => {
 		trackClick( 'section nav filter', tabFilter );
 		this.setState( { tabFilter } );
+
+		let callback = () => null;
+		// In this state: tabFilter = [ Recommended | ##All(1)## ]  tier = [ All(2) | Free | ##Premium## ]
+		// Clicking "Recommended" forces tier to be "all", since Recommend themes cannot filter on tier.
+		if ( 'recommended' === tabFilter && 'all' !== this.props.tier ) {
+			callback = () => this.onTierSelect( { value: 'all' } );
+		}
+		this.setState( { tabFilter }, callback );
 	};
 
 	render() {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -333,7 +333,7 @@ class ThemeShowcase extends React.Component {
 							filter={ filter }
 							vertical={ this.props.vertical }
 							siteId={ this.props.siteId }
-							listLabel={ this.props.listLabel }
+							listLabel={ ' ' }
 							defaultOption={ this.props.defaultOption }
 							secondaryOption={ this.props.secondaryOption }
 							placeholderCount={ this.props.placeholderCount }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -284,25 +284,27 @@ class ThemeShowcase extends React.Component {
 						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
-					<SectionNav className="themes__section-nav">
-						<NavTabs>
-							<NavItem
-								onClick={ () => this.onFilterClick( 'recommended' ) }
-								selected={ 'recommended' === this.state.tabFilter }
-							>
-								{ translate( 'Recommended' ) }
-							</NavItem>
-							<NavItem
-								onClick={ () => this.onFilterClick( 'all' ) }
-								selected={ 'all' === this.state.tabFilter }
-							>
-								{ translate( 'All Themes' ) }
-							</NavItem>
-						</NavTabs>
-					</SectionNav>
+					{ isLoggedIn && (
+						<SectionNav className="themes__section-nav">
+							<NavTabs>
+								<NavItem
+									onClick={ () => this.onFilterClick( 'recommended' ) }
+									selected={ 'recommended' === this.state.tabFilter }
+								>
+									{ translate( 'Recommended' ) }
+								</NavItem>
+								<NavItem
+									onClick={ () => this.onFilterClick( 'all' ) }
+									selected={ 'all' === this.state.tabFilter }
+								>
+									{ translate( 'All Themes' ) }
+								</NavItem>
+							</NavTabs>
+						</SectionNav>
+					) }
 					{ this.props.upsellBanner }
 
-					{ 'recommended' === this.state.tabFilter && (
+					{ 'recommended' === this.state.tabFilter && isLoggedIn && (
 						<RecommendedThemes
 							upsellUrl={ this.props.upsellUrl }
 							search={ search }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -22,6 +22,8 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import config from '@automattic/calypso-config';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { openThemesShowcase } from 'calypso/state/themes/themes-ui/actions';
@@ -417,6 +419,8 @@ class ThemeShowcase extends React.Component {
 							{ isJetpackSite && this.props.children }
 						</div>
 					) }
+					{ siteId && <QuerySitePlans siteId={ siteId } /> }
+					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal source={ 'list' } />
 					<AutoLoadingHomepageModal source={ 'list' } />
 					<ThemePreview />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -284,11 +284,7 @@ class ThemeShowcase extends React.Component {
 					/>
 				) }
 				<div className="themes__content">
-					{ ! this.props.loggedOutComponent && showBanners && (
-						<UpworkBanner location={ 'theme-banner' } />
-					) }
 					<QueryThemeFilters />
-
 					<ThemesSearchCard
 						onSearch={ this.doSearch }
 						search={ filterString + search }
@@ -320,6 +316,9 @@ class ThemeShowcase extends React.Component {
 								</NavItem>
 							</NavTabs>
 						</SectionNav>
+					) }
+					{ ! this.props.loggedOutComponent && showBanners && (
+						<UpworkBanner location={ 'theme-banner' } />
 					) }
 					{ this.props.upsellBanner }
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -52,3 +52,7 @@
 .themes__hidden-content {
 	display: none;
 }
+
+.section-nav.themes__section-nav {
+	margin-top: 1px;
+}

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -353,6 +353,7 @@ class ThemesMagicSearchCard extends React.Component {
 						) }
 						{ isPremiumThemesEnabled && showTierThemesControl && (
 							<SimplifiedSegmentedControl
+								key={ this.props.tier }
 								initialSelected={ this.props.tier }
 								options={ tiers }
 								onSelect={ this.props.select }

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -33,7 +33,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 	}
 
 	async showOnlyThemesType( type ) {
-		await this.openShowcase();
 		await driverHelper.clickWhenClickable( this.driver, By.css( `a[data-e2e-value="${ type }"]` ) );
 		await this.waitUntilThemesLoaded();
 	}
@@ -107,13 +106,6 @@ export default class ThemesPage extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.themes-magic-search-card__icon-close' )
-		);
-	}
-
-	async openShowcase() {
-		await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( `button[data-e2e-value="open-themes-button"]` )
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See #54095
* Put Recommended themes behind a new tab, and the rest of the showcase behind a tab called All Themes, with Recommended showing by default.

**Before**

![123834833-d9e18000-d8d5-11eb-96f4-08c80c4a6349](https://user-images.githubusercontent.com/2124984/125319826-1dda7900-e309-11eb-95ee-cfde9f8112e8.png)

**After**

![showcase-new](https://user-images.githubusercontent.com/2124984/125319781-11562080-e309-11eb-95b7-6755e7d76bea.png)


#### Testing instructions

* Switch to this PR and navigate to `/themes/[site]`
* Note the lack of a "Show all themes" button at the bottom of the screen 🥳 
* Make sure you can still activate themes, and the theme preview feature is shown when it's expected (WP.com simple sites)
* You should be able to search, filter themes, etc. as expected
* You should see two new tabs, Recommended and All Themes, with Recommended selected by default; you should be able to switch between those selections
* When you search or filter, you'll be shifted to All Themes
* Check mobile devices for visual errors
* Tabs should not be present on the showcase when logged out; test when logged out to make sure everything works as expected, you can still search, filter, etc.
* Test on different site types with different plans (Jetpack, Premium, Business, Atomic, etc.) to make sure everything works as expected

Related to #54083 and #54076