### PR TITLE
My Home: Remove `lodash` from My Home

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -5,7 +5,7 @@ import { Card } from '@automattic/components';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, omitBy } from 'lodash';
+import { omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ const HELP_COMPONENT_LOCATION = 'customer-home';
 const amendYouTubeLink = ( link = '' ) =>
 	link.replace( 'youtube.com/embed/', 'youtube.com/watch?v=' );
 
-const getResultLink = ( result ) => amendYouTubeLink( get( result, RESULT_LINK ) );
+const getResultLink = ( result ) => amendYouTubeLink( result[ RESULT_LINK ] );
 
 const HelpSearch = ( { searchQuery, track } ) => {
 	const translate = useTranslate();
@@ -46,8 +46,8 @@ const HelpSearch = ( { searchQuery, track } ) => {
 		}
 
 		const resultLink = getResultLink( result );
-		const type = get( result, RESULT_TYPE, RESULT_ARTICLE );
-		const tour = get( result, RESULT_TOUR );
+		const type = result[ RESULT_TYPE ] ?? RESULT_ARTICLE;
+		const tour = result[ RESULT_TOUR ];
 
 		const tracksData = omitBy(
 			{

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -5,7 +5,6 @@ import { Card } from '@automattic/components';
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,15 +48,15 @@ const HelpSearch = ( { searchQuery, track } ) => {
 		const type = result[ RESULT_TYPE ] ?? RESULT_ARTICLE;
 		const tour = result[ RESULT_TOUR ];
 
-		const tracksData = omitBy(
-			{
+		const tracksData = Object.fromEntries(
+			Object.entries( {
 				search_query: searchQuery,
 				tour,
 				result_url: resultLink,
 				location: HELP_COMPONENT_LOCATION,
-			},
-			( prop ) => typeof prop === 'undefined'
+			} ).filter( ( [ , value ] ) => typeof value !== 'undefined' )
 		);
+
 		track( `calypso_inlinehelp_${ type }_open`, tracksData );
 	};
 

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -5,7 +5,6 @@ import React, { useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
-import { times } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -36,7 +35,7 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-const placeholderChartData = times( 7, () => ( {
+const placeholderChartData = Array.from( { length: 7 }, () => ( {
 	value: Math.random(),
 } ) );
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -156,4 +155,4 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 
 const connectHome = connect( mapStateToProps, mapDispatchToProps, mergeProps );
 
-export default flowRight( connectHome, withTrackingTool( 'HotJar' ) )( Home );
+export default connectHome( withTrackingTool( 'HotJar' )( Home ) );

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'calypso/state/action-types';
@@ -39,7 +34,7 @@ const fromApi = ( payload ) => {
 	// The checklist API requests use the http_envelope query param, however on
 	// desktop the envelope is not being unpacked for some reason. This conversion
 	// ensures the payload has been unpacked.
-	const data = get( payload, 'body', payload );
+	const data = payload?.body ?? payload;
 
 	if ( ! data ) {
 		throw new TypeError( `Missing 'body' property on API response` );

--- a/client/state/selectors/get-site-checklist.js
+++ b/client/state/selectors/get-site-checklist.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import 'calypso/state/checklist/init';
@@ -16,5 +11,5 @@ import 'calypso/state/checklist/init';
  * @returns {object}        Site settings
  */
 export default function getSiteChecklist( state, siteId ) {
-	return get( state.checklist, [ siteId, 'items' ], null );
+	return state.checklist?.[ siteId ]?.items ?? null;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're removing `lodash` p4TIVU-9Bf-p2
This PR is doing our bit to remove unnecessary use from My Home

Removes `get`, `omitBy`, `times` and `flowRight` from
- `/client/my-sites/customer-home/`
- `/client/state/data-layer/wpcom/checklist/`
- `/client/state/selectors/get-site-checklist.js`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No behaviour should have changed. Veryify the following still works:

* My Home still loads the hotjar library (run `localStorage.debug = 'calypso:analytics:hotjar'` in the JS console, refresh My Home, and check that there's the `Loading HotJar script` or `Not loading HotJar script` log messages appear)
* The stats placeholder on My Home still shows 7 random bars
* The site setup checklist tasks are still displayed as expected
* The `calypso_inlinehelp_article_open` Tracks event is still fired when searching for a support doc and clicking it
* The custom even props for the `calypso_inlinehelp_article_open` event still work as expected (see the code that used to use `omitBy`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

