### PR TITLE
chore: migrate client/sections-middleware to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -179,6 +179,7 @@ module.exports = {
 			files: [
 				'client/sections-filter.js',
 				'client/sections-helper.js',
+				'client/sections-middleware.js',
 				'packages/accessible-focus/**/*',
 				'packages/calypso-products/**/*',
 				'packages/data-stores/**/*',

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -1,24 +1,17 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import page from 'page';
+import * as LoadingError from 'calypso/layout/error';
+import { performanceTrackerStart } from 'calypso/lib/performance-tracking';
+import { addReducerToStore } from 'calypso/state/add-reducer';
+import { bumpStat } from 'calypso/state/analytics/actions';
 import { setSectionLoading } from 'calypso/state/ui/actions';
 import { activateNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { bumpStat } from 'calypso/state/analytics/actions';
-import * as LoadingError from 'calypso/layout/error';
 import * as controller from './controller/index.web';
-import { pathToRegExp } from './utils';
-import { receiveSections, load } from './sections-helper';
-import isSectionEnabled from './sections-filter';
-import { addReducerToStore } from 'calypso/state/add-reducer';
-import { performanceTrackerStart } from 'calypso/lib/performance-tracking';
-
 import sections from './sections';
+import isSectionEnabled from './sections-filter';
+import { receiveSections, load } from './sections-helper';
+import { pathToRegExp } from './utils';
+
 receiveSections( sections );
 
 function activateSection( section, context ) {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

- Migrate `client/sections-middleware` to use `import/order`

#### Testing instructions

N/A

Related to #
