### PR TITLE
Legacy FSE: Fix menu styles in editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -30,7 +30,7 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 	return { templateClasses };
 } )( ( { templateClasses } ) => {
 	const blockListInception = setInterval( () => {
-		const blockListParent = document.querySelector( '.editor-styles-wrapper' );
+		const blockListParent = document.querySelector( '.block-editor-writing-flow' );
 
 		if ( ! blockListParent ) {
 			return;
@@ -38,7 +38,7 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 		clearInterval( blockListInception );
 
 		blockListParent.className = classNames(
-			'editor-styles-wrapper',
+			'block-editor-writing-flow',
 			'a8c-template-editor fse-template-part',
 			...templateClasses
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/54267

#### Changes proposed in this Pull Request

Update the Legacy FSE template editor class plugin so that it adds classes to a container inside `.editor-styles-wrapper`.

This is important, because the editor style selectors are prefixed with `.editor-styles-wrapper `, so they must target elements inside and not including the wrapper.

For example, the selector `.editor-styles-wrapper .fse-template-part .main-navigation` will not work if the wrapper div has both classes `editor-styles-wrapper` and `fse-template-part`.

#### Testing instructions

* On a site with legacy FSE enabled...
* Open a template part in the editor and see that the styles are applied to the navigation menu block

| **Before** | **After** |
| - | - |
| <img width="1086" alt="image" src="https://user-images.githubusercontent.com/1699996/125536031-bd1b58ad-e02b-4af0-8a48-125f3f953f90.png"> | <img width="1091" alt="image" src="https://user-images.githubusercontent.com/1699996/125535984-0c0b8487-de94-4531-b308-d7bb87c6522f.png"> |

