### PR TITLE
Contact: Change confirmation wording

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -231,8 +231,8 @@ class HelpContact extends React.Component {
 					confirmation: {
 						title: this.props.translate( "We're on it!" ),
 						message: this.props.translate(
-							'We normally reply within 24-48 hours but are experiencing longer delays ' +
-								'right now. We appreciate your patience and will respond as soon as we can.'
+							"We've received your message, and you'll hear back from " +
+								'one of our Happiness Engineers shortly.'
 						),
 					},
 				} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reverts the "delay" message we put in the contact form confirmation early last year, to the previous text.

<img width="348" alt="Screen Shot 2021-07-08 at 11 21 11 AM" src="https://user-images.githubusercontent.com/518059/124957369-a04bfb80-dfde-11eb-9f2f-df416b13b4b2.png">


#### Testing instructions

Submit the contact form from an account that does not have chat access, and check that the confirmation message is correct.
