### PR TITLE
chore: Refactor `packages/plans-grid` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -201,6 +201,7 @@ module.exports = {
 				'packages/js-utils/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
+				'packages/plans-grid/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
 				'packages/wpcom-checkout/**/*',

--- a/packages/plans-grid/src/badge/index.tsx
+++ b/packages/plans-grid/src/badge/index.tsx
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import classNames from 'classnames';
+import * as React from 'react';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/hooks/use-supported-plans.ts
+++ b/packages/plans-grid/src/hooks/use-supported-plans.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { useSelect } from '@wordpress/data';
-import type { Plans } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
 import { PLANS_STORE } from '../stores';
+import type { Plans } from '@automattic/data-stores';
 
 export const useSupportedPlans = (
 	locale: string,

--- a/packages/plans-grid/src/index.ts
+++ b/packages/plans-grid/src/index.ts
@@ -1,5 +1,2 @@
-/**
- * Internal dependencies
- */
 export { default } from './plans-grid';
 export type { Props } from './plans-grid';

--- a/packages/plans-grid/src/plans-accordion-item/index.tsx
+++ b/packages/plans-grid/src/plans-accordion-item/index.tsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
-import { useI18n } from '@wordpress/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
-import { sprintf } from '@wordpress/i18n';
 import { NextButton } from '@automattic/onboarding';
-import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import React from 'react';
 import PlansFeatureList from '../plans-feature-list';
 import { PLANS_STORE } from '../stores';
+import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/plans-accordion-item/plans-item-placeholder.tsx
+++ b/packages/plans-grid/src/plans-accordion-item/plans-item-placeholder.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
 import { NextButton } from '@automattic/onboarding';
-
-/**
- * Internal dependencies
- */
+import classNames from 'classnames';
+import React from 'react';
 import PlansFeatureListPlaceholder from '../plans-feature-list/plans-feature-list-placeholder';
 
 /**

--- a/packages/plans-grid/src/plans-accordion/index.tsx
+++ b/packages/plans-grid/src/plans-accordion/index.tsx
@@ -1,23 +1,14 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-import { useSelect } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
 import { Button, SVG, Path } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
-
-import type { DomainSuggestions, Plans, WPCOMFeatures } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
+import { useI18n } from '@wordpress/react-i18n';
+import React, { useState } from 'react';
+import { useSupportedPlans } from '../hooks';
 import PlanItem from '../plans-accordion-item';
 import PlanItemPlaceholder from '../plans-accordion-item/plans-item-placeholder';
 import { PLANS_STORE, WPCOM_FEATURES_STORE } from '../stores';
-import { useSupportedPlans } from '../hooks';
-
 import type { DisabledPlansMap } from '../plans-table/types';
+import type { DomainSuggestions, Plans, WPCOMFeatures } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
-import { useI18n } from '@wordpress/react-i18n';
-import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { Icon, check, close } from '@wordpress/icons';
-import type { Plans } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import React from 'react';
 import { PLANS_STORE } from '../stores';
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/plans-feature-list/index.tsx
+++ b/packages/plans-grid/src/plans-feature-list/index.tsx
@@ -1,17 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
-import { createInterpolateElement } from '@wordpress/element';
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { Icon, check, close } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import React from 'react';
 import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 
-/**
- * Internal dependencies
- */
 import '../types-patch';
 
 /**

--- a/packages/plans-grid/src/plans-feature-list/plans-feature-list-placeholder.tsx
+++ b/packages/plans-grid/src/plans-feature-list/plans-feature-list-placeholder.tsx
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classnames from 'classnames';
+import React from 'react';
 
-/**
- * Internal dependencies
- */
 import '../types-patch';
 
 /**

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -1,28 +1,21 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
+import { Title } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import type { DomainSuggestions, WPCOMFeatures, Plans } from '@automattic/data-stores';
-import { Title } from '@automattic/onboarding';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import PlansTable from '../plans-table';
+import * as React from 'react';
+import { useSupportedPlans } from '../hooks';
 import PlansAccordion from '../plans-accordion';
 import PlansDetails from '../plans-details';
+import PlansIntervalToggle from '../plans-interval-toggle';
+import PlansTable from '../plans-table';
+import { PLANS_STORE } from '../stores';
 import type {
 	CTAVariation,
 	CustomTagLinesMap,
 	DisabledPlansMap,
 	PopularBadgeVariation,
 } from '../plans-table/types';
-import PlansIntervalToggle from '../plans-interval-toggle';
-import { useSupportedPlans } from '../hooks';
-import { PLANS_STORE } from '../stores';
+import type { DomainSuggestions, WPCOMFeatures, Plans } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
-import { useI18n } from '@wordpress/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
-import { sprintf } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import type { Plans } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
+import * as React from 'react';
 import SegmentedControl from '../segmented-control';
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/plans-table/index.tsx
+++ b/packages/plans-grid/src/plans-table/index.tsx
@@ -1,24 +1,15 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
 import { useSelect } from '@wordpress/data';
-
-import type { DomainSuggestions, Plans } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
-import PlanItem from './plan-item';
+import React, { useState } from 'react';
 import { useSupportedPlans } from '../hooks';
 import { PLANS_STORE } from '../stores';
-
+import PlanItem from './plan-item';
 import type {
 	CTAVariation,
 	PopularBadgeVariation,
 	CustomTagLinesMap,
 	DisabledPlansMap,
 } from './types';
+import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -1,25 +1,16 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
-import classNames from 'classnames';
+import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
-import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
+import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-
-import type { DomainSuggestions, Plans } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import * as React from 'react';
 import PlansFeatureList from '../plans-feature-list';
 import { PLANS_STORE } from '../stores';
-
 import type { CTAVariation, PopularBadgeVariation } from './types';
+import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 
 // TODO: remove when all needed core types are available
 /*#__PURE__*/ import '../types-patch';

--- a/packages/plans-grid/src/plans-table/types.ts
+++ b/packages/plans-grid/src/plans-table/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { Plans } from '@automattic/data-stores';
 
 export type CTAVariation = 'FULL_WIDTH' | 'NORMAL';

--- a/packages/plans-grid/src/segmented-control/index.d.ts
+++ b/packages/plans-grid/src/segmented-control/index.d.ts
@@ -1,8 +1,5 @@
 // Basic TypeScript types to make SegmentedControl work in the <PlansIntervalToggle> component
 
-/**
- * External dependencies
- */
 import * as React from 'react';
 
 interface SegmentedControlProps {

--- a/packages/plans-grid/src/segmented-control/index.jsx
+++ b/packages/plans-grid/src/segmented-control/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import SegmentedControlItem from './item';
 
 /**

--- a/packages/plans-grid/src/segmented-control/item.jsx
+++ b/packages/plans-grid/src/segmented-control/item.jsx
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 
 class SegmentedControlItem extends React.Component {
 	static propTypes = {

--- a/packages/plans-grid/src/segmented-control/simplified.jsx
+++ b/packages/plans-grid/src/segmented-control/simplified.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React, { useState } from 'react';
 import SegmentedControl from '.';
 
 const noop = () => {};

--- a/packages/plans-grid/src/stores.ts
+++ b/packages/plans-grid/src/stores.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Plans, WPCOMFeatures } from '@automattic/data-stores';
 
 export const PLANS_STORE = Plans.register();


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/plans-grid` to use `import/order`

#### Testing instructions

N/A