### PR TITLE
Contact form: Fix problem when inserting phone number that begins with same digits as country code

### DIFF
--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -163,10 +163,21 @@ export function applyTemplate( phoneNumber, template, positionTracking = { pos: 
  */
 export function processNumber( inputNumber, numberRegion ) {
 	let prefix = numberRegion.nationalPrefix || '';
-	let nationalNumber = stripNonDigits( inputNumber ).replace(
-		new RegExp( '^(0*' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
-		''
-	);
+
+	let nationalNumber = stripNonDigits( inputNumber );
+	// If the number starts with a '+', then it most likely starts with an international dialing code
+	// that should be removed. Otherwise, the prefix is probably part of the national number.
+	// NANPA countries (with dial code or country dial code '1') also should have the '1' removed here.
+	if (
+		inputNumber[ 0 ] === '+' ||
+		numberRegion.dialCode === '1' ||
+		numberRegion.countryDialCode === '1'
+	) {
+		nationalNumber = nationalNumber.replace(
+			new RegExp( '^(0*' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ),
+			''
+		);
+	}
 
 	if ( numberRegion.nationalPrefix === '0' ) {
 		nationalNumber = nationalNumber.replace( /^0+/, '' );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -188,6 +188,8 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '4252222222', countries.US ), '(425) 222-2222' );
 				equal( formatNumber( '05325555555', countries.TR ), '0532 555 55 55' );
 				equal( formatNumber( '0215369851', countries.AU ), '02 1536 9851' );
+				equal( formatNumber( '3911711711', countries.IT ), '391 171 1711' );
+				equal( formatNumber( '5512345678', countries.BR ), '55 1234-5678' );
 			} );
 
 			test( 'should format as you type', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -142,6 +142,7 @@ describe( 'metadata:', () => {
 			test( 'should format full length numbers', () => {
 				equal( formatNumber( '+14252222222', countries.US ), '+1 425-222-2222' );
 				equal( formatNumber( '+905325555555', countries.TR ), '+90 532 555 55 55' );
+				equal( formatNumber( '+5555912345678', countries.BR ), '+55 55 91234-5678' );
 			} );
 
 			test( 'should format as you type', () => {
@@ -189,7 +190,7 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '05325555555', countries.TR ), '0532 555 55 55' );
 				equal( formatNumber( '0215369851', countries.AU ), '02 1536 9851' );
 				equal( formatNumber( '3911711711', countries.IT ), '391 171 1711' );
-				equal( formatNumber( '5512345678', countries.BR ), '55 1234-5678' );
+				equal( formatNumber( '5512345678', countries.BR ), '055 1234-5678' );
 			} );
 
 			test( 'should format as you type', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -143,6 +143,8 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '+14252222222', countries.US ), '+1 425-222-2222' );
 				equal( formatNumber( '+905325555555', countries.TR ), '+90 532 555 55 55' );
 				equal( formatNumber( '+5555912345678', countries.BR ), '+55 55 91234-5678' );
+				equal( formatNumber( '+393911711711', countries.IT ), '+39 391 171 1711' );
+				equal( formatNumber( '+919100123456', countries.IN ), '+91 91001 23456' );
 			} );
 
 			test( 'should format as you type', () => {
@@ -191,6 +193,8 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '0215369851', countries.AU ), '02 1536 9851' );
 				equal( formatNumber( '3911711711', countries.IT ), '391 171 1711' );
 				equal( formatNumber( '5512345678', countries.BR ), '055 1234-5678' );
+				equal( formatNumber( '9100123456', countries.IN ), '091001 23456' );
+				equal( formatNumber( '00000123456', countries.UK ), '01234 56' );
 			} );
 
 			test( 'should format as you type', () => {
@@ -276,6 +280,9 @@ describe( 'metadata:', () => {
 		} );
 		test( 'should separate country codes properly for countries with +1 and a separate leading digit', () => {
 			equal( toIcannFormat( '+18686559999', countries.TT ), '+1.8686559999' );
+		} );
+		test( 'should be able to handle other countries', () => {
+			equal( toIcannFormat( '+555512345678', countries.BR ), '+55.5512345678' );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The phone input field in the domain contact information form has had a problem for some time (issue #25039): when a user tries to input a phone number which begins with the same digits as the selected country's international dialing code, these numbers are removed from the input. Copy and pasting also doesn't work, the initial digits are removed the same.

For example, Brazil's dial code is +55, and a valid Brazilian phone number is 55 1234-5678, 55 being a national city code. This video shows what happens when you try to input that number by typing or pasting:

https://user-images.githubusercontent.com/5324818/125356590-c8b85a80-e33c-11eb-8f97-4cf6d6a2de74.mp4

This PR fixes that behavior by updating the logic of when the international dialing prefix should be removed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This component has been tweaked several times (#41783, #37603, #24870, #10447 to cite a few), so please test it thoroughly. 🙇‍♂️ 

Unit tests should all be passing: `yarn run test-client client/components/phone-input/test`, but manual testing is also appreciated. The contact information form can be reached in the checkout page when buying a domain.

* Open the contact information form, enter phone number +555512345678 and ensure Brazil becomes the selected country. The number should be formatted like +55 55 1234-5678
* Clear that number and while Brazil is still selected, try to enter phone number 5512345678. Ensure the 55 city code prefix is not removed.
* Try other combinations of countries and phone numbers, for example:
  * Select Italy (dial code +39) and enter phone number 3911711711 - ensure the initial 39 remains there
  * Select India (dial code +91) and enter phone number 9100123456 - ensure the initial 91 remains there
  * Select a NANPA (North American Numbering Plan Administrator) country - the US, Canada, etc. - enter a valid phone number and ensure it is formatted correctly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #25039
