### PR TITLE
Block patterns: switch to user locale and allow all core/Gutenberg pattern operations

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -51,7 +51,11 @@ class Block_Patterns_From_API {
 	 * @param string                    $editor_type The current editor. One of `block_editor` (default), `site_editor`.
 	 * @param Block_Patterns_Utils|null $utils       A class dependency containing utils methods.
 	 */
-	public function __construct( string $editor_type = 'block_editor', Block_Patterns_Utils $utils = null ) {
+	public function __construct( $editor_type, Block_Patterns_Utils $utils = null ) {
+		if ( ! $editor_type || ! is_string( $editor_type ) ) {
+			$editor_type = 'block_editor';
+		}
+
 		$this->editor_type      = $editor_type;
 		$this->patterns_sources = array( 'block_patterns' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
@@ -82,8 +82,8 @@ class Block_Patterns_Utils {
 	 * @return string locale slug
 	 */
 	public function get_block_patterns_locale() {
-		// Make sure to get blog locale, not user locale.
-		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+		// Block patterns display in the user locale.
+		$language = get_user_locale();
 		return \A8C\FSE\Common\get_iso_639_locale( $language );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -111,16 +111,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	 *  Tests that we're making two requests when we specify that we're on the site editor.
 	 */
 	public function test_patterns_site_editor_source_site() {
-		/**
-		 * A callback for the `a8c_enable_fse_block_patterns_api` filter.
-		 *
-		 * @return bool
-		 */
-		$should_enable_fse_block_patterns_api = function () {
-			return true;
-		};
-
-		add_filter( 'a8c_enable_fse_block_patterns_api', $should_enable_fse_block_patterns_api );
+		add_filter( 'a8c_enable_fse_block_patterns_api', '__return_true' );
 
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Block_Patterns_From_API( 'site_editor', $utils_mock );
@@ -134,7 +125,7 @@ class Block_Patterns_From_Api_Test extends TestCase {
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 
-		remove_filter( 'a8c_enable_fse_block_patterns_api', $should_enable_fse_block_patterns_api );
+		remove_filter( 'a8c_enable_fse_block_patterns_api', '__return_true' );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -255,15 +255,14 @@ function load_block_patterns_from_api( $current_screen ) {
 		return;
 	}
 
-	$patterns_sources = array( 'block_patterns' );
+	$editor_type = 'block_editor';
 
-	// While we're still testing the FSE patterns, limit activation via a filter.
-	if ( $is_site_editor && apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
-		$patterns_sources[] = 'fse_block_patterns';
+	if ( $is_site_editor ) {
+		$editor_type = 'site_editor';
 	}
 
 	require_once __DIR__ . '/block-patterns/class-block-patterns-from-api.php';
-	$block_patterns_from_api = new Block_Patterns_From_API( $patterns_sources );
+	$block_patterns_from_api = new Block_Patterns_From_API( $editor_type );
 	$block_patterns_from_api->register_patterns();
 }
 add_action( 'current_screen', __NAMESPACE__ . '\load_block_patterns_from_api' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR:

- Change the locale to the user locale to make it consistent with core patterns
- Pass site/block editor string to Block_Patterns_From_API. Let's let the Block_Patterns_From_API class house the logic as to which patterns source to load.
- Remove all methods that register/unregister Gutenberg or core patterns. Instead we'll let Gutenberg do it's thing (See: https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php )
- Updated tests.


#### Testing instructions

- [ ] Turn on some relaxing background music.
- [ ] Apply this PR's changes to your sandbox: `install-plugin.sh editing-toolkit update/block-patterns-user-locale-and-allow-gutenberg-patterns` and sandbox a test site using a block theme e.g., TT1 Blocks
- [ ] Now fire up the block editor. 
- [ ] Check that the query blocks are appearing (Gutenberg registers these in [block-patterns.php](https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php))
<img width="150" alt="Screen Shot 2021-07-26 at 11 57 18 am" src="https://user-images.githubusercontent.com/6458278/126923123-d42178bc-fb80-40f7-9f59-c09fae6007d5.png">

- [ ] Check that other Gutenberg blocks are appearing. There's only one for now: `Social links with a shared background color`

<img width="150" alt="Screen Shot 2021-07-26 at 11 50 29 am" src="https://user-images.githubusercontent.com/6458278/126923142-dfc8c0e0-090a-4292-9199-aac37da4e47b.png">

- [ ] Check that Wordpress core patterns are being loaded from the [patterns directory](https://wordpress.org/patterns/categories/columns/?orderby=favorite_count) and **not** from [WordPress core itself](https://github.com/WordPress/WordPress/blob/master/wp-includes/block-patterns.php). (Gutenberg unregisters core patterns in [block-patterns.php](https://github.com/WordPress/gutenberg/blob/trunk/lib/block-patterns.php))

For example, here's one in the columns category:

<img width="150" alt="Screen Shot 2021-07-26 at 11 50 21 am" src="https://user-images.githubusercontent.com/6458278/126923143-f8357a97-b345-462b-9363-a6babef53af5.png">

Here's the source preview from the patterns directory

<img width="150" alt="Screen Shot 2021-07-26 at 11 51 04 am" src="https://user-images.githubusercontent.com/6458278/126923140-8774b04e-5646-4767-888b-20be5d113144.png">

- [ ] Check that WPCOM patterns are being loaded from [dotcom patterns](https://dotcompatterns.wordpress.com/2021/05/07/gallery/). Here's one in French!
<img width="150" alt="Screen Shot 2021-07-26 at 11 54 34 am" src="https://user-images.githubusercontent.com/6458278/126923132-3018aa2c-cde2-42b4-8a03-d81b0d93f363.png">

- [ ] Switch your **user language**. To test translations from the patterns directory, like many other things, it's best to go with Japanese. Make sure the patterns are coming through translated.

<img width="150" alt="Screen Shot 2021-07-26 at 11 56 50 am" src="https://user-images.githubusercontent.com/6458278/126923131-fde3c8b1-9dbb-4584-b39c-1be6ae9b8e83.png">

<img width="150" alt="Screen Shot 2021-07-26 at 11 52 12 am" src="https://user-images.githubusercontent.com/6458278/126923139-c66c8b45-5fdf-4d19-a99b-c30fbacce33c.png">

- [ ] Head over to the site editor. Ensure that things work in the same way.
- [ ] Run unit tests

```bash
cd apps/editing-toolkit
yarn run test:php --testsuite block-patterns
```

- [ ] Congratulate yourself on a job well done!



Related to https://github.com/Automattic/wp-calypso/pull/53243
