### PR TITLE
Remove externalRedirect helper in favor of lib/navigate

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -4,7 +4,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import debugModule from 'debug';
-import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -33,7 +32,8 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserConnection from 'calypso/components/data/query-user-connection';
 import Spinner from 'calypso/components/spinner';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
-import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
+import { addQueryArgs } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -207,7 +207,7 @@ export class JetpackAuthorize extends Component {
 		if ( ! this.redirecting ) {
 			this.redirecting = true;
 			debug( `Redirecting to ${ url }` );
-			externalRedirect( url );
+			navigate( url );
 		}
 	}
 
@@ -255,14 +255,7 @@ export class JetpackAuthorize extends Component {
 			);
 			this.externalRedirectOnce( redirectAfterAuth );
 		} else {
-			const { target, isExternal } = this.getRedirectionTarget();
-
-			if ( isExternal ) {
-				externalRedirect( target );
-				return;
-			}
-
-			page.redirect( target );
+			navigate( this.getRedirectionTarget() );
 		}
 
 		this.setState( { isRedirecting: true } );
@@ -695,7 +688,7 @@ export class JetpackAuthorize extends Component {
 			config.isEnabled( 'jetpack/connect-redirect-pressable-credential-approval' ) &&
 			'pressable' === partnerSlug
 		) {
-			return { target: `/start/pressable-nux?blogid=${ clientId }`, isExternal: false };
+			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
 		// If the redirect is part of a Jetpack plan or product go to the checkout page
@@ -706,25 +699,19 @@ export class JetpackAuthorize extends Component {
 			// Once we decide we want to redirect the user to the checkout page and that there is a
 			// valid plan, we can safely remove it from the session storage
 			clearPlan();
-			return {
-				target: `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`,
-				isExternal: false,
-			};
+			return `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
 		}
 
 		// If the site has a Jetpack paid product, send the user back to wp-admin rather than
 		// to the Plans page.
 		if ( siteHasJetpackPaidProduct ) {
-			return { target: redirectAfterAuth, isExternal: true };
+			return redirectAfterAuth;
 		}
 
-		return {
-			target: addQueryArgs(
-				{ redirect: redirectAfterAuth },
-				`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
-			),
-			isExternal: false,
-		};
+		return addQueryArgs(
+			{ redirect: redirectAfterAuth },
+			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
+		);
 	}
 
 	renderFooterLinks() {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -67,7 +67,7 @@ import {
 	getProductFromSlug,
 	getJetpackProductDisplayName,
 } from '@automattic/calypso-products';
-import { externalRedirect } from 'calypso/lib/route/path';
+import { navigate } from 'calypso/lib/navigate';
 import { addQueryArgs } from 'calypso/lib/route';
 
 /**
@@ -98,7 +98,7 @@ export function offerResetRedirects( context, next ) {
 		: null;
 	if ( isAutomatedTransfer ) {
 		debug( 'controller: offerResetRedirects -> redirecting WoA back to wp-admin', context.params );
-		return externalRedirect( selectedSite.URL + JETPACK_ADMIN_PATH );
+		return navigate( selectedSite.URL + JETPACK_ADMIN_PATH );
 	}
 
 	// If site has a paid plan or is not a Jetpack site, redirect to Calypso's Plans page
@@ -109,7 +109,7 @@ export function offerResetRedirects( context, next ) {
 			'controller: offerResetRedirects -> redirecting to /plans since site has a plan or is not a Jetpack site',
 			context.params
 		);
-		return externalRedirect( CALYPSO_PLANS_PAGE + selectedSite.slug );
+		return navigate( CALYPSO_PLANS_PAGE + selectedSite.slug );
 	}
 
 	// If the user previously selected Jetpack Free, redirect them to their wp-admin page
@@ -120,7 +120,7 @@ export function offerResetRedirects( context, next ) {
 			'controller: offerResetRedirects -> redirecting to wp-admin because the user got here by clicking Jetpack Free',
 			context.params
 		);
-		externalRedirect( context.query.redirect || selectedSite.options.admin_url );
+		navigate( context.query.redirect || selectedSite.options.admin_url );
 		return;
 	}
 
@@ -137,9 +137,9 @@ export function offerResetRedirects( context, next ) {
 
 		const queryRedirect = context.query.redirect;
 		if ( queryRedirect ) {
-			externalRedirect( queryRedirect );
+			navigate( queryRedirect );
 		} else if ( selectedSite ) {
-			externalRedirect( selectedSite.URL + JETPACK_ADMIN_PATH );
+			navigate( selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
 	}
 

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -19,7 +19,7 @@ import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
 import { addCalypsoEnvQueryArg } from './utils';
 import { confirmJetpackInstallStatus } from 'calypso/state/jetpack-connect/actions';
-import { externalRedirect } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
@@ -53,7 +53,7 @@ class InstallInstructions extends Component {
 			type: 'install_jetpack',
 		} );
 
-		externalRedirect( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_INSTALL ) );
+		navigate( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_INSTALL ) );
 	};
 
 	activateJetpack = () => {
@@ -64,7 +64,7 @@ class InstallInstructions extends Component {
 			type: 'activate_jetpack',
 		} );
 
-		externalRedirect( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_ACTIVATE ) );
+		navigate( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_ACTIVATE ) );
 	};
 
 	renderLocaleSuggestions() {

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -16,7 +16,8 @@ import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import { JETPACK_ADMIN_PATH } from 'calypso/jetpack-connect/constants';
 import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import versionCompare from 'calypso/lib/version-compare';
-import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
+import { addQueryArgs } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
@@ -97,7 +98,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				if ( currentPlan ) {
 					if ( currentPlan === PLAN_JETPACK_FREE ) {
 						debug( `Redirecting to wpadmin` );
-						return externalRedirect( this.props.siteHomeUrl + JETPACK_ADMIN_PATH );
+						return navigate( this.props.siteHomeUrl + JETPACK_ADMIN_PATH );
 					}
 					debug( `Redirecting to checkout with ${ currentPlan } plan retrieved from cookies` );
 					this.redirect( 'checkout', url, currentPlan, queryArgs );
@@ -148,7 +149,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 				const url = addQueryArgs( { reason }, this.props.mobileAppRedirect );
 				debug( `Redirecting to mobile app ${ url }` );
-				externalRedirect( url );
+				navigate( url );
 			}
 		};
 

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import page from 'page';
-import { externalRedirect } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 
 /**
  * Internal dependencies
@@ -147,8 +147,8 @@ describe( 'parseAuthorizationQuery', () => {
 	} );
 } );
 
-jest.mock( 'calypso/lib/route/path', () => ( {
-	externalRedirect: jest.fn(),
+jest.mock( 'calypso/lib/navigate', () => ( {
+	navigate: jest.fn(),
 } ) );
 
 jest.mock( 'page', () => ( {
@@ -157,7 +157,7 @@ jest.mock( 'page', () => ( {
 
 describe( 'redirect', () => {
 	beforeEach( () => {
-		externalRedirect.mockReset();
+		navigate.mockReset();
 		page.redirect.mockReset();
 	} );
 	test( 'should fire redirect', () => {
@@ -183,7 +183,7 @@ describe( 'redirect', () => {
 
 	test( 'external redirect should be called once during remote authorization', () => {
 		redirect( 'remote_auth', 'example.com' );
-		expect( externalRedirect ).toHaveBeenCalledTimes( 1 );
+		expect( navigate ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'should redirect once', () => {

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -10,7 +10,8 @@ import page from 'page';
  */
 import config, { isCalypsoLive } from '@automattic/calypso-config';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
-import { addQueryArgs, externalRedirect, untrailingslashit } from 'calypso/lib/route';
+import { addQueryArgs, untrailingslashit } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
 import {
 	JPC_PATH_PLANS,
@@ -162,7 +163,7 @@ export function redirect( type, url, product = null, queryArgs = {} ) {
 
 	if ( type === 'remote_auth' ) {
 		urlRedirect = addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH );
-		externalRedirect( urlRedirect );
+		navigate( urlRedirect );
 	}
 
 	if ( type === 'install_instructions' ) {

--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -172,7 +172,3 @@ export function mapPostStatus( status: string ): string {
 			return 'publish,private';
 	}
 }
-
-export function externalRedirect( url: URLString ) {
-	window.location.href = url;
-}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -23,13 +23,8 @@ import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
 import NavigationComponent from 'calypso/my-sites/navigation';
-import {
-	addQueryArgs,
-	getSiteFragment,
-	sectionify,
-	externalRedirect,
-	trailingslashit,
-} from 'calypso/lib/route';
+import { addQueryArgs, getSiteFragment, sectionify, trailingslashit } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import config from '@automattic/calypso-config';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -467,7 +462,7 @@ export function siteSelection( context, next ) {
 						next();
 					}
 				} else if ( shouldRedirectToJetpackAuthorize( context, site ) ) {
-					externalRedirect( getJetpackAuthorizeURL( context, site ) );
+					navigate( getJetpackAuthorizeURL( context, site ) );
 				} else {
 					// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 					const allSitesPath = addQueryArgs(

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -24,7 +24,7 @@ import {
 import { getSelectedDomain } from 'calypso/lib/domains';
 import SectionHeader from 'calypso/components/section-header';
 import wp from 'calypso/lib/wp';
-import { externalRedirect } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 const wpcom = wp.undocumented();
@@ -199,7 +199,7 @@ class DomainConnectMapping extends React.Component {
 					const success = get( data, 'success', false );
 					const syncUxUrl = get( data, 'sync_ux_apply_url', null );
 					if ( success && syncUxUrl ) {
-						externalRedirect( syncUxUrl );
+						navigate( syncUxUrl );
 					} else {
 						this.setState( {
 							error: true,

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -11,7 +11,6 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import page from 'page';
 import { isWithinBreakpoint } from '@automattic/viewport';
 
 /**
@@ -23,8 +22,7 @@ import { toggleMySitesSidebarSection as toggleSection } from 'calypso/state/my-s
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import MySitesSidebarUnifiedItem from './item';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
-import { isExternal } from 'calypso/lib/url';
-import { externalRedirect } from 'calypso/lib/route/path';
+import { navigate } from 'calypso/lib/navigate';
 import { itemLinkMatches } from './utils';
 
 export const MySitesSidebarUnifiedMenu = ( {
@@ -54,20 +52,14 @@ export const MySitesSidebarUnifiedMenu = ( {
 		( isWithinBreakpoint( '>782px' ) && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
 
 	const onClick = () => {
+		// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
 		if ( isWithinBreakpoint( '>782px' ) ) {
 			if ( link ) {
 				if ( ! continueInCalypso( link ) ) {
 					return;
 				}
 
-				if ( isExternal( link ) ) {
-					// If the URL is external, page() will fail to replace state between different domains.
-					externalRedirect( link );
-					return;
-				}
-
-				// Only open the page if menu is NOT full-width, otherwise just open / close the section instead of directly redirecting to the section.
-				page( link );
+				navigate( link );
 			}
 		}
 

--- a/client/state/jetpack-connect/actions/retry-auth.js
+++ b/client/state/jetpack-connect/actions/retry-auth.js
@@ -7,7 +7,8 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import { addQueryArgs, externalRedirect } from 'calypso/lib/route';
+import { addQueryArgs } from 'calypso/lib/route';
+import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { REMOTE_PATH_AUTH } from 'calypso/jetpack-connect/constants';
 import { urlToSlug } from 'calypso/lib/url';
@@ -36,7 +37,7 @@ export function retryAuth( url, attemptNumber, fromParam, redirectAfterAuth ) {
 			} )
 		);
 		debug( 'retryAuth', url );
-		externalRedirect(
+		navigate(
 			addQueryArgs(
 				{
 					jetpack_connect_url: url + REMOTE_PATH_AUTH,


### PR DESCRIPTION
Removes the `externalRedirect` helper, which merely calls `window.location.href = url`, in favor of the recently added `lib/navigate` library.

An upside of `navigate` is that it checks if the URL is Calypso-internal or external and does a `page.show` navigation automatically if it's internal. Removes the need for user-space code to do that check.

Most affected usages are in Jetpack Connect.

**How to test:**
Check the affected flows and verify that redirects are still done properly.