### PR TITLE
Don't show timezone abbreviation if it's numeric

### DIFF
--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -35,6 +35,11 @@ class AppointmentInfo extends Component {
 
 		const conferenceLink = meta.conference_link || '';
 		const guessedTimezone = moment.tz.guess();
+		const userTimezoneAbbr = moment.tz( guessedTimezone ).format( 'z' );
+		// Moment timezone does not display the abbreviation for some countries(e.g. for Dubai, it shows timezone abbr as +04 ).
+		// Don't display the timezone for such countries.
+		const shouldDisplayTzAbbr = /[a-zA-Z]/g.test( userTimezoneAbbr );
+		const momentDisplayFormat = shouldDisplayTzAbbr ? 'LT z' : 'LT';
 		const isAllowedToChangeAppointment = meta.canChangeAppointment;
 
 		return (
@@ -45,6 +50,7 @@ class AppointmentInfo extends Component {
 
 				<CompactCard>
 					<FormattedHeader
+						headerText=""
 						subHeaderText={ translate( 'Your scheduled Quick Start session details are:' ) }
 					/>
 
@@ -77,7 +83,7 @@ class AppointmentInfo extends Component {
 						<FormLabel>{ translate( 'When?' ) }</FormLabel>
 						<FormSettingExplanation>
 							{ moment( beginTimestamp ).format( 'llll - ' ) }
-							{ moment.tz( endTimestamp, guessedTimezone ).format( 'LT z' ) }{ ' ' }
+							{ moment.tz( endTimestamp, guessedTimezone ).format( momentDisplayFormat ) }{ ' ' }
 							{ `(${ guessedTimezone })` }
 						</FormSettingExplanation>
 					</FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There are some locations for which moment timezone does not report a timezone abbreviation like EST. For example, Singapore timezone is displayed as +08 and Dubai timezone is reported as +04. Here's an example of how the session dashboard looks when an appointment is booked with Dubai timezone selected:

<img width="732" alt="Screenshot 2021-07-08 at 11 13 29 PM" src="https://user-images.githubusercontent.com/1269602/124977939-2fd6c600-e042-11eb-8c6e-afbc5cc8abd2.png">

This PR removes the timezone abbreviation if it doesn't contain any alphabets, so it now looks like this:

<img width="724" alt="Screenshot 2021-07-08 at 11 15 37 PM" src="https://user-images.githubusercontent.com/1269602/124978165-775d5200-e042-11eb-8a8c-3beeb8efd82b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase Quick Start product and head to the schedule appointment page at `/me/concierge`.
* Select your timezone as Dubai in the "What's your timezone?" dropdown.
* Proceed to schedule an appointment, then go back to your session dashboard at `/me/concierge`.
* Confirm that the numeric timezone abbreviation is not displayed, as shown in the screenshots above.



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
