### PR TITLE
i18n: Improve canonical and hreflang URLs on themes pages

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -63,7 +63,14 @@ const getLocalizedCanonicalUrl = ( path, locale ) => {
 		new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
 		'$2'
 	);
-	return localizeUrl( baseUrlWithoutLang, locale, false );
+	let localizedUrl = localizeUrl( baseUrlWithoutLang, locale, false );
+
+	// Remove the trailing slash if `path` doesn't have one either.
+	if ( path.slice( -1 ) !== '/' && localizedUrl.slice( -1 ) === '/' ) {
+		localizedUrl = localizedUrl.slice( 0, -1 );
+	}
+
+	return localizedUrl;
 };
 
 export const setHrefLangLinks = ( context, next ) => {

--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { makeLayout, ssrSetupLocale, setHrefLangLinks } from 'calypso/controller';
+import {
+	makeLayout,
+	ssrSetupLocale,
+	setHrefLangLinks,
+	setLocalizedCanonicalUrl,
+} from 'calypso/controller';
 import { details, fetchThemeDetailsData, notFoundError } from './controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 
@@ -15,6 +20,7 @@ export default function ( router ) {
 		fetchThemeDetailsData,
 		details,
 		setHrefLangLinks,
+		setLocalizedCanonicalUrl,
 		makeLayout,
 
 		// Error handlers

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -4,7 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import config from '@automattic/calypso-config';
 import titlecase from 'to-title-case';
@@ -744,8 +745,6 @@ class ThemeSheet extends React.Component {
 
 		const className = classNames( 'theme__sheet', { 'is-with-upsell-banner': hasUpsellBanner } );
 
-		const links = [ { rel: 'canonical', href: canonicalUrl } ];
-
 		return (
 			<Main className={ className }>
 				<QueryCanonicalTheme themeId={ this.props.id } siteId={ siteId } />
@@ -756,7 +755,7 @@ class ThemeSheet extends React.Component {
 					) /* TODO: Make QuerySitePurchases handle falsey siteId */
 				}
 				<QuerySitePlans siteId={ siteId } />
-				<DocumentHead title={ title } meta={ metas } link={ links } />
+				<DocumentHead title={ title } meta={ metas } />
 				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 				{ this.renderBar() }
 				<QueryActiveTheme siteId={ siteId } />
@@ -840,6 +839,7 @@ export default connect(
 		const theme = getCanonicalTheme( state, siteId, id );
 		const siteIdOrWpcom = siteId || 'wpcom';
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
+		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, id );
 
 		return {
 			...theme,
@@ -861,8 +861,7 @@ export default connect(
 			forumUrl: getThemeForumUrl( state, id, siteId ),
 			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
-			// No siteId specified since we want the *canonical* URL :-)
-			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),
+			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ),
 			demoUrl: getThemeDemoUrl( state, id, siteId ),
 			previousRoute: getPreviousRoute( state ),
 		};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -861,7 +861,8 @@ export default connect(
 			forumUrl: getThemeForumUrl( state, id, siteId ),
 			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
-			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ),
+			// Remove the trailing slash because the page URL doesn't have one either.
+			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),
 			demoUrl: getThemeDemoUrl( state, id, siteId ),
 			previousRoute: getPreviousRoute( state ),
 		};

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { makeLayout, ssrSetupLocale, setHrefLangLinks } from 'calypso/controller';
+import {
+	makeLayout,
+	ssrSetupLocale,
+	setHrefLangLinks,
+	setLocalizedCanonicalUrl,
+} from 'calypso/controller';
 import {
 	fetchThemeData,
 	fetchThemeFilters,
@@ -29,12 +34,13 @@ export default function ( router ) {
 	];
 	router(
 		showcaseRoutes,
-		setHrefLangLinks,
 		ssrSetupLocale,
 		fetchThemeFilters,
 		validateVertical,
 		validateFilters,
 		fetchThemeData,
+		setHrefLangLinks,
+		setLocalizedCanonicalUrl,
 		loggedOut,
 		makeLayout
 	);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -242,8 +242,6 @@ class ThemeShowcase extends React.Component {
 			{ property: 'og:site_name', content: 'WordPress.com' },
 		];
 
-		const links = [ { rel: 'canonical', href: canonicalUrl } ];
-
 		const headerIcons = [
 			{
 				label: translate( 'New' ),
@@ -270,7 +268,7 @@ class ThemeShowcase extends React.Component {
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
-				<DocumentHead title={ title } meta={ metas } link={ links } />
+				<DocumentHead title={ title } meta={ metas } />
 				<PageViewTracker
 					path={ this.props.analyticsPath }
 					title={ this.props.analyticsPageTitle }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Theme details pages:
* The canonical URL and OG URL have been localized, which is the correct way of combining canonical URLs and hreflang links. See [here](https://yoast.com/hreflang-ultimate-guide/#hreflang-canonical), for example:
  > Every language should have a rel="canonical" link pointing to itself.

Theme details & themes showcase: 
* The trailing slash has been removed from the canonical, hreflang, and OG URLs, to make them match the page's URL exactly.
* Outputting the canonical URL has been moved from the `DocumentHead` component to a new middleware/controller function, `setLocalizedCanonicalUrl`, right below to `setHrefLangLinks`. This solves the problem of the canonical URL only showing on the first page-load (disappearing after refreshing the page once or twice). 

Implementation notes:
* I’m leaving the OG tags in `DocumentHead`, because those tags are built up very dynamically and would be hard to collect at the middleware stage.
* The middleware functions have been changed to use a hard-coded https://wordpress.com base. This simplifies the code a bit and it has the added benefit that it also works correctly locally.
* In `themes/index.node.js` I had to move `setHrefLangLinks` and `setLocalizedCanonicalUrl` down a bit, until after `ssrSetupLocale`. Otherwise, `getLocaleSlug` would return an incorrect value.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

While logged out, visit in several languages (English and non-English):

1. a couple of themes (e.g. http://calypso.localhost:3000/es/theme/blank-canvas) and their /setup and /support subpages,
2. the themes showcase (e.g. http://calypso.localhost:3000/es/themes/) and their filter-subpages like /business, /blog/filter/art, /food/filter/feature:portfolio,

and do the following:

* Verify that the canonical URL and OG URL:
  1. are localized,
  2. have a https://wordpress.com base, 
  3. do not have a trailing slash,
  4. match the URL in the address bar exactly.
* Verify that the canonical URL does not disappear when reloading the page.
* Verify that the hreflang links:
  1. are still there, 
  2. have a https://wordpress.com base, 
  3. are localized correctly,
  4. do not have a trailing slash,
  5. match the URL in the address bar exactly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 291-gh-Automattic/i18n-issues
