### PR TITLE
Theme Showcase: Remove unnecessary highlight around search area

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -84,7 +84,6 @@ $z-layers: (
 		'.web-preview__inner .spinner-line': 1,
 		'.is-section-purchases .search': 1,
 		'.checklist__task': 1,
-		'.themes-magic-search-card.has-highlight': 3, // Let child .keyed-suggestions be on top of .upwork-banner
 		'.is-installing .theme': 2,
 		'.people-list-item .card__link-indicator': 2,
 		'.page__shadow-notice-cover': 2,

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -20,9 +20,7 @@
 	}
 
 	&.has-highlight {
-		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
-		position: relative;
-		z-index: z-index( 'root', '.themes-magic-search-card.has-highlight' );
+		box-shadow: none;
 	}
 
 	.search {
@@ -30,7 +28,7 @@
 		flex: 0 1 auto;
 		margin: 0 5px 0 10px;
 		height: 36px;
-		border: solid 1px var( --color-neutral-10 );
+		border: solid 1px var( --color-border-subtle );
 
 		&.has-focus,
 		&.has-focus:hover {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We no longer need to highlight the whole search bar; remove highlight around it and leave just a darker border for focus/highlight state on search input

**Before**

<img width="1195" alt="Screen Shot 2021-07-20 at 9 53 37 AM" src="https://user-images.githubusercontent.com/2124984/126336392-75e5b075-7b6e-4dba-af18-1d8617f4e781.png">

**After**

<img width="1189" alt="Screen Shot 2021-07-20 at 9 53 21 AM" src="https://user-images.githubusercontent.com/2124984/126336412-d88768ae-9735-4613-a572-8f2fff917224.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]`
* Click on the search input, add some text; the focus state should look like the After screenshot above