### PR TITLE
Composite Checkout: fix font-weight variable

### DIFF
--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -20,7 +20,7 @@ const CallToAction = styled( 'button' )< CallToActionProps >`
 		! props.buttonType || props.disabled ? '1px solid ' + props.theme.colors.borderColor : '0' };
 	background: ${ getBackgroundColor };
 	color: ${ getTextColor };
-	font-weight: theme.weights.normal;
+	font-weight: ${ ( props ) => props.theme.weights.normal };
 	text-decoration: ${ getTextDecoration };
 
 	:hover {


### PR DESCRIPTION
Just noticed a theme variable that was set as a string. This should have no visual effect on any buttons used in Checkout.