### PR TITLE
State: Modularize `importerNux` reducer

### DIFF
--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -6,6 +6,8 @@ import {
 	IMPORTER_NUX_URL_INPUT_SET,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/importer-nux/init';
+
 export const setNuxUrlInputValue = ( value ) => ( {
 	type: IMPORTER_NUX_URL_INPUT_SET,
 	value,

--- a/client/state/importer-nux/init.js
+++ b/client/state/importer-nux/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'importerNux' ], reducer );

--- a/client/state/importer-nux/package.json
+++ b/client/state/importer-nux/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { withStorageKey } from '@automattic/state-utils';
+
+/**
  * Internal dependencies
  */
 import { combineReducers } from 'calypso/state/utils';
@@ -36,7 +41,10 @@ export const siteDetails = ( state = null, action ) => {
 	return state;
 };
 
-export default combineReducers( {
-	siteDetails,
-	urlInputValue,
-} );
+export default withStorageKey(
+	'importerNux',
+	combineReducers( {
+		siteDetails,
+		urlInputValue,
+	} )
+);

--- a/client/state/importer-nux/temp-selectors.js
+++ b/client/state/importer-nux/temp-selectors.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/importer-nux/init';
+
 // TODO: Follow project conventions once finalised
 export const getNuxUrlInputValue = ( state ) => get( state, 'importerNux.urlInputValue' );
 

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -16,7 +16,6 @@ import { reducer as httpData } from 'calypso/state/data-layer/http-data';
  */
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
-import importerNux from './importer-nux/reducer';
 import sites from './sites/reducer';
 
 // Legacy reducers
@@ -26,7 +25,6 @@ const reducers = {
 	currentUser,
 	dataRequests,
 	httpData,
-	importerNux,
 	sites,
 };
 


### PR DESCRIPTION
This PR is one of many working on modularizing state in Calypso. This one handles `importerNux` state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42446.

#### Changes proposed in this Pull Request

* Modularise `importerNux` state

#### Testing instructions

I'm unable to get to the importer step in onboarding, neither from `/start/import-url`, nor from `/start/import-onboarding`. In any case I get to the domains and/or plans steps, and I'm unable to get to the import step. So verifying any usage of `importerNux` state tree initializes the reducer should be enough IMHO.

#### Note

A `no-restricted-imports` ESLint error is expected and wanted due to the fact that there are still trees that remain in the monolithic legacy reducer.