### PR TITLE
chore: migrate packages/mocha-debug-reporter to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,6 +198,7 @@ module.exports = {
 				'packages/composite-checkout/**/*',
 				'packages/data-stores/**/*',
 				'packages/launch/**/*',
+				'packages/mocha-debug-reporter/**/*',
 				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',
 			],

--- a/packages/mocha-debug-reporter/src/index.ts
+++ b/packages/mocha-debug-reporter/src/index.ts
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-import Mocha from 'mocha';
 import fs from 'fs';
 import path from 'path';
-
+import Mocha from 'mocha';
 import type { Runner, MochaOptions, Suite, Hook, Test } from 'mocha';
 
 const {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/mocha-debug-reporter` to use `import/order`

#### Testing instructions

N/A