### PR TITLE
Unified Sidebar: Add badge

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -23,7 +23,7 @@ export default function SidebarItem( props ) {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
 	} );
-	const { materialIcon, materialIconStyle, icon, customIcon, count } = props;
+	const { materialIcon, materialIconStyle, icon, customIcon, count, badge } = props;
 
 	let _preloaded = false;
 
@@ -76,6 +76,13 @@ export default function SidebarItem( props ) {
 							: props.label
 					}
 					{ !! count && <Count count={ count } /> }
+					{ !! badge && (
+						<span className="sidebar__menu-link-badge">
+							{ 'string' === typeof props.badge
+								? stripHTML( decodeEntities( props.badge ) )
+								: props.badge }
+						</span>
+					) }
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }
@@ -100,4 +107,5 @@ SidebarItem.propTypes = {
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,
 	count: PropTypes.number,
+	badge: PropTypes.string,
 };

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'calypso/components/gridicon';
 import { isExternal } from 'calypso/lib/url';
 import MaterialIcon from 'calypso/components/material-icon';
 import Count from 'calypso/components/count';
+import Badge from 'calypso/components/badge';
 import { preload } from 'calypso/sections-helper';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
@@ -76,7 +77,11 @@ export default function SidebarItem( props ) {
 							: props.label
 					}
 					{ !! count && <Count count={ count } /> }
-					{ !! badge && <span className="sidebar__menu-link-badge">{ badge }</span> }
+					{ !! badge && (
+						<Badge type="warning-clear" className="sidebar__menu-link-badge">
+							{ badge }
+						</Badge>
+					) }
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -76,13 +76,7 @@ export default function SidebarItem( props ) {
 							: props.label
 					}
 					{ !! count && <Count count={ count } /> }
-					{ !! badge && (
-						<span className="sidebar__menu-link-badge">
-							{ 'string' === typeof props.badge
-								? stripHTML( decodeEntities( props.badge ) )
-								: props.badge }
-						</span>
-					) }
+					{ !! badge && <span className="sidebar__menu-link-badge">{ badge }</span> }
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -277,3 +277,17 @@
 .sidebar__menu-wrapper {
 	border-top: 1px solid var( --color-sidebar-border );
 }
+
+.sidebar__menu-link-badge {
+	display: inline-block;
+	padding: 1px 6px;
+	border: solid 1px var( --color-border );
+	border-radius: 12px;
+	font-size: $font-body-extra-small;
+	line-height: 14px;
+	text-align: center;
+	color: var( --color-text-inverted );
+	border-color: var( --color-accent );
+	background-color: var( --color-accent );
+	margin-left: 8px;
+}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -281,13 +281,12 @@
 .sidebar__menu-link-badge {
 	display: inline-block;
 	padding: 1px 6px;
-	border: solid 1px var( --color-border );
+	border: solid 1px var( --studio-yellow );
 	border-radius: 12px;
 	font-size: $font-body-extra-small;
 	line-height: 14px;
 	text-align: center;
 	color: var( --color-text-inverted );
-	border-color: var( --color-accent );
-	background-color: var( --color-accent );
+	background-color: var( --studio-yellow );
 	margin-left: 8px;
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -156,6 +156,13 @@
 		margin: -7px 0 -8px;
 	}
 
+	.sidebar__menu-link-badge {
+		margin-left: 8px;
+		color: var( --color-warning-light );
+		padding: 1px 6px;
+		font-size: $font-body-extra-small;
+	}
+
 	.selected &,
 	.selected &:hover {
 		color: var( --color-sidebar-menu-selected-text );

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -281,12 +281,11 @@
 .sidebar__menu-link-badge {
 	display: inline-block;
 	padding: 1px 6px;
-	border: solid 1px var( --studio-yellow );
+	border: solid 1px var( --color-warning );
 	border-radius: 12px;
 	font-size: $font-body-extra-small;
 	line-height: 14px;
 	text-align: center;
-	color: var( --color-text-inverted );
-	background-color: var( --studio-yellow );
+	color: var( --color-warning-light );
 	margin-left: 8px;
 }

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -21,6 +21,7 @@ import MySitesSidebarUnifiedStatsSparkline from './sparkline';
 import { collapseAllMySitesSidebarSections } from 'calypso/state/my-sites/sidebar/actions';
 
 export const MySitesSidebarUnifiedItem = ( {
+	badge,
 	count,
 	icon,
 	isSubItem = false,
@@ -41,6 +42,7 @@ export const MySitesSidebarUnifiedItem = ( {
 
 	return (
 		<SidebarItem
+			badge={ badge }
 			count={ count }
 			label={ title }
 			link={ url }
@@ -56,6 +58,7 @@ export const MySitesSidebarUnifiedItem = ( {
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
+	badge: PropTypes.string,
 	count: PropTypes.number,
 	icon: PropTypes.string,
 	sectionId: PropTypes.string,

--- a/client/state/admin-menu/schema.js
+++ b/client/state/admin-menu/schema.js
@@ -3,6 +3,7 @@ const commonItemPropsSchema = {
 	title: { type: 'string' },
 	type: { type: 'string' },
 	url: { type: 'string' },
+	badge: { type: 'string' },
 };
 
 const menuItemsSite = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render sidebar menu item badge

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D64204-code and D64621-code on your sandbox
* Sandbox public-api
* Start local calypso
* Navigate to a site where site editor is enabled
* Make sure you see a `beta` badge next to the Site Editor both in Calypso and WP-admin

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

| calypso | wp-admin |
| - | - |
| ![image](https://user-images.githubusercontent.com/2256104/126632158-15b8fa43-646c-44da-bf82-fe0fc91378c4.png) | ![image](https://user-images.githubusercontent.com/2256104/126156147-6c044fa9-b2dd-4abc-bc61-d191c1222536.png) |

Related to https://github.com/Automattic/wp-calypso/issues/54464