### PR TITLE
Playwright: instruct CommentsComponent.publishComment to wait until everything has loaded.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -26,9 +26,11 @@ export class CommentsComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async postComment( comment: string ): Promise< void > {
+		// Wait for the page to fully load. Otherwise, the Post Comment button may not
+		// appear even if the text area is clicked on.
+		await this.page.waitForLoadState( 'networkidle' );
 		// To simulate user action first click on the field. This also exposes the
 		// submit comment button.
-		await this.page.waitForLoadState( 'load' );
 		await this.page.click( selectors.commentTextArea );
 		await this.page.fill( selectors.commentTextArea, comment );
 		await this.page.click( selectors.submitButton );

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -28,6 +28,7 @@ export class CommentsComponent extends BaseContainer {
 	async postComment( comment: string ): Promise< void > {
 		// To simulate user action first click on the field. This also exposes the
 		// submit comment button.
+		await this.page.waitForLoadState( 'load' );
 		await this.page.click( selectors.commentTextArea );
 		await this.page.fill( selectors.commentTextArea, comment );
 		await this.page.click( selectors.submitButton );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add a `this.page.waitForLoadState('networkidle')` call to the `CommentsComponent.postComment` method.

Background Details:
In #54006 a call was added to first click on the comment text area prior to entering the comment text.
This was for two reasons:
- better simulate user behavior.
- expose the Post Comment button.

However, this was not enough as intermittent failures of this method continued to crop up.

After observing the video recording it was noted that `postComment` method would execute immediately once the text area appeared, and this took place before rest of the page was loaded (including some scripts). Based on the timing of the `postComment`, intermittently the text area would be clicked on too fast, resulting in the `Post Comment` button never appearing.

This behavior was reproduced locally by throttling the network to 2G speeds then loading a published post page. Once the text area appeared, it was clicked and text entered. It took only 1 attempt to reproduce this behavior.

#### Testing instructions

TeamCity
- there should be no failure of anything related to comments.

Related
#54701
