### PR TITLE
Add new data structure to maintain marketplace product details

### DIFF
--- a/client/my-sites/marketplace/constants.ts
+++ b/client/my-sites/marketplace/constants.ts
@@ -1,23 +1,13 @@
 /**
  * External dependencies
  */
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+import { YOAST_PREMIUM } from '@automattic/calypso-products';
 import debugFactory from 'debug';
 
 export const marketplaceDebugger = debugFactory( 'marketplace-debugger' );
 
 export const MARKETPLACE_FLOW_ID = 'marketplace_flow';
 export const ANALYTICS_UI_LOCATION_MARKETPLACE_DOMAIN_SELECTION = 'marketplace_domain_selection';
-
-/**
- * Internal dependencies
- */
-import {
-	IProductDefinition,
-	IProductCollection,
-	IProductGroupCollection,
-	YOAST,
-} from 'calypso/my-sites/marketplace/types';
 
 // ********** This section to be refactored out with new definition below **********
 export default interface PluginProductMappingInterface {
@@ -34,90 +24,3 @@ export function getProductSlug( pluginSlug: keyof PluginProductMappingInterface 
 	return PLUGIN_PRODUCT_MAP[ pluginSlug ];
 }
 // ************************************************************************************
-
-// TODO: Integrate this data structure with marketplace code
-export const productGroups: IProductGroupCollection = {
-	[ YOAST ]: {
-		products: {
-			[ YOAST_PREMIUM ]: {
-				defaultPluginSlug: 'wordpress-seo',
-				pluginsToBeInstalled: [ 'wordpress-seo-premium', 'wordpress-seo', 'yoast-test-helper' ],
-				isPurchasableProduct: true,
-			},
-			[ YOAST_FREE ]: {
-				defaultPluginSlug: 'wordpress-seo',
-				pluginsToBeInstalled: [ 'wordpress-seo' ],
-				isPurchasableProduct: false,
-			},
-		},
-	},
-};
-
-/**
- * Provides the plugin that needs to be installed for a given product
- *
- * @param {string} productGroupSlug The product group the product belongs to
- * @param {string} productSlug The product slug being setup.
- * @returns {array[string]} An array of plugin slugs, returns null if product does slug not exist
- */
-export function getPluginsToInstall(
-	productGroupSlug: keyof IProductGroupCollection,
-	productSlug: keyof IProductCollection
-): string[] | null {
-	const { pluginsToBeInstalled } = productGroups[ productGroupSlug ]?.products[ productSlug ] ?? {};
-	return pluginsToBeInstalled ? pluginsToBeInstalled : null;
-}
-
-/**
- * Provides the first product found in the product group definition
- *
- * @param {string} productGroupSlug The product group required.\
- * @returns {string} The product slug
- */
-export function getDefaultProductInProductGroup(
-	productGroupSlug: keyof IProductGroupCollection
-): string | null {
-	const { products } = productGroups[ productGroupSlug ] ?? {};
-	if ( products ) {
-		const productKeys = Object.keys( products );
-		const [ product ] = productKeys;
-		return product ? product : null;
-	}
-	return null;
-}
-
-/**
- * Provides the first plugin found in the product definitions
- *
- * @param {string} productGroupSlug The product group the product belongs to
- * @param {string} productSlug The product slug being setup
- * @returns {string} The plugin slug
- */
-export function getDefaultPluginInProduct(
-	productGroupSlug: keyof IProductGroupCollection,
-	productSlug: keyof IProductCollection
-): string | null {
-	const { defaultPluginSlug } = productGroups[ productGroupSlug ]?.products[ productSlug ] ?? {};
-	return defaultPluginSlug ? defaultPluginSlug : null;
-}
-
-/**
- * Provides the first plugin found in the product definitions
- *
- * @param {string} productGroupSlug The product group the product belongs to
- * @param {string} productSlug The product slug
- * @returns {string} The product details
- */
-export function getProductDefinition(
-	productGroupSlug: keyof IProductGroupCollection,
-	productSlug: keyof IProductCollection
-): IProductDefinition | null {
-	const productDefinition = productGroups[ productGroupSlug ]?.products[ productSlug ];
-	if ( ! productDefinition ) {
-		marketplaceDebugger(
-			`Product does not exist for provided parameters: ${ productGroupSlug }, ${ productSlug }`
-		);
-		return null;
-	}
-	return productDefinition;
-}

--- a/client/my-sites/marketplace/constants.ts
+++ b/client/my-sites/marketplace/constants.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { YOAST_SEO } from '@automattic/calypso-products';
+import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
 import debugFactory from 'debug';
 
 export const marketplaceDebugger = debugFactory( 'marketplace-debugger' );
@@ -9,18 +9,115 @@ export const marketplaceDebugger = debugFactory( 'marketplace-debugger' );
 export const MARKETPLACE_FLOW_ID = 'marketplace_flow';
 export const ANALYTICS_UI_LOCATION_MARKETPLACE_DOMAIN_SELECTION = 'marketplace_domain_selection';
 
-// Marketplace plugin - product relationship mapped by SLUG
+/**
+ * Internal dependencies
+ */
+import {
+	IProductDefinition,
+	IProductCollection,
+	IProductGroupCollection,
+	YOAST,
+} from 'calypso/my-sites/marketplace/types';
+
+// ********** This section to be refactored out with new definition below **********
 export default interface PluginProductMappingInterface {
 	readonly 'wordpress-seo': string;
 	readonly 'wordpress-seo-premium': string;
 }
 
-// TODO: Refactor to a product indexed map of plugins
 export const PLUGIN_PRODUCT_MAP: PluginProductMappingInterface = {
-	'wordpress-seo': YOAST_SEO,
-	'wordpress-seo-premium': YOAST_SEO,
+	'wordpress-seo': YOAST_PREMIUM,
+	'wordpress-seo-premium': YOAST_PREMIUM,
 };
 
 export function getProductSlug( pluginSlug: keyof PluginProductMappingInterface ): string {
 	return PLUGIN_PRODUCT_MAP[ pluginSlug ];
+}
+// ************************************************************************************
+
+// TODO: Integrate this data structure with marketplace code
+export const productGroups: IProductGroupCollection = {
+	[ YOAST ]: {
+		products: {
+			[ YOAST_PREMIUM ]: {
+				defaultPluginSlug: 'wordpress-seo',
+				pluginsToBeInstalled: [ 'wordpress-seo-premium', 'wordpress-seo', 'yoast-test-helper' ],
+				isPurchasableProduct: true,
+			},
+			[ YOAST_FREE ]: {
+				defaultPluginSlug: 'wordpress-seo',
+				pluginsToBeInstalled: [ 'wordpress-seo' ],
+				isPurchasableProduct: false,
+			},
+		},
+	},
+};
+
+/**
+ * Provides the plugin that needs to be installed for a given product
+ *
+ * @param {string} productGroupSlug The product group the product belongs to
+ * @param {string} productSlug The product slug being setup.
+ * @returns {array[string]} An array of plugin slugs, returns null if product does slug not exist
+ */
+export function getPluginsToInstall(
+	productGroupSlug: keyof IProductGroupCollection,
+	productSlug: keyof IProductCollection
+): string[] | null {
+	const { pluginsToBeInstalled } = productGroups[ productGroupSlug ]?.products[ productSlug ] ?? {};
+	return pluginsToBeInstalled ? pluginsToBeInstalled : null;
+}
+
+/**
+ * Provides the first product found in the product group definition
+ *
+ * @param {string} productGroupSlug The product group required.\
+ * @returns {string} The product slug
+ */
+export function getDefaultProductInProductGroup(
+	productGroupSlug: keyof IProductGroupCollection
+): string | null {
+	const { products } = productGroups[ productGroupSlug ] ?? {};
+	if ( products ) {
+		const productKeys = Object.keys( products );
+		const [ product ] = productKeys;
+		return product ? product : null;
+	}
+	return null;
+}
+
+/**
+ * Provides the first plugin found in the product definitions
+ *
+ * @param {string} productGroupSlug The product group the product belongs to
+ * @param {string} productSlug The product slug being setup
+ * @returns {string} The plugin slug
+ */
+export function getDefaultPluginInProduct(
+	productGroupSlug: keyof IProductGroupCollection,
+	productSlug: keyof IProductCollection
+): string | null {
+	const { defaultPluginSlug } = productGroups[ productGroupSlug ]?.products[ productSlug ] ?? {};
+	return defaultPluginSlug ? defaultPluginSlug : null;
+}
+
+/**
+ * Provides the first plugin found in the product definitions
+ *
+ * @param {string} productGroupSlug The product group the product belongs to
+ * @param {string} productSlug The product slug
+ * @returns {string} The product details
+ */
+export function getProductDefinition(
+	productGroupSlug: keyof IProductGroupCollection,
+	productSlug: keyof IProductCollection
+): IProductDefinition | null {
+	const productDefinition = productGroups[ productGroupSlug ]?.products[ productSlug ];
+	if ( ! productDefinition ) {
+		marketplaceDebugger(
+			`Product does not exist for provided parameters: ${ productGroupSlug }, ${ productSlug }`
+		);
+		return null;
+	}
+	return productDefinition;
 }

--- a/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
+++ b/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+
+/**
+ * Internal dependencies
+ */
+import {
+	IProductDefinition,
+	IProductCollection,
+	IProductGroupCollection,
+} from 'calypso/my-sites/marketplace/types';
+import { marketplaceDebugger } from 'calypso/my-sites/marketplace/constants';
+
+/**
+ * A set of logical product groups, grouped by actual products, to be shown in one product (group) page
+ * i.e. : YOAST_PREMIUM, YOAST_FREE are 2 products that belong to the product group YOAST
+ * */
+export const YOAST = 'YOAST';
+
+// TODO: Integrate this data structure with marketplace code
+export const productGroups: IProductGroupCollection = {
+	[ YOAST ]: {
+		products: {
+			[ YOAST_PREMIUM ]: {
+				defaultPluginSlug: 'wordpress-seo',
+				pluginsToBeInstalled: [ 'wordpress-seo-premium', 'wordpress-seo', 'yoast-test-helper' ],
+				isPurchasableProduct: true,
+			},
+			[ YOAST_FREE ]: {
+				defaultPluginSlug: 'wordpress-seo',
+				pluginsToBeInstalled: [ 'wordpress-seo' ],
+				isPurchasableProduct: false,
+			},
+		},
+	},
+};
+
+/**
+ * Provides the plugin that needs to be installed for a given product
+ *
+ * @param {string} productGroupSlug The product group the product belongs to
+ * @param {string} productSlug The product slug being setup.
+ * @returns {array[string]} An array of plugin slugs, returns null if product does slug not exist
+ */
+export function getPluginsToInstall(
+	productGroupSlug: keyof IProductGroupCollection,
+	productSlug: keyof IProductCollection
+): string[] | null {
+	const { pluginsToBeInstalled } = productGroups[ productGroupSlug ]?.products[ productSlug ] ?? {};
+	return pluginsToBeInstalled ? pluginsToBeInstalled : null;
+}
+
+/**
+ * Provides the first product found in the product group definition
+ *
+ * @param {string} productGroupSlug The product group required.\
+ * @returns {string} The product slug
+ */
+export function getDefaultProductInProductGroup(
+	productGroupSlug: keyof IProductGroupCollection
+): string | null {
+	const { products } = productGroups[ productGroupSlug ] ?? {};
+	if ( products ) {
+		const productKeys = Object.keys( products );
+		const [ product ] = productKeys;
+		return product ? product : null;
+	}
+	return null;
+}
+
+/**
+ * Provides the first plugin found in the product definitions
+ *
+ * @param {string} productGroupSlug The product group the product belongs to
+ * @param {string} productSlug The product slug being setup
+ * @returns {string} The plugin slug
+ */
+export function getDefaultPluginInProduct(
+	productGroupSlug: keyof IProductGroupCollection,
+	productSlug: keyof IProductCollection
+): string | null {
+	const { defaultPluginSlug } = productGroups[ productGroupSlug ]?.products[ productSlug ] ?? {};
+	return defaultPluginSlug ? defaultPluginSlug : null;
+}
+
+/**
+ * Provides the first plugin found in the product definitions
+ *
+ * @param {string} productGroupSlug The product group the product belongs to
+ * @param {string} productSlug The product slug
+ * @returns {string} The product details
+ */
+export function getProductDefinition(
+	productGroupSlug: keyof IProductGroupCollection,
+	productSlug: keyof IProductCollection
+): IProductDefinition | null {
+	const productDefinition = productGroups[ productGroupSlug ]?.products[ productSlug ];
+	if ( ! productDefinition ) {
+		marketplaceDebugger(
+			`Product does not exist for provided parameters: ${ productGroupSlug }, ${ productSlug }`
+		);
+		return null;
+	}
+	return productDefinition;
+}

--- a/client/my-sites/marketplace/marketplace-product-definitions/test/test.marketplace-product-definitions.ts
+++ b/client/my-sites/marketplace/marketplace-product-definitions/test/test.marketplace-product-definitions.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+
 /**
  * Internal dependencies
  */
@@ -11,8 +12,8 @@ import {
 	getDefaultProductInProductGroup,
 	getProductDefinition,
 	productGroups,
-} from '../constants';
-import { YOAST } from '../types';
+} from '../index';
+import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 
 describe( 'Constants and product related utilities test', () => {
 	test( 'getPluginsToInstall returns the relevant plugins to be installed', () => {

--- a/client/my-sites/marketplace/test/test.constants.ts
+++ b/client/my-sites/marketplace/test/test.constants.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+/**
+ * Internal dependencies
+ */
+import {
+	getPluginsToInstall,
+	getDefaultPluginInProduct,
+	getDefaultProductInProductGroup,
+	getProductDefinition,
+	productGroups,
+} from '../constants';
+import { YOAST } from '../types';
+
+describe( 'Constants and product related utilities test', () => {
+	test( 'getPluginsToInstall returns the relevant plugins to be installed', () => {
+		const received = getPluginsToInstall( YOAST, YOAST_PREMIUM );
+		const expected = productGroups[ YOAST ].products[ YOAST_PREMIUM ].pluginsToBeInstalled;
+		expect( received ).toEqual( expected );
+
+		const receivedForNonExistentProduct = getPluginsToInstall(
+			'NON_EXISTENT_PRODUCT_GROUP',
+			'NON_EXISTENT_PRODUCT'
+		);
+		expect( receivedForNonExistentProduct ).toEqual( null );
+	} );
+
+	test( 'getDefaultProductInProductGroup returns the first found product', () => {
+		const received = getDefaultProductInProductGroup( YOAST, YOAST_PREMIUM );
+		const expected = Object.keys( productGroups[ YOAST ].products )[ 0 ];
+		expect( received ).toEqual( expected );
+
+		const receivedForNonExistentProduct = getDefaultProductInProductGroup(
+			'NON_EXISTENT_PRODUCT_GROUP'
+		);
+		expect( receivedForNonExistentProduct ).toEqual( null );
+	} );
+
+	test( 'getDefaultPluginInProduct returns the defined default plugin', () => {
+		const received = getDefaultPluginInProduct( YOAST, YOAST_PREMIUM );
+		const expected = productGroups[ YOAST ].products[ YOAST_PREMIUM ].defaultPluginSlug;
+		expect( received ).toEqual( expected );
+
+		const receivedForNonExistentProduct = getDefaultPluginInProduct(
+			'NON_EXISTENT_PRODUCT_GROUP',
+			'NON_EXISTENT_PRODUCT'
+		);
+		expect( receivedForNonExistentProduct ).toEqual( null );
+	} );
+
+	test( 'getProductDefinition returns the correct product details, given the product slug and product group', () => {
+		const received = getProductDefinition( YOAST, YOAST_FREE );
+		const expected = productGroups[ YOAST ].products[ YOAST_FREE ];
+		expect( received ).toEqual( expected );
+
+		const receivedForNonExistentProduct = getProductDefinition(
+			'NON_EXISTENT_PRODUCT_GROUP',
+			'NON_EXISTENT_PRODUCT'
+		);
+		expect( receivedForNonExistentProduct ).toEqual( null );
+	} );
+} );

--- a/client/my-sites/marketplace/types.ts
+++ b/client/my-sites/marketplace/types.ts
@@ -3,6 +3,10 @@
  */
 import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
 
+/**
+ * Internal dependencies
+ */
+import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 export interface IProductDefinition {
 	/**
 	 * defaultPluginSlug : Some plugins may not be available in the calypso product library so we specify a default plugin that is accessible in the product library
@@ -17,12 +21,6 @@ export interface IProductCollection {
 	[ YOAST_PREMIUM ]: IProductDefinition;
 	[ YOAST_FREE ]: IProductDefinition;
 }
-
-/**
- * A set of logical product groups, grouped by actual products, to be shown in one product (group) page
- * i.e. : YOAST_PREMIUM, YOAST_FREE are 2 products that belong to the product group YOAST
- * */
-export const YOAST = 'YOAST';
 
 /**
  * IProductGroupCollection is a one-to-many mapping between logical product groups and actual products

--- a/client/my-sites/marketplace/types.ts
+++ b/client/my-sites/marketplace/types.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+
+export interface IProductDefinition {
+	/**
+	 * defaultPluginSlug : Some plugins may not be available in the calypso product library so we specify a default plugin that is accessible in the product library
+	 * so that relevant details can be shown
+	 * */
+	defaultPluginSlug: string;
+	pluginsToBeInstalled: string[];
+	isPurchasableProduct: boolean;
+}
+
+export interface IProductCollection {
+	[ YOAST_PREMIUM ]: IProductDefinition;
+	[ YOAST_FREE ]: IProductDefinition;
+}
+
+/**
+ * A set of logical product groups, grouped by actual products, to be shown in one product (group) page
+ * i.e. : YOAST_PREMIUM, YOAST_FREE are 2 products that belong to the product group YOAST
+ * */
+export const YOAST = 'YOAST';
+
+/**
+ * IProductGroupCollection is a one-to-many mapping between logical product groups and actual products
+ * */
+export interface IProductGroupCollection {
+	[ YOAST ]?: {
+		products: IProductCollection;
+	};
+}

--- a/packages/calypso-products/src/constants/marketplace.ts
+++ b/packages/calypso-products/src/constants/marketplace.ts
@@ -1,3 +1,3 @@
-export const YOAST_SEO = 'yoast_premium';
-
-export const MARKETPLACE_PRODUCTS = [ YOAST_SEO ];
+export const YOAST_PREMIUM = 'yoast_premium';
+export const YOAST_FREE = 'yoast_premium';
+export const MARKETPLACE_PRODUCTS = [ YOAST_PREMIUM, YOAST_FREE ];


### PR DESCRIPTION
## Changes proposed in this Pull Request

### New declarative data structure to maintain product information
Introduced a new declarative data structure to maintain product metadata, which needs to be moved to the backend at some point in the future.

https://github.com/Automattic/wp-calypso/blob/ccaa68fdcd47de63b7c71a37b412af71bdc070c8/client/my-sites/marketplace/constants.ts#L21-L36

## Testing instructions
Run unit tests and make sure there are no failures

This change was split from  #54290
