### PR TITLE
Theme Showcase: Update WordPress.com Experts nudge, take 3

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -87,7 +87,7 @@ class UpworkBanner extends PureComponent {
 				<UpsellNudge
 					event={ 'calypso_upwork_banner_start_now_button_click' }
 					forceDisplay //Upwork banner has its own logic for showing/hiding
-					className="upwork-banner-troubleshooting"
+					className="upwork-banner__troubleshooting"
 					showIcon
 					callToAction={ translate( 'Find your expert' ) }
 					dismissPreferenceName={ 'upwork-dismissible-banner' }
@@ -96,7 +96,7 @@ class UpworkBanner extends PureComponent {
 					tracksImpressionName={ 'calypso_upwork_banner_view' }
 					tracksDismissName={ 'calypso_upwork_banner_dismiss_icon_click' }
 					tracksDismissProperties={ { location: location, plan } }
-					href="https://wordpress.com/built-by-wordpress-com/"
+					href="/built-by-wordpress-com/"
 					title={ translate( 'Let our WordPress.com experts build your site!' ) }
 					description={ translate(
 						'You want the website of your dreams. Our experts can create it for you.'

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -10,6 +10,7 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { dismissBanner } from './actions';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -18,6 +19,7 @@ import isUpworkBannerDismissed from 'calypso/state/selectors/is-upwork-banner-di
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ExternalLink from 'calypso/components/external-link';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 /**
  * Style dependencies
@@ -74,9 +76,33 @@ class UpworkBanner extends PureComponent {
 	}
 
 	render() {
-		const { isBannerVisible, translate } = this.props;
+		const { isBannerVisible, translate, location, currentPlan } = this.props;
+		const plan = currentPlan?.productSlug;
+
 		if ( ! isBannerVisible ) {
 			return null;
+		}
+		if ( config.isEnabled( 'upsell/troubleshooting' ) ) {
+			return (
+				<UpsellNudge
+					event={ 'calypso_upwork_banner_start_now_button_click' }
+					forceDisplay //Upwork banner has its own logic for showing/hiding
+					className="upwork-banner"
+					showIcon
+					callToAction={ translate( 'Find your expert' ) }
+					dismissPreferenceName={ 'upwork-dismissible-banner' }
+					tracksClickName={ 'calypso_upwork_banner_start_now_button_click' }
+					tracksClickProperties={ { location, plan } }
+					tracksImpressionName={ 'calypso_upwork_banner_view' }
+					tracksDismissName={ 'calypso_upwork_banner_dismiss_icon_click' }
+					tracksDismissProperties={ { location: location, plan } }
+					href="https://wordpress.com/built-by-wordpress-com/"
+					title={ translate( 'Let our WordPress.com experts build your site!' ) }
+					description={ translate(
+						'You want the website of your dreams. Our experts can create it for you.'
+					) }
+				/>
+			);
 		}
 		return (
 			<ExternalLink

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -89,6 +89,7 @@ class UpworkBanner extends PureComponent {
 					forceDisplay //Upwork banner has its own logic for showing/hiding
 					className="upwork-banner__troubleshooting"
 					showIcon
+					onClick={ () => window.open( 'https://wordpress.com/built-by-wordpress-com/', '_blank' ) }
 					callToAction={ translate( 'Find your expert' ) }
 					dismissPreferenceName={ 'upwork-dismissible-banner' }
 					tracksClickName={ 'calypso_upwork_banner_start_now_button_click' }
@@ -96,7 +97,7 @@ class UpworkBanner extends PureComponent {
 					tracksImpressionName={ 'calypso_upwork_banner_view' }
 					tracksDismissName={ 'calypso_upwork_banner_dismiss_icon_click' }
 					tracksDismissProperties={ { location: location, plan } }
-					href="/built-by-wordpress-com/"
+					href="#"
 					title={ translate( 'Let our WordPress.com experts build your site!' ) }
 					description={ translate(
 						'You want the website of your dreams. Our experts can create it for you.'

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -87,7 +87,7 @@ class UpworkBanner extends PureComponent {
 				<UpsellNudge
 					event={ 'calypso_upwork_banner_start_now_button_click' }
 					forceDisplay //Upwork banner has its own logic for showing/hiding
-					className="upwork-banner"
+					className="upwork-banner-troubleshooting"
 					showIcon
 					callToAction={ translate( 'Find your expert' ) }
 					dismissPreferenceName={ 'upwork-dismissible-banner' }

--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -73,3 +73,16 @@
 		}
 	}
 }
+
+@include breakpoint-deprecated( '>480px' ) {
+	.upwork-banner.is-dismissible .banner__action {
+		margin-top: 0;
+		margin-right: 28px;
+	}
+	.upwork-banner .dismissible-card__close-icon {
+		width: 16px;
+		height: 16px;
+		top: 50%;
+		transform: translateY( -50% );
+	}
+}

--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -75,11 +75,11 @@
 }
 
 @include breakpoint-deprecated( '>480px' ) {
-	.upwork-banner-troubleshooting.is-dismissible .banner__action {
+	.upwork-banner__troubleshooting.is-dismissible .banner__action {
 		margin-top: 0;
 		margin-right: 28px;
 	}
-	.upwork-banner-troubleshooting .dismissible-card__close-icon {
+	.upwork-banner__troubleshooting .dismissible-card__close-icon {
 		width: 16px;
 		height: 16px;
 		top: 50%;

--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -75,11 +75,11 @@
 }
 
 @include breakpoint-deprecated( '>480px' ) {
-	.upwork-banner.is-dismissible .banner__action {
+	.upwork-banner-troubleshooting.is-dismissible .banner__action {
 		margin-top: 0;
 		margin-right: 28px;
 	}
-	.upwork-banner .dismissible-card__close-icon {
+	.upwork-banner-troubleshooting .dismissible-card__close-icon {
 		width: 16px;
 		height: 16px;
 		top: 50%;

--- a/config/development.json
+++ b/config/development.json
@@ -167,6 +167,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": true,
+		"upsell/troubleshooting": true,
 		"woocommerce/extension-referrers": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false,

--- a/config/production.json
+++ b/config/production.json
@@ -123,6 +123,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": false,
+		"upsell/troubleshooting": false,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -126,6 +126,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": false,
+		"upsell/troubleshooting": false,
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
 		"woocommerce/store-on-non-atomic-sites": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -134,6 +134,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-component": true,
+		"upsell/troubleshooting": false,
 		"woocommerce/extension-referrers": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce the newer upsell nudge behind a feature flag so we can test it on production and figure out why it's not forwarding properly.
* Following up on #54140 and #54522, third time's a charm? :)

**Without flag**

<img width="1367" alt="Screen Shot 2021-07-13 at 1 32 53 PM" src="https://user-images.githubusercontent.com/2124984/125498902-673cf024-460b-4097-a4b0-f5bf590c679b.png">

**With flag**

Simple/Atomic

<img width="1363" alt="Screen Shot 2021-07-13 at 1 32 17 PM" src="https://user-images.githubusercontent.com/2124984/125498961-368aafa9-3de4-41ae-969e-be4ba89fda03.png">

Jetpack

<img width="1370" alt="Screen Shot 2021-07-13 at 1 32 36 PM" src="https://user-images.githubusercontent.com/2124984/125498965-248463b1-86a1-40c3-a54b-70ab8fca6059.png">


#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]?flags=upsell/troubleshooting`
* Make sure clicking on the banner/button takes you to the "Built by WordPress.com" site: https://wordpress.com/built-by-wordpress-com/
* Make sure Tracks events fire as expected (impression, click, dismiss)

Related to #54087