### PR TITLE
Checkout: Remove absolute positioning on delete button

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -166,7 +166,6 @@ function DeleteIcon( { uniqueID, product }: { uniqueID: string; product: string 
 
 function WPNonProductLineItem( {
 	lineItem,
-	coupon,
 	className = null,
 	isSummary,
 	hasDeleteButton,
@@ -174,7 +173,6 @@ function WPNonProductLineItem( {
 	createUserAndSiteBeforeTransaction,
 }: {
 	lineItem: LineItemType;
-	coupon?: boolean;
 	className?: string | null;
 	isSummary?: boolean;
 	hasDeleteButton?: boolean;
@@ -217,7 +215,6 @@ function WPNonProductLineItem( {
 			{ hasDeleteButton && removeProductFromCart && formStatus === FormStatus.READY && (
 				<>
 					<DeleteButton
-						coupon={ coupon }
 						className="checkout-line-item__remove-product"
 						buttonType="borderless"
 						disabled={ isDisabled }

--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -118,11 +118,8 @@ const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean }
 	}
 `;
 
-const DeleteButton = styled( Button )< { theme?: Theme; coupon?: boolean } >`
-	position: absolute;
-	padding: 10px;
-	right: -50px;
-	top: ${ ( props ) => ( props.coupon ? '0px' : '7px' ) };
+const DeleteButton = styled( Button )< { theme?: Theme } >`
+	padding: 0 0 0 10px;
 
 	:hover rect {
 		fill: ${ ( props ) => props.theme.colors.error };
@@ -130,11 +127,6 @@ const DeleteButton = styled( Button )< { theme?: Theme; coupon?: boolean } >`
 
 	svg {
 		opacity: 1;
-	}
-
-	.rtl & {
-		right: auto;
-		left: -50px;
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -780,18 +780,6 @@ function WPLineItem( {
 					isSummary={ isSummary }
 				/>
 			</span>
-			{ sublabel && (
-				<LineItemMeta>
-					<LineItemSublabelAndPrice product={ product } />
-					<DomainDiscountCallout product={ product } />
-					<FirstTermDiscountCallout product={ product } />
-					<CouponDiscountCallout product={ product } />
-					<IntroductoryOfferCallout product={ product } />
-				</LineItemMeta>
-			) }
-			{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
-			{ isGSuite && <GSuiteUsersList product={ product } /> }
-			{ isTitanMail && <TitanMailMeta product={ product } isRenewal={ isRenewal } /> }
 			{ hasDeleteButton && removeProductFromCart && formStatus === FormStatus.READY && (
 				<>
 					<DeleteButton
@@ -836,6 +824,19 @@ function WPLineItem( {
 					/>
 				</>
 			) }
+
+			{ sublabel && (
+				<LineItemMeta>
+					<LineItemSublabelAndPrice product={ product } />
+					<DomainDiscountCallout product={ product } />
+					<FirstTermDiscountCallout product={ product } />
+					<CouponDiscountCallout product={ product } />
+					<IntroductoryOfferCallout product={ product } />
+				</LineItemMeta>
+			) }
+			{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
+			{ isGSuite && <GSuiteUsersList product={ product } /> }
+			{ isTitanMail && <TitanMailMeta product={ product } isRenewal={ isRenewal } /> }
 
 			{ shouldShowVariantSelector && onChangePlanLength && (
 				<ItemVariationPicker

--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -23,7 +23,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { isWpComProductRenewal, getSublabel, getLabel } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
@@ -850,18 +849,3 @@ function WPLineItem( {
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
-
-WPLineItem.propTypes = {
-	siteId: PropTypes.number,
-	allowVariants: PropTypes.bool,
-	className: PropTypes.string,
-	total: PropTypes.bool,
-	tax: PropTypes.bool,
-	subtotal: PropTypes.bool,
-	isSummary: PropTypes.bool,
-	hasDeleteButton: PropTypes.bool,
-	removeProductFromCart: PropTypes.func,
-	product: PropTypes.object.isRequired,
-	onChangePlanLength: PropTypes.func,
-	createUserAndSiteBeforeTransaction: PropTypes.bool,
-};

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -83,7 +83,6 @@ export function WPOrderReviewLineItems( {
 			{ couponLineItem && (
 				<WPOrderReviewListItem key={ couponLineItem.id }>
 					<NonProductLineItem
-						coupon
 						lineItem={ couponLineItem }
 						isSummary={ isSummary }
 						hasDeleteButton={ ! isSummary }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to make it easier to embed the checkout review step in other contexts (eg: the popover cart in https://github.com/Automattic/wp-calypso/pull/52890), it would be considerably easier if the delete button was not absolutely positioned. This PR updates the step to keep the button in the regular flow instead.

#### Screenshots

Before, outside of edit mode:

<img width="568" alt="Screen Shot 2021-07-12 at 6 43 42 PM" src="https://user-images.githubusercontent.com/2036909/125364825-28b10000-e341-11eb-9a6e-96aeb3fbf318.png">

Before, inside of edit mode:

<img width="565" alt="Screen Shot 2021-07-12 at 6 43 51 PM" src="https://user-images.githubusercontent.com/2036909/125364834-2cdd1d80-e341-11eb-8bd1-04b9cc8cbc6f.png">

After, outside of edit mode:

<img width="566" alt="Screen Shot 2021-07-12 at 6 58 50 PM" src="https://user-images.githubusercontent.com/2036909/125365982-38c9df00-e343-11eb-946c-703dcfee9613.png">

After, inside of edit mode:

<img width="564" alt="Screen Shot 2021-07-12 at 6 58 34 PM" src="https://user-images.githubusercontent.com/2036909/125365999-41bab080-e343-11eb-8065-83076ae635b9.png">

#### Testing instructions

- Add a product to your cart and visit checkout.
- Verify that the delete button looks ok.
- Click to "Edit" the first step.
- Verify that the delete button looks ok.
- Add a coupon to your cart.
- Verify that the delete button on the coupon looks ok.