### PR TITLE
Checkout: Fix contactDetails argument creating cart in existingCardProcessor

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -51,6 +51,10 @@ export default async function existingCardProcessor(
 		throw new Error( 'Stripe configuration is required' );
 	}
 
+	const domainDetails = getDomainDetails( contactDetails, {
+		includeDomainDetails,
+		includeGSuiteDetails,
+	} );
 	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
@@ -58,13 +62,10 @@ export default async function existingCardProcessor(
 		country: contactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode( contactDetails ),
 		subdivisionCode: contactDetails?.state?.value,
-		domainDetails: getDomainDetails( contactDetails, {
-			includeDomainDetails,
-			includeGSuiteDetails,
-		} ),
+		domainDetails,
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
-			contactDetails: transactionData.domainDetails ?? null,
+			contactDetails: domainDetails ?? null,
 			responseCart: dataForProcessor.responseCart,
 		} ),
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/54256 where the `contactDetails` argument passed to the cart creation for the transactions endpoint was not correctly transitioned to use the data passed with the `PaymentProcessorOptions`. This data is only used by `addRegistrationDataToGSuiteCartProduct`.

Props to @daledupreez who noticed this issue.

#### Testing instructions

- Use an account that has an existing saved credit card.
- Add a G Suite product to your cart and visit checkout.
- Fill out the contact info.
- Select an existing card as the payment method.
- Make sure you have the network tab of your browser's devtools open.
- Submit the purchase.
- Verify that the `POST` request to the `/me/transactions` endpoint includes domain details in the `cart` property in the `products` array. (It's already included in the `domainDetails` property, but that's not the problem.)