### PR TITLE
Jetpack Backup: Add backup storage space component

### DIFF
--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -46,22 +46,30 @@ type Props = {
 	href: string;
 	storageLimit: number;
 	upsellOption: BackupStorageSpaceUpsellOptions;
+	usedStorage: number;
 };
 
 export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 	href,
 	storageLimit,
 	upsellOption,
+	usedStorage,
 } ) => {
 	const translate = useTranslate();
 
 	useEffect( () => {
-		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', { type: upsellOption } );
-	}, [ upsellOption ] );
+		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', {
+			type: upsellOption,
+			usedStorage,
+		} );
+	}, [ upsellOption, usedStorage ] );
 
 	const onUpsellClick = useCallback( () => {
-		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', { type: upsellOption } );
-	}, [ upsellOption ] );
+		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', {
+			type: upsellOption,
+			usedStorage,
+		} );
+	}, [ upsellOption, usedStorage ] );
 
 	const titleText =
 		'out_of_storage' === upsellOption

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -57,11 +57,11 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', { type: upsellOption } );
-	}, [] );
+	}, [ upsellOption ] );
 
 	const onUpsellClick = useCallback( () => {
 		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', { type: upsellOption } );
-	}, [] );
+	}, [ upsellOption ] );
 
 	const titleText =
 		'out_of_storage' === upsellOption

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -19,8 +19,8 @@ import './style.scss';
 
 export type BackupStorageSpaceUpsellOptions =
 	| 'no_upsell'
-	| 'first_limit'
-	| 'second_limit'
+	| 'first_upsell'
+	| 'second_upsell'
 	| 'out_of_storage';
 
 const getStatusText = (
@@ -29,10 +29,10 @@ const getStatusText = (
 	translate: typeof translateType
 ) => {
 	switch ( upsellOption ) {
-		case 'first_limit':
+		case 'first_upsell':
 			// TODO: calculate storage time, account for GB, and translate once API data is available.
 			return sprintf( 'You will reach your %1$sGB storage limit in %2$s days', storageLimit, 3 );
-		case 'second_limit':
+		case 'second_upsell':
 			return translate( 'You’re running out of storage space.' );
 		case 'out_of_storage':
 			return translate( 'You ran out of storage space.' );

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -1,42 +1,91 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback, useEffect } from 'react';
 import { Button } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'calypso/components/gridicon';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { useTranslate, translate as translateType } from 'i18n-calypso';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
+export type BackupStorageSpaceUpsellOptions =
+	| 'no_upsell'
+	| 'first_limit'
+	| 'second_limit'
+	| 'out_of_storage';
+
+const getStatusText = (
+	upsellOption: BackupStorageSpaceUpsellOptions,
+	storageLimit: number,
+	translate: typeof translateType
+) => {
+	switch ( upsellOption ) {
+		case 'first_limit':
+			// TODO: calculate storage time, account for GB, and translate once API data is available.
+			return sprintf( 'You will reach your %1$sGB storage limit in %2$s days', storageLimit, 3 );
+		case 'second_limit':
+			return translate( 'You’re running out of storage space.' );
+		case 'out_of_storage':
+			return translate( 'You ran out of storage space.' );
+		case 'no_upsell':
+		default:
+			return '';
+	}
+};
+
 type Props = {
-	actionText: string;
 	href: string;
-	statusText: string;
-	titleText: string | undefined;
+	storageLimit: number;
+	upsellOption: BackupStorageSpaceUpsellOptions;
 };
 
 export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
-	actionText,
 	href,
-	statusText,
-	titleText,
-} ) => (
-	<>
-		{ titleText && <div className="backup-storage-space-upsell__title-text">{ titleText }</div> }
-		<Button className="backup-storage-space-upsell__button" href={ href }>
-			<div className="backup-storage-space-upsell__grid">
-				<div>
-					<div className="backup-storage-space-upsell__status-text">{ statusText }</div>
-					<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
+	storageLimit,
+	upsellOption,
+} ) => {
+	const translate = useTranslate();
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', { type: upsellOption } );
+	}, [] );
+
+	const onUpsellClick = useCallback( () => {
+		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', { type: upsellOption } );
+	}, [] );
+
+	const titleText =
+		'out_of_storage' === upsellOption
+			? translate( 'Your Backup storage is full and new backups have been paused' )
+			: undefined;
+	const statusText = getStatusText( upsellOption, storageLimit, translate );
+	const actionText = translate( 'Upgrade your backup storage to 2TB' );
+
+	return (
+		<>
+			{ titleText && <div className="backup-storage-space-upsell__title-text">{ titleText }</div> }
+			<Button
+				className="backup-storage-space-upsell__button"
+				href={ href }
+				onClick={ onUpsellClick }
+			>
+				<div className="backup-storage-space-upsell__grid">
+					<div>
+						<div className="backup-storage-space-upsell__status-text">{ statusText }</div>
+						<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
+					</div>
+					<Gridicon icon="arrow-right" />
 				</div>
-				<Gridicon icon="arrow-right" />
-			</div>
-		</Button>
-	</>
-);
+			</Button>
+		</>
+	);
+};

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'calypso/components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type Props = {
+	actionText: string;
+	href: string;
+	statusText: string;
+	titleText: string | undefined;
+};
+
+export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
+	actionText,
+	href,
+	statusText,
+	titleText,
+} ) => (
+	<>
+		{ titleText && <div className="backup-storage-space-upsell__title-text">{ titleText }</div> }
+		<Button className="backup-storage-space-upsell__button" href={ href }>
+			<div className="backup-storage-space-upsell__grid">
+				<div>
+					<div className="backup-storage-space-upsell__status-text">{ statusText }</div>
+					<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
+				</div>
+				<Gridicon icon="arrow-right" />
+			</div>
+		</Button>
+	</>
+);

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -10,7 +10,7 @@ import { sprintf } from '@wordpress/i18n';
  */
 import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { useTranslate, translate as translateType } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -26,7 +26,7 @@ export type BackupStorageSpaceUpsellOptions =
 const getStatusText = (
 	upsellOption: BackupStorageSpaceUpsellOptions,
 	storageLimit: number,
-	translate: typeof translateType
+	translate: ReturnType< typeof useTranslate >
 ) => {
 	switch ( upsellOption ) {
 		case 'first_upsell':

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { FunctionComponent, useCallback, useEffect } from 'react';
 import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 
 /**
@@ -55,21 +56,26 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 	upsellOption,
 	usedStorage,
 } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	useEffect( () => {
-		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', {
-			type: upsellOption,
-			usedStorage,
-		} );
-	}, [ upsellOption, usedStorage ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', {
+				type: upsellOption,
+				usedStorage,
+			} )
+		);
+	}, [ dispatch, upsellOption, usedStorage ] );
 
 	const onUpsellClick = useCallback( () => {
-		recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', {
-			type: upsellOption,
-			usedStorage,
-		} );
-	}, [ upsellOption, usedStorage ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', {
+				type: upsellOption,
+				usedStorage,
+			} )
+		);
+	}, [ dispatch, upsellOption, usedStorage ] );
 
 	const titleText =
 		'out_of_storage' === upsellOption

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -100,7 +100,7 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 						<div className="backup-storage-space-upsell__status-text">{ statusText }</div>
 						<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
 					</div>
-					<Gridicon icon="arrow-right" />
+					<span className="backup-storage-space-upsell__action-arrow">&#8594;</span>
 				</div>
 			</Button>
 		</>

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React, { FunctionComponent, useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 
 /**
@@ -64,6 +64,7 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', {
 				type: upsellOption,
 				usedStorage,
+				path: '/backup/:site',
 			} )
 		);
 	}, [ dispatch, upsellOption, usedStorage ] );
@@ -73,6 +74,7 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', {
 				type: upsellOption,
 				usedStorage,
+				path: '/backup/:site',
 			} )
 		);
 	}, [ dispatch, upsellOption, usedStorage ] );

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -89,19 +89,17 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 
 	return (
 		<>
-			{ titleText && <div className="backup-storage-space-upsell__title-text">{ titleText }</div> }
+			{ titleText && <div className="backup-storage-space-upsell__title">{ titleText }</div> }
 			<Button
-				className="backup-storage-space-upsell__button"
+				className="backup-storage-space-upsell__call-to-action"
 				href={ href }
 				onClick={ onUpsellClick }
 			>
-				<div className="backup-storage-space-upsell__grid">
-					<div>
-						<div className="backup-storage-space-upsell__status-text">{ statusText }</div>
-						<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
-					</div>
-					<span className="backup-storage-space-upsell__action-arrow">&#8594;</span>
+				<div className="backup-storage-space-upsell__copy">
+					<div className="backup-storage-space-upsell__status">{ statusText }</div>
+					<div className="backup-storage-space-upsell__action-text">{ actionText }</div>
 				</div>
+				<span className="backup-storage-space-upsell__arrow">&#8594;</span>
 			</Button>
 		</>
 	);

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -9,6 +9,7 @@ import { sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { preventWidows } from 'calypso/lib/formatting';
 import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { useTranslate } from 'i18n-calypso';
@@ -83,8 +84,8 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 		'out_of_storage' === upsellOption
 			? translate( 'Your Backup storage is full and new backups have been paused' )
 			: undefined;
-	const statusText = getStatusText( upsellOption, storageLimit, translate );
-	const actionText = translate( 'Upgrade your backup storage to 2TB' );
+	const statusText = preventWidows( getStatusText( upsellOption, storageLimit, translate ) );
+	const actionText = preventWidows( translate( 'Upgrade your backup storage to 2TB' ) );
 
 	return (
 		<>

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/index.tsx
@@ -63,7 +63,7 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', {
 				type: upsellOption,
-				usedStorage,
+				used_storage: usedStorage,
 				path: '/backup/:site',
 			} )
 		);
@@ -73,7 +73,7 @@ export const BackupStorageSpaceUpsell: FunctionComponent< Props > = ( {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', {
 				type: upsellOption,
-				usedStorage,
+				used_storage: usedStorage,
 				path: '/backup/:site',
 			} )
 		);

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -1,0 +1,42 @@
+.backup-storage-space-upsell__title-text {
+	font-size: 1rem;
+	font-weight: bold;
+	margin-bottom: 16px;
+}
+
+a.backup-storage-space-upsell__button {
+	color: #1e1e1e;
+}
+
+.backup-storage-space-upsell__button {
+	border: 2px solid var( --studio-jetpack-green );
+	border-radius: 2px;
+	padding: 16px 24px;
+	width: 100%;
+	height: 100%;
+	font-size: 1rem;
+
+	&:hover {
+		background: var( --color-accent-0 );
+	}
+}
+
+.backup-storage-space-upsell__grid {
+	display: grid;
+	grid-template-columns: auto min-content;
+	align-items: center;
+	width: 100%;
+	text-align: left;
+
+	.gridicons-arrow-right {
+		color: var( --studio-jetpack-green );
+	}
+}
+
+.backup-storage-space-upsell__status-text {
+	margin-bottom: 0.25rem;
+}
+
+.backup-storage-space-upsell__action-text {
+	font-weight: bold;
+}

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -4,8 +4,8 @@
 	margin-bottom: 16px;
 }
 
-a.backup-storage-space-upsell__button {
-	color: #1e1e1e;
+.backup-storage-space-upsell__button.components-button {
+	color: var( --color-text );
 }
 
 .backup-storage-space-upsell__button {

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -9,12 +9,12 @@ a.backup-storage-space-upsell__button {
 }
 
 .backup-storage-space-upsell__button {
-	border: 2px solid var( --studio-jetpack-green );
+	border: 2px solid var( --color-primary );
 	border-radius: 2px;
 	padding: 16px 24px;
 	width: 100%;
 	height: 100%;
-	font-size: 1rem;
+	font-size: $font-body;
 
 	&:hover {
 		background: var( --color-accent-0 );

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -29,7 +29,7 @@ a.backup-storage-space-upsell__button {
 	text-align: left;
 
 	.gridicons-arrow-right {
-		color: var( --studio-jetpack-green );
+		color: var( --color-primary );
 	}
 }
 

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -14,7 +14,7 @@
 
 	padding: 16px 24px;
 	border: 2px solid var( --studio-jetpack-green );
-	border-radius: 4px;
+	border-radius: calc( 2 * 2px );
 
 	color: var( --color-text );
 	font-size: $font-body;
@@ -31,10 +31,6 @@
 		.backup-storage-space-upsell__arrow {
 			transform: translateX( 8px );
 		}
-	}
-
-	&:focus {
-		box-shadow: none;
 	}
 }
 

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -9,15 +9,29 @@
 }
 
 .backup-storage-space-upsell__button {
-	border: 2px solid var( --color-primary );
-	border-radius: 2px;
+	border: 2px solid var( --studio-jetpack-green );
+	border-radius: 4px;
 	padding: 16px 24px;
 	width: 100%;
 	height: 100%;
 	font-size: $font-body;
 
-	&:hover {
-		background: var( --color-accent-0 );
+	&:hover,
+	&:focus {
+		background: none;
+
+		.backup-storage-space-upsell__action-text {
+			text-decoration: underline;
+			text-decoration-thickness: 2px;
+		}
+
+		.backup-storage-space-upsell__action-arrow {
+			transform: translateX( 8px );
+		}
+	}
+
+	&:focus {
+		box-shadow: none;
 	}
 }
 
@@ -39,4 +53,12 @@
 
 .backup-storage-space-upsell__action-text {
 	font-weight: bold;
+}
+
+.backup-storage-space-upsell__action-arrow {
+	transition: transform 0.15s ease-out;
+
+	color: var( --studio-jetpack-green );
+	font-size: $font-title-medium;
+	font-weight: 600;
 }

--- a/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
+++ b/client/my-sites/backup/backup-storage-space/backup-storage-space-upsell/style.scss
@@ -1,19 +1,22 @@
-.backup-storage-space-upsell__title-text {
+.backup-storage-space-upsell__title {
 	font-size: 1rem;
 	font-weight: bold;
 	margin-bottom: 16px;
 }
 
-.backup-storage-space-upsell__button.components-button {
-	color: var( --color-text );
-}
-
-.backup-storage-space-upsell__button {
-	border: 2px solid var( --studio-jetpack-green );
-	border-radius: 4px;
-	padding: 16px 24px;
+.backup-storage-space-upsell__call-to-action.components-button {
 	width: 100%;
 	height: 100%;
+
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	column-gap: 8px;
+
+	padding: 16px 24px;
+	border: 2px solid var( --studio-jetpack-green );
+	border-radius: 4px;
+
+	color: var( --color-text );
 	font-size: $font-body;
 
 	&:hover,
@@ -25,7 +28,7 @@
 			text-decoration-thickness: 2px;
 		}
 
-		.backup-storage-space-upsell__action-arrow {
+		.backup-storage-space-upsell__arrow {
 			transform: translateX( 8px );
 		}
 	}
@@ -35,19 +38,7 @@
 	}
 }
 
-.backup-storage-space-upsell__grid {
-	display: grid;
-	grid-template-columns: auto min-content;
-	align-items: center;
-	width: 100%;
-	text-align: left;
-
-	.gridicons-arrow-right {
-		color: var( --color-primary );
-	}
-}
-
-.backup-storage-space-upsell__status-text {
+.backup-storage-space-upsell__status {
 	margin-bottom: 0.25rem;
 }
 
@@ -55,7 +46,7 @@
 	font-weight: bold;
 }
 
-.backup-storage-space-upsell__action-arrow {
+.backup-storage-space-upsell__arrow {
 	transition: transform 0.15s ease-out;
 
 	color: var( --studio-jetpack-green );

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -16,15 +16,15 @@ import { BackupStorageSpaceUpsell } from './backup-storage-space-upsell';
  */
 import './style.scss';
 
-type Props = {
-	storageLimit: number;
-	usedStorage: number;
-};
+type Props = Record< string, never >;
 
 const upsellLimit1 = 0.6;
 const upsellLimit2 = 0.85;
 
-export const BackupStorageSpace: FunctionComponent< Props > = ( { storageLimit, usedStorage } ) => {
+export const BackupStorageSpace: FunctionComponent< Props > = () => {
+	const storageLimit = 200;
+	const usedStorage = 200;
+
 	const translate = useTranslate();
 
 	const usedStorageFraction = usedStorage / storageLimit;
@@ -44,7 +44,12 @@ export const BackupStorageSpace: FunctionComponent< Props > = ( { storageLimit, 
 	let statusText;
 	let titleText;
 	if ( usedStorageFraction >= upsellLimit1 ) {
-		statusText = translate( 'You will reach your 200GB storage limit in 3 days' );
+		// TODO: calculate storage time, account for GB, and translate once API data is available.
+		statusText = sprintf(
+			'You will reach your %1$sGB storage limit in %2$s days',
+			storageLimit,
+			3
+		);
 	}
 	if ( usedStorageFraction >= upsellLimit2 ) {
 		statusText = translate( 'You’re running out of storage space.' );
@@ -78,7 +83,7 @@ export const BackupStorageSpace: FunctionComponent< Props > = ( { storageLimit, 
 						titleText={ titleText }
 						statusText={ statusText }
 						actionText={ actionText }
-						href=""
+						href="/pricing/backup"
 					/>
 				</>
 			) }

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -77,6 +77,7 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 					<BackupStorageSpaceUpsell
 						upsellOption={ upsellOption }
 						storageLimit={ storageLimit }
+						usedStorage={ usedStorage }
 						href="/pricing/backup"
 					/>
 				</>

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -62,12 +62,7 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 			<div className="backup-storage-space__progress-bar-container">
 				<div>{ translate( 'Storage space' ) }</div>
 				<div className="backup-storage-space__progress-bar">
-					<ProgressBar
-						value={ usedStorage }
-						total={ storageLimit }
-						color={ progressBarColor }
-						title={ title }
-					/>
+					<ProgressBar value={ usedStorage } total={ storageLimit } color={ progressBarColor } />
 				</div>
 				<div>{ title }</div>
 			</div>

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { sprintf } from '@wordpress/i18n';
+import { Card, ProgressBar } from '@automattic/components';
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type Props = {
+	storageLimit: number;
+	usedStorage: number;
+};
+
+export const BackupStorageSpace: FunctionComponent< Props > = ( { storageLimit, usedStorage } ) => {
+	const translate = useTranslate();
+
+	const usedStorageFraction = usedStorage / storageLimit;
+	let color = '#2C3338';
+	if ( 0.6 <= usedStorageFraction ) {
+		color = '#DEB100';
+	}
+	if ( 0.85 <= usedStorageFraction ) {
+		color = '#E65054';
+	}
+
+	// TODO: account for MB/GB and translate once API data is available
+	const title = sprintf( '%1$sGB of %2$sGB used', usedStorage, storageLimit );
+
+	return (
+		<Card className="backup-storage-space">
+			<div className="backup-storage-space__container">
+				<div>{ translate( 'Storage space' ) }</div>
+				<div className="backup-storage-space__progress-bar">
+					<ProgressBar
+						value={ usedStorage }
+						total={ storageLimit }
+						color={ color }
+						title={ title }
+					/>
+				</div>
+				<div>{ title }</div>
+			</div>
+		</Card>
+	);
+};

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -24,8 +24,8 @@ const upsellLimit2 = 0.85;
 
 const progressBarColors: Record< BackupStorageSpaceUpsellOptions, string > = {
 	no_upsell: '#2C3338',
-	first_limit: '#DEB100',
-	second_limit: '#E65054',
+	first_upsell: '#DEB100',
+	second_upsell: '#E65054',
 	out_of_storage: '#E65054',
 };
 
@@ -41,10 +41,10 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 
 	let upsellOption: BackupStorageSpaceUpsellOptions = 'no_upsell';
 	if ( usedStorageFraction >= upsellLimit1 ) {
-		upsellOption = 'first_limit';
+		upsellOption = 'first_upsell';
 	}
 	if ( usedStorageFraction >= upsellLimit2 ) {
-		upsellOption = 'second_limit';
+		upsellOption = 'second_upsell';
 	}
 	if ( usedStorage >= storageLimit ) {
 		upsellOption = 'out_of_storage';

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -9,17 +9,27 @@ import React, { FunctionComponent } from 'react';
  * Internal dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import { BackupStorageSpaceUpsell } from './backup-storage-space-upsell';
+import {
+	BackupStorageSpaceUpsell,
+	BackupStorageSpaceUpsellOptions,
+} from './backup-storage-space-upsell';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-type Props = Record< string, never >;
-
 const upsellLimit1 = 0.6;
 const upsellLimit2 = 0.85;
+
+const progressBarColors: Record< BackupStorageSpaceUpsellOptions, string > = {
+	no_upsell: '#2C3338',
+	first_limit: '#DEB100',
+	second_limit: '#E65054',
+	out_of_storage: '#E65054',
+};
+
+type Props = Record< string, never >;
 
 export const BackupStorageSpace: FunctionComponent< Props > = () => {
 	const storageLimit = 200;
@@ -29,35 +39,20 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 
 	const usedStorageFraction = usedStorage / storageLimit;
 
-	const showUpsell = upsellLimit1 <= usedStorageFraction;
-
-	let progressBarColor = '#2C3338';
+	let upsellOption: BackupStorageSpaceUpsellOptions = 'no_upsell';
 	if ( usedStorageFraction >= upsellLimit1 ) {
-		progressBarColor = '#DEB100';
+		upsellOption = 'first_limit';
 	}
 	if ( usedStorageFraction >= upsellLimit2 ) {
-		progressBarColor = '#E65054';
+		upsellOption = 'second_limit';
+	}
+	if ( usedStorage >= storageLimit ) {
+		upsellOption = 'out_of_storage';
 	}
 
-	const actionText = translate( 'Upgrade your backup storage to 2TB' );
+	const showUpsell = upsellOption !== 'no_upsell';
 
-	let statusText;
-	let titleText;
-	if ( usedStorageFraction >= upsellLimit1 ) {
-		// TODO: calculate storage time, account for GB, and translate once API data is available.
-		statusText = sprintf(
-			'You will reach your %1$sGB storage limit in %2$s days',
-			storageLimit,
-			3
-		);
-	}
-	if ( usedStorageFraction >= upsellLimit2 ) {
-		statusText = translate( 'You’re running out of storage space.' );
-	}
-	if ( 1 === usedStorageFraction ) {
-		statusText = translate( 'You ran out of storage space.' );
-		titleText = translate( 'Your Backup storage is full and new backups have been paused' );
-	}
+	const progressBarColor = progressBarColors[ upsellOption ];
 
 	// TODO: account for MB/GB and translate once API data is available
 	const title = sprintf( '%1$sGB of %2$sGB used', usedStorage, storageLimit );
@@ -80,9 +75,8 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 				<>
 					<div className="backup-storage-space__divider"></div>
 					<BackupStorageSpaceUpsell
-						titleText={ titleText }
-						statusText={ statusText }
-						actionText={ actionText }
+						upsellOption={ upsellOption }
+						storageLimit={ storageLimit }
 						href="/pricing/backup"
 					/>
 				</>

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -9,6 +9,7 @@ import React, { FunctionComponent } from 'react';
  * Internal dependencies
  */
 import { useTranslate } from 'i18n-calypso';
+import { BackupStorageSpaceUpsell } from './backup-storage-space-upsell';
 
 /**
  * Style dependencies
@@ -20,16 +21,37 @@ type Props = {
 	usedStorage: number;
 };
 
+const upsellLimit1 = 0.6;
+const upsellLimit2 = 0.85;
+
 export const BackupStorageSpace: FunctionComponent< Props > = ( { storageLimit, usedStorage } ) => {
 	const translate = useTranslate();
 
 	const usedStorageFraction = usedStorage / storageLimit;
-	let color = '#2C3338';
-	if ( 0.6 <= usedStorageFraction ) {
-		color = '#DEB100';
+
+	const showUpsell = upsellLimit1 <= usedStorageFraction;
+
+	let progressBarColor = '#2C3338';
+	if ( usedStorageFraction >= upsellLimit1 ) {
+		progressBarColor = '#DEB100';
 	}
-	if ( 0.85 <= usedStorageFraction ) {
-		color = '#E65054';
+	if ( usedStorageFraction >= upsellLimit2 ) {
+		progressBarColor = '#E65054';
+	}
+
+	const actionText = translate( 'Upgrade your backup storage to 2TB' );
+
+	let statusText;
+	let titleText;
+	if ( usedStorageFraction >= upsellLimit1 ) {
+		statusText = translate( 'You will reach your 200GB storage limit in 3 days' );
+	}
+	if ( usedStorageFraction >= upsellLimit2 ) {
+		statusText = translate( 'You’re running out of storage space.' );
+	}
+	if ( 1 === usedStorageFraction ) {
+		statusText = translate( 'You ran out of storage space.' );
+		titleText = translate( 'Your Backup storage is full and new backups have been paused' );
 	}
 
 	// TODO: account for MB/GB and translate once API data is available
@@ -37,18 +59,29 @@ export const BackupStorageSpace: FunctionComponent< Props > = ( { storageLimit, 
 
 	return (
 		<Card className="backup-storage-space">
-			<div className="backup-storage-space__container">
+			<div className="backup-storage-space__progress-bar-container">
 				<div>{ translate( 'Storage space' ) }</div>
 				<div className="backup-storage-space__progress-bar">
 					<ProgressBar
 						value={ usedStorage }
 						total={ storageLimit }
-						color={ color }
+						color={ progressBarColor }
 						title={ title }
 					/>
 				</div>
 				<div>{ title }</div>
 			</div>
+			{ showUpsell && (
+				<>
+					<div className="backup-storage-space__divider"></div>
+					<BackupStorageSpaceUpsell
+						titleText={ titleText }
+						statusText={ statusText }
+						actionText={ actionText }
+						href=""
+					/>
+				</>
+			) }
 		</Card>
 	);
 };

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -60,7 +60,9 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 	return (
 		<Card className="backup-storage-space">
 			<div className="backup-storage-space__progress-bar-container">
-				<div>{ translate( 'Storage space' ) }</div>
+				<div className="backup-storage-space__progress-heading">
+					{ translate( 'Storage space' ) }
+				</div>
 				<div className="backup-storage-space__progress-bar">
 					<ProgressBar
 						className={ progressBarWarning }
@@ -68,7 +70,7 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 						total={ storageLimit }
 					/>
 				</div>
-				<div>{ title }</div>
+				<div className="backup-storage-space__progress-usage-text">{ title }</div>
 			</div>
 			{ showUpsell && (
 				<>

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -22,11 +22,11 @@ import './style.scss';
 const upsellLimit1 = 0.6;
 const upsellLimit2 = 0.85;
 
-const progressBarColors: Record< BackupStorageSpaceUpsellOptions, string > = {
-	no_upsell: '#2C3338',
-	first_upsell: '#DEB100',
-	second_upsell: '#E65054',
-	out_of_storage: '#E65054',
+const progressBarWarnings: Record< BackupStorageSpaceUpsellOptions, string > = {
+	no_upsell: 'no-warning',
+	first_upsell: 'yellow-warning',
+	second_upsell: 'red-warning',
+	out_of_storage: 'red-warning',
 };
 
 type Props = Record< string, never >;
@@ -52,7 +52,7 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 
 	const showUpsell = upsellOption !== 'no_upsell';
 
-	const progressBarColor = progressBarColors[ upsellOption ];
+	const progressBarWarning = progressBarWarnings[ upsellOption ];
 
 	// TODO: account for MB/GB and translate once API data is available
 	const title = sprintf( '%1$sGB of %2$sGB used', usedStorage, storageLimit );
@@ -62,7 +62,11 @@ export const BackupStorageSpace: FunctionComponent< Props > = () => {
 			<div className="backup-storage-space__progress-bar-container">
 				<div>{ translate( 'Storage space' ) }</div>
 				<div className="backup-storage-space__progress-bar">
-					<ProgressBar value={ usedStorage } total={ storageLimit } color={ progressBarColor } />
+					<ProgressBar
+						className={ progressBarWarning }
+						value={ usedStorage }
+						total={ storageLimit }
+					/>
 				</div>
 				<div>{ title }</div>
 			</div>

--- a/client/my-sites/backup/backup-storage-space/index.tsx
+++ b/client/my-sites/backup/backup-storage-space/index.tsx
@@ -3,7 +3,7 @@
  */
 import { sprintf } from '@wordpress/i18n';
 import { Card, ProgressBar } from '@automattic/components';
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -35,9 +35,7 @@ const progressBarWarnings: Record< BackupStorageSpaceUpsellOptions, string > = {
 	out_of_storage: 'red-warning',
 };
 
-type Props = Record< string, never >;
-
-export const BackupStorageSpace: FunctionComponent< Props > = () => {
+export const BackupStorageSpace: React.FC = () => {
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId ) as number;

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -5,7 +5,7 @@
 	box-shadow: 0 0 0 1px #dcdcde;
 }
 
-.backup-storage-space__container {
+.backup-storage-space__progress-bar-container {
 	display: grid;
 	grid-template-columns: max-content auto max-content;
 	align-items: center;
@@ -13,4 +13,9 @@
 
 .backup-storage-space__progress-bar {
 	padding: 0 24px;
+}
+
+.backup-storage-space__divider {
+	margin: 16px -32px;
+	border-bottom: 1px solid var( --studio-gray-10 );
 }

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -9,10 +9,19 @@
 	display: grid;
 	grid-template-columns: max-content auto max-content;
 	align-items: center;
+
+	@include breakpoint-deprecated( '<480px' ) {
+		grid-template-columns: none;
+		grid-template-rows: max-content auto max-content;
+	}
 }
 
 .backup-storage-space__progress-bar {
 	padding: 0 24px;
+
+	@include breakpoint-deprecated( '<480px' ) {
+		padding: 0;
+	}
 }
 
 .backup-storage-space__divider {

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -1,0 +1,16 @@
+.backup-storage-space {
+	margin-top: 1rem;
+	padding: 16px 32px;
+	background: #fff;
+	box-shadow: 0 0 0 1px #dcdcde;
+}
+
+.backup-storage-space__container {
+	display: grid;
+	grid-template-columns: max-content auto max-content;
+	align-items: center;
+}
+
+.backup-storage-space__progress-bar {
+	padding: 0 24px;
+}

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -46,5 +46,5 @@
 
 .backup-storage-space__divider {
 	margin: 16px -32px;
-	border-bottom: 1px solid var( --studio-gray-10 );
+	border-bottom: 1px solid var( --color-neutral-10 );
 }

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -22,6 +22,26 @@
 	@include breakpoint-deprecated( '<480px' ) {
 		padding: 0;
 	}
+
+	.progress-bar {
+		&.no-warning {
+			.progress-bar__progress {
+				background-color: var( --studio-gray-80 );
+			}
+		}
+
+		&.yellow-warning {
+			.progress-bar__progress {
+				background-color: var( --studio-yellow-30 );
+			}
+		}
+
+		&.red-warning {
+			.progress-bar__progress {
+				background-color: var( --studio-red-40 );
+			}
+		}
+	}
 }
 
 .backup-storage-space__divider {

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -6,23 +6,17 @@
 }
 
 .backup-storage-space__progress-bar-container {
-	display: grid;
-	grid-template-columns: max-content auto max-content;
-	align-items: center;
+	display: flex;
+	flex-direction: column;
 	column-gap: 24px;
 
-	@include breakpoint-deprecated( '<480px' ) {
-		grid-template-columns: none;
-		grid-template-rows: max-content auto max-content;
+	@include breakpoint-deprecated( '>960px' ) {
+		flex-direction: row;
 	}
 }
 
 .backup-storage-space__progress-bar {
-	@include breakpoint-deprecated( '<960px' ) {
-		padding: initial;
-		grid-row: 2;
-		grid-column: 1 / span end;
-	}
+	flex-grow: 1;
 
 	.progress-bar {
 		&.no-warning {
@@ -52,12 +46,13 @@
 
 .backup-storage-space__progress-heading {
 	font-weight: 600;
+	margin-block-end: 8px;
+
+	@include breakpoint-deprecated( '>960px' ) {
+		margin-block-end: initial;
+	}
 }
 
 .backup-storage-space__progress-usage-text {
 	color: var( --color-text-subtle );
-
-	@include breakpoint-deprecated( '<960px' ) {
-		grid-row: 3;
-	}
 }

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -2,7 +2,7 @@
 	margin-top: 1rem;
 	padding: 16px 32px;
 	background: #fff;
-	box-shadow: 0 0 0 1px #dcdcde;
+	box-shadow: 0 0 0 1px var( --color-neutral-5 );
 }
 
 .backup-storage-space__progress-bar-container {

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -45,3 +45,11 @@
 	margin: 16px -32px;
 	border-bottom: 1px solid var( --color-neutral-10 );
 }
+
+.backup-storage-space__progress-heading {
+	font-weight: 600;
+}
+
+.backup-storage-space__progress-usage-text {
+	color: var( --color-text-subtle );
+}

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -9,6 +9,7 @@
 	display: grid;
 	grid-template-columns: max-content auto max-content;
 	align-items: center;
+	column-gap: 24px;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		grid-template-columns: none;
@@ -17,10 +18,6 @@
 }
 
 .backup-storage-space__progress-bar {
-	padding: 0 24px;
-
-	@include breakpoint-deprecated( '<480px' ) {
-		padding: 0;
 	}
 
 	.progress-bar {

--- a/client/my-sites/backup/backup-storage-space/style.scss
+++ b/client/my-sites/backup/backup-storage-space/style.scss
@@ -18,6 +18,10 @@
 }
 
 .backup-storage-space__progress-bar {
+	@include breakpoint-deprecated( '<960px' ) {
+		padding: initial;
+		grid-row: 2;
+		grid-column: 1 / span end;
 	}
 
 	.progress-bar {
@@ -52,4 +56,8 @@
 
 .backup-storage-space__progress-usage-text {
 	color: var( --color-text-subtle );
+
+	@include breakpoint-deprecated( '<960px' ) {
+		grid-row: 3;
+	}
 }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -121,7 +121,7 @@ const AdminContent = ( { selectedDate } ) => {
 
 	const backupStorageSpace = getForCurrentCROIteration( {
 		[ Iterations.ONLY_REALTIME_PRODUCTS ]: (
-			<BackupStorageSpace storageLimit={ 200 } usedStorage={ 190 } />
+			<BackupStorageSpace storageLimit={ 200 } usedStorage={ 200 } />
 		),
 	} );
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -120,9 +120,7 @@ const AdminContent = ( { selectedDate } ) => {
 		page( backupMainPath( siteSlug, { date: date.format( INDEX_FORMAT ) } ) );
 
 	const backupStorageSpace = getForCurrentCROIteration( {
-		[ Iterations.ONLY_REALTIME_PRODUCTS ]: (
-			<BackupStorageSpace storageLimit={ 200 } usedStorage={ 200 } />
-		),
+		[ Iterations.ONLY_REALTIME_PRODUCTS ]: <BackupStorageSpace />,
 	} );
 
 	return (

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -15,6 +15,10 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
+import {
+	getForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
@@ -31,6 +35,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { backupMainPath } from './paths';
 import BackupDatePicker from './backup-date-picker';
+import { BackupStorageSpace } from './backup-storage-space';
 import EnableRestoresBanner from './enable-restores-banner';
 import SearchResults from './search-results';
 import { DailyStatus, RealtimeStatus } from './status';
@@ -114,6 +119,12 @@ const AdminContent = ( { selectedDate } ) => {
 	const onDateChange = ( date ) =>
 		page( backupMainPath( siteSlug, { date: date.format( INDEX_FORMAT ) } ) );
 
+	const backupStorageSpace = getForCurrentCROIteration( {
+		[ Iterations.ONLY_REALTIME_PRODUCTS ]: (
+			<BackupStorageSpace storageLimit={ 200 } usedStorage={ 190 } />
+		),
+	} );
+
 	return (
 		<>
 			<QueryRewindCapabilities siteId={ siteId } />
@@ -131,6 +142,7 @@ const AdminContent = ( { selectedDate } ) => {
 							{ needCredentials && <EnableRestoresBanner /> }
 
 							<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
+							{ backupStorageSpace }
 							<BackupStatus selectedDate={ selectedDate } />
 						</div>
 					</div>

--- a/client/state/rewind/selectors/get-site-backup-storage-available.ts
+++ b/client/state/rewind/selectors/get-site-backup-storage-available.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+// TODO: Remove once real data is available.
+const FAKE_STORAGE_AVAILABLE = 200;
+
+/**
+ * Retrieves the amount of Jetpack Backup storage a given site has available, in gigabytes.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to retrieve storage usage.
+ * @returns The number of gigabytes (GB) available for Backup storage on the given site.
+ */
+const getSiteBackupStorageAvailable = ( state: AppState, siteId: number ): number | undefined =>
+	getRewindState( state, siteId ).storageAvailable ?? FAKE_STORAGE_AVAILABLE;
+
+export default getSiteBackupStorageAvailable;

--- a/client/state/rewind/selectors/get-site-backup-storage-used.ts
+++ b/client/state/rewind/selectors/get-site-backup-storage-used.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+// TODO: Remove once real data is available.
+const FAKE_STORAGE_USED = 200;
+
+/**
+ * Retrieves the amount of Jetpack Backup storage a given site has used, in gigabytes.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to retrieve storage usage.
+ * @returns The number of gigabytes (GB) of stored Jetpack Backups on the given site.
+ */
+const getSiteBackupStorageUsed = ( state: AppState, siteId: number ): number | undefined =>
+	getRewindState( state, siteId ).storageUsed ?? FAKE_STORAGE_USED;
+
+export default getSiteBackupStorageUsed;

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -1,3 +1,5 @@
 export { default as getInProgressBackupForSite } from './get-in-progress-backup-for-site';
+export { default as getSiteBackupStorageAvailable } from './get-site-backup-storage-available';
+export { default as getSiteBackupStorageUsed } from './get-site-backup-storage-used';
 export { default as siteHasBackupInProgress } from './site-has-backup-in-progress';
 export { default as siteHasRealtimeBackups } from './site-has-realtime-backups';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the backup storage space component as designed for the "Make backup and security products real-time only" project.

<img width="741" alt="image" src="https://user-images.githubusercontent.com/42627630/126551955-aaee5ea8-147a-4a15-acff-429b1264a603.png">

<img width="729" alt="image" src="https://user-images.githubusercontent.com/42627630/126552027-bfb86215-a9d1-497d-b823-4863c85353c4.png">

<img width="729" alt="image" src="https://user-images.githubusercontent.com/42627630/126552114-5c547a8a-49c0-4e90-a77a-8163986b00af.png">

<img width="723" alt="image" src="https://user-images.githubusercontent.com/42627630/126552175-90796c02-b1b1-40b4-9963-23e5cd808850.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `jetpack.cloud.localhost:3001/backup/{ site_slug }?flags=jetpack/only-realtime-products`
2. Edit the `usedStorage` variable in `client/my-sites/backup/backup-storage-space/index.tsx` to various values to test the different states shown in the screenshots above (10, 160, 185, and 200 covers all states).
3. Visit `jetpack.cloud.localhost:3001/backup/{ site_slug }` and verify that no storage space component displays.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1200412004370260-as-1200532973279659