### PR TITLE
Move transfer lock form to separate component and update text color

### DIFF
--- a/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
+++ b/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'calypso/lib/url/support';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const TransferLockOptOutForm = ( props ) => (
+	<div className="transfer-lock-opt-out-form">
+		<Gridicon className="transfer-lock-opt-out-form__icon" icon="notice-outline" size={ 18 } />
+		<FormLabel className="transfer-lock-opt-out-form__label">
+			<FormCheckbox
+				name="transfer-lock-opt-out"
+				disabled={ props.disabled }
+				onChange={ props.onChange }
+			/>
+			<span>
+				{ props.translate( "Opt-out of the 60-day transfer lock. {{link}}What's this?{{/link}}.", {
+					components: {
+						link: (
+							<a
+								href={ UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				} ) }
+			</span>
+		</FormLabel>
+	</div>
+);
+
+export default localize( TransferLockOptOutForm );

--- a/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
+++ b/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/index.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -43,5 +44,10 @@ const TransferLockOptOutForm = ( props ) => (
 		</FormLabel>
 	</div>
 );
+
+TransferLockOptOutForm.propTypes = {
+	disabled: PropTypes.bool,
+	onChange: PropTypes.func,
+};
 
 export default localize( TransferLockOptOutForm );

--- a/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/style.scss
+++ b/client/my-sites/domains/domain-management/components/transfer-lock-opt-out-form/style.scss
@@ -1,8 +1,4 @@
-.edit-contact-info__note {
-	color: var( --color-neutral );
-}
-
-.edit-contact-info__opt-out-notice {
+.transfer-lock-opt-out-form {
 	color: var( --color-error );
 
 	.form-checkbox {
@@ -12,11 +8,11 @@
 		}
 	}
 
-	.edit-contact-info__opt-out-notice-label {
+	.transfer-lock-opt-out-form__label {
 		margin-left: 24px;
 	}
 
-	.edit-contact-info__opt-out-notice-icon {
+	.transfer-lock-opt-out-form__icon {
 		color: var( --color-error );
 		float: left;
 	}

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -12,17 +12,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card, Dialog } from '@automattic/components';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
-import FormLabel from 'calypso/components/forms/form-label';
 import {
 	domainManagementContactsPrivacy,
 	domainManagementEdit,
 } from 'calypso/my-sites/domains/paths';
 import wp from 'calypso/lib/wp';
 import { errorNotice, successNotice, infoNotice } from 'calypso/state/notices/actions';
-import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'calypso/lib/url/support';
 import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
+import TransferLockOptOutForm from 'calypso/my-sites/domains/domain-management/components/transfer-lock-opt-out-form';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
 import { requestWhois, saveWhois } from 'calypso/state/domains/management/actions';
@@ -149,32 +147,16 @@ class EditContactInfoFormCard extends React.Component {
 	renderTransferLockOptOut() {
 		const { domainRegistrationAgreementUrl, translate } = this.props;
 		return (
-			<div>
-				<FormLabel>
-					<FormCheckbox
-						name="transfer-lock-opt-out"
-						disabled={ this.state.formSubmitting }
-						onChange={ this.onTransferLockOptOutChange }
-					/>
-					<span>
-						{ translate( 'Opt-out of the {{link}}60-day transfer lock{{/link}}.', {
-							components: {
-								link: (
-									<a
-										href={ UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						} ) }
-					</span>
-				</FormLabel>
+			<>
+				<TransferLockOptOutForm
+					disabled={ this.state.formSubmitting }
+					onChange={ this.onTransferLockOptOutChange }
+				/>
 				<DesignatedAgentNotice
 					domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
 					saveButtonLabel={ translate( 'Save contact info' ) }
 				/>
-			</div>
+			</>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/edit-contact-info/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info/style.scss
@@ -1,23 +1,3 @@
 .edit-contact-info__note {
 	color: var( --color-neutral );
 }
-
-.edit-contact-info__opt-out-notice {
-	color: var( --color-error );
-
-	.form-checkbox {
-		border: 1px solid var( --color-error );
-		&:hover {
-			border: 1px solid var( --color-error-20 );
-		}
-	}
-
-	.edit-contact-info__opt-out-notice-label {
-		margin-left: 24px;
-	}
-
-	.edit-contact-info__opt-out-notice-icon {
-		color: var( --color-error );
-		float: left;
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Many users don't notice the transfer lock opt-out checkbox at the bottom of the domain contact update form. We would like to highlight this option since many users update their contact information and then transfer their domain within the 60-day timeframe.

#### Testing instructions

Make sure that the text and checkbox now appear in red.
Make sure that the What's this? link goes to the appropriate spot.
Make sure that when updating contact info for a domain that a transfer lock IS NOT set after an update when the checkbox is checked.
Make sure that when updating the contact info for a domain that a transfer lock IS set after an update when the checkbox is NOT checked.

<img width="740" alt="Screen Shot 2021-07-12 at 1 12 20 PM" src="https://user-images.githubusercontent.com/1379730/125336835-45870c80-e31c-11eb-87eb-a5322b3365ef.png">


Related to #16853
