### PR TITLE
fix(account recovery): component state access

### DIFF
--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -33,6 +33,8 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 		onDelete: PropTypes.func,
 	};
 
+	state = {};
+
 	render() {
 		const havePhone = ! isEmpty( this.props.storedPhone );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Account Recovery / Edit phone: set initial state to `{}`

#### Testing instructions

* Verify the bug described in #54376 isn't present anymore and you're safely able to set a phone number for account recovery

fix #54376
