### PR TITLE
Unbreak direct links to monthly plans

### DIFF
--- a/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
+++ b/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
@@ -20,6 +20,9 @@ export default createSelector(
 		}
 
 		const currentPlanSlug = getCurrentPlan( state, siteId )?.productSlug;
+		if ( typeof currentPlanSlug === 'undefined' ) {
+			return true;
+		}
 
 		return (
 			( isAtomicSite( state, siteId ) && currentPlanSlug === 'jetpack_free' ) ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Links like this:
http://calypso.localhost:3000/plans/monthly/dzverhi552.wordpress.com
Are supposed to work and don't because the plan slug is unavailable when we check for eligibility of the monthly plans.

Here is a video of the issue:
https://user-images.githubusercontent.com/82778/125649650-d7ae4387-d1c2-4278-a9e3-cccdbf7e938c.mov

#### Testing instructions

1. On a free site, go to /plans and select the monthly plans
2. Reload the page. You should not be redirected to annual plans
3. Add a paid annual plan to your test site
4. Try to load the monthly plans page. You should be redirected to yearly plans
