### PR TITLE
State: Remove global shortcuts from state middleware

### DIFF
--- a/client/lib/keyboard-shortcuts/global.js
+++ b/client/lib/keyboard-shortcuts/global.js
@@ -10,7 +10,7 @@ import config from '@automattic/calypso-config';
 import { getStatsDefaultSitePage } from 'calypso/lib/route';
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 import { reduxDispatch, reduxGetState } from 'calypso/lib/redux-bridge';
-import { getSectionGroup } from 'calypso/state/ui/selectors';
+import { getSectionGroup, getSelectedSite } from 'calypso/state/ui/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 
 let singleton;
@@ -27,7 +27,6 @@ function GlobalShortcuts() {
 		return new GlobalShortcuts();
 	}
 
-	this.selectedSite = null;
 	this.bindShortcuts();
 }
 
@@ -45,8 +44,8 @@ GlobalShortcuts.prototype.bindShortcuts = function () {
 	}
 };
 
-GlobalShortcuts.prototype.setSelectedSite = function ( site ) {
-	this.selectedSite = site;
+GlobalShortcuts.prototype.getSelectedSite = function () {
+	return getSelectedSite( reduxGetState() );
 };
 
 GlobalShortcuts.prototype.openHelp = function () {
@@ -73,7 +72,7 @@ GlobalShortcuts.prototype.goToMyLikes = function () {
 };
 
 GlobalShortcuts.prototype.goToStats = function () {
-	const site = this.selectedSite;
+	const site = this.getSelectedSite();
 
 	if ( site && site.capabilities && ! site.capabilities.view_stats ) {
 		return null;
@@ -85,7 +84,7 @@ GlobalShortcuts.prototype.goToStats = function () {
 };
 
 GlobalShortcuts.prototype.goToBlogPosts = function () {
-	const site = this.selectedSite;
+	const site = this.getSelectedSite();
 
 	if ( site && site.capabilities && ! site.capabilities.edit_posts ) {
 		return null;
@@ -97,7 +96,7 @@ GlobalShortcuts.prototype.goToBlogPosts = function () {
 };
 
 GlobalShortcuts.prototype.goToPages = function () {
-	const site = this.selectedSite;
+	const site = this.getSelectedSite();
 
 	if ( site && site.capabilities && ! site.capabilities.edit_pages ) {
 		return null;

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -7,7 +7,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from '@automattic/calypso-config';
 import {
 	NOTIFICATIONS_PANEL_TOGGLE,
 	ROUTE_SET,
@@ -18,10 +17,9 @@ import {
 import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
 import { isFetchingAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import keyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
-import getGlobalKeyboardShortcuts from 'calypso/lib/keyboard-shortcuts/global';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import {
 	createImmediateLoginMessage,
@@ -29,16 +27,6 @@ import {
 } from 'calypso/state/immediate-login/utils';
 import { saveImmediateLoginInformation } from 'calypso/state/immediate-login/actions';
 import { successNotice } from 'calypso/state/notices/actions';
-
-/**
- * Module variables
- */
-const globalKeyBoardShortcutsEnabled = config.isEnabled( 'keyboard-shortcuts' );
-let globalKeyboardShortcuts;
-
-if ( globalKeyBoardShortcutsEnabled ) {
-	globalKeyboardShortcuts = getGlobalKeyboardShortcuts();
-}
 
 /**
  * Notifies user about the fact that they were automatically logged in
@@ -83,19 +71,6 @@ const notifyAboutImmediateLoginLinkEffects = once( ( dispatch, action, getState 
 } );
 
 /**
- * Sets the selectedSite for lib/keyboard-shortcuts/global
- *
- * @param {Function} dispatch - redux dispatch function
- * @param {object}   action   - the dispatched action
- * @param {Function} getState - redux getState function
- */
-const updatedSelectedSiteForKeyboardShortcuts = ( dispatch, action, getState ) => {
-	const state = getState();
-	const selectedSite = getSelectedSite( state );
-	globalKeyboardShortcuts.setSelectedSite( selectedSite );
-};
-
-/**
  * Sets isNotificationOpen for lib/keyboard-shortcuts
  *
  * @param {Function} dispatch - redux dispatch function
@@ -132,10 +107,6 @@ const handler = ( dispatch, action, getState ) => {
 		case SITES_RECEIVE:
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
-				if ( globalKeyBoardShortcutsEnabled ) {
-					updatedSelectedSiteForKeyboardShortcuts( dispatch, action, getState );
-				}
-
 				fetchAutomatedTransferStatusForSelectedSite( dispatch, getState );
 			}, 0 );
 			return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Global keyboard shortcuts currently maintain their own instance of "currently selected site". They use it when redirecting to a particular page with a site context - stats, posts, pages, etc. Because of that, we need to maintain the selected site and change it accordingly when the primary one in Redux changes. 

This PR removes the global keyboard shortcuts selected state instance in favor of using the Redux one. While this might add another use of `redux-bridge` (it's the second one in that file), it allows us to remove the related state middleware that we load unnecessarily on every single Calypso page - those global keyboard shortcuts aren't even available in staging / production.

#### Testing instructions

* Go to `/home/:site` where `:site` is one of your sites.
* Quickly press one after another: `g` then `s`.
* Verify you get redirected to `/stats/day/:site`  where `:site` is that same site.
* Switch to another site.
* Go to `/home/:anotherSite`  where `:anotherSite` is a second site.
* Quickly press one after another: `g` then `s`.
* Verify you get redirected to `/stats/day/:anotherSite` where `anotherSite` is the second site.