### PR TITLE
Welcome tour: fix footer alignment

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -85,6 +85,8 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	}
 
 	.components-card__footer {
+		width: auto;
+
 		.welcome-tour__end-text {
 			color: $gray-600;
 			font-size: 0.875rem;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Overwrite CSS to fix the misaligned footer

### Testing setup

This PR needs ETK setup:
* run `yarn start`
* run `cd apps/editing-toolkit && yarn dev --sync`

Read more on PCYsg-ly5-p2

### Testing instructions

* With ETK synced, sandbox a site and open page/post editor
* Open editor welcome tour

Fixes https://github.com/Automattic/wp-calypso/issues/54445