### PR TITLE
chore: migrate client/types to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -183,6 +183,7 @@ module.exports = {
 				'client/sections-preloaders.js',
 				'client/sections.js',
 				'client/support/**/*',
+				'client/types.ts',
 				'packages/accessible-focus/**/*',
 				'packages/calypso-products/**/*',
 				'packages/data-stores/**/*',

--- a/client/types.ts
+++ b/client/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { NonUndefined } from 'utility-types';
 
 // Web stuff


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/types` to use `import/order`

#### Testing instructions

N/A