### PR TITLE
chore: migrate packages/create-calypso-config to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,6 +194,7 @@ module.exports = {
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-products/**/*',
 				'packages/calypso-stripe/**/*',
+				'packages/create-calypso-config/**/*',
 				'packages/components/**/*',
 				'packages/composite-checkout/**/*',
 				'packages/data-stores/**/*',

--- a/packages/create-calypso-config/src/test/index.js
+++ b/packages/create-calypso-config/src/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import createConfig from '../';
 
 describe( 'index', () => {

--- a/packages/create-calypso-config/tsconfig.json
+++ b/packages/create-calypso-config/tsconfig.json
@@ -4,7 +4,7 @@
 		"outDir": "dist/esm",
 		"declarationDir": "dist/types",
 		"rootDir": "src",
-		"types": ["node"]
+		"types": [ "node" ]
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ]


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/create-calypso-config` to use `import/order`

#### Testing instructions

N/A
