### PR TITLE
chore: migrate calypso/sections-preloaders to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,6 +180,7 @@ module.exports = {
 				'client/sections-filter.js',
 				'client/sections-helper.js',
 				'client/sections-middleware.js',
+				'client/sections-preloaders.js',
 				'packages/accessible-focus/**/*',
 				'packages/calypso-products/**/*',
 				'packages/data-stores/**/*',

--- a/client/sections-preloaders.js
+++ b/client/sections-preloaders.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { preload } from './sections-helper';
 
 export function preloadEditor() {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/sections-preloaders` to use `import/order`

#### Testing instructions

N/A