### PR TITLE
chore: migrate client/sections-helper.js to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,7 +198,7 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'packages/accessible-focus/**/*', 'test/e2e/**/*' ],
+			files: [ 'packages/accessible-focus/**/*', 'test/e2e/**/*', 'client/sections-helper.js' ],
 			rules: {
 				'wpcalypso/import-docblock': 'off',
 				'import/order': [

--- a/client/sections-helper.js
+++ b/client/sections-helper.js
@@ -9,9 +9,6 @@
  * To break the dependency cycle, we introduced `sections-helper` which does not import sections.js
  */
 
-/**
- * External dependencies
- */
 import { find } from 'lodash';
 
 let sections = null;


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/sections-helper.js` to use `import/order`

#### Testing instructions

N/A
