### PR TITLE
Proof of Concept: Try adding a "My Themes" themes tab to the Theme Showcase

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -97,7 +97,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 							origin="wpcom"
 							defaultOption={ 'activate' }
 							secondaryOption={ 'tryandcustomize' }
-							noMarginBeforeHeader={ true }
 							search={ search }
 							tier={ tier }
 							filter={ filter }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -379,7 +379,6 @@ class ThemeShowcase extends React.Component {
 								<UpworkBanner location={ 'theme-banner' } />
 							) }
 							<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
-							{ isJetpackSite && this.props.children }
 						</div>
 					) }
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -363,6 +363,17 @@ class ThemeShowcase extends React.Component {
 						/>
 					) }
 					{ 'all' === this.state.tabFilter.key && (
+						( isJetpackSite ? (
+							this.props.children
+						) : (
+							<div className="theme-showcase__all-themes">
+								{ ! this.props.loggedOutComponent && showBanners && (
+									<UpworkBanner location={ 'theme-banner' } />
+								) }
+								<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
+							</div>
+						) ) }
+					{ 'uploaded' === this.state.tabFilter && (
 						<div className="theme-showcase__all-themes">
 							{ ! this.props.loggedOutComponent && showBanners && (
 								<UpworkBanner location={ 'theme-banner' } />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -311,6 +311,14 @@ class ThemeShowcase extends React.Component {
 				),
 		};
 
+		let selectedText = translate( 'All Themes' );
+
+		if ( 'recommended' === this.state.tabFilter ) {
+			selectedText = translate( 'Recommended' );
+		} else if ( 'uploaded' === this.state.tabFilter ) {
+			selectedText = translate( 'My Themes' );
+		}
+
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -372,14 +380,10 @@ class ThemeShowcase extends React.Component {
 								) }
 								<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
 							</div>
-						) ) }
+						) )
+					) }
 					{ 'uploaded' === this.state.tabFilter && (
-						<div className="theme-showcase__all-themes">
-							{ ! this.props.loggedOutComponent && showBanners && (
-								<UpworkBanner location={ 'theme-banner' } />
-							) }
-							<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
-						</div>
+						<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
 					) }
 
 					{ 'trending' === this.state.tabFilter.key && (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -230,9 +230,29 @@ class ThemeShowcase extends React.Component {
 		this.setState( { tabFilter }, callback );
 	};
 
+	expertsBanner = () => {
+		const { currentThemeId, loggedOutComponent, siteId, isLoggedIn } = this.props;
+		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
+		if ( loggedOutComponent || ! showBanners ) {
+			return;
+		}
+		return <UpworkBanner location={ 'theme-banner' } />;
+	};
+
+	allThemes = ( { themeProps } ) => {
+		const { isJetpackSite, children } = this.props;
+		if ( isJetpackSite ) {
+			return children;
+		}
+		return (
+			<div className="theme-showcase__all-themes">
+				<ThemesSelection { ...themeProps } />
+			</div>
+		);
+	};
+
 	render() {
 		const {
-			currentThemeId,
 			siteId,
 			options,
 			getScreenshotOption,
@@ -245,7 +265,6 @@ class ThemeShowcase extends React.Component {
 			filterString,
 			isMultisite,
 			locale,
-			isJetpackSite,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -281,8 +300,6 @@ class ThemeShowcase extends React.Component {
 				.filter( ( icon ) => !! icon )
 				.sort( ( a, b ) => a.order - b.order )
 		);
-
-		const showBanners = currentThemeId || ! siteId || ! isLoggedIn;
 
 		const themeProps = {
 			filter: filter,
@@ -369,17 +386,8 @@ class ThemeShowcase extends React.Component {
 					) }
 					{ this.props.upsellBanner }
 					{ 'recommended' === this.state.tabFilter.key && <RecommendedThemes { ...themeProps } /> }
-					{ 'all' === this.state.tabFilter.key &&
-						( isJetpackSite ? (
-							this.props.children
-						) : (
-							<div className="theme-showcase__all-themes">
-								{ ! this.props.loggedOutComponent && showBanners && (
-									<UpworkBanner location={ 'theme-banner' } />
-								) }
-								<ThemesSelection { ...themeProps } />
-							</div>
-						) ) }
+					{ 'all' === this.state.tabFilter.key && this.expertsBanner() }
+					{ 'all' === this.state.tabFilter.key && this.allThemes( { themeProps } ) }
 					{ 'my-themes' === this.state.tabFilter.key && <ThemesSelection { ...themeProps } /> }
 					{ 'trending' === this.state.tabFilter.key && <TrendingThemes { ...themeProps } /> }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -74,9 +74,20 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.tabFilters = {
-			RECOMMENDED: { key: 'recommended', text: props.translate( 'Recommended' ), order: 1 },
-			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 2 },
-			TRENDING: { key: 'trending', text: props.translate( 'Trending' ), order: 3 },
+			RECOMMENDED: {
+				key: 'recommended',
+				text: props.translate( 'Recommended' ),
+				order: 1,
+				show: true,
+			},
+			TRENDING: { key: 'trending', text: props.translate( 'Trending' ), order: 2, show: true },
+			MYTHEMES: {
+				key: 'my-themes',
+				text: props.translate( 'My Themes' ),
+				order: 3,
+				show: this.props.isJetpackSite,
+			},
+			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
 		};
 		this.state = {
 			tabFilter:
@@ -304,20 +315,13 @@ class ThemeShowcase extends React.Component {
 			getActionLabel: ( theme ) => getScreenshotOption( theme ).label,
 			trackScrollPage: this.props.trackScrollPage,
 			emptyContent: this.props.emptyContent,
+			scrollToSearchInput: this.scrollToSearchInput,
 			getOptions: ( theme ) =>
 				pickBy(
 					addTracking( options ),
 					( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
 				),
 		};
-
-		let selectedText = translate( 'All Themes' );
-
-		if ( 'recommended' === this.state.tabFilter ) {
-			selectedText = translate( 'Recommended' );
-		} else if ( 'uploaded' === this.state.tabFilter ) {
-			selectedText = translate( 'My Themes' );
-		}
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
@@ -348,29 +352,24 @@ class ThemeShowcase extends React.Component {
 							<NavTabs>
 								{ Object.values( this.tabFilters )
 									.sort( ( a, b ) => a.order - b.order )
-									.map( ( tabFilter ) => (
-										<NavItem
-											key={ tabFilter.key }
-											onClick={ () => this.onFilterClick( tabFilter ) }
-											selected={ tabFilter.key === this.state.tabFilter.key }
-										>
-											{ tabFilter.text }
-										</NavItem>
-									) ) }
+									.map(
+										( tabFilter ) =>
+											tabFilter.show && (
+												<NavItem
+													key={ tabFilter.key }
+													onClick={ () => this.onFilterClick( tabFilter ) }
+													selected={ tabFilter.key === this.state.tabFilter.key }
+												>
+													{ tabFilter.text }
+												</NavItem>
+											)
+									) }
 							</NavTabs>
 						</SectionNav>
 					) }
-
 					{ this.props.upsellBanner }
-
-					{ 'recommended' === this.state.tabFilter.key && (
-						<RecommendedThemes
-							listLabel={ ' ' }
-							{ ...themeProps }
-							scrollToSearchInput={ this.scrollToSearchInput }
-						/>
-					) }
-					{ 'all' === this.state.tabFilter.key && (
+					{ 'recommended' === this.state.tabFilter.key && <RecommendedThemes { ...themeProps } /> }
+					{ 'all' === this.state.tabFilter.key &&
 						( isJetpackSite ? (
 							this.props.children
 						) : (
@@ -378,21 +377,11 @@ class ThemeShowcase extends React.Component {
 								{ ! this.props.loggedOutComponent && showBanners && (
 									<UpworkBanner location={ 'theme-banner' } />
 								) }
-								<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
+								<ThemesSelection { ...themeProps } />
 							</div>
-						) )
-					) }
-					{ 'uploaded' === this.state.tabFilter && (
-						<ThemesSelection listLabel={ this.props.listLabel } { ...themeProps } />
-					) }
-
-					{ 'trending' === this.state.tabFilter.key && (
-						<TrendingThemes
-							listLabel={ ' ' }
-							{ ...themeProps }
-							scrollToSearchInput={ this.scrollToSearchInput }
-						/>
-					) }
+						) ) }
+					{ 'my-themes' === this.state.tabFilter.key && <ThemesSelection { ...themeProps } /> }
+					{ 'trending' === this.state.tabFilter.key && <TrendingThemes { ...themeProps } /> }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal source={ 'list' } />

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -28,7 +28,6 @@ import {
 } from 'calypso/state/themes/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import config from '@automattic/calypso-config';
-import ThemesSelectionHeader from './themes-selection-header';
 
 /**
  * Style dependencies
@@ -158,17 +157,11 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, upsellUrl, listLabel, noMarginBeforeHeader } = this.props;
+		const { source, query, upsellUrl } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
-				{ this.props.isLoggedIn && (
-					<ThemesSelectionHeader
-						label={ listLabel }
-						noMarginBeforeHeader={ noMarginBeforeHeader }
-					/>
-				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }
 					themes={ this.props.customizedThemesList || this.props.themes }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Testing this concept as a partial solution to #54394 and #54251 -- move "Uploaded themes" (ie. themes that have been used on this site previously) to their own tab for Atomic and Jetpack sites, so there's no need for extra headings, and you don't see duplicate themes side by side.
* I'd suggest, if we go this route, renaming the tab to something that more accurately describes what it does, since not all themes in this listing are "uploaded". Maybe "My Themes" or something like that.

**Before**

![screencapture-wordpress-themes-caroline-blog-2021-07-14-17_05_10](https://user-images.githubusercontent.com/2124984/125692881-02020168-0a01-4999-bc32-54d17c739974.png)

**After**

![screencapture-calypso-localhost-3000-themes-caroline-blog-2021-07-20-13_36_36](https://user-images.githubusercontent.com/2124984/126369975-cfb82e67-a573-4797-a651-2b87e1b3cf75.png)

#### Testing instructions

* Switch to this PR, navigate to `/themes` on a Jetpack or Atomic site
* You should see a tab for Uploaded themes that contains themes you've previously activated or uploaded
* Switch to a simple site; the Uploaded view and tab should not appear, and you should be switched to Recommended themes
