### PR TITLE
Create route & component to handle Jetpack Simple Checkout Calendly scheduling

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-schedule-appointment.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-schedule-appointment.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { InlineWidget } from 'react-calendly';
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'calypso/components/main';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+
+/**
+ * Type dependencies
+ */
+import type { UserData } from 'calypso/lib/user/user';
+
+const JetpackCheckoutScheduleAppointment: FunctionComponent = () => {
+	const currentUser = useSelector( ( state ) => getCurrentUser( state ) ) as UserData;
+
+	return (
+		<Main fullWidthLayout className="jetpack-checkout-schedule-appointment">
+			<InlineWidget
+				url="https://calendly.com/d/xfg8-3ykd/jetpack-com-onboarding-call"
+				pageSettings={ {
+					// --studio-jetpack-green
+					primaryColor: '069e08',
+				} }
+				prefill={ { email: currentUser?.email, name: currentUser?.display_name } }
+			/>
+		</Main>
+	);
+};
+
+export default JetpackCheckoutScheduleAppointment;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -19,7 +19,6 @@ import {
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import { cleanUrl } from 'calypso/jetpack-connect/utils.js';
-import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestUpdateJetpackCheckoutSupportTicket } from 'calypso/state/jetpack-checkout/actions';
@@ -33,7 +32,6 @@ interface Props {
 const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId = 0 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const userEmail = useSelector( getCurrentUserEmail );
 
 	const hasProductInfo = productSlug !== 'no_product';
 
@@ -48,8 +46,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 	const jetpackInstallInstructionsLink =
 		'https://jetpack.com/support/getting-started-with-jetpack/';
 
-	// TODO: Get the correct link to schedule 15min Happiness support session. This link is not correct.
-	const happinessAppointmentLink = `/schedule-happiness-appointment?user=${ userEmail }`;
+	const happinessAppointmentLink = '/checkout/jetpack/schedule-happiness-appointment';
 
 	const [ siteInput, setSiteInput ] = useState( '' );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -24,6 +24,7 @@ import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
 import JetpackCheckoutSitelessThankYou from './checkout-thank-you/jetpack-checkout-siteless-thank-you';
+import JetpackCheckoutScheduleAppointment from './checkout-thank-you/jetpack-checkout-schedule-appointment';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import { setSectionMiddleware } from 'calypso/controller';
 import { sites } from 'calypso/my-sites/controller';
@@ -301,6 +302,11 @@ export function jetpackCheckoutThankYou( context, next ) {
 		/>
 	);
 
+	next();
+}
+
+export function jetpackCheckoutScheduleAppointment( context, next ) {
+	context.primary = <JetpackCheckoutScheduleAppointment />;
 	next();
 }
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -11,10 +11,11 @@ import {
 	checkoutPending,
 	checkoutSiteless,
 	checkoutThankYou,
-	upsellNudge,
-	redirectToSupportSession,
-	redirectJetpackLegacyPlans,
+	jetpackCheckoutScheduleAppointment,
 	jetpackCheckoutThankYou,
+	redirectJetpackLegacyPlans,
+	redirectToSupportSession,
+	upsellNudge,
 } from './controller';
 import { noop } from './utils';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
@@ -26,6 +27,15 @@ export default function () {
 	page( '/checkout*', recordSiftScienceUser );
 
 	if ( isEnabled( 'jetpack/siteless-checkout' ) ) {
+		page(
+			'/checkout/jetpack/schedule-happiness-appointment',
+			redirectLoggedOut,
+			noSite,
+			jetpackCheckoutScheduleAppointment,
+			makeLayout,
+			clientRender
+		);
+
 		page( '/checkout/jetpack/:productSlug', noSite, checkoutSiteless, makeLayout, clientRender );
 		page(
 			'/checkout/jetpack/thank-you/no-site/:product',

--- a/client/package.json
+++ b/client/package.json
@@ -180,6 +180,7 @@
 		"qrcode.react": "^1.0.0",
 		"qs": "^6.9.1",
 		"react": "^16.12.0",
+		"react-calendly": "^2.2.1",
 		"react-click-outside": "^3.0.1",
 		"react-day-picker": "^7.4.0",
 		"react-dom": "^16.12.0",
@@ -239,9 +240,9 @@
 		"autoprefixer": "^10.2.5",
 		"component-event": "^0.2.0",
 		"component-query": "^0.0.3",
-		"react-test-renderer": "^16.12.0",
 		"pkg-dir": "^5.0.0",
 		"postcss-custom-properties": "^11.0.0",
+		"react-test-renderer": "^16.12.0",
 		"redux-mock-store": "^1.5.4"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22989,6 +22989,11 @@ react-autosize-textarea@^7.0.0, react-autosize-textarea@^7.1.0:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
+react-calendly@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-calendly/-/react-calendly-2.2.1.tgz#7c35f7747e01045dbd77e18ea1eb18adddf373cf"
+  integrity sha512-r9WJ2WNr3hjBFnE8UyFCtJiTy7InME0lghw3gA5BqAMOFe70OtLDINDRAKDSS8O1tTSxJJrFdmZ1PpFSL0NAJA==
+
 react-click-outside@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New route for Scheduling Jetpack Onboarding, `/checkout/jetpack/schedule-happiness-appointment`
   * requires user logged in
   * use new route on site less thank-you page 
* New Component to handle scheduling with embedded Calendly Widget styled with Jetpack Main Color

#### Testing instructions

1. Set `jetpack/siteless-checkout` to true in `development.json` and boot branch locally
2. Navigate to `/checkout/jetpack/thank-you/no-site/jetpack_scan` as a logged in user
2. Click "schedule a 15 min call now." in the lower right
3. Verify you are sent to `/checkout/jetpack/schedule-happiness-appointment`, matching the screenshot below: <img width="1409" alt="Screen Shot 2021-07-14 at 11 59 31 AM" src="https://user-images.githubusercontent.com/2810519/125681245-2fe17ca8-d7a2-4550-af5b-44cdb3951dc1.png">
4. Complete Scheduling an appointment, verifying that your user info is pre-filled<img width="1409" alt="Screen Shot 2021-07-14 at 11 59 37 AM" src="https://user-images.githubusercontent.com/2810519/125681187-41998b7d-2f1d-4fc8-82b8-2c07ba04572b.png">
5. Verify you are sent an email scheduling your appointment


related to: 1200479326344990-as-1200537578270027