### PR TITLE
Playwright: Remove tests and add types to calypso-e2e build to get intellisense in e2e test scripts

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -28,7 +28,9 @@
 		"mockdate": "^3.0.5"
 	},
 	"scripts": {
-		"clean": "yarn build --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json"
+		"clean": "yarn build --clean && npx rimraf dist && npx rimraf tsconfig.test.tsbuildinfo",
+		"build": "tsc --build ./tsconfig.json",
+		"pretest": "tsc --project ./tsconfig.test.json",
+		"test": "yarn jest"
 	}
 }

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"description": "Tools for e2e tests",
 	"main": "dist/cjs/src/index.js",
+	"types": "dist/types/src/index.d.ts",
 	"author": "Automattic Inc.",
 	"repository": {
 		"type": "git",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -2,7 +2,7 @@
 	"name": "@automattic/calypso-e2e",
 	"version": "0.1.0",
 	"description": "Tools for e2e tests",
-	"main": "dist/cjs/src/index.js",
+	"main": "dist/esm/src/index.js",
 	"types": "dist/types/src/index.d.ts",
 	"author": "Automattic Inc.",
 	"repository": {

--- a/packages/calypso-e2e/src/index.ts
+++ b/packages/calypso-e2e/src/index.ts
@@ -1,7 +1,10 @@
-export * as BrowserHelper from './browser-helper';
-export * as BrowserManager from './browser-manager';
-export * as MediaHelper from './media-helper';
-export * as DataHelper from './data-helper';
-export * as ElementHelper from './element-helper';
+import * as BrowserHelper from './browser-helper';
+import * as BrowserManager from './browser-manager';
+import * as DataHelper from './data-helper';
+import * as ElementHelper from './element-helper';
+import * as MediaHelper from './media-helper';
+
+export { BrowserHelper, BrowserManager, MediaHelper, DataHelper, ElementHelper };
+
 export * from './lib';
 export * from './hooks';

--- a/packages/calypso-e2e/tsconfig.json
+++ b/packages/calypso-e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "@automattic/calypso-build/typescript/ts-package.json",
 	"compilerOptions": {
+		"module": "commonjs",
 		"outDir": "dist/cjs",
 		"declarationDir": "dist/types",
 		"rootDir": "."

--- a/packages/calypso-e2e/tsconfig.json
+++ b/packages/calypso-e2e/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@automattic/calypso-build/typescript/ts-package.json",
 	"compilerOptions": {
-		"module": "commonjs",
-		"outDir": "dist/cjs",
+		"outDir": "dist/esm",
 		"declarationDir": "dist/types",
 		"rootDir": "."
 	},

--- a/packages/calypso-e2e/tsconfig.json
+++ b/packages/calypso-e2e/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"extends": "@automattic/calypso-build/typescript/ts-package.json",
 	"compilerOptions": {
-		"module": "commonjs",
 		"outDir": "dist/cjs",
 		"declarationDir": "dist/types",
 		"rootDir": "."
 	},
-	"include": [ "src", "test" ]
+	"include": [ "src" ]
 }

--- a/packages/calypso-e2e/tsconfig.json
+++ b/packages/calypso-e2e/tsconfig.json
@@ -2,8 +2,7 @@
 	"extends": "@automattic/calypso-build/typescript/ts-package.json",
 	"compilerOptions": {
 		"outDir": "dist/esm",
-		"declarationDir": "dist/types",
-		"rootDir": "."
+		"declarationDir": "dist/types"
 	},
 	"include": [ "src" ]
 }

--- a/packages/calypso-e2e/tsconfig.test.json
+++ b/packages/calypso-e2e/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/typescript/ts-package.json",
+	"compilerOptions": {
+		"noEmit": true // just type checking, no output. The output is handled by babel.
+	},
+	"include": [ "src", "test" ]
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Before, Playwright E2E JS testing scripts (`specs/specs-playwright`) didn't have any kind of type checking or intellisense when importing classes and library functions.

Now, they do!

#### What actually is changing
 - A reference to the types directory is now included in the `calypso-e2e` package build (this is the main fix)
 - The unit tests in `calypso-e2e` are not included in its build (no need, keeping cleaner)
 - The module target for the build/transpilation of `calypso-e2e` is now ESM instead of CommonJS (not completely necessary, but I think it makes the most sense. **This can definitely be taken out if this not the time or you think it's a bad move for now**)
 - A change to how we bundle the library exports and re-export them with a name. This is done because the eslint  `import/named` rule didn't like our `export * as MediaHelper` kind of syntax

### Issues Background

I took a bit of a deep dive on what is going on with out packages and building. There's a few different overlapping things here that leave us with a few different ways going forward.

Previously, when the `calypso-e2e` package was built, it...
1. Built as CommonJS (`dist/cjs`)
2. Included types in the build, but didn't include the `types` key in `package.json` that tells consumers where the types are located in the `dist` output
3. Included the unit tests for the `calyspo-e2e` package in the output build

Currently, our E2E Playwright testing scripts are written as ES Modules, which are then transformed to CommonJS by Jest using Babel (through `jest.config.js` --> `babel.config.js`), because [ESM support](https://jestjs.io/docs/ecmascript-modules) is still experimental in Jest.

A few problems arose from this configuration:
1. ESM JavaScript can't use named imports from CommonJS JavaScript, only default imports. We are using named imports everywhere in our Playwright scripts (which are ESM), but because they were pointed to the CommonJS output of the `calypso-e2e` package, the editor didn't know what to do. However, we did hit runtime errors because of the aformentioned transforming.
2. Even TypeScript files trying to consume the `calypso-e2e` package didn't have access to the types.

By adding the `types` key to the `calypso-e2e` `package.json`, we actually can fix _both_ of these errors, because, at least in VSCode, the JavaScript language service will use type files to provide intellisense in JavaScript files.

However, I think it makes sense to make the output of the `calypso-e2e` build be ES Module JavaScript. This means that output will match the JavaScript in the test scripts themselves, and it also matches what we do in almost all of our other packages in this monorepo. Everything seems to work on the assumption that the downriver consumer should handle transforming all this ESM code to whatever is needed, and in this case that transformation will be handled by Jest.

That being said, we can still build to CommonJS if needed, and we'll still get VSCode intellisense in the Playwright.

### Testing instructions

- [ ] Clean and build the `calypso-e2e` package. You can do this from the root of the mono repo by running `yarn clean` and then `yarn`.
- [ ] All tests run and pass
- [ ] Open the spec files `specs/specs-playwright` in VSCode. You should see intellisense and type information on all the named imports.

Closes #54719 
