### PR TITLE
Guard calls of potentially unsupported methods of window.performance

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -278,7 +278,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			// Notify external listeners that the iframe has loaded
 			this.props.setEditorIframeLoaded( true, this.iframePort );
 
-			window.performance?.mark( 'iframe_loaded' );
+			window.performance?.mark?.( 'iframe_loaded' );
 			this.setState( { isIframeLoaded: true, currentIFrameUrl: this.props.iframeUrl } );
 
 			return;

--- a/client/gutenberg/editor/iframe.tsx
+++ b/client/gutenberg/editor/iframe.tsx
@@ -10,7 +10,7 @@ type IframeProps = DetailedHTMLProps<
 
 const Iframe = forwardRef< HTMLIFrameElement, IframeProps >( function IFrame( props, ref ) {
 	useEffect( () => {
-		window.performance?.mark( 'iframe_rendered' );
+		window.performance?.mark?.( 'iframe_rendered' );
 	}, [ props.src ] );
 
 	// eslint-disable-next-line jsx-a11y/iframe-has-title

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -589,10 +589,10 @@ const _translationsBatch = [];
  * @param {Object} userTranslations User translations data that will override chunk translations
  */
 const _addTranslationsBatch = throttle( function ( userTranslations ) {
-	window.performance?.mark( 'add_translations_start' );
+	window.performance?.mark?.( 'add_translations_start' );
 	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
-	window.performance?.measure( 'add_translations', 'add_translations_start' );
-	window.performance?.clearMarks( 'add_translations_start' );
+	window.performance?.measure?.( 'add_translations', 'add_translations_start' );
+	window.performance?.clearMarks?.( 'add_translations_start' );
 }, 50 );
 
 /**

--- a/client/lib/performance-tracking/collectors/translations.js
+++ b/client/lib/performance-tracking/collectors/translations.js
@@ -1,10 +1,10 @@
 export const collectTranslationTimings = () => {
-	const measures = window.performance?.getEntriesByName( 'add_translations' ) || [];
+	const measures = window.performance?.getEntriesByName?.( 'add_translations' ) || [];
 	const count = measures.length;
 	const total = Math.round( measures.reduce( ( acc, measure ) => acc + measure.duration, 0 ) );
 	return { count, total };
 };
 
 export const clearTranslationTimings = () => {
-	window.performance?.clearMeasures( 'add_translations' );
+	window.performance?.clearMeasures?.( 'add_translations' );
 };


### PR DESCRIPTION
I've seen a JS error reported in Kibana, saying that `window.performance.mark` is not a function in Safari 10.1. And indeed, most `Performance` methods (basically anything but `.now()`) are [supported only since Safari 11](https://developer.mozilla.org/en-US/docs/Web/API/Performance#browser_compatibility).

Adding some `?.` operators to fix that.
