### PR TITLE
Theme Showcase: Temp fix for themes > 20 not auto-loading

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -220,7 +220,7 @@ export const ConnectedThemesSelection = connect(
 		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
 		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
 		// Jetpack themes endpoint.
-		const number = ! includes( [ 'wpcom', 'wporg' ], sourceSiteId ) ? 2000 : 20;
+		const number = ! includes( [ 'wpcom', 'wporg' ], sourceSiteId ) ? 2000 : 30;
 		const query = {
 			search,
 			page,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We'd set an arbitrary limit of 20 themes per page on WordPress.com simple sites; for some reason, this causes any themes pulled back after 20 themes in a non-paginated query (like the one for Recommended themes) to not trigger the AutoLoadingHomepage modal. 
* Update the query to 30 themes so all Recommended themes will show the AutoLoadingHomepage modal.
* Ideally we figure out how to let the AutoLoadingHomepage modal ignore the pagination query on non-paginated requests so it triggers regardless of that base number.
* I was going to leave this for a future bug fix, but it was blocking #40793, which has sat for a long time. It would be nice to ship it sooner rather than later. :) 

**Before**

![screencapture-calypso-localhost-3000-themes-carolinedotblog-wordpress-com-2021-07-16-10_10_11](https://user-images.githubusercontent.com/2124984/125961584-bb759b89-00d6-4e50-96e1-c65c1c7a0027.png)

**After**

<img width="783" alt="Screen Shot 2021-07-16 at 10 15 44 AM" src="https://user-images.githubusercontent.com/2124984/125961882-68ca1018-7c92-489f-932b-e72f073bd595.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]` on a WordPress.com simple site
* Try to activate Independent Publisher 2 from the Recommended tab
* You should see the AutoLoadingHomepage modal! Make sure it works as expected (you can activate the theme, it respects the modal settings)

Fixes #54559
