### PR TITLE
Showcase: update active theme styles

### DIFF
--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -258,6 +258,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__description {
+		align-self: center;
 		font-size: $font-body-small;
 		margin: 16px;
 
@@ -280,11 +281,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		justify-content: flex-end;
 		flex-grow: 1;
 
-		@include breakpoint-deprecated( '>660px' ) {
-			border-top: none;
-		}
-
 		@include breakpoint-deprecated( '>960px' ) {
+			border-top: none;
 			min-height: 112px;
 			padding-top: 0;
 		}

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -187,8 +187,11 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__img {
+		border-bottom: $current-theme-border;
+
 		@include breakpoint-deprecated( '>660px' ) {
 			border-right: $current-theme-border;
+			border-bottom: none;
 			max-height: 112px;
 			width: auto;
 		}
@@ -203,11 +206,6 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		@include breakpoint-deprecated( '>660px' ) {
 			width: 150px;
 		}
-	}
-
-	.current-theme__description p {
-		padding: 16px;
-		margin-bottom: 0;
 	}
 
 	.current-theme__title-wrapper {
@@ -230,11 +228,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		padding: 4px 12px;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 120px;
-		margin-left: 16px;
 		margin-bottom: 4px;
 
 		@include breakpoint-deprecated( '>660px' ) {
+			align-self: center;
 			margin-left: 8px;
+			margin-bottom: 0;
 		}
 	}
 
@@ -244,7 +243,6 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		padding-left: 16px;
 		font-size: $font-body;
 		max-width: 100%;
 
@@ -260,11 +258,16 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__description {
-		margin-top: 16px;
 		font-size: $font-body-small;
+		margin: 16px;
 
-		@include breakpoint-deprecated( '>960px' ) {
-			font-size: $font-body;
+		p {
+			color: var( --color-text-subtle );
+			margin: 8px 0 0;
+
+			@include breakpoint-deprecated( '>660px' ) {
+				margin-top: 12px;
+			}
 		}
 	}
 
@@ -273,13 +276,12 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		box-sizing: border-box;
 		padding-top: 16px;
 		display: flex;
-		align-items: center;
-		justify-content: center;
+		align-items: flex-end;
+		justify-content: flex-end;
 		flex-grow: 1;
 
 		@include breakpoint-deprecated( '>660px' ) {
-			align-items: flex-end;
-			justify-content: flex-end;
+			border-top: none;
 		}
 
 		@include breakpoint-deprecated( '>960px' ) {
@@ -296,13 +298,11 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		border-width: 1px;
 
 		&:not( .is-primary ) {
-			outline: 1px solid var( --color-neutral-10 );
+			border: 1px solid var( --color-neutral-10 );
 		}
 
-		@include breakpoint-deprecated( '>660px' ) {
-			&:last-child {
-				margin-right: 16px;
-			}
+		&:last-child {
+			margin-right: 16px;
 		}
 
 		.gridicon {

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { ConnectedThemesSelection } from './themes-selection';
-import Spinner from 'calypso/components/spinner';
 import { getRecommendedThemes } from 'calypso/state/themes/actions';
 
 import {
@@ -43,14 +42,10 @@ class RecommendedThemes extends React.Component {
 	render() {
 		return (
 			<>
-				<h2>
-					<strong>{ translate( 'Recommended themes' ) }</strong>
-				</h2>
-				{ this.props.isLoading ? (
-					<Spinner size={ 100 } />
-				) : (
-					<ConnectedThemesSelection { ...this.props } />
-				) }
+				<ConnectedThemesSelection
+					{ ...this.props }
+					listLabel={ translate( 'Recommended themes' ) }
+				/>
 			</>
 		);
 	}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -176,7 +176,6 @@ class ThemeShowcase extends React.Component {
 	 * @param {string} sections.filter override filter prop
 	 * @param {string} sections.siteSlug override siteSlug prop
 	 * @param {string} sections.searchString override searchString prop
-	 *
 	 * @returns {string} Theme showcase url
 	 */
 	constructUrl = ( sections ) => {
@@ -286,7 +285,6 @@ class ThemeShowcase extends React.Component {
 								filter={ filter }
 								vertical={ this.props.vertical }
 								siteId={ this.props.siteId }
-								listLabel={ this.props.listLabel }
 								defaultOption={ this.props.defaultOption }
 								secondaryOption={ this.props.secondaryOption }
 								placeholderCount={ this.props.placeholderCount }
@@ -343,10 +341,10 @@ class ThemeShowcase extends React.Component {
 					>
 						{ ! this.props.loggedOutComponent && (
 							<>
-								<h2>
-									<strong>{ translate( 'Advanced Themes' ) }</strong>
+								<h2 className="theme-showcase__all-themes-title">
+									{ translate( 'Advanced Themes' ) }
 								</h2>
-								<p>
+								<p className="theme-showcase__all-themes-description">
 									{ translate(
 										'These themes offer more power and flexibility, but can be harder to setup and customize.'
 									) }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -52,3 +52,19 @@
 .themes__hidden-content {
 	display: none;
 }
+
+.theme-showcase__all-themes-title {
+	font-weight: 600;
+}
+
+.theme-showcase__all-themes-title,
+.themes__themes-selection-header h2,
+.theme-showcase__all-themes-description {
+	margin-left: 16px;
+	margin-right: 16px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}

--- a/client/my-sites/themes/themes-selection-header/index.jsx
+++ b/client/my-sites/themes/themes-selection-header/index.jsx
@@ -21,9 +21,7 @@ const ThemesSelectionHeader = ( { label, noMarginBeforeHeader } ) => {
 
 	return (
 		<div className={ classes }>
-			<h2>
-				<strong>{ label || translate( 'WordPress.com themes' ) }</strong>
-			</h2>
+			<h2>{ label || translate( 'WordPress.com themes' ) }</h2>
 		</div>
 	);
 };

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -1,3 +1,7 @@
+.themes__themes-selection-header h2 {
+	font-weight: 600;
+}
+
 .themes__themes-selection-header.margin-before-header {
 	margin-top: 12px;
 }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -38,27 +38,28 @@ import './themes-selection.scss';
 class ThemesSelection extends Component {
 	static propTypes = {
 		emptyContent: PropTypes.element,
-		query: PropTypes.object.isRequired,
-		siteId: PropTypes.number,
-		onScreenshotClick: PropTypes.func,
 		getOptions: PropTypes.func,
 		getActionLabel: PropTypes.func,
 		incrementPage: PropTypes.func,
+		listLabel: PropTypes.string,
+		onScreenshotClick: PropTypes.func,
+		query: PropTypes.object.isRequired,
+		siteId: PropTypes.number,
 		// connected props
-		source: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] ),
-		themes: PropTypes.array,
-		recommendedThemes: PropTypes.array,
-		themesCount: PropTypes.number,
-		isRequesting: PropTypes.bool,
-		isLastPage: PropTypes.bool,
-		isThemeActive: PropTypes.func,
-		getPremiumThemePrice: PropTypes.func,
-		isInstallingTheme: PropTypes.func,
-		placeholderCount: PropTypes.number,
 		bookmarkRef: PropTypes.oneOfType( [
 			PropTypes.func,
 			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
+		getPremiumThemePrice: PropTypes.func,
+		isInstallingTheme: PropTypes.func,
+		isLastPage: PropTypes.bool,
+		isRequesting: PropTypes.bool,
+		isThemeActive: PropTypes.func,
+		placeholderCount: PropTypes.number,
+		recommendedThemes: PropTypes.array,
+		source: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] ),
+		themes: PropTypes.array,
+		themesCount: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -163,7 +164,7 @@ class ThemesSelection extends Component {
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
-				{ ! this.props.recommendedThemes && this.props.isLoggedIn && (
+				{ this.props.isLoggedIn && (
 					<ThemesSelectionHeader
 						label={ listLabel }
 						noMarginBeforeHeader={ noMarginBeforeHeader }


### PR DESCRIPTION
This cleans up some styles in the new active theme card, introduced in #54142. There was a stray border-top on desktop and some other small things.

**Before** | **After**
------------ | -------------
<img width="1552" alt="before-desktop" src="https://user-images.githubusercontent.com/942359/125180535-25930400-e1c9-11eb-9bb7-a3c805408b75.png"> | <img width="1552" alt="after-desktop" src="https://user-images.githubusercontent.com/942359/125180539-2d52a880-e1c9-11eb-9f95-192273a4e050.png">
![before-tablet](https://user-images.githubusercontent.com/942359/125180548-3a6f9780-e1c9-11eb-8dc7-39b043c103c3.png) | ![after-tablet](https://user-images.githubusercontent.com/942359/125180549-40657880-e1c9-11eb-98aa-ffeca8f442f2.png)
<img width="340" alt="before-mobile" src="https://user-images.githubusercontent.com/942359/125180554-4a877700-e1c9-11eb-81a7-5db84f323a28.png"> | <img width="341" alt="after-mobile" src="https://user-images.githubusercontent.com/942359/125180559-52dfb200-e1c9-11eb-8cbc-51cbc238add1.png">

**To test:**
- visit the theme showcase
- verify that the active theme banner matches the screenshots and looks good at different browser resolutions
