### PR TITLE
Signup: Remove scolling to top on step progression

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -507,42 +507,12 @@ class Signup extends React.Component {
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
-		if ( this.state.scrolling ) {
-			return;
+		if ( ! this.isEveryStepSubmitted() ) {
+			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
+			page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
+		} else if ( this.isEveryStepSubmitted() ) {
+			this.goToFirstInvalidStep();
 		}
-
-		// animate the scroll position to the top
-		const scrollPromise = new Promise( ( resolve ) => {
-			this.setState( { scrolling: true } );
-
-			const ANIMATION_LENGTH_MS = 200;
-			const startTime = window.performance.now();
-			const scrollHeight = window.pageYOffset;
-
-			const scrollToTop = ( timestamp ) => {
-				const progress = timestamp - startTime;
-
-				if ( progress < ANIMATION_LENGTH_MS ) {
-					window.scrollTo( 0, scrollHeight - ( scrollHeight * progress ) / ANIMATION_LENGTH_MS );
-					window.requestAnimationFrame( scrollToTop );
-				} else {
-					this.setState( { scrolling: false } );
-					resolve();
-				}
-			};
-
-			window.requestAnimationFrame( scrollToTop );
-		} );
-
-		// redirect the user to the next step
-		scrollPromise.then( () => {
-			if ( ! this.isEveryStepSubmitted() ) {
-				const locale = ! this.props.isLoggedIn ? this.props.locale : '';
-				page( getStepUrl( flowName, stepName, stepSectionName, locale ) );
-			} else if ( this.isEveryStepSubmitted() ) {
-				this.goToFirstInvalidStep();
-			}
-		} );
 	};
 
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -270,7 +270,13 @@ class Signup extends React.Component {
 		if ( this.props.stepName !== prevProps.stepName ) {
 			this.maybeShowSitePreview();
 			this.preloadNextStep();
+			// scrollToTop here handles cases where the viewport falls slightly below the top of the page on the next step.
+			this.scrollToTop();
 		}
+	}
+
+	scrollToTop() {
+		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
 	}
 
 	/**

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -270,7 +270,7 @@ class Signup extends React.Component {
 		if ( this.props.stepName !== prevProps.stepName ) {
 			this.maybeShowSitePreview();
 			this.preloadNextStep();
-			// scrollToTop here handles cases where the viewport falls slightly below the top of the page on the next step.
+			// `scrollToTop` here handles cases where the viewport may fall slightly below the top of the page when the next step is rendered
 			this.scrollToTop();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses #54015

It appears that the current signup code implements functionality to scroll the page to the top when progressing from one step to the next (not sure if this was a transitioning effect or meant to address some other technical concern). The implementation dates back to the earliest Calypso commits. Scrolling does seem to address the issue of the next step being rendered placing the viewport slightly below the top of the page, albeit doing it on the current step can feel pretty mechanical when a long list has to be scrolled all the way to the top before moving to the next step. The implementation was also somewhat suboptimal with splitting the scrolling across a number of callbacks called back to back via `window.requestAnimationFrame` - the API has later provided support for a "behavior" option, which can be set to "smooth" (albeit Safari requiring a polyfill for this). See our explorations in https://github.com/Automattic/wp-calypso/pull/54388 for more.

We get rid of scrolling in this PR as a transitioning effect.


#### Testing instructions

- Go to `/start/domains`, scroll to the bottom, and select one of the domains.
- The page should go to the next step directly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before | After |
| ---------- | ------- |
| ![calypso-signup-safari-polyfill](https://user-images.githubusercontent.com/1705499/124940605-cd1a0600-e012-11eb-98f9-6b8751888e54.gif) | ![calypso-signup-safari](https://user-images.githubusercontent.com/1705499/124940538-bffd1700-e012-11eb-8b13-624c7b392c42.gif) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #54015
