### PR TITLE
Jetpack Install Instructions: remove LocaleSuggestions that are never rendered

### DIFF
--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,7 +13,6 @@ import { Button } from '@automattic/components';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HelpButton from './help-button';
 import JetpackInstallStep from './install-step';
-import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
 import { addCalypsoEnvQueryArg } from './utils';
@@ -67,21 +65,12 @@ class InstallInstructions extends Component {
 		externalRedirect( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_ACTIVATE ) );
 	};
 
-	renderLocaleSuggestions() {
-		if ( this.props.isLoggedIn || ! this.props.locale ) {
-			return;
-		}
-
-		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
-	}
-
 	render() {
 		const { remoteSiteUrl } = this.props;
 		const instructionsData = this.getInstructionsData();
 
 		return (
 			<MainWrapper isWide>
-				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<FormattedHeader
 						headerText={ instructionsData.headerTitle }
@@ -136,4 +125,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight( connectComponent, localize )( InstallInstructions );
+export default connectComponent( localize( InstallInstructions ) );


### PR DESCRIPTION
The `/jetpack/connect/instructions` route doesn't have a `:locale` param and therefore the `<LocaleSuggestion />` component in the `<InstallInstructions />` component is never going to be rendered. Can be removed.

**How to test:**
Go to `/jetpack/connect/instructions?url=foo` and verify that the Jetpack install instructions are displayed.