### PR TITLE
Activity Log: Extract 'Share this event' into separate component

### DIFF
--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -34,6 +34,7 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import StreamsMediaPreview from './activity-card-streams-media-preview';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import { rewindShareRequest } from 'calypso/state/activity-log/actions';
+import ShareActivity from './share-activity';
 
 /**
  * Style dependencies
@@ -433,7 +434,9 @@ class ActivityCard extends Component {
 						<div className="activity-card__time-text">{ backupTimeDisplay }</div>
 					</div>
 				) }
-				{ ! summarize && isEnabled( 'jetpack/activity-log-sharing' ) && this.renderShareButton() }
+				{ ! summarize && isEnabled( 'jetpack/activity-log-sharing' ) && (
+					<ShareActivity siteId={ siteId } activity={ activity } />
+				) }
 				<Card>
 					<ActivityActor
 						actorAvatarUrl={ activity.actorAvatarUrl }

--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -15,7 +15,7 @@ import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/p
 import { Card } from '@automattic/components';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isSuccessfulRealtimeBackup } from 'calypso/lib/jetpack/backup-utils';
-import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { withApplySiteOffset } from 'calypso/components/site-offset';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -23,7 +23,6 @@ import ActivityActor from 'calypso/components/activity-card/activity-actor';
 import ActivityDescription from 'calypso/components/activity-card/activity-description';
 import ActivityMedia from 'calypso/components/activity-card/activity-media';
 import Button from 'calypso/components/forms/form-button';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import ExternalLink from 'calypso/components/external-link';
 import getAllowRestore from 'calypso/state/selectors/get-allow-restore';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -33,7 +32,6 @@ import PopoverMenu from 'calypso/components/popover/menu';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import StreamsMediaPreview from './activity-card-streams-media-preview';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
-import { rewindShareRequest } from 'calypso/state/activity-log/actions';
 import ShareActivity from './share-activity';
 
 /**
@@ -63,7 +61,6 @@ class ActivityCard extends Component {
 
 	topPopoverContext = React.createRef();
 	bottomPopoverContext = React.createRef();
-	sharePopoverContext = React.createRef();
 
 	constructor( props ) {
 		super( props );
@@ -72,30 +69,8 @@ class ActivityCard extends Component {
 			showTopPopoverMenu: false,
 			showBottomPopoverMenu: false,
 			showContent: false,
-			showSharePopover: false,
-			shareEmail: '',
-			showShareEmailError: false,
 		};
-
-		this.handleShareEmailChange = this.handleShareEmailChange.bind( this );
 	}
-
-	handleShareEmailChange = ( event ) =>
-		this.setState( { shareEmail: event.target.value, showShareEmailError: false } );
-
-	handleShare = () => {
-		const email = this.state.shareEmail;
-		if ( ! email.includes( '@' ) || ! email.includes( '.' ) ) {
-			this.setState( { showShareEmailError: true } );
-		} else {
-			this.props.shareActivity(
-				this.props.siteId,
-				this.props.activity.rewindId,
-				this.state.shareEmail
-			);
-			this.setState( { showSharePopover: false } );
-		}
-	};
 
 	togglePopoverMenu = ( topPopoverMenu = true ) => {
 		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_backup_actions_click' );
@@ -109,26 +84,6 @@ class ActivityCard extends Component {
 
 	closePopoverMenu = () =>
 		this.setState( { showTopPopoverMenu: false, showBottomPopoverMenu: false } );
-
-	toggleSharePopover = () => {
-		const {
-			activity: { siteId, rewindId },
-			dispatchShareActivityPopoverTracksEvent,
-		} = this.props;
-
-		if ( ! this.state.showSharePopover ) {
-			dispatchShareActivityPopoverTracksEvent( siteId, rewindId );
-		}
-
-		this.setState( { showSharePopover: ! this.state.showSharePopover } );
-	};
-
-	closeSharePopover = ( event ) => {
-		// bit of a hack here, but it works
-		if ( false === event ) {
-			this.setState( { showSharePopover: false } );
-		}
-	};
 
 	toggleSeeContent = () => {
 		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_backup_content_expand' );
@@ -305,64 +260,6 @@ class ActivityCard extends Component {
 		);
 	}
 
-	renderShareButton() {
-		const { translate } = this.props;
-
-		return (
-			<>
-				<div className="activity-card__share-button-wrap">
-					<Button
-						compact
-						borderless
-						onClick={ this.toggleSharePopover }
-						ref={ this.sharePopoverContext }
-						className="activity-card__share-button"
-					>
-						<Gridicon icon="mail" />
-						{ translate( 'Share this event' ) }
-					</Button>
-				</div>
-				<PopoverMenu
-					context={ this.sharePopoverContext.current }
-					isVisible={ this.state.showSharePopover }
-					onClose={ this.closeSharePopover }
-					position="top"
-					className="activity-card__share-popover"
-				>
-					<div className="activity-card__share-heading">
-						{ translate( 'Share this event via email' ) }
-					</div>
-					<div className="activity-card__share-description">
-						{ translate(
-							'Share what is happening with your site with your clients or business partners.'
-						) }
-					</div>
-					<div className="activity-card__share-form">
-						<FormTextInput
-							className="activity-card__share-email"
-							placeholder="Email address"
-							value={ this.state.shareEmail }
-							onChange={ this.handleShareEmailChange }
-							isError={ this.state.showShareEmailError }
-						/>
-						<Button
-							className="activity-card__share-submit"
-							disabled={ ! this.state.shareEmail }
-							onClick={ this.handleShare }
-						>
-							{ translate( 'Share' ) }
-						</Button>
-					</div>
-					{ this.state.showShareEmailError && (
-						<div className="activity-card__share-error">
-							{ translate( 'Please enter a valid email address' ) }
-						</div>
-					) }
-				</PopoverMenu>
-			</>
-		);
-	}
-
 	renderTopToolbar = () => this.renderToolbar( true );
 	renderBottomToolbar = () => this.renderToolbar( false );
 
@@ -473,19 +370,9 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-const mapDispatchToProps = ( dispatch ) => ( {
+const mapDispatchToProps = {
 	dispatchRecordTracksEvent: recordTracksEvent,
-	shareActivity: ( siteId, rewindId, email ) => {
-		dispatch(
-			withAnalytics(
-				recordTracksEvent( 'calypso_activity_share_request' ),
-				rewindShareRequest( siteId, rewindId, email )
-			)
-		);
-	},
-	dispatchShareActivityPopoverTracksEvent: ( siteId, rewindId ) =>
-		dispatch( recordTracksEvent( 'calypso_activity_share_popup', { siteId, rewindId } ) ),
-} );
+};
 
 export default connect(
 	mapStateToProps,

--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -326,13 +326,15 @@ class ActivityCard extends Component {
 			>
 				<QueryRewindState siteId={ siteId } />
 				{ ! summarize && (
-					<div className="activity-card__time">
-						<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />
-						<div className="activity-card__time-text">{ backupTimeDisplay }</div>
+					<div className="activity-card__header">
+						<div className="activity-card__time">
+							<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />
+							<div className="activity-card__time-text">{ backupTimeDisplay }</div>
+						</div>
+						{ isEnabled( 'jetpack/activity-log-sharing' ) && (
+							<ShareActivity siteId={ siteId } activity={ activity } />
+						) }
 					</div>
-				) }
-				{ ! summarize && isEnabled( 'jetpack/activity-log-sharing' ) && (
-					<ShareActivity siteId={ siteId } activity={ activity } />
 				) }
 				<Card>
 					<ActivityActor

--- a/client/components/activity-card/share-activity.tsx
+++ b/client/components/activity-card/share-activity.tsx
@@ -73,7 +73,10 @@ const SharePopover: React.FC< SharePopoverProps > = ( {
 		} else {
 			dispatch(
 				withAnalytics(
-					recordTracksEvent( 'calypso_activity_share_request' ),
+					recordTracksEvent( 'calypso_activity_share_request', {
+						site_id: siteId,
+						rewind_id: activity.rewindId,
+					} ),
 					rewindShareRequest( siteId, activity.rewindId, email )
 				)
 			);

--- a/client/components/activity-card/share-activity.tsx
+++ b/client/components/activity-card/share-activity.tsx
@@ -1,0 +1,181 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { useCallback, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { rewindShareRequest } from 'calypso/state/activity-log/actions';
+import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import Button from 'calypso/components/forms/form-button';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
+import PopoverMenu from 'calypso/components/popover/menu';
+
+type Activity = {
+	rewindId: number;
+};
+
+type OwnProps = {
+	siteId: number;
+	activity: Activity;
+};
+
+type SharePopoverProps = {
+	siteId: number;
+	activity: Activity;
+	context: React.MutableRefObject< React.ReactElement | null >;
+	isVisible: boolean;
+	onClose: ( event?: boolean ) => void;
+};
+
+const SharePopover: React.FC< SharePopoverProps > = ( {
+	siteId,
+	activity,
+	context,
+	isVisible,
+	onClose,
+} ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const [ email, setEmail ] = useState( '' );
+	const [ showEmailError, setShowEmailError ] = useState( false );
+
+	const handleEmailChange: React.ChangeEventHandler< HTMLInputElement > = useCallback(
+		( event ) => {
+			setEmail( event.target.value );
+			setShowEmailError( false );
+		},
+		[ setEmail, setShowEmailError ]
+	);
+
+	const closeOnClickOut = useCallback(
+		( event?: boolean ) => {
+			// HACK: Keep the pop-over open until
+			// we've registered a click outside of it;
+			// see onClickOut in `client/components/popover/index.jsx`
+			if ( event !== false ) {
+				return;
+			}
+
+			onClose();
+		},
+		[ onClose ]
+	);
+
+	const handleShare = useCallback( () => {
+		if ( ! email.includes( '@' ) || ! email.includes( '.' ) ) {
+			setShowEmailError( true );
+		} else {
+			dispatch(
+				withAnalytics(
+					recordTracksEvent( 'calypso_activity_share_request' ),
+					rewindShareRequest( siteId, activity.rewindId, email )
+				)
+			);
+
+			onClose();
+		}
+	}, [ email, dispatch, siteId, activity.rewindId, onClose ] );
+
+	return (
+		<PopoverMenu
+			context={ context.current }
+			isVisible={ isVisible }
+			onClose={ closeOnClickOut }
+			position="top"
+			className="activity-card__share-popover"
+		>
+			<div className="activity-card__share-heading">
+				{ translate( 'Share this event via email' ) }
+			</div>
+			<div className="activity-card__share-description">
+				{ translate(
+					'Share what is happening with your site with your clients or business partners.'
+				) }
+			</div>
+			<div className="activity-card__share-form">
+				<FormTextInput
+					className="activity-card__share-email"
+					placeholder="Email address"
+					value={ email }
+					onChange={ handleEmailChange }
+					isError={ showEmailError }
+				/>
+				<Button
+					className="activity-card__share-submit"
+					disabled={ ! email }
+					onClick={ handleShare }
+				>
+					{ translate( 'Share' ) }
+				</Button>
+			</div>
+			{ showEmailError && (
+				<div className="activity-card__share-error">
+					{ translate( 'Please enter a valid email address' ) }
+				</div>
+			) }
+		</PopoverMenu>
+	);
+};
+
+const ShareActivity: React.FC< OwnProps > = ( { siteId, activity } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const buttonRef = useRef( null );
+
+	const { rewindId } = activity;
+
+	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
+	const trackPopoverOpened = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_activity_share_popup', {
+					site_id: siteId,
+					rewind_id: rewindId,
+				} )
+			),
+		[ dispatch, siteId, rewindId ]
+	);
+	const togglePopover = () => {
+		if ( ! isPopoverVisible ) {
+			trackPopoverOpened();
+		}
+
+		setPopoverVisible( ! isPopoverVisible );
+	};
+	const closePopover = () => {
+		setPopoverVisible( false );
+	};
+
+	return (
+		<>
+			<div className="activity-card__share-button-wrap">
+				<Button
+					compact
+					borderless
+					className="activity-card__share-button"
+					ref={ buttonRef }
+					onClick={ togglePopover }
+				>
+					<Gridicon icon="mail" />
+					{ translate( 'Share this event' ) }
+				</Button>
+			</div>
+
+			<SharePopover
+				siteId={ siteId }
+				context={ buttonRef }
+				activity={ activity }
+				isVisible={ isPopoverVisible }
+				onClose={ closePopover }
+			/>
+		</>
+	);
+};
+
+export default ShareActivity;

--- a/client/components/activity-card/share-activity.tsx
+++ b/client/components/activity-card/share-activity.tsx
@@ -84,6 +84,16 @@ const SharePopover: React.FC< SharePopoverProps > = ( {
 			onClose();
 		}
 	}, [ email, dispatch, siteId, activity.rewindId, onClose ] );
+	const shareOnEnterKeyPress: React.KeyboardEventHandler = useCallback(
+		( { key } ) => {
+			if ( key !== 'Enter' ) {
+				return;
+			}
+
+			handleShare();
+		},
+		[ handleShare ]
+	);
 
 	return (
 		<PopoverMenu
@@ -108,6 +118,7 @@ const SharePopover: React.FC< SharePopoverProps > = ( {
 					value={ email }
 					onChange={ handleEmailChange }
 					isError={ showEmailError }
+					onKeyPress={ shareOnEnterKeyPress }
 				/>
 				<Button
 					className="activity-card__share-submit"

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -53,11 +53,22 @@
 	}
 }
 
+.activity-card__header {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	column-gap: 16px;
+	margin: 24px 0 8px;
+
+	.activity-card-list__secondary-card & {
+		transform: translateX( 32px );
+	}
+}
+
 .activity-card__time {
 	align-items: center;
 	display: flex;
 	flex-direction: row;
-	margin: 24px 0 8px;
 }
 
 .activity-card__time-icon {
@@ -71,6 +82,60 @@
 	font-size: $font-body-extra-small;
 	line-height: 17px;
 	margin-left: 4px;
+}
+
+.activity-card__share-button svg {
+	margin-right: 5px;
+}
+
+.activity-card__share-button.button.is-borderless.is-primary {
+	margin: 0;
+	color: var( --color-neutral-40 );
+	font-size: $font-body-extra-small;
+	line-height: $font-body;
+}
+
+.activity-card__share-heading {
+	font-size: 1rem;
+	font-weight: 600;
+	text-align: left;
+	margin-bottom: 0.25rem;
+}
+
+.activity-card__share-description {
+	font-size: 0.875rem;
+	margin-bottom: 0.75rem;
+	text-align: left;
+}
+
+.activity-card__share-popover {
+	width: 340px;
+}
+
+.activity-card__share-popover .popover__inner {
+	padding: 1rem;
+}
+
+.activity-card__share-form {
+	display: flex;
+}
+
+input[type=text].form-text-input.activity-card__share-email {
+	margin-right: 0.5rem;
+}
+
+.activity-card__share-submit {
+	width: 32%;
+
+	&.form-button {
+		margin: 0;
+	}
+}
+
+.activity-card__share-error {
+	color: var( --color-error );
+	text-align: left;
+	margin-top: 0.25rem;
 }
 
 .activity-card__activity-description {
@@ -226,69 +291,4 @@
 			margin-left: 16px;
 		}
 	}
-}
-
-.activity-card__share-button svg {
-	margin-right: 5px;
-}
-
-.activity-card__share-button-wrap {
-	position: absolute;
-	top: -6px; // Offset the button's inherit padding
-	right: 0;
-	text-align: right;
-
-	.activity-card-list__secondary-card & {
-		right: -32px;
-	}
-}
-
-.activity-card__share-button.button.is-borderless.is-primary {
-	margin: 0;
-	color: var( --color-neutral-40 );
-	font-size: $font-body-extra-small;
-	line-height: $font-body;
-}
-
-.activity-card__share-heading {
-	font-size: 1rem;
-	font-weight: 600;
-	text-align: left;
-	margin-bottom: 0.25rem;
-}
-
-.activity-card__share-description {
-	font-size: 0.875rem;
-	margin-bottom: 0.75rem;
-	text-align: left;
-}
-
-.activity-card__share-popover {
-	width: 340px;
-}
-
-.activity-card__share-popover .popover__inner {
-	padding: 1rem;
-}
-
-.activity-card__share-form {
-	display: flex;
-}
-
-input[type=text].form-text-input.activity-card__share-email {
-	margin-right: 0.5rem;
-}
-
-.activity-card__share-submit {
-	width: 32%;
-
-	&.form-button {
-		margin: 0;
-	}
-}
-
-.activity-card__share-error {
-	color: var( --color-error );
-	text-align: left;
-	margin-top: 0.25rem;
 }

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -1,4 +1,6 @@
 .activity-card {
+	position: relative;
+
 	.card {
 		padding: 16px;
 		border-radius: var( --jetpack-corners-sharp );

--- a/client/state/data-layer/wpcom/activity-log/share/index.js
+++ b/client/state/data-layer/wpcom/activity-log/share/index.js
@@ -24,15 +24,21 @@ const requestShare = ( action ) =>
 		action
 	);
 
-const successfulShare = ( siteId ) =>
+const successfulShare = ( { siteId, rewindId } ) =>
 	withAnalytics(
-		recordTracksEvent( 'calypso_activity_event_share_success', { siteId } ),
+		recordTracksEvent( 'calypso_activity_event_share_success', {
+			site_id: siteId,
+			rewind_id: rewindId,
+		} ),
 		successNotice( translate( "We've shared the event!" ) )
 	);
 
-const failedShare = ( siteId ) =>
+const failedShare = ( { siteId, rewindId } ) =>
 	withAnalytics(
-		recordTracksEvent( 'calypso_activity_event_share_failed', { siteId } ),
+		recordTracksEvent( 'calypso_activity_event_share_failed', {
+			site_id: siteId,
+			rewind_id: rewindId,
+		} ),
 		errorNotice( translate( 'The event failed to send, please try again.' ) )
 	);
 


### PR DESCRIPTION
Since the `ActivityCard` component has grown quite large, I thought it might be nice to start extracting bits and pieces from it and converting them from a class-based to a function-based structure.

#### Changes proposed in this Pull Request

##### Refactor

* Extract the `renderShareButton` method from `ActivityCard` into a new component called `ShareActivity`.
* Remove extracted code from `ActivityCard`, replacing it with instructions to render an instance of `ShareActivity`.

##### Bugfixes (incidental)

* Alter `ActivityCard` CSS and markup to ensure the 'Share this event' button is visible on all Activity cards where it's applicable, as long as the `jetpack/activity-log-event-sharing` flag is enabled.
* Update parameters passed to Tracks events for event sharing so they're tracked properly, with both the current site ID and the shared event's rewind ID.

#### Testing instructions

In either Calypso Blue or Calypso Green, visit the Activity Log; alternatively, Backup page for a site with Backup Real-time.

##### Share button refactor and screen positioning

**Expected behavior:** 'Share this event' button is located at the right side of the ActivityCard header, beside the time display.
**Actual behavior:** 'Share this event' button is not visible on any Activity card.

* Verify that the 'Share this event' button is visible on non-summarized Activity cards and looks/functions intuitively. Test specifically for click-out behavior, invalid email input, and various screen sizes.

##### Share button analytics tracking

**Expected behavior:** Tracks events are emitted when the 'Share this event' button is clicked and when an event is shared, with valid and correct parameters for the current site ID and selected event's rewind ID.
**Actual behavior:** Tracks events are emitted, but sometimes without the selected event's rewind ID. Site ID is always included, but the parameter name is incorrectly formatted as `siteId` instead of `site_id`, and its value is always rendered as `[object Object]`.

* Verify that when you click the 'Share this event' button and a popover is displayed, a Tracks event `calypso_activity_share_popup` is emitted with parameters for `site_id` and `rewind_id`.
* Verify that when you input an invalid email address, you are unable to share the event and the email field is put into an error state.
* Verify that when you input a valid email address, the event is sent successfully and two Tracks events are emitted with parameters for `site_id` and `rewind_id`, and those parameters have the correct (integer) values:
  * `calypso_activity_share_request`
  * `calypso_activity_event_share_success`

#### Reference screenshots

##### Activity card list (before / after)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/670067/125127940-eb3f3f00-e0c2-11eb-8728-f944ba260a11.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/670067/125127816-b9c67380-e0c2-11eb-9970-c5978af1cf8a.png">

##### Share button popover

<img width="369" alt="image" src="https://user-images.githubusercontent.com/670067/125128059-11fd7580-e0c3-11eb-8003-acb9cc1200d3.png">
<img width="369" alt="image" src="https://user-images.githubusercontent.com/670067/125128363-9223db00-e0c3-11eb-8308-8269eb850a8c.png">
<img width="374" alt="image" src="https://user-images.githubusercontent.com/670067/125128435-a9fb5f00-e0c3-11eb-87aa-5b66796eed29.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/670067/125128530-c26b7980-e0c3-11eb-9286-f26d668bc5be.png">
