### PR TITLE
ExPlat: Shorten timeout to 5s

### DIFF
--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Shortened timeout (trying it out at this point.)
+
 ## 0.0.2
 
 - Change dangerouslyGetExperimentAssignment to log rather than throw

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -15,7 +15,7 @@ import { createFallbackExperimentAssignment as createFallbackExperimentAssignmen
 /**
  * The number of milliseconds before we abandon fetching an experiment
  */
-const EXPERIMENT_FETCH_TIMEOUT = 5000;
+const EXPERIMENT_FETCH_TIMEOUT = 10000;
 
 export interface ExPlatClient {
 	/**
@@ -62,6 +62,7 @@ export class MissingExperimentAssignmentError extends Error {
  * Create an ExPlat Client
  *
  * @param config Configuration object
+ *
  */
 export function createExPlatClient( config: Config ): ExPlatClient {
 	if ( typeof window === 'undefined' ) {
@@ -118,11 +119,18 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 						experimentName
 					] = createWrappedExperimentAssignmentFetchAndStore( experimentName );
 				}
+
+				// Temporarilly running an A/B experiment on the timeout, see https://github.com/Automattic/wp-calypso/pull/54507
+				let experimentFetchTimeout = EXPERIMENT_FETCH_TIMEOUT;
+				if ( Math.random() > 0.5 ) {
+					experimentFetchTimeout = 5000;
+				}
+
 				// We time out the request here and not above so the fetch-and-store continues and can be
 				// returned by future uses of loadExperimentAssignment.
 				const fetchedExperimentAssignment = await Timing.timeoutPromise(
 					experimentNameToWrappedExperimentAssignmentFetchAndStore[ experimentName ](),
-					EXPERIMENT_FETCH_TIMEOUT
+					experimentFetchTimeout
 				);
 				if ( ! fetchedExperimentAssignment ) {
 					throw new Error( `Could not fetch ExperimentAssignment` );

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -15,7 +15,7 @@ import { createFallbackExperimentAssignment as createFallbackExperimentAssignmen
 /**
  * The number of milliseconds before we abandon fetching an experiment
  */
-const EXPERIMENT_FETCH_TIMEOUT = 10000;
+const EXPERIMENT_FETCH_TIMEOUT = 5000;
 
 export interface ExPlatClient {
 	/**

--- a/packages/explat-client/src/internal/timing.ts
+++ b/packages/explat-client/src/internal/timing.ts
@@ -28,7 +28,10 @@ export function timeoutPromise< T >(
 	return Promise.race( [
 		promise,
 		new Promise< null >( ( _res, rej ) =>
-			setTimeout( () => rej( new Error( 'Promise has timed-out.' ) ), timeoutMilliseconds )
+			setTimeout(
+				() => rej( new Error( `Promise has timed-out after ${ timeoutMilliseconds }ms.` ) ),
+				timeoutMilliseconds
+			)
 		),
 	] );
 }

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -242,17 +242,15 @@ describe( 'ExPlatClient.loadExperimentAssignment single-use', () => {
 		} );
 		jest.advanceTimersByTime( 10 * 1000 );
 		await expectationPromise;
-		expect( ( mockedConfig.logError as MockedFunction ).mock.calls ).toMatchInlineSnapshot( `
-		Array [
-		  Array [
-		    Object {
-		      "experimentName": "experiment_name_a",
-		      "message": "Promise has timed-out.",
-		      "source": "loadExperimentAssignment-initialError",
-		    },
-		  ],
-		]
-	` );
+		// Temporary hack for the A/B experiment, see https://github.com/Automattic/wp-calypso/pull/54507
+		const error = ( mockedConfig.logError as MockedFunction ).mock.calls[ 0 ][ 0 ];
+		expect( error ).toEqual(
+			expect.objectContaining( {
+				experimentName: 'experiment_name_a',
+				source: 'loadExperimentAssignment-initialError',
+			} )
+		);
+		expect( error.message ).toMatch( /Promise has timed-out after [0-9]+ms\./ );
 		jest.useRealTimers();
 	} );
 	it( `logError throws/secondary error: should attempt to log secondary error and return fallback`, async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re: 651-gh-Automattic/experimentation-platform, shorten the timeout to 5s

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Existing AT

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

