### PR TITLE
chore: migrate packages/calypso-stripe to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -193,6 +193,7 @@ module.exports = {
 				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-products/**/*',
+				'packages/calypso-stripe/**/*',
 				'packages/components/**/*',
 				'packages/composite-checkout/**/*',
 				'packages/data-stores/**/*',

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import { loadScript } from '@automattic/load-script';
 import debugFactory from 'debug';
 import React, { useRef, useEffect, useCallback, useState, useContext, createContext } from 'react';
-import { loadScript } from '@automattic/load-script';
 // We are several versions old for react-stripe-elements, and probably should
 // actually upgrade to the new Stripe.js anyway. Trying to use the actual types
 // for this package causes all sorts of errors because, I think, they assume


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-stripe` to use `import/order`

#### Testing instructions

N/A
