### PR TITLE
Theme showcase: Add beta badge to FSE themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -16,6 +16,7 @@ import photon from 'photon';
  */
 import { Card, Ribbon, Button } from '@automattic/components';
 import ThemeMoreButton from './more-button';
+import Badge from 'calypso/components/badge';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import InfoPopover from 'calypso/components/info-popover';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -257,7 +258,9 @@ export class Theme extends Component {
 						<h2 className="theme__info-title">
 							{ name }
 							{ this.isFullSiteEditingTheme() && (
-								<span className="theme__badge-beta">{ translate( 'Beta' ) }</span>
+								<Badge type="warning-clear" className="theme__badge-beta">
+									{ translate( 'Beta' ) }
+								</Badge>
 							) }
 						</h2>
 						{ active && (

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -257,11 +257,7 @@ export class Theme extends Component {
 						<h2 className="theme__info-title">
 							{ name }
 							{ this.isFullSiteEditingTheme() && (
-								<span className="theme__badge-beta">
-									{ translate( 'Beta', {
-										context: 'singular noun, the currently active theme',
-									} ) }
-								</span>
+								<span className="theme__badge-beta">{ translate( 'Beta' ) }</span>
 							) }
 						</h2>
 						{ active && (

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -122,7 +122,7 @@ export class Theme extends Component {
 	isFullSiteEditingTheme() {
 		const { theme } = this.props;
 		const features = get( theme, [ 'taxonomies', 'theme_feature' ] );
-		return some( features, { slug: 'full-site-editing' } );
+		return some( features, { slug: 'block-templates' } );
 	}
 
 	renderPlaceholder() {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -119,6 +119,12 @@ export class Theme extends Component {
 		return some( skillLevels, { slug: 'beginner' } );
 	}
 
+	isFullSiteEditingTheme() {
+		const { theme } = this.props;
+		const features = get( theme, [ 'taxonomies', 'theme_feature' ] );
+		return some( features, { slug: 'full-site-editing' } );
+	}
+
 	renderPlaceholder() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -248,7 +254,16 @@ export class Theme extends Component {
 					</a>
 
 					<div className="theme__info">
-						<h2 className="theme__info-title">{ name }</h2>
+						<h2 className="theme__info-title">
+							{ name }
+							{ this.isFullSiteEditingTheme() && (
+								<span className="theme__badge-beta">
+									{ translate( 'Beta', {
+										context: 'singular noun, the currently active theme',
+									} ) }
+								</span>
+							) }
+						</h2>
 						{ active && (
 							<span className="theme__badge-active">
 								{ translate( 'Active', {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -33,6 +33,11 @@ $theme-info-height: 54px;
 		.price {
 			color: var( --color-text-inverted );
 		}
+
+		.theme__badge-beta {
+			color: var( --color-text-inverted );
+			border-color: var( --color-text-inverted );
+		}
 	}
 
 	&.is-actionable {
@@ -132,6 +137,19 @@ $theme-info-height: 54px;
 	text-transform: uppercase;
 	font-size: $font-body-extra-small;
 	font-weight: 600;
+}
+
+.theme__badge-beta {
+	display: inline-block;
+	padding: 1px 6px;
+	margin-left: 6px;
+	border: 1px solid var( --studio-yellow );
+	border-radius: 12px;
+	font-size: $font-body-extra-small;
+	font-weight: 600;
+	line-height: 14px;
+	color: var( --studio-yellow );
+	text-align: center;
 }
 
 .theme__thumbnail {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -143,12 +143,12 @@ $theme-info-height: 54px;
 	display: inline-block;
 	padding: 1px 6px;
 	margin-left: 6px;
-	border: 1px solid var( --studio-yellow );
+	border: 1px solid var( --color-warning );
 	border-radius: 12px;
 	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 14px;
-	color: var( --studio-yellow );
+	color: var( --color-warning );
 	text-align: center;
 }
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -140,16 +140,7 @@ $theme-info-height: 54px;
 }
 
 .theme__badge-beta {
-	display: inline-block;
-	padding: 1px 6px;
 	margin-left: 6px;
-	border: 1px solid var( --color-warning );
-	border-radius: 12px;
-	font-size: $font-body-extra-small;
-	font-weight: 600;
-	line-height: 14px;
-	color: var( --color-warning );
-	text-align: center;
 }
 
 .theme__thumbnail {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a `Beta` label to block-based themes (tagged with `block-templates`) in the theme showcase

![image](https://user-images.githubusercontent.com/2256104/126629071-52b22768-8c74-4eed-b443-2e48506e4ea3.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Appearance -> Themes
* Confirm `block-template` themes have a `Beta` badge

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/54508
