### PR TITLE
Jetpack Checkout: add new `checkout_flow` option to Track event

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -198,6 +198,11 @@ export default function CompositeCheckout( {
 	);
 
 	const checkoutFlow: string = useMemo( () => {
+		const isSitelessJetpackCheckout = isJetpackCheckout && isNoSiteCart;
+		if ( isSitelessJetpackCheckout ) {
+			return 'jetpack_siteless_checkout';
+		}
+
 		if ( isLoggedOutCart ) {
 			if ( isJetpackCheckout ) {
 				return isUserComingFromLoginForm
@@ -207,7 +212,13 @@ export default function CompositeCheckout( {
 			return 'wpcom_registrationless';
 		}
 		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
-	}, [ isLoggedOutCart, isJetpackCheckout, isUserComingFromLoginForm, isJetpackNotAtomic ] );
+	}, [
+		isLoggedOutCart,
+		isNoSiteCart,
+		isJetpackCheckout,
+		isUserComingFromLoginForm,
+		isJetpackNotAtomic,
+	] );
 
 	const countriesList = useCountryList( overrideCountryList || [] );
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -199,10 +199,10 @@ export default function CompositeCheckout( {
 	);
 
 	const checkoutFlow = useCheckoutFlowTrackKey( {
+		hasJetpackSiteSlug: !! jetpackSiteSlug,
 		isJetpackCheckout,
 		isJetpackNotAtomic,
 		isLoggedOutCart,
-		isNoSiteCart,
 		isUserComingFromLoginForm,
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -43,6 +43,7 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import useStoredCards from './hooks/use-stored-cards';
+import useCheckoutFlowTrackKey from './hooks/use-checkout-flow-track-key';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useCreatePaymentMethods from './hooks/use-create-payment-methods';
 import webPayProcessor from './lib/web-pay-processor';
@@ -197,28 +198,13 @@ export default function CompositeCheckout( {
 		[ reduxDispatch ]
 	);
 
-	const checkoutFlow: string = useMemo( () => {
-		const isSitelessJetpackCheckout = isJetpackCheckout && isNoSiteCart;
-		if ( isSitelessJetpackCheckout ) {
-			return 'jetpack_siteless_checkout';
-		}
-
-		if ( isLoggedOutCart ) {
-			if ( isJetpackCheckout ) {
-				return isUserComingFromLoginForm
-					? 'jetpack_site_only_coming_from_login'
-					: 'jetpack_site_only';
-			}
-			return 'wpcom_registrationless';
-		}
-		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
-	}, [
+	const checkoutFlow = useCheckoutFlowTrackKey( {
+		isJetpackCheckout,
+		isJetpackNotAtomic,
 		isLoggedOutCart,
 		isNoSiteCart,
-		isJetpackCheckout,
 		isUserComingFromLoginForm,
-		isJetpackNotAtomic,
-	] );
+	} );
 
 	const countriesList = useCountryList( overrideCountryList || [] );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+
+interface Props {
+	isJetpackCheckout: boolean;
+	isJetpackNotAtomic: boolean;
+	isLoggedOutCart?: boolean;
+	isNoSiteCart?: boolean;
+	isUserComingFromLoginForm?: boolean;
+}
+
+export default function useCheckoutFlowTrackKey( {
+	isJetpackCheckout,
+	isJetpackNotAtomic,
+	isLoggedOutCart,
+	isNoSiteCart,
+	isUserComingFromLoginForm,
+}: Props ): string {
+	return useMemo( () => {
+		const isSitelessJetpackCheckout = isJetpackCheckout && isNoSiteCart;
+		if ( isSitelessJetpackCheckout ) {
+			return 'jetpack_siteless_checkout';
+		}
+
+		if ( isLoggedOutCart ) {
+			if ( isJetpackCheckout ) {
+				return isUserComingFromLoginForm
+					? 'jetpack_site_only_coming_from_login'
+					: 'jetpack_site_only';
+			}
+			return 'wpcom_registrationless';
+		}
+
+		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
+	}, [
+		isJetpackCheckout,
+		isJetpackNotAtomic,
+		isLoggedOutCart,
+		isNoSiteCart,
+		isUserComingFromLoginForm,
+	] );
+}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -7,19 +7,19 @@ interface Props {
 	isJetpackCheckout: boolean;
 	isJetpackNotAtomic: boolean;
 	isLoggedOutCart?: boolean;
-	isNoSiteCart?: boolean;
 	isUserComingFromLoginForm?: boolean;
+	hasJetpackSiteSlug: boolean;
 }
 
 export default function useCheckoutFlowTrackKey( {
+	hasJetpackSiteSlug,
 	isJetpackCheckout,
 	isJetpackNotAtomic,
 	isLoggedOutCart,
-	isNoSiteCart,
 	isUserComingFromLoginForm,
 }: Props ): string {
 	return useMemo( () => {
-		const isSitelessJetpackCheckout = isJetpackCheckout && isNoSiteCart;
+		const isSitelessJetpackCheckout = isJetpackCheckout && ! hasJetpackSiteSlug;
 		if ( isSitelessJetpackCheckout ) {
 			return 'jetpack_siteless_checkout';
 		}
@@ -35,10 +35,10 @@ export default function useCheckoutFlowTrackKey( {
 
 		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
 	}, [
+		hasJetpackSiteSlug,
 		isJetpackCheckout,
 		isJetpackNotAtomic,
 		isLoggedOutCart,
-		isNoSiteCart,
 		isUserComingFromLoginForm,
 	] );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -4,11 +4,11 @@
 import { useMemo } from 'react';
 
 interface Props {
+	hasJetpackSiteSlug: boolean;
 	isJetpackCheckout: boolean;
 	isJetpackNotAtomic: boolean;
 	isLoggedOutCart?: boolean;
 	isUserComingFromLoginForm?: boolean;
-	hasJetpackSiteSlug: boolean;
 }
 
 export default function useCheckoutFlowTrackKey( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new possible value ( `jetpack_siteless_checkout` ) to the `checkout_flow` property to facilitate tracking users going through the site-less checkout experience. 
* Create `useCheckoutFlowTrackKey` hook to abstract the logic that determines the right key.

#### Testing instructions

**Jetpack site-less checkout flow**
* Download this PR.
* Make sure the `jetpack/siteless-checkout` feature flag is enabled in the `config/development.json` file.
* Start Calypso with `yarn start`.
* Visit `/checkout/jetpack/jetpack_scan`.
* On the Network tab, search for `calypso_page_view`.
* Make sure the `checkout_flow` property is set to `jetpack_siteless_checkout`.

**Jetpack logged-out checkout flow (verify regressions are introduced)**
* On an incognito window, create a JN site.
* Set up Jetpack without connecting a WP.com user.
* On the Pricing page, select any product.
* Once you are on the Checkout page, replace `wordpress.com` with `calypso.localhost:3000`.
* On the Network tab, search for `calypso_page_view`.
* Make sure the `checkout_flow` property is set to `jetpack_siteonly_checkout`.

**Jetpack standard checkout flow (verify regressions are introduced)**
* Visit the Checkout page with any product and Jetpack site (following any flow you want).
* On the Network tab, search for `calypso_page_view`.
* Make sure the `checkout_flow` property is set to `jetpack_checkout`. 

Related to 1200479326344990-as-1200615931982481

#### Demo 

##### Jetpack site-less checkout flow

![image](https://user-images.githubusercontent.com/3418513/125979962-4821d40d-a20d-4277-a2cb-8ff644fe55fb.png)

##### Jetpack logged-out checkout flow

![image](https://user-images.githubusercontent.com/3418513/125993902-99db5087-08a3-4095-9bb2-e978de34e57a.png)

##### Jetpack checkout flow

![image](https://user-images.githubusercontent.com/3418513/125993963-a7fe337d-effc-45d9-a22b-3db92ece4574.png)

