### PR TITLE
Activity Log: Extract stream content rendering into its own component

### DIFF
--- a/client/components/activity-card/activity-card-streams-media-preview.tsx
+++ b/client/components/activity-card/activity-card-streams-media-preview.tsx
@@ -1,26 +1,13 @@
 /**
  * External dependencies
  */
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import React, { FunctionComponent } from 'react';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
-
-// FUTURE WORK: universal typings location
-// FUTURE WORK: investigate shape of this object
-// FUTURE WORK: type this as soon as it comes back from the API
-interface Activity {
-	activityMedia?: {
-		available: boolean;
-		medium_url: string;
-		type: 'Image' | string;
-		name: string;
-		url: string;
-		thumbnail_url: string;
-	};
-}
+import type { Activity } from './types';
 
 interface Props {
 	streams: Activity[];

--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -33,6 +33,7 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import StreamsMediaPreview from './activity-card-streams-media-preview';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import ShareActivity from './share-activity';
+import StreamsContent from './streams-content';
 
 /**
  * Style dependencies
@@ -97,56 +98,6 @@ class ActivityCard extends Component {
 
 		return () => {};
 	};
-
-	renderStreams( streams = [] ) {
-		const { applySiteOffset, allowRestore, moment, siteSlug, siteId, translate } = this.props;
-
-		return streams.map( ( item, index ) => {
-			const activityMedia = item.activityMedia;
-
-			if ( activityMedia && activityMedia.available ) {
-				return (
-					<div
-						key={ `activity-card__streams-item-${ index }` }
-						className="activity-card__streams-item"
-					>
-						<div className="activity-card__streams-item-title">{ activityMedia.name }</div>
-						<ActivityMedia
-							name={ activityMedia.name }
-							fullImage={ activityMedia.medium_url || activityMedia.thumbnail_url }
-						/>
-					</div>
-				);
-			}
-			return (
-				<ActivityCard
-					activity={ item }
-					allowRestore={ allowRestore }
-					applySiteOffset={ applySiteOffset }
-					key={ item.activityId }
-					moment={ moment }
-					siteSlug={ siteSlug }
-					siteId={ siteId }
-					summarize
-					translate={ translate }
-				/>
-			);
-		} );
-	}
-
-	renderActivityContent() {
-		const { activity } = this.props;
-
-		//todo: add the rest of the cases for expandable content (daily backup,...)
-		return (
-			<div className="activity-card__content">
-				{ !! activity.streams && [
-					...this.renderStreams( activity.streams ),
-					this.renderBottomToolbar(),
-				] }
-			</div>
-		);
-	}
 
 	renderExpandContentControl() {
 		const { translate } = this.props;
@@ -315,7 +266,7 @@ class ActivityCard extends Component {
 		const backupTimeDisplay = applySiteOffset
 			? applySiteOffset( activity.activityTs ).format( 'LT' )
 			: '';
-		const showActivityContent = this.state.showContent;
+		const showStreamsContent = this.state.showContent && activity.streams;
 		const hasActivityFailed = activity.activityStatus === 'error';
 
 		return (
@@ -351,7 +302,12 @@ class ActivityCard extends Component {
 
 					{ ! summarize && this.renderTopToolbar() }
 
-					{ showActivityContent && this.renderActivityContent() }
+					{ showStreamsContent && (
+						<div className="activity-card__content">
+							<StreamsContent streams={ activity.streams } />
+							{ this.renderBottomToolbar() }
+						</div>
+					) }
 				</Card>
 			</div>
 		);
@@ -376,7 +332,9 @@ const mapDispatchToProps = {
 	dispatchRecordTracksEvent: recordTracksEvent,
 };
 
-export default connect(
+const ConnectedActivityCard = connect(
 	mapStateToProps,
 	mapDispatchToProps
 )( withLocalizedMoment( withApplySiteOffset( localize( ActivityCard ) ) ) );
+
+export default ConnectedActivityCard;

--- a/client/components/activity-card/streams-content.tsx
+++ b/client/components/activity-card/streams-content.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ActivityCard from '.';
+import ActivityMedia from './activity-media';
+
+/**
+ * Type dependencies
+ */
+import { Activity } from './types';
+
+type OwnProps = {
+	streams: Activity[];
+};
+
+const StreamsContentItem: React.FC< { stream: Activity } > = ( { stream } ) => {
+	const { activityMedia } = stream;
+
+	if ( activityMedia?.available ) {
+		return (
+			<div className="activity-card__streams-item">
+				<div className="activity-card__streams-item-title">{ activityMedia.name }</div>
+				<ActivityMedia
+					name={ activityMedia.name }
+					fullImage={ activityMedia.medium_url || activityMedia.thumbnail_url }
+				/>
+			</div>
+		);
+	}
+
+	return <ActivityCard summarize activity={ stream } />;
+};
+
+const StreamsContent: React.FC< OwnProps > = ( { streams } ) => (
+	<>
+		{ streams.map( ( item, index ) => (
+			<StreamsContentItem key={ `activity-card__streams-item-${ index }` } stream={ item } />
+		) ) }
+	</>
+);
+
+export default StreamsContent;

--- a/client/components/activity-card/types.d.ts
+++ b/client/components/activity-card/types.d.ts
@@ -1,0 +1,14 @@
+// FUTURE WORK: universal typings location
+// FUTURE WORK: investigate shape of this object
+// FUTURE WORK: type this as soon as it comes back from the API
+export interface Activity {
+	streams?: Activity[];
+	activityMedia?: {
+		available: boolean;
+		medium_url: string;
+		type: 'Image' | string;
+		name: string;
+		url: string;
+		thumbnail_url: string;
+	};
+}


### PR DESCRIPTION
Part of a continued personal effort to make `ActivityCard` a little more modular and (eventually) functional instead of class-based.

#### Changes proposed in this Pull Request

* Extract the `Activity` type into a new `types.d.ts` file inside the scope of the `ActivityCard` set of components.
* Create a new `StreamsContent` component to handle displaying activity content for events with attached streams.
* Remove the existing `renderActivityContent` and `renderStreams` methods in `ActivityCard`, replacing them with a call to render `StreamsContent`.

#### Testing instructions

**Prerequisites:** Create or gain access to a site with stream content in its Activity Log and/or Backup pages.

* In any Calypso experience, select your site and navigate to the Activity Log.
* Verify that for activity items with attached stream events, the expand/collapse toggle (both at the top and bottom when expanded), content display, and (if applicable) media preview all function exactly as they do in production. Behavior and appearance should be identical.

#### Reference screenshots

<img width="757" alt="image" src="https://user-images.githubusercontent.com/670067/125852689-fc0cfca5-7609-4523-b4e1-768a2793011f.png">

<img width="729" alt="image" src="https://user-images.githubusercontent.com/670067/125852772-46529c69-ad33-441f-8223-bc479dab0eaa.png">

<img width="698" alt="image" src="https://user-images.githubusercontent.com/670067/125852835-b6275631-b4df-4516-99e4-8f5ed808eca7.png">