### PR TITLE
Removing vertical scroll experiment code from mobile plans page

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -41,35 +41,24 @@ const PLANS_LIST = getPlans();
 
 export class PlanFeaturesHeader extends Component {
 	render() {
-		const {
-			isInSignup,
-			plansWithScroll,
-			planType,
-			isInVerticalScrollingPlansExperiment,
-		} = this.props;
+		const { isInSignup, plansWithScroll, planType } = this.props;
 
 		if ( planType === PLAN_P2_FREE ) {
 			return this.renderPlansHeaderP2Free();
 		}
 
-		// Do not use the signup-specific header, unify plans for the plansWithScroll test
+		// Do not use the signup-specific header
 		if ( plansWithScroll ) {
 			return this.renderPlansHeaderNoTabs();
 		} else if ( isInSignup ) {
-			if ( isInVerticalScrollingPlansExperiment ) {
-				return this.renderPlansHeaderNoTabs();
-			}
-			return this.renderSignupHeader();
+			return this.renderPlansHeaderNoTabs();
 		}
 		return this.renderPlansHeader();
 	}
 
 	resolveIsPillInCorner() {
-		const { isInSignup, isInVerticalScrollingPlansExperiment, plansWithScroll } = this.props;
-		return (
-			( isInVerticalScrollingPlansExperiment && isInSignup && plansWithScroll ) ||
-			( ! isInVerticalScrollingPlansExperiment && isInSignup )
-		);
+		const { isInSignup, plansWithScroll } = this.props;
+		return isInSignup && plansWithScroll;
 	}
 
 	renderPlansHeader() {
@@ -377,15 +366,8 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
-		const {
-			currencyCode,
-			isInSignup,
-			plansWithScroll,
-			isInVerticalScrollingPlansExperiment,
-			isLoggedInMonthlyPricing,
-		} = this.props;
-		const displayFlatPrice =
-			isInSignup && ! plansWithScroll && ! isInVerticalScrollingPlansExperiment;
+		const { currencyCode, isInSignup, plansWithScroll, isLoggedInMonthlyPricing } = this.props;
+		const displayFlatPrice = false;
 
 		if ( fullPrice && discountedPrice ) {
 			return (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -300,7 +300,6 @@ export class PlanFeatures extends Component {
 			translate,
 			showPlanCreditsApplied,
 			isLaunchPage,
-			isInVerticalScrollingPlansExperiment,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -342,9 +341,7 @@ export class PlanFeatures extends Component {
 				hideMonthly,
 			} = properties;
 			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
-			const planDescription = isInVerticalScrollingPlansExperiment
-				? planConstantObj.getShortDescription()
-				: planConstantObj.getDescription();
+			const planDescription = planConstantObj.getShortDescription();
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -369,7 +366,6 @@ export class PlanFeatures extends Component {
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						isMonthlyPlan={ isMonthlyPlan }
 						audience={ planConstantObj.getAudience?.() }
-						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
 					/>
@@ -418,7 +414,6 @@ export class PlanFeatures extends Component {
 			siteType,
 			showPlanCreditsApplied,
 			withScroll,
-			isInVerticalScrollingPlansExperiment,
 		} = this.props;
 
 		return map( planProperties, ( properties ) => {
@@ -489,7 +484,6 @@ export class PlanFeatures extends Component {
 						title={ planConstantObj.getTitle() }
 						plansWithScroll={ withScroll }
 						isMonthlyPlan={ isMonthlyPlan }
-						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={
 							! isInSignup && ! isJetpack && this.props.kindOfPlanTypeSelector === 'interval'
 						}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,120 +1,6 @@
 $plan-features-header-banner-height: 20px;
 $plan-features-sidebar-width: 272px;
 
-/******************************************/
-/*       Vertical Scroll Experiment       */
-/*  	       pcbrnV-XN-p2               */
-/******************************************/
-
-.in-vertically-scrolled-plans-experiment {
-	// If experiment succeeds the following styles
-	// need to be moved to the corresponding selectors
-
-	// To be moved to line 651 approximately
-	.plan-features--signup {
-		.plan-features__table {
-			@media ( max-width: 1040px ) {
-				display: none;
-			}
-		}
-
-		//To be moved to line 66 approximately
-		.plan-features__mobile {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-
-			@media ( min-width: 660px ) and ( max-width: 1040px ) {
-				.plan-features__summary, .plan-features__description {
-					padding: 16px 33px;
-
-				}
-				.plan-features--signup .plan-features__pricing {
-					padding: 0 7px;
-				}
-			}
-
-			.plan-features__header {
-				display: block;
-				position: relative;
-				text-align: left;
-				box-sizing: border-box;
-				border-top: solid 8px;
-				border-radius: 2px 2px 0 0;
-				padding-bottom: 12px;
-
-				&.is-blogger-plan {
-					border-color: var( --color-plan-blogger );
-					border-bottom: solid 2px var( --color-neutral-10 );
-				}
-
-				&.is-personal-plan {
-					border-color: var( --color-plan-personal );
-					border-bottom: solid 2px var( --color-neutral-10 );
-				}
-
-				&.is-premium-plan {
-					border-color: var( --color-plan-premium );
-					border-bottom: solid 2px var( --color-neutral-10 );
-				}
-
-				&.is-business-plan {
-					border-color: var( --color-plan-business );
-					border-bottom: solid 2px var( --color-neutral-10 );
-				}
-
-				&.is-ecommerce-plan {
-					border-color: var( --color-plan-ecommerce );
-					border-bottom: solid 2px var( --color-neutral-10 );
-				}
-			}
-
-			 .plan-price {
-				font-weight: 600;
-				margin-right: 10px;
-				font-size: $font-headline-large;
-				text-align: center;
-				font-family: 'Helvetica Neue', helvetica, arial, sans-serif;
-
-				.plan-price__currency-symbol {
-					vertical-align: super;
-					font-size: $font-title-medium;
-					font-weight: 400;
-				}
-
-				.plan-price__integer {
-					font-weight: 600;
-				}
-			}
-
-			.plan-features__header-title {
-				font-size: 1.25rem;
-				color: var( --color-primary );
-				line-height: 0.7;
-			}
-
-			.plan-features__header-billing-info {
-				margin-bottom: 1.4em;
-				color: var( --color-text-subtle );
-				line-height: normal;
-				text-align: center;
-			}
-
-			.plan-features__mobile-plan {
-				max-width: 408px;
-			}
-		}
-	}
-}
-
-
-.plan-features--loading-container {
-	margin-top: 300px;
-}
-
-/******************************************/
-
-
 /* Breakpoints 1150px, */
 
 .plan-features__content {
@@ -739,6 +625,12 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.plan-features__table {
 		display: none;
 
+		.plan-features__table {
+			@media ( max-width: 1040px ) {
+				display: none;
+			}
+		}
+
 		@include breakpoint-deprecated( '>660px' ) {
 			display: table;
 			width: 100%;
@@ -855,6 +747,96 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.plan-features__header-price-group-prices {
 		display: inline-block;
 	}
+
+	.plan-features__mobile {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		@media ( min-width: 660px ) and ( max-width: 1040px ) {
+			.plan-features__summary, .plan-features__description {
+				padding: 16px 33px;
+
+			}
+			.plan-features--signup .plan-features__pricing {
+				padding: 0 7px;
+			}
+		}
+
+		.plan-features__header {
+			display: block;
+			position: relative;
+			text-align: left;
+			box-sizing: border-box;
+			border-top: solid 8px;
+			border-radius: 2px 2px 0 0;
+			padding-bottom: 12px;
+
+			&.is-blogger-plan {
+				border-color: var( --color-plan-blogger );
+				border-bottom: solid 2px var( --color-neutral-10 );
+			}
+
+			&.is-personal-plan {
+				border-color: var( --color-plan-personal );
+				border-bottom: solid 2px var( --color-neutral-10 );
+			}
+
+			&.is-premium-plan {
+				border-color: var( --color-plan-premium );
+				border-bottom: solid 2px var( --color-neutral-10 );
+			}
+
+			&.is-business-plan {
+				border-color: var( --color-plan-business );
+				border-bottom: solid 2px var( --color-neutral-10 );
+			}
+
+			&.is-ecommerce-plan {
+				border-color: var( --color-plan-ecommerce );
+				border-bottom: solid 2px var( --color-neutral-10 );
+			}
+		}
+
+		 .plan-price {
+			font-weight: 600;
+			margin-right: 10px;
+			font-size: $font-headline-large;
+			text-align: center;
+			font-family: 'Helvetica Neue', helvetica, arial, sans-serif;
+
+			.plan-price__currency-symbol {
+				vertical-align: super;
+				font-size: $font-title-medium;
+				font-weight: 400;
+			}
+
+			.plan-price__integer {
+				font-weight: 600;
+			}
+		}
+
+		.plan-features__header-title {
+			font-size: 1.25rem;
+			color: var( --color-primary );
+			line-height: 0.7;
+		}
+
+		.plan-features__header-billing-info {
+			margin-bottom: 1.4em;
+			color: var( --color-text-subtle );
+			line-height: normal;
+			text-align: center;
+		}
+
+		.plan-features__mobile-plan {
+			max-width: 408px;
+		}
+	}
+}
+
+.plan-features--loading-container {
+	margin-top: 300px;
 }
 
 .plans-features-main__group.is-scrollable {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -181,7 +181,6 @@ export class PlansFeaturesMain extends Component {
 			redirectTo,
 			siteId,
 			plansWithScroll,
-			isInVerticalScrollingPlansExperiment,
 			redirectToAddDomainFlow,
 		} = this.props;
 
@@ -225,7 +224,6 @@ export class PlansFeaturesMain extends Component {
 						availablePlans: visiblePlans,
 					} ) }
 					siteId={ siteId }
-					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
 				/>
 			</div>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -144,7 +144,6 @@ export class PlansStep extends Component {
 			flowName,
 			showTreatmentPlansReorderTest,
 			isLoadingExperiment,
-			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 		} = this.props;
 
@@ -173,7 +172,6 @@ export class PlansStep extends Component {
 						customHeader={ this.getGutenboardingHeader() }
 						showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
 						isAllPaidPlansShown={ true }
-						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
 						isReskinned={ isReskinned }
 					/>
@@ -266,7 +264,6 @@ export class PlansStep extends Component {
 
 	render() {
 		const classes = classNames( 'plans plans-step', {
-			'in-vertically-scrolled-plans-experiment': this.props.isInVerticalScrollingPlansExperiment,
 			'has-no-sidebar': true,
 			'is-wide-layout': true,
 		} );
@@ -325,10 +322,6 @@ export default connect(
 		showTreatmentPlansReorderTest:
 			'treatment' === plans_reorder_abtest_variation || isTreatmentPlansReorderTest( state ),
 		isLoadingExperiment: false,
-		// IMPORTANT NOTE: The following is always set to true. It's a hack to resolve the bug reported
-		// in https://github.com/Automattic/wp-calypso/issues/50896, till a proper cleanup and deploy of
-		// treatment for the `vertical_plan_listing_v2` experiment is implemented.
-		isInVerticalScrollingPlansExperiment: true,
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the remnant experiment code left over from the vertical scroll experiment we ran on the plans page in the signup flow. Additional context in pbxNRc-D0-p2.

#### Testing instructions

* Checkout this PR and start Calypso.
* Navigate to `http://calypso.localhost:3000/start/new`.
* Create a new account up to the plans page, using either a mobile device or a mobile device emulator.
* Confirm that the plans page renders w/ vertical scrolling and that the page works as expected.
* Navigate the flow again using a non-mobile screen size and confirm that the flow works as expected there as well.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
