### PR TITLE
State: Modularize `i18n` reducer

### DIFF
--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -14,14 +14,12 @@ import {
 	enhancer as httpDataEnhancer,
 } from 'calypso/state/data-layer/http-data';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
-import i18n from 'calypso/state/i18n/reducer';
 import currentUser from 'calypso/state/current-user/reducer';
 
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
 const rootReducer = combineReducers( {
 	httpData,
-	i18n,
 	currentUser,
 } );
 

--- a/client/state/i18n/init.js
+++ b/client/state/i18n/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'i18n' ], reducer );

--- a/client/state/i18n/language-names/actions.js
+++ b/client/state/i18n/language-names/actions.js
@@ -3,6 +3,7 @@
  */
 import { I18N_LANGUAGE_NAMES_REQUEST, I18N_LANGUAGE_NAMES_ADD } from 'calypso/state/action-types';
 
+import 'calypso/state/i18n/init';
 import 'calypso/state/data-layer/wpcom/i18n/language-names';
 
 /**

--- a/client/state/i18n/locale-suggestions/actions.js
+++ b/client/state/i18n/locale-suggestions/actions.js
@@ -6,6 +6,7 @@ import {
 	I18N_LOCALE_SUGGESTIONS_REQUEST,
 } from 'calypso/state/action-types';
 
+import 'calypso/state/i18n/init';
 import 'calypso/state/data-layer/wpcom/locale-guess';
 
 /**

--- a/client/state/i18n/package.json
+++ b/client/state/i18n/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/i18n/reducer.js
+++ b/client/state/i18n/reducer.js
@@ -1,11 +1,19 @@
 /**
+ * External dependencies
+ */
+import { withStorageKey } from '@automattic/state-utils';
+
+/**
  * Internal dependencies
  */
 import { combineReducers } from 'calypso/state/utils';
 import languageNames from './language-names/reducer';
 import localeSuggestions from './locale-suggestions/reducer';
 
-export default combineReducers( {
-	languageNames,
-	localeSuggestions,
-} );
+export default withStorageKey(
+	'i18n',
+	combineReducers( {
+		languageNames,
+		localeSuggestions,
+	} )
+);

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -17,7 +17,6 @@ import { reducer as httpData } from 'calypso/state/data-layer/http-data';
 import currencyCode from './currency-code/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
-import i18n from './i18n/reducer';
 import importerNux from './importer-nux/reducer';
 import sites from './sites/reducer';
 
@@ -29,7 +28,6 @@ const reducers = {
 	currentUser,
 	dataRequests,
 	httpData,
-	i18n,
 	importerNux,
 	sites,
 };

--- a/client/state/selectors/get-locale-suggestions.js
+++ b/client/state/selectors/get-locale-suggestions.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/i18n/init';
+
+/**
  * Returns an object of localized language names
  *
  * @param  {object}  state Global state tree

--- a/client/state/selectors/get-localized-language-names.js
+++ b/client/state/selectors/get-localized-language-names.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/i18n/init';
+
+/**
  * Returns an object of localized language names
  *
  * @param  {object}  state Global state tree


### PR DESCRIPTION
This PR is one of many working on modularizing state in Calypso. This one handles `i18n` state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42443.

#### Changes proposed in this Pull Request

* Modularise `i18n` state

#### Testing instructions

* Go to `/me/account`
* Click on the language picker to change the interface language.
* Search for some strings and verify you get relevant results as on production.
* Navigate to `/jetpack/connect/personal/pt` as a logged-out user.
* Verify you get the locale suggestion that this page is also available in English.

#### Note

A `no-restricted-imports` ESLint error is expected and wanted due to the fact that there are still trees that remain in the monolithic legacy reducer.