### PR TITLE
Improving auto-renew disable flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -680,7 +680,7 @@ class CancelPurchaseForm extends React.Component {
 			isJetpackProductSlug( purchase.productSlug ) || isJetpackPlanSlug( purchase.productSlug );
 		const productName = isJetpack ? translate( 'Jetpack' ) : translate( 'WordPress.com' );
 
-		if ( showSurvey ) {
+		if ( showSurvey && this.getSurveyDataType() !== 'cancel-autorenew' ) {
 			if ( surveyStep === steps.INITIAL_STEP ) {
 				return (
 					<div>
@@ -818,7 +818,7 @@ class CancelPurchaseForm extends React.Component {
 		const cancel = {
 			action: 'cancel',
 			disabled,
-			label: translate( 'Cancel Now' ),
+			label: translate( 'Confirm' ),
 			onClick: this.onSubmit,
 			isPrimary: true,
 		};
@@ -846,6 +846,10 @@ class CancelPurchaseForm extends React.Component {
 		const firstButtons = [ close ];
 		if ( this.shouldShowChatButton() ) {
 			firstButtons.unshift( chat );
+		}
+
+		if ( this.getSurveyDataType() === 'cancel-autorenew' ) {
+			return firstButtons.concat( [ cancel ] );
 		}
 
 		if ( surveyStep === steps.FINAL_STEP ) {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -97,8 +97,8 @@ class CancelPurchaseButton extends Component {
 			if ( success ) {
 				this.props.successNotice(
 					translate(
-						'%(purchaseName)s was successfully cancelled. It will be available ' +
-							'for use until it expires on %(subscriptionEndDate)s.',
+						'Auto-renew for %(purchaseName)s was successfully disabled. Your paid features will be available ' +
+							'for use until your plan expires on %(subscriptionEndDate)s.',
 						{
 							args: {
 								purchaseName,
@@ -113,7 +113,7 @@ class CancelPurchaseButton extends Component {
 			} else {
 				this.props.errorNotice(
 					translate(
-						'There was a problem canceling %(purchaseName)s. ' +
+						'There was a problem disabling auto-renew for %(purchaseName)s. ' +
 							'Please try again later or contact support.',
 						{
 							args: { purchaseName },
@@ -263,7 +263,7 @@ class CancelPurchaseButton extends Component {
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = translate( 'Cancel Subscription' );
+				text = translate( 'Disable Auto-renew' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
@@ -278,7 +278,7 @@ class CancelPurchaseButton extends Component {
 
 			if ( isSubscription( purchase ) ) {
 				onClick = this.handleCancelPurchaseClick;
-				text = translate( 'Cancel Subscription' );
+				text = translate( 'Disable Auto-renew' );
 			}
 		}
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -278,7 +278,7 @@ class CancelPurchaseButton extends Component {
 
 			if ( isSubscription( purchase ) ) {
 				onClick = this.handleCancelPurchaseClick;
-				text = translate( 'Disable Auto-renew' );
+				text = translate( 'Cancel Subscription' );
 			}
 		}
 

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -39,7 +39,7 @@ export function cancellationEffectHeadline( purchase, translate ) {
 
 	if ( isPlan( purchase ) ) {
 		return translate(
-			'Are you sure you want to disable the auto-renewal of %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
+			'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
 			{
 				args: {
 					purchaseName,

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -37,6 +37,21 @@ export function cancellationEffectHeadline( purchase, translate ) {
 		);
 	}
 
+	if ( isPlan( purchase ) ) {
+		return translate(
+			'Are you sure you want to disable the auto-renewal of %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
+			{
+				args: {
+					purchaseName,
+					domain,
+				},
+				components: {
+					em: <em />,
+				},
+			}
+		);
+	}
+
 	return translate(
 		'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
 		{

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -180,7 +180,7 @@ class CancelPurchase extends React.Component {
 		}
 
 		if ( isSubscription( purchase ) ) {
-			heading = this.props.translate( 'Disable auto-renew for your %(purchaseName)s Subscription', {
+			heading = this.props.translate( 'Cancel your %(purchaseName)s Subscription', {
 				args: { purchaseName },
 			} );
 		}

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -142,7 +142,7 @@ class CancelPurchase extends React.Component {
 		}
 
 		return this.props.translate(
-			'After you confirm this change, the subscription will be removed on %(expirationDate)s',
+			'After you confirm this change, auto-renew will be disabled and your subscription will be removed on %(expirationDate)s',
 			{
 				args: { expirationDate },
 			}
@@ -180,7 +180,7 @@ class CancelPurchase extends React.Component {
 		}
 
 		if ( isSubscription( purchase ) ) {
-			heading = this.props.translate( 'Cancel Your %(purchaseName)s Subscription', {
+			heading = this.props.translate( 'Disable auto-renew for your %(purchaseName)s Subscription', {
 				args: { purchaseName },
 			} );
 		}

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -294,10 +294,23 @@ const CancelPurchaseRefundInformation = ( {
 				},
 			}
 		);
+	} else if ( maybeWithinRefundPeriod( purchase ) ) {
+		text = i18n.translate(
+			"Clicking the Cancel Subscription button below will disable auto-renew and you'll be able to use %(productName)s " +
+				'until your subscription expires. When your subscription expires, the paid plan features will be automatically ' +
+				'removed from your site.',
+			{
+				args: {
+					productName: getName( purchase ),
+				},
+			}
+		);
 	} else {
 		text = i18n.translate(
-			"You'll be able to use %(productName)s until your subscription expires. " +
-				'Once it expires, it will be automatically removed from your site.',
+			'Your purchase is outside of the money-back guarantee window and is not eligible for a refund. ' +
+				"Clicking the Cancel Subscription button below will disable auto-renew and you'll be able to use %(productName)s " +
+				'until your subscription expires. When your subscription expires, the paid plan features will be automatically ' +
+				'removed from your site.',
 			{
 				args: {
 					productName: getName( purchase ),

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -296,7 +296,7 @@ const CancelPurchaseRefundInformation = ( {
 		);
 	} else {
 		text = i18n.translate(
-			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
+			"You'll be able to use %(productName)s until your subscription expires. " +
 				'Once it expires, it will be automatically removed from your site.',
 			{
 				args: {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -482,7 +482,7 @@ class ManagePurchase extends Component {
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = translate( 'Disable Auto-renew' );
+				text = translate( 'Cancel Subscription' );
 			}
 		}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -482,7 +482,7 @@ class ManagePurchase extends Component {
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = translate( 'Cancel Subscription' );
+				text = translate( 'Disable Auto-renew' );
 			}
 		}
 

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -7,7 +7,7 @@ import i18n from 'i18n-calypso';
 const titles = {
 	addCreditCard: i18n.translate( 'Add Credit Card' ),
 	addPaymentMethod: i18n.translate( 'Add Payment Method' ),
-	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
+	cancelPurchase: i18n.translate( 'Purchase Settings' ),
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
 	changePaymentMethod: i18n.translate( 'Change Payment Method' ),
 	addCardDetails: i18n.translate( 'Add Credit Card' ),
@@ -30,7 +30,7 @@ Object.defineProperties( titles, {
 		get: () => i18n.translate( 'Add Payment Method' ),
 	},
 	cancelPurchase: {
-		get: () => i18n.translate( 'Cancel Purchase' ),
+		get: () => i18n.translate( 'Purchase Settings' ),
 	},
 	confirmCancelDomain: {
 		get: () => i18n.translate( 'Cancel Domain' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* This PR addresses the confusing flow for disabling auto-renew on subscriptions in the use case where a user has auto-renew enabled and is not eligible for a refund..
* Currently that functionality is described as "cancel"ing the plan and it's causing confusion among customers who expect a refund (which the flow does not issue).
* This PR adds additional context on the confirmation page to inform them that they aren't eligible for a refund and that by disabling auto-renew, they will lose their paid plan features on expiration.
* This PR also removes the cancellation survey from the flow, since it doesn't make sense to ask a person why they're leaving if they're simply disabling auto-renew, and because legal has provided feedback that there should be minimal interstitial steps between requesting cancellation and processing it..

Here are screenshots of the updated flow:
<img width="1062" alt="CleanShot 2021-07-20 at 16 29 59@2x" src="https://user-images.githubusercontent.com/35781181/126395852-0d26828b-33f2-4264-be41-638548d28251.png">

<img width="1063" alt="CleanShot 2021-07-20 at 16 30 10@2x" src="https://user-images.githubusercontent.com/35781181/126395870-26dac386-2e3d-4a65-ab90-3fea337d195e.png">

<img width="1078" alt="CleanShot 2021-07-20 at 16 30 24@2x" src="https://user-images.githubusercontent.com/35781181/126395883-727b0b7c-6643-4e15-a462-67b53951caad.png">

<img width="1058" alt="CleanShot 2021-07-20 at 16 31 19@2x" src="https://user-images.githubusercontent.com/35781181/126395889-11a06f56-9c8f-4b94-8b7f-f26caa04b0b2.png">


#### Testing instructions

* Checkout this PR and start Calypso.
* Using a test account with a site on a paid plan, navigate to `wordpress.com/me/purchases`
* Click the plan purchase for that site.
* Enable auto-renew if it isn't already on.
* Click on "Cancel Subscription"
* Go through the flow and confirm that you're able to disable auto-renew.
* Confirm that the manage screen for that plan now shows a an option to "remove" the plan and that the flow still works.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #54383
