### PR TITLE
Update the appearance of the domain search show more results button

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -593,8 +593,6 @@ class RegisterDomainStep extends React.Component {
 			'register-domain-step__next-page--is-loading': isLoading,
 		} );
 		return (
-			// <CompactCard className={ className } onClick={ this.showNextPage } disabled={ isLoading }>
-			// 	{ this.props.translate( 'Show more results' ) }
 			<CompactCard className={ className }>
 				<Button
 					className="register-domain-step__next-page-button"

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -34,7 +34,7 @@ import Search from '@automattic/search';
  */
 import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
-import { CompactCard, Button } from '@automattic/components';
+import { CompactCard } from '@automattic/components';
 import Notice from 'calypso/components/notice';
 import StickyPanel from 'calypso/components/sticky-panel';
 import {
@@ -593,17 +593,8 @@ class RegisterDomainStep extends React.Component {
 			'register-domain-step__next-page--is-loading': isLoading,
 		} );
 		return (
-			<CompactCard className={ className }>
-				<Button
-					className="register-domain-step__next-page-button"
-					disabled={ isLoading }
-					busy={ isLoading }
-					onClick={ this.showNextPage }
-					primary
-					borderless
-				>
-					{ this.props.translate( 'Show more results' ) }
-				</Button>
+			<CompactCard className={ className } onClick={ this.showNextPage } disabled={ isLoading }>
+				{ this.props.translate( 'Show more results' ) }
 			</CompactCard>
 		);
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -599,6 +599,8 @@ class RegisterDomainStep extends React.Component {
 					disabled={ isLoading }
 					busy={ isLoading }
 					onClick={ this.showNextPage }
+					primary
+					borderless
 				>
 					{ this.props.translate( 'Show more results' ) }
 				</Button>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -34,7 +34,7 @@ import Search from '@automattic/search';
  */
 import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
-import { CompactCard } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import Notice from 'calypso/components/notice';
 import StickyPanel from 'calypso/components/sticky-panel';
 import {
@@ -593,8 +593,17 @@ class RegisterDomainStep extends React.Component {
 			'register-domain-step__next-page--is-loading': isLoading,
 		} );
 		return (
-			<CompactCard className={ className } onClick={ this.showNextPage } disabled={ isLoading }>
-				{ this.props.translate( 'Show more results' ) }
+			// <CompactCard className={ className } onClick={ this.showNextPage } disabled={ isLoading }>
+			// 	{ this.props.translate( 'Show more results' ) }
+			<CompactCard className={ className }>
+				<Button
+					className="register-domain-step__next-page-button"
+					disabled={ isLoading }
+					busy={ isLoading }
+					onClick={ this.showNextPage }
+				>
+					{ this.props.translate( 'Show more results' ) }
+				</Button>
 			</CompactCard>
 		);
 	}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -119,6 +119,12 @@
 	}
 }
 
+button.register-domain-step__next-page-button {
+	font-size: 0.875rem;
+	font-weight: 500; /* stylelint-disable-line */
+}
+
+
 body.is-section-domains {
 	.register-domain-step {
 		button.register-domain-step__next-page-button {
@@ -138,8 +144,6 @@ body.is-section-signup.is-white-signup {
 			padding: 0.57em 1.17em;
 			border-radius: 4px; /* stylelint-disable-line */
 
-			font-size: 0.875rem;
-			font-weight: 500; /* stylelint-disable-line */
 			letter-spacing: 0.32px;
 			line-height: 1.25rem;
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -127,7 +127,7 @@ button.register-domain-step__next-page-button {
 
 body.is-section-domains {
 	.register-domain-step {
-		&__next-page-button {
+		button.register-domain-step__next-page-button {
 			color: var( --color-link );
 			border: none;
 			box-shadow: none;
@@ -140,7 +140,7 @@ body.is-section-signup.is-white-signup {
 		background: none;
 		box-shadow: none;
 
-		&-button {
+		button.register-domain-step__next-page-button {
 			padding: 0.57em 1.17em;
 			border-radius: 4px; /* stylelint-disable-line */
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -108,6 +108,7 @@
 }
 
 .register-domain-step__next-page {
+	color: var( --color-link );
 	display: flex;
 	justify-content: center;
 }
@@ -122,21 +123,15 @@ body.is-section-signup.is-white-signup {
 	.register-domain-step__next-page {
 		background: none;
 		box-shadow: none;
+		padding: 0.57em 1.17em;
+		font-size: 0.875rem;
+		font-weight: 500; /* stylelint-disable-line */
+		letter-spacing: 0.32px;
+		line-height: 1.25rem;
 
-		button.register-domain-step__next-page-button {
-			padding: 0.57em 1.17em;
-			border-radius: 4px; /* stylelint-disable-line */
-
-			font-size: 0.875rem;
-			font-weight: 500; /* stylelint-disable-line */
-			letter-spacing: 0.32px;
-			line-height: 1.25rem;
-
-			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
-
-			@include break-mobile {
-				padding: 0.65em 2.8em;
-			}
+		@include break-mobile {
+			padding: 0.65em 2.8em;
 		}
 	}
 }
+

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -119,18 +119,35 @@
 	}
 }
 
+body.is-section-domains {
+	.register-domain-step {
+		button.register-domain-step__next-page-button {
+			color: var( --color-link );
+			border: none;
+			box-shadow: none;
+		}
+	}
+}
+
 body.is-section-signup.is-white-signup {
 	.register-domain-step__next-page {
 		background: none;
 		box-shadow: none;
-		padding: 0.57em 1.17em;
-		font-size: 0.875rem;
-		font-weight: 500; /* stylelint-disable-line */
-		letter-spacing: 0.32px;
-		line-height: 1.25rem;
 
-		@include break-mobile {
-			padding: 0.65em 2.8em;
+		button.register-domain-step__next-page-button {
+			padding: 0.57em 1.17em;
+			border-radius: 4px; /* stylelint-disable-line */
+
+			font-size: 0.875rem;
+			font-weight: 500; /* stylelint-disable-line */
+			letter-spacing: 0.32px;
+			line-height: 1.25rem;
+
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+
+			@include break-mobile {
+				padding: 0.65em 2.8em;
+			}
 		}
 	}
 }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -127,7 +127,7 @@ button.register-domain-step__next-page-button {
 
 body.is-section-domains {
 	.register-domain-step {
-		button.register-domain-step__next-page-button {
+		&__next-page-button {
 			color: var( --color-link );
 			border: none;
 			box-shadow: none;
@@ -140,7 +140,7 @@ body.is-section-signup.is-white-signup {
 		background: none;
 		box-shadow: none;
 
-		button.register-domain-step__next-page-button {
+		&-button {
 			padding: 0.57em 1.17em;
 			border-radius: 4px; /* stylelint-disable-line */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to update the appearance of the "Show more results" button at the bottom of the domain suggestions list as specified in: 1146722293412575-as-1200601027531820.

#### Testing instructions

Use the "Link to Calypso live" link below to view the build for this branch. 
Go to the domain suggestions page.
Make sure that the button looks like the "New" version shown in the screenshot below:

Old button in /domains/add:
<img width="1077" alt="Screen Shot 2021-07-14 at 4 33 48 PM" src="https://user-images.githubusercontent.com/1379730/125689309-7bb8f22d-4c4f-4a20-a770-f62d8dbd40d6.png">

Old button in /start/domains:
<img width="1165" alt="Screen Shot 2021-07-16 at 10 42 13 AM" src="https://user-images.githubusercontent.com/1379730/125965568-5f8f857c-041e-4a3e-b914-405c70047733.png">


New card in /domains/add:
<img width="1165" alt="Screen Shot 2021-07-16 at 10 48 19 AM" src="https://user-images.githubusercontent.com/1379730/125966536-0fa79fd3-9082-496f-a3a5-41e50ec2c57a.png">



New card in /start/domains:
<img width="1165" alt="Screen Shot 2021-07-16 at 10 48 10 AM" src="https://user-images.githubusercontent.com/1379730/125966552-71d064e1-c7d8-4a70-98e2-a8a33f1e9e34.png">


