### PR TITLE
My Home: Improve accessibility of buttons in Quick links section

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -71,6 +71,7 @@ export const QuickLinks = ( {
 			{ isStaticHomePage ? (
 				<ActionBox
 					href={ editHomePageUrl }
+					hideLinkIndicator
 					onClick={ trackEditHomepageAction }
 					label={ translate( 'Edit homepage' ) }
 					materialIcon="laptop"
@@ -78,6 +79,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/post/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
@@ -86,6 +88,7 @@ export const QuickLinks = ( {
 			{ isStaticHomePage ? (
 				<ActionBox
 					href={ `/page/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
@@ -93,6 +96,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/comments/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackManageCommentsAction }
 					label={ translate( 'Manage comments' ) }
 					materialIcon="mode_comment"
@@ -101,6 +105,7 @@ export const QuickLinks = ( {
 			{ isStaticHomePage ? (
 				<ActionBox
 					href={ `/post/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
@@ -108,6 +113,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/page/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
@@ -133,6 +139,7 @@ export const QuickLinks = ( {
 			) }
 			<ActionBox
 				href={ `/themes/${ siteSlug }` }
+				hideLinkIndicator
 				onClick={ trackChangeThemeAction }
 				label={ translate( 'Change theme' ) }
 				materialIcon="view_quilt"
@@ -140,6 +147,7 @@ export const QuickLinks = ( {
 			{ canAddEmail ? (
 				<ActionBox
 					href={ `/email/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackAddEmailAction }
 					label={ translate( 'Add email' ) }
 					materialIcon="email"
@@ -147,6 +155,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/domains/add/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackAddDomainAction }
 					label={ translate( 'Add a domain' ) }
 					gridicon="domains"

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -46,22 +45,24 @@ export const QuickLinks = ( {
 	showCustomizer,
 	canAddEmail,
 	menusUrl,
-	editHomepageAction,
-	writePostAction,
-	addPageAction,
-	manageCommentsAction,
+	trackEditHomepageAction,
+	trackWritePostAction,
+	trackAddPageAction,
+	trackManageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	changeThemeAction,
+	trackChangeThemeAction,
 	trackDesignLogoAction,
 	trackAnchorPodcastAction,
-	addEmailAction,
-	addDomainAction,
+	trackAddEmailAction,
+	trackAddDomainAction,
 	isExpanded,
 	expand,
 	collapse,
 	isUnifiedNavEnabled,
 	siteAdminUrl,
+	editHomePageUrl,
+	siteSlug,
 } ) => {
 	const translate = useTranslate();
 
@@ -69,39 +70,45 @@ export const QuickLinks = ( {
 		<div className="quick-links__boxes">
 			{ isStaticHomePage ? (
 				<ActionBox
-					onClick={ editHomepageAction }
+					href={ editHomePageUrl }
+					onClick={ trackEditHomepageAction }
 					label={ translate( 'Edit homepage' ) }
 					materialIcon="laptop"
 				/>
 			) : (
 				<ActionBox
-					onClick={ writePostAction }
+					href={ `/post/${ siteSlug }` }
+					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
 				/>
 			) }
 			{ isStaticHomePage ? (
 				<ActionBox
-					onClick={ addPageAction }
+					href={ `/page/${ siteSlug }` }
+					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
 				/>
 			) : (
 				<ActionBox
-					onClick={ manageCommentsAction }
+					href={ `/comments/${ siteSlug }` }
+					onClick={ trackManageCommentsAction }
 					label={ translate( 'Manage comments' ) }
 					materialIcon="mode_comment"
 				/>
 			) }
 			{ isStaticHomePage ? (
 				<ActionBox
-					onClick={ writePostAction }
+					href={ `/post/${ siteSlug }` }
+					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
 				/>
 			) : (
 				<ActionBox
-					onClick={ addPageAction }
+					href={ `/page/${ siteSlug }` }
+					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
 				/>
@@ -125,19 +132,22 @@ export const QuickLinks = ( {
 				/>
 			) }
 			<ActionBox
-				onClick={ changeThemeAction }
+				href={ `/themes/${ siteSlug }` }
+				onClick={ trackChangeThemeAction }
 				label={ translate( 'Change theme' ) }
 				materialIcon="view_quilt"
 			/>
 			{ canAddEmail ? (
 				<ActionBox
-					onClick={ addEmailAction }
+					href={ `/email/${ siteSlug }` }
+					onClick={ trackAddEmailAction }
 					label={ translate( 'Add email' ) }
 					materialIcon="email"
 				/>
 			) : (
 				<ActionBox
-					onClick={ addDomainAction }
+					href={ `/domains/add/${ siteSlug }` }
+					onClick={ trackAddDomainAction }
 					label={ translate( 'Add a domain' ) }
 					gridicon="domains"
 				/>
@@ -189,7 +199,7 @@ export const QuickLinks = ( {
 	);
 };
 
-const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) => ( dispatch ) => {
+const trackEditHomepageAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_edit_homepage_click', {
@@ -198,10 +208,9 @@ const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) => ( dispatch )
 			bumpStat( 'calypso_customer_home', 'my_site_edit_homepage' )
 		)
 	);
-	page( editHomePageUrl );
 };
 
-const writePostAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackWritePostAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_write_post_click', {
@@ -210,10 +219,9 @@ const writePostAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_write_post' )
 		)
 	);
-	page( `/post/${ siteSlug }` );
 };
 
-const addPageAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackAddPageAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_add_page_click', {
@@ -222,10 +230,9 @@ const addPageAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_add_page' )
 		)
 	);
-	page( `/page/${ siteSlug }` );
 };
 
-const manageCommentsAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackManageCommentsAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_manage_comments_click', {
@@ -234,7 +241,6 @@ const manageCommentsAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_manage_comments' )
 		)
 	);
-	page( `/comments/${ siteSlug }` );
 };
 
 const trackEditMenusAction = ( isStaticHomePage ) =>
@@ -253,7 +259,7 @@ const trackCustomizeThemeAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_customize_theme' )
 	);
 
-const changeThemeAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackChangeThemeAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_change_theme_click', {
@@ -262,7 +268,6 @@ const changeThemeAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_change_theme' )
 		)
 	);
-	page( `/themes/${ siteSlug }` );
 };
 
 const trackDesignLogoAction = ( isStaticHomePage ) =>
@@ -281,7 +286,7 @@ const trackAnchorPodcastAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_anchor_podcast' )
 	);
 
-const addEmailAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackAddEmailAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_add_email_click', {
@@ -290,10 +295,9 @@ const addEmailAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_add_email' )
 		)
 	);
-	page( `/email/${ siteSlug }` );
 };
 
-const addDomainAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackAddDomainAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_add_domain_click', {
@@ -302,7 +306,6 @@ const addDomainAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_add_domain' )
 		)
 	);
-	page( `/domains/add/${ siteSlug }` );
 };
 
 /**
@@ -344,37 +347,37 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = {
-	editHomepageAction,
-	writePostAction,
-	addPageAction,
-	manageCommentsAction,
+	trackEditHomepageAction,
+	trackWritePostAction,
+	trackAddPageAction,
+	trackManageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	changeThemeAction,
+	trackChangeThemeAction,
 	trackDesignLogoAction,
 	trackAnchorPodcastAction,
-	addEmailAction,
-	addDomainAction,
+	trackAddEmailAction,
+	trackAddDomainAction,
 	expand: () => savePreference( 'homeQuickLinksToggleStatus', 'expanded' ),
 	collapse: () => savePreference( 'homeQuickLinksToggleStatus', 'collapsed' ),
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { editHomePageUrl, isStaticHomePage, siteSlug } = stateProps;
+	const { isStaticHomePage } = stateProps;
 	return {
 		...stateProps,
 		...dispatchProps,
-		editHomepageAction: () => dispatchProps.editHomepageAction( editHomePageUrl, isStaticHomePage ),
-		writePostAction: () => dispatchProps.writePostAction( siteSlug, isStaticHomePage ),
-		addPageAction: () => dispatchProps.addPageAction( siteSlug, isStaticHomePage ),
-		manageCommentsAction: () => dispatchProps.manageCommentsAction( siteSlug, isStaticHomePage ),
+		trackEditHomepageAction: () => dispatchProps.trackEditHomepageAction( isStaticHomePage ),
+		trackWritePostAction: () => dispatchProps.trackWritePostAction( isStaticHomePage ),
+		trackAddPageAction: () => dispatchProps.trackAddPageAction( isStaticHomePage ),
+		trackManageCommentsAction: () => dispatchProps.trackManageCommentsAction( isStaticHomePage ),
 		trackEditMenusAction: () => dispatchProps.trackEditMenusAction( isStaticHomePage ),
 		trackCustomizeThemeAction: () => dispatchProps.trackCustomizeThemeAction( isStaticHomePage ),
-		changeThemeAction: () => dispatchProps.changeThemeAction( siteSlug, isStaticHomePage ),
+		trackChangeThemeAction: () => dispatchProps.trackChangeThemeAction( isStaticHomePage ),
 		trackDesignLogoAction: () => dispatchProps.trackDesignLogoAction( isStaticHomePage ),
 		trackAnchorPodcastAction: () => dispatchProps.trackAnchorPodcastAction( isStaticHomePage ),
-		addEmailAction: () => dispatchProps.addEmailAction( siteSlug, isStaticHomePage ),
-		addDomainAction: () => dispatchProps.addDomainAction( siteSlug, isStaticHomePage ),
+		trackAddEmailAction: () => dispatchProps.trackAddEmailAction( isStaticHomePage ),
+		trackAddDomainAction: () => dispatchProps.trackAddDomainAction( isStaticHomePage ),
 		...ownProps,
 	};
 };

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -52,6 +52,7 @@ export const QuickLinks = ( {
 			{ isStaticHomePage ? (
 				<ActionBox
 					href={ editHomePageUrl }
+					hideLinkIndicator
 					onClick={ trackEditHomepageAction }
 					label={ translate( 'Edit homepage' ) }
 					materialIcon="laptop"
@@ -59,6 +60,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/post/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
@@ -67,6 +69,7 @@ export const QuickLinks = ( {
 			{ isStaticHomePage ? (
 				<ActionBox
 					href={ `/page/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
@@ -74,6 +77,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/comments/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackManageCommentsAction }
 					label={ translate( 'Manage comments' ) }
 					materialIcon="mode_comment"
@@ -82,6 +86,7 @@ export const QuickLinks = ( {
 			{ isStaticHomePage ? (
 				<ActionBox
 					href={ `/post/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
@@ -89,6 +94,7 @@ export const QuickLinks = ( {
 			) : (
 				<ActionBox
 					href={ `/page/${ siteSlug }` }
+					hideLinkIndicator
 					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
@@ -97,6 +103,7 @@ export const QuickLinks = ( {
 			{ showCustomizer && (
 				<ActionBox
 					href={ menusUrl }
+					hideLinkIndicator
 					onClick={ trackEditMenusAction }
 					label={ translate( 'Edit menus' ) }
 					materialIcon="list"
@@ -105,6 +112,7 @@ export const QuickLinks = ( {
 			{ showCustomizer && (
 				<ActionBox
 					href={ customizeUrl }
+					hideLinkIndicator
 					onClick={ trackCustomizeThemeAction }
 					label={ translate( 'Customize theme' ) }
 					materialIcon="palette"

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -34,15 +33,17 @@ export const QuickLinks = ( {
 	isStaticHomePage,
 	showCustomizer,
 	menusUrl,
-	editHomepageAction,
-	writePostAction,
-	addPageAction,
-	manageCommentsAction,
+	trackEditHomepageAction,
+	trackWritePostAction,
+	trackAddPageAction,
+	trackManageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
 	isExpanded,
 	expand,
 	collapse,
+	editHomePageUrl,
+	siteSlug,
 } ) => {
 	const translate = useTranslate();
 
@@ -50,39 +51,45 @@ export const QuickLinks = ( {
 		<div className="wp-for-teams-quick-links__boxes quick-links__boxes">
 			{ isStaticHomePage ? (
 				<ActionBox
-					onClick={ editHomepageAction }
+					href={ editHomePageUrl }
+					onClick={ trackEditHomepageAction }
 					label={ translate( 'Edit homepage' ) }
 					materialIcon="laptop"
 				/>
 			) : (
 				<ActionBox
-					onClick={ writePostAction }
+					href={ `/post/${ siteSlug }` }
+					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
 				/>
 			) }
 			{ isStaticHomePage ? (
 				<ActionBox
-					onClick={ addPageAction }
+					href={ `/page/${ siteSlug }` }
+					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
 				/>
 			) : (
 				<ActionBox
-					onClick={ manageCommentsAction }
+					href={ `/comments/${ siteSlug }` }
+					onClick={ trackManageCommentsAction }
 					label={ translate( 'Manage comments' ) }
 					materialIcon="mode_comment"
 				/>
 			) }
 			{ isStaticHomePage ? (
 				<ActionBox
-					onClick={ writePostAction }
+					href={ `/post/${ siteSlug }` }
+					onClick={ trackWritePostAction }
 					label={ translate( 'Write blog post' ) }
 					materialIcon="edit"
 				/>
 			) : (
 				<ActionBox
-					onClick={ addPageAction }
+					href={ `/page/${ siteSlug }` }
+					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
 					materialIcon="insert_drive_file"
 				/>
@@ -119,7 +126,7 @@ export const QuickLinks = ( {
 	);
 };
 
-const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) => ( dispatch ) => {
+const trackEditHomepageAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_edit_homepage_click', {
@@ -128,10 +135,9 @@ const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) => ( dispatch )
 			bumpStat( 'calypso_customer_home', 'my_site_edit_homepage' )
 		)
 	);
-	page( editHomePageUrl );
 };
 
-const writePostAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackWritePostAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_write_post_click', {
@@ -140,10 +146,9 @@ const writePostAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_write_post' )
 		)
 	);
-	page( `/post/${ siteSlug }` );
 };
 
-const addPageAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackAddPageAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_add_page_click', {
@@ -152,10 +157,9 @@ const addPageAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_add_page' )
 		)
 	);
-	page( `/page/${ siteSlug }` );
 };
 
-const manageCommentsAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
+const trackManageCommentsAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_customer_home_my_site_manage_comments_click', {
@@ -164,7 +168,6 @@ const manageCommentsAction = ( siteSlug, isStaticHomePage ) => ( dispatch ) => {
 			bumpStat( 'calypso_customer_home', 'my_site_manage_comments' )
 		)
 	);
-	page( `/comments/${ siteSlug }` );
 };
 
 const trackEditMenusAction = ( isStaticHomePage ) =>
@@ -205,10 +208,10 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = {
-	editHomepageAction,
-	writePostAction,
-	addPageAction,
-	manageCommentsAction,
+	trackEditHomepageAction,
+	trackWritePostAction,
+	trackAddPageAction,
+	trackManageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
 	expand: () => savePreference( 'homeQuickLinksToggleStatus', 'expanded' ),
@@ -216,14 +219,14 @@ const mapDispatchToProps = {
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { editHomePageUrl, isStaticHomePage, siteSlug } = stateProps;
+	const { isStaticHomePage } = stateProps;
 	return {
 		...stateProps,
 		...dispatchProps,
-		editHomepageAction: () => dispatchProps.editHomepageAction( editHomePageUrl, isStaticHomePage ),
-		writePostAction: () => dispatchProps.writePostAction( siteSlug, isStaticHomePage ),
-		addPageAction: () => dispatchProps.addPageAction( siteSlug, isStaticHomePage ),
-		manageCommentsAction: () => dispatchProps.manageCommentsAction( siteSlug, isStaticHomePage ),
+		trackEditHomepageAction: () => dispatchProps.trackEditHomepageAction( isStaticHomePage ),
+		trackWritePostAction: () => dispatchProps.trackWritePostAction( isStaticHomePage ),
+		trackAddPageAction: () => dispatchProps.trackAddPageAction( isStaticHomePage ),
+		trackManageCommentsAction: () => dispatchProps.trackManageCommentsAction( isStaticHomePage ),
 		trackEditMenusAction: () => dispatchProps.trackEditMenusAction( isStaticHomePage ),
 		trackCustomizeThemeAction: () => dispatchProps.trackCustomizeThemeAction( isStaticHomePage ),
 		...ownProps,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* IMHO, I think there is no need to use the button here, so I make all of the ActionBox items under Quick links to be **a** tag name with **href** attribute and rename action handler with prefix **track** because all of them will only do tracking now.

Here is the screenshot of these elements in Firefox's accessibility tools you can see they have labels and the keyboard error is fixed.

![image](https://user-images.githubusercontent.com/13596067/125924181-21b59a65-5e4a-43f8-91e1-de38622f3728.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to My Home and expand quick links
2. Navigate the Quick links section using tab navigation, or try using those buttons with a screen reader (e.g. VoiceOver in macOS)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/54483
