### PR TITLE
chore: Refactor apps/editing-toolkit to use import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,6 +177,7 @@ module.exports = {
 		},
 		{
 			files: [
+				'apps/editing-toolkit/**/*',
 				'client/sections-filter.js',
 				'client/sections-helper.js',
 				'client/sections-middleware.js',

--- a/apps/editing-toolkit/bin/babel-transform.js
+++ b/apps/editing-toolkit/bin/babel-transform.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const babelJest = require( 'babel-jest' );
 
 module.exports = babelJest.createTransformer( {

--- a/apps/editing-toolkit/bin/js-unit-setup.js
+++ b/apps/editing-toolkit/bin/js-unit-setup.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import '@testing-library/jest-dom/extend-expect';
 
 // hack until we can upgrade to react@16.9.0

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/block-helpers.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/block-helpers.test.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getCategoryWithFallbacks } from '.';
 
 jest.mock( '@wordpress/blocks', () => ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { getCategories } from '@wordpress/blocks';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips.js
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
 import {
 	__unstableInserterMenuExtension,
 	__experimentalInserterMenuExtension,
 } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-
-/**
- * Internal dependencies
- */
+import { debounce } from 'lodash';
 import ContextualTip from './contextual-tips/contextual-tip';
+
 import './contextual-tips/style.scss';
 
 // InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/contextual-tip.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/contextual-tip.js
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import { get, filter, deburr, lowerCase, includes } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import { Tip } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
+import { withSelect } from '@wordpress/data';
+import { get, filter, deburr, lowerCase, includes } from 'lodash';
 import tipsList from './list';
 
 function ContextualTip( { searchTerm, random = false, canUserCreate } ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/list.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/list.js
@@ -1,12 +1,5 @@
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import TipLink from './tip-link';
 
 function getTipDescription( text, conversion, textFallback ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/tip-link.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-inserter-modifications/contextual-tips/tip-link.js
@@ -1,11 +1,4 @@
-/**
- * WordPress dependencies
- */
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import { inIframe, isSimpleSite } from './utils';
 
 const isEditorIFramed = inIframe();

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/index.ts
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './src/premium-block-patterns';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/domain-suggestions.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/domain-suggestions.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { DomainSuggestions } from '@automattic/data-stores';
 
 DomainSuggestions.register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import './domain-suggestions';
 import './plans';
 import './site';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Launch } from '@automattic/data-stores';
 
 export type LaunchStepType = Launch.LaunchStepType;

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/plans.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/plans.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Plans } from '@automattic/data-stores';
 
 Plans.register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/site.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/site.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Site } from '@automattic/data-stores';
 
 Site.register( { client_id: '', client_secret: '' } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/wpcom-features.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/wpcom-features.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { WPCOMFeatures } from '@automattic/data-stores';
 
 WPCOMFeatures.register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/hide-plugin-buttons-mobile.js
@@ -1,5 +1,1 @@
-/**
- * Internal dependencies
- */
-
 import './hide-plugin-buttons-mobile.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './index.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/edit.js
@@ -1,11 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * WordPress dependencies
- */
-import ServerSideRender from '@wordpress/server-side-render';
-import { Fragment } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -17,11 +11,11 @@ import {
 	withFontSizes,
 } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import ServerSideRender from '@wordpress/server-side-render';
 
 const NavigationMenuEdit = ( {
 	attributes,

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/index.js
@@ -1,14 +1,8 @@
-/**
- * WordPress dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import edit from './edit';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import edit from './edit';
+
 import './style.scss';
 
 const icon = (

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/edit.js
@@ -1,18 +1,11 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-/**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
- * WordPress dependencies
- */
+import { InnerBlocks } from '@wordpress/block-editor';
 import { compose, withState } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { PostTitle } from '@wordpress/editor';
-import { InnerBlocks } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
+import classNames from 'classnames';
 
 class PostContentEdit extends Component {
 	toggleEditing() {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/index.js
@@ -1,17 +1,11 @@
-/**
- * External dependencies
- */
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { registerBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
+import { getCategoryWithFallbacks } from '../../../block-helpers';
 import edit from './edit';
 import save from './save';
-import { getCategoryWithFallbacks } from '../../../block-helpers';
+
 import './style.scss';
 
 registerBlockType( 'a8c/post-content', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/save.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/save.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { InnerBlocks } from '@wordpress/block-editor';
 
 export default () => <InnerBlocks.Content />;

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/edit.js
@@ -1,22 +1,12 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /* global fullSiteEditing */
-/**
- * External dependencies
- */
-import classNames from 'classnames';
 
-/**
- * WordPress dependencies
- */
 import { AlignmentToolbar, BlockControls } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
+import classNames from 'classnames';
 import { withSiteOptions } from '../../lib';
 import { RenderedCreditChoice } from './footer-credit-choices';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/footer-credit-choices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/footer-credit-choices.js
@@ -1,8 +1,6 @@
-/* eslint-disable wpcalypso/import-docblock */
 /* global fullSiteEditing */
-/**
- * WordPress dependencies
- */
+
+// eslint-disable-next-line no-restricted-imports
 import { Icon } from '@wordpress/components';
 
 const { footerCreditOptions } = fullSiteEditing;

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/index.js
@@ -1,14 +1,8 @@
-/**
- * WordPress dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import edit from './edit';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import edit from './edit';
+
 import './style.scss';
 
 registerBlockType( 'a8c/site-credit', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
@@ -1,12 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import classNames from 'classnames';
 
-/**
- * WordPress dependencies
- */
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -18,15 +11,12 @@ import {
 	withColors,
 	withFontSizes,
 } from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
+import classNames from 'classnames';
 import { withSiteOptions } from '../../lib';
 
 const noop = () => {};

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/index.js
@@ -1,14 +1,8 @@
-/**
- * WordPress dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import edit from './edit';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import edit from './edit';
+
 import './style.scss';
 
 registerBlockType( 'a8c/site-description', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
@@ -1,13 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import classNames from 'classnames';
 
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -18,14 +10,12 @@ import {
 	withColors,
 	withFontSizes,
 } from '@wordpress/block-editor';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
-import { Fragment } from '@wordpress/element';
 import { PanelBody } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import { withSiteOptions } from '../../lib';
 
 const noop = () => {};

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/index.js
@@ -1,14 +1,8 @@
-/**
- * WordPress dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import edit from './edit';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import edit from './edit';
+
 import './style.scss';
 
 registerBlockType( 'a8c/site-title', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
@@ -1,26 +1,17 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /* global fullSiteEditing */
-/**
- * External dependencies
- */
-import classNames from 'classnames';
-import { get } from 'lodash';
 
-/**
- * WordPress dependencies
- */
-import { parse, createBlock } from '@wordpress/blocks';
 import { BlockEdit } from '@wordpress/block-editor';
+import { parse, createBlock } from '@wordpress/blocks';
 import { Button, Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Fragment, useEffect, useState, createRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import classNames from 'classnames';
+import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/index.js
@@ -1,17 +1,12 @@
 /* global fullSiteEditing */
-/**
- * WordPress dependencies
- */
+
 import { registerBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-
-/**
- * Internal dependencies
- */
-import edit from './edit';
+import { __ } from '@wordpress/i18n';
 import { getCategoryWithFallbacks } from '../../../block-helpers';
+import edit from './edit';
+
 import './style.scss';
 import './site-logo';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/site-logo.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/site-logo.js
@@ -1,7 +1,3 @@
-/* eslint-disable wpcalypso/import-docblock */
-/**
- * WordPress dependencies
- */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/block-inserter/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/block-inserter/index.js
@@ -1,14 +1,7 @@
 /* global fullSiteEditing */
 
-/**
- * External dependencies
- */
 import domReady from '@wordpress/dom-ready';
 import { render } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import PostContentBlockAppender from './post-content-block-appender';
 
 const CONTAINER_CLASS_NAME = 'fse-post-content-block-inserter';

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/block-inserter/post-content-block-appender.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/block-inserter/post-content-block-appender.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Inserter } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/image-block-keywords/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/image-block-keywords/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { addFilter } from '@wordpress/hooks';
 
 const additionalKeywords = [ 'logo', 'brand', 'emblem', 'hallmark' ];

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import './block-inserter';
 import './template-validity-override';
 import './image-block-keywords';

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/remove-editor-panels/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/remove-editor-panels/index.js
@@ -1,8 +1,5 @@
 /* global fullSiteEditing */
 
-/**
- * External dependencies
- */
 import { dispatch, subscribe } from '@wordpress/data';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/suppress-draft-action/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/suppress-draft-action/index.js
@@ -1,8 +1,5 @@
 /* global fullSiteEditing */
 
-/**
- * External dependencies
- */
 import { use } from '@wordpress/data';
 
 // The purpose of this override is to prevent Switch to Draft action for template CPTs.

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/suppress-trash-action/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/suppress-trash-action/index.js
@@ -1,8 +1,5 @@
 /* global fullSiteEditing */
 
-/**
- * External dependencies
- */
 import { use } from '@wordpress/data';
 
 // The purpose of this override is to prevent trash action from deleting template CPTs.

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/template-validity-override/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/editor/template-validity-override/index.js
@@ -1,8 +1,5 @@
 /* global fullSiteEditing */
 
-/**
- * External dependencies
- */
 import { select, dispatch, subscribe } from '@wordpress/data';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import './blocks/navigation-menu';
 import './blocks/post-content';
 import './blocks/site-credit';

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-previous.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-previous.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { useEffect, useRef } from '@wordpress/element';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-site-options.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-site-options.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-
-/**
- * Internal dependencies
- */
+import { __, sprintf } from '@wordpress/i18n';
 import { usePrevious } from './use-previous';
 
 export function useSiteOptions(

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/with-site-options.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/with-site-options.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import { useSiteOptions } from './use-site-options';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/close-button-override/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/close-button-override/index.js
@@ -1,17 +1,12 @@
 /* global fullSiteEditing */
 
-/**
- * External dependencies
- */
-import domReady from '@wordpress/dom-ready';
-import ReactDOM from 'react-dom';
-import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-imports
 import { Button, Dashicon } from '@wordpress/components';
+import domReady from '@wordpress/dom-ready';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import ReactDOM from 'react-dom';
 
-/**
- * Internal dependencies
- */
 import './style.scss';
 
 function BackButtonOverride( { defaultLabel, defaultUrl } ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -1,15 +1,9 @@
 /* global fullSiteEditing */
-/**
- * External dependencies
- */
-import classNames from 'classnames';
-import { get, map } from 'lodash';
 
-/**
- * WordPress dependencies
- */
 import { withSelect } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
+import classNames from 'classnames';
+import { get, map } from 'lodash';
 
 const EditorTemplateClasses = withSelect( ( select ) => {
 	const { getEntityRecord } = select( 'core' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/template-update-notice/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/template-update-notice/index.js
@@ -1,9 +1,7 @@
 /* global fullSiteEditing */
-/**
- * External dependencies
- */
-import domReady from '@wordpress/dom-ready';
+
 import { dispatch } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
 domReady( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/focused-launch.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/focused-launch.ts
@@ -1,5 +1,2 @@
-/**
- * Internal dependencies
- */
 import './src/stores';
 import './src/attach-focused-launch';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/gutenboarding-launch.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/gutenboarding-launch.ts
@@ -1,5 +1,2 @@
-/**
- * Internal dependencies
- */
 import './src/stores';
 import './src/attach-launch-sidebar';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/launch-button.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/launch-button.ts
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './src/launch-button';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-focused-launch.tsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { hasQueryArg } from '@wordpress/url';
 import FocusedLaunchModal from '@automattic/launch';
-
-/**
- * Internal dependencies
- */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+import { hasQueryArg } from '@wordpress/url';
+import React from 'react';
 import { inIframe } from '../../block-inserter-modifications/contextual-tips/utils';
+import { IMMEDIATE_LAUNCH_QUERY_ARG } from './constants';
 import { LAUNCH_STORE, SITE_STORE } from './stores';
 import { openCheckout, redirectToWpcomPath, getCurrentLaunchFlowUrl } from './utils';
-import { IMMEDIATE_LAUNCH_QUERY_ARG } from './constants';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/attach-launch-sidebar.tsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
-import { doAction, hasAction } from '@wordpress/hooks';
-import { LaunchContext } from '@automattic/launch';
 import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
-
-/**
- * Internal dependencies
- */
+import { LaunchContext } from '@automattic/launch';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { doAction, hasAction } from '@wordpress/hooks';
+import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+import React from 'react';
+import { inIframe } from '../../block-inserter-modifications/contextual-tips/utils';
+import { FLOW_ID } from './constants';
 import LaunchModal from './launch-modal';
 import { LAUNCH_STORE } from './stores';
-import { FLOW_ID } from './constants';
 import { openCheckout, redirectToWpcomPath, getCurrentLaunchFlowUrl } from './utils';
-import { inIframe } from '../../block-inserter-modifications/contextual-tips/utils';
 
 const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -1,18 +1,12 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import domReady from '@wordpress/dom-ready';
-import { dispatch } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import 'a8c-fse-common-data-stores';
-import '@wordpress/editor';
-
-/**
- * Internal dependencies
- */
+import { dispatch } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+import { __ } from '@wordpress/i18n';
 import { inIframe } from '../../../block-inserter-modifications/contextual-tips/utils';
 import { GUTENBOARDING_LAUNCH_FLOW } from '../constants';
+
+import 'a8c-fse-common-data-stores';
+import '@wordpress/editor';
 import './styles.scss';
 
 let handled = false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { LAUNCH_STORE } from '../stores';
 import LaunchMenuItem from './item';
 import type { LaunchStepType } from '../../../common/data-stores/launch';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/item.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/item.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { Button, SVG, Circle } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 
 const circle = (
 	<SVG viewBox="0 0 24 24">

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
+import { useLocale } from '@automattic/i18n-utils';
+import { LaunchContext, useOnLaunch } from '@automattic/launch';
+import { Modal, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Modal, Button } from '@wordpress/components';
 import { Icon, wordpress, close } from '@wordpress/icons';
-import { LaunchContext, useOnLaunch } from '@automattic/launch';
-import { useLocale } from '@automattic/i18n-utils';
-
-/**
- * Internal dependencies
- */
-import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
+import classnames from 'classnames';
+import React from 'react';
 import Launch from '../launch';
-import LaunchSidebar from '../launch-sidebar';
 import LaunchProgress from '../launch-progress';
+import LaunchSidebar from '../launch-sidebar';
+import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 
 import './styles.scss';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { LAUNCH_STORE } from '../stores';
 
 import './styles.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-sidebar/index.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { Title, SubTitle, ActionButtons, NextButton } from '@automattic/onboarding';
-
-/**
- * Internal dependencies
- */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
 import LaunchMenu from '../launch-menu';
 import { LAUNCH_STORE } from '../stores';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-step/index.tsx
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
-/**
- * Internal dependencies
- */
 import './styles.scss';
 
 export interface Props {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -1,22 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';
+import { useLocale } from '@automattic/i18n-utils';
+import { useDomainSelection, useSiteDomains, useDomainSearch } from '@automattic/launch';
+import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useLocale } from '@automattic/i18n-utils';
-import DomainPicker, { mockDomainSuggestion } from '@automattic/domain-picker';
-import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { FLOW_ID } from '../../constants';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE } from '../../stores';
-import { useDomainSelection, useSiteDomains, useDomainSearch } from '@automattic/launch';
-
-import { FLOW_ID } from '../../constants';
 
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const { __, hasTranslation } = useI18n();

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -1,18 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
-import { ThemeProvider } from 'emotion-theming';
-import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { Button, Tip } from '@wordpress/components';
-import { Icon, check } from '@wordpress/icons';
-import { useSiteDomains, useDomainSuggestion, useDomainSearch, useTitle } from '@automattic/launch';
-import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
-import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 import {
 	CheckoutStepBody,
 	checkoutTheme,
@@ -23,10 +8,18 @@ import {
 	SubmitButtonWrapper,
 	FormStatus,
 } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
+import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
+import { useSiteDomains, useDomainSuggestion, useDomainSearch, useTitle } from '@automattic/launch';
+import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
+import { Button, Tip } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { Icon, check } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import { ThemeProvider } from 'emotion-theming';
+import React from 'react';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE, PLANS_STORE } from '../../stores';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -1,16 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { __ } from '@wordpress/i18n';
-import { TextControl, Tip } from '@wordpress/components';
-import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
-
-/**
- * Internal dependencies
- */
-import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { useTitle } from '@automattic/launch';
+import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
+import { TextControl, Tip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
+
 import './styles.scss';
 
 const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -1,18 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { useSite } from '@automattic/launch';
+import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
+import PlansGrid from '@automattic/plans-grid';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import PlansGrid from '@automattic/plans-grid';
-import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
-import { useSite } from '@automattic/launch';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE } from '../../stores';
+
 import './styles.scss';
 
 const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch/index.tsx
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-/**
- * Internal dependencies
- */
-import NameStep from '../launch-steps/name-step';
+import React from 'react';
 import DomainStep from '../launch-steps/domain-step';
-import PlanStep from '../launch-steps/plan-step';
 import FinalStep from '../launch-steps/final-step';
+import NameStep from '../launch-steps/name-step';
+import PlanStep from '../launch-steps/plan-step';
 import { LAUNCH_STORE } from '../stores';
 
 import './styles.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/stores/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/stores/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import 'a8c-fse-common-data-stores';
 
 export const SITE_STORE = 'automattic/site';

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/utils.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { doAction, hasAction } from '@wordpress/hooks';
 import { addQueryArgs } from '@wordpress/url';
 import { FOCUSED_LAUNCH_FLOW, IMMEDIATE_LAUNCH_QUERY_ARG } from './constants';

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import apiFetch from '@wordpress/api-fetch';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/edit.js
@@ -2,16 +2,9 @@
 // disabled CSS class rule due to existing code already
 // that users the non-conformant classnames
 
-/**
- * WordPress dependencies
- */
+import { Button, DateTimePicker, Dropdown, Placeholder } from '@wordpress/components';
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
-import { Button, DateTimePicker, Dropdown, Placeholder } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { EventCountdownIcon } from './icon';
 
 const edit = ( { attributes, setAttributes, className } ) => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/icon.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/icon.js
@@ -1,11 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { Path, SVG } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
 export const EventCountdownIcon = () => (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z" />

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/index.js
@@ -1,15 +1,9 @@
-/**
- * WordPress dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import { EventCountdownIcon } from './icon';
 import edit from './edit';
+import { EventCountdownIcon } from './icon';
 import view from './view';
+
 import './editor.scss';
 import './style.scss';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/view.js
@@ -2,14 +2,7 @@
 // disabled CSS class rule due to existing code already
 // that users the non-conformant classnames
 
-/**
- * WordPress dependencies
- */
 import { __, _x } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
 
 const view = ( { attributes, className, isEditView } ) => {
 	// Expected values in save.

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/index.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './blocks/src/index';

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
@@ -1,16 +1,6 @@
-/**
- * External dependencies
- */
-import { registerPlugin } from '@wordpress/plugins';
-import { withDispatch, withSelect, select } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import registerStore from './src/store';
-import registerDOMUpdater from './src/dom-updater';
-import GlobalStylesSidebar from './src/global-styles-sidebar';
+import { withDispatch, withSelect, select } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
 import {
 	FONT_BASE,
 	FONT_BASE_DEFAULT,
@@ -20,6 +10,9 @@ import {
 	FONT_OPTIONS,
 	SITE_NAME,
 } from './src/constants';
+import registerDOMUpdater from './src/dom-updater';
+import GlobalStylesSidebar from './src/global-styles-sidebar';
+import registerStore from './src/store';
 
 // Tell Webpack to compile this into CSS
 import './editor.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/dom-updater.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/dom-updater.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { subscribe, select } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { isEmpty, isEqual } from 'lodash';

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/font-pairings-panel.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/font-pairings-panel.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
-import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import NoSupport from './no-support';
 
 export default ( { fontPairings, fontBase, fontHeadings, update } ) => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/font-selection-panel.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/font-selection-panel.js
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
- * WordPress dependencies.
- */
 import { SelectControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import NoSupport from './no-support';
 
 export default ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/global-styles-sidebar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/global-styles-sidebar.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { Button, PanelBody } from '@wordpress/components';
+import { dispatch } from '@wordpress/data';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQueryArg } from '@wordpress/url';
-import { useEffect } from '@wordpress/element';
-import { dispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { FONT_BASE, FONT_HEADINGS } from './constants';
 import FontPairingsPanel from './font-pairings-panel';
 import FontSelectionPanel from './font-selection-panel';
 import { GlobalStylesIcon } from './icon';
-import { FONT_BASE, FONT_HEADINGS } from './constants';
 
 const ANY_PROPERTY = 'ANY_PROPERTY';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/icon.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/icon.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Path, SVG } from '@wordpress/components';
 
 // For now, this icon shows a font style picker. Once we add colors, we'll want colors.

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/no-support.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/no-support.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { __, sprintf } from '@wordpress/i18n';
 
 export default ( { unsupportedFeature } ) => (

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/store.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import apiFetch from '@wordpress/api-fetch';
 import { registerStore } from '@wordpress/data';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/static/style.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/static/style.css
@@ -7,13 +7,13 @@ h6,
 .editor-post-title .editor-post-title__block .editor-post-title__input,
 h1.entry-title.entry-title,
 .entry-title.entry-title {
-	font-family: var(--font-headings, var(--font-headings-default));
+	font-family: var( --font-headings, var( --font-headings-default ) );
 }
 
 body,
 p,
 li {
-	font-family: var(--font-base, var(--font-base-default));
+	font-family: var( --font-base, var( --font-base-default ) );
 }
 
 /*

--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/block-appender.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/block-appender.js
@@ -2,15 +2,7 @@
 // disabled CSS class rule due to existing code already
 // that users the non-conformant classnames
 
-/**
- * External dependencies
- */
-
 import { __ } from '@wordpress/i18n';
-
-/**
- * WordPress dependencies
- */
 
 export const BlockAppender = ( props ) => {
 	const { onClick } = props;

--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/icon.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/icon.js
@@ -1,10 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { Path, SVG } from '@wordpress/components';
-/**
- * Internal dependencies
- */
+
 export const TimelineIcon = () => (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M15 13v1.2h-2.2V6h-1.6v2.2H9V7H4v4h5V9.8h2.2V18h1.6v-2.2H15V17h5v-4z" />

--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerTimelineBlock } from './timeline';
 import { registerTimelineItemBlock } from './timeline-item';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/timeline-item.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/timeline-item.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import {
 	InspectorControls,
 	InnerBlocks,
@@ -13,10 +10,6 @@ import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { positionLeft, positionRight } from '@wordpress/icons';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { TimelineIcon } from './icon';
 
 function Controls( { alignment, clientId, toggleAlignment } ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/timeline.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/timeline.js
@@ -2,22 +2,14 @@
 // disabled CSS class rule due to existing code already
 // that users the non-conformant classnames
 
-/**
- * External dependencies
- */
-
 import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { ToggleControl, PanelBody } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { TimelineIcon } from './icon';
 import { BlockAppender } from './block-appender';
+import { TimelineIcon } from './icon';
 
 export function registerTimelineBlock() {
 	registerBlockType( 'jetpack/timeline', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/index.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './blocks/src/index';

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/blog-posts-block-editor.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/blog-posts-block-editor.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import { settings } from './synced-newspack-blocks/blocks/homepage-articles/index';
 import { registerQueryStore } from './synced-newspack-blocks/blocks/homepage-articles/store';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/blog-posts-block-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/blog-posts-block-view.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './synced-newspack-blocks/blocks/homepage-articles/view';

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/carousel-block-editor.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/carousel-block-editor.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
-
-/**
- * External dependencies
- */
 import { settings } from './synced-newspack-blocks/blocks/carousel/index';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/carousel-block-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/carousel-block-view.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './synced-newspack-blocks/blocks/carousel/view';

--- a/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/index.js
@@ -1,24 +1,18 @@
-/**
- * WordPress dependencies
- */
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	registerBlockType,
 	switchToBlockType,
 	getPossibleBlockTransformations,
 } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 import { Placeholder, RangeControl, PanelBody, Notice } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/block-editor';
 import { select, dispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
+import { transforms, isValidHomepagePostsBlockType } from './transforms';
+
 import './editor.scss';
 import './style.scss';
-import { transforms, isValidHomepagePostsBlockType } from './transforms';
 
 const icon = (
 	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/transforms.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/transforms.js
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-
-/**
- * WordPress dependencies
- */
 import { createBlock } from '@wordpress/blocks';
 
 const HOMEPAGE_POSTS_BLOCK_TYPES = [ 'a8c/blog-posts', 'newspack-blocks/homepage-articles' ];

--- a/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/index.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './blocks/posts-list';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
-import { registerPlugin } from '@wordpress/plugins';
-import { dispatch } from '@wordpress/data';
 import { initializeTracksWithIdentity, PatternDefinition } from '@automattic/page-pattern-modal';
+import { dispatch } from '@wordpress/data';
 import React from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { registerPlugin } from '@wordpress/plugins';
 import { PagePatternsPlugin } from './page-patterns-plugin';
+
 import './store';
 import './index.scss';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -1,12 +1,10 @@
-/**
- * External dependencies
- */
-import '@wordpress/nux';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { addFilter, removeFilter } from '@wordpress/hooks';
 import { PagePatternModal, PatternDefinition } from '@automattic/page-pattern-modal';
+import { useSelect, useDispatch } from '@wordpress/data';
 import React, { useCallback } from '@wordpress/element';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
+
+import '@wordpress/nux';
 
 const INSERTING_HOOK_NAME = 'isInsertingPagePattern';
 const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-pattern';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
 import type { Reducer } from 'redux';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/index.js
@@ -1,5 +1,2 @@
-/**
- * Internal dependencies
- */
 import './src/whats-new';
 import './src/store';

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/store.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { registerStore } from '@wordpress/data';
 
 const DEFAULT_STATE = {

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -1,16 +1,13 @@
 /*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
 import './public-path';
 
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { Fill, MenuItem } from '@wordpress/components';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { registerPlugin } from '@wordpress/plugins';
-import { useEffect } from '@wordpress/element';
-import { useState } from 'react';
 import WhatsNewGuide from '@automattic/whats-new';
+import { Fill, MenuItem } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { useState } from 'react';
 
 function WhatsNewMenuItem() {
 	const [ showGuide, setShowGuide ] = useState( false );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/index.ts
@@ -1,5 +1,2 @@
-/**
- * Internal dependencies
- */
 import './src/attach-sidebar';
 import './src/store';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, createPortal, useState } from '@wordpress/element';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
+import { useEffect, createPortal, useState } from '@wordpress/element';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -1,18 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { get } from 'lodash';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button as OriginalButton } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { plus } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { get } from 'lodash';
+import React from 'react';
 
-/**
- * Internal dependencies
- */
 import './style.scss';
 
 const Button = ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -1,19 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { _x } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { applyFilters } from '@wordpress/hooks';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-
-/**
- * Internal dependencies
- */
+import classNames from 'classnames';
+import React from 'react';
 import { Post } from '../../types';
+
 import './style.scss';
 
 interface NavItemProps {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,33 +1,27 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { forwardRef, useLayoutEffect, useRef, useEffect } from '@wordpress/element';
-import { decodeEntities } from '@wordpress/html-entities';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Button as OriginalButton,
 	IsolatedEventContainer,
 	withConstrainedTabbing,
 } from '@wordpress/components';
-import { chevronLeft } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { forwardRef, useLayoutEffect, useRef, useEffect } from '@wordpress/element';
 import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
-import { get, isEmpty, partition } from 'lodash';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
+import { ESCAPE } from '@wordpress/keycodes';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
-import { ESCAPE } from '@wordpress/keycodes';
-import { compose } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
+import { get, isEmpty, partition } from 'lodash';
+import React from 'react';
 import { STORE_KEY, POST_IDS_TO_EXCLUDE } from '../../constants';
+import { Post } from '../../types';
 import CreatePage from '../create-page';
 import NavItem from '../nav-item';
 import SiteIcon from '../site-icon';
-import { Post } from '../../types';
+
 import './style.scss';
 
 const Button = forwardRef(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/site-icon/index.tsx
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useSelect } from '@wordpress/data';
-import { Icon, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { Icon, wordpress } from '@wordpress/icons';
+import React from 'react';
 
 export default function SiteIcon(): JSX.Element {
 	// The site icon url should be available from /wp/v2/settings or similar in the future,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -1,18 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button as OriginalButton } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { STORE_KEY } from '../../constants';
 import SiteIcon from '../site-icon';
+
 import './style.scss';
 
 const Button = ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import { combineReducers, registerStore } from '@wordpress/data';
-import type { Reducer } from 'redux';
-import type { DispatchFromMap, SelectFromMap } from '@automattic/data-stores';
-
-/**
- * Internal dependencies
- */
 import { actions, Action } from './actions';
 import { STORE_KEY } from './constants';
+import type { DispatchFromMap, SelectFromMap } from '@automattic/data-stores';
+import type { Reducer } from 'redux';
 
 const opened: Reducer< boolean, Action > = ( state = false, action ) => {
 	switch ( action.type ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/test/attach-sidebar.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/test/attach-sidebar.test.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { __experimentalMainDashboardButton } from '@wordpress/edit-post';
 
 test( '__experimentalMainDashboardButton should be available', () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
@@ -1,7 +1,5 @@
-/**
- * Internal dependencies
- */
 import { register } from './src/store';
+
 import './src/disable-core-nux';
 import './src/block-editor-nux';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -2,21 +2,15 @@
 import './public-path';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
+
+import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import { Guide, GuidePage } from '@wordpress/components';
-import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
-
-/**
- * Internal dependencies
- */
-import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
-import WpcomNux from './welcome-modal/wpcom-nux';
+import { registerPlugin } from '@wordpress/plugins';
 import { DEFAULT_VARIANT, BLANK_CANVAS_VARIANT } from './store';
+import WpcomNux from './welcome-modal/wpcom-nux';
+import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: function WpcomBlockEditorNux() {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -1,7 +1,5 @@
-/**
- * External dependencies
- */
 import { select, dispatch, subscribe } from '@wordpress/data';
+
 import '@wordpress/nux'; //ensure nux store loads
 
 // Disable nux and welcome guide features from core.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -1,10 +1,8 @@
-/**
- * External dependencies
- */
-import 'a8c-fse-common-data-stores';
 import apiFetch from '@wordpress/api-fetch';
-import { apiFetch as apiFetchControls, controls } from '@wordpress/data-controls';
 import { combineReducers, registerStore } from '@wordpress/data';
+import { apiFetch as apiFetchControls, controls } from '@wordpress/data-controls';
+
+import 'a8c-fse-common-data-stores';
 
 export const DEFAULT_VARIANT = 'tour';
 export const BLANK_CANVAS_VARIANT = 'blank-canvas-tour';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import waitForExpect from 'wait-for-expect';
-
-/**
- * Internal dependencies
- */
 import { dispatch, select } from '@wordpress/data';
+import waitForExpect from 'wait-for-expect';
 import { register, DEFAULT_VARIANT } from '../store';
 
 const STORE_KEY = 'automattic/wpcom-welcome-guide';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
@@ -1,21 +1,16 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
+
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Guide, GuidePage } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-
-/**
- * Internal dependencies
- */
-import './style.scss';
 import blockPickerImage from './images/block-picker.svg';
 import editorImage from './images/editor.svg';
 import previewImage from './images/preview.svg';
 import privateImage from './images/private.svg';
+
+import './style.scss';
 
 function WpcomNux() {
 	const { show, isNewPageLayoutModalOpen, isManuallyOpened } = useSelect( ( select ) => ( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/icons/maximize.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/icons/maximize.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { SVG, Path } from '@wordpress/primitives';
 
 const minimize = (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/icons/minimize.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/icons/minimize.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { SVG, Path } from '@wordpress/primitives';
 
 const minimize = (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/icons/thumbs_down.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/icons/thumbs_down.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { SVG, Path } from '@wordpress/primitives';
 
 const thumbsDown = (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/pagination.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/pagination.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { times } from 'lodash';
-
-/**
- * WordPress dependencies
- */
+import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { SVG, Circle } from '@wordpress/primitives';
-import { Button } from '@wordpress/components';
+import { times } from 'lodash';
 
 /*
  * Copied from the Guide Component: https://github.com/WordPress/gutenberg/blob/4bbfbc13603d28fcc45368c529954164bf8581de/packages/components/src/guide/page-control.js#L3

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -1,22 +1,16 @@
-/**
- * Internal dependencies
- */
-import './style-tour.scss';
-import PaginationControl from './pagination';
-import minimize from './icons/minimize';
-import thumbsUp from './icons/thumbs_up';
-import thumbsDown from './icons/thumbs_down';
-
-/**
- * External dependencies
- */
-import classNames from 'classnames';
-import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
-import { close } from '@wordpress/icons';
-import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import classNames from 'classnames';
+import minimize from './icons/minimize';
+import thumbsDown from './icons/thumbs_down';
+import thumbsUp from './icons/thumbs_up';
+import PaginationControl from './pagination';
+
+import './style-tour.scss';
 
 // eslint-disable-next-line react-hooks/exhaustive-deps
 const useEffectOnlyOnce = ( func ) => useEffect( func, [] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 const addBlock = 'https://s0.wp.com/i/editor-welcome-tour/slide-add-block.gif';
 const allBlocks = 'https://s0.wp.com/i/editor-welcome-tour/slide-all-blocks.gif';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -1,21 +1,15 @@
-/**
- * Internal dependencies
- */
-import WelcomeTourCard from './tour-card';
-import getTourContent from './tour-content';
-import maximize from './icons/maximize';
-import './style-tour.scss';
-
-/**
- * External dependencies
- */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { Button, Flex } from '@wordpress/components';
-import { Icon } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState, useRef } from '@wordpress/element';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { __ } from '@wordpress/i18n';
-import { useLocale } from '@automattic/i18n-utils';
+import { Icon } from '@wordpress/icons';
+import maximize from './icons/maximize';
+import WelcomeTourCard from './tour-card';
+import getTourContent from './tour-content';
+
+import './style-tour.scss';
 
 function LaunchWpcomWelcomeTour() {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;

--- a/apps/editing-toolkit/jest.config.js
+++ b/apps/editing-toolkit/jest.config.js
@@ -11,10 +11,10 @@
  * config file for e2e tests.
  */
 
+const path = require( 'path' );
 // @wordpress/scripts manually adds additional Jest config ontop of
 // @wordpress/jest-preset-default so we pull in this file to extend it
 const defaults = require( '@wordpress/scripts/config/jest-unit.config.js' );
-const path = require( 'path' );
 
 // Basically, CWD, so 'apps/editing-toolkit'.
 // Without this, it tries to use 'apps/editing-toolkit/bin'

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -1,14 +1,11 @@
 /**
- **** WARNING: No ES6 modules here. Not transpiled! ****
+ * WARNING: No ES6 modules here. Not transpiled! *
  */
 /* eslint-disable import/no-nodejs-modules */
 
-/**
- * External dependencies
- */
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const webpack = require( 'webpack' );
 
 const FSE_MODULE_PREFIX = 'a8c-fse';
@@ -26,7 +23,6 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  * @see {@link https://webpack.js.org/api/cli/}
- *
  * @param   {object}  env                           environment options
  * @param   {string}  env.source                    plugin slugs, comma separated list
  * @param   {object}  argv                          options map


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `apps/editing-toolkit` to use `import/order`

#### Testing instructions

N/A