### PR TITLE
Full Site Editing: allow toggling of the Site Editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -324,3 +324,11 @@ function load_error_reporting() {
 	require_once __DIR__ . '/error-reporting/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_error_reporting' );
+
+/**
+ * Universal themes.
+ */
+function load_universal_themes() {
+	require_once __DIR__ . '/wpcom-universal-themes/index.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_universal_themes', 11 ); // load just after the Gutenberg plugin.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -22,13 +22,23 @@ define( 'OPTION_NAME', 'is_fse_activated' );
  */
 function is_core_fse_active() {
 	// If `gutenberg_is_fse_theme` is false, this is a non-starter.
-	$gutenberg_is_fse_theme = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
-	if ( ! $gutenberg_is_fse_theme ) {
+	if ( ! is_fse_theme() ) {
 		return false;
 	}
 
 	// Now we just check for our own option.
 	return (bool) get_option( OPTION_NAME );
+}
+
+/**
+ * Proxy for `gutenberg_is_fse_theme` with `function_exists` guarding.
+ *
+ * @uses gutenberg_is_fse_theme
+ *
+ * @return boolean
+ */
+function is_fse_theme() {
+	return function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
 }
 
 /**
@@ -70,6 +80,10 @@ function load_core_fse() {
  * @return void
  */
 function load_universal_helpers() {
+	// we don't need to show anything to non-FSE-capable themes.
+	if ( ! is_fse_theme() ) {
+		return;
+	}
 	if ( apply_filters( 'a8c_hide_core_fse_activation', false ) ) {
 		return;
 	}
@@ -102,7 +116,7 @@ function add_submenu() {
 function theme_nag() {
 	$is_active        = is_core_fse_active();
 	$is_themes_screen = 'themes' === get_current_screen()->id;
-	$is_fse_theme     = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+	$is_fse_theme     = is_fse_theme();
 	if ( $is_active || ! $is_themes_screen || ! $is_fse_theme ) {
 		return;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -79,7 +79,7 @@ function load_core_fse() {
  *
  * @return void
  */
-function load_universal_helpers() {
+function load_helpers() {
 	// we don't need to show anything to non-FSE-capable themes.
 	if ( ! is_fse_theme() ) {
 		return;
@@ -90,6 +90,17 @@ function load_universal_helpers() {
 	add_action( 'admin_notices', __NAMESPACE__ . '\theme_nag' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
 	add_action( 'admin_init', __NAMESPACE__ . '\init_settings' );
+}
+
+/**
+ * Unloads our menus
+ *
+ * @return void
+ */
+function unload_helpers() {
+	remove_action( 'admin_notices', __NAMESPACE__ . '\theme_nag' );
+	remove_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
+	remove_action( 'admin_init', __NAMESPACE__ . '\init_settings' );
 }
 
 /**
@@ -260,13 +271,18 @@ function display_fse_section() {
  * @return void
  */
 function init() {
-	load_universal_helpers();
 	// always unload first since we will add below only when needed.
 	unload_core_fse();
+	unload_helpers();
+
+	load_helpers();
 	if ( is_core_fse_active() ) {
 		load_core_fse();
 	}
 }
-
-// As of this writing we don't need to add this to any hooks, so just run it.
+// For WPcom REST API requests to work properly.
+add_action( 'restapi_theme_init', __NAMESPACE__ . '\init' );
+// Just run it.
 init();
+
+

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -7,7 +7,7 @@
  * @package A8C\FSE
  */
 
-namespace A8C\FSE\Universal_Themes;
+namespace A8C\FSE;
 
 /**
  * This is the option name for enabling/disabling.
@@ -72,6 +72,7 @@ function load_core_fse() {
 	add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 	add_filter( 'menu_order', 'gutenberg_menu_order' );
 	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 }
 
 /**
@@ -163,6 +164,7 @@ function unload_core_fse() {
 	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 	remove_filter( 'menu_order', 'gutenberg_menu_order' );
 	add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+	add_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 }
 
 /**
@@ -284,5 +286,3 @@ function init() {
 add_action( 'restapi_theme_init', __NAMESPACE__ . '\init' );
 // Just run it.
 init();
-
-

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -108,12 +108,20 @@ function theme_nag() {
 	}
 	$message = sprintf(
 		/* translators: %s: URL for linking to activation subpage */
-		__( 'You are running a theme capable of Full Site Editing! <a href="%s">Click here</a> to try out the new Site Editor.', 'full-site-editing' ),
+		__( 'You are running a theme capable of Full Site Editing! <a href="%s" class="button">Try the Site Editor</a>', 'full-site-editing' ),
 		admin_url( 'themes.php?page=site-editor-toggle' )
 	);
 	printf(
 		'<div class="notice is-dismissible"><p>%s</p></div>',
-		wp_kses( $message, array( 'a' => array( 'href' => array() ) ) )
+		wp_kses(
+			$message,
+			array(
+				'a' => array(
+					'href'  => array(),
+					'class' => array(),
+				),
+			)
+		)
 	);
 
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * For supporting classic and block themes on WPcom.
+ *
+ * Themes with support for Full Site Editing will not be automatically activated into FSE mode.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE\Universal_Themes;
+
+/**
+ * This is the option name for enabling/disabling.
+ */
+define( 'OPTION_NAME', 'is_fse_activated' );
+
+/**
+ * Checks if Core's FSE is active via this plugin,
+ * always returning false when `gutenberg_is_fse_theme` is false.
+ *
+ * @return boolean Core FSE is active.
+ */
+function is_core_fse_active() {
+	// If `gutenberg_is_fse_theme` is false, this is a non-starter.
+	$gutenberg_is_fse_theme = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+	if ( ! $gutenberg_is_fse_theme ) {
+		return false;
+	}
+
+	// Now we just check for our own option.
+	return (bool) get_option( OPTION_NAME );
+}
+
+/**
+ * Activates Core FSE by setting our option.
+ * Note that even setting this option to true will make no difference on a classic theme.
+ *
+ * @return void
+ */
+function activate_core_fse() {
+	update_option( OPTION_NAME, true );
+}
+
+/**
+ * Deactivates Core FSE by removing our option.
+ *
+ * @return void
+ */
+function deactivate_core_fse() {
+	delete_option( OPTION_NAME );
+}
+
+/**
+ * Hook and unhook Gutenberg's FSE things.
+ *
+ * @return void
+ */
+function load_core_fse() {
+	// perfect parity would put the admin notices back but we don't want that.
+	add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
+	add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
+	add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
+	add_filter( 'menu_order', 'gutenberg_menu_order' );
+	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+}
+
+/**
+ * Loads our menus
+ *
+ * @return void
+ */
+function load_universal_helpers() {
+	if ( apply_filters( 'a8c_hide_core_fse_activation', false ) ) {
+		return;
+	}
+	add_action( 'admin_notices', __NAMESPACE__ . '\theme_nag' );
+	add_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
+	add_action( 'admin_init', __NAMESPACE__ . '\init_settings' );
+}
+
+/**
+ * Adds our submenu
+ *
+ * @return void
+ */
+function add_submenu() {
+	add_theme_page(
+		__( 'Site Editor (beta)', 'full-site-editing' ),
+		__( 'Site Editor (beta)', 'full-site-editing' ),
+		'edit_theme_options',
+		'site-editor-toggle',
+		__NAMESPACE__ . '\menu_page'
+	);
+}
+
+/**
+ * Prints an admin notice on the themes screen when an FSE theme is active and
+ * this plugin's toggle is inactive. Links to our submenu for activation.
+ *
+ * @return void
+ */
+function theme_nag() {
+	$is_active        = is_core_fse_active();
+	$is_themes_screen = 'themes' === get_current_screen()->id;
+	$is_fse_theme     = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+	if ( $is_active || ! $is_themes_screen || ! $is_fse_theme ) {
+		return;
+	}
+	$message = sprintf(
+		/* translators: %s: URL for linking to activation subpage */
+		__( 'You are running a theme capable of Full Site Editing! <a href="%s">Click here</a> to try out the new Site Editor.', 'full-site-editing' ),
+		admin_url( 'themes.php?page=site-editor-toggle' )
+	);
+	printf(
+		'<div class="notice is-dismissible"><p>%s</p></div>',
+		wp_kses( $message, array( 'a' => array( 'href' => array() ) ) )
+	);
+
+}
+
+/**
+ * Unhooks anything that Gutenberg uses for Full Site Editing
+ *
+ * @return void
+ */
+function unload_core_fse() {
+	remove_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
+	remove_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
+	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
+	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
+	remove_filter( 'menu_order', 'gutenberg_menu_order' );
+	add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+}
+
+/**
+ * Hides the Template and Template Part Custom Post Types' UI
+ *
+ * @return void
+ */
+function hide_template_cpts() {
+	global $wp_post_types;
+	if ( isset( $wp_post_types['wp_template'] ) ) {
+		$wp_post_types['wp_template']->show_ui = false;
+	}
+	if ( isset( $wp_post_types['wp_template_part'] ) ) {
+		$wp_post_types['wp_template_part']->show_ui = false;
+	}
+}
+
+/**
+ * Prints the screen for our toggle page
+ *
+ * @return void
+ */
+function menu_page() {
+	?>
+	<div
+		id="site-editor-toggle"
+		class="wrap"
+	>
+	<h1><?php esc_html_e( 'Site Editor (beta)', 'full-site-editing' ); ?></h1>
+	<?php settings_errors(); ?>
+	<form method="post" action="options.php">
+		<?php settings_fields( 'site-editor-toggle' ); ?>
+		<?php do_settings_sections( 'site-editor-toggle' ); ?>
+		<?php submit_button(); ?>
+	</form>
+	</div>
+	<?php
+}
+
+/**
+ * Adds our settings sections and fields
+ *
+ * @return void
+ */
+function init_settings() {
+	add_settings_section(
+		'fse_toggle_section',
+		// The empty string ensures the render function won't output a h2.
+		'',
+		__NAMESPACE__ . '\display_fse_section',
+		'site-editor-toggle'
+	);
+	add_settings_field(
+		'fse-universal-theme-toggle',
+		__( 'Site Editor', 'full-site-editing' ),
+		__NAMESPACE__ . '\do_field',
+		'site-editor-toggle',
+		'fse_toggle_section'
+	);
+	register_setting(
+		'site-editor-toggle',
+		OPTION_NAME
+	);
+}
+
+/**
+ * Prints our setting field
+ *
+ * @return void
+ */
+function do_field() {
+	$value       = (bool) get_option( OPTION_NAME ) ? 1 : 0;
+	$for_sprintf = <<<HTML
+	<label for="%s">
+		<input type="checkbox" name="%s" id="%s" value="1" %s />
+		%s
+	</label>
+HTML;
+	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+	printf(
+		$for_sprintf,
+		OPTION_NAME,
+		OPTION_NAME,
+		OPTION_NAME,
+		checked( 1, $value, false ),
+		esc_html__( 'Enable Site Editor', 'full-site-editing' )
+	);
+	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+/**
+ * Prints our settings section
+ *
+ * @return void
+ */
+function display_fse_section() {
+	printf(
+		'<p>%s</p>',
+		esc_html__( 'The Site Editor is an exciting new direction for WordPress themes! Blocks are now the foundation of your whole site and everything is editable.', 'full-site-editing' )
+	);
+}
+
+/**
+ * Run everything
+ *
+ * @return void
+ */
+function init() {
+	load_universal_helpers();
+	// always unload first since we will add below only when needed.
+	unload_core_fse();
+	if ( is_core_fse_active() ) {
+		load_core_fse();
+	}
+}
+
+// As of this writing we don't need to add this to any hooks, so just run it.
+init();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -112,7 +112,11 @@ function unload_helpers() {
 function add_submenu() {
 	add_theme_page(
 		__( 'Site Editor (beta)', 'full-site-editing' ),
-		__( 'Site Editor (beta)', 'full-site-editing' ),
+		sprintf(
+		/* translators: %s: "beta" label. */
+			__( 'Site Editor %s', 'full-site-editing' ),
+			'<span class="awaiting-mod">' . esc_html__( 'beta', 'full-site-editing' ) . '</span>'
+		),
 		'edit_theme_options',
 		'site-editor-toggle',
 		__NAMESPACE__ . '\menu_page'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -12,7 +12,7 @@ namespace A8C\FSE;
 /**
  * This is the option name for enabling/disabling.
  */
-define( 'OPTION_NAME', 'is_fse_activated' );
+define( 'ACTIVATE_FSE_OPTION_NAME', 'is_fse_activated' );
 
 /**
  * Checks if Core's FSE is active via this plugin,
@@ -27,7 +27,7 @@ function is_core_fse_active() {
 	}
 
 	// Now we just check for our own option.
-	return (bool) get_option( OPTION_NAME );
+	return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
 }
 
 /**
@@ -48,7 +48,7 @@ function is_fse_theme() {
  * @return void
  */
 function activate_core_fse() {
-	update_option( OPTION_NAME, true );
+	update_option( ACTIVATE_FSE_OPTION_NAME, true );
 }
 
 /**
@@ -57,7 +57,7 @@ function activate_core_fse() {
  * @return void
  */
 function deactivate_core_fse() {
-	delete_option( OPTION_NAME );
+	delete_option( ACTIVATE_FSE_OPTION_NAME );
 }
 
 /**
@@ -230,7 +230,7 @@ function init_settings() {
 	);
 	register_setting(
 		'site-editor-toggle',
-		OPTION_NAME
+		ACTIVATE_FSE_OPTION_NAME
 	);
 }
 
@@ -240,7 +240,7 @@ function init_settings() {
  * @return void
  */
 function do_field() {
-	$value       = (bool) get_option( OPTION_NAME ) ? 1 : 0;
+	$value       = (bool) get_option( ACTIVATE_FSE_OPTION_NAME ) ? 1 : 0;
 	$for_sprintf = <<<HTML
 	<label for="%s">
 		<input type="checkbox" name="%s" id="%s" value="1" %s />
@@ -250,9 +250,9 @@ HTML;
 	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	printf(
 		$for_sprintf,
-		OPTION_NAME,
-		OPTION_NAME,
-		OPTION_NAME,
+		ACTIVATE_FSE_OPTION_NAME,
+		ACTIVATE_FSE_OPTION_NAME,
+		ACTIVATE_FSE_OPTION_NAME,
 		checked( 1, $value, false ),
 		esc_html__( 'Enable Site Editor', 'full-site-editing' )
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -77,6 +77,22 @@ function load_core_fse() {
 }
 
 /**
+ * Unhooks anything that Gutenberg uses for Full Site Editing
+ *
+ * @return void
+ */
+function unload_core_fse() {
+	remove_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
+	remove_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
+	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
+	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
+	remove_filter( 'menu_order', 'gutenberg_menu_order' );
+	add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+	add_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
+}
+
+/**
  * Loads our menus
  *
  * @return void
@@ -155,22 +171,6 @@ function theme_nag() {
 		)
 	);
 
-}
-
-/**
- * Unhooks anything that Gutenberg uses for Full Site Editing
- *
- * @return void
- */
-function unload_core_fse() {
-	remove_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
-	remove_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
-	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
-	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
-	remove_filter( 'menu_order', 'gutenberg_menu_order' );
-	add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
-	add_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
-	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -73,6 +73,7 @@ function load_core_fse() {
 	add_filter( 'menu_order', 'gutenberg_menu_order' );
 	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
 }
 
 /**
@@ -169,6 +170,23 @@ function unload_core_fse() {
 	remove_filter( 'menu_order', 'gutenberg_menu_order' );
 	add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
 	add_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
+	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
+}
+
+/**
+ * Filter for `block_editor_settings_all` in order to prevent expermiental
+ * blocks from showing up in the post editor when FSE is inactive.
+ *
+ * @param [array] $editor_settings Editor settings.
+ * @return array Possibly modified editor settings.
+ */
+function hide_fse_blocks( $editor_settings ) {
+	// this shouldn't even be hooked under this condition, but let's be sure.
+	if ( is_core_fse_active() ) {
+		return $editor_settings;
+	}
+	$editor_settings['__unstableEnableFullSiteEditingBlocks'] = false;
+	return $editor_settings;
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -12,7 +12,7 @@ namespace A8C\FSE;
 /**
  * This is the option name for enabling/disabling.
  */
-define( 'ACTIVATE_FSE_OPTION_NAME', 'is_fse_activated' );
+define( 'ACTIVATE_FSE_OPTION_NAME', 'wpcom_is_fse_activated' );
 
 /**
  * Checks if Core's FSE is active via this plugin,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -52,12 +52,12 @@ function activate_core_fse() {
 }
 
 /**
- * Deactivates Core FSE by removing our option.
+ * Deactivates Core FSE by setting the option to NULL (matches the Options API).
  *
  * @return void
  */
 function deactivate_core_fse() {
-	delete_option( ACTIVATE_FSE_OPTION_NAME );
+	update_option( ACTIVATE_FSE_OPTION_NAME, null );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a toggle in `wp-admin` that allows enabling of the Site Editor and other related functionality tied to `gutenberg_is_fse_theme`.

#### Testing instructions

1. Apply D64218-code to your sandbox
2. Activate `pub/tt1-blocks` on your sandbox.
3. Proxy should be active. (The toggle is only shown to proxied requests)

_NOTE:_ These screenshots are taken in wp-admin. The `(beta)` badge will look different (yellow, with outline) as in #54681

| State  |  Screenshot |
|---|---|
|  Before | <img width="273" alt="Screen Shot 2021-07-20 at 16 07 38" src="https://user-images.githubusercontent.com/195089/126395589-27633776-2e23-4851-b552-241facd438ee.png"> |
| After, enabled  | <img width="274" alt="Screen Shot 2021-07-20 at 16 05 09" src="https://user-images.githubusercontent.com/195089/126395341-46584149-71da-4ce1-9161-91a977d96a20.png"> |
| After, disabled | <img width="274" alt="Screen Shot 2021-07-20 at 16 05 55" src="https://user-images.githubusercontent.com/195089/126395388-563f7c0d-3642-4d73-aec2-d3a04599f05c.png"> |

Note that we'll have to merge Automattic/themes#4340 to revert Blockbase's own Site Editor hiding before making this live.