### PR TITLE
State: Modularize userSettings tree

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -20,7 +20,6 @@ import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
 import sites from './sites/reducer';
-import userSettings from './user-settings/reducer';
 
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
@@ -33,7 +32,6 @@ const reducers = {
 	i18n,
 	importerNux,
 	sites,
-	userSettings,
 };
 
 export default combineReducers( reducers );

--- a/client/state/selectors/get-original-user-setting.js
+++ b/client/state/selectors/get-original-user-setting.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
 
 /**
  * Given a settingName, returns that original setting if it exists or null

--- a/client/state/selectors/get-unsaved-user-settings.js
+++ b/client/state/selectors/get-unsaved-user-settings.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
+
+/**
  * Returns all unsaved user settings as one object
  *
  *

--- a/client/state/selectors/get-user-setting.js
+++ b/client/state/selectors/get-user-setting.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
 
 /**
  * Given a settingName, returns that setting if it exists or null

--- a/client/state/selectors/get-user-settings.js
+++ b/client/state/selectors/get-user-settings.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
+
+/**
  * Returns all user settings as one object
  *
  *

--- a/client/state/selectors/has-unsaved-user-settings.js
+++ b/client/state/selectors/has-unsaved-user-settings.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
 
 /**
  * Check if there are any unsaved settings

--- a/client/state/selectors/has-user-settings.js
+++ b/client/state/selectors/has-user-settings.js
@@ -1,11 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
+
+/**
  * Returns a boolean signifying whether there are settings or not
  *
  *
  * @param {object} state Global state tree
  * @returns {boolean} true is the user has settings object
  */
-
 export default function hasUserSettings( state ) {
 	return !! state.userSettings.settings;
 }

--- a/client/state/selectors/is-pending-email-change.js
+++ b/client/state/selectors/is-pending-email-change.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
 
 /**
  * Returns true if there is a pending email change, false if not.

--- a/client/state/selectors/is-two-step-enabled.js
+++ b/client/state/selectors/is-two-step-enabled.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
 
 /**
  * Is two-step enabled for the current user?

--- a/client/state/selectors/is-two-step-sms-enabled.js
+++ b/client/state/selectors/is-two-step-sms-enabled.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
 
 /**
  * Is two-step sms enabled for the current user?

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -13,6 +13,7 @@ import {
 	USER_SETTINGS_UNSAVED_REMOVE,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/user-settings/init';
 import 'calypso/state/data-layer/wpcom/me/settings';
 
 export { default as setUserSetting } from './thunks/set-user-setting';

--- a/client/state/user-settings/init.js
+++ b/client/state/user-settings/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'userSettings' ], reducer );

--- a/client/state/user-settings/package.json
+++ b/client/state/user-settings/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+import { withStorageKey } from '@automattic/state-utils';
 
 /**
  * Internal dependencies
@@ -112,11 +112,14 @@ export const failed = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( {
-	settings,
-	unsavedSettings,
-	fetching,
-	updatingPassword,
-	updating,
-	failed,
-} );
+export default withStorageKey(
+	'userSettings',
+	combineReducers( {
+		settings,
+		unsavedSettings,
+		fetching,
+		updatingPassword,
+		updating,
+		failed,
+	} )
+);

--- a/client/state/user-settings/selectors.js
+++ b/client/state/user-settings/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/user-settings/init';
+
+/**
  *
  * @param {object} state Global state tree
  */

--- a/client/state/user-settings/thunks/save-two-step-sms-settings.js
+++ b/client/state/user-settings/thunks/save-two-step-sms-settings.js
@@ -9,6 +9,8 @@ import {
 import { USER_SETTINGS_SAVE } from 'calypso/state/action-types';
 import wp from 'calypso/lib/wp';
 
+import 'calypso/state/user-settings/init';
+
 const wpcom = wp.undocumented();
 
 /**

--- a/client/state/user-settings/thunks/save-unsaved-user-settings.js
+++ b/client/state/user-settings/thunks/save-unsaved-user-settings.js
@@ -9,6 +9,8 @@ import {
 import wp from 'calypso/lib/wp';
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 
+import 'calypso/state/user-settings/init';
+
 const wpcom = wp.undocumented();
 
 /**

--- a/client/state/user-settings/thunks/set-user-setting.js
+++ b/client/state/user-settings/thunks/set-user-setting.js
@@ -14,6 +14,7 @@ import {
 	setUnsavedUserSetting,
 } from 'calypso/state/user-settings/actions';
 
+import 'calypso/state/user-settings/init';
 import 'calypso/state/data-layer/wpcom/me/settings';
 
 const debug = debugFactory( 'calypso:user:settings' );


### PR DESCRIPTION
This PR is one of many working on modularizing state in Calypso. This one handles the user settings state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42490.

#### Changes proposed in this Pull Request

* Modularise user settings state

#### Testing instructions

* Verify that there are no areas that access the `userSettings` state tree without specifically initializing it.
* Test the following pages and flows and verify they work the same as before:
  * `/me`
  * `/me/account`
  * `/me/security/two-step`
* Verify all tests pass.

#### Note

A `no-restricted-imports` ESLint error is expected and wanted due to the fact that there are still trees that remain in the monolithic legacy reducer.