### PR TITLE
chore: migrate packages/babel-plugin-i18n-calypso to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
 				'client/support/**/*',
 				'client/types.ts',
 				'packages/accessible-focus/**/*',
+				'packages/babel-plugin-i18n-calypso/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-products/**/*',
 				'packages/components/**/*',

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -32,13 +32,10 @@
  *
  */
 
-/**
- * External dependencies
- */
+const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
+const { relative, sep } = require( 'path' );
 const { po } = require( 'gettext-parser' );
 const { merge, isEmpty, forEach } = require( 'lodash' );
-const { relative, sep } = require( 'path' );
-const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
 
 /**
  * Default output headers if none specified in plugin options.

--- a/packages/babel-plugin-i18n-calypso/tsconfig.json
+++ b/packages/babel-plugin-i18n-calypso/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/babel-plugin-i18n-calypso` to use `import/order`

#### Testing instructions

N/A