### PR TITLE
Theme showcase: Move recommended to be the first tab

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -74,9 +74,9 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.tabFilters = {
-			RECOMMENDED: { key: 'recommended', text: props.translate( 'Recommended' ) },
-			ALL: { key: 'all', text: props.translate( 'All Themes' ) },
-			TRENDING: { key: 'trending', text: props.translate( 'Trending' ) },
+			RECOMMENDED: { key: 'recommended', text: props.translate( 'Recommended' ), order: 1 },
+			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 2 },
+			TRENDING: { key: 'trending', text: props.translate( 'Trending' ), order: 3 },
 		};
 		this.state = {
 			tabFilter:
@@ -338,15 +338,17 @@ class ThemeShowcase extends React.Component {
 					{ isLoggedIn && (
 						<SectionNav className="themes__section-nav" selectedText={ this.state.tabFilter.text }>
 							<NavTabs>
-								{ Object.values( this.tabFilters ).map( ( tabFilter ) => (
-									<NavItem
-										key={ tabFilter.key }
-										onClick={ () => this.onFilterClick( tabFilter ) }
-										selected={ tabFilter.key === this.state.tabFilter.key }
-									>
-										{ tabFilter.text }
-									</NavItem>
-								) ) }
+								{ Object.values( this.tabFilters )
+									.sort( ( a, b ) => a.order - b.order )
+									.map( ( tabFilter ) => (
+										<NavItem
+											key={ tabFilter.key }
+											onClick={ () => this.onFilterClick( tabFilter ) }
+											selected={ tabFilter.key === this.state.tabFilter.key }
+										>
+											{ tabFilter.text }
+										</NavItem>
+									) ) }
 							</NavTabs>
 						</SectionNav>
 					) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -74,8 +74,8 @@ class ThemeShowcase extends React.Component {
 		this.scrollRef = React.createRef();
 		this.bookmarkRef = React.createRef();
 		this.tabFilters = {
-			ALL: { key: 'all', text: props.translate( 'All Themes' ) },
 			RECOMMENDED: { key: 'recommended', text: props.translate( 'Recommended' ) },
+			ALL: { key: 'all', text: props.translate( 'All Themes' ) },
 			TRENDING: { key: 'trending', text: props.translate( 'Trending' ) },
 		};
 		this.state = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Theme showcase: Move recommended to be the first tab

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the theme showcase and check out the tabs

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/54690
