### PR TITLE
Smells Like Incorrect Grammar: Replace "Nevermind" with "Never Mind" when deleting a domain

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -243,7 +243,7 @@ class RemoveDomainDialog extends Component {
 				action: 'cancel',
 				disabled: this.props.isRemoving,
 				isPrimary: true,
-				label: translate( 'Nevermind' ),
+				label: translate( 'Never Mind' ),
 			},
 			{
 				action: 'remove',


### PR DESCRIPTION
This is a followup to https://github.com/Automattic/wp-calypso/pull/54183.

Because when you're going to delete a domain, your choice is really between deleting the domain and not deleting it -- not between deleting the domain and listening to a Nirvana album :smile: 

(But seriously, it's an understandable mistake, especially since this usage of "nevermind" has apparently become a bit more popular recently.  But grammatically, it means something else and is wrong here.  References: https://www.merriam-webster.com/words-at-play/origin-of-never-mind-nevermind-and-nvm and https://www.grammarly.com/blog/nevermind-or-never-mind/)

To test, you can add a free domain to your site and then go to remove the domain from the Manage Purchases page.

### Before

![current-1](https://user-images.githubusercontent.com/235183/124826756-3af6fc80-df43-11eb-9729-e4b8e34160a8.png)

![current-2](https://user-images.githubusercontent.com/235183/124826757-3af6fc80-df43-11eb-9b28-f55d9e48bd54.png)

### After

![new-1](https://user-images.githubusercontent.com/235183/124826758-3af6fc80-df43-11eb-8bff-1fe10634d1ae.png)

![new-2](https://user-images.githubusercontent.com/235183/124826759-3b8f9300-df43-11eb-99d3-87195c0d2c47.png)