### PR TITLE
State: Modularize `currencyCode` reducer

### DIFF
--- a/client/state/currency-code/init.js
+++ b/client/state/currency-code/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'currencyCode' ], reducer );

--- a/client/state/currency-code/package.json
+++ b/client/state/currency-code/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/currency-code/reducer.js
+++ b/client/state/currency-code/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { withStorageKey } from '@automattic/state-utils';
+
+/**
  * Internal dependencies
  */
 import {
@@ -29,4 +34,4 @@ function reducer( state = null, action ) {
 	return state;
 }
 
-export default withSchemaValidation( schema, reducer );
+export default withStorageKey( 'currencyCode', withSchemaValidation( schema, reducer ) );

--- a/client/state/currency-code/selectors.js
+++ b/client/state/currency-code/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'calypso/state/currency-code/init';
+
+/**
  * Returns the currency code for the current user.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -9,6 +9,7 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/plans';
+import 'calypso/state/currency-code/init';
 import 'calypso/state/plans/init';
 
 /**

--- a/client/state/products-list/actions.js
+++ b/client/state/products-list/actions.js
@@ -9,6 +9,7 @@ import {
 } from 'calypso/state/action-types';
 import { ensureNumericCost } from './assembler';
 
+import 'calypso/state/currency-code/init';
 import 'calypso/state/products-list/init';
 
 export function receiveProductsList( productsList ) {

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -14,7 +14,6 @@ import { reducer as httpData } from 'calypso/state/data-layer/http-data';
 /**
  * Reducers
  */
-import currencyCode from './currency-code/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import i18n from './i18n/reducer';
@@ -25,7 +24,6 @@ import sites from './sites/reducer';
 // The reducers in this list are not modularized, and are always loaded on boot.
 // Please do not add to this list. See #39261 and p4TIVU-9lM-p2 for more details.
 const reducers = {
-	currencyCode,
 	currentUser,
 	dataRequests,
 	httpData,

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -25,6 +25,7 @@ import {
 import wpcom from 'calypso/lib/wp';
 
 import 'calypso/state/data-layer/wpcom/sites/plan-transfer';
+import 'calypso/state/currency-code/init';
 
 /**
  * Cancels the specified plan trial for the given site.

--- a/client/state/sites/products/actions.js
+++ b/client/state/sites/products/actions.js
@@ -20,6 +20,8 @@ import {
 } from 'calypso/state/action-types';
 import wpcom from 'calypso/lib/wp';
 
+import 'calypso/state/currency-code/init';
+
 /**
  * Returns an action object to be used in signalling that products for the given site have been cleared.
  *


### PR DESCRIPTION
This PR is one of many working on modularizing state in Calypso. This one handles `currencyCode` state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #54444.

#### Changes proposed in this Pull Request

* Modularise `currencyCode` state

#### Testing instructions

* Verify the following pages display the same currency as before, with no errors in the console:
  * As a logged-in user:
    * `/plans/:site` where `:site` is your site slug.
    * `/start/plans` (you'll need to fill the domains step first).
  * As a logged-out user:
    * `/jetpack/connect/store`

#### Note

A `no-restricted-imports` ESLint error is expected and wanted due to the fact that there are still trees that remain in the monolithic legacy reducer.