### PR TITLE
chore: migrate packages/js-utils to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,6 +197,7 @@ module.exports = {
 				'packages/components/**/*',
 				'packages/composite-checkout/**/*',
 				'packages/data-stores/**/*',
+				'packages/js-utils/**/*',
 				'packages/launch/**/*',
 				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',

--- a/packages/js-utils/src/test/unique-by.js
+++ b/packages/js-utils/src/test/unique-by.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import uniqueBy from '../unique-by';
 
 describe( 'uniqueBy()', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/js-utils` to use `import/order`

#### Testing instructions

N/A