### PR TITLE
Playwright: click on the View Post button on post-publish panel instead of snackbar.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -17,7 +17,6 @@ const selectors = {
 
 	// Publish panel (including post-publish)
 	publishPanel: '.editor-post-publish-panel',
-	viewPostButton: 'text=View Post',
 };
 
 /**
@@ -149,13 +148,18 @@ export class GutenbergEditorPage extends BaseContainer {
 	 * @param {boolean} visit Whether to then visit the page.
 	 * @returns {Promise<void} No return value.
 	 */
-	async publish( { visit = false }: { visit?: boolean } ): Promise< void > {
+	async publish( { visit = false }: { visit?: boolean } = {} ): Promise< string > {
 		await this.frame.click( `${ selectors.editPostHeader } >> text=Publish` );
 		await this.frame.click( `${ selectors.publishPanel } >> text=Publish` );
+		const viewPublishedArticleButton = await this.frame.waitForSelector(
+			`${ selectors.publishPanel } a:has-text("View")`
+		);
+		const publishedURL = ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 
 		if ( visit ) {
 			await this._visitPublishedEntryFromPublishPane();
 		}
+		return publishedURL;
 	}
 
 	/**
@@ -166,7 +170,7 @@ export class GutenbergEditorPage extends BaseContainer {
 	async _visitPublishedEntryFromPublishPane(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForNavigation(),
-			this.frame.click( selectors.viewPostButton ),
+			this.frame.click( `${ selectors.publishPanel } a:has-text("View")` ),
 		] );
 		await this.page.waitForLoadState( 'networkidle' );
 	}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -17,6 +17,7 @@ const selectors = {
 
 	// Publish panel (including post-publish)
 	publishPanel: '.editor-post-publish-panel',
+	viewButton: '.editor-post-publish-panel a:has-text("View")',
 };
 
 /**
@@ -151,9 +152,7 @@ export class GutenbergEditorPage extends BaseContainer {
 	async publish( { visit = false }: { visit?: boolean } = {} ): Promise< string > {
 		await this.frame.click( `${ selectors.editPostHeader } >> text=Publish` );
 		await this.frame.click( `${ selectors.publishPanel } >> text=Publish` );
-		const viewPublishedArticleButton = await this.frame.waitForSelector(
-			`${ selectors.publishPanel } a:has-text("View")`
-		);
+		const viewPublishedArticleButton = await this.frame.waitForSelector( selectors.viewButton );
 		const publishedURL = ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
 
 		if ( visit ) {
@@ -170,7 +169,7 @@ export class GutenbergEditorPage extends BaseContainer {
 	async _visitPublishedEntryFromPublishPane(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForNavigation(),
-			this.frame.click( `${ selectors.publishPanel } a:has-text("View")` ),
+			this.frame.click( selectors.viewButton ),
 		] );
 		await this.page.waitForLoadState( 'networkidle' );
 	}

--- a/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
@@ -59,7 +59,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 	} );
 
-	describe.skip( 'Like an existing post', function () {
+	describe( 'Like an existing post', function () {
 		let publishedPostPage;
 
 		it( 'Log in', async function () {

--- a/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import {
 	DataHelper,
 	LoginFlow,
@@ -9,9 +10,6 @@ import {
 	setupHooks,
 } from '@automattic/calypso-e2e';
 
-/**
- * Constants
- */
 const quote =
 	'The foolish man seeks happiness in the distance. The wise grows it under his feet.\n— James Oppenheim';
 
@@ -47,7 +45,8 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 
 		it( 'Publish and visit post', async function () {
-			await gutenbergEditorPage.publish( { visit: true } );
+			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
+			assert.strictEqual( await page.url(), publishedURL );
 		} );
 
 		it( 'Like post', async function () {
@@ -60,7 +59,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 	} );
 
-	describe( 'Like an existing post', function () {
+	describe.skip( 'Like an existing post', function () {
 		let publishedPostPage;
 
 		it( 'Log in', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to change the element that is clicked on as part of the `GutenbergEditorPage.publish` process.

Changes:
- use the post-publish panel's `View Post` button instead of the `View Post` link in the snackbar.
- return the published article's URL by default to the caller, to be used in assertions.
- add an assertion to the `test/e2e/specs/specs-playwright/wp-likes__post-spec.js` spec to assert on the returned article URL.

Background Details:

Currently, the `publish` process of an article results in the page object locating and clicking on the floating snackbar that appears post-publish for approximately 5 seconds. This has led to a couple of issues when running E2E tests:
1. the snackbar is still animating when Playwright clicks.
2. the snackbar is gone by the time the click event occurs.

Both scenarios result in non-navigation and therefore failed tests.

Instead, the `View Post` link on the post-publish panel is to be used to navigate to the published article.
While this has its own issues (eg. post-publish panel being auto-dismissed due to a bug) this is more in line with expected user behavior.

#### Testing instructions

TeamCity
- ensure tests do not fail due to publish process.

Related to #
