### PR TITLE
Nav Unification: Hide quick switcher when SSO is inactive

### DIFF
--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -1,10 +1,10 @@
 /**
  * External Dependencies
  */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import classNames from 'classnames';
 import { useI18n } from '@wordpress/react-i18n';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import config from '@automattic/calypso-config';
 
 /**
@@ -15,6 +15,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import versionCompare from 'calypso/lib/version-compare';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 
 /**
  * Style dependencies
@@ -27,6 +29,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	const ref = useRef( null );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -34,29 +37,39 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	const jetpackVersion = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'jetpack_version' )
 	);
+	const isSsoActive = useSelector( ( state ) => isJetpackModuleActive( state, siteId, 'sso' ) );
 
-	const handleToggle = ( bool ) => {
-		if ( isBoolean( bool ) ) {
-			setIsOpen( bool );
-		} else {
-			setIsOpen( ! isOpen );
-		}
-	};
+	const handleToggle = useCallback(
+		( bool ) => {
+			if ( isBoolean( bool ) ) {
+				setIsOpen( bool );
+			} else {
+				setIsOpen( ! isOpen );
+			}
+		},
+		[ isOpen ]
+	);
 
-	const handleClosing = ( e ) => {
-		if ( e instanceof KeyboardEvent ) {
-			if ( e.key === 'Escape' ) {
+	const handleClosing = useCallback(
+		( e ) => {
+			if ( e instanceof KeyboardEvent ) {
+				if ( e.key === 'Escape' ) {
+					handleToggle( false );
+				}
+				return;
+			}
+
+			if ( ref.current && ! ref.current.contains( e.target ) ) {
 				handleToggle( false );
 			}
-			return;
-		}
-
-		if ( ref.current && ! ref.current.contains( e.target ) ) {
-			handleToggle( false );
-		}
-	};
+		},
+		[ handleToggle ]
+	);
 
 	useEffect( () => {
+		if ( isAtomic ) {
+			dispatch( fetchModuleList( siteId ) );
+		}
 		// Close the component when a click outside happens or users clicks Esc key.
 		document.addEventListener( 'click', handleClosing, true );
 		document.addEventListener( 'keydown', handleClosing, true );
@@ -66,7 +79,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 			document.removeEventListener( 'click', handleClosing, true );
 			document.removeEventListener( 'keydown', handleClosing, true );
 		};
-	}, [] );
+	}, [ siteId, isAtomic, dispatch, handleClosing ] );
 
 	if ( ! config.isEnabled( 'nav-unification/switcher' ) ) {
 		return null;
@@ -79,6 +92,11 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 
 	// Disable for Atomic sites that are running below Jetpack 9.9
 	if ( isAtomic && jetpackVersion && versionCompare( jetpackVersion, '9.9-alpha', '<' ) ) {
+		return null;
+	}
+
+	// Hide the quick switcher when SSO is inactive, since Nav Unification is disabled on WP Admin.
+	if ( isAtomic && ! isSsoActive ) {
 		return null;
 	}
 

--- a/client/components/screen-options-tab/test/index.js
+++ b/client/components/screen-options-tab/test/index.js
@@ -14,8 +14,14 @@ import { fireEvent, screen } from '@testing-library/react';
 import ScreenOptionsTab from '../index';
 import { render as rtlRender } from 'config/testing-library';
 import { reducer as ui } from 'calypso/state/ui/reducer';
+import jetpack from 'calypso/state/jetpack/reducer';
 
-const render = ( el, options ) => rtlRender( el, { ...options, reducers: { ui } } );
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useDispatch: jest.fn( () => () => {} ),
+} ) );
+
+const render = ( el, options ) => rtlRender( el, { ...options, reducers: { ui, jetpack } } );
 
 const siteId = 1;
 const adminUrl = 'https://example.wordpress.com/wp-admin';
@@ -24,7 +30,14 @@ const initialState = {
 	ui: { selectedSiteId: siteId },
 	sites: {
 		items: {
-			[ siteId ]: { options: { admin_url: adminUrl }, jetpack: false },
+			[ siteId ]: { options: { admin_url: adminUrl, is_wpcom_atomic: false }, jetpack: false },
+		},
+	},
+	jetpack: {
+		modules: {
+			items: {
+				[ siteId ]: { sso: { active: true } },
+			},
 		},
 	},
 };
@@ -33,7 +46,7 @@ describe( 'ScreenOptionsTab', () => {
 	test( 'it renders correctly', () => {
 		render( <ScreenOptionsTab wpAdminPath="index.php" />, { initialState } );
 
-		expect( screen.getByRole( 'button' ) ).toBeTruthy();
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeTruthy();
 	} );
 
 	test( 'does not render on all-sites screens', () => {
@@ -53,7 +66,44 @@ describe( 'ScreenOptionsTab', () => {
 				...initialState,
 				sites: {
 					items: {
-						[ siteId ]: { options: { admin_url: adminUrl }, jetpack: true },
+						[ siteId ]: { options: { admin_url: adminUrl, is_wpcom_atomic: false }, jetpack: true },
+					},
+				},
+			},
+		} );
+
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeNull();
+	} );
+
+	test( 'does render on Atomic sites', () => {
+		render( <ScreenOptionsTab wpAdminPath="index.php" />, {
+			initialState: {
+				...initialState,
+				sites: {
+					items: {
+						[ siteId ]: { options: { admin_url: adminUrl, is_wpcom_atomic: true }, jetpack: true },
+					},
+				},
+			},
+		} );
+
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeTruthy();
+	} );
+
+	test( 'does not render when the SSO module is disabled', () => {
+		render( <ScreenOptionsTab wpAdminPath="index.php" />, {
+			initialState: {
+				...initialState,
+				sites: {
+					items: {
+						[ siteId ]: { options: { admin_url: adminUrl, is_wpcom_atomic: true }, jetpack: true },
+					},
+				},
+				jetpack: {
+					modules: {
+						items: {
+							[ siteId ]: { sso: { active: false } },
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/54499

#### Changes proposed in this Pull Request

Since Nav Unification is disabled on WP Admin when the SSO is inactive, this PR hides the Quick Switcher from Calypso when such module is inactive. 

#### Testing instructions

- Make sure the Quick Switcher is NOT visible on Atomic sites when the SSO module is inactive (you can deactivate from `wp-admin/admin.php?page=jetpack#/settings`).
- Make sure the Quick Switcher is visible on Simple sites.
- Make sure the Quick Switcher is visible on Atomic sites when the SSO module is active.
