### PR TITLE
chore: migrate packages/calypso-config to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -190,6 +190,7 @@ module.exports = {
 				'desktop/webpack.config.js',
 				'packages/accessible-focus/**/*',
 				'packages/babel-plugin-i18n-calypso/**/*',
+				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-products/**/*',
 				'packages/components/**/*',

--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-import cookie from 'cookie';
-
-/**
- * Internal dependencies
- */
-
 import createConfig from '@automattic/create-calypso-config';
-import type { ConfigData } from '@automattic/create-calypso-config';
+import cookie from 'cookie';
 import desktopOverride from './desktop';
+import type { ConfigData } from '@automattic/create-calypso-config';
 
 declare global {
 	interface Window {

--- a/packages/calypso-config/tsconfig.json
+++ b/packages/calypso-config/tsconfig.json
@@ -4,7 +4,7 @@
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",
 		"rootDir": "src",
-		"types": ["node"]
+		"types": [ "node" ]
 	},
 	"include": [ "src" ],
 	"references": [ { "path": "../create-calypso-config" } ]


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-config` to use `import/order`

#### Testing instructions

N/A
