### PR TITLE
Add simple scrolling bar to keyed suggestions

### DIFF
--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -4,6 +4,8 @@
 	left: 0;
 	width: 100%;
 	margin-left: -1px;
+	overflow-y: auto;
+	max-height: 50vh;
 }
 
 .keyed-suggestions__suggestions {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add simple scrolling bar to keyed suggestions

![2021-07-14_15-48](https://user-images.githubusercontent.com/937354/125690951-07832aed-beec-431b-b952-91ff1364927a.png)
^ Before

![2021-07-14_15-47](https://user-images.githubusercontent.com/937354/125690935-0ef9723e-3260-4258-83ec-8a2699b12ed9.png)
^ After

#### Testing instructions


* Go to theme showcase
* click Filters -> Subject -> Show all
* To see before: Use the code in this PR https://github.com/Automattic/wp-calypso/pull/54514
* To see after: Use the code in this branch
