### PR TITLE
desktop: fix devtools and zoom controls

### DIFF
--- a/desktop/app/lib/menu/debug-menu.js
+++ b/desktop/app/lib/menu/debug-menu.js
@@ -2,10 +2,13 @@ const { BrowserWindow } = require( 'electron' );
 
 module.exports = [
 	{
-		role: 'reload',
-	},
-	{
-		role: 'forceReload',
+		label: 'Force Reload',
+		accelerator: 'Shift+CmdOrCtrl+R',
+		click: function () {
+			const window = BrowserWindow.getFocusedWindow();
+			const view = window.getBrowserView();
+			view.webContents.reloadIgnoringCache();
+		},
 	},
 	{
 		label: 'Developer Tools',

--- a/desktop/app/lib/menu/debug-menu.js
+++ b/desktop/app/lib/menu/debug-menu.js
@@ -12,7 +12,8 @@ module.exports = [
 		accelerator: 'Alt+CmdOrCtrl+I',
 		click: function () {
 			const window = BrowserWindow.getFocusedWindow();
-			window.openDevTools( { mode: 'undocked' } );
+			const view = window.getBrowserView();
+			view.webContents.openDevTools( { mode: 'right' } );
 		},
 	},
 ];

--- a/desktop/app/lib/menu/view-menu.js
+++ b/desktop/app/lib/menu/view-menu.js
@@ -69,7 +69,23 @@ menuItems.push(
 	{
 		type: 'separator',
 	},
-	...debugMenu
+	{
+		label: 'Reload',
+		accelerator: 'CommandOrControl+R',
+		visible: true,
+		click: function () {
+			const window = BrowserWindow.getFocusedWindow();
+			const view = window.getBrowserView();
+			view.webContents.reload();
+		},
+	},
+	{
+		type: 'separator',
+	},
+	{
+		label: 'Developer',
+		submenu: debugMenu,
+	}
 );
 
 module.exports = menuItems;

--- a/desktop/app/lib/menu/view-menu.js
+++ b/desktop/app/lib/menu/view-menu.js
@@ -10,6 +10,7 @@ const platform = require( '../../lib/platform' );
  * Module variables
  */
 const menuItems = [];
+const ZOOMFACTOR = 0.2;
 
 menuItems.push(
 	{
@@ -30,41 +31,57 @@ menuItems.push(
 		type: 'separator',
 	},
 	{
-		role: 'zoomIn',
+		label: 'Zoom In',
+		visible: true,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+Shift+=',
+		click: zoomIn,
 	},
 	{
 		// enable ZoomIn shortcut to work both with and without Shift
 		// the default accelerator added by Electron is CommandOrControl+Shift+=
-		role: 'zoomIn',
+		label: 'Zoom In',
 		visible: false,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+=',
+		click: zoomIn,
 	},
 	{
-		role: 'zoomOut',
+		label: 'Zoom Out',
+		visible: true,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+-',
+		click: zoomOut,
 	},
 	{
-		role: 'resetZoom',
+		label: 'Reset Zoom',
+		visible: true,
+		acceleratorWorksWhenHidden: true,
+		accelerator: 'CommandOrControl+0',
+		click: resetZoom,
 	},
 	// backup shortcuts for numeric keypad,
 	// see https://github.com/electron/electron/issues/5256#issuecomment-692068367
 	{
-		role: 'zoomIn',
+		label: 'Numberic Keypad: Zoom In',
 		visible: false,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+numadd',
+		click: zoomIn,
 	},
 	{
-		role: 'zoomOut',
+		label: 'Numeric Keypad: Zoom Out',
 		visible: false,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+numsub',
+		click: zoomOut,
 	},
 	{
-		role: 'resetZoom',
+		label: 'Numeric Keypad: Reset Zoom',
 		visible: false,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+num0',
+		click: resetZoom,
 	},
 	{
 		type: 'separator',
@@ -87,5 +104,25 @@ menuItems.push(
 		submenu: debugMenu,
 	}
 );
+
+function zoomIn() {
+	const window = BrowserWindow.getFocusedWindow();
+	const view = window.getBrowserView();
+	const zoom = view.webContents.getZoomLevel();
+	view.webContents.setZoomLevel( Math.min( zoom + ZOOMFACTOR, 3 ) );
+}
+
+function zoomOut() {
+	const window = BrowserWindow.getFocusedWindow();
+	const view = window.getBrowserView();
+	const zoom = view.webContents.getZoomLevel();
+	view.webContents.setZoomLevel( Math.max( zoom - ZOOMFACTOR, -1.0 ) );
+}
+
+function resetZoom() {
+	const window = BrowserWindow.getFocusedWindow();
+	const view = window.getBrowserView();
+	view.webContents.setZoomLevel( 0 );
+}
 
 module.exports = menuItems;

--- a/desktop/app/lib/menu/view-menu.js
+++ b/desktop/app/lib/menu/view-menu.js
@@ -65,16 +65,11 @@ menuItems.push(
 		visible: false,
 		acceleratorWorksWhenHidden: true,
 		accelerator: 'CommandOrControl+num0',
-	}
+	},
+	{
+		type: 'separator',
+	},
+	...debugMenu
 );
-
-if ( process.env.WP_DESKTOP_DEBUG ) {
-	menuItems.push(
-		{
-			type: 'separator',
-		},
-		...debugMenu
-	);
-}
 
 module.exports = menuItems;


### PR DESCRIPTION
### Description

Open devtools for browserview, not the main window. This PR also ensures that the Reload and Force Reload actions work on the browser view instead of the main window.

In addition, Developer Tools are now exposed to all users under a "Developer" sub-menu.

<img width="373" alt="wp-desktop-view-menu" src="https://user-images.githubusercontent.com/8979548/128552004-60da9ac0-68db-425d-9194-744e522d038f.png">
