### PR TITLE
chore: Refactor `packages/wpcom-checkout` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -187,9 +187,10 @@ module.exports = {
 				'packages/accessible-focus/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-products/**/*',
+				'packages/components/**/*',
 				'packages/composite-checkout/**/*',
 				'packages/data-stores/**/*',
-				'packages/components/**/*',
+				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',
 			],
 			rules: {

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { Button } from '@automattic/composite-checkout';
 import { TranslateResult } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from './styled';
 
 // Disabling this to make migrating files easier

--- a/packages/wpcom-checkout/src/google-pay-mark.tsx
+++ b/packages/wpcom-checkout/src/google-pay-mark.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 export function GooglePayMark( { fill }: { fill: string } ): JSX.Element {

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import useDisplayCartMessages from './use-display-cart-messages';
 
 export * from './transformations';

--- a/packages/wpcom-checkout/src/is-wpcom-product-renewal.ts
+++ b/packages/wpcom-checkout/src/is-wpcom-product-renewal.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export function isWpComProductRenewal( product: ResponseCartProduct ): boolean {

--- a/packages/wpcom-checkout/src/payment-method-logos.ts
+++ b/packages/wpcom-checkout/src/payment-method-logos.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import styled from '@emotion/styled';
 
 export const PaymentMethodLogos = styled.span`

--- a/packages/wpcom-checkout/src/payment-method-store.ts
+++ b/packages/wpcom-checkout/src/payment-method-store.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@automattic/composite-checkout';
 
 export interface StoreStateValue {

--- a/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React, { useCallback } from 'react';
-import debugFactory from 'debug';
-import { useI18n } from '@wordpress/react-i18n';
 import { ProcessPayment } from '@automattic/composite-checkout';
-import type { PaymentMethod } from '@automattic/composite-checkout';
-import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
-
-/**
- * Internal dependencies
- */
-import PaymentRequestButton from '../payment-request-button';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import React, { useCallback } from 'react';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import PaymentRequestButton from '../payment-request-button';
 import { usePaymentRequestOptions, useStripePaymentRequest } from './web-pay-utils';
+import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
+import type { PaymentMethod } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'composite-checkout:apple-pay-payment-method' );
 

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import debugFactory from 'debug';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
 import {
 	Button,
 	FormStatus,
@@ -14,15 +7,14 @@ import {
 	useSelect,
 	useDispatch,
 } from '@automattic/composite-checkout';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
-import styled from '../styled';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import React from 'react';
 import Field from '../field';
-import { SummaryLine, SummaryDetails } from '../summary-details';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import styled from '../styled';
+import { SummaryLine, SummaryDetails } from '../summary-details';
 import type {
 	PaymentMethodStore,
 	StoreSelectors,
@@ -30,6 +22,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
+import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:bancontact-payment-method' );
 

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import debugFactory from 'debug';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
 import {
 	Button,
 	FormStatus,
@@ -14,15 +7,14 @@ import {
 	useSelect,
 	useDispatch,
 } from '@automattic/composite-checkout';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
-import styled from '../styled';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import React from 'react';
 import Field from '../field';
-import { SummaryLine, SummaryDetails } from '../summary-details';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import styled from '../styled';
+import { SummaryLine, SummaryDetails } from '../summary-details';
 import type {
 	PaymentMethodStore,
 	StoreSelectors,
@@ -30,6 +22,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
+import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:eps-payment-method' );
 

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import debugFactory from 'debug';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
 import {
 	Button,
 	FormStatus,
@@ -14,15 +7,14 @@ import {
 	useSelect,
 	useDispatch,
 } from '@automattic/composite-checkout';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
-import styled from '../styled';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import React from 'react';
 import Field from '../field';
-import { SummaryLine, SummaryDetails } from '../summary-details';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import styled from '../styled';
+import { SummaryLine, SummaryDetails } from '../summary-details';
 import type {
 	PaymentMethodStore,
 	StoreSelectors,
@@ -30,6 +22,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
+import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:giropay-payment-method' );
 

--- a/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React, { useCallback } from 'react';
-import debugFactory from 'debug';
 import { ProcessPayment } from '@automattic/composite-checkout';
-import type { PaymentMethod } from '@automattic/composite-checkout';
-import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
-
-/**
- * Internal dependencies
- */
+import debugFactory from 'debug';
+import React, { useCallback } from 'react';
+import { GooglePayMark } from '../google-pay-mark';
+import { PaymentMethodLogos } from '../payment-method-logos';
 import PaymentRequestButton from '../payment-request-button';
 import { usePaymentRequestOptions, useStripePaymentRequest } from './web-pay-utils';
-import { PaymentMethodLogos } from '../payment-method-logos';
-import { GooglePayMark } from '../google-pay-mark';
+import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
+import type { PaymentMethod } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:google-pay-payment-method' );
 

--- a/packages/wpcom-checkout/src/payment-methods/p24.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/p24.tsx
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import debugFactory from 'debug';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
 import {
 	Button,
 	FormStatus,
@@ -14,15 +7,14 @@ import {
 	useSelect,
 	useDispatch,
 } from '@automattic/composite-checkout';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
-import styled from '../styled';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import React from 'react';
 import Field from '../field';
-import { SummaryLine, SummaryDetails } from '../summary-details';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import styled from '../styled';
+import { SummaryLine, SummaryDetails } from '../summary-details';
 import type {
 	PaymentMethodStore,
 	StoreSelectors,
@@ -30,6 +22,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
+import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
 // Disabling this to make migration easier
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/wpcom-checkout/src/payment-methods/paypal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/paypal.tsx
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import styled from '@emotion/styled';
-import debugFactory from 'debug';
-import { useI18n } from '@wordpress/react-i18n';
 import {
 	FormStatus,
 	TransactionStatus,
@@ -13,12 +6,12 @@ import {
 	useFormStatus,
 	Button,
 } from '@automattic/composite-checkout';
-import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import React from 'react';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:paypal' );
 

--- a/packages/wpcom-checkout/src/payment-methods/web-pay-utils.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/web-pay-utils.tsx
@@ -1,16 +1,13 @@
-/**
- * External dependencies
- */
-import { useState, useCallback, useEffect, useMemo } from 'react';
-import debugFactory from 'debug';
 import { useLineItems } from '@automattic/composite-checkout';
-import type { LineItem } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import type {
 	Stripe,
 	StripeConfiguration,
 	StripePaymentRequest,
 	PaymentRequestOptions,
 } from '@automattic/calypso-stripe';
+import type { LineItem } from '@automattic/composite-checkout';
 
 const debug = debugFactory( 'wpcom-checkout:web-pay-utils' );
 

--- a/packages/wpcom-checkout/src/payment-request-button.tsx
+++ b/packages/wpcom-checkout/src/payment-request-button.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React, { MouseEvent } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
-import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
-import type { StripePaymentRequest } from '@automattic/calypso-stripe';
-
-/**
- * Internal dependencies
- */
-import styled from './styled';
 import { GooglePayMark } from './google-pay-mark';
+import styled from './styled';
+import type { StripePaymentRequest } from '@automattic/calypso-stripe';
 
 // Disabling this rule to make migrating this to calypso easier with fewer changes
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/wpcom-checkout/src/styled.ts
+++ b/packages/wpcom-checkout/src/styled.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import styled, { CreateStyled } from '@emotion/styled';
 import type { Theme } from '@automattic/composite-checkout';
 

--- a/packages/wpcom-checkout/src/summary-details.ts
+++ b/packages/wpcom-checkout/src/summary-details.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import styled from './styled';
 
 export const SummaryDetails = styled.ul`

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
 import type { LineItem } from '@automattic/composite-checkout';
 import type { ResponseCart, TaxBreakdownItem } from '@automattic/shopping-cart';

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { LineItem } from '@automattic/composite-checkout';
 import type {
 	RequestCartProduct,

--- a/packages/wpcom-checkout/src/use-display-cart-messages.tsx
+++ b/packages/wpcom-checkout/src/use-display-cart-messages.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { useRef, useEffect } from 'react';
 import type {
 	ResponseCart,

--- a/packages/wpcom-checkout/src/use-is-web-payment-available.ts
+++ b/packages/wpcom-checkout/src/use-is-web-payment-available.ts
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { useEffect, useState } from 'react';
 import debugFactory from 'debug';
+import { useEffect, useState } from 'react';
 import type { Stripe, StripeConfiguration } from '@automattic/calypso-stripe';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-is-web-pay-available' );

--- a/packages/wpcom-checkout/test/postal-code.js
+++ b/packages/wpcom-checkout/test/postal-code.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { tryToGuessPostalCodeFormat } from '../src';
 
 describe( 'Postal Code Utils', () => {

--- a/packages/wpcom-checkout/test/product-url-encoding.ts
+++ b/packages/wpcom-checkout/test/product-url-encoding.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { encodeProductForUrl, decodeProductFromUrl } from '../src/product-url-encoding';
 
 describe( 'encodeProductForUrl', () => {

--- a/packages/wpcom-checkout/test/transformations.js
+++ b/packages/wpcom-checkout/test/transformations.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	getLineItemsFromCart,
 	getCreditsLineItemFromCart,


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/components` to use `import/order`

#### Testing instructions

N/A