### PR TITLE
chore: migrate packages/tree-select to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -208,6 +208,7 @@ module.exports = {
 				'packages/shopping-cart/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
+				'packages/tree-select/**/*',
 				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',
 			],

--- a/packages/tree-select/test/index.js
+++ b/packages/tree-select/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import treeSelect from '../src';
 
 describe( 'index', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/tree-select` to use `import/order`

#### Testing instructions

N/A