### PR TITLE
Jetpack Search Purchase: remove unused code for logged-out state

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -271,8 +271,6 @@ export function connect( context, next ) {
 			<SearchPurchase
 				ctaFrom={ query.cta_from /* origin tracking params */ }
 				ctaId={ query.cta_id /* origin tracking params */ }
-				locale={ params.locale }
-				path={ path }
 				type={ type }
 				url={ query.url }
 			/>

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -37,8 +37,9 @@ export default function () {
 	].join( '|' );
 
 	page(
-		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?`,
+		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?/${ locale }`,
 		controller.redirectToSiteLessCheckout,
+		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.loginBeforeJetpackSearch,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
@@ -95,16 +96,6 @@ export default function () {
 		siteSelection,
 		controller.offerResetRedirects,
 		controller.offerResetContext
-	);
-
-	page(
-		`/jetpack/connect/:type(${ planTypeString })?/${ locale }`,
-		controller.redirectWithoutLocaleIfLoggedIn,
-		controller.persistMobileAppFlow,
-		controller.setMasterbar,
-		controller.connect,
-		makeLayout,
-		clientRender
 	);
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso, makeLayout, clientRender );

--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import HelpButton from './help-button';
-import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import MainHeader from './main-header';
@@ -22,7 +21,6 @@ import SiteUrlInput from './site-url-input';
 import { cleanUrl } from './utils';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { persistSession, retrieveMobileRedirect } from './persistence-utils';
@@ -31,14 +29,12 @@ import { urlToSlug } from 'calypso/lib/url';
 import searchSites from 'calypso/components/search-sites';
 import jetpackConnection from './jetpack-connection';
 
-import { IS_DOT_COM_GET_SEARCH, JPC_PATH_REMOTE_INSTALL } from './constants';
+import { IS_DOT_COM_GET_SEARCH } from './constants';
 import { FLOW_TYPES } from './flow-types';
 import { ALREADY_CONNECTED } from './connection-notice-types';
 
 export class SearchPurchase extends Component {
 	static propTypes = {
-		locale: PropTypes.string,
-		path: PropTypes.string,
 		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
 		url: PropTypes.string,
 		processJpSite: PropTypes.func,
@@ -75,9 +71,6 @@ export class SearchPurchase extends Component {
 	UNSAFE_componentWillMount() {
 		if ( this.props.url ) {
 			this.checkUrl( cleanUrl( this.props.url ) );
-		}
-		if ( ! this.props.isLoggedIn ) {
-			this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
 		}
 	}
 
@@ -189,20 +182,11 @@ export class SearchPurchase extends Component {
 		);
 	}
 
-	renderLocaleSuggestions() {
-		if ( this.props.isLoggedIn || ! this.props.locale ) {
-			return;
-		}
-
-		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
-	}
-
 	render() {
 		const { renderFooter, status } = this.props;
 
 		return (
 			<MainWrapper>
-				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
 					<MainHeader type={ 'jetpack_search' } />
 
@@ -229,7 +213,6 @@ const connectComponent = connect(
 		return {
 			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 			getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
-			isLoggedIn: !! getCurrentUserId( state ),
 			isMobileAppFlow,
 			isRequestingSites: isRequestingSites( state ),
 			jetpackConnectSite,

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -102,7 +102,6 @@ export function purchase( context, next ) {
 		<SearchPurchase
 			ctaFrom={ query.cta_from /* origin tracking params */ }
 			ctaId={ query.cta_id /* origin tracking params */ }
-			locale={ params.locale }
 			path={ path }
 			type={ type }
 			url={ query.url }

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import HelpButton from '../../jetpack-connect/help-button';
-import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import MainHeader from '../../jetpack-connect/main-header';
@@ -22,7 +21,6 @@ import SiteUrlInput from '../../jetpack-connect/site-url-input';
 import { cleanUrl } from '../../jetpack-connect/utils';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { persistSession, retrieveMobileRedirect } from '../../jetpack-connect/persistence-utils';
@@ -30,14 +28,12 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { urlToSlug } from 'calypso/lib/url';
 import searchSites from 'calypso/components/search-sites';
 import jetpackConnection from '../../jetpack-connect/jetpack-connection';
-import { IS_DOT_COM_GET_SEARCH, JPC_PATH_REMOTE_INSTALL } from '../../jetpack-connect/constants';
+import { IS_DOT_COM_GET_SEARCH } from '../../jetpack-connect/constants';
 import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
 import { ALREADY_CONNECTED } from '../../jetpack-connect/connection-notice-types';
 
 export class SearchPurchase extends Component {
 	static propTypes = {
-		locale: PropTypes.string,
-		path: PropTypes.string,
 		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
 		url: PropTypes.string,
 		processJpSite: PropTypes.func,
@@ -74,9 +70,6 @@ export class SearchPurchase extends Component {
 	UNSAFE_componentWillMount() {
 		if ( this.props.url ) {
 			this.checkUrl( cleanUrl( this.props.url ), true );
-		}
-		if ( ! this.props.isLoggedIn ) {
-			this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
 		}
 	}
 
@@ -186,20 +179,11 @@ export class SearchPurchase extends Component {
 		);
 	}
 
-	renderLocaleSuggestions() {
-		if ( this.props.isLoggedIn || ! this.props.locale ) {
-			return;
-		}
-
-		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
-	}
-
 	render() {
 		const { renderFooter, status } = this.props;
 
 		return (
 			<MainWrapper>
-				{ this.renderLocaleSuggestions() }
 				<div className="purchase-product__site-url-entry-container">
 					<MainHeader type={ 'jetpack_search' } />
 
@@ -226,7 +210,6 @@ const connectComponent = connect(
 		return {
 			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 			getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
-			isLoggedIn: !! getCurrentUserId( state ),
 			isMobileAppFlow,
 			isRequestingSites: isRequestingSites( state ),
 			jetpackConnectSite,


### PR DESCRIPTION
On the `/jetpack/connect/jetpack_search` and `/purchase-product/jetpack_search` routes we show UI to select a site and purchase Jetpack Search for it. This UI is shown only for logged in users. Logged out sessions are redirected to login.

In the `/jetpack/connect` case, it's done by the `loginBeforeJetpackSearch` handler which targets specifically the `jetpack_search` product.

That allows us to remove code that checks the "not logged in" case, because that case never happens. We can remove rendering of the `<LocaleSuggestions />` component, and also a `this.goToRemoteInstall()` which didn't work anyway because the method doesn't exist. When you go to:
```
https://wordpress.com/jetpack/connect/jetpack_search/es
```
you can see that the current Calypso crashes on that route:
<img width="566" alt="Screenshot 2021-07-13 at 12 46 55" src="https://user-images.githubusercontent.com/664258/125439618-2cd40d47-e397-4dfa-9fc5-f0ea0734b650.png">

We are fixing this bug by removing the handler for `/jetpack/connect/:type/:interval/:locale` that doesn't call the `loginBeforeJetpackSearch` handler (and therefore proceeds to crash) and merging it with the `/jetpack/connect/:type/:interval` one.

**How to test:**
Check that both mentioned `jetpack_search` routes redirect logged-out sessions to login and show the right UI (site input/search and a button) for logged-in sessions.