### PR TITLE
Iframe Bridge: fix crash when MediaUpload doesn't have onClose or onSelect prop

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1198,7 +1198,7 @@ function initPort( message ) {
 			);
 
 			mediaSelectChannel.port1.onmessage = ( { data } ) => {
-				this.props.onSelect( data );
+				this.props.onSelect?.( data );
 
 				// this is a once-only port
 				// to send more messages we have to re-open the
@@ -1207,7 +1207,7 @@ function initPort( message ) {
 			};
 
 			mediaCancelChannel.port1.onmessage = () => {
-				this.props.onClose();
+				this.props.onClose?.();
 
 				// this is a once-only port
 				// to send more messages we have to re-open the


### PR DESCRIPTION
Fixes a crash often reported as client JS error in Kibana:

<img width="736" alt="Screenshot 2021-07-15 at 11 32 21" src="https://user-images.githubusercontent.com/664258/125766005-2a9ff99d-bbfd-48d6-af9a-d3b3524fee05.png">

Steps to reproduce:
- start editing a post in Calypso Gutenframe
- insert an Image block
- click on "Select Image". It opens a Calypso Media modal
- click "Cancel" in the modal to close it without selecting anything
- there is a JS exception reported in console

It's because Gutenberg renders the `<MediaUpload />` component without the `onClose` prop. Most of the time it only has `onSelect` and `render`.

I patched this by adding an `?.` operator to the `onClose` call. And added it to the `onSelect` call, too, because the `onSelect` prop is not exactly guaranteed either.