### PR TITLE
Jetpack Search: improve handling of missing Jetpack site

### DIFF
--- a/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
@@ -44,7 +44,7 @@ const JetpackDisconnectedWPCOM: FunctionComponent = () => {
 			<p>
 				{ preventWidows(
 					translate(
-						'Please visit {{siteUrl/}} to ensure your site loading correctly and reconnect Jetpack if necessary.',
+						'Please visit {{siteUrl/}} to ensure your site is loading correctly and reconnect Jetpack if necessary.',
 						{
 							components: {
 								siteUrl: <ExternalLink href={ siteUrl }>{ siteUrl }</ExternalLink>,

--- a/client/components/jetpack/jetpack-disconnected/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected/index.tsx
@@ -43,7 +43,7 @@ const JetpackDisconnected: FunctionComponent = () => {
 		<span className="jetpack-disconnected__paragraph" key="paragraph-2">
 			{ preventWidows(
 				translate(
-					'Please visit {{siteUrl/}} to ensure your site loading correctly and reconnect Jetpack if necessary.',
+					'Please visit {{siteUrl/}} to ensure your site is loading correctly and reconnect Jetpack if necessary.',
 					{
 						components: {
 							siteUrl: <ExternalLink href={ siteUrl }>{ siteUrl }</ExternalLink>,

--- a/client/my-sites/jetpack-search/main-jetpack.tsx
+++ b/client/my-sites/jetpack-search/main-jetpack.tsx
@@ -13,6 +13,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 	isFetchingUserPurchases,
 } from 'calypso/state/purchases/selectors';
+import JetpackSearchDisconnected from './disconnected';
 import JetpackSearchPlaceholder from './placeholder';
 import JetpackSearchUpsell from './upsell';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -40,16 +41,22 @@ export default function JetpackSearchMainJetpack( { siteId }: Props ): ReactElem
 	// Have we loaded the necessary purchases and modules? If not, show the placeholder.
 	const modules = useSelector( ( state ) => getJetpackModules( state, siteId ) );
 
-	const isRequestingModules =
-		useSelector( ( state ) => isFetchingJetpackModules( state, siteId ) ) || ! modules;
+	const isRequestingModules = useSelector( ( state ) => isFetchingJetpackModules( state, siteId ) );
 
 	// On Jetpack sites, we need to check if the search module is active, rather than checking settings.
 	const isJetpackSearchModuleActive = useSelector( ( state ) =>
 		isJetpackModuleActive( state, siteId, 'search' )
 	);
 
-	if ( isRequestingPurchases || isRequestingModules ) {
+	// isRequestingModules is null if a request hasn't been triggered yet
+	const isLoading = isRequestingPurchases || isRequestingModules || isRequestingModules === null;
+
+	if ( isLoading ) {
 		return <JetpackSearchPlaceholder siteId={ siteId } isJetpack={ true } />;
+	}
+
+	if ( ! isLoading && modules === null ) {
+		return <JetpackSearchDisconnected />;
 	}
 
 	if ( ! hasSearchProduct ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we show the page at `/jetpack-search` and we're working with a Jetpack site, we ask the site's API for a list of enabled modules. At the moment, if the API doesn't respond or there's an error, the loading placeholder just stays in place.

This PR checks to see if module loading has completed, and displays the 'disconnected' page if we can't reach the site's API.

#### Testing instructions

* Start Jetpack Cloud locally using `CALYPSO_ENV=jetpack-cloud-development yarn start`.
* Navigate to http://jetpack.cloud.localhost:3000/jetpack-search/.
* Choose a standard Jetpack site and make sure it displays the current search status.

<img width="761" alt="Screen Shot 2021-07-16 at 16 09 15" src="https://user-images.githubusercontent.com/17325/125890408-1e4627e9-5652-41a9-a6b4-e036d04dbdad.png">

* Choose a Jetpack site that's not currently contactable - like a local dev site on ngrok with the tunnel turned off - and make sure you get the 'disconnected' page after a few seconds.

<img width="798" alt="Screen Shot 2021-07-16 at 16 09 27" src="https://user-images.githubusercontent.com/17325/125890460-7ba625ea-c7e0-4123-a16a-e98a99ab0dca.png">

Part of https://github.com/Automattic/wp-calypso/issues/53689.