### PR TITLE
Playwright: additional tweaks to sidebar.click

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -839,7 +839,7 @@ object RunCalypsoPlaywrightE2eDesktopTests : BuildType({
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export DEBUG=pw:api
 
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-media__edit-spec.js
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -839,7 +839,7 @@ object RunCalypsoPlaywrightE2eDesktopTests : BuildType({
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export DEBUG=pw:api
 
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-media__edit-spec.js
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -144,6 +144,8 @@ export class SidebarComponent extends BaseContainer {
 			[ elementHandle ]
 		);
 
+		await elementHandle.waitForElementState( 'stable' );
+
 		await elementHandle.click();
 
 		await this.page.waitForLoadState( 'domcontentloaded' );

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -124,7 +124,7 @@ export class SidebarComponent extends BaseContainer {
 	 */
 	async _click( selector: string ): Promise< void > {
 		// Wait for these promises in no particular order. We simply want to ensure the sidebar
-		// and the page is in a state to accept inputs.
+		// and the page is not animating and is ready to accept inputs.
 		await Promise.all( [
 			this.page.waitForLoadState( 'load' ),
 			this.sidebar.waitForElementState( 'stable' ),
@@ -132,6 +132,9 @@ export class SidebarComponent extends BaseContainer {
 
 		const elementHandle = await this.page.waitForSelector( selector );
 
+		// Scroll to reveal the element fully using a page function if required.
+		// This workaround is necessary as the sidebar is 'sticky' in calypso, so a traditional
+		// scroll behavior does not adequately expose the sidebar element.
 		await this.page.evaluate(
 			( [ element ] ) => {
 				const elementBottom = element.getBoundingClientRect().bottom;
@@ -143,8 +146,6 @@ export class SidebarComponent extends BaseContainer {
 			},
 			[ elementHandle ]
 		);
-
-		await elementHandle.waitForElementState( 'stable' );
 
 		await elementHandle.click();
 

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -126,7 +126,7 @@ export class SidebarComponent extends BaseContainer {
 		// Wait for these promises in no particular order. We simply want to ensure the sidebar
 		// and the page is in a state to accept inputs.
 		await Promise.all( [
-			this.page.waitForLoadState( 'domcontentloaded' ),
+			this.page.waitForLoadState( 'load' ),
 			this.sidebar.waitForElementState( 'stable' ),
 		] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes additional tweaks in an effort to make the `_click` method more reliable when interacting with both Simple and Atomic sites.

Changes:
- change the `waitForLoadState` from `domcontentloaded` to `load`
- addition of `waitForElementStable` after a potential scroll has occurred

Background Details:

[navigation lifecycle](https://playwright.dev/docs/navigations/#navigation-lifecycle)

The `domcontentloaded` event is the first one to be fired in a navigation lifecycle and is fired when the document content has been parsed. `load` is fired when _some_ scripts (documentation is unclear what constitutes _some_) have been executed and images/resources loaded. `networkidle` is fired once dynamically loaded scripts are completed and no network requests are made for at least 500ms.

There also exists slight behavior difference between Simple and Atomic sites when the login flow takes users from `/log-in` to `/home` from Playwright's perspective.

Simple: dashboard is loaded and the `networkidle` event is fired about ~25s later.
Atomic: dashboard is loaded and the `networkidle` event is fired about ~3s later.

It is possible to solve the flakey `SidebarComponent._click` action by setting the `waitForLoadState('networkidle')` but this will result in every SidebarComponent interaction on Simple site to take an additional ~25s, which is an unacceptable delay.

#### Testing instructions

TeamCity
- ensure that sidebar interaction in tests (eg. SEO Preview) are not failing due to flakiness in clicking. To verify, view any video recordings that are in the `artifacts` tab.
- no failures should be occurring on Atomic sidebar interaction.

Related to #
