### PR TITLE
Make KeyedSuggestions float

### DIFF
--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -1,3 +1,12 @@
+.keyed-suggestions {
+	position: absolute;
+	z-index: 9000;
+	top: 37px;
+	left: 0;
+	width: 100%;
+	margin-left: -1px;
+}
+
 .keyed-suggestions__suggestions {
 	display: flex;
 	flex-direction: column;

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -290,6 +290,15 @@ class ThemesMagicSearchCard extends React.Component {
 			...difference( Object.keys( filters ), preferredOrderOfTaxonomies ),
 		];
 
+		// Check if we want to render suggestions or welcome banner
+		const renderSuggestions =
+			this.state.editedSearchElement !== '' && this.state.editedSearchElement.length > 2;
+
+		let isWelcomeBarVisible = ! renderSuggestions;
+		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
+			isWelcomeBarVisible = isWelcomeBarEnabled;
+		}
+
 		const searchField = (
 			<Search
 				onSearch={ this.props.onSearch }
@@ -307,7 +316,16 @@ class ThemesMagicSearchCard extends React.Component {
 				overlayStyling={ this.searchTokens }
 				fitsContainer={ this.props.isBreakpointActive && this.state.searchIsOpen }
 				hideClose={ true }
-			/>
+			>
+				{ renderSuggestions && (
+					<KeyedSuggestions
+						ref={ this.setSuggestionsRefs( 'suggestions' ) }
+						terms={ this.props.filters }
+						input={ this.state.editedSearchElement }
+						suggest={ this.suggest }
+					/>
+				) }
+			</Search>
 		);
 
 		const magicSearchClass = classNames( 'themes-magic-search', {
@@ -317,15 +335,6 @@ class ThemesMagicSearchCard extends React.Component {
 		const themesSearchCardClass = classNames( 'themes-magic-search-card', {
 			'has-highlight': this.state.searchIsOpen,
 		} );
-
-		// Check if we want to render suggestions or welcome banner
-		const renderSuggestions =
-			this.state.editedSearchElement !== '' && this.state.editedSearchElement.length > 2;
-
-		let isWelcomeBarVisible = ! renderSuggestions;
-		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
-			isWelcomeBarVisible = isWelcomeBarEnabled;
-		}
 
 		return (
 			<div className={ magicSearchClass }>
@@ -376,14 +385,6 @@ class ThemesMagicSearchCard extends React.Component {
 					</div>
 				</StickyPanel>
 				<div role="presentation" onClick={ this.handleClickInside }>
-					{ renderSuggestions && (
-						<KeyedSuggestions
-							ref={ this.setSuggestionsRefs( 'suggestions' ) }
-							terms={ this.props.filters }
-							input={ this.state.editedSearchElement }
-							suggest={ this.suggest }
-						/>
-					) }
 					{ isWelcomeBarVisible && (
 						<MagicSearchWelcome
 							ref={ this.setSuggestionsRefs( 'welcome' ) }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -18,6 +18,7 @@
 	}
 
 	.search {
+		position: relative;
 		flex: 0 1 auto;
 		margin: 0 10px;
 		height: 36px;


### PR DESCRIPTION
## Parent PR: #54514 **This does not merge into trunk**

#### Changes proposed in this Pull Request

* KeyedSuggestions is floating

![2021-07-13_11-24](https://user-images.githubusercontent.com/937354/125489410-7dbb6bef-7f28-45ac-9c8a-263f328f48b0.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to theme showcase and type a search

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
