### PR TITLE
My Home: Fix locale query param sent with checklist API calls

### DIFF
--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -72,7 +72,7 @@ export const fetchChecklist = ( action ) =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'GET',
-			apiNamespace: 'rest/v1.2',
+			apiVersion: '1.2',
 			query: {
 				http_envelope: 1,
 				with_domain_verification: action.isSiteEligibleForFSE ? 1 : 0,
@@ -97,7 +97,7 @@ export const updateChecklistTask = ( action ) =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'POST',
-			apiNamespace: 'rest/v1.1',
+			apiVersion: '1.1',
 			query: {
 				http_envelope: 1,
 			},


### PR DESCRIPTION
Newer `wpcom/v2` APIs use `?_locale=en` to specify the locale, and older `rest/v1.x` APIs use `?locale=en` (without the underscore).

The code in the checklist data-layer was incorrectly using the `apiNamespace` property in requests, which instructs the locale middleware to use the wrong query param. Switching to the `apiVersion` property lets the middleware know to use the other query parameter.

For reference the, the middleware code that decides whether to use `locale` or `_locale` is here:
https://github.com/automattic/wp-calypso/blob/25a725fc2409d2aa9a807221d389fa404cc4c7f5/client/lib/wp/localization/index.js#L24

This should fix part of #54273 where the site title task is being incorrectly marked as complete. That's because the locale of the API call isn't set correctly and the backend thinks the title has already been changed (i.e. `'Título del sitio' !== 'Site Title'` so it marks the title as changed).

#### Changes proposed in this Pull Request

* Update the checklist data-layer so it uses `apiVersion` instead of `apiNamespace`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load My Home on an unlaunched site and confirm the checklist loads
* Skip the WordPress.com app task to verify that API call works as it used to (you might need to create a new user to make the task skippable)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54273
