### PR TITLE
Block rescheduling of sessions if the appointment is less than 60 minutes away

### DIFF
--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -13,7 +13,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import QuerySites from 'calypso/components/data/query-sites';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryConciergeAppointmentDetails from 'calypso/components/data/query-concierge-appointment-details';
-import { Button, CompactCard } from '@automattic/components';
+import { Button } from '@automattic/components';
 import Main from 'calypso/components/main';
 import { localize } from 'i18n-calypso';
 import Confirmation from '../shared/confirmation';
@@ -25,6 +25,7 @@ import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedu
 import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { renderDisallowed } from '../shared/utils';
 
 class ConciergeCancel extends Component {
 	static propTypes = {
@@ -51,24 +52,6 @@ class ConciergeCancel extends Component {
 					<div className="cancel__placeholder-button is-placeholder" />
 				</div>
 			</div>
-		);
-	}
-
-	renderDisallowed() {
-		const { translate, siteSlug } = this.props;
-		return (
-			<>
-				<HeaderCake backHref={ `/me/quickstart/${ siteSlug }/book` }>
-					{ translate( 'Reschedule or cancel' ) }
-				</HeaderCake>
-				<CompactCard>
-					<div>
-						{ translate(
-							'Sorry, you cannot reschedule or cancel less than 60 minutes before the session.'
-						) }
-					</div>
-				</CompactCard>
-			</>
 		);
 	}
 
@@ -116,7 +99,7 @@ class ConciergeCancel extends Component {
 				const canChangeAppointment = appointmentDetails?.meta.canChangeAppointment;
 
 				if ( appointmentDetails && ! canChangeAppointment ) {
-					return this.renderDisallowed();
+					return renderDisallowed( translate, siteSlug );
 				}
 
 				return (

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -10,6 +10,7 @@ import { without } from 'lodash';
 /**
  * Internal dependencies
  */
+import HeaderCake from 'calypso/components/header-cake';
 import { CompactCard } from '@automattic/components';
 import Timezone from 'calypso/components/timezone';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -77,6 +78,24 @@ class CalendarStep extends Component {
 		}
 	}
 
+	renderDisallowed() {
+		const { translate, siteSlug } = this.props;
+		return (
+			<>
+				<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
+					{ translate( 'Reschedule or cancel' ) }
+				</HeaderCake>
+				<CompactCard>
+					<div>
+						{ translate(
+							'Sorry, you cannot reschedule or cancel less than 60 minutes before the session.'
+						) }
+					</div>
+				</CompactCard>
+			</>
+		);
+	}
+
 	render() {
 		const {
 			appointmentDetails,
@@ -88,6 +107,10 @@ class CalendarStep extends Component {
 			scheduleId,
 			translate,
 		} = this.props;
+		const canChangeAppointment = appointmentDetails?.meta.canChangeAppointment;
+		if ( appointmentDetails && ! canChangeAppointment ) {
+			return this.renderDisallowed();
+		}
 
 		return (
 			<div>

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -10,7 +10,6 @@ import { without } from 'lodash';
 /**
  * Internal dependencies
  */
-import HeaderCake from 'calypso/components/header-cake';
 import { CompactCard } from '@automattic/components';
 import Timezone from 'calypso/components/timezone';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -29,6 +28,7 @@ import {
 import AvailableTimePicker from '../shared/available-time-picker';
 import { CONCIERGE_STATUS_BOOKING, CONCIERGE_STATUS_BOOKED } from '../constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { renderDisallowed } from '../shared/utils';
 
 class CalendarStep extends Component {
 	static propTypes = {
@@ -78,24 +78,6 @@ class CalendarStep extends Component {
 		}
 	}
 
-	renderDisallowed() {
-		const { translate, siteSlug } = this.props;
-		return (
-			<>
-				<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
-					{ translate( 'Reschedule or cancel' ) }
-				</HeaderCake>
-				<CompactCard>
-					<div>
-						{ translate(
-							'Sorry, you cannot reschedule or cancel less than 60 minutes before the session.'
-						) }
-					</div>
-				</CompactCard>
-			</>
-		);
-	}
-
 	render() {
 		const {
 			appointmentDetails,
@@ -109,7 +91,7 @@ class CalendarStep extends Component {
 		} = this.props;
 		const canChangeAppointment = appointmentDetails?.meta.canChangeAppointment;
 		if ( appointmentDetails && ! canChangeAppointment ) {
-			return this.renderDisallowed();
+			return renderDisallowed( translate, site.slug );
 		}
 
 		return (

--- a/client/me/concierge/shared/utils.js
+++ b/client/me/concierge/shared/utils.js
@@ -12,7 +12,7 @@ import { CompactCard } from '@automattic/components';
 export const renderDisallowed = ( translate, siteSlug ) => {
 	return (
 		<>
-			<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
+			<HeaderCake backHref={ `/me/quickstart/${ siteSlug }/book` }>
 				{ translate( 'Reschedule or cancel' ) }
 			</HeaderCake>
 			<CompactCard>

--- a/client/me/concierge/shared/utils.js
+++ b/client/me/concierge/shared/utils.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'calypso/components/header-cake';
+import { CompactCard } from '@automattic/components';
+
+export const renderDisallowed = ( translate, siteSlug ) => {
+	return (
+		<>
+			<HeaderCake backHref={ `/me/concierge/${ siteSlug }/book` }>
+				{ translate( 'Reschedule or cancel' ) }
+			</HeaderCake>
+			<CompactCard>
+				<div>
+					{ translate(
+						'Sorry, you cannot reschedule or cancel less than 60 minutes before the session.'
+					) }
+				</div>
+			</CompactCard>
+		</>
+	);
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow users from rescheduling their appointment less than 60 minutes before the appointment is scheduled to begin.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE: Follow the instructions under the "Testing pre-instructions" section in D63674-code to ensure that test appointments are not assigned to HEs.

* Purchase a Quick Start product and schedule an appointment.
* Visit /me/concierge and click on the "Reschedule or cancel" button. 
* Then in the following page, click on the "Reschedule session" button. Keep this page open and refresh page less than one hour before session is supposed to begin. Verify that this page shows an error message about not being able to reschedule sessions less than one before the session. 

<img width="1220" alt="Screenshot 2021-07-08 at 10 49 04 PM" src="https://user-images.githubusercontent.com/1269602/124976117-e4bbb380-e03f-11eb-957f-45b004b441dc.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


