### PR TITLE
chore: Tweak `import/order` config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -213,6 +213,7 @@ module.exports = {
 						alphabetize: {
 							order: 'asc',
 						},
+						groups: [ 'builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'type' ],
 					},
 				],
 			},
@@ -246,6 +247,7 @@ module.exports = {
 		jsdoc: {
 			mode: 'typescript',
 		},
+		'import/internal-regex': '^calypso/',
 	},
 	rules: {
 		// REST API objects include underscores

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,7 +209,7 @@ module.exports = {
 				'import/order': [
 					'error',
 					{
-						'newlines-between': 'always',
+						'newlines-between': 'never',
 						alphabetize: {
 							order: 'asc',
 						},

--- a/bin/import-order.sh
+++ b/bin/import-order.sh
@@ -28,5 +28,5 @@ do
 	removeComments "$file"
 done < <(find -E "$DIR" -type f  -regex '.*\.[jt]sx?' -print0)
 
-prettify "$DIR"
 fix "$DIR"
+prettify "$DIR"

--- a/test/e2e/lib/async-base-container.js
+++ b/test/e2e/lib/async-base-container.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as driverHelper from './driver-helper';
 import * as driverManager from './driver-manager';
 

--- a/test/e2e/lib/components/current-theme-component.js
+++ b/test/e2e/lib/components/current-theme-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class CurrentThemeComponent extends AsyncBaseContainer {

--- a/test/e2e/lib/components/editor-confirmation-sidebar-component.js
+++ b/test/e2e/lib/components/editor-confirmation-sidebar-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/enter-a-domain-component.js
+++ b/test/e2e/lib/components/enter-a-domain-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 import * as slackNotifier from '../slack-notifier';

--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -1,5 +1,4 @@
 import { By, Key } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/gutenboarding-language-picker.js
+++ b/test/e2e/lib/components/gutenboarding-language-picker.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/components/inline-help-checklist-component.js
+++ b/test/e2e/lib/components/inline-help-checklist-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/inline-help-popover-component.js
+++ b/test/e2e/lib/components/inline-help-popover-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/logged-out-masterbar-component.js
+++ b/test/e2e/lib/components/logged-out-masterbar-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class LoggedOutMasterbarComponent extends AsyncBaseContainer {

--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/new-user-domain-registration-unavailable-component.js
+++ b/test/e2e/lib/components/new-user-domain-registration-unavailable-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class NewUserRegistrationUnavailableComponent extends AsyncBaseContainer {

--- a/test/e2e/lib/components/no-sites-component.js
+++ b/test/e2e/lib/components/no-sites-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/notices-component.js
+++ b/test/e2e/lib/components/notices-component.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/notifications-component.js
+++ b/test/e2e/lib/components/notifications-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/page-preview-component.js
+++ b/test/e2e/lib/components/page-preview-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import ViewPagePage from '../../lib/pages/view-page-page.js';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/components/page-preview-external-component.js
+++ b/test/e2e/lib/components/page-preview-external-component.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import ViewPagePage from '../../lib/pages/view-page-page.js';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/components/payment-button-front-end-component.js
+++ b/test/e2e/lib/components/payment-button-front-end-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/post-preview-component.js
+++ b/test/e2e/lib/components/post-preview-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import ViewPostPage from '../../lib/pages/view-post-page.js';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/components/post-preview-external-component.js
+++ b/test/e2e/lib/components/post-preview-external-component.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import ViewPostPage from '../../lib/pages/view-post-page.js';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/components/revisions-modal-component.js
+++ b/test/e2e/lib/components/revisions-modal-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/components/section-nav-component.js
+++ b/test/e2e/lib/components/section-nav-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By, promise } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import { getJetpackHost } from '../data-helper';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/components/shopping-cart-widget-component.js
+++ b/test/e2e/lib/components/shopping-cart-widget-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 // import DisconnectSurveyPage from '../pages/disconnect-survey-page.js';
 import * as dataHelper from '../data-helper';

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager';

--- a/test/e2e/lib/components/site-preview-component.js
+++ b/test/e2e/lib/components/site-preview-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/step-wrapper-component.js
+++ b/test/e2e/lib/components/step-wrapper-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/thank-you-modal-component.js
+++ b/test/e2e/lib/components/thank-you-modal-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/components/theme-dialog-component.js
+++ b/test/e2e/lib/components/theme-dialog-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/theme-switch-confirmation-component.js
+++ b/test/e2e/lib/components/theme-switch-confirmation-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/components/widget-contact-info-component.js
+++ b/test/e2e/lib/components/widget-contact-info-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 
 export default class WidgetContactInfoComponent extends AsyncBaseContainer {

--- a/test/e2e/lib/components/wizard-navigation-component.js
+++ b/test/e2e/lib/components/wizard-navigation-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container.js';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/data-helper.js
+++ b/test/e2e/lib/data-helper.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-
 import phrase from 'asana-phrase';
 import config from 'config';
 import { difference, map } from 'lodash';

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -9,7 +9,6 @@ import {
 	WebElement,
 	WebElementCondition,
 } from 'selenium-webdriver';
-
 import * as dataHelper from './data-helper';
 import * as driverManager from './driver-manager';
 

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -8,7 +8,6 @@ import chrome from 'selenium-webdriver/chrome';
 import firefox from 'selenium-webdriver/firefox';
 import proxy from 'selenium-webdriver/proxy';
 import * as remote from 'selenium-webdriver/remote';
-
 import * as dataHelper from './data-helper';
 import { generatePath } from './test-utils';
 

--- a/test/e2e/lib/flows/activate-account-flow.js
+++ b/test/e2e/lib/flows/activate-account-flow.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import EmailClient from '../email-client';
 
 const signupInboxId = config.get( 'signupInboxId' );

--- a/test/e2e/lib/flows/create-site-flow.js
+++ b/test/e2e/lib/flows/create-site-flow.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import FindADomainComponent from '../components/find-a-domain-component';
 import * as driverHelper from '../driver-helper';
 import MyHomePage from '../pages/my-home-page';

--- a/test/e2e/lib/flows/gutenboarding-flow.js
+++ b/test/e2e/lib/flows/gutenboarding-flow.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
 import AcquireIntentPage from '../pages/gutenboarding/acquire-intent-page.js';

--- a/test/e2e/lib/flows/jetpack-connect-flow.js
+++ b/test/e2e/lib/flows/jetpack-connect-flow.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import SidebarComponent from '../components/sidebar-component';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper';
@@ -12,7 +11,6 @@ import WPAdminJetpackPage from '../pages/wp-admin/wp-admin-jetpack-page.js';
 import WPAdminLogonPage from '../pages/wp-admin/wp-admin-logon-page';
 import WPAdminSidebar from '../pages/wp-admin/wp-admin-sidebar.js';
 import WporgCreatorPage from '../pages/wporg-creator-page';
-
 import LoginFlow from './login-flow';
 // import NoticesComponent from '../components/notices-component';
 

--- a/test/e2e/lib/flows/pressable-nux-flow.js
+++ b/test/e2e/lib/flows/pressable-nux-flow.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../driver-helper';
 import WPAdminLogonPage from '../pages/wp-admin/wp-admin-logon-page';
 

--- a/test/e2e/lib/flows/sign-up-flow.js
+++ b/test/e2e/lib/flows/sign-up-flow.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../data-helper';
 import * as driverManager from '../driver-manager';
 import EmailClient from '../email-client';

--- a/test/e2e/lib/gutenberg/blocks/blog-posts-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/blog-posts-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class BlogPostsBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class ContactFormBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class ContactInfoBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/embeds-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/embeds-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 export default class EmbedsBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/file-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/file-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 export class FileBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class GalleryMasonryBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/gutenberg-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gutenberg-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/gutenberg/blocks/image-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/image-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 export class ImageBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class LayoutGridBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/markdown-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/markdown-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 export default class MarkdownBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/payment-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/payment-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 export default class SimplePaymentsBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/premium-content-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/premium-content-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class PremiumContentBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class RatingStarBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/shortcode-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/shortcode-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 export class ShortcodeBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class SlideshowBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/subscriptions-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/subscriptions-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class SubscriptionsBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class TiledGalleryBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
@@ -1,7 +1,5 @@
 import { By } from 'selenium-webdriver';
-
 import * as driverHelper from '../../driver-helper';
-
 import GutenbergBlockComponent from './gutenberg-block-component';
 
 class YoutubeBlockComponent extends GutenbergBlockComponent {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -1,11 +1,9 @@
 import { kebabCase } from 'lodash';
 import webdriver, { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import GuideComponent from '../components/guide-component.js';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
-
 import { ContactFormBlockComponent } from './blocks';
 import { FileBlockComponent } from './blocks/file-block-component';
 import { ImageBlockComponent } from './blocks/image-block-component';

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -1,10 +1,8 @@
 import { By, Key } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 import * as driverManager from '../driver-manager';
 import * as SlackNotifier from '../slack-notifier';
-
 import GutenbergEditorComponent from './gutenberg-editor-component';
 
 export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer {

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -1,11 +1,8 @@
 import assert from 'assert';
-
 import { By } from 'selenium-webdriver';
-
 import SiteEditorComponent from '../../components/site-editor-component';
 import * as driverHelper from '../../driver-helper';
 import GutenbergEditorComponent from '../gutenberg-editor-component';
-
 import { clearEventsStack, getEventsStack, getTotalEventsFiredForBlock } from './utils';
 
 export function createGeneralTests( { it, editorType, postType } ) {

--- a/test/e2e/lib/hooks/browser/browser-logs.js
+++ b/test/e2e/lib/hooks/browser/browser-logs.js
@@ -1,6 +1,5 @@
 import fs from 'fs/promises';
 import path from 'path';
-
 import { logging } from 'selenium-webdriver';
 
 export const saveBrowserLogs = async ( { tempDir, driver } ) => {

--- a/test/e2e/lib/hooks/mocha.js
+++ b/test/e2e/lib/hooks/mocha.js
@@ -1,8 +1,6 @@
 import { mkdtemp } from 'fs/promises';
 import path from 'path';
-
 import config from 'config';
-
 import { buildHooks as buildBrowserHooks } from './browser';
 import { buildHooks as buildVideoHooks, isVideoEnabled } from './video';
 

--- a/test/e2e/lib/hooks/video/framebuffer.js
+++ b/test/e2e/lib/hooks/video/framebuffer.js
@@ -2,7 +2,6 @@ import { spawn } from 'child_process';
 import { accessSync } from 'fs';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
-
 import { getTestNameWithTime } from '../../test-utils';
 
 export const getFreeDisplay = () => {

--- a/test/e2e/lib/hooks/video/index.js
+++ b/test/e2e/lib/hooks/video/index.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import { buildHooks as buildFramebufferHooks, getFreeDisplay } from './framebuffer';
 import { buildHooks as buildVideoHooks } from './video-recorder';
 

--- a/test/e2e/lib/hooks/video/video-recorder.js
+++ b/test/e2e/lib/hooks/video/video-recorder.js
@@ -2,9 +2,7 @@ import { spawn } from 'child_process';
 import { createWriteStream } from 'fs';
 import { rename, mkdir, unlink } from 'fs/promises';
 import path from 'path';
-
 import ffmpeg from 'ffmpeg-static';
-
 import { getTestNameWithTime } from '../../test-utils';
 
 const kill = ( proc ) =>

--- a/test/e2e/lib/media-helper.js
+++ b/test/e2e/lib/media-helper.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import { PassThrough } from 'stream';
-
 import fs from 'fs-extra';
 import pngitxt from 'png-itxt';
 import sanitize from 'sanitize-filename';

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -1,9 +1,7 @@
 /* eslint-disable mocha/no-top-level-hooks */
 
 import assert from 'assert';
-
 import config from 'config';
-
 import * as driverManager from './driver-manager';
 
 const afterHookTimeoutMS = config.get( 'afterHookTimeoutMS' );

--- a/test/e2e/lib/pages/accept-invite-page.js
+++ b/test/e2e/lib/pages/accept-invite-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/account/account-settings-page.js
+++ b/test/e2e/lib/pages/account/account-settings-page.js
@@ -1,5 +1,4 @@
 import { By, Condition } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as dataHelper from '../../data-helper';
 import * as driverHelper from '../../driver-helper.js';

--- a/test/e2e/lib/pages/account/close-account-page.js
+++ b/test/e2e/lib/pages/account/close-account-page.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/cancel-domain-page.js
+++ b/test/e2e/lib/pages/cancel-domain-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import NoticesComponent from '../components/notices-component';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/cancel-purchase-page.js
+++ b/test/e2e/lib/pages/cancel-purchase-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/comments-page.js
+++ b/test/e2e/lib/pages/comments-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/pages/customer-home-page.js
+++ b/test/e2e/lib/pages/customer-home-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class CustomerHomePage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/customizer-page.js
+++ b/test/e2e/lib/pages/customizer-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/pages/disconnect-survey-page.js
+++ b/test/e2e/lib/pages/disconnect-survey-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import NoticesComponent from '../components/notices-component';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/domain-details-page.js
+++ b/test/e2e/lib/pages/domain-details-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/domain-map-page.js
+++ b/test/e2e/lib/pages/domain-map-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class MapADomainPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/domain-my-own-page.js
+++ b/test/e2e/lib/pages/domain-my-own-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/pages/domain-only-settings-page.js
+++ b/test/e2e/lib/pages/domain-only-settings-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/domains-page.js
+++ b/test/e2e/lib/pages/domains-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/edit-team-member-page.js
+++ b/test/e2e/lib/pages/edit-team-member-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/editor-page.js
+++ b/test/e2e/lib/pages/editor-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/external/jetpackcom-features-design-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-features-design-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/external/jetpackcom-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 import * as driverManager from '../../driver-manager';

--- a/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-pricing-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/external/jetpackcom-search-landing-page.js
+++ b/test/e2e/lib/pages/external/jetpackcom-search-landing-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/external/paypal-checkout-page.js
+++ b/test/e2e/lib/pages/external/paypal-checkout-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/frontend/comment-likes-component.js
+++ b/test/e2e/lib/pages/frontend/comment-likes-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/frontend/comments-area-component.js
+++ b/test/e2e/lib/pages/frontend/comments-area-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/frontend/post-area-component.js
+++ b/test/e2e/lib/pages/frontend/post-area-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/frontend/post-likes-component.js
+++ b/test/e2e/lib/pages/frontend/post-likes-component.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 export default class PostLikesComponent extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/gutenboarding/designs-page.js
+++ b/test/e2e/lib/pages/gutenboarding/designs-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as dataHelper from '../../data-helper';
 

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/gutenboarding/features-page.js
+++ b/test/e2e/lib/pages/gutenboarding/features-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/gutenboarding/new-page.js
+++ b/test/e2e/lib/pages/gutenboarding/new-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as dataHelper from '../../data-helper';
 import * as driverHelper from '../../driver-helper';

--- a/test/e2e/lib/pages/gutenboarding/plans-page.js
+++ b/test/e2e/lib/pages/gutenboarding/plans-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/gutenboarding/signup-page.js
+++ b/test/e2e/lib/pages/gutenboarding/signup-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/gutenboarding/style-preview-page.js
+++ b/test/e2e/lib/pages/gutenboarding/style-preview-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as dataHelper from '../../data-helper';
 import * as driverHelper from '../../driver-helper';

--- a/test/e2e/lib/pages/importer-page.js
+++ b/test/e2e/lib/pages/importer-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/invite-error-page.js
+++ b/test/e2e/lib/pages/invite-error-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/invite-people-page.js
+++ b/test/e2e/lib/pages/invite-people-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import NavBarComponent from '../components/nav-bar-component.js';
 import SidebarComponent from '../components/sidebar-component.js';

--- a/test/e2e/lib/pages/jetpack-authorize-page.js
+++ b/test/e2e/lib/pages/jetpack-authorize-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/pages/jetpack-plans-sales-page.js
+++ b/test/e2e/lib/pages/jetpack-plans-sales-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/jetpack/jetpack-connect-add-credentials-page.js
+++ b/test/e2e/lib/pages/jetpack/jetpack-connect-add-credentials-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/jetpack/jetpack-connect-page.js
+++ b/test/e2e/lib/pages/jetpack/jetpack-connect-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/landing-page.js
+++ b/test/e2e/lib/pages/landing-page.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class LandingPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -1,5 +1,4 @@
 import { By, Key } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/magic-login-page.js
+++ b/test/e2e/lib/pages/magic-login-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/manage-purchase-page.js
+++ b/test/e2e/lib/pages/manage-purchase-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/marketing/traffic-page.js
+++ b/test/e2e/lib/pages/marketing/traffic-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 import * as driverManager from '../../driver-manager.js';

--- a/test/e2e/lib/pages/media-page.js
+++ b/test/e2e/lib/pages/media-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager';

--- a/test/e2e/lib/pages/my-home-page.js
+++ b/test/e2e/lib/pages/my-home-page.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import GuideComponent from '../components/guide-component';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/my-plan-page.js
+++ b/test/e2e/lib/pages/my-plan-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import SectionNavComponent from '../components/section-nav-component';
 import * as driverHelper from '../driver-helper';

--- a/test/e2e/lib/pages/not-found-page.js
+++ b/test/e2e/lib/pages/not-found-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class NotFoundPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/pages-page.js
+++ b/test/e2e/lib/pages/pages-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/pages/people-page.js
+++ b/test/e2e/lib/pages/people-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import SectionNavComponent from '../components/section-nav-component';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import SectionNavComponent from '../components/section-nav-component';
 import * as dataHelper from '../data-helper';

--- a/test/e2e/lib/pages/plugin-details-page.js
+++ b/test/e2e/lib/pages/plugin-details-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/plugins-browser-page.js
+++ b/test/e2e/lib/pages/plugins-browser-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 import * as SlackNotifier from '../slack-notifier';

--- a/test/e2e/lib/pages/plugins-page.js
+++ b/test/e2e/lib/pages/plugins-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/posts-page.js
+++ b/test/e2e/lib/pages/posts-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 import { currentScreenSize } from '../driver-manager';

--- a/test/e2e/lib/pages/pressable/pressable-approve-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-approve-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/pressable/pressable-logon-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-logon-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/pressable/pressable-site-settings-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-site-settings-page.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/pressable/pressable-sites-page.js
+++ b/test/e2e/lib/pages/pressable/pressable-sites-page.js
@@ -1,8 +1,6 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
-
 import PressableSiteSettingsPage from './pressable-site-settings-page';
 
 export default class PressableSitesPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/private-site-login-page.js
+++ b/test/e2e/lib/pages/private-site-login-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class PrivateSiteLoginPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/profile-page.js
+++ b/test/e2e/lib/pages/profile-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/purchases-page.js
+++ b/test/e2e/lib/pages/purchases-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/reader-manage-page.js
+++ b/test/e2e/lib/pages/reader-manage-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper';

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/revoke-page.js
+++ b/test/e2e/lib/pages/revoke-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/settings-page.js
+++ b/test/e2e/lib/pages/settings-page.js
@@ -1,10 +1,8 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import NoticesComponent from '../components/notices-component';
 import SectionNavComponent from '../components/section-nav-component';
 import * as driverHelper from '../driver-helper.js';
-
 import DisconnectSurveyPage from './disconnect-survey-page.js';
 
 export default class SettingsPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/signup/about-page.js
+++ b/test/e2e/lib/pages/signup/about-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/checkout-page.js
+++ b/test/e2e/lib/pages/signup/checkout-page.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/checkout-thankyou-page.js
+++ b/test/e2e/lib/pages/signup/checkout-thankyou-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/choose-a-theme-page.js
+++ b/test/e2e/lib/pages/signup/choose-a-theme-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/create-your-account-page.js
+++ b/test/e2e/lib/pages/signup/create-your-account-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/domain-first-page.js
+++ b/test/e2e/lib/pages/signup/domain-first-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import { getJetpackHost } from '../../data-helper.js';
 import * as driverHelper from '../../driver-helper.js';

--- a/test/e2e/lib/pages/signup/reader-landing-page.js
+++ b/test/e2e/lib/pages/signup/reader-landing-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/signup-processing-page.js
+++ b/test/e2e/lib/pages/signup/signup-processing-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 import LoginPage from '../../pages/login-page';

--- a/test/e2e/lib/pages/signup/site-style-page.js
+++ b/test/e2e/lib/pages/signup/site-style-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/site-title-page.js
+++ b/test/e2e/lib/pages/signup/site-title-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/site-type-page.js
+++ b/test/e2e/lib/pages/signup/site-type-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/start-page.js
+++ b/test/e2e/lib/pages/signup/start-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as dataHelper from '../../data-helper';
 import * as driverHelper from '../../driver-helper';

--- a/test/e2e/lib/pages/signup/upsell-page.js
+++ b/test/e2e/lib/pages/signup/upsell-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/signup/view-blog-page.js
+++ b/test/e2e/lib/pages/signup/view-blog-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 
 export default class ViewBlogPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/site-editor-page.js
+++ b/test/e2e/lib/pages/site-editor-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 

--- a/test/e2e/lib/pages/stats-page.js
+++ b/test/e2e/lib/pages/stats-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper';

--- a/test/e2e/lib/pages/stats/activity-page.js
+++ b/test/e2e/lib/pages/stats/activity-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/theme-detail-page.js
+++ b/test/e2e/lib/pages/theme-detail-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/theme-preview-page.js
+++ b/test/e2e/lib/pages/theme-preview-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/themes-page.js
+++ b/test/e2e/lib/pages/themes-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper';

--- a/test/e2e/lib/pages/transfer-domain-page.js
+++ b/test/e2e/lib/pages/transfer-domain-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 

--- a/test/e2e/lib/pages/transfer-domain-precheck-page.js
+++ b/test/e2e/lib/pages/transfer-domain-precheck-page.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 
 export default class TransferDomainPrecheckPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/view-page-page.js
+++ b/test/e2e/lib/pages/view-page-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import PaymentButtonFrontEndComponent from '../components/payment-button-front-end-component';
 import * as driverHelper from '../driver-helper.js';

--- a/test/e2e/lib/pages/view-post-page.js
+++ b/test/e2e/lib/pages/view-post-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import PaymentButtonFrontEndComponent from '../components/payment-button-front-end-component';
 import * as driverHelper from '../driver-helper';

--- a/test/e2e/lib/pages/view-site-page.js
+++ b/test/e2e/lib/pages/view-site-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 

--- a/test/e2e/lib/pages/wp-admin/wp-admin-customizer-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-customizer-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 
 export default class WPAdminCustomizerPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/wp-admin/wp-admin-dashboard-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-dashboard-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 
 export default class WPAdminDashboardPage extends AsyncBaseContainer {

--- a/test/e2e/lib/pages/wp-admin/wp-admin-in-place-approve-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-in-place-approve-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/wp-admin/wp-admin-in-place-plans-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-in-place-plans-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper.js';
 

--- a/test/e2e/lib/pages/wp-admin/wp-admin-jetpack-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-jetpack-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/wp-admin/wp-admin-logon-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-logon-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/wp-admin/wp-admin-new-user-page.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-new-user-page.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 

--- a/test/e2e/lib/pages/wp-admin/wp-admin-sidebar.js
+++ b/test/e2e/lib/pages/wp-admin/wp-admin-sidebar.js
@@ -1,5 +1,4 @@
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../../async-base-container';
 import * as driverHelper from '../../driver-helper';
 import * as driverManager from '../../driver-manager';

--- a/test/e2e/lib/pages/wp-home-page.js
+++ b/test/e2e/lib/pages/wp-home-page.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import { By } from 'selenium-webdriver';
-
 import localizationData from '../../localization-data.json';
 import AsyncBaseContainer from '../async-base-container';
 

--- a/test/e2e/lib/pages/wporg-creator-page.js
+++ b/test/e2e/lib/pages/wporg-creator-page.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import AsyncBaseContainer from '../async-base-container';
 import * as dataHelper from '../data-helper';
 import * as driverHelper from '../driver-helper';

--- a/test/e2e/lib/shared-steps/wp-signup-spec.js
+++ b/test/e2e/lib/shared-steps/wp-signup-spec.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-
 import InlineHelpChecklistComponent from '../components/inline-help-checklist-component.js';
 import SitePreviewComponent from '../components/site-preview-component.js';
 import MyHomePage from '../pages/my-home-page';

--- a/test/e2e/lib/slack-notifier.js
+++ b/test/e2e/lib/slack-notifier.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import slack from 'slack-notify';
-
 import * as dataHelper from './data-helper';
 import * as driverManager from './driver-manager';
 

--- a/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-seo-preview.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
+++ b/test/e2e/specs/specs-calypso/wp-calypso-user-agent.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';
 import WPHomePage from '../../lib/pages/wp-home-page';

--- a/test/e2e/specs/specs-calypso/wp-editor__edit-media-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-editor__edit-media-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import SideBarComponent from '../../lib/components/sidebar-component';
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';
 import LoginFlow from '../../lib/flows/login-flow.js';

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__create-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__create-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import LanguagePickerComponent from '../../lib/components/gutenboarding-language-picker';
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper.js';

--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as driverManager from '../../lib/driver-manager.js';
 import LoginFlow from '../../lib/flows/login-flow.js';
 import NewPage from '../../lib/pages/gutenboarding/new-page.js';

--- a/test/e2e/specs/specs-calypso/wp-import-site-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-import-site-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import SideBarComponent from '../../lib/components/sidebar-component';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-inline-help-support-search-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import InlineHelpPopoverComponent from '../../lib/components/inline-help-popover-component';
 import SidebarComponent from '../../lib/components/sidebar-component';
 import SupportSearchComponent from '../../lib/components/support-search-component';

--- a/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__editor-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import NoSitesComponent from '../../lib/components/no-sites-component.js';
 import NoticesComponent from '../../lib/components/notices-component.js';

--- a/test/e2e/specs/specs-calypso/wp-invite-users__revoke-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__revoke-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NoticesComponent from '../../lib/components/notices-component.js';
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-invite-users__viewer-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NoticesComponent from '../../lib/components/notices-component.js';
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-launch-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-launch-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import FindADomainComponent from '../../lib/components/find-a-domain-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component';
 import * as dataHelper from '../../lib/data-helper.js';

--- a/test/e2e/specs/specs-calypso/wp-likes-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-likes-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';
 import LoginFlow from '../../lib/flows/login-flow';

--- a/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-log-in-out-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';
 import LoginPage from '../../lib/pages/login-page';

--- a/test/e2e/specs/specs-calypso/wp-manage-domains__add-a-domain-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains__add-a-domain-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import FindADomainComponent from '../../lib/components/find-a-domain-component.js';
 import SecurePaymentComponent from '../../lib/components/secure-payment-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component.js';

--- a/test/e2e/specs/specs-calypso/wp-manage-domains__map-a-domain-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains__map-a-domain-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import EnterADomainComponent from '../../lib/components/enter-a-domain-component';
 import FindADomainComponent from '../../lib/components/find-a-domain-component.js';
 import * as dataHelper from '../../lib/data-helper.js';

--- a/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-my-home-support-search-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import SidebarComponent from '../../lib/components/sidebar-component';
 import SupportSearchComponent from '../../lib/components/support-search-component';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-calypso/wp-notifications-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-notifications-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import NotificationsComponent from '../../lib/components/notifications-component.js';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__comparing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__comparing-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__renew-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__renew-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component';
 import SecurePaymentComponent from '../../lib/components/secure-payment-component';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__upgrade-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__upgrade-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SecurePaymentComponent from '../../lib/components/secure-payment-component';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-plan-purchase__viewing-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SecurePaymentComponent from '../../lib/components/secure-payment-component';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-calypso/wp-reader-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-reader-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import NotificationsComponent from '../../lib/components/notifications-component.js';
 import * as dataHelper from '../../lib/data-helper.js';

--- a/test/e2e/specs/specs-calypso/wp-signup-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-signup-spec.js
@@ -2,7 +2,6 @@
 import assert from 'assert';
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import FindADomainComponent from '../../lib/components/find-a-domain-component.js';
 import NavBarComponent from '../../lib/components/nav-bar-component';
 import NewUserRegistrationUnavailableComponent from '../../lib/components/new-user-domain-registration-unavailable-component';

--- a/test/e2e/specs/specs-calypso/wp-ssr-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-ssr-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import * as dataHelper from '../../lib/data-helper';
 import LoginPage from '../../lib/pages/login-page';
 import ThemesPage from '../../lib/pages/themes-page';

--- a/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-stats-insights-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-theme__multisite-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__multisite-activate-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SidebarComponent from '../../lib/components/sidebar-component';
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-theme__multisite-preview-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__multisite-preview-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SidebarComponent from '../../lib/components/sidebar-component';
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-activate-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SidebarComponent from '../../lib/components/sidebar-component';
 import ThemeDialogComponent from '../../lib/components/theme-dialog-component.js';
 import ThemeSwitchConfirmationComponent from '../../lib/components/theme-switch-confirmation-component.js';

--- a/test/e2e/specs/specs-calypso/wp-theme__switch-preview-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-theme__switch-preview-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager.js';
 import LoginFlow from '../../lib/flows/login-flow.js';

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-connect-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import SecurePaymentComponent from '../../lib/components/secure-payment-component';
 import ThankYouModalComponent from '../../lib/components/thank-you-modal-component';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-plans-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import SecurePaymentComponent from '../../lib/components/secure-payment-component.js';
 import ShoppingCartWidgetComponent from '../../lib/components/shopping-cart-widget-component.js';

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-plugins__activating-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-plugins__activating-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import NoticesComponent from '../../lib/components/notices-component';
 import { getJetpackHost } from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-plugins__searching-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-plugins__searching-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import { getJetpackHost } from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';
 import LoginFlow from '../../lib/flows/login-flow';

--- a/test/e2e/specs/specs-jetpack/wp-jetpack-settings-writing-media-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-jetpack-settings-writing-media-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';
 import LoginFlow from '../../lib/flows/login-flow';

--- a/test/e2e/specs/specs-jetpack/wp-log-in-out-spec.js
+++ b/test/e2e/specs/specs-jetpack/wp-log-in-out-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import LoggedOutMasterbarComponent from '../../lib/components/logged-out-masterbar-component';
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import * as dataHelper from '../../lib/data-helper';

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-
 import {
 	DataHelper,
 	LoginFlow,

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-blocks-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';
 import LoginFlow from '../../lib/flows/login-flow.js';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-coblocks-spec.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverHelper from '../../lib/driver-helper';
 import * as driverManager from '../../lib/driver-manager';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-focused-launch-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import PagePreviewComponent from '../../lib/components/page-preview-component';
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper.js';
 import * as driverManager from '../../lib/driver-manager.js';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By } from 'selenium-webdriver';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import NoticesComponent from '../../lib/components/notices-component.js';
 import PostPreviewComponent from '../../lib/components/post-preview-component';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-post-editor-tracking-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverManager from '../../lib/driver-manager.js';
 import LoginFlow from '../../lib/flows/login-flow.js';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { By, Key } from 'selenium-webdriver';
-
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import SiteEditorComponent from '../../lib/components/site-editor-component.js';
 import * as dataHelper from '../../lib/data-helper.js';

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-upgrade-spec.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-
 import config from 'config';
 import { times } from 'lodash';
-
 import NavBarComponent from '../../lib/components/nav-bar-component.js';
 import * as dataHelper from '../../lib/data-helper.js';
 import * as driverHelper from '../../lib/driver-helper';

--- a/test/e2e/specs/specs-wpcom/wp-comments-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-comments-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';
 import LoginFlow from '../../lib/flows/login-flow';

--- a/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-gutenberg-experimental-features-spec.js
@@ -1,7 +1,5 @@
 import assert from 'assert';
-
 import config from 'config';
-
 import * as dataHelper from '../../lib/data-helper';
 import * as driverManager from '../../lib/driver-manager';
 import LoginFlow from '../../lib/flows/login-flow.js';

--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -1,5 +1,4 @@
 import config from 'config';
-
 import SidebarComponent from '../../lib/components/sidebar-component.js';
 import SiteEditorComponent from '../../lib/components/site-editor-component';
 import * as dataHelper from '../../lib/data-helper';


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

This PR applies a few tweaks to the original config of `import/order`, after getting some feedback from previous PRs:

- Treat packages starting with `^calypso/` as internal (see [`import/internal-regex`](https://github.com/benmosher/eslint-plugin-import/blob/master/README.md#importinternal-regex))
- Configure `internal` packages to appear after `external` but before relative paths (see [`groups`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#groups-array))
- Disable empty lines between import groups (see [`newlines-between`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#newlines-between-ignorealwaysalways-and-inside-groupsnever)
- Tweak the migration script to run prettier after eslint.

Apply the above options to the files that were migrated already:
* `client/sections-filter.js`
* `client/sections-helper.js` 
* `packages/accessible-focus`
* `test/e2e`
