### PR TITLE
Change wording on appointment page

### DIFF
--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -145,15 +145,12 @@ class AppointmentInfo extends Component {
 			<div>
 				<Confirmation
 					title={ translate( 'Your upcoming appointment' ) }
-					description={ translate(
-						'Get all your questions ready ' + '-- we look forward to chatting!',
-						{
-							args: {
-								beginTime: moment( beginTimestamp ).format( beginTimeFormat ),
-								duration: moment( endTimestamp ).diff( beginTimestamp, 'minutes' ),
-							},
-						}
-					) }
+					description={ translate( 'Get all your questions ready — we look forward to chatting!', {
+						args: {
+							beginTime: moment( beginTimestamp ).format( beginTimeFormat ),
+							duration: moment( endTimestamp ).diff( beginTimestamp, 'minutes' ),
+						},
+					} ) }
 				/>
 				{ this.renderAppointmentDetails() }
 			</div>

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -146,9 +146,7 @@ class AppointmentInfo extends Component {
 				<Confirmation
 					title={ translate( 'Your upcoming appointment' ) }
 					description={ translate(
-						'We can talk about anything related to your site. ' +
-							'Get all your questions ready ' +
-							'-- we look forward to chatting!',
+						'Get all your questions ready ' + '-- we look forward to chatting!',
 						{
 							args: {
 								beginTime: moment( beginTimestamp ).format( beginTimeFormat ),


### PR DESCRIPTION
## Changes proposed in this Pull Request

To help avoid confusion with what our scope of support is for quick start calls it seems best to remove the beginning sentence in the appointment confirmation page.

**Before**
[![Screenshot](https://d.pr/i/TvR991+)](https://d.pr/i/TvR991)

**After**
[![Screenshot](https://d.pr/rvxmH3+)](https://d.pr/rvxmH3)

## Testing instructions

* Go to http://calypso.localhost:3000/me/concierge
* Schedule an appointment
* Go back to http://calypso.localhost:3000/me/concierge
* View the statement below the top image