### PR TITLE
`withDeleteUser`: simplify success & error notices

### DIFF
--- a/client/data/users/use-delete-user-mutation.js
+++ b/client/data/users/use-delete-user-mutation.js
@@ -9,14 +9,16 @@ import { useMutation, useQueryClient } from 'react-query';
  */
 import wp from 'calypso/lib/wp';
 
-function useDeleteUserMutation( siteId ) {
+function useDeleteUserMutation( siteId, queryOptions = {} ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation(
 		( { userId, variables } ) =>
 			wp.req.post( `/sites/${ siteId }/users/${ userId }/delete`, variables ),
 		{
-			onSuccess() {
+			...queryOptions,
+			onSuccess( ...args ) {
 				queryClient.invalidateQueries( [ 'users', siteId ] );
+				queryOptions.onSuccess?.( ...args );
 			},
 		}
 	);

--- a/client/my-sites/people/delete-user/with-delete-user.js
+++ b/client/my-sites/people/delete-user/with-delete-user.js
@@ -12,13 +12,13 @@ import { useTranslate } from 'i18n-calypso';
 import useDeleteUserMutation from 'calypso/data/users/use-delete-user-mutation';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
-const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
-	const showNotice = React.useRef();
+const withDeleteUser = ( Component ) => ( props ) => {
+	const { siteId, user, isMultisite, siteSlug } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	React.useEffect( () => {
-		showNotice.current = () => {
+	const { deleteUser } = useDeleteUserMutation( siteId, {
+		onSuccess() {
 			dispatch(
 				successNotice(
 					isMultisite
@@ -34,24 +34,11 @@ const useSuccessNotice = ( isSuccess, user, isMultisite, siteSlug ) => {
 				)
 			);
 			page.redirect( `/people/team${ siteSlug ? `/${ siteSlug }` : '' }` );
-		};
-	}, [ dispatch, isMultisite, siteSlug, translate, user.login ] );
-
-	React.useEffect( () => {
-		isSuccess && showNotice.current();
-	}, [ isSuccess ] );
-};
-
-const useErrorNotice = ( isError, user, isMultisite, error ) => {
-	const showNotice = React.useRef();
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	React.useEffect( () => {
-		showNotice.current = ( errorObj ) => {
+		},
+		onError( error ) {
 			let message;
-			if ( 'user_owns_domain_subscription' === errorObj.error ) {
-				const domains = errorObj.data ?? errorObj.message.split( ',' );
+			if ( 'user_owns_domain_subscription' === error.error ) {
+				const domains = error.data ?? error.message.split( ',' );
 				message = translate(
 					'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 					'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
@@ -66,8 +53,8 @@ const useErrorNotice = ( isError, user, isMultisite, error ) => {
 						},
 					}
 				);
-			} else if ( 'user_has_active_subscriptions' === errorObj.error ) {
-				const productNames = errorObj.data ?? [];
+			} else if ( 'user_has_active_subscriptions' === error.error ) {
+				const productNames = error.data ?? [];
 				message = translate(
 					'@%(user)s owns following product used on this site: {{strong}}%(productNames)s{{/strong}}. This product will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
 					'@%(user)s owns following products used on this site: {{strong}}%(productNames)s{{/strong}}. These products will have to be transferred to a different site, user, or canceled before removing or deleting @%(user)s.',
@@ -95,20 +82,8 @@ const useErrorNotice = ( isError, user, isMultisite, error ) => {
 			}
 
 			dispatch( errorNotice( message, { id: 'delete-user-notice' } ) );
-		};
-	}, [ dispatch, isMultisite, translate, user.login ] );
-
-	React.useEffect( () => {
-		isError && showNotice.current( error );
-	}, [ isError, error ] );
-};
-
-const withDeleteUser = ( Component ) => ( props ) => {
-	const { siteId, user, isMultisite, siteSlug } = props;
-	const { deleteUser, isSuccess, isError, error } = useDeleteUserMutation( siteId );
-
-	useSuccessNotice( isSuccess, user, isMultisite, siteSlug );
-	useErrorNotice( isError, user, isMultisite, error );
+		},
+	} );
 
 	return <Component { ...props } deleteUser={ deleteUser } />;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sibling PR to #54348

* `withDeleteUser`: use a simpler approach to dispatch success and error notices

#### Testing instructions

1. Go to `/people/team` and choose on of the people on your team which isn't you
2. Attempt to delete the user from your team
3. Is the user delete and are you redirected to the `/people/team`?
4. Go back to 1., but block network requests to `public-api.wordpress.com/rest/v1.1/sites/*/users/*/delete` – an error notice should be shown in step 3.
5. Attempt to delete a user which own a subscription (domain and/or other types), an appropriate error should be shown

Follow-up to #50992 
