### PR TITLE
desktop: enable dynamic feature flags for development

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import debugModule from 'debug';
@@ -976,11 +977,13 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.horizontal && ! this.userCreationComplete() && (
-					<div className="signup-form__separator">
-						<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
-					</div>
-				) }
+				{ ! config.isEnabled( 'desktop' ) &&
+					this.props.horizontal &&
+					! this.userCreationComplete() && (
+						<div className="signup-form__separator">
+							<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
+						</div>
+					) }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 					<SocialSignupForm

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -83,55 +83,62 @@ class SocialSignupForm extends Component {
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
 
 		return (
-			<div className="signup-form__social">
-				{ ! this.props.compact && (
-					<p>{ preventWidows( this.props.translate( 'Or create an account using:' ) ) }</p>
-				) }
+			// Note: we allow social sign-in on the Desktop app, but not social sign-up. Existing config flags do
+			// not distinguish between sign-in and sign-up but instead use the catch-all `signup/social` flag.
+			// Therefore we need to make an exception for the desktop app directly in this component because there
+			// are many places in which the social signup form is rendered based only on the presence of the
+			// `signup/social` config flag.
+			! config.isEnabled( 'desktop' ) && (
+				<div className="signup-form__social">
+					{ ! this.props.compact && (
+						<p>{ preventWidows( this.props.translate( 'Or create an account using:' ) ) }</p>
+					) }
 
-				<div className="signup-form__social-buttons">
-					<GoogleLoginButton
-						clientId={ config( 'google_oauth_client_id' ) }
-						responseHandler={ this.handleGoogleResponse }
-						uxMode={ uxMode }
-						redirectUri={ redirectUri }
-						onClick={ () => this.trackSocialLogin( 'google' ) }
-						socialServiceResponse={
-							this.props.socialService === 'google' ? this.props.socialServiceResponse : null
-						}
-						isReskinned={ this.props.isReskinned }
-					/>
-
-					<AppleLoginButton
-						clientId={ config( 'apple_oauth_client_id' ) }
-						responseHandler={ this.handleAppleResponse }
-						uxMode={ uxModeApple }
-						redirectUri={ redirectUri }
-						onClick={ () => this.trackSocialLogin( 'apple' ) }
-						socialServiceResponse={
-							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
-						}
-					/>
-
-					<p className="signup-form__social-buttons-tos">
-						{ this.props.translate(
-							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-								' are creating an account and you agree to our' +
-								' {{a}}Terms of Service{{/a}}.',
-							{
-								components: {
-									a: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
+					<div className="signup-form__social-buttons">
+						<GoogleLoginButton
+							clientId={ config( 'google_oauth_client_id' ) }
+							responseHandler={ this.handleGoogleResponse }
+							uxMode={ uxMode }
+							redirectUri={ redirectUri }
+							onClick={ () => this.trackSocialLogin( 'google' ) }
+							socialServiceResponse={
+								this.props.socialService === 'google' ? this.props.socialServiceResponse : null
 							}
-						) }
-					</p>
+							isReskinned={ this.props.isReskinned }
+						/>
+
+						<AppleLoginButton
+							clientId={ config( 'apple_oauth_client_id' ) }
+							responseHandler={ this.handleAppleResponse }
+							uxMode={ uxModeApple }
+							redirectUri={ redirectUri }
+							onClick={ () => this.trackSocialLogin( 'apple' ) }
+							socialServiceResponse={
+								this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
+							}
+						/>
+
+						<p className="signup-form__social-buttons-tos">
+							{ this.props.translate(
+								"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
+									' are creating an account and you agree to our' +
+									' {{a}}Terms of Service{{/a}}.',
+								{
+									components: {
+										a: (
+											<a
+												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+					</div>
 				</div>
-			</div>
+			)
 		);
 	}
 }

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -34,4 +34,11 @@ module.exports = function ( { view } ) {
 	view.webContents.on( 'update-target-url', function ( event, url ) {
 		targetURL = url;
 	} );
+
+	view.webContents.on( 'will-redirect', function ( _, url ) {
+		if ( url.includes( 'https://wordpress.com/log-in/apple/callback' ) ) {
+			log.info( 'Redirecting to URL: ', url );
+			view.webContents.loadURL( url );
+		}
+	} );
 };

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -45,12 +45,12 @@ const receiveChannels = [
 
 function fflagOverrides() {
 	const payload = {};
-	let fflags = process.env.WP_DESKTOP_DEBUG_FEATURES;
-	if ( fflags !== undefined ) {
-		fflags = fflags.split( ',' );
-		for ( let i = 0; i < fflags.length; i++ ) {
-			payload[ fflags[ i ] ] = true;
-		}
+	const fflags = process.env.WP_DESKTOP_DEBUG_FEATURES
+		? process.env.WP_DESKTOP_DEBUG_FEATURES.split( ',' )
+		: [];
+	for ( let i = 0; i < fflags.length; i++ ) {
+		const kv = fflags[ i ].split( ':' );
+		payload[ kv[ 0 ] ] = kv[ 1 ] === 'true' ? true : false;
 	}
 	return payload;
 }

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -43,11 +43,24 @@ const receiveChannels = [
 	'toggle-notification-bar',
 ];
 
+function fflagOverrides() {
+	const payload = {};
+	let fflags = process.env.WP_DESKTOP_DEBUG_FEATURES;
+	if ( fflags !== undefined ) {
+		fflags = fflags.split( ',' );
+		for ( let i = 0; i < fflags.length; i++ ) {
+			payload[ fflags[ i ] ] = true;
+		}
+	}
+	return payload;
+}
+
 ( async () => {
 	const config = await ipcRenderer.invoke( 'get-config' );
 	const styles = {
 		titleBarPaddingLeft: process.platform !== 'darwin' ? '0px' : '77px',
 	};
+	const features = fflagOverrides();
 	contextBridge.exposeInMainWorld( 'electron', {
 		send: ( channel, ...args ) => {
 			if ( sendChannels.includes( channel ) ) {
@@ -76,5 +89,6 @@ const receiveChannels = [
 		},
 		config,
 		styles,
+		features,
 	} );
 } )();

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -16,8 +16,8 @@ const config = {
 const features = {
 	desktop: true,
 	'desktop-promo': false,
-	'sign-in-with-apple': false,
-	'signup/social': false,
+	'sign-in-with-apple': true,
+	'signup/social': true,
 	'login/magic-login': false,
 };
 

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -17,6 +17,8 @@ const features = {
 	desktop: true,
 	'desktop-promo': false,
 	'sign-in-with-apple': true,
+	// Note: there is also a sign-in-with-apple/redirect flag
+	// that may/may not be relevant to override for the Desktop app.
 	'signup/social': true,
 	'login/magic-login': false,
 };

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -16,10 +16,10 @@ const config = {
 const features = {
 	desktop: true,
 	'desktop-promo': false,
-	'sign-in-with-apple': true,
+	'sign-in-with-apple': false,
 	// Note: there is also a sign-in-with-apple/redirect flag
 	// that may/may not be relevant to override for the Desktop app.
-	'signup/social': true,
+	'signup/social': false,
 	'login/magic-login': false,
 };
 
@@ -27,6 +27,9 @@ export default ( data: ConfigData ): ConfigData => {
 	data = Object.assign( data, config );
 	if ( data.features ) {
 		data.features = Object.assign( data.features, features );
+	}
+	if ( window.electron && window.electron.features ) {
+		data.features = Object.assign( data.features, window.electron.features );
 	}
 
 	return data;


### PR DESCRIPTION
### Description

~~This PR enables social login (Apple, Google) for the Desktop app.~~

Update: there is some minor UI cleanup here but we are _not_ merging social login into the desktop app. Rather, we will be enabling the ability to inject feature flags at runtime for further development testing.

### To-Dos

- [x] Handle logging in with Google and Apple
- [x]  ~~Handle account creation (more involved, likely requires a custom protocol handler)~~ (NOT IN SCOPE: we can explore social signup at later date.) 

~~At account creation, both Google and Apple bounce the user to an external window (browser for Google, operating system dialog for Apple). So in both cases the redirect URL will have to be overriden in order to pass authentication back to the app.~~

### To Test

~~This change depends on changes to the webapp in production. Since those changes aren't merged, you'll need to run Calypso locally but with https enabled (since the social login redirects don't permit `http`).~~

Use the instructions in PCYsg-5YE-p2 for `"Running the Node.js server at port 443 (https)"` to redirect requests to WordPress.com to a locally-running instance of Calypso. This involves: (1) generating a self-signed HTTPS certificate (2) replacing Calypso config secrets with those generating from your sandbox, (3) updating your hosts file and finally (4) building and running Calypso locally in production mode. (It's a lot of steps, but the instructions are pretty detailed.)

Build the desktop app locally (or download the latest publicly available build) and attempt to sign in with Google or Apple with an account where these third-party logins are connected.