### PR TITLE
Add Siteless Checkout "Thank you completed" page w/ redirect

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import React, { FC } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { Card } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	isProductsListFetching as getIsProductListFetching,
+	getProductName,
+} from 'calypso/state/products-list/selectors';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	productSlug: string | 'no_product';
+}
+
+const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const hasProductInfo = productSlug !== 'no_product';
+
+	const productName = useSelector( ( state ) =>
+		hasProductInfo ? getProductName( state, productSlug ) : null
+	) as string | null;
+
+	const isProductListFetching = useSelector( ( state ) =>
+		getIsProductListFetching( state )
+	) as boolean;
+
+	const contactSupportLink = 'https://jetpack.com/support/getting-started-with-jetpack/';
+
+	return (
+		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">
+			<PageViewTracker
+				path="/pricing/jetpack-free/welcome"
+				title="Pricing > Jetpack Free > Welcome to Jetpack"
+			/>
+			<Card className="jetpack-checkout-siteless-thank-you-completed__card">
+				<div className="jetpack-checkout-siteless-thank-you-completed__card-main">
+					<JetpackLogo size={ 45 } />
+					<h1
+						className={
+							isProductListFetching
+								? 'jetpack-checkout-siteless-thank-you-completed__main-message-loading'
+								: 'jetpack-checkout-siteless-thank-you-completed__main-message'
+						}
+					>
+						{ translate( 'Your %(productName)s subscription will be activated soon', {
+							args: {
+								productName,
+							},
+						} ) }
+					</h1>
+					<p>
+						{ translate(
+							'As soon as your subscription is activated you will receive a confirmation email from our Happiness Engineers.'
+						) }
+					</p>
+					<p>
+						{ translate( '{{a}}Contact us{{/a}} at any time if you need assistance with Jetpack.', {
+							components: {
+								a: (
+									<a
+										className="jetpack-checkout-siteless-thank-you-completed__link"
+										onClick={ () =>
+											dispatch(
+												recordTracksEvent(
+													'calypso_siteless_checkout_completed_support_link_clicked',
+													{
+														product_slug: productSlug,
+													}
+												)
+											)
+										}
+										href={ contactSupportLink }
+									/>
+								),
+							},
+						} ) }
+					</p>
+				</div>
+			</Card>
+		</Main>
+	);
+};
+
+export default JetpackCheckoutSitelessThankYouCompleted;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -41,13 +41,14 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } 
 		getIsProductListFetching( state )
 	) as boolean;
 
-	const contactSupportLink = 'https://jetpack.com/support/getting-started-with-jetpack/';
+	const contactSupportLink = 'https://wordpress.com/help/contact';
 
 	return (
 		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">
 			<PageViewTracker
-				path="/pricing/jetpack-free/welcome"
-				title="Pricing > Jetpack Free > Welcome to Jetpack"
+				path="/checkout/jetpack/thank-you-completed/no-site/:product"
+				title="Checkout > Jetpack Siteless Thank You Completed"
+				properties={ { product_slug: productSlug } }
 			/>
 			<Card className="jetpack-checkout-siteless-thank-you-completed__card">
 				<div className="jetpack-checkout-siteless-thank-you-completed__card-main">

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -35,11 +35,9 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } 
 
 	const productName = useSelector( ( state ) =>
 		hasProductInfo ? getProductName( state, productSlug ) : null
-	) as string | null;
+	);
 
-	const isProductListFetching = useSelector( ( state ) =>
-		getIsProductListFetching( state )
-	) as boolean;
+	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
 
 	const contactSupportLink = 'https://wordpress.com/help/contact';
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -41,11 +41,9 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 
 	const productName = useSelector( ( state ) =>
 		hasProductInfo ? getProductName( state, productSlug ) : null
-	) as string | null;
+	);
 
-	const isProductListFetching = useSelector( ( state ) =>
-		getIsProductListFetching( state )
-	) as boolean;
+	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
 
 	const supportTicketStatus = useSelector( ( state ) =>
 		getJetpackCheckoutSupportTicketStatus( state, receiptId )
@@ -79,7 +77,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 
 	useEffect( () => {
 		if ( supportTicketStatus && supportTicketStatus === 'success' ) {
-			page.redirect( `/checkout/jetpack/thank-you-completed/no-site/${ productSlug }` );
+			page( `/checkout/jetpack/thank-you-completed/no-site/${ productSlug }` );
 		}
 	}, [ supportTicketStatus, productSlug, receiptId ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -70,10 +70,10 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 				recordTracksEvent( 'calypso_siteless_checkout_submit_website_address', {
 					product_slug: productSlug,
 					site_url: siteUrl,
+					receipt_id: receiptId,
 				} )
 			);
 			dispatch( requestUpdateJetpackCheckoutSupportTicket( siteUrl, receiptId ) );
-			// On successful response redirect to schedule 15min Happiness support page? (Calendly?)
 		}
 	}, [ siteInput, dispatch, productSlug, receiptId ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -4,6 +4,7 @@
 import React, { FC, useState, useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import classNames from 'classnames';
 import { Card } from '@automattic/components';
 
@@ -78,10 +79,9 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 
 	useEffect( () => {
 		if ( supportTicketStatus && supportTicketStatus === 'success' ) {
-			// redirect to "Site submitted & email sent" UI page. /checkout/jetpack/thank-you-completed/:product_slug
-			console.log( 'Site URL was submitted sucessfully.' );
+			page.redirect( `/checkout/jetpack/thank-you-completed/no-site/${ productSlug }` );
 		}
-	}, [ supportTicketStatus, receiptId ] );
+	}, [ supportTicketStatus, productSlug, receiptId ] );
 
 	return (
 		<Main fullWidthLayout className="jetpack-checkout-siteless-thank-you">

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -675,6 +675,62 @@
 	}
 }
 
+.jetpack-checkout-siteless-thank-you-completed {
+	&.main.is-wide-layout {
+		max-width: 744px;
+	}
+	.jetpack-checkout-siteless-thank-you-completed__card {
+		padding: 0;
+		box-shadow: 0 0 40px 0 #00000014;
+
+		width: 100%;
+		max-width: none;
+
+		> div.jetpack-checkout-siteless-thank-you-completed__card-main {
+			box-sizing: border-box;
+			padding: 26px;
+			@include break-mobile {
+				padding: 76px;
+			}
+		}
+
+		.jetpack-logo {
+			margin-bottom: 48px;
+		}
+
+		h1 {
+			@include break-mobile {
+				font-size: $font-headline-medium;
+			}
+		}
+		p {
+			@include break-mobile {
+				font-size: 18px; /* stylelint-disable-line */
+				line-height: 1.75rem;
+			}
+		}
+
+		a.jetpack-checkout-siteless-thank-you-completed__link,
+		a.jetpack-checkout-siteless-thank-you-completed__feature-link {
+			text-decoration: underline;
+			color: var( --color-studio-black );
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.jetpack-checkout-siteless-thank-you-completed__main-message {
+			font-size: 2.25rem;
+			font-weight: 700;
+			margin-bottom: 24px;
+
+			@include break-mobile {
+				font-size: 3rem;
+			}
+		}
+	}
+}
+
 .jetpack-checkout-siteless-thank-you {
 	.jetpack-checkout-siteless-thank-you__card {
 		display: flex;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -677,7 +677,7 @@
 
 .jetpack-checkout-siteless-thank-you-completed {
 	&.main.is-wide-layout {
-		max-width: 744px;
+		max-width: 660px;
 	}
 	.jetpack-checkout-siteless-thank-you-completed__card {
 		padding: 0;
@@ -722,10 +722,11 @@
 		.jetpack-checkout-siteless-thank-you-completed__main-message {
 			font-size: 2.25rem;
 			font-weight: 700;
-			margin-bottom: 24px;
-
+			margin-bottom: 56px;
+			line-height: 1;
 			@include break-mobile {
 				font-size: 3rem;
+				line-height: 1.25;
 			}
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -728,6 +728,10 @@
 				font-size: 3rem;
 			}
 		}
+
+		.jetpack-checkout-siteless-thank-you-completed__main-messag-loading {
+			@include placeholder( --color-neutral-20 );
+		}
 	}
 }
 
@@ -845,6 +849,15 @@
 			.button.jetpack-checkout-siteless-thank-you__form-submit {
 				margin: 0;
 				&.is-primary {
+					&.is-busy {
+						background-image: linear-gradient(
+							-45deg,
+							var( --studio-jetpack-green-40 ) 28%,
+							var( --studio-jetpack-green-50 ) 28%,
+							var( --studio-jetpack-green-50 ) 72%,
+							var( --studio-jetpack-green-40 ) 72%
+						);
+					}
 					background-color: var( --studio-jetpack-green-50 );
 					border-color: var( --studio-jetpack-green-50 );
 					&:hover {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -772,7 +772,6 @@
 		.jetpack-checkout-siteless-thank-you__form-group {
 			display: flex;
 			flex-direction: column;
-			padding-bottom: 1.5em;
 			@include break-mobile {
 				display: flex;
 				flex-direction: row;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -726,7 +726,6 @@
 			line-height: 1;
 			@include break-mobile {
 				font-size: 3rem;
-				line-height: 1.25;
 			}
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -730,7 +730,7 @@
 			}
 		}
 
-		.jetpack-checkout-siteless-thank-you-completed__main-messag-loading {
+		.jetpack-checkout-siteless-thank-you-completed__main-message-loading {
 			@include placeholder( --color-neutral-20 );
 		}
 	}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -25,6 +25,7 @@ import CheckoutPendingComponent from './checkout-thank-you/pending';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
 import JetpackCheckoutSitelessThankYou from './checkout-thank-you/jetpack-checkout-siteless-thank-you';
 import JetpackCheckoutScheduleAppointment from './checkout-thank-you/jetpack-checkout-schedule-appointment';
+import JetpackCheckoutSitelessThankYouCompleted from './checkout-thank-you/jetpack-checkout-siteless-thank-you-completed';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
@@ -299,6 +300,18 @@ export function jetpackCheckoutThankYou( context, next ) {
 			site={ context.params.site }
 			productSlug={ context.params.product }
 			isUserlessCheckoutFlow={ isUserlessCheckoutFlow }
+		/>
+	);
+
+	next();
+}
+
+export function jetpackCheckoutThankYouCompleted( context, next ) {
+	const { receiptId } = context.query;
+	context.primary = (
+		<JetpackCheckoutSitelessThankYouCompleted
+			productSlug={ context.params.product }
+			receiptId={ receiptId }
 		/>
 	);
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -13,6 +13,7 @@ import {
 	checkoutThankYou,
 	jetpackCheckoutScheduleAppointment,
 	jetpackCheckoutThankYou,
+	jetpackCheckoutThankYouCompleted,
 	redirectJetpackLegacyPlans,
 	redirectToSupportSession,
 	upsellNudge,
@@ -37,6 +38,13 @@ export default function () {
 		);
 
 		page( '/checkout/jetpack/:productSlug', noSite, checkoutSiteless, makeLayout, clientRender );
+		page(
+			'/checkout/jetpack/thank-you-completed/no-site/:product',
+			noSite,
+			jetpackCheckoutThankYouCompleted,
+			makeLayout,
+			clientRender
+		);
 		page(
 			'/checkout/jetpack/thank-you/no-site/:product',
 			noSite,

--- a/client/state/products-list/selectors/is-products-list-fetching.js
+++ b/client/state/products-list/selectors/is-products-list-fetching.js
@@ -3,6 +3,12 @@
  */
 import 'calypso/state/products-list/init';
 
+/**
+ * Are we currently fetching the products list?.
+ *
+ * @param {object} state - Global state tree
+ * @returns {boolean} - True if the product list is currently fetching, false otherwise.
+ */
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
 }

--- a/client/state/selectors/get-jetpack-checkout-support-ticket-status.ts
+++ b/client/state/selectors/get-jetpack-checkout-support-ticket-status.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import 'calypso/state/data-layer/wpcom/jetpack-checkout/support-ticket';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the response status of the post-purchase Zendesk ticket.
+ * Returns false if the receipt ID is unknown, or there is no information yet.
+ *
+ * @param  {object}    state       Global state tree
+ * @param  {number}    receiptId   The ID of the receipt link to the Zendesk support ticket
+ * @returns {string}	           The response status, will be 'pending', or 'success', or 'failed' or false
+ */
+export default function getJetpackCheckoutSupportTicketStatus(
+	state: AppState,
+	receiptId: number
+): string {
+	return state.jetpackCheckout?.requestStatus?.[ receiptId ];
+}

--- a/config/development.json
+++ b/config/development.json
@@ -93,7 +93,7 @@
 		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
-		"jetpack/siteless-checkout": true,
+		"jetpack/siteless-checkout": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Created a new `getJetpackCheckoutSupportTicketStatus` selector to retrieve the status of the "Submit site url" request.
* On the siteless checkout onboarding UI (siteless thank you page), I made the UI respond to the 'pending', 'completed', and 'failed' states when submitting the site url.
    - Disable submit button when request is 'pending'.
    - Make submit button "Busy" when request is 'pending'
    - Display error message below input field when request is 'failed'.
    - Redirect to the "Thank you completed" page when request is 'success'. - Redirect to: `/checkout/jetpack/thank-you-completed/no-site/:product_slug`
* Created route & controller for new "Thank you completed" page route (`/checkout/jetpack/thank-you-completed/no-site/:product_slug`)
* Created the `JetpackCheckoutSitelessThankYouCompleted` page component and SCSS styles.

Asana task: 1200479326344990-as-1200597353180730

#### Testing instructions

**To simply view the UI:**

1. Download this PR.
1. Edit the `config/development.json` file and enable the `jetpack/siteless-checkout` feature flag.
1. Start Calypso with `yarn start`. You need to do this since this PR introduces a new feature flag.
1. Go to http://calypso.localhost:3000/checkout/jetpack/thank-you-completed/no-site/jetpack_scan
1. Verify the page looks looks good, like the Figma mockup listed in the Asana task (linked above), and verify all the SCSS styles look ok for desktop and mobile views.

**To test the "Submit site URL" error behaviors & success redirect to the new UI:**

1. Patch your sandbox with D63168-code.
1. Patch your sandbox with D63915-code.
1. Sandbox `public-api.wordpress.com`.
1. Download this PR.
1. Edit the `config/development.json` file and enable the `jetpack/siteless-checkout` feature flag.
1. Start Calypso with `yarn start`. You need to do this since this PR introduces a new feature flag.
1. Complete the siteless checkout flow.
1. When you get to the Siteless Onboarding UI (the thank you page), enter a non-valid url (like a random string) into the input box and submit.
1. Verify the submit button has a "busy" state when submitting.
1. Verify you receive an error message underneath the input box.
1. Now submit a valid site url.
1. Verify that you are redirected to the new "Thank you completed" UI page.
1. Verify the page looks like the Figma mockup listed in the Asana task (linked above)

#### Screenshot:

<img width="792" alt="Screenshot on 2021-07-19 at 11-56-01" src="https://user-images.githubusercontent.com/11078128/126190101-eaffd51b-d55d-45b7-865f-28601b68c125.png">



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->