### PR TITLE
Janitorial: Remove even more unused component state

### DIFF
--- a/apps/notifications/src/panel/templates/status-bar.jsx
+++ b/apps/notifications/src/panel/templates/status-bar.jsx
@@ -15,13 +15,11 @@ export class StatusBar extends React.Component {
 
 	state = {
 		isVisible: false,
-		timeoutHandle: null,
 	};
 
 	disappear = () => {
 		this.setState( {
 			isVisible: false,
-			timeoutHandle: null,
 		} );
 
 		this.props.statusReset();
@@ -41,7 +39,7 @@ export class StatusBar extends React.Component {
 		const component = this;
 
 		/* We only want this to appear for a bit, then disappear */
-		const timeout = window.setTimeout(
+		window.setTimeout(
 			function () {
 				component.disappear();
 			},
@@ -50,7 +48,6 @@ export class StatusBar extends React.Component {
 
 		this.setState( {
 			isVisible: true,
-			timeoutHandle: timeout,
 		} );
 	}
 

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -53,10 +53,6 @@ class InlineHelpRichResult extends Component {
 		article: 'reader',
 	};
 
-	state = {
-		showDialog: false,
-	};
-
 	handleClick = ( event ) => {
 		const isLocaleEnglish = 'en' === getLocaleSlug();
 		const { type, tour, link, searchQuery, postId } = this.props;

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -49,7 +49,6 @@ class AutoRenewToggle extends Component {
 	state = {
 		showAutoRenewDisablingDialog: false,
 		showPaymentMethodDialog: false,
-		isTogglingToward: null,
 		isRequesting: false,
 	};
 
@@ -138,7 +137,6 @@ class AutoRenewToggle extends Component {
 		}
 
 		this.setState( {
-			isTogglingToward,
 			isRequesting: true,
 		} );
 

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -93,7 +93,6 @@ class Security2faBackupCodesList extends React.Component {
 
 	onCopy = () => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked On 2fa Copy to clipboard Button' );
-		this.setState( { isCopied: true } );
 	};
 
 	saveCodesToFile = () => {

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -50,7 +50,6 @@ class DeleteUser extends React.Component {
 	};
 
 	state = {
-		showDialog: false,
 		radioOption: false,
 		reassignUser: false,
 		authorSelectorToggled: false,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -66,7 +66,6 @@ class AboutStep extends Component {
 			verticalParentId: props.verticalParentId,
 			siteTopicValue: props.siteTopic,
 			userExperience: props.userExperience,
-			pendingStoreClick: false,
 			hasPrepopulatedVertical,
 		};
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up more of the unused component state in Calypso (following similar cleanups in #54208, #54282, and #54347). There are even more instances here and there, but this is more than enough for a single PR, and some of the [reported remaining instances](https://lgtm.com/projects/g/Automattic/wp-calypso/alerts/?mode=tree&ruleFocus=1506221406550) might be false positives.

#### Testing instructions

Verify that the removed component state is not used.

#### Note

There are pre-existing ESLint errors that I'm intentionally not touching here to prevent the PR from becoming bigger than I'd like.