### PR TITLE
chore: migrate packages/spec-xunit-reporter to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,6 +202,7 @@ module.exports = {
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
 				'packages/spec-junit-reporter/**/*',
+				'packages/spec-xunit-reporter/**/*',
 				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',
 			],

--- a/packages/spec-xunit-reporter/lib/spec-xunit-reporter.js
+++ b/packages/spec-xunit-reporter/lib/spec-xunit-reporter.js
@@ -1,9 +1,5 @@
 // This code combines the Mocha spec and xunit outputs with a dynamically allocated directory for xunit output
 
-/**
- * Module dependencies.
- */
-
 const mocha = require( 'mocha' );
 const Spec = mocha.reporters.Spec;
 const XUnit = mocha.reporters.XUnit;

--- a/packages/spec-xunit-reporter/tsconfig.json
+++ b/packages/spec-xunit-reporter/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/spec-xunit-reporter` to use `import/order`

#### Testing instructions

N/A
