### PR TITLE
Jetpack Utils: Import calypso-products functions directly from calypso-products API

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/utils.ts
@@ -1,8 +1,11 @@
 /**
  * External dependencies
  */
-import isJetpackPurchasableItem from '@automattic/calypso-products/src/is-jetpack-purchasable-item';
-import isJetpackLegacyItem from '@automattic/calypso-products/src/is-jetpack-legacy-item';
+import {
+	isJetpackPurchasableItem,
+	isJetpackLegacyItem,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -12,10 +15,9 @@ import { COMPARE_PLANS_QUERY_PARAM } from './constants';
 /**
  * Type dependencies
  */
-import {
+import type {
 	JetpackLegacyPlanSlug,
 	JetpackPurchasableItemSlug,
-	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import type { PlanRecommendation } from './types';
 import type { Duration } from '../types';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/52381 some functions and constants from the `@automattic/calypso-products` package were imported into the Jetpack plans utils file, but they were imported directly from their definitions in the `src` directory of the npm package. While this works, it's dangerous since the directory structure of an npm package isn't part of its public API and could change without warning. It's safer to rely on the public API of the package instead.

This PR modifies the imports to use the public API.

#### Testing instructions

None should be required; the file is TypeScript and opening it in a TS-supported editor (unfortunately we have no automated type checking in calypso) should prove that the imports are correct.