### PR TITLE
Remove most wpcom.undocumented().site() methods

### DIFF
--- a/client/blocks/shortcode/index.js
+++ b/client/blocks/shortcode/index.js
@@ -11,20 +11,16 @@ function useRenderedShortcode( siteId, shortcode ) {
 	useEffect( () => {
 		// set the result to `null` and remember what `siteId` and `shortcode` are we requesting
 		setRequestState( { siteId, shortcode, result: null } );
-		wpcom
-			.undocumented()
-			.site( siteId )
-			.shortcodes( { shortcode } )
-			.then( ( result ) =>
-				setRequestState( ( prevState ) => {
-					// if the response doesn't match the request, ignore it (race condition)
-					if ( prevState.siteId !== siteId || prevState.shortcode !== shortcode ) {
-						return prevState;
-					}
-					// store the matching response into `result`
-					return { siteId, shortcode, result };
-				} )
-			);
+		wpcom.req.get( `/sites/${ siteId }/shortcodes/render`, { shortcode } ).then( ( result ) =>
+			setRequestState( ( prevState ) => {
+				// if the response doesn't match the request, ignore it (race condition)
+				if ( prevState.siteId !== siteId || prevState.shortcode !== shortcode ) {
+					return prevState;
+				}
+				// store the matching response into `result`
+				return { siteId, shortcode, result };
+			} )
+		);
 	}, [ siteId, shortcode ] );
 
 	return requestState.result;

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -15,11 +15,6 @@ const resources = [
 	[ 'statsInsights', 'stats/insights', '1.1' ],
 	[ 'statsFileDownloads', 'stats/file-downloads', '1.1' ],
 	[ 'statsAds', 'wordads/stats', '1.1' ],
-	[ 'sshCredentialsNew', 'ssh-credentials/new', '1.1', 'post' ],
-	[ 'sshCredentialsMine', 'ssh-credentials/mine', '1.1' ],
-	[ 'sshCredentialsMineDelete', 'ssh-credentials/mine/delete', '1.1', 'post' ],
-	[ 'sshScanToggle', 'ssh-credentials/mine', '1.1', 'post' ],
-	[ 'getOption', 'option/' ],
 ];
 
 const list = function ( resourceOptions ) {
@@ -85,95 +80,6 @@ function UndocumentedSite( id, wpcom ) {
 	this.wpcom = wpcom;
 	this._id = id;
 }
-
-UndocumentedSite.prototype.domains = function () {
-	return this.wpcom.req.get( `/sites/${ this._id }/domains`, { apiVersion: '1.2' } );
-};
-
-UndocumentedSite.prototype.shortcodes = function ( attributes, callback ) {
-	return this.wpcom.req.get( '/sites/' + this._id + '/shortcodes/render', attributes, callback );
-};
-
-UndocumentedSite.prototype.setOption = function ( query, callback ) {
-	return this.wpcom.req.post(
-		'/sites/' + this._id + '/option',
-		{
-			option_name: query.option_name,
-			is_array: query.is_array,
-			site_option: query.site_option,
-		},
-		{ option_value: query.option_value },
-		callback
-	);
-};
-
-UndocumentedSite.prototype.postCounts = function ( options, callback ) {
-	const query = Object.assign(
-		{
-			type: 'post',
-			apiNamespace: 'wpcom/v2',
-		},
-		options
-	);
-
-	const type = query.type;
-	delete query.type;
-
-	return this.wpcom.req.get( '/sites/' + this._id + '/post-counts/' + type, query, callback );
-};
-
-/**
- * Requests the status of a guided transfer
- *
- * @returns {Promise} Resolves to the response containing the transfer status
- */
-UndocumentedSite.prototype.getGuidedTransferStatus = function () {
-	debug( '/sites/:site:/transfer' );
-	return this.wpcom.req.get( '/sites/' + this._id + '/transfer', {
-		apiNamespace: 'wpcom/v2',
-	} );
-};
-
-/**
- * Saves guided transfer host details
- *
- * @param {object} hostDetails  Host details
- * @returns {Promise} Resolves to the response containing the transfer status
- */
-UndocumentedSite.prototype.saveGuidedTransferHostDetails = function ( hostDetails ) {
-	debug( '/sites/:site:/transfer' );
-	return this.wpcom.req.post( {
-		path: '/sites/' + this._id + '/transfer',
-		body: hostDetails,
-		apiNamespace: 'wpcom/v2',
-	} );
-};
-
-/**
- * Returns a single site connection.
- *
- * @param  {number}  connectionId The connection ID to get.
- * @returns {Promise}              A Promise to resolve when complete.
- */
-UndocumentedSite.prototype.getConnection = function ( connectionId ) {
-	debug( '/sites/:site_id:/publicize-connections/:connection_id: query' );
-	return this.wpcom.req.get( {
-		path: '/sites/' + this._id + '/publicize-connections/' + connectionId,
-		apiVersion: '1.1',
-	} );
-};
-
-/**
- * Runs Theme Setup (Headstart).
- *
- * @returns {Promise} A Promise to resolve when complete.
- */
-UndocumentedSite.prototype.runThemeSetup = function () {
-	return this.wpcom.req.post( {
-		path: '/sites/' + this._id + '/theme-setup',
-		apiNamespace: 'wpcom/v2',
-	} );
-};
 
 /**
  * Requests Store orders stats

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1327,18 +1327,6 @@ Undocumented.prototype.paypalExpressUrl = function ( data, fn ) {
 	return this.wpcom.req.post( '/me/paypal-express-url', data, fn );
 };
 
-/**
- * Update primary domain for blog
- *
- * @param {number} siteId The site ID
- * @param {string} domain The domain to set as primary
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.setPrimaryDomain = function ( siteId, domain, fn ) {
-	debug( '/sites/:site_id/domains/primary' );
-	return this.wpcom.req.post( '/sites/' + siteId + '/domains/primary', {}, { domain: domain }, fn );
-};
-
 function addReaderContentWidth( params ) {
 	if ( params.content_width ) {
 		return;

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -223,17 +223,11 @@ function configure( site, plugin, dispatch ) {
 	}
 
 	const saveOption = () => {
-		const query = {
-			option_name: option,
-			option_value: optionValue,
-			site_option: false,
-			is_array: false,
-		};
-
-		return wpcom
-			.undocumented()
-			.site( site.ID )
-			.setOption( query, ( error, data ) => {
+		return wpcom.req.post(
+			`/sites/${ site.ID }/option`,
+			{ option_name: option },
+			{ option_value: optionValue },
+			( error, data ) => {
 				if (
 					! error &&
 					'vaultpress' === plugin.slug &&
@@ -258,7 +252,8 @@ function configure( site, plugin, dispatch ) {
 					siteId: site.ID,
 					slug: plugin.slug,
 				} );
-			} );
+			}
+		);
 	};
 
 	// We don't need to check for VaultPress
@@ -266,10 +261,10 @@ function configure( site, plugin, dispatch ) {
 		return saveOption();
 	}
 
-	return wpcom
-		.undocumented()
-		.site( site.ID )
-		.getOption( { option_name: option }, ( getError, getData ) => {
+	return wpcom.req.get(
+		`/sites/${ site.ID }/option`,
+		{ option_name: option },
+		( getError, getData ) => {
 			if ( get( getData, 'option_value' ) === optionValue ) {
 				// Already registered with this key
 				dispatch( {
@@ -291,7 +286,8 @@ function configure( site, plugin, dispatch ) {
 				return;
 			}
 			return saveOption();
-		} );
+		}
+	);
 }
 
 export function fetchInstallInstructions( siteId ) {

--- a/client/state/posts/counts/actions.js
+++ b/client/state/posts/counts/actions.js
@@ -45,12 +45,8 @@ export function requestPostCounts( siteId, postType ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.site( siteId )
-			.postCounts( {
-				type: postType,
-			} )
+		return wpcom.req
+			.get( `/sites/${ siteId }/post-counts/${ postType }`, { apiNamespace: 'wpcom/v2' } )
 			.then( ( data ) => {
 				dispatch( receivePostCounts( siteId, postType, data.counts ) );
 				dispatch( {

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -117,10 +117,8 @@ export function fetchConnection( siteId, connectionId ) {
 			siteId,
 		} );
 
-		return wpcom
-			.undocumented()
-			.site( siteId )
-			.getConnection( connectionId )
+		return wpcom.req
+			.get( `/sites/${ siteId }/publicize-connections/${ connectionId }` )
 			.then( ( connection ) => {
 				dispatch( {
 					type: PUBLICIZE_CONNECTION_RECEIVE,

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { createSiteDomainObject } from './assembler';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import {
 	DOMAIN_PRIVACY_ENABLE,
 	DOMAIN_PRIVACY_DISABLE,
@@ -28,7 +28,6 @@ import 'calypso/state/data-layer/wpcom/domains/privacy/index.js';
  * Module vars
  */
 const debug = debugFactory( 'calypso:state:sites:domains:actions' );
-const wpcom = wp.undocumented();
 const noop = () => {};
 
 /**
@@ -119,9 +118,8 @@ export function fetchSiteDomains( siteId ) {
 	return ( dispatch ) => {
 		dispatch( domainsRequestAction( siteId ) );
 
-		return wpcom
-			.site( siteId )
-			.domains()
+		return wpcom.req
+			.get( `/sites/${ siteId }/domains`, { apiVersion: '1.2' } )
 			.then( ( data ) => {
 				const { domains = [] } = data;
 				dispatch( domainsRequestSuccessAction( siteId ) );
@@ -156,9 +154,9 @@ export function disableDomainPrivacy( siteId, domain ) {
 	};
 }
 
-export const setPrimaryDomain = ( siteId, domainName, onComplete = noop ) => ( dispatch ) => {
-	debug( 'setPrimaryDomain', siteId, domainName );
-	return wpcom.setPrimaryDomain( siteId, domainName, ( error, data ) => {
+export const setPrimaryDomain = ( siteId, domain, onComplete = noop ) => ( dispatch ) => {
+	debug( 'setPrimaryDomain', siteId, domain );
+	return wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain }, ( error, data ) => {
 		if ( error ) {
 			return onComplete( error, data );
 		}

--- a/client/state/sites/guided-transfer/actions.js
+++ b/client/state/sites/guided-transfer/actions.js
@@ -62,10 +62,8 @@ export function requestGuidedTransferStatus( siteId ) {
 				error,
 			} );
 
-		return wpcom
-			.undocumented()
-			.site( siteId )
-			.getGuidedTransferStatus()
+		return wpcom.req
+			.get( `/sites/${ siteId }/transfer`, { apiNamespace: 'wpcom/v2' } )
 			.then( success )
 			.catch( failure );
 	};
@@ -114,10 +112,8 @@ export function saveHostDetails( siteId, data ) {
 			dispatch( successNotice( translate( 'Thanks for confirming those details!' ) ) );
 		};
 
-		return wpcom
-			.undocumented()
-			.site( siteId )
-			.saveGuidedTransferHostDetails( data )
+		return wpcom.req
+			.post( { path: `/sites/${ siteId }/transfer`, apiNamespace: 'wpcom/v2' }, data )
 			.then( success )
 			.catch( failure );
 	};

--- a/client/state/theme-setup/actions.js
+++ b/client/state/theme-setup/actions.js
@@ -22,10 +22,11 @@ export function runThemeSetup( siteId ) {
 			type: THEME_SETUP_REQUEST,
 		} );
 
-		return wpcom
-			.undocumented()
-			.site( siteId )
-			.runThemeSetup()
+		return wpcom.req
+			.post( {
+				path: `/sites/${ siteId }/theme-setup`,
+				apiNamespace: 'wpcom/v2',
+			} )
 			.then( ( response ) => {
 				dispatch( {
 					type: THEME_SETUP_RESULT,


### PR DESCRIPTION
Removes most methods from `wpcom.undocumented().site()` except ones related to stats. The stats methods are called in a peculiar way and will have to be migrated all at once.

Places that need special attention IMO:
- was there really just one call of `wpcom.undocumented().site().domains()`? The generic `domains` name of the method makes it difficult to grep for. The last relevant PR is #19983 by @klimeryk
- verify that the `setOptions`/`getOptions` calls are migrated correctly. They happen only at one place that's difficult to test: when installing VaultPress or Akismet during Jetpack setup. I removed the `apiVersion: '1'` spec and left the default `1.1`, because I verified that the endpoint works OK anyway and I verified the backend PHP impl, too. Also the `site_option` and `is_array` params can be omitted because they have a default value already.

