### PR TITLE
Add an upload animation for large imports

### DIFF
--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -106,7 +106,12 @@ class UploadingPane extends React.PureComponent {
 				return (
 					<div>
 						<p>{ uploaderPrompt }</p>
-						<ProgressBar className={ progressClasses } value={ uploadPercent } total={ 100 } />
+						<ProgressBar
+							className={ progressClasses }
+							value={ uploadPercent }
+							total={ 100 }
+							isPulsing={ uploadPercent > 99 || importerState === appStates.UPLOAD_PROCESSING }
+						/>
 					</div>
 				);
 			}

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -193,6 +193,12 @@ class UploadingPane extends React.PureComponent {
 		const urlDescription = isValidUrl
 			? this.props?.optionalUrl?.description
 			: this.props?.optionalUrl?.invalidDescription;
+		const uploadButtonEnabled =
+			[ appStates.READY_FOR_UPLOAD, appStates.UPLOAD_FAILURE ].includes(
+				importerStatus.importerState
+			) &&
+			this.state.fileToBeUploaded &&
+			this.validateUrl( this.state.urlInput );
 
 		return (
 			<div>
@@ -247,9 +253,7 @@ class UploadingPane extends React.PureComponent {
 						<ImporterActionButton
 							primary
 							onClick={ this.initiateFromUploadButton }
-							disabled={
-								! this.state.fileToBeUploaded || ! this.validateUrl( this.state.urlInput )
-							}
+							disabled={ ! uploadButtonEnabled }
 						>
 							{ this.props.translate( 'Upload' ) }
 						</ImporterActionButton>

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -63,6 +63,12 @@
 .importer__upload-progress {
 	&.progress-bar {
 		width: 80%;
+
+		&.is-pulsing {
+			.progress-bar__progress {
+				background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-light) 28%, var(--color-accent-light) 72%, var(--color-accent) 72%);
+			}
+		}
 	}
 
 	.progress-bar__progress {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For large imports, the processing step takes longer. This is particularly noticeable for Substack imports where if a URL is provided, the processing step includes fetching additional information from the Substack API. To inform the user that something is indeed happening & things haven't stalled, we use an animation in the progress bar at this stage.

This also includes a fix to disable the upload button when we're uploading.

#### Testing instructions

See demo:

[Video](https://user-images.githubusercontent.com/533/124897372-dfd51080-dffb-11eb-9704-9fa57c23d9b5.mp4)

1. Go to http://calypso.localhost:3000/import/
2. Choose a non-atomic site.
3. Click Substack, and import a rather large file. 
4. See the UI behaviour.

#### Related
See suggestions here: p1625566659475200-slack-C01A60HCGUA