### PR TITLE
Domains: Include tooltips for domain management header items

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -20,6 +20,7 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
  * Style dependencies
  */
 import './style.scss';
+import Tooltip from 'calypso/components/tooltip';
 
 class ListHeader extends React.PureComponent {
 	static propTypes = {
@@ -38,6 +39,33 @@ class ListHeader extends React.PureComponent {
 		isChecked: false,
 	};
 
+	elementsData = {
+		transferLock: {
+			ref: React.createRef(),
+			getVisibility: () => this.state?.transferLockTooltipVisible,
+		},
+		privacy: {
+			ref: React.createRef(),
+			getVisibility: () => this.state?.privacyTooltipVisible,
+		},
+		autoRenew: {
+			ref: React.createRef(),
+			getVisibility: () => this.state?.autoRenewTooltipVisible,
+		},
+		email: {
+			ref: React.createRef(),
+			getVisibility: () => this.state?.emailTooltipVisible,
+		},
+	};
+
+	enableTooltip = ( name ) => {
+		this.setState( { [ `${ name }TooltipVisible` ]: true } );
+	};
+
+	disableTooltip = ( name ) => {
+		this.setState( { [ `${ name }TooltipVisible` ]: false } );
+	};
+
 	stopPropagation = ( event ) => {
 		event.stopPropagation();
 	};
@@ -54,7 +82,12 @@ class ListHeader extends React.PureComponent {
 		return (
 			<>
 				<div className="list__domain-link" />
-				<div className="list__domain-transfer-lock">
+				<div
+					className="list__domain-transfer-lock"
+					onMouseEnter={ () => this.enableTooltip( 'transferLock' ) }
+					onMouseLeave={ () => this.disableTooltip( 'transferLock' ) }
+					ref={ this.elementsData.transferLock.ref }
+				>
 					<span>{ translate( 'Transfer lock' ) }</span>
 					<InfoPopover iconSize={ 18 }>
 						{ translate(
@@ -64,7 +97,12 @@ class ListHeader extends React.PureComponent {
 						) }
 					</InfoPopover>
 				</div>
-				<div className="list__domain-privacy">
+				<div
+					className="list__domain-privacy"
+					onMouseEnter={ () => this.enableTooltip( 'privacy' ) }
+					onMouseLeave={ () => this.disableTooltip( 'privacy' ) }
+					ref={ this.elementsData.privacy.ref }
+				>
 					<span>{ translate( 'Privacy' ) }</span>
 					<InfoPopover iconSize={ 18 }>
 						{ translate(
@@ -74,7 +112,12 @@ class ListHeader extends React.PureComponent {
 						) }
 					</InfoPopover>
 				</div>
-				<div className="list__domain-auto-renew">
+				<div
+					className="list__domain-auto-renew"
+					onMouseEnter={ () => this.enableTooltip( 'autoRenew' ) }
+					onMouseLeave={ () => this.disableTooltip( 'autoRenew' ) }
+					ref={ this.elementsData.autoRenew.ref }
+				>
 					<span>{ translate( 'Auto-renew' ) }</span>
 					<InfoPopover iconSize={ 18 }>
 						{ translate(
@@ -83,7 +126,12 @@ class ListHeader extends React.PureComponent {
 						) }
 					</InfoPopover>
 				</div>
-				<div className="list__domain-email">
+				<div
+					className="list__domain-email"
+					onMouseEnter={ () => this.enableTooltip( 'email' ) }
+					onMouseLeave={ () => this.disableTooltip( 'email' ) }
+					ref={ this.elementsData.email.ref }
+				>
 					<span>{ translate( 'Email' ) }</span>
 					<InfoPopover iconSize={ 18 }>
 						{ translate(
@@ -101,6 +149,37 @@ class ListHeader extends React.PureComponent {
 					</InfoPopover>
 				</div>
 				<div className="list__domain-options"></div>
+
+				<>
+					<Tooltip
+						context={ this.elementsData.transferLock.ref.current }
+						isVisible={ this.elementsData.transferLock.getVisibility() }
+						position="top"
+					>
+						{ translate( 'Transfer lock' ) }
+					</Tooltip>
+					<Tooltip
+						context={ this.elementsData.privacy.ref.current }
+						isVisible={ this.elementsData.privacy.getVisibility() }
+						position="top"
+					>
+						{ translate( 'Privacy' ) }
+					</Tooltip>
+					<Tooltip
+						context={ this.elementsData.autoRenew.ref.current }
+						isVisible={ this.elementsData.autoRenew.getVisibility() }
+						position="top"
+					>
+						{ translate( 'Auto-renew' ) }
+					</Tooltip>
+					<Tooltip
+						context={ this.elementsData.email.ref.current }
+						isVisible={ this.elementsData.email.getVisibility() }
+						position="top"
+					>
+						{ translate( 'Email' ) }
+					</Tooltip>
+				</>
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -15,6 +15,7 @@ import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getTitanProductName } from 'calypso/lib/titan';
 import { ListAllActions } from 'calypso/my-sites/domains/domain-management/list/utils';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import withDimensions from 'calypso/lib/with-dimensions';
 
 /**
  * Style dependencies
@@ -39,7 +40,7 @@ class ListHeader extends React.PureComponent {
 		isChecked: false,
 	};
 
-	elementsData = {
+	headerElements = {
 		transferLock: {
 			ref: React.createRef(),
 			getVisibility: () => this.state?.transferLockTooltipVisible,
@@ -76,110 +77,86 @@ class ListHeader extends React.PureComponent {
 		}
 	};
 
-	renderDefaultHeaderContent() {
+	renderHeaderItems() {
 		const { translate } = this.props;
+		const items = [
+			{
+				className: 'list__domain-transfer-lock',
+				name: 'transferLock',
+				title: translate( 'Transfer lock' ),
+				popoverText: translate(
+					'When enabled, a transfer lock prevents your domain from being transferred to another ' +
+						'provider. Sometimes the transfer lock cannot be disabled, such as when a domain ' +
+						'is recently registered.'
+				),
+			},
 
+			{
+				className: 'list__domain-privacy',
+				name: 'privacy',
+				title: translate( 'Privacy' ),
+				popoverText: translate(
+					'Enabling domain privacy protection hides your contact information from public view. ' +
+						'For some domain extensions, such as some country specific domain extensions, ' +
+						'privacy protection is not available.'
+				),
+			},
+
+			{
+				className: 'list__domain-auto-renew',
+				name: 'autoRenew',
+				title: translate( 'Auto-renew' ),
+				popoverText: translate(
+					'When auto-renew is enabled, we will automatically attempt to renew your domain 30 days ' +
+						'before it expires, to ensure you do not lose access to your domain.'
+				),
+			},
+
+			{
+				className: 'list__domain-email',
+				name: 'email',
+				title: translate( 'Email' ),
+				popoverText: translate(
+					'You can receive email using your custom domain by purchasing %(titanMailService)s or %(googleMailService)s, or by ' +
+						'setting up email forwarding. Note that email forwarding requires a plan subscription.',
+					{
+						args: {
+							googleMailService: getGoogleMailServiceFamily(),
+							titanMailService: getTitanProductName(),
+						},
+						comment:
+							'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s will be "Professional Email" translated',
+					}
+				),
+			},
+		];
+
+		return items.map( ( item ) => (
+			<div
+				className={ item.className }
+				onMouseEnter={ () => this.enableTooltip( item.name ) }
+				onMouseLeave={ () => this.disableTooltip( item.name ) }
+				ref={ this.headerElements[ item.name ].ref }
+			>
+				<span>{ item.title }</span>
+				<InfoPopover iconSize={ 18 }>{ item.popoverText }</InfoPopover>
+				<Tooltip
+					context={ this.headerElements[ item.name ].ref.current }
+					isVisible={ this.headerElements[ item.name ].getVisibility() }
+					position="top"
+				>
+					{ item.title }
+				</Tooltip>
+			</div>
+		) );
+	}
+
+	renderDefaultHeaderContent() {
 		return (
 			<>
 				<div className="list__domain-link" />
-				<div
-					className="list__domain-transfer-lock"
-					onMouseEnter={ () => this.enableTooltip( 'transferLock' ) }
-					onMouseLeave={ () => this.disableTooltip( 'transferLock' ) }
-					ref={ this.elementsData.transferLock.ref }
-				>
-					<span>{ translate( 'Transfer lock' ) }</span>
-					<InfoPopover iconSize={ 18 }>
-						{ translate(
-							'When enabled, a transfer lock prevents your domain from being transferred to another ' +
-								'provider. Sometimes the transfer lock cannot be disabled, such as when a domain ' +
-								'is recently registered.'
-						) }
-					</InfoPopover>
-				</div>
-				<div
-					className="list__domain-privacy"
-					onMouseEnter={ () => this.enableTooltip( 'privacy' ) }
-					onMouseLeave={ () => this.disableTooltip( 'privacy' ) }
-					ref={ this.elementsData.privacy.ref }
-				>
-					<span>{ translate( 'Privacy' ) }</span>
-					<InfoPopover iconSize={ 18 }>
-						{ translate(
-							'Enabling domain privacy protection hides your contact information from public view. ' +
-								'For some domain extensions, such as some country specific domain extensions, ' +
-								'privacy protection is not available.'
-						) }
-					</InfoPopover>
-				</div>
-				<div
-					className="list__domain-auto-renew"
-					onMouseEnter={ () => this.enableTooltip( 'autoRenew' ) }
-					onMouseLeave={ () => this.disableTooltip( 'autoRenew' ) }
-					ref={ this.elementsData.autoRenew.ref }
-				>
-					<span>{ translate( 'Auto-renew' ) }</span>
-					<InfoPopover iconSize={ 18 }>
-						{ translate(
-							'When auto-renew is enabled, we will automatically attempt to renew your domain 30 days ' +
-								'before it expires, to ensure you do not lose access to your domain.'
-						) }
-					</InfoPopover>
-				</div>
-				<div
-					className="list__domain-email"
-					onMouseEnter={ () => this.enableTooltip( 'email' ) }
-					onMouseLeave={ () => this.disableTooltip( 'email' ) }
-					ref={ this.elementsData.email.ref }
-				>
-					<span>{ translate( 'Email' ) }</span>
-					<InfoPopover iconSize={ 18 }>
-						{ translate(
-							'You can receive email using your custom domain by purchasing %(titanMailService)s or %(googleMailService)s, or by ' +
-								'setting up email forwarding. Note that email forwarding requires a plan subscription.',
-							{
-								args: {
-									googleMailService: getGoogleMailServiceFamily(),
-									titanMailService: getTitanProductName(),
-								},
-								comment:
-									'%(googleMailService)s can be either "G Suite" or "Google Workspace"; %(titanMailService)s will be "Professional Email" translated',
-							}
-						) }
-					</InfoPopover>
-				</div>
+				{ this.renderHeaderItems() }
 				<div className="list__domain-options"></div>
-
-				<>
-					<Tooltip
-						context={ this.elementsData.transferLock.ref.current }
-						isVisible={ this.elementsData.transferLock.getVisibility() }
-						position="top"
-					>
-						{ translate( 'Transfer lock' ) }
-					</Tooltip>
-					<Tooltip
-						context={ this.elementsData.privacy.ref.current }
-						isVisible={ this.elementsData.privacy.getVisibility() }
-						position="top"
-					>
-						{ translate( 'Privacy' ) }
-					</Tooltip>
-					<Tooltip
-						context={ this.elementsData.autoRenew.ref.current }
-						isVisible={ this.elementsData.autoRenew.getVisibility() }
-						position="top"
-					>
-						{ translate( 'Auto-renew' ) }
-					</Tooltip>
-					<Tooltip
-						context={ this.elementsData.email.ref.current }
-						isVisible={ this.elementsData.email.getVisibility() }
-						position="top"
-					>
-						{ translate( 'Email' ) }
-					</Tooltip>
-				</>
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -15,7 +15,6 @@ import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getTitanProductName } from 'calypso/lib/titan';
 import { ListAllActions } from 'calypso/my-sites/domains/domain-management/list/utils';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
-import withDimensions from 'calypso/lib/with-dimensions';
 
 /**
  * Style dependencies
@@ -40,24 +39,36 @@ class ListHeader extends React.PureComponent {
 		isChecked: false,
 	};
 
-	headerElements = {
-		transferLock: {
-			ref: React.createRef(),
-			getVisibility: () => this.state?.transferLockTooltipVisible,
-		},
-		privacy: {
-			ref: React.createRef(),
-			getVisibility: () => this.state?.privacyTooltipVisible,
-		},
-		autoRenew: {
-			ref: React.createRef(),
-			getVisibility: () => this.state?.autoRenewTooltipVisible,
-		},
-		email: {
-			ref: React.createRef(),
-			getVisibility: () => this.state?.emailTooltipVisible,
-		},
-	};
+	constructor() {
+		super();
+		this.state = {};
+		this.headerElements = {
+			transferLock: {
+				ref: React.createRef(),
+				enableTooltip: this.enableTooltip.bind( this, 'transferLock' ),
+				disableTooltip: this.disableTooltip.bind( this, 'transferLock' ),
+				tooltipName: 'transferLockTooltipVisible',
+			},
+			privacy: {
+				ref: React.createRef(),
+				enableTooltip: this.enableTooltip.bind( this, 'privacy' ),
+				disableTooltip: this.disableTooltip.bind( this, 'privacy' ),
+				tooltipName: 'privacyTooltipVisible',
+			},
+			autoRenew: {
+				ref: React.createRef(),
+				enableTooltip: this.enableTooltip.bind( this, 'autoRenew' ),
+				disableTooltip: this.disableTooltip.bind( this, 'autoRenew' ),
+				tooltipName: 'autoRenewTooltipVisible',
+			},
+			email: {
+				ref: React.createRef(),
+				enableTooltip: this.enableTooltip.bind( this, 'email' ),
+				disableTooltip: this.disableTooltip.bind( this, 'email' ),
+				tooltipName: 'emailTooltipVisible',
+			},
+		};
+	}
 
 	enableTooltip = ( name ) => {
 		this.setState( { [ `${ name }TooltipVisible` ]: true } );
@@ -133,16 +144,17 @@ class ListHeader extends React.PureComponent {
 
 		return items.map( ( item ) => (
 			<div
+				key={ item.name }
 				className={ item.className }
-				onMouseEnter={ () => this.enableTooltip( item.name ) }
-				onMouseLeave={ () => this.disableTooltip( item.name ) }
+				onMouseEnter={ this.headerElements[ item.name ].enableTooltip }
+				onMouseLeave={ this.headerElements[ item.name ].disableTooltip }
 				ref={ this.headerElements[ item.name ].ref }
 			>
 				<span>{ item.title }</span>
 				<InfoPopover iconSize={ 18 }>{ item.popoverText }</InfoPopover>
 				<Tooltip
 					context={ this.headerElements[ item.name ].ref.current }
-					isVisible={ this.headerElements[ item.name ].getVisibility() }
+					isVisible={ this.state[ this.headerElements[ item.name ].tooltipName ] }
 					position="top"
 				>
 					{ item.title }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
On the domain management page, when the user language is not English and the column translations are longer than the English text, the column headings are truncated. This PR improves this experience by adding a tooltip (while hovering) containing the full text.

#### Testing instructions
Visit the `/domains/manage?site=all` page and hover over the headers. Check that the tooltip is being displayed.

<img width="1070" alt="after" src="https://user-images.githubusercontent.com/18705930/125395002-ef988000-e380-11eb-80f1-ab83ceca1b9e.png">