### PR TITLE
Inline Support Modal: clean up breakpoints

### DIFF
--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -18,13 +18,6 @@
 		bottom: 5%;
 		width: 90%;
 		height: 90%;
-	}
-
-	@include breakpoint-deprecated( '>860px' ) {
-		max-width: 860px;
-	}
-
-	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 860px;
 	}
 }


### PR DESCRIPTION
This fixes the disallowed breakpoint found in [this comment](https://github.com/Automattic/wp-calypso/pull/54413/files#r669133853).

**To test:**
- visit an inline support link (i.e. /devdocs/design/inline-support-link/)
- verify that the modal is full-width on mobile, 90% width on tablets (up to 955px), and 860px on devices wider than 955px