### PR TITLE
Jetpack Cloud: finish removing Connect, Checkout and Plans sections

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -156,10 +156,6 @@ const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
 		const loggedOutRoutes = [ '/start', '/api/oauth/token', '/connect' ];
 
-		if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-			loggedOutRoutes.push( '/jetpack/connect', '/plans' );
-		}
-
 		if ( isJetpackCloud() && config.isEnabled( 'jetpack/pricing-page' ) ) {
 			loggedOutRoutes.push( '/pricing' );
 			getLanguageSlugs().forEach( ( slug ) => loggedOutRoutes.push( `/${ slug }/pricing` ) );
@@ -342,7 +338,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		// Dead-end the sections the user can't access when logged out
 		page( '*', function ( context, next ) {
 			//see server/pages/index for prod redirect
-			if ( ! config.isEnabled( 'jetpack-cloud/connect' ) && '/plans' === context.pathname ) {
+			if ( '/plans' === context.pathname ) {
 				const queryFor = context.query && context.query.for;
 				if ( queryFor && 'jetpack' === queryFor ) {
 					window.location =

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -14,19 +14,12 @@ import { setLocale } from 'calypso/state/ui/language/actions';
 import { addQueryArgs } from 'calypso/lib/route';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
-	const { pathname } = context;
 	const urlQueryArgs = context.query;
-	const { site: siteFromUrl } = urlQueryArgs;
 	const { locale } = context.params;
 
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
 		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
-		return;
-	}
-
-	if ( /\/(pricing|plans)$/.test( pathname ) && siteFromUrl ) {
-		page.redirect( addQueryArgs( urlQueryArgs, `${ pathname }/${ siteFromUrl }` ) );
 		return;
 	}
 

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -23,6 +23,11 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 		return;
 	}
 
+	if ( context.pathname.endsWith( '/pricing' ) && urlQueryArgs.site ) {
+		page.redirect( addQueryArgs( urlQueryArgs, `${ context.pathname }/${ urlQueryArgs.site }` ) );
+		return;
+	}
+
 	context.store.dispatch( hideMasterbar() );
 	context.header = <Header urlQueryArgs={ urlQueryArgs } />;
 	context.footer = <JetpackComFooter />;

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { jetpackPricingContext } from './controller';
-import config from '@automattic/calypso-config';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 
@@ -13,10 +12,5 @@ import './style.scss';
 
 export default function (): void {
 	jetpackPlans( `/:locale/pricing`, jetpackPricingContext );
-
 	jetpackPlans( `/pricing`, loggedInSiteSelection, jetpackPricingContext );
-
-	if ( config.isEnabled( 'jetpack-cloud/connect' ) ) {
-		jetpackPlans( `/plans/:site?`, loggedInSiteSelection, jetpackPricingContext );
-	}
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -208,7 +208,7 @@ export default function () {
 	);
 
 	// Visiting /checkout without a plan or product should be redirected to /plans
-	page( '/checkout', isEnabled( 'jetpack-cloud/connect' ) ? '/plans' : '/pricing' );
+	page( '/checkout', '/plans' );
 
 	page(
 		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',

--- a/client/my-sites/plans/jetpack-plans/build-checkout-url.ts
+++ b/client/my-sites/plans/jetpack-plans/build-checkout-url.ts
@@ -70,7 +70,7 @@ export default function buildCheckoutURL(
 		? `/checkout/${ siteSlug }/${ productsString }`
 		: `/jetpack/connect/${ productsString }`;
 
-	return isJetpackCloud() && ! config.isEnabled( 'jetpack-cloud/connect' )
+	return isJetpackCloud()
 		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` )
 		: addQueryArgs( urlQueryArgs, path );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -466,7 +466,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud-pricing',
-		paths: [ '/pricing', '/plans', '/[^\\/]+/pricing' ],
+		paths: [ '/pricing', '/[^\\/]+/pricing' ],
 		module: 'calypso/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -624,8 +624,6 @@ export default function pages() {
 					);
 				} else {
 					res.redirect( 'https://wordpress.com/pricing' );
-				} else {
-					next();
 				}
 			} else {
 				next();

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -622,7 +622,7 @@ export default function pages() {
 					res.redirect(
 						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
 					);
-				} else if ( ! config.isEnabled( 'jetpack-cloud/connect' ) ) {
+				} else {
 					res.redirect( 'https://wordpress.com/pricing' );
 				} else {
 					next();

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -37,7 +37,6 @@
 		"dev/preferences-helper": true,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": false,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/only-realtime-products": false,
@@ -66,13 +65,11 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
-		"checkout": true,
 		"jetpack-cloud-auth": true,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"jetpack-connect": true,
 		"jetpack-search": true,
 		"scan": true
 	},

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -32,7 +32,6 @@
 		"checkout/google-pay": true,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
@@ -57,13 +56,11 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
-		"checkout": true,
 		"jetpack-cloud-auth": false,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"jetpack-connect": true,
 		"jetpack-search": true,
 		"scan": true
 	},

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -35,7 +35,6 @@
 		"i18n/community-translator": false,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": false,
 		"jetpack/backups-date-picker": true,
 		"jetpack/only-realtime-products": false,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -34,7 +34,6 @@
 		"checkout/google-pay": false,
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud/connect": false,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/only-realtime-products": false,
@@ -63,13 +62,11 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
-		"checkout": true,
 		"jetpack-cloud-auth": true,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"jetpack-connect": true,
 		"jetpack-search": true,
 		"scan": true
 	},


### PR DESCRIPTION
This is a followup to #51658 that really and completely removes Jetpack Connect, Checkout and Plans sections from Jetpack Cloud. Discussed with @rcanepa in https://github.com/Automattic/wp-calypso/pull/51658#issuecomment-878964515

It removes the `jetpack-connect` and `checkout` items from the `sections` list in the config files. Without removing this, the `/checkout` and `/jetpack/connect` routes were still accessible in the staging and dev environments.

It also removes the `jetpack-cloud/connect` feature flag which was always false since #51658. This part of the PR is mostly a revert of #47770 by @monsieur-z.

There's also no `/plans` route in Jetpack Cloud, so I'm removing all references to it.

There are a few places that deserve some explanation, I'm commenting directly in the code.

**How to test:**
Verify that this is really what we want to do and that the patch does the job correctly.