### PR TITLE
Monitor: remove flag for Monitor mobile settings

### DIFF
--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -150,8 +150,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 
 					<div className="site-settings__child-settings">
 						{ this.settingsMonitorEmailCheckbox() }
-						{ config.isEnabled( 'settings/security/monitor/wp-note' ) &&
-							this.settingsMonitorWpNoteCheckbox() }
+						{ this.settingsMonitorWpNoteCheckbox() }
 					</div>
 				</Card>
 			</div>

--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,6 @@
 		"security/security-checkup": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,7 +106,6 @@
 		"security/security-checkup": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,7 +114,6 @@
 		"security/security-checkup": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a replay of #32203, but this time we're enabling this for everyone at once.

It depends on D64140-code 

#### Testing instructions

* Head over to http://calypso.localhost:3000/settings/security/
* Pick different Jetpack sites in the site picker. 
* You should see this:
![image](https://user-images.githubusercontent.com/426388/55956564-8f2bad00-5c64-11e9-9c42-fbe112785b1b.png)

Internal discussion: p1HpG7-6zd-p2
