### PR TITLE
Remove the config( 'rtl' ) flag

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -138,7 +138,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		user: false,
 		env: calypsoEnv,
 		sanitize: sanitize,
-		isRTL: config( 'rtl' ),
+		isRTL: false,
 		requestFrom: request.query.from,
 		isWCComConnect,
 		isWooDna: wooDnaConfig( request.query ).isWooDnaFlow(),

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -119,7 +119,6 @@
 	],
 	"english_locales": [ "en", "en-gb" ],
 	"readerFollowingSource": "calypso",
-	"rtl": false,
 	"siftscience_key": false,
 	"signup_url": false,
 	"gutenboarding_url": false,

--- a/config/client.json
+++ b/config/client.json
@@ -28,7 +28,6 @@
 	"oauth_url",
 	"readerFollowingSource",
 	"rebrand_cities_prefix",
-	"rtl",
 	"siftscience_key",
 	"signup_url",
 	"support-user",

--- a/config/development.json
+++ b/config/development.json
@@ -8,7 +8,6 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "horizon.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"signup_url": "/start",
 	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -7,7 +7,6 @@
 	"hostname": "jetpack.cloud.localhost",
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
-	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -5,7 +5,6 @@
 	"client_slug": "browser",
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",

--- a/config/production.json
+++ b/config/production.json
@@ -130,7 +130,6 @@
 		"wordpress-action-search": false,
 		"nav-unification/switcher": true
 	},
-	"rtl": false,
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -6,7 +6,6 @@
 	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"signup_url": "/start",
 	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/test.json
+++ b/config/test.json
@@ -6,7 +6,6 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -7,7 +7,6 @@
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"rtl": false,
 	"signup_url": "/start",
 	"gutenboarding_url": "/new",
 	"login_url": "https://wordpress.com/wp-login.php",


### PR DESCRIPTION
The `config( 'rtl' )` flag is always `false` and is used only at one place. And it's not something that should be obviously configurable in different environments.

The `isRTL` value in `getDefaultContext` doesn't matter much, because it will be overwritten anyway, with a value derived from `context.lang`, in `attachI18n`.