### PR TITLE
My Home: update "add a menu" link to use customizer with tour

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -16,10 +16,9 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/curren
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
-import getMenusUrl from 'calypso/state/selectors/get-menus-url';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
@@ -340,7 +339,7 @@ export default connect( ( state ) => {
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
 		isEmailUnverified: ! isCurrentUserEmailVerified( state ),
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
-		menusUrl: getMenusUrl( state, siteId ),
+		menusUrl: getCustomizerUrl( state, siteId, null, null, 'add-menu' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		tasks: taskList.getAll(),

--- a/client/state/sites/selectors/get-customizer-url.js
+++ b/client/state/sites/selectors/get-customizer-url.js
@@ -10,19 +10,22 @@ import isJetpackSite from './is-jetpack-site';
 /**
  * Returns the customizer URL for a site, or null if it cannot be determined.
  *
- * @param   {object}  state     Global state tree
- * @param   {?number} siteId    Site ID
- * @param   {string}  panel     Optional panel to autofocus
- * @param   {string}  returnUrl Optional return url for when the user closes the customizer
- * @returns {string}            Customizer URL
+ * @param   {object}  state        Global state tree
+ * @param   {?number} siteId       Site ID
+ * @param   {?string} panel        Optional panel to autofocus
+ * @param   {?string} returnUrl    Optional return url for when the user closes the customizer
+ * @param   {?string} guide        Optional parameter to show a help guide in the customizer. possible values:
+ *                                 'add-menu' and 'social-media' show custom guides, any other value shows the default guide
+ * @returns {string}               Customizer URL
  */
-export default function getCustomizerUrl( state, siteId, panel, returnUrl ) {
+export default function getCustomizerUrl( state, siteId, panel, returnUrl, guide ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		const url = [ '' ].concat( [ 'customize', panel, siteSlug ].filter( Boolean ) ).join( '/' );
 		return addQueryArgs(
 			{
 				return: returnUrl,
+				guide,
 			},
 			url
 		);
@@ -42,6 +45,7 @@ export default function getCustomizerUrl( state, siteId, panel, returnUrl ) {
 		{
 			return: returnUrl,
 			...getCustomizerFocus( panel ),
+			guide,
 		},
 		adminUrl
 	);

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3164,6 +3164,55 @@ describe( 'selectors', () => {
 			);
 		} );
 
+		test( 'should prepend guide parameter for WordPress.com site', () => {
+			const customizerUrl = getCustomizerUrl(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								jetpack: false,
+							},
+						},
+					},
+				},
+				77203199,
+				'identity',
+				null,
+				'test-guide'
+			);
+
+			chaiExpect( customizerUrl ).to.equal( '/customize/identity/example.com?guide=test-guide' );
+		} );
+
+		test( 'should prepend guide parameter for Jetpack site', () => {
+			const customizerUrl = getCustomizerUrl(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.com/wp-admin/',
+								},
+							},
+						},
+					},
+				},
+				77203199,
+				'identity',
+				null,
+				'test-guide'
+			);
+
+			chaiExpect( customizerUrl ).to.equal(
+				'https://example.com/wp-admin/customize.php?autofocus%5Bsection%5D=title_tagline&guide=test-guide'
+			);
+		} );
+
 		describe( 'browser', () => {
 			beforeAll( () => {
 				global.window = {


### PR DESCRIPTION
As discussed in https://github.com/Automattic/wp-calypso/issues/54436 we wanted to investigate whether it's feasible to use the tour to guide users through editing their site menu.

It turned out that the customizer currently only supports a one step tour on wpcom.

This and D64107-code are a potential implementation of the basic idea suggested in https://github.com/Automattic/wp-calypso/issues/54436

#### Testing instructions

Apply D64107-code to your sandbox.
Apply this PR,
Open My Home for a pre launched site and click on the _Add a Menu_ checklist item
![edit-menus](https://user-images.githubusercontent.com/22446385/125731718-937f6fc9-052a-4941-a8c2-01b22a123165.gif)
