### PR TITLE
Signup: Refactor scrolling-to-top on step progression

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -518,6 +518,7 @@ class Signup extends React.Component {
 			window.scrollTo( {
 				top: 0,
 				left: 0,
+				behavior: 'smooth',
 			} );
 		} );
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -507,42 +507,12 @@ class Signup extends React.Component {
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
-		if ( this.state.scrolling ) {
-			return;
+		if ( ! this.isEveryStepSubmitted() ) {
+			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
+			page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
+		} else if ( this.isEveryStepSubmitted() ) {
+			this.goToFirstInvalidStep();
 		}
-
-		// animate the scroll position to the top
-		const scrollPromise = new Promise( ( resolve ) => {
-			this.setState( { scrolling: true } );
-
-			const ANIMATION_LENGTH_MS = 200;
-			const startTime = window.performance.now();
-			const scrollHeight = window.pageYOffset;
-
-			const scrollToTop = ( timestamp ) => {
-				const progress = timestamp - startTime;
-
-				if ( progress < ANIMATION_LENGTH_MS ) {
-					window.scrollTo( 0, scrollHeight - ( scrollHeight * progress ) / ANIMATION_LENGTH_MS );
-					window.requestAnimationFrame( scrollToTop );
-				} else {
-					this.setState( { scrolling: false } );
-					resolve();
-				}
-			};
-
-			window.requestAnimationFrame( scrollToTop );
-		} );
-
-		// redirect the user to the next step
-		scrollPromise.then( () => {
-			if ( ! this.isEveryStepSubmitted() ) {
-				const locale = ! this.props.isLoggedIn ? this.props.locale : '';
-				page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
-			} else if ( this.isEveryStepSubmitted() ) {
-				this.goToFirstInvalidStep();
-			}
-		} );
 	};
 
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -504,14 +504,37 @@ class Signup extends React.Component {
 		return window.location.origin + path;
 	};
 
+	// animate the scroll position to the top
+	scrollToTop() {
+		return new Promise( ( resolve ) => {
+			const resolveScrolling = () => {
+				if ( 0 === window.pageYOffset ) {
+					window.removeEventListener( 'scroll', resolveScrolling );
+					resolve();
+				}
+			};
+
+			window.addEventListener( 'scroll', resolveScrolling );
+			window.scrollTo( {
+				top: 0,
+				left: 0,
+			} );
+		} );
+	}
+
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
-	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
-		if ( ! this.isEveryStepSubmitted() ) {
-			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
-			page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
-		} else if ( this.isEveryStepSubmitted() ) {
-			this.goToFirstInvalidStep();
+	goToStep = async ( stepName, stepSectionName, flowName = this.props.flowName ) => {
+		// redirect the user to the next step
+		try {
+			await this.scrollToTop();
+		} finally {
+			if ( ! this.isEveryStepSubmitted() ) {
+				const locale = ! this.props.isLoggedIn ? this.props.locale : '';
+				page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
+			} else if ( this.isEveryStepSubmitted() ) {
+				this.goToFirstInvalidStep();
+			}
 		}
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Addresses #54015

Refactors the more complex programmatic scrolling with a single call to the same API method ([window.scrollTo](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollto)). 

The current implementation in trunk executes the scrolling by splitting it across a series of callbacks that are stacked before the next repaint. This achieves a somewhat smooth transitioning from the current position to the top of the window. The implementation dates back [4](https://github.com/Automattic/wp-calypso/pull/10599) to 6 years ago in the initial Calypso commit. This appears to be before the `behavior` ('smooth') option was added to the API, so we can now achieve the same effect via a single call - in effect reducing both the complexity and the surface area for errors. This should potentially help with the concerns in #54015 (although needs more [confirmation/investigation](https://github.com/Automattic/wp-calypso/issues/54015#issuecomment-876530306)). 

The PR is marked as draft as it's meant to gauge curiosity/input for addressing #54015 at this moment.

### Testing instructions

I have only tested the change on `/start/domains` and `/start/with-design-picker/domains` in a browser, so potentially there are things that I am missing.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/start/domains`, scroll to the bottom, and select one of the domains.
- The page should scroll to the top, then go to the next step, like previously.

### Regressions, known issues

It looks like Safari does not yet support the CSS `scroll-behavior` property that is needed for the smooth effect in the options to `window.scrollTo`. This looks like a bug in Safari (see https://stackoverflow.com/a/52321518)? There is a polyfill ([smoothscroll-polyfill](https://www.npmjs.com/package/smoothscroll-polyfill)) that we can utilise to get the desired effect. This worked fine and consistently in my tests. The only change was a call to `smoothscroll.polyfill(); ` somewhere in the file. See gifs below. 

(I guess it would be easier to revert usage of a polyfill when the issue is fixed - in contrast to what we have right now)

| Safari - smooth scrolling (no polyfill) | Safari - smooth scrolling (polyfill) |
| ---------- | ------- |
| ![calypso-signup-safari](https://user-images.githubusercontent.com/1705499/124940538-bffd1700-e012-11eb-8b13-624c7b392c42.gif) | ![calypso-signup-safari-polyfill](https://user-images.githubusercontent.com/1705499/124940605-cd1a0600-e012-11eb-98f9-6b8751888e54.gif) |

### Alternatives/options for addressing 54015

1. Disable scrolling for the specific step only, as suggested in the issue. 

~I find this to be less desirable, more like a last resort.~ I feel that keeping the behavior consistent/unified across all steps in a flow should be preferred, although scrolling a big list does feel awkward especially on mobile. If we choose this path, then we should make sure to not reintroduce whatever technical concerns (outside aesthetics) that scrolling to the top fixes (e.g. see next point for what may be a regression). Maybe we can try without "smoothing" on longer lists? 🤔 

2. Remove scrolling altogether until we figure out a better/different transition.

I considered this option initially. I tried to trace the implementation to its initial commits to see if there was any other technical motivation for the scrolling, but I sort of gave up on that path. Upon testing a bit more in the browser, I notice that without the scrolling there may be cases where the viewport falls slightly below the top coordinates when the next step is rendered. See gif below. Not sure if this was just something due to performance issues on my end. I guess it is also something that we can address differently if we decide against scrolling. You can try to reproduce this in commit https://github.com/Automattic/wp-calypso/commit/c790cd9556673f7cef0d571e180fe9fb52c5935f, which removes scrolling.

![calypso-signup-no-scroll-regression](https://user-images.githubusercontent.com/1705499/124804633-30e4f600-df63-11eb-8e91-b898a1c66ff9.gif)

3. Rethink the step progression/transition behavior.

This will need design input. It's also possible to skip the "behavior" option and have the page jump to the top and then proceed to the next step. Sometimes this is not even noticeable (that a jump happens), so the user just gets to see the next page immediately rendered (without the regression mentioned in point 2 above). You can try this from commit https://github.com/Automattic/wp-calypso/commit/c0884124a19f7186ab8bcaa4f85b3fd74f3294c5, which removes the smoothing.

4. Apply the scrolling only at the step being rendered VS the previous one (to address the potential regression in point 2 above and not have to scroll a long list).

5. There's always another alternative. 😀 

CC @ollierozdarz