### PR TITLE
Themes: hide FSE themes from sites not currently running an FSE theme

### DIFF
--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -30,7 +30,7 @@ const fetchFilters = ( action ) =>
 
 const storeFilters = ( action, data ) => {
 	let filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
-	filters = action.isCoreFse ? data : omit( data, 'feature.block-templates' );
+	filters = action.isCoreFse ? filters : omit( filters, 'feature.block-templates' );
 	return { type: THEME_FILTERS_ADD, filters };
 };
 

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -14,6 +14,7 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isSiteEligibleForFullSiteEditing from 'calypso/state/selectors/is-site-eligible-for-full-site-editing';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
@@ -28,7 +29,8 @@ const fetchFilters = ( action ) =>
 	);
 
 const storeFilters = ( action, data ) => {
-	const filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
+	let filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
+	filters = action.isCoreFse ? data : omit( data, 'feature.block-templates' );
 	return { type: THEME_FILTERS_ADD, filters };
 };
 
@@ -46,10 +48,12 @@ registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 			const state = store.getState();
 			const selectedSiteId = getSelectedSiteId( state );
 			const isFse = isSiteEligibleForFullSiteEditing( state, selectedSiteId );
+			const isCoreFse = isSiteUsingCoreSiteEditor( state, selectedSiteId );
 
 			return themeFiltersHandlers( store, {
 				...action,
 				isFse,
+				isCoreFse,
 			} );
 		},
 	],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* hide FSE themes (`Block Templates` under Features) from sites not currently running an FSE theme

#### Testing instructions

On a site _with_ FSE active: themes with **Block Templates** Feature _should_ be searchable through the theme search interface.

![image](https://user-images.githubusercontent.com/195089/126386332-150dc8da-8fdc-4ffa-aceb-e40adbed9245.png)

On a site _without_ FSE active: themes with **Block Templates** Feature _should not_ be searchable through the theme search interface.