### PR TITLE
editor tracks - fix replace blocks flow not triggering insert event

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -4,6 +4,7 @@
 import { use, select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { applyFilters } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 import { find, isEqual } from 'lodash';
 import debugFactory from 'debug';
 
@@ -652,8 +653,11 @@ if (
 	registerDelegateEventSubscriber(
 		'wpcom-block-editor-template-part-detach-blocks',
 		'before',
-		() => {
-			ignoreNextReplaceBlocksAction = true;
+		( mapping, event, target ) => {
+			const item = target.querySelector( '.components-menu-item__item' );
+			if ( item?.innerText === __( 'Detach blocks from template part' ) ) {
+				ignoreNextReplaceBlocksAction = true;
+			}
 		}
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Cleans up a bug introduced in https://github.com/Automattic/wp-calypso/pull/53592.

In the above PR, an event was tracked via a selector but had extra conditions used to determine the proper context if the event should fire:

https://github.com/Automattic/wp-calypso/blob/f7b5d6d975a9954151611dd777b78b472fb8d1d9/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-template-part-detach-blocks.js#L24-L25

A subscriber was also added to this event, but its function did not contain the same extra conditions to determine proper context as the original event.  Therefore other actions taking place that match this selector (`'.components-menu-item__button'` such as replacing a block's type via the block toolbar), are unintentionally triggering the subscriber function for the event.  Here we have added the extra conditions to the subscriber function to prevent it from firing in the wrong circumstances.

![Screen Shot 2021-07-09 at 12 16 04 PM](https://user-images.githubusercontent.com/5414230/125115696-8b37a100-e0a0-11eb-9489-062a7fc21c85.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Insert a paragraph block in the editor, enter some text.
* Using the block toolbar, transform this into a heading block
* verify the 'wpcom_block_pick_block_inserted' event is sent as expected.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53410
