### PR TITLE
Jetpack: update styles on site-less checkout thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -177,7 +177,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 						<h2>{ translate( 'Do you need help?' ) }</h2>
 						<p>
 							{ translate(
-								'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 min call now{{/a}}.',
+								'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 minute call now{{/a}}.',
 								{
 									components: {
 										a: (

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -81,7 +81,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 			/>
 			<Card className="jetpack-checkout-siteless-thank-you__card">
 				<div className="jetpack-checkout-siteless-thank-you__card-main">
-					<JetpackLogo full size={ 45 } />
+					<JetpackLogo size={ 45 } />
 					{ hasProductInfo && <QueryProducts type="jetpack" /> }
 					<h1 className="jetpack-checkout-siteless-thank-you__main-message">
 						{ translate( 'Thank you for your purchase!' ) }{ ' ' }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -680,7 +680,7 @@
 		display: flex;
 		flex-direction: column;
 		padding: 0;
-		border-radius: calc( 2px * 2 );
+		border-radius: 4px; /* stylelint-disable-line */
 		overflow: hidden;
 		box-shadow: 0 0 40px 0 #00000014;
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -748,7 +748,7 @@
 
 			.jetpack-checkout-siteless-thank-you__step-number {
 				color: white;
-				background-color: var( --studio-jetpack-green-50 );
+				background-color: var( --studio-jetpack-green-40 );
 				text-align: center;
 				border-radius: 50%; /* stylelint-disable-line */
 				font-size: $font-title-small;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -680,6 +680,8 @@
 		display: flex;
 		flex-direction: column;
 		padding: 0;
+		border-radius: calc( 2px * 2 );
+		overflow: hidden;
 		box-shadow: 0 0 40px 0 #00000014;
 
 		width: 100%;
@@ -696,16 +698,21 @@
 		}
 
 		h1 {
-			font-size: 3rem;
-			line-height: 3.25rem;
-			padding-bottom: 24px;
+			line-height: 1;
+			@include break-mobile {
+				font-size: $font-headline-medium;
+			}
 			+ p {
-				font-size: 1.5rem;
-				line-height: 2rem;
+				font-size: 18px; /* stylelint-disable-line */
+				line-height: 1.5rem;
+				@include break-mobile {
+					font-size: $font-title-medium;
+					line-height: 2rem;
+				}
 			}
 		}
 		h2 {
-			font-size: 1.5rem;
+			font-size: $font-title-medium;
 			font-weight: 700;
 			line-height: 1.75rem;
 			padding-bottom: 16px;
@@ -721,9 +728,9 @@
 
 		> div {
 			box-sizing: border-box;
-			padding: 15px 26px 26px;
+			padding: 26px;
 			@include break-mobile {
-				padding: 30px 76px 55px;
+				padding: 76px;
 			}
 		}
 		.jetpack-checkout-siteless-thank-you__card-main {
@@ -733,18 +740,32 @@
 		.jetpack-checkout-siteless-thank-you__step {
 			display: flex;
 			align-items: flex-start;
+			padding-bottom: 40px;
+
+			&:last-of-type {
+				padding-bottom: 0;
+			}
+
 			.jetpack-checkout-siteless-thank-you__step-number {
 				color: white;
 				background-color: var( --studio-jetpack-green-50 );
 				text-align: center;
-				border-radius: 50%;
-				font-size: 1.25rem;
-				width: 1.8rem;
-				height: 1.8rem;
+				border-radius: 50%; /* stylelint-disable-line */
+				font-size: $font-title-small;
+				font-weight: 600;
+				width: rem( 32px );
+				height: rem( 32px );
 			}
 			.jetpack-checkout-siteless-thank-you__step-content {
 				flex: 1;
 				padding: 0 10px 0 16px;
+				p {
+					@include break-mobile {
+						font-size: 18px; /* stylelint-disable-line */
+						line-height: 1.75rem;
+					}
+					margin: 0;
+				}
 			}
 		}
 
@@ -792,7 +813,7 @@
 			display: flex;
 			align-items: flex-end;
 
-			background-color: var( --color-neutral-5 );
+			background-color: #f9f9f6;
 			> div {
 				max-width: 456px;
 			}
@@ -814,7 +835,11 @@
 		}
 
 		.jetpack-checkout-siteless-thank-you__product-info-loading {
-			@include placeholder( --color-neutral-30 );
+			@include placeholder( --color-neutral-20 );
+		}
+
+		.jetpack-checkout-siteless-thank-you__form-label {
+			margin-top: 24px;
 		}
 	}
 }
@@ -834,22 +859,20 @@
 			padding: 96px;
 		}
 
-		// TODO min width
-		// TODO primary button color
 		.jetpack-checkout-thank-you__main-message {
-			font-size: 36px;
+			font-size: $font-headline-small;
 			font-weight: 700;
 			margin-bottom: 24px;
 
 			@include break-mobile {
-				font-size: 48px;
+				font-size: $font-headline-medium;
 			}
 		}
 
 		.jetpack-checkout-thank-you__sub-message-loading,
 		.jetpack-checkout-thank-you__sub-message {
-			font-size: 24px;
-			font-weight: 500;
+			font-size: $font-title-medium;
+			font-weight: 500; /* stylelint-disable-line */
 			margin-bottom: 64px;
 		}
 
@@ -861,7 +884,7 @@
 
 		.jetpack-checkout-thank-you__button,
 		.jetpack-checkout-thank-you__button:visited {
-			border-radius: 4px;
+			border-radius: calc( 2px * 2 );
 			// button colors imported from packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
 			background-color: var( --studio-jetpack-green-50 );
 			border-color: var( --studio-jetpack-green-50 );
@@ -886,6 +909,6 @@
 
 	.jetpack-checkout-thank-you__sub-message-loading,
 	.jetpack-checkout-thank-you__email-message-loading {
-		@include placeholder( --color-neutral-30 );
+		@include placeholder( --color-neutral-20 );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update styles to match the work done in https://github.com/Automattic/wp-calypso/pull/54532/ — we should merge that one first because it changes the Jetpack logo color.
* Uses only the Jetpack mark, not the full logo.
* Changes “min” to “minute” as per p1HpG7-cri-p2#comment-47829

Related to #54253

#### Testing instructions

1. Patch your WPCOM sandbox with D63168-code. (we need this to be able to complete the _site-less_ checkout)
1. Add `define( 'USE_STORE_SANDBOX', true );` to `wp-content/mu-plugins/0-sandbox.php`
1. Sandbox `public-api.wordpress.com`.
1. Download this PR.
1. Edit the `config/development.json` file and enable the `jetpack/siteless-checkout` feature flag.
1. Start Calypso with `yarn start`. You need to do this since this PR introduces a new feature flag.
1. Visit http://calypso.localhost:3000/checkout/jetpack/jetpack_scan
1. Verify the Thank You page looks like the screenshots below.


#### Screenshots

Desktop | Mobile
--|--
![image](https://user-images.githubusercontent.com/390760/125788159-8825403e-fe2b-45d6-b94c-23538259de13.png) | ![image](https://user-images.githubusercontent.com/390760/125788148-a6f12022-37dc-4dc9-ab99-6c41a468f6d7.png)
