### PR TITLE
chore: Refactor packages/data-stores to use import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -203,6 +203,7 @@ module.exports = {
 				'client/sections-helper.js',
 				'packages/accessible-focus/**/*',
 				'packages/calypso-products/**/*',
+				'packages/data-stores/**/*',
 				'test/e2e/**/*',
 			],
 			rules: {

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -1,12 +1,17 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data-controls';
 import { stringify } from 'qs';
 
-/**
- * Internal dependencies
- */
+import type { WpcomClientCredentials } from '../shared-types';
+import {
+	wpcomRequest,
+	fetchAndParse,
+	requestAllBlogsAccess,
+	reloadProxy,
+	wait,
+} from '../wpcom-request-controls';
+
+import { STORE_KEY, POLL_APP_PUSH_INTERVAL_SECONDS } from './constants';
+import { remoteLoginUser } from './controls';
 import type {
 	AuthOptionsSuccessResponse,
 	AuthOptionsErrorResponse,
@@ -18,16 +23,6 @@ import type {
 	PushNotificationSentData,
 	LoginCompleteData,
 } from './types';
-import { STORE_KEY, POLL_APP_PUSH_INTERVAL_SECONDS } from './constants';
-import {
-	wpcomRequest,
-	fetchAndParse,
-	requestAllBlogsAccess,
-	reloadProxy,
-	wait,
-} from '../wpcom-request-controls';
-import { remoteLoginUser } from './controls';
-import type { WpcomClientCredentials } from '../shared-types';
 import { getNextTaskId } from './utils';
 
 export interface ActionsConfig extends WpcomClientCredentials {

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -1,6 +1,5 @@
 import { select } from '@wordpress/data-controls';
 import { stringify } from 'qs';
-import type { WpcomClientCredentials } from '../shared-types';
 import {
 	wpcomRequest,
 	fetchAndParse,
@@ -10,6 +9,8 @@ import {
 } from '../wpcom-request-controls';
 import { STORE_KEY, POLL_APP_PUSH_INTERVAL_SECONDS } from './constants';
 import { remoteLoginUser } from './controls';
+import { getNextTaskId } from './utils';
+import type { WpcomClientCredentials } from '../shared-types';
 import type {
 	AuthOptionsSuccessResponse,
 	AuthOptionsErrorResponse,
@@ -21,7 +22,6 @@ import type {
 	PushNotificationSentData,
 	LoginCompleteData,
 } from './types';
-import { getNextTaskId } from './utils';
 
 export interface ActionsConfig extends WpcomClientCredentials {
 	/**

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -1,6 +1,5 @@
 import { select } from '@wordpress/data-controls';
 import { stringify } from 'qs';
-
 import type { WpcomClientCredentials } from '../shared-types';
 import {
 	wpcomRequest,
@@ -9,7 +8,6 @@ import {
 	reloadProxy,
 	wait,
 } from '../wpcom-request-controls';
-
 import { STORE_KEY, POLL_APP_PUSH_INTERVAL_SECONDS } from './constants';
 import { remoteLoginUser } from './controls';
 import type {

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -11,7 +11,6 @@ import { controls } from './controls';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';
 
-
 export * from './types';
 export type { State };
 

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -1,10 +1,8 @@
 import { registerStore } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
-
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
-
 import { createActions, ActionsConfig } from './actions';
 import { STORE_KEY } from './constants';
 import { controls } from './controls';

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -1,20 +1,16 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 
-/**
- * Internal dependencies
- */
-import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
-import { createActions, ActionsConfig } from './actions';
-import { controls } from './controls';
-import * as selectors from './selectors';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
+
+import { createActions, ActionsConfig } from './actions';
+import { STORE_KEY } from './constants';
+import { controls } from './controls';
+import reducer, { State } from './reducer';
+import * as selectors from './selectors';
+
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -1,13 +1,13 @@
 import { registerStore } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import { createActions, ActionsConfig } from './actions';
 import { STORE_KEY } from './constants';
 import { controls } from './controls';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
-import type { LoginFlowState } from './types';
 import type { Action } from './actions';
+import type { LoginFlowState } from './types';
 import { getNextTaskId } from './utils';
 
 export const loginFlowState: Reducer< LoginFlowState, Action > = (

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -1,8 +1,8 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
+import { getNextTaskId } from './utils';
 import type { Action } from './actions';
 import type { LoginFlowState } from './types';
-import { getNextTaskId } from './utils';
+import type { Reducer } from 'redux';
 
 export const loginFlowState: Reducer< LoginFlowState, Action > = (
 	state = 'ENTER_USERNAME_OR_EMAIL',

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Action } from './actions';
 import type { LoginFlowState } from './types';
 import { getNextTaskId } from './utils';

--- a/packages/data-stores/src/auth/selectors.ts
+++ b/packages/data-stores/src/auth/selectors.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { State } from './reducer';
 
 export const getErrors = ( state: State ) => state.errors;

--- a/packages/data-stores/src/auth/test/actions.ts
+++ b/packages/data-stores/src/auth/test/actions.ts
@@ -6,9 +6,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { createActions } from '../actions';
 import { STORE_KEY } from '../constants';
 

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -6,9 +6,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { dispatch, select } from '@wordpress/data';
 import { parse } from 'qs';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -16,9 +13,6 @@ import 'jest-fetch-mock';
 import nock from 'nock';
 import waitForExpect from 'wait-for-expect';
 
-/**
- * Internal dependencies
- */
 import { register } from '..';
 
 jest.mock( '../constants', () => ( {

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -7,11 +7,12 @@
  */
 
 import { dispatch, select } from '@wordpress/data';
-import { parse } from 'qs';
-import wpcomRequest from 'wpcom-proxy-request';
-import 'jest-fetch-mock';
 import nock from 'nock';
+import { parse } from 'qs';
 import waitForExpect from 'wait-for-expect';
+import wpcomRequest from 'wpcom-proxy-request';
+
+import 'jest-fetch-mock';
 
 import { register } from '..';
 

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -11,9 +11,7 @@ import nock from 'nock';
 import { parse } from 'qs';
 import waitForExpect from 'wait-for-expect';
 import wpcomRequest from 'wpcom-proxy-request';
-
 import 'jest-fetch-mock';
-
 import { register } from '..';
 
 jest.mock( '../constants', () => ( {

--- a/packages/data-stores/src/auth/test/reducer.ts
+++ b/packages/data-stores/src/auth/test/reducer.ts
@@ -6,11 +6,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
-import { errors, loginFlowState, usernameOrEmail } from '../reducer';
 import { createActions } from '../actions';
+import { errors, loginFlowState, usernameOrEmail } from '../reducer';
 
 const { reset, receiveAuthOptions, clearErrors } = createActions( {
 	client_id: '',

--- a/packages/data-stores/src/domain-suggestions/actions.ts
+++ b/packages/data-stores/src/domain-suggestions/actions.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type {
 	DomainSuggestion,
 	DomainSuggestionQuery,

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -1,8 +1,6 @@
 import { registerStore } from '@wordpress/data';
-
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -1,18 +1,14 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
-import * as actions from './actions';
-import * as resolvers from './resolvers';
-import * as selectors from './selectors';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
+
+import * as actions from './actions';
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+
 
 export * from './types';
 export * from './constants';

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -1,11 +1,11 @@
 import { registerStore } from '@wordpress/data';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
 export * from './types';
 export * from './constants';

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -9,7 +9,6 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-
 export * from './types';
 export * from './constants';
 export { getFormattedPrice } from './utils';

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
-import type { DomainCategory, DomainSuggestionState, DomainAvailabilities } from './types';
-import { DataStatus } from './constants';
 import type { Action } from './actions';
+import { DataStatus } from './constants';
+import type { DomainCategory, DomainSuggestionState, DomainAvailabilities } from './types';
 import { stringifyDomainQueryObject } from './utils';
 
 const initialDomainSuggestionState: DomainSuggestionState = {

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -1,9 +1,9 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
-import type { Action } from './actions';
 import { DataStatus } from './constants';
-import type { DomainCategory, DomainSuggestionState, DomainAvailabilities } from './types';
 import { stringifyDomainQueryObject } from './utils';
+import type { Action } from './actions';
+import type { DomainCategory, DomainSuggestionState, DomainAvailabilities } from './types';
+import type { Reducer } from 'redux';
 
 const initialDomainSuggestionState: DomainSuggestionState = {
 	state: DataStatus.Uninitialized,

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Action } from './actions';
 import { DataStatus } from './constants';
 import type { DomainCategory, DomainSuggestionState, DomainAvailabilities } from './types';

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -1,13 +1,9 @@
-/**
- * External dependencies
- */
-import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
+import { stringify } from 'qs';
 import validator from 'validator';
 
-/**
- * Internal dependencies
- */
+import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
+
 import {
 	receiveCategories,
 	receiveDomainSuggestionsSuccess,
@@ -15,9 +11,8 @@ import {
 	fetchDomainSuggestions,
 	receiveDomainAvailability,
 } from './actions';
-import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
-import { getFormattedPrice } from './utils';
 import type { DomainSuggestion, DomainSuggestionQuery } from './types';
+import { getFormattedPrice } from './utils';
 
 function getAvailabilityURL( domainName: string ) {
 	return `https://public-api.wordpress.com/rest/v1.3/domains/${ encodeURIComponent(

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -1,9 +1,7 @@
 import { translate } from 'i18n-calypso';
 import { stringify } from 'qs';
 import validator from 'validator';
-
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
-
 import {
 	receiveCategories,
 	receiveDomainSuggestionsSuccess,

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -9,8 +9,8 @@ import {
 	fetchDomainSuggestions,
 	receiveDomainAvailability,
 } from './actions';
-import type { DomainSuggestion, DomainSuggestionQuery } from './types';
 import { getFormattedPrice } from './utils';
+import type { DomainSuggestion, DomainSuggestionQuery } from './types';
 
 function getAvailabilityURL( domainName: string ) {
 	return `https://public-api.wordpress.com/rest/v1.3/domains/${ encodeURIComponent(

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
 import { STORE_KEY, DataStatus } from './constants';
+import type { State } from './reducer';
 import type {
 	DomainAvailability,
 	DomainAvailabilities,
@@ -15,7 +10,6 @@ import type {
 	DomainSuggestionQuery,
 	DomainSuggestionSelectorOptions,
 } from './types';
-import type { State } from './reducer';
 import { stringifyDomainQueryObject, normalizeDomainSuggestionQuery } from './utils';
 
 export const getCategories = ( state: State ): DomainCategory[] => {

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -1,5 +1,4 @@
 import { select } from '@wordpress/data';
-
 import { STORE_KEY, DataStatus } from './constants';
 import type { State } from './reducer';
 import type {

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -1,5 +1,6 @@
 import { select } from '@wordpress/data';
 import { STORE_KEY, DataStatus } from './constants';
+import { stringifyDomainQueryObject, normalizeDomainSuggestionQuery } from './utils';
 import type { State } from './reducer';
 import type {
 	DomainAvailability,
@@ -9,7 +10,6 @@ import type {
 	DomainSuggestionQuery,
 	DomainSuggestionSelectorOptions,
 } from './types';
-import { stringifyDomainQueryObject, normalizeDomainSuggestionQuery } from './utils';
 
 export const getCategories = ( state: State ): DomainCategory[] => {
 	// Sort domain categories by tier, then by title.

--- a/packages/data-stores/src/domain-suggestions/test/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/test/reducer.ts
@@ -1,10 +1,6 @@
-/**
- * Internal dependencies
- */
-
+import { DataStatus } from '../constants';
 import { domainSuggestions } from '../reducer';
 import type { DomainSuggestionState, DomainSuggestion } from '../types';
-import { DataStatus } from '../constants';
 
 describe( 'domainSuggestions', () => {
 	const initialTimeStamp = Date.now();

--- a/packages/data-stores/src/domain-suggestions/test/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/test/selectors.ts
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
 import { select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
 
-/**
- * Internal dependencies
- */
 import { register } from '..';
 import { DataStatus } from '../constants';
 

--- a/packages/data-stores/src/domain-suggestions/test/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/test/selectors.ts
@@ -1,6 +1,5 @@
 import { select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-
 import { register } from '..';
 import { DataStatus } from '../constants';
 

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { DataStatus } from './constants';
 
 export interface DomainSuggestionQuery {

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import deterministicStringify from 'fast-json-stable-stringify';
 import formatCurrency from '@automattic/format-currency';
+import deterministicStringify from 'fast-json-stable-stringify';
 
-/**
- * Internal dependencies
- */
 import type { DomainSuggestionQuery, DomainSuggestionSelectorOptions } from './types';
 
 /**

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -1,6 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
 import deterministicStringify from 'fast-json-stable-stringify';
-
 import type { DomainSuggestionQuery, DomainSuggestionSelectorOptions } from './types';
 
 /**

--- a/packages/data-stores/src/i18n/actions.ts
+++ b/packages/data-stores/src/i18n/actions.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { LocalizedLanguageNames } from './types';
 
 export const setLocalizedLanguageNames = (

--- a/packages/data-stores/src/i18n/index.ts
+++ b/packages/data-stores/src/i18n/index.ts
@@ -1,18 +1,13 @@
-/**
- * External dependencies
- */
-import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
+
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
-/**
- * Internal dependencies
- */
+import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
-import * as actions from './actions';
-import * as selectors from './selectors';
 import * as resolvers from './resolvers';
+import * as selectors from './selectors';
 
 export type { State };
 export type { LocalizedLanguageNames } from './types';

--- a/packages/data-stores/src/i18n/index.ts
+++ b/packages/data-stores/src/i18n/index.ts
@@ -1,8 +1,6 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/i18n/index.ts
+++ b/packages/data-stores/src/i18n/index.ts
@@ -1,11 +1,11 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
 export type { State };
 export type { LocalizedLanguageNames } from './types';

--- a/packages/data-stores/src/i18n/reducer.ts
+++ b/packages/data-stores/src/i18n/reducer.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { I18nAction } from './actions';
 import type { LocalizedLanguageNames } from './types';
 

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { apiFetch } from '@wordpress/data-controls';
 import type { APIFetchOptions } from '@wordpress/api-fetch';
+import { apiFetch } from '@wordpress/data-controls';
 import { addQueryArgs } from '@wordpress/url';
 
 import { setLocalizedLanguageNames } from './actions';

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -1,9 +1,9 @@
-import type { APIFetchOptions } from '@wordpress/api-fetch';
 import { apiFetch } from '@wordpress/data-controls';
 import { addQueryArgs } from '@wordpress/url';
 import { setLocalizedLanguageNames } from './actions';
 import { LANGUAGE_NAMES_URL } from './constants';
 import type { LocalizedLanguageNames } from './types';
+import type { APIFetchOptions } from '@wordpress/api-fetch';
 
 export function* getLocalizedLanguageNames( locale: string ) {
 	const localizedLanguageNames: LocalizedLanguageNames = yield apiFetch( {

--- a/packages/data-stores/src/i18n/resolvers.ts
+++ b/packages/data-stores/src/i18n/resolvers.ts
@@ -1,7 +1,6 @@
 import type { APIFetchOptions } from '@wordpress/api-fetch';
 import { apiFetch } from '@wordpress/data-controls';
 import { addQueryArgs } from '@wordpress/url';
-
 import { setLocalizedLanguageNames } from './actions';
 import { LANGUAGE_NAMES_URL } from './constants';
 import type { LocalizedLanguageNames } from './types';

--- a/packages/data-stores/src/i18n/selectors.ts
+++ b/packages/data-stores/src/i18n/selectors.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { State } from './reducer';
 import type { LocalizedLanguageNames } from './types';
 

--- a/packages/data-stores/src/i18n/test/reducer.js
+++ b/packages/data-stores/src/i18n/test/reducer.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import reducer from '../reducer';
 import { setLocalizedLanguageNames } from '../actions';
+import reducer from '../reducer';
 
 describe( 'i18n reducer', () => {
 	describe( 'localizedLanguageNames', () => {

--- a/packages/data-stores/src/i18n/test/resolvers.js
+++ b/packages/data-stores/src/i18n/test/resolvers.js
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
 import { apiFetch } from '@wordpress/data-controls';
 import { addQueryArgs } from '@wordpress/url';
 
-/**
- * Internal dependencies
- */
-import { getLocalizedLanguageNames } from '../resolvers';
 import { setLocalizedLanguageNames } from '../actions';
 import { LANGUAGE_NAMES_URL } from '../constants';
+import { getLocalizedLanguageNames } from '../resolvers';
 
 describe( 'i18n resolvers', () => {
 	describe( 'getLocalizedLanguageNames', () => {

--- a/packages/data-stores/src/i18n/test/resolvers.js
+++ b/packages/data-stores/src/i18n/test/resolvers.js
@@ -1,6 +1,5 @@
 import { apiFetch } from '@wordpress/data-controls';
 import { addQueryArgs } from '@wordpress/url';
-
 import { setLocalizedLanguageNames } from '../actions';
 import { LANGUAGE_NAMES_URL } from '../constants';
 import { getLocalizedLanguageNames } from '../resolvers';

--- a/packages/data-stores/src/i18n/test/selectors.js
+++ b/packages/data-stores/src/i18n/test/selectors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getLocalizedLanguageNames } from '../selectors';
 
 describe( 'i18n selectors', () => {

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -1,18 +1,15 @@
-/**
- * Internal dependencies
- */
 import * as Auth from './auth';
-import * as User from './user';
 import * as DomainSuggestions from './domain-suggestions';
+import * as I18n from './i18n';
+import * as Launch from './launch';
 import persistenceConfigFactory from './persistence-config-factory';
 import * as Plans from './plans';
-import * as Site from './site';
-import * as Verticals from './verticals';
-import * as Launch from './launch';
-import * as WPCOMFeatures from './wpcom-features';
-import * as VerticalsTemplates from './verticals-templates';
-import * as I18n from './i18n';
 import * as Reader from './reader';
+import * as Site from './site';
+import * as User from './user';
+import * as Verticals from './verticals';
+import * as VerticalsTemplates from './verticals-templates';
+import * as WPCOMFeatures from './wpcom-features';
 
 export {
 	Auth,

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -1,16 +1,12 @@
-/**
- * External dependencies
- */
-import type * as DomainSuggestions from '../domain-suggestions';
 import { select } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import type { LaunchStepType } from './types';
-import type { ReturnOrGeneratorYieldUnion } from '../mapped-types';
-import { PLANS_STORE } from './constants';
 import type { Plans } from '..';
+import type * as DomainSuggestions from '../domain-suggestions';
+import type { ReturnOrGeneratorYieldUnion } from '../mapped-types';
+
+import { PLANS_STORE } from './constants';
+import type { LaunchStepType } from './types';
+
 
 export const setSidebarFullscreen = () =>
 	( {

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -1,9 +1,7 @@
 import { select } from '@wordpress/data';
-
 import type { Plans } from '..';
 import type * as DomainSuggestions from '../domain-suggestions';
 import type { ReturnOrGeneratorYieldUnion } from '../mapped-types';
-
 import { PLANS_STORE } from './constants';
 import type { LaunchStepType } from './types';
 

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -1,8 +1,8 @@
 import { select } from '@wordpress/data';
+import { PLANS_STORE } from './constants';
 import type { Plans } from '..';
 import type * as DomainSuggestions from '../domain-suggestions';
 import type { ReturnOrGeneratorYieldUnion } from '../mapped-types';
-import { PLANS_STORE } from './constants';
 import type { LaunchStepType } from './types';
 
 export const setSidebarFullscreen = () =>

--- a/packages/data-stores/src/launch/actions.ts
+++ b/packages/data-stores/src/launch/actions.ts
@@ -7,7 +7,6 @@ import type { ReturnOrGeneratorYieldUnion } from '../mapped-types';
 import { PLANS_STORE } from './constants';
 import type { LaunchStepType } from './types';
 
-
 export const setSidebarFullscreen = () =>
 	( {
 		type: 'SET_SIDEBAR_FULLSCREEN',

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -1,18 +1,14 @@
-/**
- * External dependencies
- */
-import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
 
-/**
- * Internal dependencies
- */
-import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
-import * as actions from './actions';
-import * as selectors from './selectors';
-import persistOptions from './persist';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
+
+import * as actions from './actions';
+import { STORE_KEY } from './constants';
+import persistOptions from './persist';
+import reducer, { State } from './reducer';
+import * as selectors from './selectors';
+
 
 export type { State };
 export type { LaunchStepType } from './types';

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -1,11 +1,11 @@
 import { plugins, registerStore, use } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import persistOptions from './persist';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
 export type { State };
 export type { LaunchStepType } from './types';

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -1,8 +1,6 @@
 import { plugins, registerStore, use } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import persistOptions from './persist';

--- a/packages/data-stores/src/launch/index.ts
+++ b/packages/data-stores/src/launch/index.ts
@@ -9,7 +9,6 @@ import persistOptions from './persist';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';
 
-
 export type { State };
 export type { LaunchStepType } from './types';
 export { STORE_KEY };

--- a/packages/data-stores/src/launch/persist.ts
+++ b/packages/data-stores/src/launch/persist.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import persistenceConfigFactory from '../persistence-config-factory';
 
 export default persistenceConfigFactory( 'WP_LAUNCH' );

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -1,17 +1,12 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
+
+import type { Plans } from '..';
 import type * as DomainSuggestions from '../domain-suggestions';
 
-/**
- * Internal dependencies
- */
+import type { LaunchAction } from './actions';
 import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';
-import type { LaunchAction } from './actions';
-import type { Plans } from '..';
 
 const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
 	if ( action.type === 'SET_STEP' ) {

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -1,9 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Plans } from '..';
 import type * as DomainSuggestions from '../domain-suggestions';
-
 import type { LaunchAction } from './actions';
 import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';

--- a/packages/data-stores/src/launch/reducer.ts
+++ b/packages/data-stores/src/launch/reducer.ts
@@ -1,10 +1,10 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
+import { LaunchStep } from './data';
 import type { Plans } from '..';
 import type * as DomainSuggestions from '../domain-suggestions';
 import type { LaunchAction } from './actions';
-import { LaunchStep } from './data';
 import type { LaunchStepType } from './types';
+import type { Reducer } from 'redux';
 
 const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
 	if ( action.type === 'SET_STEP' ) {

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -1,8 +1,8 @@
 import { select } from '@wordpress/data';
-import type { Plans } from '..';
-import type * as DomainSuggestions from '../domain-suggestions';
 import { STORE_KEY as LAUNCH_STORE, PLANS_STORE } from './constants';
 import { LaunchSequence, LaunchStep } from './data';
+import type { Plans } from '..';
+import type * as DomainSuggestions from '../domain-suggestions';
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
 

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -8,7 +8,6 @@ import { LaunchSequence, LaunchStep } from './data';
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
 
-
 export const getLaunchSequence = (): typeof LaunchSequence => LaunchSequence;
 export const getLaunchStep = (): typeof LaunchStep => LaunchStep;
 

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -1,8 +1,6 @@
 import { select } from '@wordpress/data';
-
 import type { Plans } from '..';
 import type * as DomainSuggestions from '../domain-suggestions';
-
 import { STORE_KEY as LAUNCH_STORE, PLANS_STORE } from './constants';
 import { LaunchSequence, LaunchStep } from './data';
 import type { State } from './reducer';

--- a/packages/data-stores/src/launch/selectors.ts
+++ b/packages/data-stores/src/launch/selectors.ts
@@ -1,18 +1,13 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { LaunchSequence, LaunchStep } from './data';
-import { STORE_KEY as LAUNCH_STORE, PLANS_STORE } from './constants';
+import type { Plans } from '..';
+import type * as DomainSuggestions from '../domain-suggestions';
 
+import { STORE_KEY as LAUNCH_STORE, PLANS_STORE } from './constants';
+import { LaunchSequence, LaunchStep } from './data';
 import type { State } from './reducer';
 import type { LaunchStepType } from './types';
-import type * as DomainSuggestions from '../domain-suggestions';
-import type { Plans } from '..';
+
 
 export const getLaunchSequence = (): typeof LaunchSequence => LaunchSequence;
 export const getLaunchStep = (): typeof LaunchStep => LaunchStep;

--- a/packages/data-stores/src/launch/types.ts
+++ b/packages/data-stores/src/launch/types.ts
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import type { ValuesType } from 'utility-types';
 
-/**
- * Internal dependencies
- */
 import type { LaunchStep } from './data';
 
 export type LaunchStepType = ValuesType< typeof LaunchStep >;

--- a/packages/data-stores/src/launch/types.ts
+++ b/packages/data-stores/src/launch/types.ts
@@ -1,4 +1,4 @@
-import type { ValuesType } from 'utility-types';
 import type { LaunchStep } from './data';
+import type { ValuesType } from 'utility-types';
 
 export type LaunchStepType = ValuesType< typeof LaunchStep >;

--- a/packages/data-stores/src/launch/types.ts
+++ b/packages/data-stores/src/launch/types.ts
@@ -1,5 +1,4 @@
 import type { ValuesType } from 'utility-types';
-
 import type { LaunchStep } from './data';
 
 export type LaunchStepType = ValuesType< typeof LaunchStep >;

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { FunctionKeys } from 'utility-types';
 
 /**

--- a/packages/data-stores/src/plans/actions.ts
+++ b/packages/data-stores/src/plans/actions.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
 
 type setFeaturesAction = {

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 export const STORE_KEY = 'automattic/onboard/plans';
 
 export const FREE_PLAN_PRODUCT_ID = 1;

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -1,18 +1,14 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
-import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
-/**
- * Internal dependencies
- */
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
+import { controls } from '../wpcom-request-controls';
+
+import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
-import * as actions from './actions';
-import * as selectors from './selectors';
 import * as resolvers from './resolvers';
-import { controls } from '../wpcom-request-controls';
+import * as selectors from './selectors';
+
 
 export type { State };
 export type {

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -1,8 +1,6 @@
 import { registerStore } from '@wordpress/data';
-
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -1,11 +1,11 @@
 import { registerStore } from '@wordpress/data';
-import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
 export type { State };
 export type {

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -9,7 +9,6 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-
 export type { State };
 export type {
 	Plan,

--- a/packages/data-stores/src/plans/mock/apis/features.ts
+++ b/packages/data-stores/src/plans/mock/apis/features.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { FeaturesByType } from '../../types';
 
 // Individual Features

--- a/packages/data-stores/src/plans/mock/apis/plans.ts
+++ b/packages/data-stores/src/plans/mock/apis/plans.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import * as MockData from '../';
 import type {
 	PricedAPIPlanFree,

--- a/packages/data-stores/src/plans/mock/store/features.ts
+++ b/packages/data-stores/src/plans/mock/store/features.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import * as MockData from '../';
 import type { PlanSimplifiedFeature, PlanFeature } from '../../types';
 

--- a/packages/data-stores/src/plans/mock/store/plans.ts
+++ b/packages/data-stores/src/plans/mock/store/plans.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import * as MockData from '../';
 import type { Plan } from '../../types';
 

--- a/packages/data-stores/src/plans/mock/store/products.ts
+++ b/packages/data-stores/src/plans/mock/store/products.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { PlanProduct } from '../../types';
 
 // Plan products

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
 import type { PlanAction } from './actions';
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
 

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { PlanAction } from './actions';
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
 

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
 import type { PlanAction } from './actions';
 import type { Plan, PlanFeature, FeaturesByType, PlanProduct } from './types';
+import type { Reducer } from 'redux';
 
 // create a Locale type just for code readability
 type Locale = string;

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -1,13 +1,17 @@
-/**
- * External dependencies
- */
-import { stringify } from 'qs';
 import formatCurrency from '@automattic/format-currency';
+import { stringify } from 'qs';
 
-/**
- * Internal dependencies
- */
+import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
+
 import { setFeatures, setFeaturesByType, setPlanProducts, setPlans } from './actions';
+import {
+	TIMELESS_PLAN_FREE,
+	TIMELESS_PLAN_PREMIUM,
+	plansProductSlugs,
+	monthlySlugs,
+	annualSlugs,
+	FEATURE_IDS_THAT_REQUIRE_ANNUALLY_BILLED_PLAN,
+} from './constants';
 import type {
 	PricedAPIPlan,
 	APIPlanDetail,
@@ -19,15 +23,6 @@ import type {
 	PlanSlug,
 	DetailsAPIFeature,
 } from './types';
-import {
-	TIMELESS_PLAN_FREE,
-	TIMELESS_PLAN_PREMIUM,
-	plansProductSlugs,
-	monthlySlugs,
-	annualSlugs,
-	FEATURE_IDS_THAT_REQUIRE_ANNUALLY_BILLED_PLAN,
-} from './constants';
-import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
 
 const MONTHLY_PLAN_BILLING_PERIOD = 31;
 

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -1,8 +1,6 @@
 import formatCurrency from '@automattic/format-currency';
 import { stringify } from 'qs';
-
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
-
 import { setFeatures, setFeaturesByType, setPlanProducts, setPlans } from './actions';
 import {
 	TIMELESS_PLAN_FREE,

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
 import deprecate from '@wordpress/deprecated';
 
-/**
- * Internal dependencies
- */
-import type { State } from './reducer';
 import {
 	DEFAULT_PAID_PLAN,
 	TIMELESS_PLAN_ECOMMERCE,
@@ -15,6 +8,7 @@ import {
 	STORE_KEY,
 	FREE_PLAN_PRODUCT_ID,
 } from './constants';
+import type { State } from './reducer';
 import type {
 	Plan,
 	PlanFeature,

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -1,6 +1,5 @@
 import { select } from '@wordpress/data';
 import deprecate from '@wordpress/deprecated';
-
 import {
 	DEFAULT_PAID_PLAN,
 	TIMELESS_PLAN_ECOMMERCE,

--- a/packages/data-stores/src/plans/test-utils/index.ts
+++ b/packages/data-stores/src/plans/test-utils/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { PlanFeature } from '../types';
 
 export const buildPlanFeaturesDict = (

--- a/packages/data-stores/src/plans/test/actions.ts
+++ b/packages/data-stores/src/plans/test/actions.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import * as Actions from '../actions';
 import * as MockData from '../mock';
 import { buildPlanFeaturesDict } from '../test-utils';

--- a/packages/data-stores/src/plans/test/reducer.ts
+++ b/packages/data-stores/src/plans/test/reducer.ts
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
-import reducer from '../reducer';
 import { setPlans, setFeaturesByType, setFeatures, setPlanProducts } from '../actions';
 import * as MockData from '../mock';
+import reducer from '../reducer';
 import { buildPlanFeaturesDict } from '../test-utils';
 
 const MOCK_LOCALE = 'test-locale';

--- a/packages/data-stores/src/plans/test/resolvers.ts
+++ b/packages/data-stores/src/plans/test/resolvers.ts
@@ -1,10 +1,6 @@
-/**
- * Internal dependencies
- */
-import { getSupportedPlans } from '../resolvers';
 import * as MockData from '../mock';
+import { getSupportedPlans } from '../resolvers';
 import { buildPlanFeaturesDict } from '../test-utils';
-
 import type { PricedAPIPlan } from '../types';
 
 // Don't need to mock specific functions for any tests, but mocking

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -1,16 +1,10 @@
-/**
- * External dependencies
- */
 import * as deprecate from '@wordpress/deprecated';
 
-/**
- * Internal dependencies
- */
-import * as Selectors from '../selectors';
-import * as MockData from '../mock';
-import { buildPlanFeaturesDict } from '../test-utils';
 import { TIMELESS_PLAN_ECOMMERCE, TIMELESS_PLAN_FREE, FREE_PLAN_PRODUCT_ID } from '../constants';
+import * as MockData from '../mock';
 import type { State } from '../reducer';
+import * as Selectors from '../selectors';
+import { buildPlanFeaturesDict } from '../test-utils';
 
 // Test data
 const MOCK_LOCALE_1 = 'test-locale-1';

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -1,5 +1,4 @@
 import * as deprecate from '@wordpress/deprecated';
-
 import { TIMELESS_PLAN_ECOMMERCE, TIMELESS_PLAN_FREE, FREE_PLAN_PRODUCT_ID } from '../constants';
 import * as MockData from '../mock';
 import type { State } from '../reducer';

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -1,9 +1,9 @@
 import * as deprecate from '@wordpress/deprecated';
 import { TIMELESS_PLAN_ECOMMERCE, TIMELESS_PLAN_FREE, FREE_PLAN_PRODUCT_ID } from '../constants';
 import * as MockData from '../mock';
-import type { State } from '../reducer';
 import * as Selectors from '../selectors';
 import { buildPlanFeaturesDict } from '../test-utils';
+import type { State } from '../reducer';
 
 // Test data
 const MOCK_LOCALE_1 = 'test-locale-1';

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { plansProductSlugs, plansSlugs } from './constants';
 
 export type StorePlanSlug = typeof plansProductSlugs[ number ];

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,5 +1,4 @@
 import { plugins, registerStore, use } from '@wordpress/data';
-import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -7,6 +6,7 @@ import persistOptions from './persist';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
 export type { State };
 export { STORE_KEY };

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,8 +1,6 @@
 import { plugins, registerStore, use } from '@wordpress/data';
-
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import persistOptions from './persist';

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,19 +1,15 @@
-/**
- * External dependencies
- */
 import { plugins, registerStore, use } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
-import * as resolvers from './resolvers';
-import * as actions from './actions';
-import * as selectors from './selectors';
-import persistOptions from './persist';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
+
+import * as actions from './actions';
+import { STORE_KEY } from './constants';
+import persistOptions from './persist';
+import reducer, { State } from './reducer';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+
 
 export type { State };
 export { STORE_KEY };

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -10,7 +10,6 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-
 export type { State };
 export { STORE_KEY };
 

--- a/packages/data-stores/src/reader/persist.ts
+++ b/packages/data-stores/src/reader/persist.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import persistenceConfigFactory from '../persistence-config-factory';
 
 export default persistenceConfigFactory( 'WP_READER' );

--- a/packages/data-stores/src/reader/reducer.ts
+++ b/packages/data-stores/src/reader/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { ReaderTeam, ReaderAction } from './actions';
 
 const teams: Reducer< ReaderTeam[] | null, ReaderAction > = ( state = null, action ) => {

--- a/packages/data-stores/src/reader/reducer.ts
+++ b/packages/data-stores/src/reader/reducer.ts
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
 import type { ReaderTeam, ReaderAction } from './actions';
 
 const teams: Reducer< ReaderTeam[] | null, ReaderAction > = ( state = null, action ) => {

--- a/packages/data-stores/src/reader/reducer.ts
+++ b/packages/data-stores/src/reader/reducer.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
 import type { ReaderTeam, ReaderAction } from './actions';
+import type { Reducer } from 'redux';
 
 const teams: Reducer< ReaderTeam[] | null, ReaderAction > = ( state = null, action ) => {
 	if ( action.type === 'FETCH_READER_TEAMS_SUCCESS' ) {

--- a/packages/data-stores/src/reader/resolvers.ts
+++ b/packages/data-stores/src/reader/resolvers.ts
@@ -1,8 +1,6 @@
-/**
- * Internal dependencies
- */
-import { fetchReaderTeamsSuccess, ReaderTeamsResponse } from './actions';
 import { wpcomRequest } from '../wpcom-request-controls';
+
+import { fetchReaderTeamsSuccess, ReaderTeamsResponse } from './actions';
 
 export function* isA8cTeamMember(): Generator {
 	try {

--- a/packages/data-stores/src/reader/resolvers.ts
+++ b/packages/data-stores/src/reader/resolvers.ts
@@ -1,5 +1,4 @@
 import { wpcomRequest } from '../wpcom-request-controls';
-
 import { fetchReaderTeamsSuccess, ReaderTeamsResponse } from './actions';
 
 export function* isA8cTeamMember(): Generator {

--- a/packages/data-stores/src/reader/selectors.ts
+++ b/packages/data-stores/src/reader/selectors.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { State } from './reducer';
 
 export const isA8cTeamMember = ( state: State ): boolean =>

--- a/packages/data-stores/src/reader/test/reader-store.test.ts
+++ b/packages/data-stores/src/reader/test/reader-store.test.ts
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
+import { dispatch, select } from '@wordpress/data';
 import waitForExpect from 'wait-for-expect';
 import wpcomRequest from 'wpcom-proxy-request';
 
-/**
- * Internal dependencies
- */
-import { dispatch, select } from '@wordpress/data';
-import { register } from '../index';
 import { STORE_KEY } from '../constants';
+import { register } from '../index';
 import readerReducer from '../reducer';
 
 jest.mock( 'wpcom-proxy-request', () => ( {

--- a/packages/data-stores/src/reader/test/reader-store.test.ts
+++ b/packages/data-stores/src/reader/test/reader-store.test.ts
@@ -1,7 +1,6 @@
 import { dispatch, select } from '@wordpress/data';
 import waitForExpect from 'wait-for-expect';
 import wpcomRequest from 'wpcom-proxy-request';
-
 import { STORE_KEY } from '../constants';
 import { register } from '../index';
 import readerReducer from '../reducer';

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,6 +1,6 @@
-/**
- * Internal dependencies
- */
+import type { WpcomClientCredentials } from '../shared-types';
+import { wpcomRequest } from '../wpcom-request-controls';
+
 import type {
 	CreateSiteParams,
 	NewSiteErrorResponse,
@@ -11,8 +11,6 @@ import type {
 	Domain,
 	SiteLaunchError as SiteLaunchErrorType,
 } from './types';
-import type { WpcomClientCredentials } from '../shared-types';
-import { wpcomRequest } from '../wpcom-request-controls';
 import { SiteLaunchError } from './types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,5 +1,6 @@
-import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
+import { SiteLaunchError } from './types';
+import type { WpcomClientCredentials } from '../shared-types';
 import type {
 	CreateSiteParams,
 	NewSiteErrorResponse,
@@ -10,7 +11,6 @@ import type {
 	Domain,
 	SiteLaunchError as SiteLaunchErrorType,
 } from './types';
-import { SiteLaunchError } from './types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const fetchSite = () => ( {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,6 +1,5 @@
 import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
-
 import type {
 	CreateSiteParams,
 	NewSiteErrorResponse,

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -10,7 +10,6 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-
 export * from './types';
 export type { State };
 

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -1,19 +1,15 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
-import { createActions } from './actions';
-import * as resolvers from './resolvers';
-import * as selectors from './selectors';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import type { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
+
+import { createActions } from './actions';
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -1,9 +1,7 @@
 import { registerStore } from '@wordpress/data';
-
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import type { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
-
 import { createActions } from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -1,12 +1,12 @@
 import { registerStore } from '@wordpress/data';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
-import type { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
 import { createActions } from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { WpcomClientCredentials } from '../shared-types';
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
+import type { Action } from './actions';
 import {
 	NewSiteBlogDetails,
 	NewSiteErrorResponse,
@@ -15,7 +10,6 @@ import {
 	SiteLaunchState,
 	SiteLaunchStatus,
 } from './types';
-import type { Action } from './actions';
 
 export const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
 	if ( action.type === 'RECEIVE_NEW_SITE' ) {

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -1,6 +1,4 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
-import type { Action } from './actions';
 import {
 	NewSiteBlogDetails,
 	NewSiteErrorResponse,
@@ -9,6 +7,8 @@ import {
 	SiteLaunchState,
 	SiteLaunchStatus,
 } from './types';
+import type { Action } from './actions';
+import type { Reducer } from 'redux';
 
 export const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
 	if ( action.type === 'RECEIVE_NEW_SITE' ) {

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Action } from './actions';
 import {
 	NewSiteBlogDetails,

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { dispatch } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
 import { wpcomRequest } from '../wpcom-request-controls';
+
 import { STORE_KEY } from './constants';
 import type { SiteDetails, Domain } from './types';
 

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -1,7 +1,5 @@
 import { dispatch } from '@wordpress/data';
-
 import { wpcomRequest } from '../wpcom-request-controls';
-
 import { STORE_KEY } from './constants';
 import type { SiteDetails, Domain } from './types';
 

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import type { State } from './reducer';
 import { STORE_KEY } from './constants';
+import type { State } from './reducer';
 import { SiteLaunchStatus } from './types';
 
 export const getState = ( state: State ) => state;

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -1,7 +1,7 @@
 import { select } from '@wordpress/data';
 import { STORE_KEY } from './constants';
-import type { State } from './reducer';
 import { SiteLaunchStatus } from './types';
+import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
 

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -1,5 +1,4 @@
 import { select } from '@wordpress/data';
-
 import { STORE_KEY } from './constants';
 import type { State } from './reducer';
 import { SiteLaunchStatus } from './types';

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -1,9 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * Internal dependencies
- */
+
 import { createActions } from '../actions';
 import { SiteLaunchError } from '../types';
 

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -6,9 +6,7 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
+import { createActions } from '../actions';
 import { sites, launchStatus } from '../reducer';
 import {
 	SiteLaunchError,
@@ -17,7 +15,6 @@ import {
 	SiteDetails,
 	SiteError,
 } from '../types';
-import { createActions } from '../actions';
 
 describe( 'Site', () => {
 	const siteDetailsResponse: SiteDetails = {

--- a/packages/data-stores/src/site/test/resolvers.ts
+++ b/packages/data-stores/src/site/test/resolvers.ts
@@ -6,11 +6,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
-import { getSite } from '../resolvers';
 import { register } from '../';
+import { getSite } from '../resolvers';
 
 beforeAll( () => {
 	register( { client_id: '', client_secret: '' } );

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -6,15 +6,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { dispatch, select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
 
-/**
- * Internal dependencies
- */
 import { register } from '..';
 
 jest.mock( 'wpcom-proxy-request', () => ( {

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -8,7 +8,6 @@
 
 import { dispatch, select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-
 import { register } from '..';
 
 jest.mock( 'wpcom-proxy-request', () => ( {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { FeatureId } from '../wpcom-features';
 
 export interface NewSiteBlogDetails {

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -1,19 +1,14 @@
-/**
- * External dependencies
- */
 import { stringify } from 'qs';
 
-/**
- * Internal dependencies
- */
+import type { WpcomClientCredentials } from '../shared-types';
+import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
+
 import type {
 	CurrentUser,
 	CreateAccountParams,
 	NewUserErrorResponse,
 	NewUserSuccessResponse,
 } from './types';
-import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
-import type { WpcomClientCredentials } from '../shared-types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const receiveCurrentUser = ( currentUser: CurrentUser ) => ( {

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -1,8 +1,6 @@
 import { stringify } from 'qs';
-
 import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
-
 import type {
 	CurrentUser,
 	CreateAccountParams,

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'qs';
-import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
+import type { WpcomClientCredentials } from '../shared-types';
 import type {
 	CurrentUser,
 	CreateAccountParams,

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -10,7 +10,6 @@ import reducer, { State } from './reducer';
 import { createResolvers } from './resolvers';
 import * as selectors from './selectors';
 
-
 export * from './types';
 export type { State };
 

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -1,12 +1,12 @@
 import { registerStore } from '@wordpress/data';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
-import type { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
 import { createActions } from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import { createResolvers } from './resolvers';
 import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { WpcomClientCredentials } from '../shared-types';
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -1,19 +1,15 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
-import { createActions } from './actions';
-import { createResolvers } from './resolvers';
-import * as selectors from './selectors';
-import { controls } from '../wpcom-request-controls';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import type { WpcomClientCredentials } from '../shared-types';
+import { controls } from '../wpcom-request-controls';
+
+import { createActions } from './actions';
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import { createResolvers } from './resolvers';
+import * as selectors from './selectors';
+
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -1,9 +1,7 @@
 import { registerStore } from '@wordpress/data';
-
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import type { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
-
 import { createActions } from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
-import type { CurrentUser, NewUser, NewUserErrorResponse } from './types';
 import type { Action } from './actions';
+import type { CurrentUser, NewUser, NewUserErrorResponse } from './types';
 
 export const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( state, action ) => {
 	switch ( action.type ) {

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
 import type { Action } from './actions';
 import type { CurrentUser, NewUser, NewUserErrorResponse } from './types';
+import type { Reducer } from 'redux';
 
 export const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( state, action ) => {
 	switch ( action.type ) {

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Action } from './actions';
 import type { CurrentUser, NewUser, NewUserErrorResponse } from './types';
 

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -1,9 +1,7 @@
-/**
- * Internal dependencies
- */
-import { wpcomRequest } from '../wpcom-request-controls';
-import { createActions } from './actions';
 import type { WpcomClientCredentials } from '../shared-types';
+import { wpcomRequest } from '../wpcom-request-controls';
+
+import { createActions } from './actions';
 import type { CurrentUser } from './types';
 
 declare global {

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -1,6 +1,6 @@
-import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
 import { createActions } from './actions';
+import type { WpcomClientCredentials } from '../shared-types';
 import type { CurrentUser } from './types';
 
 declare global {

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -1,6 +1,5 @@
 import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
-
 import { createActions } from './actions';
 import type { CurrentUser } from './types';
 

--- a/packages/data-stores/src/user/selectors.ts
+++ b/packages/data-stores/src/user/selectors.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;

--- a/packages/data-stores/src/user/test/actions.ts
+++ b/packages/data-stores/src/user/test/actions.ts
@@ -6,9 +6,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { createActions } from '../actions';
 
 const client_id = 'magic_client_id';

--- a/packages/data-stores/src/user/test/reducer.ts
+++ b/packages/data-stores/src/user/test/reducer.ts
@@ -6,11 +6,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
-import { currentUser, newUserData, newUserError, isFetchingNewUser } from '../reducer';
 import { createActions } from '../actions';
+import { currentUser, newUserData, newUserError, isFetchingNewUser } from '../reducer';
 
 const {
 	receiveCurrentUser,

--- a/packages/data-stores/src/user/test/resolvers.ts
+++ b/packages/data-stores/src/user/test/resolvers.ts
@@ -6,9 +6,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { createResolvers } from '../resolvers';
 
 const { getCurrentUser } = createResolvers( { client_id: '', client_secret: '' } );

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { Action } from 'redux';
 
 export interface CurrentUser {

--- a/packages/data-stores/src/verticals-templates/actions.ts
+++ b/packages/data-stores/src/verticals-templates/actions.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { Template } from './types';
 
 export const receiveTemplates = ( verticalId: string, templates: Template[] ) => ( {

--- a/packages/data-stores/src/verticals-templates/index.ts
+++ b/packages/data-stores/src/verticals-templates/index.ts
@@ -1,8 +1,6 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/verticals-templates/index.ts
+++ b/packages/data-stores/src/verticals-templates/index.ts
@@ -9,7 +9,6 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-
 export * from './types';
 export type { State };
 

--- a/packages/data-stores/src/verticals-templates/index.ts
+++ b/packages/data-stores/src/verticals-templates/index.ts
@@ -1,18 +1,14 @@
-/**
- * External dependencies
- */
-import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
 
-/**
- * Internal dependencies
- */
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
+import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
-import * as actions from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/verticals-templates/index.ts
+++ b/packages/data-stores/src/verticals-templates/index.ts
@@ -1,11 +1,11 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
 export * from './types';
 export type { State };

--- a/packages/data-stores/src/verticals-templates/reducer.ts
+++ b/packages/data-stores/src/verticals-templates/reducer.ts
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
-import type { Template } from './types';
 import type { Action } from './actions';
+import type { Template } from './types';
 
 const templates: Reducer< Record< string, Template[] | undefined >, Action > = (
 	state = {},

--- a/packages/data-stores/src/verticals-templates/reducer.ts
+++ b/packages/data-stores/src/verticals-templates/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Action } from './actions';
 import type { Template } from './types';
 

--- a/packages/data-stores/src/verticals-templates/reducer.ts
+++ b/packages/data-stores/src/verticals-templates/reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
 import type { Action } from './actions';
 import type { Template } from './types';
+import type { Reducer } from 'redux';
 
 const templates: Reducer< Record< string, Template[] | undefined >, Action > = (
 	state = {},

--- a/packages/data-stores/src/verticals-templates/resolvers.ts
+++ b/packages/data-stores/src/verticals-templates/resolvers.ts
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { apiFetch } from '@wordpress/data-controls';
 
-/**
- * Internal dependencies
- */
 import { receiveTemplates } from './actions';
 import type { getTemplates as getTemplatesSelector } from './selectors';
 import type { Template } from './types';

--- a/packages/data-stores/src/verticals-templates/resolvers.ts
+++ b/packages/data-stores/src/verticals-templates/resolvers.ts
@@ -1,5 +1,4 @@
 import { apiFetch } from '@wordpress/data-controls';
-
 import { receiveTemplates } from './actions';
 import type { getTemplates as getTemplatesSelector } from './selectors';
 import type { Template } from './types';

--- a/packages/data-stores/src/verticals-templates/selectors.ts
+++ b/packages/data-stores/src/verticals-templates/selectors.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { State } from './reducer';
 
 /**

--- a/packages/data-stores/src/verticals/actions.ts
+++ b/packages/data-stores/src/verticals/actions.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { Vertical } from './types';
 
 export const receiveVerticals = ( verticals: Vertical[] ) => ( {

--- a/packages/data-stores/src/verticals/index.ts
+++ b/packages/data-stores/src/verticals/index.ts
@@ -1,8 +1,6 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
-
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';

--- a/packages/data-stores/src/verticals/index.ts
+++ b/packages/data-stores/src/verticals/index.ts
@@ -1,18 +1,14 @@
-/**
- * External dependencies
- */
-import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
 
-/**
- * Internal dependencies
- */
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
+import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
-import * as actions from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
 
 export type { Vertical } from './types';
 export type { State };

--- a/packages/data-stores/src/verticals/index.ts
+++ b/packages/data-stores/src/verticals/index.ts
@@ -9,7 +9,6 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-
 export type { Vertical } from './types';
 export type { State };
 

--- a/packages/data-stores/src/verticals/index.ts
+++ b/packages/data-stores/src/verticals/index.ts
@@ -1,11 +1,11 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
 export type { Vertical } from './types';
 export type { State };

--- a/packages/data-stores/src/verticals/reducer.ts
+++ b/packages/data-stores/src/verticals/reducer.ts
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
-import type { Vertical } from './types';
 import type { Action } from './actions';
+import type { Vertical } from './types';
 
 const verticals: Reducer< Vertical[], Action > = ( state = [], action ) => {
 	if ( action.type === 'RECEIVE_VERTICALS' ) {

--- a/packages/data-stores/src/verticals/reducer.ts
+++ b/packages/data-stores/src/verticals/reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
-import type { Reducer } from 'redux';
 import type { Action } from './actions';
 import type { Vertical } from './types';
+import type { Reducer } from 'redux';
 
 const verticals: Reducer< Vertical[], Action > = ( state = [], action ) => {
 	if ( action.type === 'RECEIVE_VERTICALS' ) {

--- a/packages/data-stores/src/verticals/reducer.ts
+++ b/packages/data-stores/src/verticals/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { Reducer } from 'redux';
-
 import type { Action } from './actions';
 import type { Vertical } from './types';
 

--- a/packages/data-stores/src/verticals/resolvers.ts
+++ b/packages/data-stores/src/verticals/resolvers.ts
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { apiFetch } from '@wordpress/data-controls';
 
-/**
- * Internal dependencies
- */
 import { receiveVerticals } from './actions';
 import type { Vertical } from './types';
 

--- a/packages/data-stores/src/verticals/resolvers.ts
+++ b/packages/data-stores/src/verticals/resolvers.ts
@@ -1,5 +1,4 @@
 import { apiFetch } from '@wordpress/data-controls';
-
 import { receiveVerticals } from './actions';
 import type { Vertical } from './types';
 

--- a/packages/data-stores/src/verticals/selectors.ts
+++ b/packages/data-stores/src/verticals/selectors.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;

--- a/packages/data-stores/src/wpcom-features/features-data.tsx
+++ b/packages/data-stores/src/wpcom-features/features-data.tsx
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
 import * as Plans from '../plans';
+
 import type { FeatureId, Feature } from './types';
-/**
- * Internal dependencies
- */
+
 const {
 	TIMELESS_PLAN_PERSONAL,
 	TIMELESS_PLAN_PREMIUM,

--- a/packages/data-stores/src/wpcom-features/features-data.tsx
+++ b/packages/data-stores/src/wpcom-features/features-data.tsx
@@ -1,5 +1,4 @@
 import * as Plans from '../plans';
-
 import type { FeatureId, Feature } from './types';
 
 const {

--- a/packages/data-stores/src/wpcom-features/index.ts
+++ b/packages/data-stores/src/wpcom-features/index.ts
@@ -1,14 +1,9 @@
-/**
- * External dependencies
- */
-import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
 import type { Reducer, AnyAction } from 'redux';
+
 import type { SelectFromMap } from '../mapped-types';
 
-/**
- * Internal dependencies
- */
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';

--- a/packages/data-stores/src/wpcom-features/index.ts
+++ b/packages/data-stores/src/wpcom-features/index.ts
@@ -1,10 +1,10 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import type { Reducer, AnyAction } from 'redux';
-import type { SelectFromMap } from '../mapped-types';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';
+import type { SelectFromMap } from '../mapped-types';
+import type { Reducer, AnyAction } from 'redux';
 
 export type { State };
 export type { FeatureId, Feature } from './types';

--- a/packages/data-stores/src/wpcom-features/index.ts
+++ b/packages/data-stores/src/wpcom-features/index.ts
@@ -1,9 +1,7 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import type { Reducer, AnyAction } from 'redux';
-
 import type { SelectFromMap } from '../mapped-types';
-
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as selectors from './selectors';

--- a/packages/data-stores/src/wpcom-features/reducer.ts
+++ b/packages/data-stores/src/wpcom-features/reducer.ts
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import type { AnyAction, Reducer } from 'redux';
 
-/**
- * Internal dependencies
- */
-import type { Feature, FeatureId } from './types';
 import { featuresList } from './features-data';
+import type { Feature, FeatureId } from './types';
 
 export type State = Record< FeatureId, Feature >;
 

--- a/packages/data-stores/src/wpcom-features/reducer.ts
+++ b/packages/data-stores/src/wpcom-features/reducer.ts
@@ -1,6 +1,6 @@
-import type { AnyAction, Reducer } from 'redux';
 import { featuresList } from './features-data';
 import type { Feature, FeatureId } from './types';
+import type { AnyAction, Reducer } from 'redux';
 
 export type State = Record< FeatureId, Feature >;
 

--- a/packages/data-stores/src/wpcom-features/reducer.ts
+++ b/packages/data-stores/src/wpcom-features/reducer.ts
@@ -1,5 +1,4 @@
 import type { AnyAction, Reducer } from 'redux';
-
 import { featuresList } from './features-data';
 import type { Feature, FeatureId } from './types';
 

--- a/packages/data-stores/src/wpcom-features/selectors.ts
+++ b/packages/data-stores/src/wpcom-features/selectors.ts
@@ -1,5 +1,5 @@
-import type { PlanSlug } from '../plans';
 import { plansOrder } from '../plans/constants';
+import type { PlanSlug } from '../plans';
 import type { State } from './reducer';
 import type { FeatureId } from './types';
 

--- a/packages/data-stores/src/wpcom-features/selectors.ts
+++ b/packages/data-stores/src/wpcom-features/selectors.ts
@@ -4,7 +4,6 @@ import { plansOrder } from '../plans/constants';
 import type { State } from './reducer';
 import type { FeatureId } from './types';
 
-
 export const getAllFeatures = ( state: State ) => state;
 
 export const getRecommendedPlanSlug = (

--- a/packages/data-stores/src/wpcom-features/selectors.ts
+++ b/packages/data-stores/src/wpcom-features/selectors.ts
@@ -1,11 +1,9 @@
-/**
- * Internal dependencies
- */
+import type { PlanSlug } from '../plans';
+import { plansOrder } from '../plans/constants';
+
 import type { State } from './reducer';
 import type { FeatureId } from './types';
 
-import { plansOrder } from '../plans/constants';
-import type { PlanSlug } from '../plans';
 
 export const getAllFeatures = ( state: State ) => state;
 

--- a/packages/data-stores/src/wpcom-features/selectors.ts
+++ b/packages/data-stores/src/wpcom-features/selectors.ts
@@ -1,6 +1,5 @@
 import type { PlanSlug } from '../plans';
 import { plansOrder } from '../plans/constants';
-
 import type { State } from './reducer';
 import type { FeatureId } from './types';
 

--- a/packages/data-stores/src/wpcom-features/types.ts
+++ b/packages/data-stores/src/wpcom-features/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { PlanSlug } from '../plans';
 
 export type FeatureId =

--- a/packages/data-stores/src/wpcom-request-controls/index.ts
+++ b/packages/data-stores/src/wpcom-request-controls/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import wpcomProxyRequest, {
 	reloadProxy as triggerReloadProxy,
 	requestAllBlogsAccess as triggerRequestAllBlogsAccess,


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/data-stores` to use `import/order`

#### Testing instructions

N/A