### PR TITLE
Adding account-only signup flow

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -121,5 +121,15 @@ export function getSignupUrl(
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 	}
 
+	if (
+		includes( get( currentQuery, 'redirect_to' ), 'action=jetpack-sso' ) &&
+		includes( get( currentQuery, 'redirect_to' ), 'sso_nonce=' )
+	) {
+		const oauth2Params = new URLSearchParams( {
+			oauth2_redirect: redirectTo,
+		} );
+		signupUrl = `/start/account?${ oauth2Params.toString() }`;
+	}
+
 	return signupUrl;
 }

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -125,10 +125,10 @@ export function getSignupUrl(
 		includes( get( currentQuery, 'redirect_to' ), 'action=jetpack-sso' ) &&
 		includes( get( currentQuery, 'redirect_to' ), 'sso_nonce=' )
 	) {
-		const oauth2Params = new URLSearchParams( {
-			oauth2_redirect: redirectTo,
+		const params = new URLSearchParams( {
+			redirect_to: redirectTo,
 		} );
-		signupUrl = `/start/account?${ oauth2Params.toString() }`;
+		signupUrl = `/start/account?${ params.toString() }`;
 	}
 
 	return signupUrl;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -121,10 +121,7 @@ export function getSignupUrl(
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 	}
 
-	if (
-		includes( get( currentQuery, 'redirect_to' ), 'action=jetpack-sso' ) &&
-		includes( get( currentQuery, 'redirect_to' ), 'sso_nonce=' )
-	) {
+	if ( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) ) {
 		const params = new URLSearchParams( {
 			redirect_to: redirectTo,
 		} );

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -49,7 +49,11 @@ export function login( {
 	}
 
 	if ( redirectTo ) {
-		url = addQueryArgs( { redirect_to: redirectTo }, url );
+		if ( redirectTo.indexOf( 'jetpack-sso' ) !== -1 ) {
+			url = redirectTo;
+		} else {
+			url = addQueryArgs( { redirect_to: redirectTo }, url );
+		}
 	}
 
 	if ( emailAddress ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -49,11 +49,9 @@ export function login( {
 	}
 
 	if ( redirectTo ) {
-		if ( redirectTo.indexOf( 'jetpack-sso' ) !== -1 ) {
-			url = redirectTo;
-		} else {
-			url = addQueryArgs( { redirect_to: redirectTo }, url );
-		}
+		url = redirectTo.includes( 'jetpack-sso' )
+			? redirectTo
+			: addQueryArgs( { redirect_to: redirectTo }, url );
 	}
 
 	if ( emailAddress ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,7 +16,7 @@ export function generateFlows( {
 		{
 			name: 'account',
 			steps: [ 'user' ],
-			destination: '/',
+			destination: getRedirectDestination,
 			description: 'Create an account without a blog.',
 			lastModified: '2020-08-12',
 			pageTitle: translate( 'Create an account' ),

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -46,6 +46,8 @@ function getRedirectDestination( dependencies ) {
 			new URL( dependencies.oauth2_redirect ).host === 'public-api.wordpress.com'
 		) {
 			return dependencies.oauth2_redirect;
+		} else if ( dependencies.redirect ) {
+			return dependencies.redirect;
 		}
 	} catch {
 		return '/';

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -138,6 +138,7 @@ export function generateSteps( {
 				'username',
 				'marketing_price_group',
 				'plans_reorder_abtest_variation',
+				'redirect',
 			],
 			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
 			props: {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -385,8 +385,6 @@ export class UserStep extends Component {
 			return this.props.initialContext.query.oauth2_redirect;
 		}
 		if ( this.props.initialContext.canonicalPath.indexOf( '/start/account' ) !== -1 ) {
-			// const queryArgs = new URLSearchParams( this.props.initialContext.query.redirect_to );
-			// alert ( this.props.initialContext.query.redirect_to );
 			return this.props.initialContext.query.redirect_to;
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -384,7 +384,7 @@ export class UserStep extends Component {
 		) {
 			return this.props.initialContext.query.oauth2_redirect;
 		}
-		if ( this.props.initialContext.canonicalPath.indexOf( '/start/account' ) !== -1 ) {
+		if ( this.props.initialContext.canonicalPath.includes( '/start/account' ) ) {
 			return this.props.initialContext.query.redirect_to;
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -384,7 +384,7 @@ export class UserStep extends Component {
 		) {
 			return this.props.initialContext.query.oauth2_redirect;
 		}
-		if ( this.props.initialContext.canonicalPath.includes( '/start/account' ) ) {
+		if ( this.props.initialContext?.canonicalPath?.startsWith( '/start/account' ) ) {
 			return this.props.initialContext.query.redirect_to;
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -382,6 +382,11 @@ export class UserStep extends Component {
 		) {
 			return this.props.initialContext.query.oauth2_redirect;
 		}
+		if ( this.props.initialContext.canonicalPath.indexOf( '/start/account' ) !== -1 ) {
+			// const queryArgs = new URLSearchParams( this.props.initialContext.query.redirect_to );
+			// alert ( this.props.initialContext.query.redirect_to );
+			return this.props.initialContext.query.redirect_to;
+		}
 
 		const stepAfterRedirect =
 			getNextStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn ) ||

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -224,6 +224,8 @@ export class UserStep extends Component {
 		if ( oauth2Signup ) {
 			dependencies.oauth2_client_id = data.queryArgs.oauth2_client_id;
 			dependencies.oauth2_redirect = data.queryArgs.oauth2_redirect;
+		} else if ( data.queryArgs.redirect_to ) {
+			dependencies.redirect = data.queryArgs.redirect_to;
 		}
 
 		this.props.submitSignupStep(

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -84,6 +84,8 @@ export const redirectTo = combineReducers( {
 				const { path, query } = action;
 				if ( startsWith( path, '/log-in' ) ) {
 					return query.redirect_to || state;
+				} else if ( startsWith( path, '/start/account' ) ) {
+					return query.redirect_to || state;
 				} else if ( '/jetpack/connect/authorize' === path ) {
 					return addQueryArgs( query, path );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* This PR adds a case for user-only account flow for Jetpack SSO.
* Additional details at pau2Xa-38j-p2.
* TODO: this PR doesn't yet address the final redirect.

#### Testing instructions
* Checkout this PR and start Calypso
* Open `https://equal-chimpanzee.jurassic.ninja/wp-login.php` in an Incognito window.
* Click "Log in with WordPress.com"
* Click "Create a new account" and confirm that you're taken to `/start/account/PARAMS`
* Grab that path, including params, and paste add it onto `calypso.localhost:3000`
* Confirm that you're taken through the user-only flow.
* At this point it should redirect you to the Reader, but it needs to redirect you to the provided redirect url.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
