### PR TITLE
Converts domain names to logmein links

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -54,17 +54,20 @@ class RegistrantVerificationPage extends Component {
 	getVerificationSuccessState = ( domains ) => {
 		const { translate } = this.props;
 
-		const verifiedDomains = domains.join( ', ' );
+		const DomainLinks = domains.map( ( domain, index ) => [
+			index > 0 && ', ',
+			<a key={ domain } href={ `https://${ domain }?logmein=1` }>
+				{ domain }
+			</a>,
+		] );
 
 		return {
 			title: translate( 'Success!' ),
 			message: translate(
-				'Thank your for verifying your contact information for:{{br /}}{{strong}}%(domain)s{{/strong}}.',
+				'Thank your for verifying your contact information for:{{br /}}{{strong}}{{domainLinks /}}{{/strong}}.',
 				{
-					args: {
-						domain: verifiedDomains,
-					},
 					components: {
+						domainLinks: DomainLinks,
 						strong: <strong />,
 						br: <br />,
 					},
@@ -130,7 +133,7 @@ class RegistrantVerificationPage extends Component {
 			return {
 				title: translate( 'Already verified.' ),
 				message: translate(
-					"You've already verified {{strong}}%(email)s{{/strong}} for:{{br /}}{{strong}}%(domain)s{{/strong}}.",
+					"You've already verified {{strong}}%(email)s{{/strong}} for:{{br /}}{{strong}}{{a}}%(domain)s{{/a}}{{/strong}}.",
 					{
 						args: {
 							email: email,
@@ -139,6 +142,7 @@ class RegistrantVerificationPage extends Component {
 						components: {
 							strong: <strong />,
 							br: <br />,
+							a: <a href={ `https://${ domain }?logmein=1` } />,
 						},
 					}
 				),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change converts domains to logmein links on domain contact verification page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update the WHOIS details on an ICANN-regulated TLD (gTLDs like com, blog, etc.) and set new first, last or email fields. This should trigger the verification email.
* The link in the email goes through public-api first so you might need to edit it to get to the real link, you can also use this JS snippet:
```js
(new URL(<URL in email>)).searchParams.get('redirect_to').replace('https://wordpress.com','http://calypso.localhost:3000')
```
* You should see that the domains have been converted to logmein links (with `?logmein=1` appended)
![image](https://user-images.githubusercontent.com/5436027/125780528-22c0bc6a-1676-4f3f-9da1-59d04985449e.png)
* Reload the page, this will show the "already verified" screen which also contains the logmein link for the domain.

![image](https://user-images.githubusercontent.com/5436027/125779757-32b6532b-4a32-4b37-9c64-f621a4959829.png)




<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes #54548
