### PR TITLE
Fix Show More position in domain picker

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -491,6 +491,7 @@ class RegisterDomainStep extends React.Component {
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }
+				{ this.renderSideContent() }
 				{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
 				<QueryContactDetailsCache />
 			</div>
@@ -1419,9 +1420,12 @@ class RegisterDomainStep extends React.Component {
 					hasResults &&
 					isFreeDomainExplainerVisible &&
 					this.renderFreeDomainExplainer() }
-				{ this.props.isReskinned && ! this.state.loadingResults && this.props.reskinSideContent }
 			</DomainSearchResults>
 		);
+	}
+
+	renderSideContent() {
+		return this.props.isReskinned && ! this.state.loadingResults && this.props.reskinSideContent;
 	}
 
 	getFetchAlgo() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reorders the domain picker UI to show the "Show More" button above promotional texts.

#### Before and after

#### Desktop

| Before | After |
| ------ | ----- |
| ![wordpress com_start](https://user-images.githubusercontent.com/17054134/126294880-8d0e0f64-52b7-48a5-8540-5fb0c2a00288.png) | ![calypso localhost_3000_start](https://user-images.githubusercontent.com/17054134/126295055-8c2ccc2a-c516-4dda-bf5a-cfe4cf5c15cd.png) |

#### Mobile

| Before | After |
| ------ | ----- |
| ![wordpress com_start_domains(Pixel 2 XL)](https://user-images.githubusercontent.com/17054134/126295565-7005590a-5162-4636-9a80-0cde0ff565f0.png) | ![calypso localhost_3000_start(Pixel 2 XL)](https://user-images.githubusercontent.com/17054134/126295695-75d40ce9-985e-465f-9b9a-6bfc22cc89bd.png) |

#### Testing instructions

1. Go to /start
2. Search for a domain 
3. The results (including "Show more button") should look exactly like production on Desktop.
4. The show more button should be right after the results on mobile.
5. Show more button should work as expected.


Fixes https://github.com/Automattic/wp-calypso/issues/53744
