### PR TITLE
Playwright: update how `filterThemes` work.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -53,22 +53,19 @@ export class ThemesPage extends BaseContainer {
 	}
 
 	/**
-	 * Filters the themes on page by clicking on the selector passed in as argument.
+	 * Filters the themes on page according to the pricing structure.
 	 *
 	 * @param {string} type Pre-defined types of themes.
 	 * @returns {Promise<void>} No return value.
 	 */
 	async filterThemes( type: 'All' | 'Free' | 'Premium' ): Promise< void > {
-		await this.page.click( selectors.showAllThemesButton );
-		const searchToolbar = await this.page.waitForSelector( selectors.searchToolbar );
-		const button = await searchToolbar.waitForSelector(
-			`a[data-e2e-value=${ type.toLowerCase() }]`
-		);
-		await button.click();
-		// This will wait for all placeholder classes to return to hidden state.
+		const selector = `a[data-e2e-value=${ type.toLowerCase() }]`;
+		await this.page.click( selector );
+		// Wait for placeholder to disappear (indicating load is completed).
 		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
-		// Verify that filter has been successfully applied.
-		const isSelected = await button.getAttribute( 'aria-checked' );
+		const isSelected = await this.page.$eval( selector, ( element ) =>
+			element.getAttribute( 'aria-checked' )
+		);
 		assert.strictEqual( isSelected, 'true' );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

PR #54361 updated how the theme toolbar behaves; it no longer is hidden behind a `Show all` button at bottom of the page.

Changes:
- `ThemesPage.filterThemes` method has revised call ordering to locate the button, click on the button, wait for the loading to complete then confirm the button has been clicked.

#### Testing instructions

TeamCity:
- ensure tests in the Themes section pass.


