### PR TITLE
Inline Support Modal: add max-width and update styling

### DIFF
--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -72,6 +72,7 @@
 	}
 
 	figure img {
+		display: inherit;
 		margin-bottom: 0;
 	}
 

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -1,9 +1,10 @@
 .support-article-dialog__story-content {
+	color: var( --color-neutral-70 );
+	font-size: $font-body;
+	line-height: 1.7;
 	margin: 0;
 	padding-top: 16px;
 	position: relative;
-	font-size: $font-title-small;
-	line-height: 1.7;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
@@ -62,11 +63,16 @@
 		height: auto;
 		display: inline;
 		margin: auto;
+		margin-bottom: 12px;
 
 		&.emojify__emoji {
 			height: 1em;
 			margin-bottom: 0;
 		}
+	}
+
+	figure img {
+		margin-bottom: 0;
 	}
 
 	audio {
@@ -175,7 +181,7 @@
 		position: relative;
 		margin-bottom: 24px;
 		padding: 11px 24px;
-		border-radius: 1px;
+		border-radius: 2px;
 		background: var( --color-neutral-0 );
 		box-sizing: border-box;
 		font-size: $font-body-small;

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -20,8 +20,12 @@
 		height: 90%;
 	}
 
+	@include breakpoint-deprecated( '>860px' ) {
+		max-width: 860px;
+	}
+
 	@include breakpoint-deprecated( '>960px' ) {
-		width: 960px;
+		max-width: 860px;
 	}
 }
 

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -40,24 +40,6 @@
 	}
 }
 
-.support-article-dialog__story-content {
-	.toc-jump {
-		display: none;
-	}
-
-	color: var( --color-neutral-70 );
-	font-size: $font-title-small;
-	line-height: 28px;
-}
-
-.support-article-dialog__story-content img {
-	margin-bottom: 12px;
-}
-
-.support-article-dialog__story-content figure img {
-	margin-bottom: 0;
-}
-
 .support-article-dialog__header-title a {
 	text-decoration: none;
 	clear: none;
@@ -97,6 +79,12 @@
 
 .support-article-dialog__header {
 	margin-bottom: 23px;
+}
+
+.support-article-dialog__story-content {
+	.toc-jump {
+		display: none;
+	}
 }
 
 .support-article-dialog .embed-youtube,

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -4,26 +4,22 @@
 }
 
 .support-article-dialog.dialog.card {
+	margin: 0 auto;
 	position: absolute;
 	top: 0;
 	bottom: 0;
-	left: 0;
-	right: 0;
 	max-width: 100%;
+	max-height: 100%;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		top: 5%;
 		bottom: 5%;
-		left: 5%;
-		right: 5%;
 		width: 90%;
+		height: 90%;
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-		left: 12.5%;
-		right: 12.5%;
-		width: 75%;
-		width: 80vw;
+		width: 960px;
 	}
 }
 

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -8,6 +8,8 @@
 	position: absolute;
 	top: 0;
 	bottom: 0;
+	width: 100%;
+	height: 100%;
 	max-width: 100%;
 	max-height: 100%;
 


### PR DESCRIPTION
As a quick patch to #54194 while designs are explored, this addresses some styling issue with the Inline Support modal. It updates the font-size to Calypso's body font, adds a max-width for legibility, and fixes image alignment in the content.

**Before** | **After**
------------ | -------------
<img width="1610" alt="Screen Shot 2021-07-09 at 10 55 56 AM" src="https://user-images.githubusercontent.com/942359/125103095-02bdfe00-e0aa-11eb-920e-f5fcb8d9c051.png"> | <img width="1610" alt="Screen Shot 2021-07-09 at 11 09 08 AM" src="https://user-images.githubusercontent.com/942359/125103036-ef129780-e0a9-11eb-91d1-7bfa9f297338.png">
<img width="340" alt="Screen Shot 2021-07-09 at 10 57 15 AM" src="https://user-images.githubusercontent.com/942359/125103149-110c1a00-e0aa-11eb-9e08-a3db5585aa8d.png"> | <img width="341" alt="Screen Shot 2021-07-09 at 10 57 01 AM" src="https://user-images.githubusercontent.com/942359/125103128-0baecf80-e0aa-11eb-987f-039aa4930654.png">

**To test:**
- visit an inline support link (i.e. `/devdocs/design/inline-support-link/`)
- verify that the modal looks good at different browser resolutions
- verify that image alignment is correct