### PR TITLE
Jetpack Pricing Page: Track new event specific to the site-only checkout flow

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -69,6 +69,20 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		);
 	}, [ dispatch, rootUrl, siteSlug, viewTrackerPath ] );
 
+	const { unlinked, purchasetoken, purchaseNonce, site } = urlQueryArgs;
+	const canDoSiteOnlyCheckout = unlinked && !! site && ( !! purchasetoken || purchaseNonce );
+	useEffect( () => {
+		if ( canDoSiteOnlyCheckout ) {
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_siteonly_pricing_page_visit', {
+					site: siteSlug,
+					path: viewTrackerPath,
+					root_path: rootUrl,
+				} )
+			);
+		}
+	}, [ canDoSiteOnlyCheckout, dispatch, rootUrl, siteSlug, viewTrackerPath ] );
+
 	useEffect( () => {
 		setDuration( defaultDuration );
 	}, [ defaultDuration ] );

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -70,7 +70,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	}, [ dispatch, rootUrl, siteSlug, viewTrackerPath ] );
 
 	const { unlinked, purchasetoken, purchaseNonce, site } = urlQueryArgs;
-	const canDoSiteOnlyCheckout = unlinked && !! site && ( !! purchasetoken || purchaseNonce );
+	const canDoSiteOnlyCheckout = unlinked && !! site && !! ( purchasetoken || purchaseNonce );
 	useEffect( () => {
 		if ( canDoSiteOnlyCheckout ) {
 			dispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the new `calypso_jetpack_siteonly_pricing_page_visit` Track event to cloud.jetpack.com/pricing, which tracks users going through the new Logged Out Visitor Checkout fow.

#### Testing instructions

* Download this PR and start Calypso Green with `yarn start-jetpack-cloud`.
* Visit `/pricing`.
* Make sure the `calypso_jetpack_siteonly_pricing_page_visit` is not tracked.
* Visit `/pricing/old-stoat.jurassic.ninja?site=old-stoat.jurassic.ninja&unlinked=1&purchaseNonce=ABCDEFGHI` (it doesn't matter whether you own the site, or whether the `purchaseNonce` is valid).
* Make sure the `calypso_jetpack_siteonly_pricing_page_visit` is tracked.

Related to 1164141197617539-as-1200606869349574

#### Demo

##### Standard flow (`calypso_jetpack_siteonly_pricing_page_visit` is not tracked)
![image](https://user-images.githubusercontent.com/3418513/125702132-9f331a04-4ecc-4d78-a2f4-1c845387b82a.png)

##### Logged Out Visitor Checkout flow (`calypso_jetpack_siteonly_pricing_page_visit` is tracked)
![image](https://user-images.githubusercontent.com/3418513/125702103-ff982ede-81ec-4a5b-9f4d-16372d4cab56.png)

