### PR TITLE
Theme Showcase Search Revamp

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -84,7 +84,7 @@ $z-layers: (
 		'.web-preview__inner .spinner-line': 1,
 		'.is-section-purchases .search': 1,
 		'.checklist__task': 1,
-		'.themes-magic-search-card.has-highlight': 1,
+		'.themes-magic-search-card.has-highlight': 3, // Let child .keyed-suggestions be on top of .upwork-banner
 		'.is-installing .theme': 2,
 		'.people-list-item .card__link-indicator': 2,
 		'.page__shadow-notice-cover': 2,

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -390,9 +390,9 @@ class KeyedSuggestions extends React.Component {
 			rendered.push(
 				suggestions[ key ].map( ( value, i ) => {
 					const taxonomyName = terms[ key ][ value ].name;
-					const hasHighlight = noOfSuggestions + i === this.state.suggestionPosition;
+					const isSelected = noOfSuggestions + i === this.state.suggestionPosition;
 					const className = classNames( 'keyed-suggestions__value', {
-						'has-highlight': hasHighlight,
+						'is-selected': isSelected,
 					} );
 					return (
 						/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/mouse-events-have-key-events */

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -1,3 +1,12 @@
+.keyed-suggestions {
+	position: absolute;
+	z-index: 9000;
+	top: 37px;
+	left: 0;
+	width: 100%;
+	margin-left: -1px;
+}
+
 .keyed-suggestions__suggestions {
 	display: flex;
 	flex-direction: column;

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -48,7 +48,7 @@
 	font-size: $font-body;
 	cursor: pointer;
 
-	&.has-highlight {
+	&.is-selected {
 		background-color: var( --color-primary );
 		color: var( --color-text-inverted );
 
@@ -90,7 +90,7 @@
 	&::before {
 		@include long-content-fade();
 
-		.has-highlight & {
+		.is-selected & {
 			@include long-content-fade( $color: var( --color-primary-rgb ) );
 		}
 	}

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -1,6 +1,5 @@
 .keyed-suggestions {
 	position: absolute;
-	z-index: 9000;
 	top: 37px;
 	left: 0;
 	width: 100%;

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -4,6 +4,8 @@
 	left: 0;
 	width: 100%;
 	margin-left: -1px;
+	overflow-y: auto;
+	max-height: 50vh;
 }
 
 .keyed-suggestions__suggestions {

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -300,7 +300,8 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 		}
 
 		&:last-child {
-			margin-right: 16px;
+			// Matches with .segmented-control padding in .theme-magic-search-card
+			margin-right: 11px;
 		}
 
 		.gridicon {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -57,6 +57,11 @@
 	box-shadow: none;
 	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
 	border-top: 0;
+	.section-nav-tab__link {
+		@include breakpoint-deprecated( '>480px' ) {
+			padding-top: 8px;
+		}
+	}
 }
 
 .theme-showcase__all-themes-title {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -54,7 +54,9 @@
 }
 
 .section-nav.themes__section-nav {
-	margin-top: 1px;
+	box-shadow: none;
+	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
+	border-top: 0;
 }
 
 .theme-showcase__all-themes-title {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -55,7 +55,7 @@
 
 .section-nav.themes__section-nav {
 	box-shadow: none;
-	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
+	border: 1px solid var( --color-border-subtle );
 	border-top: 0;
 	.section-nav-tab__link {
 		@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -59,7 +59,6 @@ class ThemesMagicSearchCard extends React.Component {
 			editedSearchElement: '',
 			cursorPosition: 0,
 			searchInput: this.props.search,
-			isWelcomeBarEnabled: false,
 			isPopoverVisible: false,
 		};
 	}
@@ -275,15 +274,9 @@ class ThemesMagicSearchCard extends React.Component {
 		this.focusOnInput();
 	};
 
-	handleWelcomeBarToggle = () => {
-		this.setState( ( prevState ) => ( {
-			isWelcomeBarEnabled: ! prevState.isWelcomeBarEnabled,
-		} ) );
-	};
-
 	render() {
 		const { translate, filters, showTierThemesControl } = this.props;
-		const { isWelcomeBarEnabled, isPopoverVisible } = this.state;
+		const { isPopoverVisible } = this.state;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
 
 		const tiers = [
@@ -363,15 +356,12 @@ class ThemesMagicSearchCard extends React.Component {
 						{ config.isEnabled( 'theme/showcase-revamp' ) && (
 							<div>
 								<Button
-									oldOnClick={ this.handleWelcomeBarToggle }
 									onClick={ this.togglePopover }
 									className="components-button themes-magic-search-card__advanced-toggle"
 									ref={ ( ref ) => ( this.popoverButtonRef = ref ) }
 								>
 									<Gridicon icon="cog" size={ 18 } />
-									{ isWelcomeBarEnabled
-										? translate( 'Hide Advanced' )
-										: translate( 'Show Advanced' ) }
+									{ translate( 'Filters' ) }
 								</Button>
 								<Popover
 									context={ this.popoverButtonRef }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -296,9 +296,7 @@ class ThemesMagicSearchCard extends React.Component {
 				initialValue={ this.state.searchInput }
 				value={ this.state.searchInput }
 				ref={ this.setSearchInputRef }
-				placeholder={ translate(
-					'Search by style or feature: portfolio, store, multiple menus, or…'
-				) }
+				placeholder={ translate( 'Search for themes' ) }
 				analyticsGroup="Themes"
 				delaySearch={ true }
 				onSearchOpen={ this.onSearchOpen }
@@ -351,6 +349,19 @@ class ThemesMagicSearchCard extends React.Component {
 								/>
 							</div>
 						) }
+						{ config.isEnabled( 'theme/showcase-revamp' ) && (
+							<div>
+								<Button
+									onClick={ this.handleWelcomeBarToggle }
+									className="components-button themes-magic-search-card__advanced-toggle"
+								>
+									<Gridicon icon="cog" size={ 18 } />
+									{ isWelcomeBarEnabled
+										? translate( 'Hide Advanced' )
+										: translate( 'Show Advanced' ) }
+								</Button>
+							</div>
+						) }
 						{ isPremiumThemesEnabled && showTierThemesControl && (
 							<SimplifiedSegmentedControl
 								key={ this.props.tier }
@@ -361,18 +372,6 @@ class ThemesMagicSearchCard extends React.Component {
 									'showcase-revamp': config.isEnabled( 'theme/showcase-revamp' ),
 								} ) }
 							/>
-						) }
-						{ config.isEnabled( 'theme/showcase-revamp' ) && (
-							<div>
-								<Button
-									onClick={ this.handleWelcomeBarToggle }
-									className="is-link themes-magic-search-card__advanced-toggle"
-								>
-									{ isWelcomeBarEnabled
-										? translate( 'Hide Advanced' )
-										: translate( 'Show Advanced' ) }
-								</Button>
-							</div>
 						) }
 					</div>
 				</StickyPanel>

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -335,6 +335,31 @@ class ThemesMagicSearchCard extends React.Component {
 						/>
 					</div>
 				) }
+				{ config.isEnabled( 'theme/showcase-revamp' ) && (
+					<div>
+						<Button
+							onClick={ this.togglePopover }
+							className="components-button themes-magic-search-card__advanced-toggle"
+							ref={ ( ref ) => ( this.popoverButtonRef = ref ) }
+						>
+							<Gridicon icon="cog" size={ 18 } />
+							{ translate( 'Filters' ) }
+						</Button>
+						<Popover
+							context={ this.popoverButtonRef }
+							isVisible={ isPopoverVisible }
+							onClose={ this.closePopover }
+							position="bottom"
+						>
+							<MagicSearchWelcome
+								ref={ this.setSuggestionsRefs( 'welcome' ) }
+								taxonomies={ filtersKeys }
+								topSearches={ [] }
+								suggestionsCallback={ this.welcomeBarAddText }
+							/>
+						</Popover>
+					</div>
+				) }
 			</Search>
 		);
 
@@ -356,31 +381,6 @@ class ThemesMagicSearchCard extends React.Component {
 						onClick={ this.handleClickInside }
 					>
 						{ searchField }
-						{ config.isEnabled( 'theme/showcase-revamp' ) && (
-							<div>
-								<Button
-									onClick={ this.togglePopover }
-									className="components-button themes-magic-search-card__advanced-toggle"
-									ref={ ( ref ) => ( this.popoverButtonRef = ref ) }
-								>
-									<Gridicon icon="cog" size={ 18 } />
-									{ translate( 'Filters' ) }
-								</Button>
-								<Popover
-									context={ this.popoverButtonRef }
-									isVisible={ isPopoverVisible }
-									onClose={ this.closePopover }
-									position="bottom"
-								>
-									<MagicSearchWelcome
-										ref={ this.setSuggestionsRefs( 'welcome' ) }
-										taxonomies={ filtersKeys }
-										topSearches={ [] }
-										suggestionsCallback={ this.welcomeBarAddText }
-									/>
-								</Popover>
-							</div>
-						) }
 						{ isPremiumThemesEnabled && showTierThemesControl && (
 							<SimplifiedSegmentedControl
 								key={ this.props.tier }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -290,6 +290,15 @@ class ThemesMagicSearchCard extends React.Component {
 			...difference( Object.keys( filters ), preferredOrderOfTaxonomies ),
 		];
 
+		// Check if we want to render suggestions or welcome banner
+		const renderSuggestions =
+			this.state.editedSearchElement !== '' && this.state.editedSearchElement.length > 2;
+
+		let isWelcomeBarVisible = ! renderSuggestions;
+		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
+			isWelcomeBarVisible = isWelcomeBarEnabled;
+		}
+
 		const searchField = (
 			<Search
 				onSearch={ this.props.onSearch }
@@ -307,7 +316,16 @@ class ThemesMagicSearchCard extends React.Component {
 				overlayStyling={ this.searchTokens }
 				fitsContainer={ this.props.isBreakpointActive && this.state.searchIsOpen }
 				hideClose={ true }
-			/>
+			>
+				{ renderSuggestions && (
+					<KeyedSuggestions
+						ref={ this.setSuggestionsRefs( 'suggestions' ) }
+						terms={ this.props.filters }
+						input={ this.state.editedSearchElement }
+						suggest={ this.suggest }
+					/>
+				) }
+			</Search>
 		);
 
 		const magicSearchClass = classNames( 'themes-magic-search', {
@@ -317,15 +335,6 @@ class ThemesMagicSearchCard extends React.Component {
 		const themesSearchCardClass = classNames( 'themes-magic-search-card', {
 			'has-highlight': this.state.searchIsOpen,
 		} );
-
-		// Check if we want to render suggestions or welcome banner
-		const renderSuggestions =
-			this.state.editedSearchElement !== '' && this.state.editedSearchElement.length > 2;
-
-		let isWelcomeBarVisible = ! renderSuggestions;
-		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
-			isWelcomeBarVisible = isWelcomeBarEnabled;
-		}
 
 		return (
 			<div className={ magicSearchClass }>
@@ -376,14 +385,6 @@ class ThemesMagicSearchCard extends React.Component {
 					</div>
 				</StickyPanel>
 				<div role="presentation" onClick={ this.handleClickInside }>
-					{ renderSuggestions && (
-						<KeyedSuggestions
-							ref={ this.setSuggestionsRefs( 'suggestions' ) }
-							terms={ this.props.filters }
-							input={ this.state.editedSearchElement }
-							suggest={ this.suggest }
-						/>
-					) }
 					{ isWelcomeBarVisible && (
 						<MagicSearchWelcome
 							ref={ this.setSuggestionsRefs( 'welcome' ) }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -309,7 +309,6 @@ class ThemesMagicSearchCard extends React.Component {
 				onKeyDown={ this.onKeyDown }
 				onClick={ this.onClick }
 				overlayStyling={ this.searchTokens }
-				fitsContainer={ this.props.isBreakpointActive && this.state.searchIsOpen }
 				hideClose={ true }
 			>
 				{ renderSuggestions && (

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -79,6 +79,10 @@ class ThemesMagicSearchCard extends React.Component {
 		this.setState( ( oldState ) => ( { isPopoverVisible: ! oldState.isPopoverVisible } ) );
 	};
 
+	closePopover = () => {
+		this.setState( { isPopoverVisible: false } );
+	};
+
 	onSearchOpen = () => {
 		this.setState( { searchIsOpen: true } );
 	};
@@ -365,8 +369,7 @@ class ThemesMagicSearchCard extends React.Component {
 								<Popover
 									context={ this.popoverButtonRef }
 									isVisible={ isPopoverVisible }
-									// onClose={ this.closePopover }
-									// className="component__popover"
+									onClose={ this.closePopover }
 									position="bottom"
 								>
 									<MagicSearchWelcome

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -323,6 +323,18 @@ class ThemesMagicSearchCard extends React.Component {
 						suggest={ this.suggest }
 					/>
 				) }
+				{ this.state.searchInput !== '' && (
+					<div className="themes-magic-search-card__icon">
+						<Gridicon
+							icon="cross"
+							className="themes-magic-search-card__icon-close"
+							tabIndex="0"
+							onClick={ this.clearSearch }
+							aria-controls={ 'search-component-magic-search' }
+							aria-label={ translate( 'Clear Search' ) }
+						/>
+					</div>
+				) }
 			</Search>
 		);
 
@@ -344,18 +356,6 @@ class ThemesMagicSearchCard extends React.Component {
 						onClick={ this.handleClickInside }
 					>
 						{ searchField }
-						{ this.state.searchInput !== '' && (
-							<div className="themes-magic-search-card__icon">
-								<Gridicon
-									icon="cross"
-									className="themes-magic-search-card__icon-close"
-									tabIndex="0"
-									onClick={ this.clearSearch }
-									aria-controls={ 'search-component-magic-search' }
-									aria-label={ translate( 'Clear Search' ) }
-								/>
-							</div>
-						) }
 						{ config.isEnabled( 'theme/showcase-revamp' ) && (
 							<div>
 								<Button

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -304,7 +304,9 @@ class ThemesMagicSearchCard extends React.Component {
 				initialValue={ this.state.searchInput }
 				value={ this.state.searchInput }
 				ref={ this.setSearchInputRef }
-				placeholder={ translate( 'Search for themes' ) }
+				placeholder={ translate(
+					'Search by style or feature: portfolio, store, multiple menus, or…'
+				) }
 				analyticsGroup="Themes"
 				delaySearch={ true }
 				onSearchOpen={ this.onSearchOpen }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -21,8 +21,9 @@
 
 	.search {
 		flex: 0 1 auto;
-		margin: 0;
-		height: 58px;
+		margin: 0 10px;
+		height: 36px;
+		border: solid 1px var( --color-neutral-10 );
 
 		&.has-focus,
 		&.has-focus:hover {
@@ -65,6 +66,14 @@
 		.segmented-control__link,
 		.segmented-control__text {
 			min-width: inherit;
+		}
+
+		.segmented-control__item.is-selected {
+			background: var( --color-neutral-100 );
+
+			a {
+				color: var( --color-text-inverted );
+			}
 		}
 
 		&.showcase-revamp {
@@ -219,9 +228,13 @@
 	pointer-events: none;
 }
 
-.button.is-link.themes-magic-search-card__advanced-toggle {
+.button.themes-magic-search-card__advanced-toggle {
 	font-size: 0.75rem;
-	margin-top: 3px;
-	margin-right: 10px;
 	white-space: nowrap;
+	border: 1px solid var( --color-neutral-10 );
+
+	.gridicon {
+		top: 0;
+		margin: 0 5px 0 0;
+	}
 }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -175,18 +175,19 @@
 
 .themes-magic-search-card__welcome-header {
 	background-color: var( --color-neutral-0 );
-	border-bottom: 1px solid var( --color-neutral-5 );
-	border-top: 0;
-	padding: 4px 8px;
+	border: 0;
+	padding: 6px 12px 0;
 	font-size: $font-body-small;
 
 	text-transform: uppercase;
-	color: var( --color-neutral-70 );
+	color: var( --color-neutral-50 );
+	text-align: left;
 }
 
 .themes-magic-search-card__welcome-taxonomies {
 	display: flex;
 	flex-wrap: wrap;
+	padding: 6px 12px 12px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-wrap: nowrap;
@@ -194,12 +195,18 @@
 }
 
 .themes-magic-search-card__welcome-taxonomy {
+	border: 1px solid var( --color-neutral-5 );
+	border-left: 0;
+	&:first-child {
+		border-left: 1px solid var( --color-neutral-5 );
+	}
+
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
 	text-align: center;
 	flex: 1 0 auto;
 	overflow: hidden;
-	padding: 10px 6px;
+	padding: 12px;
 	margin: 0;
 	font-size: $font-body-small;
 	line-height: 16px;
@@ -213,7 +220,7 @@
 
 	.gridicon {
 		fill: var( --color-neutral-70 );
-		margin: 0 auto;
+		margin-right: 10px;
 		transition: fill 200ms ease-in;
 	}
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -20,6 +20,7 @@
 	}
 
 	.search {
+		position: relative;
 		flex: 0 1 auto;
 		margin: 0 10px;
 		height: 36px;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -239,7 +239,7 @@
 .button.themes-magic-search-card__advanced-toggle {
 	font-size: 0.75rem;
 	white-space: nowrap;
-	border: 1px solid var( --color-neutral-10 );
+	border: 0;
 
 	.gridicon {
 		top: 0;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -13,6 +13,12 @@
 		0 1px 2px var( --color-neutral-0 );
 	transition: all 0.15s ease-in-out;
 
+	@include breakpoint-deprecated( '<660px' ) {
+		flex-wrap: wrap;
+		justify-content: center;
+		padding-top: 10px;
+	}
+
 	&.has-highlight {
 		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
 		position: relative;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -47,7 +47,8 @@
 	}
 
 	.themes-magic-search-card__icon {
-		margin-left: 8px;
+		margin-left: 4px;
+		margin-right: 4px;
 		display: flex;
 		color: var( --color-primary );
 		cursor: pointer;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -9,7 +9,7 @@
 	display: flex;
 	align-items: center;
 	background: white;
-	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
+	border: 1px solid var( --color-border-subtle );
 	border-bottom: 0;
 	transition: all 0.15s ease-in-out;
 
@@ -183,7 +183,7 @@
 	font-size: $font-body-small;
 
 	text-transform: uppercase;
-	color: var( --color-neutral-50 );
+	color: var( --color-text-subtle );
 	text-align: left;
 }
 
@@ -198,10 +198,10 @@
 }
 
 .themes-magic-search-card__welcome-taxonomy {
-	border: 1px solid var( --color-neutral-5 );
+	border: 1px solid var( --color-border-subtle );
 	border-left: 0;
 	&:first-child {
-		border-left: 1px solid var( --color-neutral-5 );
+		border-left: 1px solid var( --color-border-subtle );
 	}
 
 	display: flex;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -81,6 +81,9 @@
 
 			a {
 				color: var( --color-text-inverted );
+				&:hover {
+					color: var( --color-neutral-70 );
+				}
 			}
 		}
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -76,6 +76,12 @@
 			min-width: inherit;
 		}
 
+		// Default padding is 8px 12px,
+		// Add one to Y for alignment in theme showcase search
+		.segmented-control__link {
+			padding: 9px 12px;
+		}
+
 		.segmented-control__item.is-selected {
 			background: var( --color-neutral-100 );
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -183,7 +183,6 @@
 }
 
 .themes-magic-search-card__welcome-header {
-	background-color: var( --color-neutral-0 );
 	border: 0;
 	padding: 6px 12px 0;
 	font-size: $font-body-small;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -28,7 +28,7 @@
 	.search {
 		position: relative;
 		flex: 0 1 auto;
-		margin: 0 10px;
+		margin: 0 5px 0 10px;
 		height: 36px;
 		border: solid 1px var( --color-neutral-10 );
 
@@ -94,7 +94,7 @@
 		}
 
 		&.showcase-revamp {
-			padding: 11px 10px;
+			padding: 11px 10px 11px 5px;
 		}
 	}
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -105,6 +105,18 @@
 }
 
 /*
+ * Align SVGs and nearby text
+ */
+.themes-magic-search-card__welcome-taxonomy-icon-container,
+.themes-magic-search-card__welcome-taxonomy-text-container {
+	vertical-align: middle;
+	display: inline-block;
+}
+.themes-magic-search-card__welcome-taxonomy-text-container {
+	padding-bottom: 2px;
+}
+
+/*
  * Tokens
  */
 .themes-magic-search-card__token {
@@ -209,8 +221,6 @@
 		border-left: 1px solid var( --color-border-subtle );
 	}
 
-	display: flex;
-	flex-direction: row;
 	text-align: center;
 	flex: 1 0 auto;
 	overflow: hidden;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -9,8 +9,8 @@
 	display: flex;
 	align-items: center;
 	background: white;
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
-		0 1px 2px var( --color-neutral-0 );
+	border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
+	border-bottom: 0;
 	transition: all 0.15s ease-in-out;
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -114,7 +114,7 @@ class MagicSearchWelcome extends React.Component {
 					icon={ taxonomyToGridicon( taxonomy ) }
 					className="themes-magic-search-card__welcome-taxonomy-icon"
 					size={ 18 }
-				/>
+				/>{ ' ' }
 				{ taxonomyTranslations[ taxonomy ] ||
 					i18n.translate( 'Unknown', {
 						context: 'Theme Showcase filter name',

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -110,15 +110,19 @@ class MagicSearchWelcome extends React.Component {
 				key={ taxonomy }
 				data-key={ taxonomy }
 			>
-				<Gridicon
-					icon={ taxonomyToGridicon( taxonomy ) }
-					className="themes-magic-search-card__welcome-taxonomy-icon"
-					size={ 18 }
-				/>{ ' ' }
-				{ taxonomyTranslations[ taxonomy ] ||
-					i18n.translate( 'Unknown', {
-						context: 'Theme Showcase filter name',
-					} ) }
+				<span className="themes-magic-search-card__welcome-taxonomy-icon-container">
+					<Gridicon
+						icon={ taxonomyToGridicon( taxonomy ) }
+						className="themes-magic-search-card__welcome-taxonomy-icon"
+						size={ 18 }
+					/>{ ' ' }
+				</span>
+				<span className="themes-magic-search-card__welcome-taxonomy-text-container">
+					{ taxonomyTranslations[ taxonomy ] ||
+						i18n.translate( 'Unknown', {
+							context: 'Theme Showcase filter name',
+						} ) }
+				</span>
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rework the theme showcase search
  * All / Free / Premium buttons - reworked
  * Advanced search toggle - reworked
  * Clear button - now inside
  * Suggestions - now floating

#### BEFORE

![2021-07-14_13-30](https://user-images.githubusercontent.com/937354/125674048-32e33cc1-048c-4e33-b13c-69e98a85ac0f.png)
^ Before - Initial

![2021-07-14_13-30_1](https://user-images.githubusercontent.com/937354/125674083-300f82b5-2845-4dc2-8666-5059a177a7d7.png)
^ Before - Magic Welcome

![2021-07-14_13-30_2](https://user-images.githubusercontent.com/937354/125674108-dd885984-c2da-4393-bf55-1e5cb016669a.png)
^ Before - Keyed Suggestions

#### AFTER

![2021-07-15_10-03](https://user-images.githubusercontent.com/937354/125810925-840d313e-cf7f-4b44-ad6b-5c4e8e37431d.png)
^ After - Initial

![2021-07-15_10-04](https://user-images.githubusercontent.com/937354/125810934-65f988d8-203c-48a7-a78b-edde27e61697.png)
^ After - Magic Welcome (Now in popover)

![2021-07-15_10-04_1](https://user-images.githubusercontent.com/937354/125810954-2c57d5af-aa65-4911-93b2-c6ea689872af.png)
^ After - Keyed Suggestions (Now floating)

#### Testing instructions

* Go to theme showcase and use the search
  * See suggestions while typing in 'sidebar'
  * All/Free/Premium filters
  * Filter button -> Features/Column/Subject

Related to #54392
