### PR TITLE
chore: migrate client/support to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
 				'client/sections-middleware.js',
 				'client/sections-preloaders.js',
 				'client/sections.js',
+				'client/support/**/*',
 				'packages/accessible-focus/**/*',
 				'packages/calypso-products/**/*',
 				'packages/data-stores/**/*',

--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
 import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 import { rebootNormally } from 'calypso/lib/user/support-user-interop';
 import { isSupportSession } from 'calypso/state/support/selectors';


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/support` to use `import/order`

#### Testing instructions

N/A
