### PR TITLE
chore: migrate client/sections-filter to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,7 +198,12 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'packages/accessible-focus/**/*', 'test/e2e/**/*', 'client/sections-helper.js' ],
+			files: [
+				'packages/accessible-focus/**/*',
+				'test/e2e/**/*',
+				'client/sections-helper.js',
+				'client/sections-filter.js',
+			],
 			rules: {
 				'wpcalypso/import-docblock': 'off',
 				'import/order': [

--- a/client/sections-filter.js
+++ b/client/sections-filter.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 export default function isSectionEnabled( section ) {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/sections-filter.js` to use `import/order`

#### Testing instructions

N/A
