### PR TITLE
Domains: Replace "loch ness monster" graphic with "find a domain" graphic

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -21,6 +21,7 @@ import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
+import Illustration from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
 
 /**
  * Style dependencies
@@ -33,10 +34,7 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 		return (
 			<div>
 				<QuerySiteDomains siteId={ siteId } />
-				<EmptyContent
-					className="domain-only-site__placeholder"
-					illustration={ '/calypso/images/drake/drake-browser.svg' }
-				/>
+				<EmptyContent className="domain-only-site__placeholder" illustration={ Illustration } />
 			</div>
 		);
 	}
@@ -69,7 +67,7 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 				actionURL={ canCreateSite && createSiteUrl }
 				secondaryAction={ translate( 'Manage domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
-				illustration={ '/calypso/images/drake/drake-browser.svg' }
+				illustration={ Illustration }
 			>
 				<Button
 					className="empty-content__action button"


### PR DESCRIPTION
#### Changes proposed in this Pull Request
It just replaces the loch ness monster illustration with the 'find a domain' one. 😸 

#### Testing instructions
Check that the illustration was correctly replaced.

##### Before
<img width="939" alt="loch-ness" src="https://user-images.githubusercontent.com/18705930/125397540-74d16400-e384-11eb-9374-44c3ef425fbc.png">

##### After
<img width="923" alt="find-a-domain" src="https://user-images.githubusercontent.com/18705930/125397532-7307a080-e384-11eb-8bee-98f41fae58c5.png">