### PR TITLE
Shopping Cart: Update provider context value every time the cart changes

### DIFF
--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -188,6 +188,8 @@ export default function useShoppingCartManager( {
 		}
 	}, [ hookState.queuedActions, cacheStatus ] );
 
+	const responseCart = lastValidResponseCart.current;
+
 	const shoppingCartManager = useMemo(
 		() => ( {
 			isLoading,
@@ -203,21 +205,10 @@ export default function useShoppingCartManager( {
 			replaceProductInCart,
 			replaceProductsInCart,
 			reloadFromServer,
-			responseCart: lastValidResponseCart.current,
+			responseCart,
 		} ),
-		// We want to make sure that the valid responseCart object is returned when
-		// it changes, but lastValidResponseCart is a ref so we have to depend on
-		// the data that generates it: responseCartWithoutTempProducts. We can't
-		// use responseCartWithoutTempProducts for the data itself though because
-		// we don't want to return it if it isn't valid. We also don't want to use
-		// a useState for the valid cart because then it will require an extra
-		// render before the valid cart data is returned, during which time the
-		// other variables (eg: isPendingUpdate) will already have changed.
-		// Therefore, please ignore any warnings that this array contains that
-		// value as an unnecessary dependency (I wont disable the eslint warning
-		// because we might want to see other dependency warnings).
 		[
-			responseCartWithoutTempProducts,
+			responseCart,
 			isLoading,
 			isPendingUpdate,
 			loadingErrorForManager,

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -58,7 +58,7 @@ export default function useShoppingCartManager( {
 	const cartMiddleware = useMemo( () => [ syncCartToServer ], [ syncCartToServer ] );
 	const [ hookState, hookDispatch ] = useShoppingCartReducer( cartMiddleware );
 
-	const responseCart: TempResponseCart = hookState.responseCart;
+	const tempResponseCart: TempResponseCart = hookState.responseCart;
 	const couponStatus: CouponStatus = hookState.couponStatus;
 	const cacheStatus: CacheStatus = hookState.cacheStatus;
 	const loadingError: string | undefined = hookState.loadingError;
@@ -158,8 +158,8 @@ export default function useShoppingCartManager( {
 		hookState.queuedActions.length > 0 || cacheStatus !== 'valid' || ! cartKey;
 
 	const responseCartWithoutTempProducts = useMemo(
-		() => convertTempResponseCartToResponseCart( responseCart ),
-		[ responseCart ]
+		() => convertTempResponseCartToResponseCart( tempResponseCart ),
+		[ tempResponseCart ]
 	);
 	const lastValidResponseCart = useRef< ResponseCart >( responseCartWithoutTempProducts );
 	if ( cacheStatus === 'valid' ) {

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -205,8 +205,19 @@ export default function useShoppingCartManager( {
 			reloadFromServer,
 			responseCart: lastValidResponseCart.current,
 		} ),
+		// We want to make sure that the valid responseCart object is returned when
+		// it changes, but lastValidResponseCart is a ref so we have to depend on
+		// the data that generates it: responseCartWithoutTempProducts. We can't
+		// use responseCartWithoutTempProducts for the data itself though because
+		// we don't want to return it if it isn't valid. We also don't want to use
+		// a useState for the valid cart because then it will require an extra
+		// render before the valid cart data is returned, during which time the
+		// other variables (eg: isPendingUpdate) will already have changed.
+		// Therefore, please ignore any warnings that this array contains that
+		// value as an unnecessary dependency (I wont disable the eslint warning
+		// because we might want to see other dependency warnings).
 		[
-			lastValidResponseCart,
+			responseCartWithoutTempProducts,
 			isLoading,
 			isPendingUpdate,
 			loadingErrorForManager,

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -96,7 +96,7 @@ export default function useShoppingCartManager( {
 				cartValidCallbacks.current.push( resolve );
 			} );
 		},
-		[ hookDispatch, isMounted ]
+		[ hookDispatch ]
 	);
 
 	const addProductsToCart: AddProductsToCart = useCallback(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As mentioned by @jsnajdr in https://github.com/Automattic/wp-calypso/pull/47175#discussion_r669372504, there are some misleading dependencies in the memoized return value of the `useShoppingCartManager` hook that generates the context value for the `ShoppingCartProvider`. Notably, the value depends on a cached copy of the updated response cart (`lastValidResponseCart`) that is only updated when the cart becomes valid, but that copy is a ref, so it will never actually change.

If we don't depend on a non-ref version of the cart, there's a risk (however small) that the `responseCart` returned by the hook will have out-of-date data. This probably never happens in practice because when `cacheStatus` changes so that the cart becomes valid, which regenerates `lastValidResponseCart`, it also changes one of the other variables that is already a dependency (`isPendingUpdate`, `isLoading`, or `loadingErrorForManager`), but it is a little convoluted.

We also don't want to return the updated data if it's invalid (the point of https://github.com/Automattic/wp-calypso/pull/47175) and we don't want to create a new `useState` for the valid cache (this is how it was several versions ago) because then updating the cache (with a `useEffect`) will require another render before `responseCart` is correct, and during that render the other variables (particularly `isPendingUpdate`) will have already updated, providing misleading data to the consumer.

Therefore, this PR changes the dependency to `lastValidResponseCart.current` (with an alias to avoid linting errors). By itself this is not reliable because the object could change without a render, but since the object is only modified when the `cacheStatus` changes (and that _does_ cause a render), this creates a correct dependency for `responseCart`.

#### Testing instructions

- Add a product to your cart and visit checkout.
- Modify the cart in some way (eg: changing the term length, adding a coupon, changing the contact details) and verify that the form is disabled with a busy state, then becomes active again with the changes applied.