### PR TITLE
Upsell Nudge: Prevent canceling card validation if cards have not changed

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -124,13 +124,13 @@ export class UpsellNudge extends React.Component {
 		if ( this.props.isLoading ) {
 			return;
 		}
+		if ( ! this.haveCardsChanged() ) {
+			debug( 'cancelling validating contact info; cards have not changed' );
+			return;
+		}
 		if ( this.props.cards.length === 0 ) {
 			debug( 'not validating contact info because there are no cards' );
 			this.setState( { isContactInfoValid: false } );
-			return;
-		}
-		if ( ! this.haveCardsChanged() ) {
-			debug( 'cancelling validating contact info; cards have not changed' );
 			return;
 		}
 		debug( 'validating contact info' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/54256 modified the `UpsellNudge` component so that, whenever its `cards` prop (the user's saved cards) change (eg: while loading), it will re-validate the contact info on the first one to determine if the one-click upsell modal can be used. However, if there are no cards, then it bails early and marks the contact info as invalid. 

This might have created a infinite loop because when `validateContactInfo` bails early and marks the contact info as invalid, it does so with `setState` and `setState` will trigger `componentDidUpdate`, which will trigger `validateContactInfo`.

This PR reorders `validateContactInfo` so that it instead takes no action if the card info has not changed. This should mean that if there are no cards saved, we will only mark the contact info as invalid once.

Fixes https://github.com/Automattic/wp-calypso/issues/54396

#### Testing instructions

- Use an account with no valid saved cards.
- To get the upsell to appear you'll need a Personal or Premium plan already purchased, then visit `/checkout/offer-quickstart-session/1234/example.com` where `example.com` is your site (the number is a receipt ID but doesn't really matter so you can just make it up).
- Click "Yes, I want a WordPress Expert by my side!".
- Verify that you're redirected to checkout.
