### PR TITLE
CODEOWNERS: Add some dirs for Calypso Framework squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,6 +94,10 @@
 /packages/explat-* @Automattic/experimentation-platform
 
 # Framework
+/client/boot @Automattic/team-calypso-frameworks
+/client/controller @Automattic/team-calypso-frameworks
+/client/layout @Automattic/team-calypso-frameworks
+/client/server @Automattic/team-calypso-frameworks
 /packages/js-utils @Automattic/team-calypso-frameworks
 
 # Jetpack Search


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds @Automattic/team-calypso-frameworks as codeowner of some critical Calypso directories.

#### Testing instructions

Testing is not needed.