### PR TITLE
Legacy Dotcom FSE: Prevent multiple calls to iframe open template part event handler

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import $ from 'jquery';
-import { filter, find, forEach, get, map, partialRight } from 'lodash';
+import { debounce, filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse } from '@wordpress/blocks';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
@@ -877,25 +877,32 @@ function openCustomizer( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function openTemplatePartLinks( calypsoPort ) {
-	$( '#editor' ).on( 'click', '.template__block-container .template-block__overlay a', ( e ) => {
-		e.preventDefault();
-		e.stopPropagation(); // Otherwise it will port the message twice.
+	$( '#editor' ).on(
+		'click',
+		'.template__block-container .template-block__overlay a',
+		// Prevents multiple calls. We suspect changes in React 17 to be the root cause,
+		// but not entirely certain. We'll remove this code soon when core FSE is released.
+		// See https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation
+		debounce( ( e ) => {
+			e.preventDefault();
+			e.stopPropagation(); // Otherwise it will port the message twice.
 
-		// Get the template part ID from the current href.
-		const templatePartId = parseInt( getQueryArg( e.target.href, 'post' ), 10 );
+			// Get the template part ID from the current href.
+			const templatePartId = parseInt( getQueryArg( e.target.href, 'post' ), 10 );
 
-		const { port2 } = new MessageChannel();
-		calypsoPort.postMessage(
-			{
-				action: 'openTemplatePart',
-				payload: {
-					templatePartId,
-					unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
+			const { port2 } = new MessageChannel();
+			calypsoPort.postMessage(
+				{
+					action: 'openTemplatePart',
+					payload: {
+						templatePartId,
+						unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
+					},
 				},
-			},
-			[ port2 ]
-		);
-	} );
+				[ port2 ]
+			);
+		} )
+	);
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

When legacy dotcom FSE is run against the most recent version of Gutenberg (it's currently pinned to an older version), clicking on an edit template part button ("Edit Header" or "Edit Footer") in the Calypso iframe leads to an improperly formed browser URL. (e.g. `?fse_parent_post=2` instead of `?fse_parent_post=12`)

![2021-07-09 10 58 01](https://user-images.githubusercontent.com/5414230/125118622-d0f66880-e0a4-11eb-8dda-5cb3e862bba2.gif)

In this PR, we debounce an event handler invoked when opening legacy FSE template parts to avoid calling it multiple times. This is a hack-y fix, and is meant to be a stopgap until we remove the experience entirely when core FSE is rolled out and legacy users are migrated.

### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Verifying the bug**
* Setup a legacy dotcom FSE simple site
* Sandbox the site, the public api, and the widgets endpoint
* In `sandbox-0.php` override the pinned legacy dotcom FSE version by copying and pasting `define( 'GUTENBERG_PLUGIN_VERSION', 'v11.0.0' );` into the file.
* Navigate to the legacy site editor by visiting any page
* Click directly on one of the edit template part buttons ("Edit Header" or "Edit Footer"). Avoid clicking on the overlay (the problem only manifests when clicking on the button)
* Ensure that the browser url `?fse_parent_post` query param id is correct (The id for the query param shouldn't match the id for the resource)

**Verifying the fix**
* Set up dev environment for `wp-calypso/apps/wpcom-block-editor` Run `install-plugin.sh wpcom-block-editor fix/legacy-fse-template-part-links` called from the sandbox
* I was having trouble getting Calypso to respect the sandbox updates. If you have issues, try closing the calypso window and deleting the browser cache.
* Navigate to the legacy site editor by visiting any page
* Click directly on one of the edit template part buttons ("Edit Header" or "Edit Footer"). Avoid clicking on the overlay (the problem only manifests when clicking on the button)
* Ensure that the browser url `?fse_parent_post` query param id is correct (The id for the query param shouldn't match the id for the resource)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/54418
