### PR TITLE
<DotPager> component supports reduced motion a11y setting

### DIFF
--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/mixins';
+
 .dot-pager__pages {
 	overflow: hidden;
 	display: flex;
@@ -8,6 +10,7 @@
 	flex-shrink: 0;
 	margin-left: 0;
 	transition: all 0.5s ease-in-out;
+	@include reduce-motion( 'transition' );
 	opacity: 1;
 
 	&.is-prev,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* <DotPager> component supports reduced motion a11y setting

Reduced motion is an important a11y media query and allows users who are disoriented/nauseated by animations to opt-out.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The controls isn't used anywhere on `trunk`, but you can test in the devdocs: `http://calypso.localhost:3000/devdocs/design/dot-pager`
* Toggle your computer's reduce motion settings and test the pager (on macOS settings are in `System Preferences > Accessibility > Display > Display > Reduce motion`

Here's what it looks like when applied to the new pager on My Home:

https://user-images.githubusercontent.com/1500769/125897271-d170d571-b528-4d56-8521-2ca386b204b1.mov



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

