### PR TITLE
Add FSE themes tab

### DIFF
--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -15,6 +15,7 @@ export default class Badge extends React.Component {
 	static propTypes = {
 		type: PropTypes.oneOf( [
 			'warning',
+			'warning-clear',
 			'success',
 			'info',
 			'info-blue',

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -1,6 +1,6 @@
 .badge {
 	display: inline-block;
-    // A number large enough to exceed height of any badge to make it look like a pill
+	// A number large enough to exceed height of any badge to make it look like a pill
 	border-radius: 1000px; /* stylelint-disable-line scales/radii */
 	padding: $badge-padding-y $badge-padding-x;
 	font-size: $font-body-small;

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -1,10 +1,17 @@
 .badge {
 	display: inline-block;
-	border-radius: 1000px; // A number large enough to exceed height of any badge to make it look like a pill
+    // A number large enough to exceed height of any badge to make it look like a pill
+	border-radius: 1000px; /* stylelint-disable-line scales/radii */
 	padding: $badge-padding-y $badge-padding-x;
 	font-size: $font-body-small;
 	line-height: 17px;
 	height: 18px;
+}
+
+.badge--warning-clear {
+	color: var( --color-warning );
+	border: 1px solid var( --color-warning );
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
 }
 
 .badge--warning {

--- a/client/my-sites/themes/fse-themes.jsx
+++ b/client/my-sites/themes/fse-themes.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useQuery } from 'react-query';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+import { ConnectedThemesSelection } from './themes-selection';
+
+const FseThemes = ( props ) => {
+	// useQuery also provides 'error', currently unused here
+	const { data, isLoading } = useQuery(
+		'fse-themes',
+		() =>
+			wpcom.req.get( '/themes', {
+				filter: 'block-templates',
+				number: 50,
+				tier: '',
+				apiVersion: '1.2',
+			} ),
+		{}
+	);
+	return (
+		<ConnectedThemesSelection
+			isLoading={ isLoading }
+			customizedThemesList={ data?.themes ?? [] }
+			{ ...props }
+		/>
+	);
+};
+export default FseThemes;

--- a/client/my-sites/themes/fse-themes.jsx
+++ b/client/my-sites/themes/fse-themes.jsx
@@ -2,17 +2,18 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { useQuery } from 'react-query';
 
 /**
  * Internal dependencies
  */
+import EmptyContent from 'calypso/components/empty-content';
 import wpcom from 'calypso/lib/wp';
 import { ConnectedThemesSelection } from './themes-selection';
 
-const FseThemes = ( props ) => {
-	// useQuery also provides 'error', currently unused here
-	const { data, isLoading } = useQuery(
+const FseThemes = localize( ( { translate, ...restProps } ) => {
+	const { data, error, isLoading } = useQuery(
 		'fse-themes',
 		() =>
 			wpcom.req.get( '/themes', {
@@ -23,12 +24,15 @@ const FseThemes = ( props ) => {
 			} ),
 		{}
 	);
+	if ( error ) {
+		return <EmptyContent title={ translate( 'Sorry, no themes found.' ) } />;
+	}
 	return (
 		<ConnectedThemesSelection
 			isLoading={ isLoading }
 			customizedThemesList={ data?.themes ?? [] }
-			{ ...props }
+			{ ...restProps }
 		/>
 	);
-};
+} );
 export default FseThemes;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -89,7 +89,9 @@ class ThemeShowcase extends React.Component {
 				show: this.props.isJetpackSite,
 			},
 			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
-			FSE: {
+		};
+		if ( config.isEnabled( 'gutenboarding/site-editor' ) ) {
+			this.tabFilters.FSE = {
 				key: 'fse',
 				text: (
 					<span>
@@ -98,8 +100,8 @@ class ThemeShowcase extends React.Component {
 					</span>
 				),
 				order: 5,
-			},
-		};
+			};
+		}
 		this.state = {
 			tabFilter:
 				this.props.loggedOutComponent || this.props.search || this.props.filter || this.props.tier

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -89,9 +89,7 @@ class ThemeShowcase extends React.Component {
 				show: this.props.isJetpackSite,
 			},
 			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
-		};
-		if ( config.isEnabled( 'gutenboarding/site-editor' ) ) {
-			this.tabFilters.FSE = {
+			FSE: {
 				key: 'fse',
 				text: (
 					<span>
@@ -100,8 +98,9 @@ class ThemeShowcase extends React.Component {
 					</span>
 				),
 				order: 5,
-			};
-		}
+				show: config.isEnabled( 'gutenboarding/site-editor' ),
+			},
+		};
 		this.state = {
 			tabFilter:
 				this.props.loggedOutComponent || this.props.search || this.props.filter || this.props.tier

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -42,6 +42,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
 import RecommendedThemes from './recommended-themes';
 import TrendingThemes from './trending-themes';
+import FseThemes from './fse-themes';
 
 /**
  * Style dependencies
@@ -88,6 +89,7 @@ class ThemeShowcase extends React.Component {
 				show: this.props.isJetpackSite,
 			},
 			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
+			FSE: { key: 'fse', text: props.translate( 'FSE' ), order: 4 },
 		};
 		this.state = {
 			tabFilter:
@@ -390,6 +392,9 @@ class ThemeShowcase extends React.Component {
 					{ 'all' === this.state.tabFilter.key && this.allThemes( { themeProps } ) }
 					{ 'my-themes' === this.state.tabFilter.key && <ThemesSelection { ...themeProps } /> }
 					{ 'trending' === this.state.tabFilter.key && <TrendingThemes { ...themeProps } /> }
+					{ 'fse' === this.state.tabFilter.key && (
+						<FseThemes listLabel={ ' ' } { ...themeProps } />
+					) }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal source={ 'list' } />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -43,6 +43,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import RecommendedThemes from './recommended-themes';
 import TrendingThemes from './trending-themes';
 import FseThemes from './fse-themes';
+import Badge from 'calypso/components/badge';
 
 /**
  * Style dependencies
@@ -94,7 +95,9 @@ class ThemeShowcase extends React.Component {
 				text: (
 					<span>
 						{ props.translate( 'Full Site Editing' ) }
-						<span className="theme-showcase__badge-beta ">{ props.translate( 'Beta' ) }</span>
+						<Badge type="warning-clear" className="theme-showcase__badge-beta">
+							{ props.translate( 'Beta' ) }
+						</Badge>
 					</span>
 				),
 				order: 5,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -89,7 +89,7 @@ class ThemeShowcase extends React.Component {
 				show: this.props.isJetpackSite,
 			},
 			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
-			FSE: { key: 'fse', text: props.translate( 'FSE' ), order: 4 },
+			FSE: { key: 'fse', text: props.translate( 'Full Site Editing' ), order: 4 },
 		};
 		this.state = {
 			tabFilter:

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -89,7 +89,16 @@ class ThemeShowcase extends React.Component {
 				show: this.props.isJetpackSite,
 			},
 			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
-			FSE: { key: 'fse', text: props.translate( 'Full Site Editing' ), order: 4 },
+			FSE: {
+				key: 'fse',
+				text: (
+					<span>
+						{ props.translate( 'Full Site Editing' ) }
+						<span className="theme-showcase__badge-beta ">{ props.translate( 'Beta' ) }</span>
+					</span>
+				),
+				order: 5,
+			},
 		};
 		this.state = {
 			tabFilter:

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -405,9 +405,7 @@ class ThemeShowcase extends React.Component {
 					{ 'all' === this.state.tabFilter.key && this.allThemes( { themeProps } ) }
 					{ 'my-themes' === this.state.tabFilter.key && <ThemesSelection { ...themeProps } /> }
 					{ 'trending' === this.state.tabFilter.key && <TrendingThemes { ...themeProps } /> }
-					{ 'fse' === this.state.tabFilter.key && (
-						<FseThemes listLabel={ ' ' } { ...themeProps } />
-					) }
+					{ 'fse' === this.state.tabFilter.key && <FseThemes { ...themeProps } /> }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal source={ 'list' } />

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -79,3 +79,16 @@
 		margin-right: 0;
 	}
 }
+
+.theme-showcase__badge-beta {
+	display: inline-block;
+	padding: 1px 6px;
+	margin-left: 6px;
+	border: 1px solid var( --studio-yellow );
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
+	font-size: $font-body-extra-small;
+	font-weight: 600;
+	line-height: 14px;
+	color: var( --studio-yellow );
+	text-align: center;
+}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -81,14 +81,5 @@
 }
 
 .theme-showcase__badge-beta {
-	display: inline-block;
-	padding: 1px 6px;
 	margin-left: 6px;
-	border: 1px solid var( --color-warning );
-	border-radius: 12px; /* stylelint-disable-line scales/radii */
-	font-size: $font-body-extra-small;
-	font-weight: 600;
-	line-height: 14px;
-	color: var( --color-warning );
-	text-align: center;
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -89,6 +89,6 @@
 	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 14px;
-	color: var( --studio-yellow );
+	color: var( --color-warning );
 	text-align: center;
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -84,7 +84,7 @@
 	display: inline-block;
 	padding: 1px 6px;
 	margin-left: 6px;
-	border: 1px solid var( --studio-yellow );
+	border: 1px solid var( --color-warning );
 	border-radius: 12px; /* stylelint-disable-line scales/radii */
 	font-size: $font-body-extra-small;
 	font-weight: 600;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add FSE themes tab
  * `gutenboarding/site-editor` tag must be enabled to see. Should this flag be reused or should we make a themes specific one?

#### Testing instructions


* Visit http://calypso.localhost:3000/?flags=gutenboarding/site-editor
* Navigate to themes showcase (Appearance -> Themes)
* See the new FSE tab and test it out

![2021-07-20_14-21](https://user-images.githubusercontent.com/937354/126383198-32b4a2c6-eb01-478b-a2a3-a2570d704ff2.png)


Related to https://github.com/Automattic/wp-calypso/issues/54389
