### PR TITLE
Add tracks to the domain connect mapping page

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -26,6 +26,7 @@ import SectionHeader from 'calypso/components/section-header';
 import wp from 'calypso/lib/wp';
 import { navigate } from 'calypso/lib/navigate';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const wpcom = wp.undocumented();
 
@@ -63,6 +64,8 @@ class DomainConnectMapping extends React.Component {
 
 		const { translate } = this.props;
 
+		this.props.recordConfigureYourDomainError( this.props.selectedDomainName );
+
 		return (
 			<Notice status="is-error" icon="notice" onDismissClick={ this.dismissNotice }>
 				{ translate(
@@ -94,6 +97,8 @@ class DomainConnectMapping extends React.Component {
 					'take effect at your domain provider.'
 			);
 		}
+
+		this.props.recordConfigureYourDomainSuccess( this.props.selectedDomainName );
 
 		return (
 			<Notice status="is-success" icon="checkmark" showDismiss={ false }>
@@ -178,6 +183,8 @@ class DomainConnectMapping extends React.Component {
 	applyDomainConnectMappingTemplate = () => {
 		this.setState( { submitting: true } );
 
+		this.props.recordConfigureYourDomainClick( this.props.selectedDomainName );
+
 		const redirectUri =
 			'https://wordpress.com' +
 			domainManagementDomainConnectMapping(
@@ -198,7 +205,12 @@ class DomainConnectMapping extends React.Component {
 				( data ) => {
 					const success = get( data, 'success', false );
 					const syncUxUrl = get( data, 'sync_ux_apply_url', null );
+
 					if ( success && syncUxUrl ) {
+						this.props.recordConfigureYourDomainRedirect(
+							this.props.selectedDomainName,
+							syncUxUrl
+						);
 						navigate( syncUxUrl );
 					} else {
 						this.setState( {
@@ -227,6 +239,35 @@ class DomainConnectMapping extends React.Component {
 	};
 }
 
-export default connect( ( state ) => ( {
-	currentRoute: getCurrentRoute( state ),
-} ) )( localize( DomainConnectMapping ) );
+const recordConfigureYourDomainClick = ( domain_name ) =>
+	recordTracksEvent( 'calypso_domain_connect_configure_your_domain_click', {
+		domain_name,
+	} );
+
+const recordConfigureYourDomainRedirect = ( domain_name, sync_ux_url ) =>
+	recordTracksEvent( 'calypso_domain_connect_configure_your_domain_recirect', {
+		domain_name,
+		sync_ux_url,
+	} );
+
+const recordConfigureYourDomainSuccess = ( domain_name ) =>
+	recordTracksEvent( 'calypso_domain_connect_configure_your_domain_success', {
+		domain_name,
+	} );
+
+const recordConfigureYourDomainError = ( domain_name ) =>
+	recordTracksEvent( 'calypso_domain_connect_configure_your_domain_error', {
+		domain_name,
+	} );
+
+export default connect(
+	( state ) => ( {
+		currentRoute: getCurrentRoute( state ),
+	} ),
+	{
+		recordConfigureYourDomainClick,
+		recordConfigureYourDomainRedirect,
+		recordConfigureYourDomainSuccess,
+		recordConfigureYourDomainError,
+	}
+)( localize( DomainConnectMapping ) );

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import page from 'page';
-import { get } from 'lodash';
 import { parse } from 'qs';
 import { connect } from 'react-redux';
 
@@ -48,7 +47,7 @@ class DomainConnectMapping extends React.Component {
 
 	isDomainConnectComplete = () => {
 		const queryObject = parse( window.location.search.replace( '?', '' ) );
-		const status = get( queryObject, 'status', null );
+		const status = queryObject?.status;
 		const redirectUriStatusString = this.getRedirectUriStatusString();
 
 		// Some domain providers return the status string as a key rather than the value of
@@ -203,8 +202,8 @@ class DomainConnectMapping extends React.Component {
 			)
 			.then(
 				( data ) => {
-					const success = get( data, 'success', false );
-					const syncUxUrl = get( data, 'sync_ux_apply_url', null );
+					const success = data?.success;
+					const syncUxUrl = data?.sync_ux_apply_url;
 
 					if ( success && syncUxUrl ) {
 						this.props.recordConfigureYourDomainRedirect(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to add tracks to the domain connect mapping page to see how frequently this feature is used.

The way this flow works is that when you click on the "Connect Your Domain" button we make a call to WPCOM that fetches the appropriate URL to redirect the user to so they can authenticate to their domain provider.
The browser is redirected to this URL.
The user performs authentication at the provider.
The provider redirects the browser back to WordPRess.com so we can show the user a success (or failure) message.

We want to record the click, the successful fetching of the redirect URL, and the final success or failure upon redirection back to WPCOM.

#### Testing instructions

Select a mapped domain that does not have WPCOM NS/A records for which domain connect is supported.
Navigate to /domains/manage/<domain-name>/domain-connect-mapping/<site-name>
Click on the "Connect Your Domain" button.
This should record the "click" and "redirect" events.
You will be redirected back to WordPress.com. Replace `wordpress.com` in the redirect URL and replace it with `calypso.localhost:3000` to record the success event.
You can simulate an error by either returning an error from the `getDomainConnectSyncUxUrl` endpoint or by setting the `success` or `syncUxUrl` values in the returned URL to some invalid values (`null` would work).