### PR TITLE
chore: migrate packages/viewport to import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,6 +209,7 @@ module.exports = {
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
 				'packages/tree-select/**/*',
+				'packages/viewport/**/*',
 				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',
 			],

--- a/packages/viewport/test/index.js
+++ b/packages/viewport/test/index.js
@@ -1,9 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
+
 import 'regenerator-runtime';
 
 let viewport;

--- a/packages/viewport/tsconfig.json
+++ b/packages/viewport/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/viewport` to use `import/order`

#### Testing instructions

N/A
