### PR TITLE
chore: Migrate `packages/domain-picker` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,6 +198,7 @@ module.exports = {
 				'packages/composite-checkout/**/*',
 				'packages/create-calypso-config/**/*',
 				'packages/data-stores/**/*',
+				'packages/domain-picker/**/*',
 				'packages/js-utils/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',

--- a/packages/domain-picker/src/__mocks__/suggestions.ts
+++ b/packages/domain-picker/src/__mocks__/suggestions.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { DomainSuggestion } from '@automattic/data-stores/src/domain-suggestions';
 
 export const MOCK_DOMAIN_SUGGESTION: DomainSuggestion = {

--- a/packages/domain-picker/src/__tests__/search-and-select-domain-suggestion.tsx
+++ b/packages/domain-picker/src/__tests__/search-and-select-domain-suggestion.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
-import { screen, render, fireEvent } from '@testing-library/react';
 import { DataStatus } from '@automattic/data-stores/src/domain-suggestions';
-
-/**
- * Internal dependencies
- */
+import { screen, render, fireEvent } from '@testing-library/react';
+import * as React from 'react';
 import '../__mocks__/matchMedia.mock';
 import { MOCK_DOMAIN_SUGGESTION } from '../__mocks__';
 import DomainPicker from '../components';

--- a/packages/domain-picker/src/components/domain-categories/index.tsx
+++ b/packages/domain-picker/src/components/domain-categories/index.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import { Button } from '@wordpress/components';
-import { Icon, chevronDown } from '@wordpress/icons';
-import classNames from 'classnames';
-import { useI18n } from '@wordpress/react-i18n';
-import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { useState } from '@wordpress/element';
+import { Icon, chevronDown } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import * as React from 'react';
 import { DOMAIN_SUGGESTIONS_STORE } from '../../constants';
 
 /**

--- a/packages/domain-picker/src/components/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/components/domain-name-explanation/index.tsx
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
+import React, { FunctionComponent } from 'react';
 
 export const DomainNameExplanationImage: FunctionComponent = () => {
 	const { __, isRTL } = useI18n();

--- a/packages/domain-picker/src/components/domain-suggestion-item/__mocks__/index.ts
+++ b/packages/domain-picker/src/components/domain-suggestion-item/__mocks__/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { MOCK_DOMAIN_SUGGESTION } from '../../../__mocks__/suggestions';
 
 export const MOCK_SUGGESTION_ITEM_PARTIAL_PROPS = {

--- a/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
+import * as React from 'react';
+import { MOCK_SUGGESTION_ITEM_PARTIAL_PROPS } from '../__mocks__';
+import SuggestionItem from '../suggestion-item';
 import type { RenderResult } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
 // https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 import '../../../__mocks__/matchMedia.mock';
-
-import SuggestionItem from '../suggestion-item';
-import { MOCK_SUGGESTION_ITEM_PARTIAL_PROPS } from '../__mocks__';
 
 const renderComponent = ( props = {} ): RenderResult =>
 	render( <SuggestionItem { ...MOCK_SUGGESTION_ITEM_PARTIAL_PROPS } { ...props } /> );

--- a/packages/domain-picker/src/components/domain-suggestion-item/__tests__/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/__tests__/use-your-domain-item.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
+import * as React from 'react';
 import UseYourDomainItem from '../use-your-domain-item';
 
 describe( '<UseYourDomainItem />', () => {

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item-placeholder.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item-placeholder.tsx
@@ -1,9 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import React, { FunctionComponent } from 'react';
+
 import classnames from 'classnames';
+import React, { FunctionComponent } from 'react';
 import type { SUGGESTION_ITEM_TYPE } from './suggestion-item';
 
 const DomainPickerSuggestionItemPlaceholder: FunctionComponent< {

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item-wrapper.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item-wrapper.tsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import * as React from 'react';
-
-/**
- * Internal dependencies
- */
 import { SUGGESTION_ITEM_TYPE_BUTTON } from './suggestion-item';
-
 import type { SUGGESTION_ITEM_TYPE } from './suggestion-item';
 
 // to avoid nesting buttons, wrap the item with a div instead of button in button mode

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
@@ -1,26 +1,14 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-/**
- * External dependencies
- */
-import * as React from 'react';
-import classnames from 'classnames';
-import { useI18n } from '@wordpress/react-i18n';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
-
-/**
- * Wordpress dependencies
- */
-import { createInterpolateElement } from '@wordpress/element';
 import { Spinner, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import * as React from 'react';
 import InfoTooltip from '../info-tooltip';
 import WrappingComponent from './suggestion-item-wrapper';
 // TODO: remove when all needed core types are available

--- a/packages/domain-picker/src/components/domain-suggestion-item/use-your-domain-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/use-your-domain-item.tsx
@@ -1,14 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import * as React from 'react';
+
 import { ArrowButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import * as React from 'react';
 import WrappingComponent from './suggestion-item-wrapper';
 
 interface Props {

--- a/packages/domain-picker/src/components/index.tsx
+++ b/packages/domain-picker/src/components/index.tsx
@@ -1,19 +1,25 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import React, { FunctionComponent, useState, useEffect, Fragment } from 'react';
-import { times } from 'lodash';
-import { Button, TextControl, Notice } from '@wordpress/components';
-import { Icon, search } from '@wordpress/icons';
+
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
+import { Button, TextControl, Notice } from '@wordpress/components';
+import { Icon, search } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import type { DomainSuggestions } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
+import { times } from 'lodash';
+import React, { FunctionComponent, useState, useEffect, Fragment } from 'react';
+import {
+	DOMAIN_SUGGESTIONS_TO_SHOW,
+	DOMAIN_SUGGESTIONS_TO_SHOW_EXPANDED,
+	domainIsAvailableStatus,
+} from '../constants';
+import {
+	useDomainSuggestions,
+	useDomainAvailabilities,
+	usePersistentSelectedDomain,
+} from '../hooks';
+import { getDomainSuggestionsVendor } from '../utils';
+import DomainCategories from './domain-categories';
+import { DomainNameExplanationImage } from './domain-name-explanation';
 import {
 	DomainSuggestionItem,
 	DomainSuggestionItemUseYourDomain,
@@ -21,19 +27,7 @@ import {
 	SUGGESTION_ITEM_TYPE_RADIO,
 	SUGGESTION_ITEM_TYPE,
 } from './domain-suggestion-item';
-import DomainCategories from './domain-categories';
-import { DomainNameExplanationImage } from './domain-name-explanation';
-import {
-	useDomainSuggestions,
-	useDomainAvailabilities,
-	usePersistentSelectedDomain,
-} from '../hooks';
-import { getDomainSuggestionsVendor } from '../utils';
-import {
-	DOMAIN_SUGGESTIONS_TO_SHOW,
-	DOMAIN_SUGGESTIONS_TO_SHOW_EXPANDED,
-	domainIsAvailableStatus,
-} from '../constants';
+import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Style dependencies

--- a/packages/domain-picker/src/components/info-tooltip/index.tsx
+++ b/packages/domain-picker/src/components/info-tooltip/index.tsx
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent, useState } from 'react';
-import classnames from 'classnames';
 import { Popover, Button } from '@wordpress/components';
 import { info } from '@wordpress/icons';
+import classnames from 'classnames';
+import React, { FunctionComponent, useState } from 'react';
 
 /**
  * Style dependencies

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { DomainSuggestions } from '@automattic/data-stores';
 
 export const DOMAIN_SUGGESTIONS_TO_SHOW = 5;

--- a/packages/domain-picker/src/hooks/use-domain-availabilities.ts
+++ b/packages/domain-picker/src/hooks/use-domain-availabilities.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import { DOMAIN_SUGGESTIONS_STORE } from '../constants';
 
 export function useDomainAvailabilities() {

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import { useSelect, useDispatch } from '@wordpress/data';
-import type { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
-import type { DomainSuggestion } from '@automattic/data-stores/src/domain-suggestions/types';
 import { useDebounce } from 'use-debounce';
-
-/**
- * Internal dependencies
- */
 import {
 	DOMAIN_SUGGESTIONS_STORE,
 	DOMAIN_SEARCH_DEBOUNCE_INTERVAL,
 	DOMAIN_QUERY_MINIMUM_LENGTH,
 } from '../constants';
+import type { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
+import type { DomainSuggestion } from '@automattic/data-stores/src/domain-suggestions/types';
 
 type DomainSuggestionsResult = {
 	allDomainSuggestions: DomainSuggestion[] | undefined;

--- a/packages/domain-picker/src/hooks/use-persistent-selected-domain.ts
+++ b/packages/domain-picker/src/hooks/use-persistent-selected-domain.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import * as React from 'react';
 import type { DomainSuggestions } from '@automattic/data-stores';
 

--- a/packages/domain-picker/src/index.tsx
+++ b/packages/domain-picker/src/index.tsx
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 export { default } from './components';
 export type { Props } from './components';
 

--- a/packages/domain-picker/src/utils/__tests__/is-good-default-domain-query.ts
+++ b/packages/domain-picker/src/utils/__tests__/is-good-default-domain-query.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isGoodDefaultDomainQuery } from '../';
 
 describe( 'isGoodDefaultDomainQuery', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/domain-picker` to use `import/order`

#### Testing instructions

N/A