### PR TITLE
DevDocs: Fix import statement in Dot-Pager example

### DIFF
--- a/client/components/dot-pager/README.md
+++ b/client/components/dot-pager/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```js
-import DotPager from 'calypso/blocks/dot-pager';
+import DotPager from 'calypso/components/dot-pager';
 
 function myDotPager() {
 	return (


### PR DESCRIPTION
This PR updates the code in the Dot-Pager DevDocs example to point to the current location in the code tree.


#### Testing instructions

It's probably sufficient just to check the locations of the file relative to the repo root:
```
ls client/blocks/dot-pager
ls client/components/dot-pager/
```

![wp-calypso_—_user92d63294_jurassic-ninja2____apps_user92d63294_public_—_-bash_—_73×45](https://user-images.githubusercontent.com/5952255/124841243-26ad1100-dfd0-11eb-9252-afcb9d7c02aa.jpg)

But if you're really keen you can import the component to go from:

![My_Home_‹_Julesaus_Test_Headstart_—_WordPress_com](https://user-images.githubusercontent.com/5952255/124841083-c6b66a80-dfcf-11eb-9444-29fb0148b38e.jpg)

to

![My_Home_‹_Julesaus_Test_Headstart_—_WordPress_com](https://user-images.githubusercontent.com/5952255/124841301-40e6ef00-dfd0-11eb-8ff3-d5c088b0eac6.jpg)
