### PR TITLE
Toolbar: Only toggle the toolbar in the TransferPending component 

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -33,10 +33,6 @@ const RESEND_SUCCESS = 'RESEND_SUCCESS';
 class AtomicStoreThankYouCard extends Component {
 	state = { resendStatus: RESEND_NOT_SENT };
 
-	componentDidMount() {
-		this.props.showMasterbar();
-	}
-
 	componentDidUpdate( prevProps ) {
 		/**
 		 * This clears the  error in the event the email is verified in another tab

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -20,6 +20,10 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import {
+	hideMasterbar as hideMasterbarAction,
+	showMasterbar as showMasterbarAction,
+} from 'calypso/state/ui/masterbar-visibility/actions';
 
 class TransferPending extends PureComponent {
 	static propTypes = {
@@ -28,6 +32,14 @@ class TransferPending extends PureComponent {
 		siteId: PropTypes.number.isRequired,
 		transfer: PropTypes.object,
 	};
+
+	componentDidMount() {
+		this.props.hideMasterbar();
+	}
+
+	componentWillUnmount() {
+		this.props.showMasterbar();
+	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const { transfer, error } = nextProps;
@@ -132,5 +144,9 @@ export default connect(
 		siteSlug: getSiteSlug( state, siteId ),
 		transfer: getAtomicTransfer( state, siteId ),
 	} ),
-	{ showErrorNotice: errorNotice }
+	{
+		showErrorNotice: errorNotice,
+		hideMasterbar: hideMasterbarAction,
+		showMasterbar: showMasterbarAction,
+	}
 )( localize( TransferPending ) );

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -20,10 +20,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import {
-	hideMasterbar as hideMasterbarAction,
-	showMasterbar as showMasterbarAction,
-} from 'calypso/state/ui/masterbar-visibility/actions';
+import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 class TransferPending extends PureComponent {
 	static propTypes = {
@@ -146,7 +143,7 @@ export default connect(
 	} ),
 	{
 		showErrorNotice: errorNotice,
-		hideMasterbar: hideMasterbarAction,
-		showMasterbar: showMasterbarAction,
+		hideMasterbar,
+		showMasterbar,
 	}
 )( localize( TransferPending ) );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -42,7 +42,6 @@ import UpsellNudge, {
 } from './upsell-nudge';
 import { MARKETING_COUPONS_KEY } from 'calypso/lib/analytics/utils';
 import { TRUENAME_COUPONS } from 'calypso/lib/domains';
-import { hideMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 const debug = debugFactory( 'calypso:checkout-controller' );
 
@@ -364,10 +363,4 @@ function getRememberedCoupon() {
 	}
 	debug( 'not returning any coupon code.' );
 	return null;
-}
-
-// Call hideTheMasterbar 1st in index.js page route to prevent masterBar from appearing briefly before disappearing.
-export function hideTheMasterbar( context, next ) {
-	context.store.dispatch( hideMasterbar() );
-	next();
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -15,7 +15,6 @@ import {
 	redirectToSupportSession,
 	redirectJetpackLegacyPlans,
 	jetpackCheckoutThankYou,
-	hideTheMasterbar,
 } from './controller';
 import { noop } from './utils';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
@@ -77,7 +76,6 @@ export default function () {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId?',
-		hideTheMasterbar,
 		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #54225 we made a change to hide the toolbar on the `/thank-you`
route. During testing the incorrect assumption was made that this was
only affecting sites that were being transferred to Atomic.

This changes it so the hiding and showing of the toolbar is done in the
`TransferPending` component, to make sure that it doesn't stay hidden
for any reason.

#### Testing instructions

* Create a new free site
* Upgrade to a premium plan via the 'Plans' link in the sidebar
* Check that you still have a toolbar on the Thank You page
* Upgrade to an e-commerce plan
* Make sure the toolbar is hidden on the transfer pending page
* Check that it is shown again on the resulting thank you page.
