### PR TITLE
Shopping Cart: Improve offline errors

### DIFF
--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -74,10 +74,12 @@ export default function useRefetchOnFocus(
 
 		window.addEventListener( 'visibilitychange', handleFocusChange );
 		window.addEventListener( 'focus', handleFocusChange );
+		window.addEventListener( 'online', handleFocusChange );
 
 		return () => {
 			window.removeEventListener( 'visibilitychange', handleFocusChange );
 			window.removeEventListener( 'focus', handleFocusChange );
+			window.removeEventListener( 'online', handleFocusChange );
 		};
 	}, [ options.refetchOnWindowFocus, lastCart.cart_generated_at_timestamp, refetch, cacheStatus ] );
 }

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -38,6 +38,14 @@ export default function useRefetchOnFocus(
 			return [ undefined, 'visible', 'prerender' ].includes( document.visibilityState );
 		}
 
+		function isOffline(): boolean {
+			try {
+				return ! window.navigator.onLine;
+			} catch {
+				return true;
+			}
+		}
+
 		function wasLastFetchRecent(): boolean {
 			const nowInSeconds = convertMsToSecs( Date.now() );
 			const lastRefreshTime = lastCart.cart_generated_at_timestamp;
@@ -53,6 +61,10 @@ export default function useRefetchOnFocus(
 			}
 			if ( wasLastFetchRecent() ) {
 				debug( 'last fetch was quite recent; ignoring' );
+				return;
+			}
+			if ( isOffline() ) {
+				debug( 'network is offline; ignoring' );
 				return;
 			}
 

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -26,7 +26,11 @@ export default function useRefetchOnFocus(
 	refetch: () => void
 ): void {
 	useEffect( () => {
-		if ( ! options.refetchOnWindowFocus || cacheStatus !== 'valid' ) {
+		if ( ! options.refetchOnWindowFocus ) {
+			return;
+		}
+		// Refresh only if the cart is not pending any other operations
+		if ( cacheStatus !== 'valid' && cacheStatus !== 'error' ) {
 			return;
 		}
 

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -241,11 +241,21 @@ function shoppingCartReducer(
 		case 'RAISE_ERROR':
 			switch ( action.error ) {
 				case 'GET_SERVER_CART_ERROR':
+					return {
+						...state,
+						cacheStatus: 'error',
+						loadingError:
+							action.message ||
+							'Error while fetching the shopping cart. Please check your network connection and try again.',
+						loadingErrorType: action.error,
+					};
 				case 'SET_SERVER_CART_ERROR':
 					return {
 						...state,
 						cacheStatus: 'error',
-						loadingError: action.message,
+						loadingError:
+							action.message ||
+							'Error while updating the shopping cart endpoint. Please check your network connection and try again.',
 						loadingErrorType: action.error,
 					};
 				default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes four related changes to the shopping cart package:

1. If either the shopping-cart GET or POST operations fail without an error message, this adds a generic error message (otherwise a message might not be displayed to the user, leaving them in a loading state forever with no information).
2. If the cart is in an error state (eg: because of trying to auto-refresh when offline), this now allows the cart to attempt to auto-refresh again when refocused. This probably doesn't happen often but it seems nicer than forcing the user to reload.
3. This now prevents the cart from auto-refreshing if offline. This should prevent connection errors caused by auto-refresh when a computer is reconnecting to the network.
4. The auto-refresh also triggers when the online status changes (subject to all the other conditions regarding auto-refresh on focus).

#### Testing instructions

1. Add a product to your cart and visit checkout.
2. Disable your network connection somehow (eg: using the browser's devtools to simulate being offline).
3. Open a new tab and wait for approximately 1 minute (probably longer just to be sure).
4. Switch back to the checkout tab with no network enabled.
5. Verify that nothing happens and that checkout still appears active. (_Before this PR, checkout would enter a loading state forever with no error message._)
6. Re-enable the network connection.
7. Switch to another tab briefly (it can be less than a minute).
8. Switch back to the checkout tab with the network enabled.
9. Verify that you see a brief flash where checkout enters a loading state and then becomes active again.

The third change (no auto-refresh when offline) will actually prevent you from seeing the first change (default error messages), but if you want to test the first change also, you can disable the `isOffline()` check in `useRefetchOnFocus` and repeat the above steps. You'll see when you get to step 5 that you get an error message that looks like this (note that the message does have a close button, but you can't see it because it is trying to load it from the network which is disabled; this is an unrelated issue).

<img width="647" alt="Screen Shot 2021-07-12 at 5 49 34 PM" src="https://user-images.githubusercontent.com/2036909/125363222-3b760580-e33e-11eb-8804-7258c64f701e.png">
 