### PR TITLE
Theme Search: Fix filters popover

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -110,14 +110,20 @@ class MagicSearchWelcome extends React.Component {
 				key={ taxonomy }
 				data-key={ taxonomy }
 			>
-				<span className="themes-magic-search-card__welcome-taxonomy-icon-container">
+				<span
+					className="themes-magic-search-card__welcome-taxonomy-icon-container"
+					data-key={ taxonomy }
+				>
 					<Gridicon
 						icon={ taxonomyToGridicon( taxonomy ) }
 						className="themes-magic-search-card__welcome-taxonomy-icon"
 						size={ 18 }
 					/>{ ' ' }
 				</span>
-				<span className="themes-magic-search-card__welcome-taxonomy-text-container">
+				<span
+					className="themes-magic-search-card__welcome-taxonomy-text-container"
+					data-key={ taxonomy }
+				>
 					{ taxonomyTranslations[ taxonomy ] ||
 						i18n.translate( 'Unknown', {
 							context: 'Theme Showcase filter name',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the theme showcase, clicking "Filters" which reveals the "Magic Welcome Popover" had a bug where clicking an item would fill out "null:" in the search instead of the desired filter, like "feature:". This fixes the bug.
  * The cause of the bug is that late in the cycle of the revamp, [I added `<spans>`](https://github.com/Automattic/wp-calypso/blob/7fa581030913cea1fdb75c4ab684cc3d64daa6e6/client/my-sites/themes/themes-magic-search-card/welcome.jsx#L113-L116) that wrap elements to help alignment. However, [the onClick handler looks for a data- attribute](https://github.com/Automattic/wp-calypso/blob/7fa581030913cea1fdb75c4ab684cc3d64daa6e6/client/my-sites/themes/themes-magic-search-card/welcome.jsx#L28) that is no longer in the right place after the spans were added.

![magic-welcome-popover-bug](https://user-images.githubusercontent.com/937354/126179070-0a2218ee-2179-4249-811f-d6947b0fe42d.jpg)

^ Before

![2021-07-19_09-45](https://user-images.githubusercontent.com/937354/126179097-92b8e978-1f67-4a62-94a8-19ac5d7ec511.png)

^ After

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Theme showcase
* Click 'filters'
* Click one of the three filters, "Feature" "Columns" or "Subject"
* Expect to see: Text in the search bar filled out with a dropdown of autocomplete suggestions.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
