### PR TITLE
State free domain policy on /plans for all users

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -264,9 +264,9 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Free domain for one year' ),
 		getDescription: () =>
 			i18n.translate(
-				'Get a free domain for one year. ' +
-					'Doesn’t apply to plan upgrades, renewals, or to premium domains. ' +
-					'After one year, domain renews at its {{a}}regular price{{/a}}.',
+				'All paid WordPress.com plans purchased for an annual term include one year of free domain registration. ' +
+					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br}}{{br}}' +
+					'This offer is redeemable one time only, and does not apply to plan upgrades, renewals, or premium domains.',
 				{
 					components: {
 						a: (
@@ -276,6 +276,7 @@ export const FEATURES_LIST = {
 								rel="noopener noreferrer"
 							/>
 						),
+						br: <br />,
 					},
 				}
 			),
@@ -448,9 +449,9 @@ export const FEATURES_LIST = {
 			}
 
 			return i18n.translate(
-				'Get a free domain for one year. ' +
-					'Doesn’t apply to plan upgrades, renewals, or to premium domains. ' +
-					'After one year, domain renews at its {{a}}regular price{{/a}}.',
+				'All paid WordPress.com plans purchased for an annual term include one year of free domain registration. ' +
+					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br /}}{{br /}}' +
+					'This offer is redeemable one time only, and does not apply to plan upgrades, renewals, or premium domains.',
 				{
 					components: {
 						a: (
@@ -460,6 +461,7 @@ export const FEATURES_LIST = {
 								rel="noopener noreferrer"
 							/>
 						),
+						br: <br />,
 					},
 				}
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -73,7 +73,6 @@ import {
 	isWpComEcommercePlan,
 	isWpComBusinessPlan,
 	getPlanClass,
-	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
@@ -1032,18 +1031,6 @@ const ConnectedPlanFeatures = connect(
 				if ( ! isLoggedInMonthlyPricing && ( ! isInSignup || isPlaceholder ) ) {
 					planFeatures = planFeatures.filter(
 						( { availableForCurrentPlan = true } ) => availableForCurrentPlan
-					);
-				}
-
-				// Strip the "Free domain for one year" feature out for the site's /plans page
-				// if the user is already on a paid annual plan
-				if (
-					isPaid &&
-					! isMonthly( sitePlan?.product_slug ) &&
-					( ! isInSignup || isPlaceholder )
-				) {
-					planFeatures = planFeatures.filter(
-						( feature ) => FEATURE_CUSTOM_DOMAIN !== feature.getSlug()
 					);
 				}
 

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -30,8 +30,8 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Do you sell domains?' ) }
 				answer={ translate(
-					'Yes! The Personal, Premium, Business, and eCommerce plans include a free custom domain for one year. That includes new' +
-						' domains purchased through WordPress.com or your own existing domain that you can map' +
+					'Yes! Annual and biannual Personal, Premium, Business, and eCommerce plans include a free custom domain for one year. ' +
+						'That includes new domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. Does not apply to premium domains. Domain name should be' +
 						' registered within one year of the purchase of the plan to use this promotion. Registered' +
 						' domain names will renew at regular prices. {{a}}Find out more about domains.{{/a}}',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* This PR restore the Free Domain line item to the /plans page.
* This reverts the change introduced in #52015, which was made because there was customer confusion during upgrades. Some customers expected to get _another_ free year when they upgraded.
* The tooltip states the following:

"Get a free domain for one year. Doesn’t apply to plan upgrades, renewals, or to premium domains. After one year, domain renews at its regular price."

Here's a screenshot with the tooltip expanded:
<img width="1115" alt="CleanShot 2021-07-15 at 15 33 21@2x" src="https://user-images.githubusercontent.com/35781181/125846886-1174c43a-2b7a-47e5-9bc8-9ebbcb56a1ce.png">


#### Testing instructions
* Checkout this PR and navigate to `http://calypso.localhost:3000/plans/SITESLUG`.
* Confirm that the pricing table displays the domain policy.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52015
