### PR TITLE
Global-Styles/Customizer: Fix linting errors which came up during ETK…

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles-fonts-message-control.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles-fonts-message-control.php
@@ -84,13 +84,13 @@ class Global_Styles_Fonts_Message_Control extends \WP_Customize_Control {
 
 		$base_url = null;
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( 'http://calypso.localhost:3000' === $_GET['calypsoOrigin'] ) {
+		if ( isset( $_GET['calypsoOrigin'] ) && 'http://calypso.localhost:3000' === $_GET['calypsoOrigin'] ) {
 			$base_url = 'http://calypso.localhost:3000/';
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		} elseif ( 'https://horizon.wordpress.com' === $_GET['calypsoOrigin'] ) {
+		} elseif ( isset( $_GET['calypsoOrigin'] ) && 'https://horizon.wordpress.com' === $_GET['calypsoOrigin'] ) {
 			$base_url = 'https://horizon.wordpress.com/';
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		} elseif ( 'https://wpcalypso.wordpress.com' === $_GET['calypsoOrigin'] ) {
+		} elseif ( isset( $_GET['calypsoOrigin'] ) && 'https://wpcalypso.wordpress.com' === $_GET['calypsoOrigin'] ) {
 			$base_url = 'https://wpcalypso.wordpress.com/';
 		} else {
 			$base_url = 'https://www.wordpress.com/';


### PR DESCRIPTION
#### Testing instructions

1. Check out this pull request. Load calypso development environment `yarn && yarn start`
1. Load the editing-toolkit-plugin by changing into the editing toolkit plugin directory and using `yarn dev --sync`
1. Create a site with the theme twenty-twenty one
1. Go to customizer. Expand the fonts section. 
1. Find the link which says: "Click here to open the Block Editor and change your fonts."
1. Click the link. It should open the block editor in calypso (It's important that the block editor is opened in calypso, not wordpress.com), and should expand the global styles sidebar.

1. Download the editing-toolkit plugin artifact from this build
1. On an atomic side, deactivate any existing editing toolkit plugin
1. Install this version of the editing toolkit plugin
1. Open customizer. Find the same link.
1. When you click it, this time it should open wordpress.com (which will redirect to wp-admin), and then the global styles sidebar should be expanded


https://user-images.githubusercontent.com/10274366/125983242-0098461c-33b1-45c1-a787-0035ce3f162e.mov

