### PR TITLE
Theme Showcase: Higher z-index on search so focus outline doesn't get cut off

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -84,6 +84,7 @@ $z-layers: (
 		'.web-preview__inner .spinner-line': 1,
 		'.is-section-purchases .search': 1,
 		'.checklist__task': 1,
+		'.themes-magic-search-card.has-highlight': 1,
 		'.is-installing .theme': 2,
 		'.people-list-item .card__link-indicator': 2,
 		'.page__shadow-notice-cover': 2,

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -15,6 +15,8 @@
 
 	&.has-highlight {
 		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
+		position: relative;
+		z-index: z-index( 'root', '.themes-magic-search-card.has-highlight' );
 	}
 
 	.search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set a z-index on the theme search bar so its focus state does not get cut off by the tabs bar.

**Before**

<img width="1355" alt="Screen Shot 2021-07-13 at 12 50 04 PM" src="https://user-images.githubusercontent.com/2124984/125493366-55ed9b3b-def6-4634-bafb-b94e7aacd427.png">

**After**

<img width="1362" alt="Screen Shot 2021-07-13 at 12 49 49 PM" src="https://user-images.githubusercontent.com/2124984/125493386-370d77ad-a594-485e-ac5c-cb8ccb2af00a.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes`
* Click in the search bar; the focus should appear around the whole bar, not under the tabs 
