### PR TITLE
Checkout: Refactor variant picker and add tests

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
@@ -19,9 +19,9 @@ export type WPCOMProductVariant = {
 
 export type ItemVariationPickerProps = {
 	selectedItem: ResponseCartProduct;
-	getItemVariants: ( productSlug: WPCOMProductSlug ) => WPCOMProductVariant[];
 	onChangeItemVariant: OnChangeItemVariant;
 	isDisabled: boolean;
+	variants: WPCOMProductVariant[];
 };
 
 export type OnChangeItemVariant = (
@@ -32,12 +32,10 @@ export type OnChangeItemVariant = (
 
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( {
 	selectedItem,
-	getItemVariants,
 	onChangeItemVariant,
 	isDisabled,
+	variants,
 } ) => {
-	const variants = getItemVariants( selectedItem.product_slug );
-
 	if ( variants.length < 2 ) {
 		return null;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
@@ -41,7 +41,7 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 	}
 
 	return (
-		<TermOptions>
+		<TermOptions className="item-variation-picker">
 			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
 				<ProductVariant
 					key={ productVariant.variantLabel }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -77,6 +77,7 @@ export default function WPCheckoutOrderReview( {
 	getItemVariants,
 	onChangePlanLength,
 	siteUrl,
+	siteId,
 	isSummary,
 	createUserAndSiteBeforeTransaction,
 }: {
@@ -86,6 +87,7 @@ export default function WPCheckoutOrderReview( {
 	getItemVariants?: GetProductVariants;
 	onChangePlanLength?: OnChangeItemVariant;
 	siteUrl?: string;
+	siteId?: number | undefined;
 	isSummary?: boolean;
 	createUserAndSiteBeforeTransaction?: boolean;
 } ): JSX.Element {
@@ -133,6 +135,7 @@ export default function WPCheckoutOrderReview( {
 
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems
+					siteId={ siteId }
 					removeProductFromCart={ removeProductFromCart }
 					removeCoupon={ removeCouponAndClearField }
 					getItemVariants={ getItemVariants }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -22,7 +22,6 @@ import {
 	isDomainTransfer,
 } from '@automattic/calypso-products';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
-import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
@@ -74,7 +73,6 @@ export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
 	couponFieldStateProps,
-	getItemVariants,
 	onChangePlanLength,
 	siteUrl,
 	siteId,
@@ -84,7 +82,6 @@ export default function WPCheckoutOrderReview( {
 	className?: string;
 	removeProductFromCart?: RemoveProductFromCart;
 	couponFieldStateProps: CouponFieldStateProps;
-	getItemVariants?: GetProductVariants;
 	onChangePlanLength?: OnChangeItemVariant;
 	siteUrl?: string;
 	siteId?: number | undefined;
@@ -138,7 +135,6 @@ export default function WPCheckoutOrderReview( {
 					siteId={ siteId }
 					removeProductFromCart={ removeProductFromCart }
 					removeCoupon={ removeCouponAndClearField }
-					getItemVariants={ getItemVariants }
 					onChangePlanLength={ onChangePlanLength }
 					isSummary={ isSummary }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -160,7 +156,6 @@ WPCheckoutOrderReview.propTypes = {
 	isSummary: PropTypes.bool,
 	className: PropTypes.string,
 	removeProductFromCart: PropTypes.func,
-	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
 	siteUrl: PropTypes.string,
 	couponFieldStateProps: PropTypes.object.isRequired,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -62,7 +62,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PaymentMethodStep from './payment-method-step';
 import CheckoutHelpLink from './checkout-help-link';
 import type { CountryListItem } from '../types/country-list-item';
-import type { GetProductVariants } from '../hooks/product-variants';
 import type { OnChangeItemVariant } from '../components/item-variation-picker';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
@@ -133,7 +132,6 @@ export default function WPCheckout( {
 	siteId,
 	siteUrl,
 	countriesList,
-	getItemVariants,
 	addItemToCart,
 	showErrorMessageBriefly,
 	isLoggedOutCart,
@@ -145,7 +143,6 @@ export default function WPCheckout( {
 	siteId: number | undefined;
 	siteUrl: string | undefined;
 	countriesList: CountryListItem[];
-	getItemVariants: GetProductVariants;
 	addItemToCart: ( item: Partial< RequestCartProduct > ) => void;
 	showErrorMessageBriefly: ( error: string ) => void;
 	isLoggedOutCart: boolean;
@@ -468,7 +465,6 @@ export default function WPCheckout( {
 							removeProductFromCart={ removeProductFromCart }
 							couponFieldStateProps={ couponFieldStateProps }
 							onChangePlanLength={ changePlanLength }
-							getItemVariants={ getItemVariants }
 							siteUrl={ siteUrl }
 							siteId={ siteId }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -470,6 +470,7 @@ export default function WPCheckout( {
 							onChangePlanLength={ changePlanLength }
 							getItemVariants={ getItemVariants }
 							siteUrl={ siteUrl }
+							siteId={ siteId }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
 					}

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -50,11 +50,8 @@ import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/s
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import { getSublabel, getLabel } from '../lib/translate-cart';
-import type {
-	WPCOMProductSlug,
-	WPCOMProductVariant,
-	OnChangeItemVariant,
-} from './item-variation-picker';
+import { useGetProductVariants } from '../hooks/product-variants';
+import type { OnChangeItemVariant } from './item-variation-picker';
 import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
 import {
 	getProductDisplayCost,
@@ -309,7 +306,6 @@ export function WPOrderReviewLineItems( {
 	isSummary,
 	removeProductFromCart,
 	removeCoupon,
-	getItemVariants,
 	onChangePlanLength,
 	createUserAndSiteBeforeTransaction,
 }: {
@@ -318,7 +314,6 @@ export function WPOrderReviewLineItems( {
 	isSummary?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
 	removeCoupon: RemoveCouponFromCart;
-	getItemVariants?: ( productSlug: WPCOMProductSlug ) => WPCOMProductVariant[];
 	onChangePlanLength?: OnChangeItemVariant;
 	createUserAndSiteBeforeTransaction?: boolean;
 } ): JSX.Element {
@@ -336,7 +331,6 @@ export function WPOrderReviewLineItems( {
 							siteId={ siteId }
 							hasDeleteButton={ canItemBeDeleted( product ) }
 							removeProductFromCart={ removeProductFromCart }
-							getItemVariants={ getItemVariants }
 							onChangePlanLength={ onChangePlanLength }
 							isSummary={ isSummary }
 							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -828,7 +822,6 @@ function WPLineItem( {
 	className,
 	hasDeleteButton,
 	removeProductFromCart,
-	getItemVariants,
 	onChangePlanLength,
 	isSummary,
 	createUserAndSiteBeforeTransaction,
@@ -838,7 +831,6 @@ function WPLineItem( {
 	className?: string;
 	hasDeleteButton?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
-	getItemVariants?: ( productSlug: WPCOMProductSlug ) => WPCOMProductVariant[];
 	onChangePlanLength?: OnChangeItemVariant;
 	isSummary?: boolean;
 	createUserAndSiteBeforeTransaction?: boolean;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -362,7 +362,6 @@ WPOrderReviewLineItems.propTypes = {
 	isSummary: PropTypes.bool,
 	removeProductFromCart: PropTypes.func,
 	removeCoupon: PropTypes.func,
-	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
 };
 
@@ -985,7 +984,6 @@ WPLineItem.propTypes = {
 	hasDeleteButton: PropTypes.bool,
 	removeProductFromCart: PropTypes.func,
 	product: PropTypes.object.isRequired,
-	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
 	createUserAndSiteBeforeTransaction: PropTypes.bool,
 };

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -328,6 +328,7 @@ export function WPOrderReviewLineItems( {
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem
 							product={ product }
+							allowVariants
 							siteId={ siteId }
 							hasDeleteButton={ canItemBeDeleted( product ) }
 							removeProductFromCart={ removeProductFromCart }
@@ -817,6 +818,7 @@ function GSuiteDiscountCallout( {
 
 function WPLineItem( {
 	product,
+	allowVariants,
 	siteId,
 	className,
 	hasDeleteButton,
@@ -826,6 +828,7 @@ function WPLineItem( {
 	createUserAndSiteBeforeTransaction,
 }: {
 	product: ResponseCartProduct;
+	allowVariants?: boolean;
 	siteId?: number | undefined;
 	className?: string;
 	hasDeleteButton?: boolean;
@@ -862,7 +865,7 @@ function WPLineItem( {
 
 	const productSlug = product?.product_slug;
 
-	const shouldShowVariantSelector = product && ! isRenewal;
+	const shouldShowVariantSelector = allowVariants && product && ! isRenewal;
 	const variants = useGetProductVariants( siteId, productSlug );
 
 	const isGSuite =

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -360,10 +360,12 @@ export function WPOrderReviewLineItems( {
 
 WPOrderReviewLineItems.propTypes = {
 	className: PropTypes.string,
+	siteId: PropTypes.number,
 	isSummary: PropTypes.bool,
 	removeProductFromCart: PropTypes.func,
 	removeCoupon: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
+	createUserAndSiteBeforeTransaction: PropTypes.bool,
 };
 
 function GSuiteUsersList( { product }: { product: ResponseCartProduct } ) {
@@ -979,6 +981,8 @@ function WPLineItem( {
 }
 
 WPLineItem.propTypes = {
+	siteId: PropTypes.number,
+	allowVariants: PropTypes.bool,
 	className: PropTypes.string,
 	total: PropTypes.bool,
 	tax: PropTypes.bool,

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -305,6 +305,7 @@ export function WPNonProductLineItem( {
 
 export function WPOrderReviewLineItems( {
 	className,
+	siteId,
 	isSummary,
 	removeProductFromCart,
 	removeCoupon,
@@ -313,6 +314,7 @@ export function WPOrderReviewLineItems( {
 	createUserAndSiteBeforeTransaction,
 }: {
 	className?: string;
+	siteId?: number | undefined;
 	isSummary?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
 	removeCoupon: RemoveCouponFromCart;
@@ -331,6 +333,7 @@ export function WPOrderReviewLineItems( {
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem
 							product={ product }
+							siteId={ siteId }
 							hasDeleteButton={ canItemBeDeleted( product ) }
 							removeProductFromCart={ removeProductFromCart }
 							getItemVariants={ getItemVariants }
@@ -821,6 +824,7 @@ function GSuiteDiscountCallout( {
 
 function WPLineItem( {
 	product,
+	siteId,
 	className,
 	hasDeleteButton,
 	removeProductFromCart,
@@ -830,6 +834,7 @@ function WPLineItem( {
 	createUserAndSiteBeforeTransaction,
 }: {
 	product: ResponseCartProduct;
+	siteId?: number | undefined;
 	className?: string;
 	hasDeleteButton?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
@@ -863,10 +868,11 @@ function WPLineItem( {
 	const isDisabled = formStatus !== FormStatus.READY;
 
 	const isRenewal = isWpComProductRenewal( product );
-	// Show the variation picker when this is not a renewal
-	const shouldShowVariantSelector = getItemVariants && product && ! isRenewal;
 
 	const productSlug = product?.product_slug;
+
+	const shouldShowVariantSelector = product && ! isRenewal;
+	const variants = useGetProductVariants( siteId, productSlug );
 
 	const isGSuite =
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) || isGoogleWorkspaceProductSlug( productSlug );
@@ -965,10 +971,10 @@ function WPLineItem( {
 				</>
 			) }
 
-			{ shouldShowVariantSelector && getItemVariants && onChangePlanLength && (
+			{ shouldShowVariantSelector && onChangePlanLength && (
 				<ItemVariationPicker
+					variants={ variants }
 					selectedItem={ product }
-					getItemVariants={ getItemVariants }
 					onChangeItemVariant={ onChangePlanLength }
 					isDisabled={ isDisabled }
 				/>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -18,7 +18,7 @@ import {
 import { useIsWebPayAvailable } from '@automattic/wpcom-checkout';
 import { ThemeProvider } from 'emotion-theming';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+import type { ResponseCart } from '@automattic/shopping-cart';
 import colorStudio from '@automattic/color-studio';
 import { useStripe } from '@automattic/calypso-stripe';
 import type { PaymentCompleteCallbackArguments } from '@automattic/composite-checkout';
@@ -33,7 +33,6 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import { getPlan } from '@automattic/calypso-products';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -56,7 +55,6 @@ import existingCardProcessor from './lib/existing-card-processor';
 import payPalProcessor from './lib/paypal-express-processor';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
-import { useProductVariants } from './hooks/product-variants';
 import { translateResponseCartToWPCOMCart } from './lib/translate-cart';
 import useCountryList from './hooks/use-country-list';
 import useCachedDomainContactDetails from './hooks/use-cached-domain-contact-details';
@@ -411,12 +409,6 @@ export default function CompositeCheckout( {
 		  } );
 	debug( 'filtered payment method objects', paymentMethods );
 
-	const planSlugs = getPlanProductSlugs( responseCart.products );
-	const getItemVariants = useProductVariants( {
-		siteId,
-		productSlug: planSlugs.length > 0 ? planSlugs[ 0 ] : undefined,
-	} );
-
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(
 		purchaseId,
 		productAliasFromUrl,
@@ -674,7 +666,6 @@ export default function CompositeCheckout( {
 					siteId={ updatedSiteId }
 					siteUrl={ updatedSiteSlug }
 					countriesList={ countriesList }
-					getItemVariants={ getItemVariants }
 					addItemToCart={ addItemWithEssentialProperties }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					isLoggedOutCart={ !! isLoggedOutCart }
@@ -684,14 +675,6 @@ export default function CompositeCheckout( {
 			</CheckoutProvider>
 		</React.Fragment>
 	);
-}
-
-function getPlanProductSlugs( items: ResponseCartProduct[] ): string[] {
-	return items
-		.filter( ( item ) => {
-			return getPlan( item.product_slug );
-		} )
-		.map( ( item ) => item.product_slug );
 }
 
 function getAnalyticsPath(

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
@@ -88,18 +88,22 @@ export function useGetProductVariants(
 		}
 	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
 
-	const getProductVariantFromAvailableVariant = (
-		variant: AvailableProductVariant
-	): WPCOMProductVariant => {
-		return {
-			variantLabel: getTermText( variant.plan.term, translate ),
-			variantDetails: <VariantPrice variant={ variant } />,
-			productSlug: variant.planSlug,
-			productId: variant.product.product_id,
-		};
-	};
+	const getProductVariantFromAvailableVariant = useCallback(
+		( variant: AvailableProductVariant ): WPCOMProductVariant => {
+			return {
+				variantLabel: getTermText( variant.plan.term, translate ),
+				variantDetails: <VariantPrice variant={ variant } />,
+				productSlug: variant.planSlug,
+				productId: variant.product.product_id,
+			};
+		},
+		[ translate ]
+	);
 
-	return productsWithPrices.map( getProductVariantFromAvailableVariant );
+	return useMemo( () => productsWithPrices.map( getProductVariantFromAvailableVariant ), [
+		productsWithPrices,
+		getProductVariantFromAvailableVariant,
+	] );
 }
 
 function VariantPrice( { variant }: { variant: AvailableProductVariant } ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -135,23 +135,7 @@ function VariantPriceDiscount( { variant }: { variant: AvailableProductVariant }
 }
 
 function useVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
-	const reduxDispatch = useDispatch();
-
 	const chosenPlan = getPlan( productSlug );
-
-	const [ haveFetchedPlans, setHaveFetchedPlans ] = useState( false );
-	const shouldFetchPlans = ! chosenPlan;
-
-	useEffect( () => {
-		// Trigger at most one HTTP request
-		debug( 'deciding whether to request plan variant data' );
-		if ( shouldFetchPlans && ! haveFetchedPlans ) {
-			debug( 'dispatching request for plan variant data' );
-			reduxDispatch( requestPlans() );
-			reduxDispatch( requestProductsList() );
-			setHaveFetchedPlans( true );
-		}
-	}, [ haveFetchedPlans, shouldFetchPlans, reduxDispatch ] );
 
 	if ( ! chosenPlan ) {
 		return [];

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -68,10 +68,12 @@ export function useGetProductVariants(
 	const reduxDispatch = useDispatch();
 
 	const variantProductSlugs = useVariantPlanProductSlugs( productSlug );
+	debug( 'variantProductSlugs', variantProductSlugs );
 
 	const productsWithPrices = useSelector( ( state ) => {
 		return computeProductsWithPrices( state, siteId, variantProductSlugs, 0, {} );
 	} );
+	debug( 'productsWithPrices', productsWithPrices );
 
 	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );
 	const shouldFetchProducts = ! productsWithPrices;

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import styled from '@emotion/styled';
+import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import formatCurrency, { CURRENCIES } from '@automattic/format-currency';

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -568,9 +568,20 @@ describe( 'CompositeCheckout', () => {
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );
 
-		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'One month' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'One year' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Two years' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the variant picker if there are no variants after clicking into edit mode', async () => {
+		const cartChanges = { products: [ domainProduct ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
+		fireEvent.click( editOrderButton );
+
+		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Two years' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'removes a product from the cart after clicking to remove it in edit mode', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -28,8 +28,6 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
-jest.mock( 'calypso/state/products-list/selectors/get-products-list' );
-import { getProductsList } from 'calypso/state/products-list/selectors/get-products-list';
 jest.mock( 'calypso/state/plans/selectors' );
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 
@@ -153,6 +151,17 @@ const planWithoutDomainBiannual = {
 	item_subtotal_display: 'R$144',
 };
 
+getPlanRawPrice.mockImplementation( () => 144 );
+getPlansBySiteId.mockImplementation( () => ( {
+	data: [
+		{
+			interval: 365,
+			productSlug: planWithoutDomain.product_slug,
+			currentPlan: true,
+		},
+	],
+} ) );
+
 const fetchStripeConfiguration = async () => {
 	return {
 		public_key: 'abc123',
@@ -213,13 +222,35 @@ describe( 'CompositeCheckout', () => {
 				},
 				sites: { items: {} },
 				siteSettings: { items: {} },
-				ui: { selectedSiteId: 123 },
+				ui: { selectedSiteId: siteId },
 				productsList: {
 					items: {
-						'personal-bundle': {
-							product_id: 1009,
-							product_name: 'Plan',
-							product_slug: 'personal-bundle',
+						[ planWithoutDomain.product_slug ]: {
+							product_id: planWithoutDomain.product_id,
+							product_slug: planWithoutDomain.product_slug,
+							product_type: 'bundle',
+							available: true,
+							is_domain_registration: false,
+							cost_display: planWithoutDomain.item_subtotal_display,
+							currency_code: planWithoutDomain.currency,
+						},
+						[ planWithoutDomainMonthly.product_slug ]: {
+							product_id: planWithoutDomainMonthly.product_id,
+							product_slug: planWithoutDomainMonthly.product_slug,
+							product_type: 'bundle',
+							available: true,
+							is_domain_registration: false,
+							cost_display: planWithoutDomainMonthly.item_subtotal_display,
+							currency_code: planWithoutDomainMonthly.currency,
+						},
+						[ planWithoutDomainBiannual.product_slug ]: {
+							product_id: planWithoutDomainBiannual.product_id,
+							product_slug: planWithoutDomainBiannual.product_slug,
+							product_type: 'bundle',
+							available: true,
+							is_domain_registration: false,
+							cost_display: planWithoutDomainBiannual.item_subtotal_display,
+							currency_code: planWithoutDomainBiannual.currency,
 						},
 						domain_map: {
 							product_id: 5,
@@ -532,46 +563,6 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the variant picker if there are variants after clicking into edit mode', async () => {
-		getPlanRawPrice.mockImplementation( () => 144 );
-		getPlansBySiteId.mockImplementation( () => ( {
-			data: [
-				{
-					interval: 365,
-					productSlug: planWithoutDomain.product_slug,
-					currentPlan: true,
-				},
-			],
-		} ) );
-		getProductsList.mockImplementation( () => ( {
-			[ planWithoutDomain.product_slug ]: {
-				product_id: planWithoutDomain.product_id,
-				product_slug: planWithoutDomain.product_slug,
-				product_type: 'bundle',
-				available: true,
-				is_domain_registration: false,
-				cost_display: planWithoutDomain.item_subtotal_display,
-				currency_code: planWithoutDomain.currency,
-			},
-			[ planWithoutDomainMonthly.product_slug ]: {
-				product_id: planWithoutDomainMonthly.product_id,
-				product_slug: planWithoutDomainMonthly.product_slug,
-				product_type: 'bundle',
-				available: true,
-				is_domain_registration: false,
-				cost_display: planWithoutDomainMonthly.item_subtotal_display,
-				currency_code: planWithoutDomainMonthly.currency,
-			},
-			[ planWithoutDomainBiannual.product_slug ]: {
-				product_id: planWithoutDomainBiannual.product_id,
-				product_slug: planWithoutDomainBiannual.product_slug,
-				product_type: 'bundle',
-				available: true,
-				is_domain_registration: false,
-				cost_display: planWithoutDomainBiannual.item_subtotal_display,
-				currency_code: planWithoutDomainBiannual.currency,
-			},
-		} ) );
-
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -151,6 +151,57 @@ const planWithoutDomainBiannual = {
 	item_subtotal_display: 'R$144',
 };
 
+const planLevel2 = {
+	product_name: 'WordPress.com Business',
+	product_slug: 'business-bundle',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	free_trial: false,
+	meta: '',
+	product_id: 1008,
+	volume: 1,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+};
+
+const planLevel2Monthly = {
+	product_name: 'WordPress.com Business Monthly',
+	product_slug: 'business-bundle-monthly',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	free_trial: false,
+	meta: '',
+	product_id: 1018,
+	volume: 1,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+};
+
+const planLevel2Biannual = {
+	product_name: 'WordPress.com Business 2 Year',
+	product_slug: 'business-bundle-2y',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	free_trial: false,
+	meta: '',
+	product_id: 1028,
+	volume: 1,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+};
+
 getPlanRawPrice.mockImplementation( () => 144 );
 getPlansBySiteId.mockImplementation( () => ( {
 	data: [
@@ -251,6 +302,33 @@ describe( 'CompositeCheckout', () => {
 							is_domain_registration: false,
 							cost_display: planWithoutDomainBiannual.item_subtotal_display,
 							currency_code: planWithoutDomainBiannual.currency,
+						},
+						[ planLevel2.product_slug ]: {
+							product_id: planWithoutDomain.product_id,
+							product_slug: planWithoutDomain.product_slug,
+							product_type: 'bundle',
+							available: true,
+							is_domain_registration: false,
+							cost_display: planWithoutDomain.item_subtotal_display,
+							currency_code: planWithoutDomain.currency,
+						},
+						[ planLevel2Monthly.product_slug ]: {
+							product_id: planLevel2Monthly.product_id,
+							product_slug: planLevel2Monthly.product_slug,
+							product_type: 'bundle',
+							available: true,
+							is_domain_registration: false,
+							cost_display: planLevel2Monthly.item_subtotal_display,
+							currency_code: planLevel2Monthly.currency,
+						},
+						[ planLevel2Biannual.product_slug ]: {
+							product_id: planLevel2Biannual.product_id,
+							product_slug: planLevel2Biannual.product_slug,
+							product_type: 'bundle',
+							available: true,
+							is_domain_registration: false,
+							cost_display: planLevel2Biannual.item_subtotal_display,
+							currency_code: planLevel2Biannual.currency,
 						},
 						domain_map: {
 							product_id: 5,
@@ -563,7 +641,7 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'renders the variant picker if there are variants after clicking into edit mode', async () => {
-		const cartChanges = { products: [ planWithoutDomain ] };
+		const cartChanges = { products: [ planLevel2 ] };
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
 		fireEvent.click( editOrderButton );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors how plan variants work in checkout. Here's how it worked before this PR:

First `CompositeCheckout` picks out the first plan slug in the cart (if any) and passes it to `useProductVariants`. That hook passes it to `useVariantPlanProductSlugs` which finds the Plan object from Redux state (fetching it from the API if necessary) and (if its `group` is WPCOM or Jetpack) returns an array of plan slugs that match its `group` and `type` (via `findPlansKeys` which runs a complex query on the hardcoded data in `PLANS_LIST`). Now that we have the variant product slugs for the first plan in the cart, `useProductVariants` continues, using `computeProductsWithPrices` to create product objects that include prices (of type `AvailableProductVariant`). 

Here's where it gets a little confusing. `useProductVariants` returns a _function_ (that accepts a product slug but basically just uses that to determine if it's the same as the plan slug that was passed into the hook in the first place) that returns an array of `WPCOMProductVariant` objects for every `AvailableProductVariant` it fetched from the variant slugs. The returned function is passed down via prop drilling to `WPOrderReviewLineItems` and its `WPLineItem` children which uses it to show `ItemVariationPicker`, passing in that product's slug.

Instead of creating this variant picker function at the top of the render tree, this PR instead calls a hook within each product's `WPLineItem` that checks to see if there are variants for the product and returns the necessary `WPCOMProductVariant` objects. (A side benefit of this simplification is that we could now display multiple variant pickers if there were multiple products in the cart which had allowed variants.)

This makes it much easier to modify the variant picker, like in https://github.com/Automattic/wp-calypso/pull/53904

#### Screenshots

On a site that has an annual premium plan upgrading to a business plan, this is editing the order in checkout:

![before-term-downgrade](https://user-images.githubusercontent.com/2036909/123002676-2bdb5080-d380-11eb-8c27-ec6622f5683c.png)

#### Testing instructions

This PR should not change any behavior.

- Using a site which has a free plan, add a paid plan (of any term length) to your cart and visit checkout.
- Click the "Edit" button at the top-right of the first step.
- Verify that you see a variation picker for the plan and that it includes the monthly, yearly, and two-year plan variants.
