### PR TITLE
Remove the jetpack/connect-redirect-pressable-credential-approval feature flag

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -357,19 +357,8 @@ export class JetpackAuthorize extends Component {
 
 	shouldRedirectJetpackStart( props = this.props ) {
 		const { partnerSlug, partnerID } = props;
-		const pressableRedirectFlag = config.isEnabled(
-			'jetpack/connect-redirect-pressable-credential-approval'
-		);
 
-		// If the redirect flag is set, then we conditionally redirect the Pressable client to
-		// a credential approval screen. Otherwise, we need to redirect all other partners back
-		// to wp-admin.
-		if ( pressableRedirectFlag ) {
-			return partnerID && 'pressable' !== partnerSlug;
-		}
-
-		// If partner ID query param is set, then assume that the connection is from the Jetpack Start flow.
-		return !! partnerID;
+		return partnerID && 'pressable' !== partnerSlug;
 	}
 
 	handleSignIn = () => {
@@ -684,10 +673,7 @@ export class JetpackAuthorize extends Component {
 		const { partnerSlug, selectedPlanSlug, siteHasJetpackPaidProduct } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
-		if (
-			config.isEnabled( 'jetpack/connect-redirect-pressable-credential-approval' ) &&
-			'pressable' === partnerSlug
-		) {
+		if ( 'pressable' === partnerSlug ) {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -84,7 +84,6 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
-		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -54,7 +54,6 @@
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": false,
 		"jetpack/concierge-sessions": false,
-		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -55,7 +55,6 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
-		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,


### PR DESCRIPTION
The flag is always true in development, stage, production, i.e., all the most important environments.

**How to test:**
I don't really know: go through the Jetpack Connect flow initiated from Pressable and verify that it works? @ebinnion might know more.
