### PR TITLE
Add new card when you haven't used your free domain credit

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,9 +15,18 @@ import { domainAddNew, domainUseYourDomain } from 'calypso/my-sites/domains/path
 import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
 import { isFreePlan } from '@automattic/calypso-products';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-function EmptyDomainsListNudge( { selectedSite, hasDomainCredit } ) {
+function EmptyDomainsListCard( { selectedSite, hasDomainCredit, dispatchRecordTracksEvent } ) {
 	const translate = useTranslate();
+
+	const getActionClickHandler = ( type, buttonURL, sourceCardType ) => () => {
+		dispatchRecordTracksEvent( 'calypso_empty_domain_list_card_action', {
+			button_type: type,
+			button_url: buttonURL,
+			source_card_type: sourceCardType,
+		} );
+	};
 
 	const siteHasPaidPlan =
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
@@ -42,7 +52,7 @@ function EmptyDomainsListNudge( { selectedSite, hasDomainCredit } ) {
 		actionURL = domainAddNew( selectedSite.slug );
 		secondaryAction = translate( 'I have a domain' );
 		secondaryActionURL = domainUseYourDomain( selectedSite.slug );
-		contentType = 'domain_credit';
+		contentType = 'free_domain_credit';
 	}
 
 	return (
@@ -54,8 +64,14 @@ function EmptyDomainsListNudge( { selectedSite, hasDomainCredit } ) {
 				illustrationWidth={ 150 }
 				action={ action }
 				actionURL={ actionURL }
+				actionCallback={ getActionClickHandler( 'primary', actionURL, contentType ) }
 				secondaryAction={ secondaryAction }
 				secondaryActionURL={ secondaryActionURL }
+				secondartActionCallback={ getActionClickHandler(
+					'secondary',
+					secondaryActionURL,
+					contentType
+				) }
 			/>
 			<TrackComponentView
 				eventName="calypso_get_your_domain_empty_impression"
@@ -65,10 +81,13 @@ function EmptyDomainsListNudge( { selectedSite, hasDomainCredit } ) {
 	);
 }
 
-EmptyDomainsListNudge.propTypes = {
+EmptyDomainsListCard.propTypes = {
 	selectedSite: PropTypes.object,
 	hasDomainCredit: PropTypes.bool,
 	domains: PropTypes.array,
+	dispatchRecordTracksEvent: PropTypes.func,
 };
 
-export default EmptyDomainsListNudge;
+export default connect( null, { dispatchRecordTracksEvent: recordTracksEvent } )(
+	EmptyDomainsListCard
+);

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -5,19 +5,26 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
-import EmptyContent from 'calypso/components/empty-content';
+import { Card, Button } from '@automattic/components';
 import { domainAddNew, domainUseYourDomain } from 'calypso/my-sites/domains/paths';
 import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
 import { isFreePlan } from '@automattic/calypso-products';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-function EmptyDomainsListCard( { selectedSite, hasDomainCredit, dispatchRecordTracksEvent } ) {
+import './style.scss';
+
+function EmptyDomainsListCard( {
+	selectedSite,
+	hasDomainCredit,
+	isCompact,
+	dispatchRecordTracksEvent,
+} ) {
 	const translate = useTranslate();
 
 	const getActionClickHandler = ( type, buttonURL, sourceCardType ) => () => {
@@ -55,24 +62,41 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, dispatchRecordTr
 		contentType = 'free_domain_credit';
 	}
 
+	const illustration = customerHomeIllustrationTaskFindDomain && (
+		<img src={ customerHomeIllustrationTaskFindDomain } alt="" width={ 150 } />
+	);
+
 	return (
 		<Card>
-			<EmptyContent
-				title={ title }
-				line={ line }
-				illustration={ customerHomeIllustrationTaskFindDomain }
-				illustrationWidth={ 150 }
-				action={ action }
-				actionURL={ actionURL }
-				actionCallback={ getActionClickHandler( 'primary', actionURL, contentType ) }
-				secondaryAction={ secondaryAction }
-				secondaryActionURL={ secondaryActionURL }
-				secondartActionCallback={ getActionClickHandler(
-					'secondary',
-					secondaryActionURL,
-					contentType
-				) }
-			/>
+			<div
+				className={ classNames( 'empty-domains-list-card', {
+					'is-compact': isCompact,
+					'has-title-only': title && ! line,
+				} ) }
+			>
+				<div className="empty-domains-list-card__illustration">{ illustration }</div>
+				<div className="empty-domains-list-card__content">
+					<div className="empty-domains-list-card__text">
+						{ title ? <h2>{ title }</h2> : null }
+						{ line ? <h3>{ line }</h3> : null }
+					</div>
+					<div className="empty-domains-list-card__actions">
+						<Button
+							primary
+							onClick={ getActionClickHandler( 'primary', actionURL, contentType ) }
+							href={ actionURL }
+						>
+							{ action }
+						</Button>
+						<Button
+							onClick={ getActionClickHandler( 'secondary', secondaryActionURL, contentType ) }
+							href={ secondaryActionURL }
+						>
+							{ secondaryAction }
+						</Button>
+					</div>
+				</div>
+			</div>
 			<TrackComponentView
 				eventName="calypso_get_your_domain_empty_impression"
 				eventProperties={ { content_type: contentType } }
@@ -84,6 +108,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, dispatchRecordTr
 EmptyDomainsListCard.propTypes = {
 	selectedSite: PropTypes.object,
 	hasDomainCredit: PropTypes.bool,
+	isCompact: PropTypes.bool,
 	domains: PropTypes.array,
 	dispatchRecordTracksEvent: PropTypes.func,
 };

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-nudge.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-nudge.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import EmptyContent from 'calypso/components/empty-content';
+import { domainAddNew, domainUseYourDomain } from 'calypso/my-sites/domains/paths';
+import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
+import { isFreePlan } from '@automattic/calypso-products';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+
+function EmptyDomainsListNudge( { selectedSite, hasDomainCredit } ) {
+	const translate = useTranslate();
+
+	const siteHasPaidPlan =
+		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
+
+	if ( siteHasPaidPlan && ! hasDomainCredit ) {
+		return null;
+	}
+
+	let title = translate( 'Get your domain' );
+	let line = translate( 'Get a free one-year domain registration or transfer with any paid plan.' );
+	let action = translate( 'Upgrade to a plan' );
+	let actionURL = `/plans/${ selectedSite.slug }`;
+	let secondaryAction = translate( 'Just search for a domain' );
+	let secondaryActionURL = domainAddNew( selectedSite.slug );
+	let contentType = 'no_plan';
+
+	if ( siteHasPaidPlan && hasDomainCredit ) {
+		title = translate( 'Claim your free domain' );
+		line = translate(
+			'You have a free one-year domain registration or transfer included with your plan.'
+		);
+		action = translate( 'Search for a domain' );
+		actionURL = domainAddNew( selectedSite.slug );
+		secondaryAction = translate( 'I have a domain' );
+		secondaryActionURL = domainUseYourDomain( selectedSite.slug );
+		contentType = 'domain_credit';
+	}
+
+	return (
+		<Card>
+			<EmptyContent
+				title={ title }
+				line={ line }
+				illustration={ customerHomeIllustrationTaskFindDomain }
+				illustrationWidth={ 150 }
+				action={ action }
+				actionURL={ actionURL }
+				secondaryAction={ secondaryAction }
+				secondaryActionURL={ secondaryActionURL }
+			/>
+			<TrackComponentView
+				eventName="calypso_get_your_domain_empty_impression"
+				eventProperties={ { content_type: contentType } }
+			/>
+		</Card>
+	);
+}
+
+EmptyDomainsListNudge.propTypes = {
+	selectedSite: PropTypes.object,
+	hasDomainCredit: PropTypes.bool,
+	domains: PropTypes.array,
+};
+
+export default EmptyDomainsListNudge;

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -52,7 +52,7 @@ import InfoPopover from 'calypso/components/info-popover';
 import ExternalLink from 'calypso/components/external-link';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import AddDomainButton from 'calypso/my-sites/domains/domain-management/list/add-domain-button';
-import EmptyDomainsListNudge from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-nudge';
+import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-card';
 
 /**
  * Style dependencies
@@ -138,7 +138,7 @@ export class List extends React.Component {
 				<div className="domain-management-list__primary-domain">{ this.renderPrimaryDomain() }</div>
 
 				{ ! this.isLoading() && (
-					<EmptyDomainsListNudge
+					<EmptyDomainsListCard
 						selectedSite={ selectedSite }
 						hasDomainCredit={ this.props.hasDomainCredit }
 					/>

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -23,11 +23,8 @@ import { domainManagementRoot, domainManagementList } from 'calypso/my-sites/dom
 import { Button, Card, CompactCard } from '@automattic/components';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import EmptyContent from 'calypso/components/empty-content';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -55,6 +52,7 @@ import InfoPopover from 'calypso/components/info-popover';
 import ExternalLink from 'calypso/components/external-link';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import AddDomainButton from 'calypso/my-sites/domains/domain-management/list/add-domain-button';
+import EmptyDomainsListNudge from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-nudge';
 
 /**
  * Style dependencies
@@ -110,35 +108,6 @@ export class List extends React.Component {
 		}
 	}
 
-	domainCreditsInfoNotice() {
-		if ( ! this.props.hasDomainCredit ) {
-			return null;
-		}
-
-		const { translate } = this.props;
-
-		return (
-			<Notice
-				status="is-success"
-				showDismiss={ false }
-				text={ translate( 'Free domain available' ) }
-				icon="info-outline"
-				className="domain-management__claim-free-domain"
-			>
-				<NoticeAction
-					onClick={ this.props.clickClaimDomainNotice }
-					href={ `/domains/add/${ this.props.selectedSite.slug }` }
-				>
-					{ translate( 'Claim Free Domain' ) }
-					<TrackComponentView
-						eventName={ 'calypso_domain_credit_reminder_impression' }
-						eventProperties={ { cta_name: 'domain_info_notice' } }
-					/>
-				</NoticeAction>
-			</Notice>
-		);
-	}
-
 	filterOutWpcomDomains( domains ) {
 		return domains.filter(
 			( domain ) => domain.type !== type.WPCOM || domain.isWpcomStagingDomain
@@ -146,29 +115,35 @@ export class List extends React.Component {
 	}
 
 	renderNewDesign() {
+		const { selectedSite, currentRoute, translate } = this.props;
+
 		return (
 			<>
 				<div className="domains__header">
 					<FormattedHeader
 						brandFont
 						className="domain-management__page-heading"
-						headerText={ this.props.translate( 'Site Domains' ) }
-						subHeaderText={ this.props.translate( 'Manage the domains connected to your site.' ) }
+						headerText={ translate( 'Site Domains' ) }
+						subHeaderText={ translate( 'Manage the domains connected to your site.' ) }
 						align="left"
 					/>
 					<div className="domains__header-buttons">
-						<HeaderCart
-							selectedSite={ this.props.selectedSite }
-							currentRoute={ this.props.currentRoute }
-						/>
+						<HeaderCart selectedSite={ selectedSite } currentRoute={ currentRoute } />
 						{ this.addDomainButton() }
 					</div>
 				</div>
 
 				{ this.domainWarnings() }
-				{ this.domainCreditsInfoNotice() }
 
 				<div className="domain-management-list__primary-domain">{ this.renderPrimaryDomain() }</div>
+
+				{ ! this.isLoading() && (
+					<EmptyDomainsListNudge
+						selectedSite={ selectedSite }
+						hasDomainCredit={ this.props.hasDomainCredit }
+					/>
+				) }
+
 				<div className="domain-management-list__items">{ this.listNewItems() }</div>
 				<DomainToPlanNudge />
 			</>

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -115,7 +115,9 @@ export class List extends React.Component {
 	}
 
 	renderNewDesign() {
-		const { selectedSite, currentRoute, translate } = this.props;
+		const { selectedSite, domains, currentRoute, translate } = this.props;
+
+		const nonWpcomDomains = this.filterOutWpcomDomains( domains );
 
 		return (
 			<>
@@ -137,7 +139,7 @@ export class List extends React.Component {
 
 				<div className="domain-management-list__primary-domain">{ this.renderPrimaryDomain() }</div>
 
-				{ ! this.isLoading() && (
+				{ ! this.isLoading() && nonWpcomDomains.length === 0 && (
 					<EmptyDomainsListCard
 						selectedSite={ selectedSite }
 						hasDomainCredit={ this.props.hasDomainCredit }
@@ -145,6 +147,15 @@ export class List extends React.Component {
 				) }
 
 				<div className="domain-management-list__items">{ this.listNewItems() }</div>
+
+				{ ! this.isLoading() && nonWpcomDomains.length > 0 && (
+					<EmptyDomainsListCard
+						selectedSite={ selectedSite }
+						hasDomainCredit={ this.props.hasDomainCredit }
+						isCompact={ true }
+					/>
+				) }
+
 				<DomainToPlanNudge />
 			</>
 		);

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/mixins';
+
 .domain-management-list__notice {
 	margin-bottom: 0;
 }
@@ -332,5 +334,66 @@
 
 	.domain-item__upsell {
 		margin-left: auto;
+	}
+}
+
+.empty-domains-list-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	h2 {
+		@extend .wp-brand-font;
+		color: var( --color-neutral-70 );
+		font-size: $font-headline-small;
+	}
+
+	h3 {
+		color: var( --color-neutral-50 );
+		font-size: $font-body;
+	}
+
+	.empty-domains-list-card__text {
+		text-align: center;
+		margin-bottom: 30px;
+	}
+
+	.empty-domains-list-card__content {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.empty-domains-list-card__actions {
+		text-align: center;
+		& > .button {
+			margin: 10px 10px 0 0;
+		}
+	}
+
+	&.is-compact {
+		flex-direction: row-reverse;
+
+		h2 {
+			font-size: $font-title-medium;
+		}
+
+		> .empty-domains-list-card__illustration {
+			margin-left: 40px;
+		}
+
+		.empty-domains-list-card__text {
+			margin-bottom: 10px;
+			text-align: initial;
+		}
+
+		.empty-domains-list-card__actions {
+			text-align: initial;
+		}
+
+		.empty-domains-list-card__content {
+			align-items: normal;
+			width: 100%;
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
 .domain-management-list__notice {
@@ -341,11 +342,14 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	margin-top: 32px;
+	margin-bottom: 32px;
 
 	h2 {
 		@extend .wp-brand-font;
 		color: var( --color-neutral-70 );
-		font-size: $font-headline-small;
+		font-size: $font-title-large;
+		margin-top: 24px;
 	}
 
 	h3 {
@@ -355,7 +359,7 @@
 
 	.empty-domains-list-card__text {
 		text-align: center;
-		margin-bottom: 30px;
+		margin-bottom: 10px;
 	}
 
 	.empty-domains-list-card__content {
@@ -367,33 +371,42 @@
 	.empty-domains-list-card__actions {
 		text-align: center;
 		& > .button {
-			margin: 10px 10px 0 0;
+			margin: 16px 16px 0 0;
+		}
+		& > .button:last-child {
+			margin-right: 0;
 		}
 	}
 
-	&.is-compact {
-		flex-direction: row-reverse;
+	@include break-small {
+		&.is-compact {
+			flex-direction: row-reverse;
+			margin-top: 0;
+			margin-bottom: 0;
 
-		h2 {
-			font-size: $font-title-medium;
-		}
+			h2 {
+				font-size: $font-title-medium;
+				margin-top: 0;
+			}
 
-		> .empty-domains-list-card__illustration {
-			margin-left: 40px;
-		}
+			> .empty-domains-list-card__illustration {
+				margin-left: 40px;
+				margin-right: 24px;
+			}
 
-		.empty-domains-list-card__text {
-			margin-bottom: 10px;
-			text-align: initial;
-		}
+			.empty-domains-list-card__text {
+				margin-bottom: 10px;
+				text-align: initial;
+			}
 
-		.empty-domains-list-card__actions {
-			text-align: initial;
-		}
+			.empty-domains-list-card__actions {
+				text-align: initial;
+			}
 
-		.empty-domains-list-card__content {
-			align-items: normal;
-			width: 100%;
+			.empty-domains-list-card__content {
+				align-items: normal;
+				width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add new empty content component to better surface that you have option to purchase a domain or get one for free if you have a plan. The positioning of the new cards might look a bit strange but once the rest of the changes are applied it should all look okay.

#### Changes proposed in this Pull Request

* Add new `EmptyDomainsListCard` component that will be shown if you have a plan and didn't use your free credit or if you don't have a plan

It looks like this (depending if you have a plan and free credit or not):
<img width="1057" alt="Screenshot 2021-07-29 at 13 39 03" src="https://user-images.githubusercontent.com/1355045/127478262-1bd33fae-1c42-4a32-9cfc-e7404f7b9329.png">
<img width="407" alt="Screenshot 2021-07-29 at 13 39 18" src="https://user-images.githubusercontent.com/1355045/127478268-6c0e5b75-dcf6-4cc6-be56-a98855851fc5.png">
<img width="1063" alt="Screenshot 2021-07-29 at 13 40 02" src="https://user-images.githubusercontent.com/1355045/127478273-63b2a2b1-4aac-44a5-a382-32889e337949.png">
<img width="413" alt="Screenshot 2021-07-29 at 13 40 34" src="https://user-images.githubusercontent.com/1355045/127478275-422e86ba-97a4-45f7-92e7-d55b9bced7fd.png">

#### Testing instructions

* Open local calypso with this branch or calypso live and then check how the card looks for:
** the domain list for a site with plan but without registered domain
** a site without plan
** a site with plan and without registered domain but with mapped domain

