### PR TITLE
chore: Migrate packages/calypso-products to use import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -199,10 +199,11 @@ module.exports = {
 		},
 		{
 			files: [
-				'packages/accessible-focus/**/*',
-				'test/e2e/**/*',
-				'client/sections-helper.js',
 				'client/sections-filter.js',
+				'client/sections-helper.js',
+				'packages/accessible-focus/**/*',
+				'packages/calypso-products/**/*',
+				'test/e2e/**/*',
 			],
 			rules: {
 				'wpcalypso/import-docblock': 'off',

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PRODUCT_WPCOM_SEARCH, PRODUCT_WPCOM_SEARCH_MONTHLY } from './wpcom';
 
 export const GROUP_JETPACK = 'GROUP_JETPACK';

--- a/packages/calypso-products/src/get-domain-product-ranking.js
+++ b/packages/calypso-products/src/get-domain-product-ranking.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
-import { isDomainRegistration } from './is-domain-registration';
 import { isDomainMapping } from './is-domain-mapping';
+import { isDomainRegistration } from './is-domain-registration';
 
 export function getDomainProductRanking( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/get-domain.js
+++ b/packages/calypso-products/src/get-domain.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function getDomain( product ) {

--- a/packages/calypso-products/src/get-included-domain-purchase-amount.js
+++ b/packages/calypso-products/src/get-included-domain-purchase-amount.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function getIncludedDomainPurchaseAmount( product ) {

--- a/packages/calypso-products/src/get-interval-type-for-term.js
+++ b/packages/calypso-products/src/get-interval-type-for-term.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from './constants';
 
 export function getIntervalTypeForTerm( term ) {

--- a/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
+++ b/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
@@ -1,5 +1,4 @@
 import { TranslateResult } from 'i18n-calypso';
-
 import { formatProduct } from './format-product';
 import { getJetpackProductsCallToAction } from './translations';
 import type { Product } from './types';

--- a/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
+++ b/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
 import { TranslateResult } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { getJetpackProductsCallToAction } from './translations';
-
-/**
- * Type dependencies
- */
 import type { Product } from './types';
 
 /**

--- a/packages/calypso-products/src/get-jetpack-product-description.js
+++ b/packages/calypso-products/src/get-jetpack-product-description.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { getJetpackProductsDescriptions } from './translations';
 

--- a/packages/calypso-products/src/get-jetpack-product-display-name.js
+++ b/packages/calypso-products/src/get-jetpack-product-display-name.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { getJetpackProductsDisplayNames } from './translations';
 

--- a/packages/calypso-products/src/get-jetpack-product-short-name.js
+++ b/packages/calypso-products/src/get-jetpack-product-short-name.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { getJetpackProductsShortNames } from './translations';
 

--- a/packages/calypso-products/src/get-jetpack-product-tagline.js
+++ b/packages/calypso-products/src/get-jetpack-product-tagline.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { getJetpackProductsTaglines } from './translations';
 

--- a/packages/calypso-products/src/get-product-class.js
+++ b/packages/calypso-products/src/get-product-class.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isJetpackBackupSlug } from './is-jetpack-backup-slug';
 
 export function getProductClass( productSlug ) {

--- a/packages/calypso-products/src/get-product-from-slug.js
+++ b/packages/calypso-products/src/get-product-from-slug.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { PRODUCTS_LIST } from './products-list';
 

--- a/packages/calypso-products/src/get-product-term-variants.ts
+++ b/packages/calypso-products/src/get-product-term-variants.ts
@@ -1,12 +1,5 @@
-/**
- * Internal dependencies
- */
 import { TERMS_LIST } from './constants';
 import { PRODUCTS_LIST } from './products-list';
-
-/**
- * Type dependencies
- */
 import type { ProductSlug } from './types';
 
 /**

--- a/packages/calypso-products/src/get-product-yearly-variant.ts
+++ b/packages/calypso-products/src/get-product-yearly-variant.ts
@@ -1,12 +1,5 @@
-/**
- * Internal dependencies
- */
 import { TERM_ANNUALLY } from './constants';
 import { PRODUCTS_LIST } from './products-list';
-
-/**
- * Type dependencies
- */
 import type { ProductSlug } from './types';
 
 /**

--- a/packages/calypso-products/src/get-products-slugs.js
+++ b/packages/calypso-products/src/get-products-slugs.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { JETPACK_PRODUCTS_LIST } from './constants';
 
 export function getProductsSlugs() {

--- a/packages/calypso-products/src/gsuite-product-slug.js
+++ b/packages/calypso-products/src/gsuite-product-slug.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	GSUITE_BASIC_SLUG,

--- a/packages/calypso-products/src/includes-product.js
+++ b/packages/calypso-products/src/includes-product.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function includesProduct( products, product ) {

--- a/packages/calypso-products/src/is-biennially.js
+++ b/packages/calypso-products/src/is-biennially.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_BIENNIAL_PERIOD } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-blogger.js
+++ b/packages/calypso-products/src/is-blogger.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isBloggerPlan } from './main';
 import { formatProduct } from './format-product';
+import { isBloggerPlan } from './main';
 
 export function isBlogger( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-bundled.js
+++ b/packages/calypso-products/src/is-bundled.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isBundled( product ) {

--- a/packages/calypso-products/src/is-business.js
+++ b/packages/calypso-products/src/is-business.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isBusinessPlan } from './main';
 import { formatProduct } from './format-product';
+import { isBusinessPlan } from './main';
 
 export function isBusiness( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-chargeback.js
+++ b/packages/calypso-products/src/is-chargeback.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_CHARGEBACK } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-complete.js
+++ b/packages/calypso-products/src/is-complete.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isCompletePlan } from './main';
 import { formatProduct } from './format-product';
+import { isCompletePlan } from './main';
 
 export function isComplete( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-concierge-session.js
+++ b/packages/calypso-products/src/is-concierge-session.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isConciergeSession( product ) {

--- a/packages/calypso-products/src/is-credits.js
+++ b/packages/calypso-products/src/is-credits.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isCredits( product ) {

--- a/packages/calypso-products/src/is-custom-design.js
+++ b/packages/calypso-products/src/is-custom-design.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isCustomDesign( product ) {

--- a/packages/calypso-products/src/is-delayed-domain-transfer.js
+++ b/packages/calypso-products/src/is-delayed-domain-transfer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isDomainTransfer } from './is-domain-transfer';
 
 export function isDelayedDomainTransfer( product ) {

--- a/packages/calypso-products/src/is-dependent-product.js
+++ b/packages/calypso-products/src/is-dependent-product.js
@@ -1,11 +1,3 @@
-/**
- * Internal dependencies
- */
-import { formatProduct } from './format-product';
-import { getDomain } from './get-domain';
-import { isDomainMapping } from './is-domain-mapping';
-import { isDomainRegistration } from './is-domain-registration';
-import { isPlan } from './is-plan';
 import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -15,6 +7,11 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 } from './constants';
+import { formatProduct } from './format-product';
+import { getDomain } from './get-domain';
+import { isDomainMapping } from './is-domain-mapping';
+import { isDomainRegistration } from './is-domain-registration';
+import { isPlan } from './is-plan';
 
 const productDependencies = {
 	domain: {

--- a/packages/calypso-products/src/is-domain-mapping.js
+++ b/packages/calypso-products/src/is-domain-mapping.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isDomainMapping( product ) {

--- a/packages/calypso-products/src/is-domain-product.js
+++ b/packages/calypso-products/src/is-domain-product.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isDomainMapping } from './is-domain-mapping';
 import { isDomainRegistration } from './is-domain-registration';

--- a/packages/calypso-products/src/is-domain-redemption.js
+++ b/packages/calypso-products/src/is-domain-redemption.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isDomainRedemption( product ) {

--- a/packages/calypso-products/src/is-domain-registration.js
+++ b/packages/calypso-products/src/is-domain-registration.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isDomainRegistration( product ) {

--- a/packages/calypso-products/src/is-domain-transfer-product.js
+++ b/packages/calypso-products/src/is-domain-transfer-product.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isDomainTransfer } from './is-domain-transfer';
 

--- a/packages/calypso-products/src/is-domain-transfer.js
+++ b/packages/calypso-products/src/is-domain-transfer.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { formatProduct } from './format-product';
 import { domainProductSlugs } from './constants';
+import { formatProduct } from './format-product';
 
 export function isDomainTransfer( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-dot-com-plan.js
+++ b/packages/calypso-products/src/is-dot-com-plan.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isPlan } from './is-plan';
 import { isJetpackPlan } from './is-jetpack-plan';
+import { isPlan } from './is-plan';
 
 export function isDotComPlan( product ) {
 	return isPlan( product ) && ! isJetpackPlan( product );

--- a/packages/calypso-products/src/is-ecommerce.js
+++ b/packages/calypso-products/src/is-ecommerce.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isEcommercePlan } from './main';
 import { formatProduct } from './format-product';
+import { isEcommercePlan } from './main';
 
 export function isEcommerce( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-enterprise.js
+++ b/packages/calypso-products/src/is-enterprise.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_WPCOM_ENTERPRISE } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-free-jetpack-plan.js
+++ b/packages/calypso-products/src/is-free-jetpack-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_JETPACK_FREE } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-free-plan.js
+++ b/packages/calypso-products/src/is-free-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_FREE } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-free-wordpress-com-domain.js
+++ b/packages/calypso-products/src/is-free-wordpress-com-domain.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isFreeWordPressComDomain( product ) {

--- a/packages/calypso-products/src/is-gsuite.js
+++ b/packages/calypso-products/src/is-gsuite.js
@@ -1,13 +1,10 @@
-/**
- * Internal dependencies
- */
+import { formatProduct } from './format-product';
 import {
 	isGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from './gsuite-product-slug';
-import { formatProduct } from './format-product';
 
 export function isGoogleWorkspace( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-guided-transfer.js
+++ b/packages/calypso-products/src/is-guided-transfer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isGuidedTransfer( product ) {

--- a/packages/calypso-products/src/is-jetpack-anti-spam-slug.js
+++ b/packages/calypso-products/src/is-jetpack-anti-spam-slug.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { JETPACK_ANTI_SPAM_PRODUCTS } from './constants';
 
 export function isJetpackAntiSpamSlug( productSlug ) {

--- a/packages/calypso-products/src/is-jetpack-anti-spam.js
+++ b/packages/calypso-products/src/is-jetpack-anti-spam.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isJetpackAntiSpamSlug } from './is-jetpack-anti-spam-slug';
 

--- a/packages/calypso-products/src/is-jetpack-backup-slug.js
+++ b/packages/calypso-products/src/is-jetpack-backup-slug.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { JETPACK_BACKUP_PRODUCTS } from './constants';
 
 export function isJetpackBackupSlug( productSlug ) {

--- a/packages/calypso-products/src/is-jetpack-backup.js
+++ b/packages/calypso-products/src/is-jetpack-backup.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isJetpackBackupSlug } from './is-jetpack-backup-slug';
 

--- a/packages/calypso-products/src/is-jetpack-business.js
+++ b/packages/calypso-products/src/is-jetpack-business.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
-import { isJetpackPlan } from './is-jetpack-plan';
 import { isBusiness } from './is-business';
+import { isJetpackPlan } from './is-jetpack-plan';
 
 export function isJetpackBusiness( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-jetpack-cloud-product-slug.js
+++ b/packages/calypso-products/src/is-jetpack-cloud-product-slug.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { JETPACK_BACKUP_PRODUCTS, JETPACK_SCAN_PRODUCTS } from './constants';
 
 export function isJetpackCloudProductSlug( productSlug ) {

--- a/packages/calypso-products/src/is-jetpack-legacy-item.ts
+++ b/packages/calypso-products/src/is-jetpack-legacy-item.ts
@@ -1,11 +1,4 @@
-/**
- * Internal dependencies
- */
 import { JETPACK_LEGACY_PLANS } from './constants';
-
-/**
- * Type dependencies
- */
 import type { JetpackLegacyPlanSlug } from './types';
 
 export default function isJetpackLegacyItem( itemSlug: string ): itemSlug is JetpackLegacyPlanSlug {

--- a/packages/calypso-products/src/is-jetpack-monthly-plan.js
+++ b/packages/calypso-products/src/is-jetpack-monthly-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isJetpackPlan } from './is-jetpack-plan';
 import { isMonthlyProduct } from './is-monthly';
 

--- a/packages/calypso-products/src/is-jetpack-plan-slug.js
+++ b/packages/calypso-products/src/is-jetpack-plan-slug.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { planMatches } from './main';
 import { GROUP_JETPACK } from './constants';
+import { planMatches } from './main';
 
 export function isJetpackPlanSlug( productSlug ) {
 	return planMatches( productSlug, { group: GROUP_JETPACK } );

--- a/packages/calypso-products/src/is-jetpack-plan.js
+++ b/packages/calypso-products/src/is-jetpack-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isJetpackPlanSlug } from './is-jetpack-plan-slug';
 

--- a/packages/calypso-products/src/is-jetpack-premium.js
+++ b/packages/calypso-products/src/is-jetpack-premium.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isJetpackPlan } from './is-jetpack-plan';
 import { isPremium } from './is-premium';

--- a/packages/calypso-products/src/is-jetpack-product-slug.js
+++ b/packages/calypso-products/src/is-jetpack-product-slug.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { JETPACK_PRODUCTS_LIST } from './constants';
 
 export function isJetpackProductSlug( productSlug ) {

--- a/packages/calypso-products/src/is-jetpack-product.js
+++ b/packages/calypso-products/src/is-jetpack-product.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isJetpackProductSlug } from './is-jetpack-product-slug';
 

--- a/packages/calypso-products/src/is-jetpack-purchasable-item.ts
+++ b/packages/calypso-products/src/is-jetpack-purchasable-item.ts
@@ -1,11 +1,4 @@
-/**
- * Internal dependencies
- */
 import { JETPACK_LEGACY_PLANS, JETPACK_PRODUCTS_LIST, JETPACK_RESET_PLANS } from './constants';
-
-/**
- * Type dependencies
- */
 import type { JetpackPurchasableItemSlug } from './types';
 
 export default function isJetpackPurchasableItem(

--- a/packages/calypso-products/src/is-jetpack-scan-slug.js
+++ b/packages/calypso-products/src/is-jetpack-scan-slug.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { JETPACK_SCAN_PRODUCTS } from './constants';
 
 export function isJetpackScanSlug( productSlug ) {

--- a/packages/calypso-products/src/is-jetpack-scan.js
+++ b/packages/calypso-products/src/is-jetpack-scan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isJetpackScanSlug } from './is-jetpack-scan-slug';
 

--- a/packages/calypso-products/src/is-jetpack-search.js
+++ b/packages/calypso-products/src/is-jetpack-search.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { JETPACK_SEARCH_PRODUCTS } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-jpphp-bundle.js
+++ b/packages/calypso-products/src/is-jpphp-bundle.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_HOST_BUNDLE } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-marketplace-product.ts
+++ b/packages/calypso-products/src/is-marketplace-product.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { MARKETPLACE_PRODUCTS } from './constants';
 
 export function isMarketplaceProduct( product: { productSlug: string } ): boolean {

--- a/packages/calypso-products/src/is-monthly.js
+++ b/packages/calypso-products/src/is-monthly.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { JETPACK_MONTHLY_PLANS, PLAN_MONTHLY_PERIOD, WPCOM_MONTHLY_PLANS } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/is-no-ads.js
+++ b/packages/calypso-products/src/is-no-ads.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isNoAds( product ) {

--- a/packages/calypso-products/src/is-p2-plus.js
+++ b/packages/calypso-products/src/is-p2-plus.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isP2PlusPlan } from './main';
 import { formatProduct } from './format-product';
+import { isP2PlusPlan } from './main';
 
 export function isP2Plus( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-personal.js
+++ b/packages/calypso-products/src/is-personal.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isPersonalPlan } from './main';
 import { formatProduct } from './format-product';
+import { isPersonalPlan } from './main';
 
 export function isPersonal( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-plan.js
+++ b/packages/calypso-products/src/is-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 import { isBlogger } from './is-blogger';
 import { isBusiness } from './is-business';
@@ -8,9 +5,9 @@ import { isEcommerce } from './is-ecommerce';
 import { isEnterprise } from './is-enterprise';
 import { isJetpackPlan } from './is-jetpack-plan';
 import { isJpphpBundle } from './is-jpphp-bundle';
+import { isP2Plus } from './is-p2-plus';
 import { isPersonal } from './is-personal';
 import { isPremium } from './is-premium';
-import { isP2Plus } from './is-p2-plus';
 
 export function isPlan( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-premium.js
+++ b/packages/calypso-products/src/is-premium.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isPremiumPlan } from './main';
 import { formatProduct } from './format-product';
+import { isPremiumPlan } from './main';
 
 export function isPremium( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-security-daily.js
+++ b/packages/calypso-products/src/is-security-daily.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isSecurityDailyPlan } from './main';
 import { formatProduct } from './format-product';
+import { isSecurityDailyPlan } from './main';
 
 export function isSecurityDaily( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-security-realtime.js
+++ b/packages/calypso-products/src/is-security-realtime.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isSecurityRealTimePlan } from './main';
 import { formatProduct } from './format-product';
+import { isSecurityRealTimePlan } from './main';
 
 export function isSecurityRealTime( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-site-redirect.js
+++ b/packages/calypso-products/src/is-site-redirect.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isSiteRedirect( product ) {

--- a/packages/calypso-products/src/is-space-upgrade.js
+++ b/packages/calypso-products/src/is-space-upgrade.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isSpaceUpgrade( product ) {

--- a/packages/calypso-products/src/is-theme.js
+++ b/packages/calypso-products/src/is-theme.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isTheme( product ) {

--- a/packages/calypso-products/src/is-titan-mail.js
+++ b/packages/calypso-products/src/is-titan-mail.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { formatProduct } from './format-product';
 import { TITAN_MAIL_MONTHLY_SLUG } from './constants';
+import { formatProduct } from './format-product';
 
 export function isTitanMail( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-traffic-guide.js
+++ b/packages/calypso-products/src/is-traffic-guide.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { formatProduct } from './format-product';
 import { WPCOM_TRAFFIC_GUIDE } from './constants';
+import { formatProduct } from './format-product';
 
 export function isTrafficGuide( product ) {
 	product = formatProduct( product );

--- a/packages/calypso-products/src/is-unlimited-space.js
+++ b/packages/calypso-products/src/is-unlimited-space.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isUnlimitedSpace( product ) {

--- a/packages/calypso-products/src/is-unlimited-themes.js
+++ b/packages/calypso-products/src/is-unlimited-themes.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isUnlimitedThemes( product ) {

--- a/packages/calypso-products/src/is-video-press.js
+++ b/packages/calypso-products/src/is-video-press.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isVideoPress( product ) {

--- a/packages/calypso-products/src/is-vip-plan.js
+++ b/packages/calypso-products/src/is-vip-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatProduct } from './format-product';
 
 export function isVipPlan( product ) {

--- a/packages/calypso-products/src/is-yearly.js
+++ b/packages/calypso-products/src/is-yearly.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_ANNUAL_PERIOD } from './constants';
 import { formatProduct } from './format-product';
 

--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -4,7 +4,6 @@ import {
 	getUrlFromParts,
 	determineUrlType,
 } from '@automattic/calypso-url';
-
 import {
 	TERM_MONTHLY,
 	TERM_ANNUALLY,
@@ -26,7 +25,6 @@ import {
 	TYPE_P2_PLUS,
 } from './constants';
 import { PLANS_LIST } from './plans-list';
-
 import { isJetpackBusiness, isBusiness, isEnterprise, isEcommerce, isVipPlan } from '.';
 
 export function getPlans() {

--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -1,12 +1,10 @@
-/**
- * Internal dependencies
- */
 import {
 	format as formatUrl,
 	getUrlParts,
 	getUrlFromParts,
 	determineUrlType,
 } from '@automattic/calypso-url';
+
 import {
 	TERM_MONTHLY,
 	TERM_ANNUALLY,
@@ -28,6 +26,7 @@ import {
 	TYPE_P2_PLUS,
 } from './constants';
 import { PLANS_LIST } from './plans-list';
+
 import { isJetpackBusiness, isBusiness, isEnterprise, isEcommerce, isVipPlan } from '.';
 
 export function getPlans() {

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -1,13 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import i18n, { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
+import i18n, { translate } from 'i18n-calypso';
+import React from 'react';
+
+
 import {
 	FEATURE_BACKUP_DAILY_V2,
 	FEATURE_13GB_STORAGE,

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import i18n, { translate } from 'i18n-calypso';
 import React from 'react';
 
-
 import {
 	FEATURE_BACKUP_DAILY_V2,
 	FEATURE_13GB_STORAGE,

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import i18n, { translate } from 'i18n-calypso';
 import React from 'react';
-
 import {
 	FEATURE_BACKUP_DAILY_V2,
 	FEATURE_13GB_STORAGE,

--- a/packages/calypso-products/src/plans-utilities.js
+++ b/packages/calypso-products/src/plans-utilities.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN,
 	BEST_VALUE_PLANS,

--- a/packages/calypso-products/src/products-list.ts
+++ b/packages/calypso-products/src/products-list.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -42,10 +39,6 @@ import {
 	PRODUCT_JETPACK_BACKUP_PRO_MONTHLY,
 } from './constants';
 import { getJetpackProductsShortNames } from './translations';
-
-/**
- * Type dependencies
- */
 import type { ProductSlug, JetpackProductSlug, WPComProductSlug, Product } from './types';
 
 const PRODUCT_SHORT_NAMES = getJetpackProductsShortNames();

--- a/packages/calypso-products/src/translations.js
+++ b/packages/calypso-products/src/translations.js
@@ -1,6 +1,5 @@
 import { translate } from 'i18n-calypso';
 import React, { createElement } from 'react';
-
 import {
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,

--- a/packages/calypso-products/src/translations.js
+++ b/packages/calypso-products/src/translations.js
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import React, { createElement } from 'react';
 import { translate } from 'i18n-calypso';
+import React, { createElement } from 'react';
 
-/**
- * Internal dependencies
- */
 import {
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -1,5 +1,4 @@
-import type { TranslateResult } from 'i18n-calypso';
-
+import * as features from './constants/features';
 import type {
 	GROUP_JETPACK,
 	GROUP_WPCOM,
@@ -13,7 +12,7 @@ import type {
 	TYPES_LIST,
 	PERIOD_LIST,
 } from './constants';
-import * as features from './constants/features';
+import type { TranslateResult } from 'i18n-calypso';
 
 const featureValues = Object.values( features );
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -1,4 +1,3 @@
-
 import type { TranslateResult } from 'i18n-calypso';
 
 import type {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -1,12 +1,6 @@
-/**
- * Internal dependencies
- */
-import * as features from './constants/features';
 
-/**
- * Type dependencies
- */
 import type { TranslateResult } from 'i18n-calypso';
+
 import type {
 	GROUP_JETPACK,
 	GROUP_WPCOM,
@@ -20,6 +14,7 @@ import type {
 	TYPES_LIST,
 	PERIOD_LIST,
 } from './constants';
+import * as features from './constants/features';
 
 const featureValues = Object.values( features );
 

--- a/packages/calypso-products/test/choose-default-customer-type.js
+++ b/packages/calypso-products/test/choose-default-customer-type.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { chooseDefaultCustomerType } from '../src';
 import { PLAN_ECOMMERCE_2_YEARS, PLAN_PREMIUM, PLAN_FREE, PLAN_PERSONAL } from '../src/constants';
 

--- a/packages/calypso-products/test/get-interval-type-for-term.js
+++ b/packages/calypso-products/test/get-interval-type-for-term.js
@@ -1,9 +1,5 @@
-/**
- * Internal dependencies
- */
-
-import { getIntervalTypeForTerm } from '../src/get-interval-type-for-term';
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../src/constants';
+import { getIntervalTypeForTerm } from '../src/get-interval-type-for-term';
 
 describe( 'getIntervalTypeForTerm', () => {
 	test( 'should return 2-year intervalType if current plan is a 2-year plan', () => {

--- a/packages/calypso-products/test/get-popular-plan-spec.js
+++ b/packages/calypso-products/test/get-popular-plan-spec.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getPopularPlanSpec } from '../src';
 import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PREMIUM } from '../src/constants';
 

--- a/packages/calypso-products/test/is-jetpack-legacy-item.js
+++ b/packages/calypso-products/test/is-jetpack-legacy-item.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-import isJetpackLegacyItem from '../src/is-jetpack-legacy-item';
 import {
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
@@ -10,6 +6,7 @@ import {
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 } from '../src/constants';
+import isJetpackLegacyItem from '../src/is-jetpack-legacy-item';
 
 describe( 'isJetpackLegacyItem', () => {
 	it( 'should return true if the item is a Jetpack legacy item', () => {

--- a/packages/calypso-products/test/is-jetpack-purchasable-item.js
+++ b/packages/calypso-products/test/is-jetpack-purchasable-item.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-import isJetpackPurchasableItem from '../src/is-jetpack-purchasable-item';
 import {
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
@@ -10,6 +6,7 @@ import {
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 } from '../src/constants';
+import isJetpackPurchasableItem from '../src/is-jetpack-purchasable-item';
 
 describe( 'isJetpackPurchasableItem', () => {
 	it( 'should return true if the item is a Jetpack product', () => {

--- a/packages/calypso-products/test/plan-levels-match.js
+++ b/packages/calypso-products/test/plan-levels-match.js
@@ -1,13 +1,7 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testPlansArrayIndependentOfOrder"] }] */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 
-/**
- * Internal dependencies
- */
 import { planLevelsMatch } from '../src';
 import {
 	PLAN_BUSINESS_MONTHLY,

--- a/packages/calypso-products/test/plan-levels-match.js
+++ b/packages/calypso-products/test/plan-levels-match.js
@@ -1,7 +1,6 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["testPlansArrayIndependentOfOrder"] }] */
 
 import { expect } from 'chai';
-
 import { planLevelsMatch } from '../src';
 import {
 	PLAN_BUSINESS_MONTHLY,

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 
-/**
- * Internal dependencies
- */
 import {
 	FEATURE_ALL_PERSONAL_FEATURES,
 	FEATURE_AUDIO_UPLOADS,

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import {
 	FEATURE_ALL_PERSONAL_FEATURES,
 	FEATURE_AUDIO_UPLOADS,

--- a/packages/calypso-products/test/plan-other.js
+++ b/packages/calypso-products/test/plan-other.js
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-
-/**
- * Internal dependencies
- */
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from '../src/constants';
 import { calculateMonthlyPrice, getBillingMonthsForTerm, getTermDuration } from '../src/index';
 

--- a/packages/calypso-products/test/plans-link.js
+++ b/packages/calypso-products/test/plans-link.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { plansLink } from '../src';
 
 describe( 'plansLink', () => {

--- a/packages/calypso-products/test/product-values.js
+++ b/packages/calypso-products/test/product-values.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	isJetpackPlan,
 	isJetpackPlanSlug,

--- a/packages/calypso-products/test/products-list.js
+++ b/packages/calypso-products/test/products-list.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { objectIsProduct } from '../src';
 
 describe( 'objectIsProduct', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-products` to use `import/order`

#### Testing instructions

N/A