### PR TITLE
Legacy FSE: Fix navigating back to page template

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import $ from 'jquery';
-import { debounce, filter, find, forEach, get, map, partialRight } from 'lodash';
+import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse } from '@wordpress/blocks';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
@@ -877,32 +877,25 @@ function openCustomizer( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function openTemplatePartLinks( calypsoPort ) {
-	$( '#editor' ).on(
-		'click',
-		'.template__block-container .template-block__overlay a',
-		// Prevents multiple calls. We suspect changes in React 17 to be the root cause,
-		// but not entirely certain. We'll remove this code soon when core FSE is released.
-		// See https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation
-		debounce( ( e ) => {
-			e.preventDefault();
-			e.stopPropagation(); // Otherwise it will port the message twice.
+	$( '#editor' ).on( 'click', '.template__block-container .template-block__overlay a', ( e ) => {
+		e.preventDefault();
+		e.stopPropagation(); // Otherwise it will port the message twice.
 
-			// Get the template part ID from the current href.
-			const templatePartId = parseInt( getQueryArg( e.target.href, 'post' ), 10 );
+		// Get the template part ID from the current href.
+		const templatePartId = parseInt( getQueryArg( e.target.href, 'post' ), 10 );
 
-			const { port2 } = new MessageChannel();
-			calypsoPort.postMessage(
-				{
-					action: 'openTemplatePart',
-					payload: {
-						templatePartId,
-						unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
-					},
+		const { port2 } = new MessageChannel();
+		calypsoPort.postMessage(
+			{
+				action: 'openTemplatePart',
+				payload: {
+					templatePartId,
+					unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
 				},
-				[ port2 ]
-			);
-		} )
-	);
+			},
+			[ port2 ]
+		);
+	} );
 }
 
 /**

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -421,7 +421,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			const { templatePartId, unsavedChanges } = payload;
 
 			// Prevent navigating to edit the template part if it's already being edited.
-			// Solves an issue where a click event to edit the tempalte part is received twice.
+			// Solves an issue where a click event to edit the template part is received twice.
 			if (
 				new RegExp( `\\/edit\\/wp_template_part\\/.+\\/${ templatePartId }\\?`, 'i' ).test(
 					window.location.href

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -420,8 +420,6 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		if ( EditorActions.OpenTemplatePart === action ) {
 			const { templatePartId, unsavedChanges } = payload;
 
-			const templatePartUrl = this.getTemplateEditorUrl( templatePartId );
-
 			// Prevent navigating to edit the template part if it's already being edited.
 			// Solves an issue where a click event to edit the tempalte part is received twice.
 			if (
@@ -432,6 +430,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 				return;
 			}
 
+			const templatePartUrl = this.getTemplateEditorUrl( templatePartId );
 			this.navigate( templatePartUrl, unsavedChanges );
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -419,7 +419,19 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 
 		if ( EditorActions.OpenTemplatePart === action ) {
 			const { templatePartId, unsavedChanges } = payload;
+
 			const templatePartUrl = this.getTemplateEditorUrl( templatePartId );
+
+			// Prevent navigating to edit the template part if it's already being edited.
+			// Solves an issue where a click event to edit the tempalte part is received twice.
+			if (
+				new RegExp( `\\/edit\\/wp_template_part\\/.+\\/${ templatePartId }\\?`, 'i' ).test(
+					window.location.href
+				)
+			) {
+				return;
+			}
+
 			this.navigate( templatePartUrl, unsavedChanges );
 		}
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -422,6 +422,8 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 
 			// Prevent navigating to edit the template part if it's already being edited.
 			// Solves an issue where a click event to edit the template part is received twice.
+			// Example URL we're testing for, where the `templatePartId` is 2:
+			// `/edit/wp_template_part/{site}/2?fse_parent_post=42`
 			if (
 				new RegExp( `\\/edit\\/wp_template_part\\/.+\\/${ templatePartId }\\?`, 'i' ).test(
 					window.location.href


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #54418, alternative to #54416, which wasn't fixing the issue for me.

Prevents "double navigating" to edit the template part, which causes the `fse_parent_post` query param to be incorrect, and breaks navigating back to the correct page editor.

#### Testing instructions

**Verifying the bug**

* Setup a legacy dotcom FSE simple site
* Navigate to the legacy site editor by visiting any page
* Click directly on one of the edit template part buttons ("Edit Header" or "Edit Footer"). Avoid clicking on the overlay (the problem only manifests when clicking on the button)
* Ensure that the browser url `?fse_parent_post` query param id isn't correct (The id for the query param shouldn't match the id for the resource)
* Clicking "< Page Layout" will take you a list of template parts

**Verifying the fix**

* Sandbox `widgets.wp.com`
* Run `install-plugin.sh wpcom-block-editor fix/legacy-fse-template-part-links-take-2` from the sandbox
* If you have issues loading the script updates, try closing the calypso window and deleting the browser cache.
* Navigate to the legacy site editor by visiting any page, using the **calypso.live link from this PR, or a local build**
* Click directly on one of the edit template part buttons ("Edit Header" or "Edit Footer"). Avoid clicking on the overlay (the problem only manifests when clicking on the button)
* Ensure that the browser url `?fse_parent_post` query param id is correct (The id for the query param shouldn't match the id for the resource)
* Clicking "< Page Layout" should take you back to editing the page
