### PR TITLE
chore: Refactor packages/composite-checkout to use import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
 				'client/support/**/*',
 				'packages/accessible-focus/**/*',
 				'packages/calypso-products/**/*',
+				'packages/composite-checkout/**/*',
 				'packages/data-stores/**/*',
 				'test/e2e/**/*',
 			],

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import React, { useState, useEffect, useMemo } from 'react';
-import styled from '@emotion/styled';
 import {
 	Checkout,
 	CheckoutStepArea,
@@ -26,6 +21,8 @@ import {
 	useFormStatus,
 	makeSuccessResponse,
 } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import React, { useState, useEffect, useMemo } from 'react';
 import { StripeHookProvider, useStripe } from '../src/lib/stripe-demo';
 
 const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';

--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal Classes
- */
-import styled from '../lib/styled';
 import joinClasses from '../lib/join-classes';
+import styled from '../lib/styled';
 import { Theme } from '../lib/theme';
 
 const CallToAction = styled( 'button' )< CallToActionProps >`

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { ErrorInfo } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import React, { ErrorInfo } from 'react';
 import styled from '../lib/styled';
 
 const debug = debugFactory( 'composite-checkout:checkout-error-boundary' );

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { useEffect } from 'react';
 import { keyframes } from '@emotion/core';
-import PropTypes from 'prop-types';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 import joinClasses from '../lib/join-classes';
-import Button from './button';
 import styled from '../lib/styled';
+import Button from './button';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
 

--- a/packages/composite-checkout/src/components/checkout-next-step-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-next-step-button.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import Button, { ButtonProps } from './button';
 
 function CheckoutNextStepButton( {

--- a/packages/composite-checkout/src/components/checkout-order-summary.tsx
+++ b/packages/composite-checkout/src/components/checkout-order-summary.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import { CheckoutSummaryCard, useLineItems, useLineItemsOfType, useTotal } from '../public-api';
+import React from 'react';
 import styled from '../lib/styled';
+import { CheckoutSummaryCard, useLineItems, useLineItemsOfType, useTotal } from '../public-api';
 
 export default function CheckoutOrderSummaryStep() {
 	const [ items ] = useLineItems();

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
-import debugFactory from 'debug';
-import { useI18n } from '@wordpress/react-i18n';
 import { sprintf } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import styled from '../lib/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
 import joinClasses from '../lib/join-classes';
-import RadioButton from './radio-button';
+import styled from '../lib/styled';
 import {
 	useAllPaymentMethods,
 	usePaymentMethod,
@@ -22,8 +14,9 @@ import {
 	useEvents,
 	useFormStatus,
 } from '../public-api';
-import CheckoutErrorBoundary from './checkout-error-boundary';
 import { FormStatus } from '../types';
+import CheckoutErrorBoundary from './checkout-error-boundary';
+import RadioButton from './radio-button';
 
 const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,30 +1,23 @@
-/**
- * External dependencies
- */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ThemeProvider } from 'emotion-theming';
-import debugFactory from 'debug';
-import { useI18n } from '@wordpress/react-i18n';
 import { DataRegistry } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import { ThemeProvider } from 'emotion-theming';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CheckoutContext from '../lib/checkout-context';
-import CheckoutErrorBoundary from './checkout-error-boundary';
+import { useFormStatusManager } from '../lib/form-status';
 import { LineItemsProvider } from '../lib/line-items';
 import { defaultRegistry, RegistryProvider } from '../lib/registry';
-import { useFormStatusManager } from '../lib/form-status';
-import { useTransactionStatusManager } from '../lib/transaction-status';
 import defaultTheme from '../lib/theme';
+import { useTransactionStatusManager } from '../lib/transaction-status';
 import {
 	validateArg,
 	validateLineItems,
 	validatePaymentMethods,
 	validateTotal,
 } from '../lib/validation';
-import TransactionStatusHandler from './transaction-status-handler';
 import { LineItem, CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
+import CheckoutErrorBoundary from './checkout-error-boundary';
+import TransactionStatusHandler from './transaction-status-handler';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 

--- a/packages/composite-checkout/src/components/checkout-review-order.tsx
+++ b/packages/composite-checkout/src/components/checkout-review-order.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import joinClasses from '../lib/join-classes';
 import { useLineItems } from '../public-api';
 import {

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -1,6 +1,6 @@
-/**
- * External dependencies
- */
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import PropTypes from 'prop-types';
 import React, {
 	Dispatch,
 	SetStateAction,
@@ -9,21 +9,10 @@ import React, {
 	useEffect,
 	useState,
 } from 'react';
-import debugFactory from 'debug';
-import PropTypes from 'prop-types';
-import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import joinClasses from '../lib/join-classes';
-import CheckoutErrorBoundary from './checkout-error-boundary';
 import { useFormStatus } from '../lib/form-status';
-import LoadingContent from './loading-content';
-import CheckoutSubmitButton from './checkout-submit-button';
-import Button from './button';
-import { CheckIcon } from './shared-icons';
-import CheckoutNextStepButton from './checkout-next-step-button';
+import joinClasses from '../lib/join-classes';
+import styled from '../lib/styled';
+import { Theme } from '../lib/theme';
 import {
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummary,
@@ -32,9 +21,13 @@ import {
 	useEvents,
 	usePaymentMethod,
 } from '../public-api';
-import styled from '../lib/styled';
-import { Theme } from '../lib/theme';
 import { FormStatus, CheckoutStepProps } from '../types';
+import Button from './button';
+import CheckoutErrorBoundary from './checkout-error-boundary';
+import CheckoutNextStepButton from './checkout-next-step-button';
+import CheckoutSubmitButton from './checkout-submit-button';
+import LoadingContent from './loading-content';
+import { CheckIcon } from './shared-icons';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import joinClasses from '../lib/join-classes';
-import CheckoutErrorBoundary from './checkout-error-boundary';
 import { useFormStatus, FormStatus, usePaymentMethod, useProcessPayment } from '../public-api';
+import CheckoutErrorBoundary from './checkout-error-boundary';
 
 export default function CheckoutSubmitButton( {
 	className,

--- a/packages/composite-checkout/src/components/default-steps.tsx
+++ b/packages/composite-checkout/src/components/default-steps.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import CheckoutOrderSummaryStep, {
 	CheckoutOrderSummaryStepTitle,
 	CheckoutOrderSummary,
 } from './checkout-order-summary';
-import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
 import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
+import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
 import type { CheckoutStepProps, OrderSummaryData } from '../types';
 
 export function getDefaultOrderSummary(): OrderSummaryData {

--- a/packages/composite-checkout/src/components/error-message.tsx
+++ b/packages/composite-checkout/src/components/error-message.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import styled from '../lib/styled';
 
 export default function ErrorMessage( { children }: { children?: React.ReactNode } ) {

--- a/packages/composite-checkout/src/components/field.tsx
+++ b/packages/composite-checkout/src/components/field.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { LabelHTMLAttributes, InputHTMLAttributes, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React, { LabelHTMLAttributes, InputHTMLAttributes, HTMLAttributes } from 'react';
 import styled from '../lib/styled';
 import Button from './button';
 

--- a/packages/composite-checkout/src/components/grid-row.tsx
+++ b/packages/composite-checkout/src/components/grid-row.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import styled from '../lib/styled';
 
 export default function GridRow( { gap, columnWidths, className, children }: GridRowProps ) {

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { keyframes } from '@emotion/core';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import styled from '../lib/styled';
 
 const LoadingContentWrapper = styled.div`

--- a/packages/composite-checkout/src/components/order-review-line-items.tsx
+++ b/packages/composite-checkout/src/components/order-review-line-items.tsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import joinClasses from '../lib/join-classes';
-import type { LineItem } from '../types';
 import styled from '../lib/styled';
+import type { LineItem } from '../types';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
 

--- a/packages/composite-checkout/src/components/payment-logos.tsx
+++ b/packages/composite-checkout/src/components/payment-logos.tsx
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export function VisaLogo( { className }: { className?: string } ) {
 	return (

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { Theme } from '../lib/theme';
+import React, { useState } from 'react';
 import styled from '../lib/styled';
+import { Theme } from '../lib/theme';
 
 const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >

--- a/packages/composite-checkout/src/components/shared-icons.tsx
+++ b/packages/composite-checkout/src/components/shared-icons.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import styled from '../lib/styled';
 
 export function CheckIcon( { className, id }: { className?: string; id: string } ) {

--- a/packages/composite-checkout/src/components/spinner.tsx
+++ b/packages/composite-checkout/src/components/spinner.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { keyframes } from '@emotion/core';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import styled from '../lib/styled';
 
 export default function Spinner( { className }: { className?: string } ) {

--- a/packages/composite-checkout/src/components/transaction-status-handler.ts
+++ b/packages/composite-checkout/src/components/transaction-status-handler.ts
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import { useCallback, useEffect } from 'react';
-import debugFactory from 'debug';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import { usePaymentMethodId } from '../lib/payment-methods';
-import useMessages from './use-messages';
-import useEvents from './use-events';
+import debugFactory from 'debug';
+import { useCallback, useEffect } from 'react';
 import { useFormStatus } from '../lib/form-status';
+import { usePaymentMethodId } from '../lib/payment-methods';
 import { useTransactionStatus } from '../lib/transaction-status';
 import { TransactionStatus } from '../types';
+import useEvents from './use-events';
+import useMessages from './use-messages';
 
 const debug = debugFactory( 'composite-checkout:transaction-status-handler' );
 

--- a/packages/composite-checkout/src/components/use-events.ts
+++ b/packages/composite-checkout/src/components/use-events.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useContext } from 'react';
-
-/**
- * Internal dependencies
- */
 import CheckoutContext from '../lib/checkout-context';
 
 export default function useEvents() {

--- a/packages/composite-checkout/src/components/use-messages.ts
+++ b/packages/composite-checkout/src/components/use-messages.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useContext } from 'react';
-
-/**
- * Internal dependencies
- */
 import CheckoutContext from '../lib/checkout-context';
 
 export default function useMessages() {

--- a/packages/composite-checkout/src/components/use-process-payment.ts
+++ b/packages/composite-checkout/src/components/use-process-payment.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { useCallback, useMemo, useState } from 'react';
-import debugFactory from 'debug';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import debugFactory from 'debug';
+import { useCallback, useMemo, useState } from 'react';
 import {
 	usePaymentProcessors,
 	useTransactionStatus,

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { createContext } from 'react';
 import {
 	FormStatus,

--- a/packages/composite-checkout/src/lib/form-status.ts
+++ b/packages/composite-checkout/src/lib/form-status.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useCallback, useContext, useEffect, useMemo, useReducer } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { useCallback, useContext, useEffect, useMemo, useReducer } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import {
 	FormStatus,

--- a/packages/composite-checkout/src/lib/line-items-context.ts
+++ b/packages/composite-checkout/src/lib/line-items-context.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { createContext } from 'react';
 import { LineItemsState } from '../types';
 

--- a/packages/composite-checkout/src/lib/line-items.tsx
+++ b/packages/composite-checkout/src/lib/line-items.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React, { useContext, useMemo } from 'react';
-
-/**
- * Internal dependencies
- */
-import LineItemsContext from './line-items-context';
 import { LineItemsProviderProps, LineItem } from '../types';
+import LineItemsContext from './line-items-context';
 
 export const LineItemsProvider: React.FC< LineItemsProviderProps > = ( {
 	items,

--- a/packages/composite-checkout/src/lib/payment-methods/alipay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/alipay.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import styled from '@emotion/styled';
-import debugFactory from 'debug';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import Field from '../../components/field';
+import debugFactory from 'debug';
+import React from 'react';
 import Button from '../../components/button';
+import Field from '../../components/field';
+import { registerStore, useSelect, useDispatch } from '../../lib/registry';
 import { FormStatus, useLineItems } from '../../public-api';
 import { useFormStatus } from '../form-status';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
-import { registerStore, useSelect, useDispatch } from '../../lib/registry';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 
 const debug = debugFactory( 'composite-checkout:alipay-payment-method' );
 

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import styled from '@emotion/styled';
-import debugFactory from 'debug';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import debugFactory from 'debug';
+import React from 'react';
 import Button from '../../components/button';
 import { FormStatus, useLineItems, useEvents } from '../../public-api';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import PaymentLogo from './payment-logo.js';
 
 const debug = debugFactory( 'composite-checkout:existing-card-payment-method' );

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import styled from '@emotion/styled';
-import debugFactory from 'debug';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import Field from '../../components/field';
+import debugFactory from 'debug';
+import React from 'react';
 import Button from '../../components/button';
-import { FormStatus, useLineItems } from '../../public-api';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
-import { useFormStatus } from '../form-status';
+import Field from '../../components/field';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+import { FormStatus, useLineItems } from '../../public-api';
+import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 
 const debug = debugFactory( 'composite-checkout:ideal-payment-method' );
 

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { useContext } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import CheckoutContext from '../checkout-context';
+import { useContext } from 'react';
 import { PaymentMethod } from '../../types';
+import CheckoutContext from '../checkout-context';
 
 const debug = debugFactory( 'composite-checkout:payment-methods' );
 

--- a/packages/composite-checkout/src/lib/payment-methods/payment-logo.js
+++ b/packages/composite-checkout/src/lib/payment-methods/payment-logo.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import styled from '@emotion/styled';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import {
 	VisaLogo,
 	AmexLogo,

--- a/packages/composite-checkout/src/lib/payment-methods/sofort.js
+++ b/packages/composite-checkout/src/lib/payment-methods/sofort.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import styled from '@emotion/styled';
-import debugFactory from 'debug';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import Field from '../../components/field';
+import debugFactory from 'debug';
+import React from 'react';
 import Button from '../../components/button';
-import { FormStatus, useLineItems } from '../../public-api';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
-import { useFormStatus } from '../form-status';
+import Field from '../../components/field';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+import { FormStatus, useLineItems } from '../../public-api';
+import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 
 const debug = debugFactory( 'composite-checkout:sofort-payment-method' );
 

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -1,29 +1,22 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
 import styled from '@emotion/styled';
-import { useTheme } from 'emotion-theming';
-import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
-import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
-import debugFactory from 'debug';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
-import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
-import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import debugFactory from 'debug';
+import { useTheme } from 'emotion-theming';
+import React, { useState } from 'react';
+import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
+import Button from '../../components/button';
 import Field from '../../components/field';
 import GridRow from '../../components/grid-row';
-import Button from '../../components/button';
-import PaymentLogo from './payment-logo';
-import { FormStatus, useLineItems } from '../../public-api';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
 import Spinner from '../../components/spinner';
-import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+import { FormStatus, useLineItems } from '../../public-api';
+import { useFormStatus } from '../form-status';
+import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import PaymentLogo from './payment-logo';
 
 const debug = debugFactory( 'composite-checkout:stripe-payment-method' );
 

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useContext } from 'react';
-
-/**
- * Internal dependencies
- */
 import CheckoutContext from '../lib/checkout-context';
 import {
 	PaymentProcessorFunction,

--- a/packages/composite-checkout/src/lib/registry.ts
+++ b/packages/composite-checkout/src/lib/registry.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import {
 	createRegistry,
 	RegistryProvider,
@@ -10,8 +7,8 @@ import {
 	StoreConfig,
 	SelectorMap,
 } from '@wordpress/data';
-import { useRef } from 'react';
 import debugFactory from 'debug';
+import { useRef } from 'react';
 
 const debug = debugFactory( 'composite-checkout:registry' );
 

--- a/packages/composite-checkout/src/lib/stripe-demo.js
+++ b/packages/composite-checkout/src/lib/stripe-demo.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import debugFactory from 'debug';
 import React, { useEffect, useReducer, useState, useContext, createContext } from 'react';
 import { injectStripe, StripeProvider, Elements } from 'react-stripe-elements';
-import debugFactory from 'debug';
 
 const debug = debugFactory( 'composite-checkout:lib-stripe' );
 const StripeContext = createContext();

--- a/packages/composite-checkout/src/lib/styled-components/ie-fallback.ts
+++ b/packages/composite-checkout/src/lib/styled-components/ie-fallback.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import styled from '../styled';
 
 export const LeftColumn = styled.div`

--- a/packages/composite-checkout/src/lib/styled-components/payment-method-logos.ts
+++ b/packages/composite-checkout/src/lib/styled-components/payment-method-logos.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import styled from '../styled';
 
 export const PaymentMethodLogos = styled.span`

--- a/packages/composite-checkout/src/lib/styled-components/summary-details.ts
+++ b/packages/composite-checkout/src/lib/styled-components/summary-details.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import styled from '../styled';
 
 export const SummaryDetails = styled.ul`

--- a/packages/composite-checkout/src/lib/styled.ts
+++ b/packages/composite-checkout/src/lib/styled.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import styled, { CreateStyled } from '@emotion/styled';
-
-/**
- * Internal dependencies
- */
 import { Theme } from './theme';
 
 export default styled as CreateStyled< Theme >;

--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { swatches } from './swatches';
 
 export type Theme = {

--- a/packages/composite-checkout/src/lib/transaction-status.ts
+++ b/packages/composite-checkout/src/lib/transaction-status.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useCallback, useContext, useMemo, useReducer } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { useCallback, useContext, useMemo, useReducer } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import {
 	TransactionStatus,

--- a/packages/composite-checkout/src/lib/validation.ts
+++ b/packages/composite-checkout/src/lib/validation.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	PaymentMethod,
 	LineItem,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -1,13 +1,12 @@
-/**
- * Internal dependencies
- */
 import Button from './components/button';
 import CheckoutErrorBoundary from './components/checkout-error-boundary';
-import PaymentLogo from './lib/payment-methods/payment-logo';
+import CheckoutModal from './components/checkout-modal';
+import CheckoutOrderSummaryStep, {
+	CheckoutOrderSummary,
+	CheckoutOrderSummaryStepTitle,
+} from './components/checkout-order-summary';
+import CheckoutPaymentMethods from './components/checkout-payment-methods';
 import { CheckoutProvider } from './components/checkout-provider';
-import useMessages from './components/use-messages';
-import useEvents from './components/use-events';
-import CheckoutSubmitButton from './components/checkout-submit-button';
 import {
 	Checkout,
 	CheckoutStep,
@@ -23,15 +22,44 @@ import {
 	CheckoutStepAreaWrapper,
 	SubmitButtonWrapper,
 } from './components/checkout-steps';
-import CheckoutPaymentMethods from './components/checkout-payment-methods';
+import CheckoutSubmitButton from './components/checkout-submit-button';
+import {
+	getDefaultOrderSummary,
+	getDefaultOrderSummaryStep,
+	getDefaultPaymentMethodStep,
+	getDefaultOrderReviewStep,
+} from './components/default-steps';
 import {
 	OrderReviewLineItems,
 	OrderReviewTotal,
 	OrderReviewSection,
 } from './components/order-review-line-items';
-import CheckoutModal from './components/checkout-modal';
-import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
+import RadioButton from './components/radio-button';
+import { CheckIcon as CheckoutCheckIcon } from './components/shared-icons';
+import useEvents from './components/use-events';
+import useMessages from './components/use-messages';
+import useProcessPayment from './components/use-process-payment';
+import { useFormStatus } from './lib/form-status';
+import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processor-response-error';
 import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
+import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
+import { createAlipayPaymentMethodStore, createAlipayMethod } from './lib/payment-methods/alipay';
+import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
+import { createIdealPaymentMethodStore, createIdealMethod } from './lib/payment-methods/ideal';
+import PaymentLogo from './lib/payment-methods/payment-logo';
+import { createSofortPaymentMethodStore, createSofortMethod } from './lib/payment-methods/sofort';
+import {
+	createStripeMethod,
+	createStripePaymentMethodStore,
+} from './lib/payment-methods/stripe-credit-card-fields';
+import {
+	usePaymentProcessor,
+	usePaymentProcessors,
+	makeManualResponse,
+	makeSuccessResponse,
+	makeRedirectResponse,
+	makeErrorResponse,
+} from './lib/payment-processors';
 import {
 	createRegistry,
 	defaultRegistry,
@@ -41,39 +69,8 @@ import {
 	useRegistry,
 	useSelect,
 } from './lib/registry';
-import { createIdealPaymentMethodStore, createIdealMethod } from './lib/payment-methods/ideal';
-import { createSofortPaymentMethodStore, createSofortMethod } from './lib/payment-methods/sofort';
-import { createAlipayPaymentMethodStore, createAlipayMethod } from './lib/payment-methods/alipay';
-import {
-	createStripeMethod,
-	createStripePaymentMethodStore,
-} from './lib/payment-methods/stripe-credit-card-fields';
-import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
-import CheckoutOrderSummaryStep, {
-	CheckoutOrderSummary,
-	CheckoutOrderSummaryStepTitle,
-} from './components/checkout-order-summary';
-import {
-	getDefaultOrderSummary,
-	getDefaultOrderSummaryStep,
-	getDefaultPaymentMethodStep,
-	getDefaultOrderReviewStep,
-} from './components/default-steps';
-import { useFormStatus } from './lib/form-status';
-import { CheckIcon as CheckoutCheckIcon } from './components/shared-icons';
-import { useTransactionStatus } from './lib/transaction-status';
-import {
-	usePaymentProcessor,
-	usePaymentProcessors,
-	makeManualResponse,
-	makeSuccessResponse,
-	makeRedirectResponse,
-	makeErrorResponse,
-} from './lib/payment-processors';
-import useProcessPayment from './components/use-process-payment';
-import RadioButton from './components/radio-button';
 import checkoutTheme from './lib/theme';
-import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processor-response-error';
+import { useTransactionStatus } from './lib/transaction-status';
 export * from './types';
 
 export type { Theme } from './lib/theme';

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { DataRegistry } from '@wordpress/data';
 import { ReactElement } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Theme } from './lib/theme';
 
 export interface CheckoutStepProps {

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-
-/**
- * Internal dependencies
- */
 import {
 	CheckoutProvider,
 	FormStatus,

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import React, { useState, useContext } from 'react';
 import {
 	render,
 	getAllByLabelText as getAllByLabelTextInNode,
@@ -10,11 +6,8 @@ import {
 	fireEvent,
 	act,
 } from '@testing-library/react';
+import React, { useState, useContext } from 'react';
 import '@testing-library/jest-dom/extend-expect';
-
-/**
- * Internal dependencies
- */
 import {
 	Checkout,
 	CheckoutProvider,

--- a/packages/composite-checkout/test/join-classes.js
+++ b/packages/composite-checkout/test/join-classes.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import joinClasses from '../src/lib/join-classes';
 
 describe( 'joinClasses', function () {

--- a/packages/composite-checkout/test/line-items.js
+++ b/packages/composite-checkout/test/line-items.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-
-/**
- * Internal dependencies
- */
 import { LineItemsProvider, useLineItems } from '../src/lib/line-items';
 
 // React writes to console.error when a component throws before re-throwing


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/composite-checkout` to use `import/order`

#### Testing instructions

N/A