### PR TITLE
Move `selectSiteIfLoggedIn` to my-sites controller

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -100,4 +100,3 @@ export const redirectWithoutLocaleParamIfLoggedIn = () => {};
 export const render = () => {};
 export const ProviderWrappedLayout = () => null;
 export const notFound = () => null;
-export const selectSiteIfLoggedIn = () => null;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -27,8 +27,6 @@ import {
 } from 'calypso/state/immediate-login/selectors';
 import { getSiteFragment } from 'calypso/lib/route';
 import { render, hydrate } from './web-util.js';
-import { composeHandlers } from 'calypso/controller/shared';
-import { sites, siteSelection } from 'calypso/my-sites/controller';
 
 /**
  * Re-export
@@ -174,16 +172,3 @@ export const notFound = ( context, next ) => {
 
 	next();
 };
-
-export function selectSiteIfLoggedIn( context, next ) {
-	const state = context.store.getState();
-	if ( ! isUserLoggedIn( state ) ) {
-		next();
-		return;
-	}
-
-	// Logged in: Terminate the regular handler path by not calling next()
-	// and render the site selection screen, redirecting the user if they
-	// only have one site.
-	composeHandlers( siteSelection, sites, makeLayout, render )( context );
-}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -10,6 +10,8 @@ import { removeQueryArgs } from '@wordpress/url';
 /**
  * Internal Dependencies
  */
+import { composeHandlers } from 'calypso/controller/shared';
+import { render } from 'calypso/controller/web-util';
 import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -675,4 +677,17 @@ export function getJetpackAuthorizeURL( context, site ) {
 		},
 		trailingslashit( site?.URL ) + 'wp-admin/'
 	);
+}
+
+export function selectSiteIfLoggedIn( context, next ) {
+	const state = context.store.getState();
+	if ( ! isUserLoggedIn( state ) ) {
+		next();
+		return;
+	}
+
+	// Logged in: Terminate the regular handler path by not calling next()
+	// and render the site selection screen, redirecting the user if they
+	// only have one site.
+	composeHandlers( siteSelection, sites, makeLayout, render )( context );
 }

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -5,10 +5,9 @@ import {
 	makeLayout,
 	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
-	selectSiteIfLoggedIn,
 } from 'calypso/controller';
 import { details, fetchThemeDetailsData } from './controller';
-import { createNavigation, siteSelection } from 'calypso/my-sites/controller';
+import { createNavigation, selectSiteIfLoggedIn, siteSelection } from 'calypso/my-sites/controller';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import { translate } from 'i18n-calypso';

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -6,9 +6,13 @@ import {
 	makeLayout,
 	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
-	selectSiteIfLoggedIn,
 } from 'calypso/controller';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	selectSiteIfLoggedIn,
+	siteSelection,
+	sites,
+} from 'calypso/my-sites/controller';
 import { loggedOut } from './controller';
 import { loggedIn, upload } from './controller-logged-in';
 import { fetchAndValidateVerticalsAndFilters } from './validate-filters';


### PR DESCRIPTION
This method deals exclusively with `my-sites` concerns, so it shouldn't exist on the root controller.

The issue was introduced in #54244 and caused a regression in bundle size, by pulling `my-sites` into the main entry point bundle.

This PR should separate the concerns, allowing for `my-sites` state to no longer be necessary for the entry point, while still being available to both `/theme` and `/themes`.

#### Changes proposed in this Pull Request

* Move `selectSiteIfLoggedIn` to my-sites controller

#### Testing instructions

Please follow the testing instructions on #54244.
