### PR TITLE
Site Editor Tracking: Add events for selecting content items in the navigation sidebar

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -460,6 +460,13 @@ const trackSiteEditorChangeTemplatePart = ( id ) => {
 	} );
 };
 
+const trackSiteEditorChangeContent = ( { type, slug } ) => {
+	tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_item_edit', {
+		item_type: type,
+		item_slug: slug,
+	} );
+};
+
 /**
  * Tracks editEntityRecord for global styles updates.
  *
@@ -555,6 +562,7 @@ const REDUX_TRACKING = {
 		addTemplate: trackSiteEditorCreateTemplate,
 		setTemplate: trackSiteEditorChangeTemplate,
 		setTemplatePart: trackSiteEditorChangeTemplatePart,
+		setPage: trackSiteEditorChangeContent,
 	},
 	'core/edit-post': {
 		setIsListViewOpened: trackListViewToggle,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -460,11 +460,32 @@ const trackSiteEditorChangeTemplatePart = ( id ) => {
 	} );
 };
 
+/**
+ * Variable used to track the time of the last `trackSiteEditorChange` function
+ * call. This is used to debounce the function because it's called twice due to
+ * a bug. We prefer the first call because that's when the
+ * `getNavigationPanelActiveMenu` function returns the actual active menu.
+ *
+ * Keep this for backward compatibility.
+ * Fixed in: https://github.com/WordPress/gutenberg/pull/33286
+ */
+let lastTrackSiteEditorChangeContentCall = 0;
 const trackSiteEditorChangeContent = ( { type, slug } ) => {
+	if ( Date.now() - lastTrackSiteEditorChangeContentCall < 50 ) {
+		return;
+	}
+
+	const activeMenu = select( 'core/edit-site' ).getNavigationPanelActiveMenu();
+	if ( ! type && activeMenu === 'content-categories' ) {
+		type = 'taxonomy_category';
+	}
+
 	tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_item_edit', {
 		item_type: type,
 		item_slug: slug,
 	} );
+
+	lastTrackSiteEditorChangeContentCall = Date.now();
 };
 
 /**

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -406,6 +406,14 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			await deleteTemplatesAndTemplateParts( this.driver );
 		} );
 
+		it( 'should skip tracking "wpcom_block_editor_nav_sidebar_item_edit" when editor just loaded (no query params)', async function () {
+			const eventsStack = await getEventsStack( this.driver );
+			const isEditEventNotTriggered = ! eventsStack.find(
+				( [ eventName ] ) => eventName === 'wpcom_block_editor_nav_sidebar_item_edit'
+			);
+			assert( isEditEventNotTriggered );
+		} );
+
 		createGeneralTests( { it, editorType: 'site' } );
 
 		describe( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
@@ -1017,6 +1025,21 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				const [ , editEventData ] = editEvents[ 0 ];
 				assert.strictEqual( editEventData.item_type, 'taxonomy_category' );
 				assert.strictEqual( editEventData.item_slug, 'uncategorized' );
+			} );
+
+			it( 'should skip tracking "wpcom_block_editor_nav_sidebar_item_edit" when editor just loaded (with query params)', async function () {
+				await this.driver.navigate().refresh();
+				await driverHelper.acceptAlertIfPresent( this.driver );
+
+				const editor = await SiteEditorComponent.Expect( this.driver );
+				await editor.waitForTemplateToLoad();
+				await editor.waitForTemplatePartsToLoad();
+
+				const eventsStack = await getEventsStack( this.driver );
+				const isEditEventNotTriggered = ! eventsStack.find(
+					( [ eventName ] ) => eventName === 'wpcom_block_editor_nav_sidebar_item_edit'
+				);
+				assert( isEditEventNotTriggered );
 			} );
 		} );
 

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -395,7 +395,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			await editor.waitForTemplatePartsToLoad();
 			await deleteTemplatesAndTemplateParts( this.driver );
 		} );
-		/*
+
 		createGeneralTests( { it, editorType: 'site' } );
 
 		describe( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
@@ -818,7 +818,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				);
 			} );
 		} );
-*/
+
 		describe( 'Navigation sidebar', function () {
 			it( 'should track "wpcom_block_editor_nav_sidebar_open" when sidebar is opened', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -395,7 +395,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			await editor.waitForTemplatePartsToLoad();
 			await deleteTemplatesAndTemplateParts( this.driver );
 		} );
-
+		/*
 		createGeneralTests( { it, editorType: 'site' } );
 
 		describe( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
@@ -818,7 +818,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				);
 			} );
 		} );
-
+*/
 		describe( 'Navigation sidebar', function () {
 			it( 'should track "wpcom_block_editor_nav_sidebar_open" when sidebar is opened', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
@@ -974,6 +974,28 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 				);
 
 				assert( isBackToDashboardLocated );
+			} );
+
+			it( 'should track "wpcom_block_editor_nav_sidebar_item_edit" when switching to a content item', async function () {
+				const pagesMenuItemLocator = By.css(
+					'[role="region"][aria-label="Navigation Sidebar"] [role="menu"] [title="Pages"] button'
+				);
+				await driverHelper.clickWhenClickable( this.driver, pagesMenuItemLocator );
+
+				const contentMenuItemLocator = By.css(
+					'[role="region"][aria-label="Navigation Sidebar"] [role="menu"] [title="Home"] button'
+				);
+				await driverHelper.clickWhenClickable( this.driver, contentMenuItemLocator );
+
+				const eventsStack = await getEventsStack( this.driver );
+				const editEvents = eventsStack.filter(
+					( [ eventName ] ) => eventName === 'wpcom_block_editor_nav_sidebar_item_edit'
+				);
+				// TODO: Change this to 1 once https://github.com/WordPress/gutenberg/pull/33286 fix is deployed
+				assert.strictEqual( editEvents.length, 2 );
+				const [ , editEventData ] = editEvents[ 0 ];
+				assert.strictEqual( editEventData.item_type, 'page' );
+				assert.strictEqual( editEventData.item_slug, 'home' );
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Track selecting content item in the navigation sidebar
  * Event name: `wpcom_block_editor_nav_sidebar_item_edit`
  * Event properties:
    * `item_type` - type of the selected item (page, post, category, etc.)
    * `item_slug` - slug of the selected item 

Note `setPage`is called twice due to a bug in Gutenberg: WordPress/gutenberg#33286

#### Testing instructions

* Open Site Editor
* Open navigation sidebar
* Change to a content item
* Make sure event is tracked

Make sure E2E tests are passing.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
