### PR TITLE
Add InlineSupportLink rather than external link

### DIFF
--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -20,9 +20,9 @@ import { trackClick } from '../helpers';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
-import ExternalLink from 'calypso/components/external-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import config from '@automattic/calypso-config';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 /**
  * Style dependencies
@@ -124,13 +124,14 @@ class CurrentTheme extends Component {
 									</div>
 									<p>
 										{ translate( 'This is the active theme on your site.' ) }{ ' ' }
-										<ExternalLink
-											href={ localizeUrl( 'https://wordpress.com/support/changing-themes/' ) }
-											icon
-											target="__blank"
+										<InlineSupportLink
+											supportPostId={ 184023 }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/changing-themes/'
+											) }
 										>
 											{ translate( 'Learn more.' ) }
-										</ExternalLink>
+										</InlineSupportLink>
 									</p>
 								</div>
 							</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `InlineSupportLink` to show documentation in a modal rather than linking to the support site in a new window.

**Before**

<img width="1364" alt="Screen Shot 2021-07-13 at 5 26 16 PM" src="https://user-images.githubusercontent.com/2124984/125527377-58079a20-293d-4924-842d-817b2cece3fa.png">

<img width="1665" alt="Screen Shot 2021-07-13 at 5 30 44 PM" src="https://user-images.githubusercontent.com/2124984/125527896-853d4f2b-915e-4a1c-8404-f667024ed97e.png">

**After**

<img width="1368" alt="Screen Shot 2021-07-13 at 5 24 24 PM" src="https://user-images.githubusercontent.com/2124984/125527322-f7b9d78e-1e83-4873-8afc-979b04509a65.png">
<img width="1204" alt="Screen Shot 2021-07-13 at 5 24 33 PM" src="https://user-images.githubusercontent.com/2124984/125527325-7cca6d3c-152f-4bee-901e-fd13c445cd2b.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes`
* Click on the "Learn more" link under the Current Theme box
* You should open a modal window with the contents of the "Changing themes" support doc rather than navigating to the support site


Related to #54391
