### PR TITLE
Create and Add Jetpack-Free Welcome UI

### DIFF
--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -15,7 +15,7 @@ import useAriaProps from 'calypso/lib/a11y/use-aria-props';
  * Module constants
  */
 const PALETTE = colorStudio.colors;
-const COLOR_JETPACK = PALETTE[ 'Jetpack Green 50' ];
+const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
 const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
 
 const LogoPathSize32 = ( { monochrome = false } ) => {

--- a/client/components/jetpack/jetpack-free-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/index.tsx
@@ -41,7 +41,11 @@ const JetpackFreeWelcome: FC = () => {
 				<div className="jetpack-free-welcome__card-main">
 					<JetpackLogo size={ 45 } />
 					<h1 className="jetpack-free-welcome__main-message">
-						{ translate( 'Welcome to Jetpack!' ) }{ ' ' }
+						{ translate( 'Welcome{{br/}} to Jetpack!', {
+							components: {
+								br: <br />,
+							},
+						} ) }{ ' ' }
 						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
 					</h1>
 					<p>{ translate( "Here's how to get started with Jetpack." ) }</p>

--- a/client/components/jetpack/jetpack-free-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/index.tsx
@@ -13,7 +13,6 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Style dependencies
@@ -161,16 +160,8 @@ const JetpackFreeWelcome: FC = () => {
 								}
 								href={ featuresComparisonLink }
 							>
-								<div className="jetpack-free-welcome__feature-nav-button-content">
-									{ translate( 'Want to learn more about our products?' ) }
-									<br />
-									<strong>
-										{ translate( 'See how Jetpack can help grow your business or hobby' ) }
-									</strong>
-								</div>
-								<div className="jetpack-free-welcome__feature-nav-button-icon">
-									<Gridicon icon="arrow-right" size={ 24 } />
-								</div>
+								<span>{ translate( 'Want to learn more about our products?' ) }</span>
+								<span>{ translate( 'See how Jetpack can help grow your business or hobby' ) }</span>
 							</a>
 						</div>
 					</div>

--- a/client/components/jetpack/jetpack-free-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/index.tsx
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import React, { FC } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { Card } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import Gridicon from 'calypso/components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const JetpackFreeWelcome: FC = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const jetpackInstallInstructionsLink =
+		'https://jetpack.com/support/getting-started-with-jetpack/';
+	const featureLink1 = 'https://jetpack.com/features/design/content-delivery-network/';
+	const featureLink2 = 'https://jetpack.com/features/security/downtime-monitoring/';
+	const featureLink3 = 'https://jetpack.com/features/growth/automatic-publishing/';
+	const featuresComparisonLink = 'https://jetpack.com/features/comparison/';
+
+	return (
+		<Main wideLayout className="jetpack-free-welcome">
+			<PageViewTracker
+				path="/pricing/jetpack-free/welcome"
+				title="Pricing > Jetpack Free > Welcome to Jetpack"
+			/>
+			<Card className="jetpack-free-welcome__card">
+				<div className="jetpack-free-welcome__card-main">
+					<JetpackLogo size={ 45 } />
+					<h1 className="jetpack-free-welcome__main-message">
+						{ translate( 'Welcome to Jetpack!' ) }{ ' ' }
+						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+					</h1>
+					<p>{ translate( "Here's how to get started with Jetpack." ) }</p>
+					<div className="jetpack-free-welcome__step">
+						<div className="jetpack-free-welcome__step-number">1</div>
+						<div className="jetpack-free-welcome__step-content">
+							<h2>{ translate( 'Install Jetpack' ) }</h2>
+							<p>
+								{ translate(
+									'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													className="jetpack-free-welcome__link"
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ () =>
+														dispatch(
+															recordTracksEvent(
+																'calypso_siteless_free_page_install_instructions_link_clicked',
+																{
+																	product_slug: 'jetpack_free',
+																}
+															)
+														)
+													}
+													href={ jetpackInstallInstructionsLink }
+												/>
+											),
+										},
+									}
+								) }
+							</p>
+						</div>
+					</div>
+					<div className="jetpack-free-welcome__step">
+						<div className="jetpack-free-welcome__step-number">2</div>
+						<div className="jetpack-free-welcome__step-content">
+							<h2>{ translate( 'Try our powerful free features' ) }</h2>
+							<ul className="jetpack-free-welcome__features">
+								<li>
+									{ translate( '{{a}}Speed up your site{{/a}} with our CDN.', {
+										components: {
+											a: (
+												<a
+													className="jetpack-free-welcome__feature-link"
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ () =>
+														dispatch( recordTracksEvent( 'jetpack_free_welcome_cdn_link_clicked' ) )
+													}
+													href={ featureLink1 }
+												/>
+											),
+										},
+									} ) }
+								</li>
+								<li>
+									{ translate(
+										'{{a}}Make sure your site is online{{/a}} with our Downtime Monitor.',
+										{
+											components: {
+												a: (
+													<a
+														className="jetpack-free-welcome__feature-link"
+														target="_blank"
+														rel="noopener noreferrer"
+														onClick={ () =>
+															dispatch(
+																recordTracksEvent(
+																	'jetpack_free_welcome_downtime_monitor_link_clicked'
+																)
+															)
+														}
+														href={ featureLink2 }
+													/>
+												),
+											},
+										}
+									) }
+								</li>
+								<li>
+									{ translate( '{{a}}Grow your brand{{/a}} with our Social Media Tools.', {
+										components: {
+											a: (
+												<a
+													className="jetpack-free-welcome__feature-link"
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ () =>
+														dispatch(
+															recordTracksEvent(
+																'jetpack_free_welcome_social_media_tools_link_clicked'
+															)
+														)
+													}
+													href={ featureLink3 }
+												/>
+											),
+										},
+									} ) }
+								</li>
+							</ul>
+							<a
+								className="jetpack-free-welcome__feature-nav-button"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent( 'jetpack_free_welcome_learn_products_link_clicked' )
+									)
+								}
+								href={ featuresComparisonLink }
+							>
+								<div className="jetpack-free-welcome__feature-nav-button-content">
+									{ translate( 'Want to learn more about our products?' ) }
+									<br />
+									<strong>
+										{ translate( 'See how Jetpack can help grow your business or hobby' ) }
+									</strong>
+								</div>
+								<div className="jetpack-free-welcome__feature-nav-button-icon">
+									<Gridicon icon="arrow-right" size={ 24 } />
+								</div>
+							</a>
+						</div>
+					</div>
+				</div>
+			</Card>
+		</Main>
+	);
+};
+
+export default JetpackFreeWelcome;

--- a/client/components/jetpack/jetpack-free-welcome/style.scss
+++ b/client/components/jetpack/jetpack-free-welcome/style.scss
@@ -26,22 +26,21 @@
 		}
 
 		h1 {
+			line-height: 1;
 			@include break-mobile {
-				font-size: 3rem;
-				line-height: 3.25rem;
-				padding-bottom: 24px;
+				font-size: $font-headline-medium;
 			}
 			+ p {
 				font-size: 18px; /* stylelint-disable-line */
 				line-height: 1.5rem;
 				@include break-mobile {
-					font-size: 1.5rem;
+					font-size: $font-title-medium;
 					line-height: 2rem;
 				}
 			}
 		}
 		h2 {
-			font-size: 1.5rem;
+			font-size: $font-title-medium;
 			font-weight: 700;
 			line-height: 1.75rem;
 			padding-bottom: 16px;
@@ -60,14 +59,20 @@
 			display: flex;
 			align-items: flex-start;
 			padding-bottom: 40px;
+
+			&:last-of-type {
+				padding-bottom: 0;
+			}
+
 			.jetpack-free-welcome__step-number {
 				color: white;
-				background-color: var( --studio-jetpack-green-50 );
+				background-color: var( --studio-jetpack-green-40 );
 				text-align: center;
 				border-radius: 50%; /* stylelint-disable-line */
-				font-size: 1.25rem;
-				width: 1.8rem;
-				height: 1.8rem;
+				font-size: $font-title-small;
+				font-weight: 600;
+				width: rem( 32px );
+				height: rem( 32px );
 			}
 			.jetpack-free-welcome__step-content {
 				flex: 1;
@@ -102,24 +107,46 @@
 		}
 
 		.jetpack-free-welcome__feature-nav-button {
-			display: flex;
-			align-items: center;
-			justify-content: space-between;
-			border: 2px solid var( --studio-jetpack-green-50 );
-			border-radius: calc( 2px * 2 );
-			padding: 16px 24px;
-			text-decoration: none;
+			position: relative;
+			display: block;
+			padding: 16px 64px 16px 24px;
 			color: var( --color-studio-black );
-			&:hover {
-				text-decoration: underline;
+			border: 2px solid var( --studio-jetpack-green-40 );
+			border-radius: calc( 2px * 2 );
+			text-decoration: none;
+
+			span {
+				display: block;
+
+				&:last-of-type {
+					font-weight: 600;
+				}
 			}
 
-			.jetpack-free-welcome__feature-nav-button-icon {
-				padding-left: 24px;
-				color: var( --studio-jetpack-green-50 );
-				> svg {
-					display: block;
+			&:hover,
+				&:focus {
+					//box-shadow: 0px 0px 40px rgba( 0, 0, 0, 0.08 );
+
+					span:last-of-type {
+						text-decoration: underline;
+						text-decoration-thickness: 2px;
+					}
+
+					&::after {
+						transform: translateY( -50% ) translateX( 8px );
+					}
 				}
+
+			&::after {
+				content: '→';
+				position: absolute;
+				top: 50%;
+				right: 24px;
+				font-size: $font-title-medium;
+				font-weight: 600;
+				color: var( --studio-jetpack-green-40 );
+				transform: translateY( -50% );
+				transition: transform 0.15s ease-out;
 			}
 		}
 	}

--- a/client/components/jetpack/jetpack-free-welcome/style.scss
+++ b/client/components/jetpack/jetpack-free-welcome/style.scss
@@ -1,0 +1,121 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
+.jetpack-free-welcome {
+	&.main.is-wide-layout {
+		max-width: 744px;
+	}
+	.jetpack-free-welcome__card {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+		box-shadow: 0 0 40px 0 #00000014;
+
+		width: 100%;
+		max-width: none;
+
+		@include break-medium {
+			flex-direction: row;
+			width: auto;
+			max-width: 1200px;
+		}
+
+		.jetpack-logo {
+			margin-bottom: 25px;
+		}
+
+		h1 {
+			font-size: 3rem;
+			line-height: 3.25rem;
+			padding-bottom: 24px;
+			+ p {
+				font-size: 1.5rem;
+				line-height: 2rem;
+			}
+		}
+		h2 {
+			font-size: 1.5rem;
+			font-weight: 700;
+			line-height: 1.75rem;
+			padding-bottom: 16px;
+		}
+
+		a.jetpack-free-welcome__link,
+		a.jetpack-free-welcome__feature-link {
+			text-decoration: underline;
+			color: var( --color-studio-black );
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		> div {
+			box-sizing: border-box;
+			padding: 15px 26px 26px;
+			@include break-mobile {
+				padding: 30px 76px 55px;
+			}
+		}
+
+		.jetpack-free-welcome__step {
+			display: flex;
+			align-items: flex-start;
+			.jetpack-free-welcome__step-number {
+				color: white;
+				background-color: var( --studio-jetpack-green-50 );
+				text-align: center;
+				border-radius: 50%; /* stylelint-disable-line */
+				font-size: 1.25rem;
+				width: 1.8rem;
+				height: 1.8rem;
+			}
+			.jetpack-free-welcome__step-content {
+				flex: 1;
+				padding: 0 10px 0 16px;
+				p {
+					font-size: 18px; /* stylelint-disable-line */
+					line-height: 1.75rem;
+				}
+			}
+		}
+
+		.jetpack-free-welcome__main-message {
+			font-size: 2.25rem;
+			font-weight: 700;
+			margin-bottom: 24px;
+
+			@include break-mobile {
+				font-size: 3rem;
+			}
+		}
+
+		.jetpack-free-welcome__features {
+			margin: 0 0 0 10px;
+			padding: 0 0 36px 5px;
+			font-size: 18px; /* stylelint-disable-line */
+			line-height: 2rem;
+		}
+
+		.jetpack-free-welcome__feature-nav-button {
+			display: flex;
+			align-items: center;
+			border: 2px solid var( --studio-jetpack-green-50 );
+			border-radius: calc( 2px * 2 );
+			padding: 16px 24px;
+			text-decoration: none;
+			color: var( --color-studio-black );
+			&:hover {
+				text-decoration: underline;
+			}
+			.jetpack-free-welcome__feature-nav-button-content {
+				padding-right: 8px;
+			}
+			.jetpack-free-welcome__feature-nav-button-icon {
+				padding-left: 8px;
+				text-align: right;
+				color: var( --studio-jetpack-green-50 );
+			}
+		}
+	}
+}

--- a/client/components/jetpack/jetpack-free-welcome/style.scss
+++ b/client/components/jetpack/jetpack-free-welcome/style.scss
@@ -7,31 +7,37 @@
 		max-width: 744px;
 	}
 	.jetpack-free-welcome__card {
-		display: flex;
-		flex-direction: column;
 		padding: 0;
 		box-shadow: 0 0 40px 0 #00000014;
 
 		width: 100%;
 		max-width: none;
 
-		@include break-medium {
-			flex-direction: row;
-			width: auto;
-			max-width: 1200px;
+		> div.jetpack-free-welcome__card-main {
+			box-sizing: border-box;
+			padding: 26px;
+			@include break-mobile {
+				padding: 76px;
+			}
 		}
 
 		.jetpack-logo {
-			margin-bottom: 25px;
+			margin-bottom: 48px;
 		}
 
 		h1 {
-			font-size: 3rem;
-			line-height: 3.25rem;
-			padding-bottom: 24px;
+			@include break-mobile {
+				font-size: 3rem;
+				line-height: 3.25rem;
+				padding-bottom: 24px;
+			}
 			+ p {
-				font-size: 1.5rem;
-				line-height: 2rem;
+				font-size: 18px; /* stylelint-disable-line */
+				line-height: 1.5rem;
+				@include break-mobile {
+					font-size: 1.5rem;
+					line-height: 2rem;
+				}
 			}
 		}
 		h2 {
@@ -50,17 +56,10 @@
 			}
 		}
 
-		> div {
-			box-sizing: border-box;
-			padding: 15px 26px 26px;
-			@include break-mobile {
-				padding: 30px 76px 55px;
-			}
-		}
-
 		.jetpack-free-welcome__step {
 			display: flex;
 			align-items: flex-start;
+			padding-bottom: 40px;
 			.jetpack-free-welcome__step-number {
 				color: white;
 				background-color: var( --studio-jetpack-green-50 );
@@ -74,8 +73,11 @@
 				flex: 1;
 				padding: 0 10px 0 16px;
 				p {
-					font-size: 18px; /* stylelint-disable-line */
-					line-height: 1.75rem;
+					@include break-mobile {
+						font-size: 18px; /* stylelint-disable-line */
+						line-height: 1.75rem;
+					}
+					margin: 0;
 				}
 			}
 		}
@@ -92,14 +94,17 @@
 
 		.jetpack-free-welcome__features {
 			margin: 0 0 0 10px;
-			padding: 0 0 36px 5px;
-			font-size: 18px; /* stylelint-disable-line */
-			line-height: 2rem;
+			padding: 0 0 32px 5px;
+			@include break-mobile {
+				font-size: 18px; /* stylelint-disable-line */
+				line-height: 2rem;
+			}
 		}
 
 		.jetpack-free-welcome__feature-nav-button {
 			display: flex;
 			align-items: center;
+			justify-content: space-between;
 			border: 2px solid var( --studio-jetpack-green-50 );
 			border-radius: calc( 2px * 2 );
 			padding: 16px 24px;
@@ -108,13 +113,13 @@
 			&:hover {
 				text-decoration: underline;
 			}
-			.jetpack-free-welcome__feature-nav-button-content {
-				padding-right: 8px;
-			}
+
 			.jetpack-free-welcome__feature-nav-button-icon {
-				padding-left: 8px;
-				text-align: right;
+				padding-left: 24px;
 				color: var( --studio-jetpack-green-50 );
+				> svg {
+					display: block;
+				}
 			}
 		}
 	}

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -14,6 +14,7 @@ import SelectorPage from './selector';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getMonthlySlugFromYearly, getYearlySlugFromMonthly } from './convert-slug-terms';
+import JetpackFreeWelcomePage from 'calypso/components/jetpack/jetpack-free-welcome';
 
 /**
  * Type dependencies
@@ -84,3 +85,8 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 
 	next();
 };
+
+export function jetpackFreeWelcome( context: PageJS.Context, next: () => void ): void {
+	context.primary = <JetpackFreeWelcomePage />;
+	next();
+}

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -7,9 +7,11 @@ import page from 'page';
  * Internal dependencies
  */
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { productSelect } from './controller';
+import { productSelect, jetpackFreeWelcome } from './controller';
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
+	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );
+
 	page(
 		`${ rootUrl }/:duration?/:site?`,
 		...rest,

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -12,7 +12,6 @@ import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
-import { addQueryArgs } from 'calypso/lib/route';
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 import getJetpackRecommendationsUrl from 'calypso/state/selectors/get-jetpack-recommendations-url';
 
@@ -61,14 +60,8 @@ const buildHref = (
 	// if there is a site in the URL also
 	const isSiteinContext = siteId || site;
 
-	// Jetpack Connect flow uses `url` instead of `site` as the query parameter for a site URL
-	const { site: url, ...restQueryArgs } = urlQueryArgs;
-
 	return isJetpackCloud() && ! isSiteinContext
-		? addQueryArgs(
-				{ url, ...restQueryArgs, plan: PLAN_JETPACK_FREE },
-				`https://wordpress.com${ JPC_PATH_BASE }`
-		  )
+		? '/pricing/jetpack-free/welcome'
 		: wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;
 };
 

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -13,7 +13,7 @@ import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
-import { addQueryArgs } from 'calypso/lib/url';
+import { addQueryArgs } from 'calypso/lib/route';
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 import getJetpackRecommendationsUrl from 'calypso/state/selectors/get-jetpack-recommendations-url';
 

--- a/config/development.json
+++ b/config/development.json
@@ -94,7 +94,7 @@
 		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
-		"jetpack/siteless-checkout": false,
+		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the [Simple Jetpack.com Checkout project](p1HpG7-cfR-p2), this PR adds a new UI page rendered when a user chooses the Jetpack Free product and there is no site defined in the URL.

#### Implementation notes: 

- Add new route & controller for the Jetpack Free Welcome page ( `/pricing/jetpack-free/welcome` )
- Create new `JetpackFreeWelcomePage` component & SCSS
- Modify the Jetpack Free product button to point to the new Welcome page when there is no site in the URL.

Asana card: 1200479326344990-as-1200537578270032

#### Screenshot:
<img width="970" alt="Screenshot on 2021-07-13 at 18-25-08" src="https://user-images.githubusercontent.com/11078128/125533252-1d696066-233d-415c-906e-73983e49d788.png">


#### Testing instructions

- Checkout this PR branch and edit the `config/development.json` file and enable the `jetpack/siteless-checkout` feature flag.
- .Run this PR in Jetpack Cloud env (`yarn start-jetpack-cloud`)
- Go to http://jetpack.cloud.localhost:3000/pricing/jetpack-free/welcome and verify the welcome UI looks like the screenshot above and like the Figma mockup linked in the Asana card.
- Verify you can access the page when both logged-in and when logged-out.
- Verify all the links go to the correct locations.
- Go to http://jetpack.cloud.localhost:3000/pricing and verify the Jetpack Free button points to `/pricing/jetpack-free/welcome` when there is **no site in the url**.
- Verify the tracks 'page-view' event fires and the events fire on each link click.
- Verify there are no errors in the console.
- Run unit tests and verify they all pass:
    - `yarn test-client client/my-sites/plans/jetpack-plans/jetpack-free-card/test/use-jetpack-free-button-props.js`


- <!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->