### PR TITLE
Enable 'jetpack/siteless-checkout' feature flag in Staging

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -92,7 +92,7 @@
 		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
-		"jetpack/siteless-checkout": false,
+		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -61,7 +61,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
-		"jetpack/siteless-checkout": false,
+		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -47,7 +47,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/siteless-checkout": false,
+		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -37,6 +37,8 @@
 		"jetpack/search-product": true,
 		"jetpack/pricing-page": true,
 		"jetpack/server-credentials-advanced-flow": true,
+		"jetpack/siteless-checkout": true,
+		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -43,7 +43,7 @@
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/siteless-checkout": false,
+		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,7 +63,7 @@
 		"jetpack/only-realtime-products": false,
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
-		"jetpack/siteless-checkout": false,
+		"jetpack/siteless-checkout": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the`jetpack/siteless-checkout` feature flag in all environments **_except not Production_**

To launch the Simple Jetpack.com checkout flow project internally, we need to enable the `jetpack/siteless-checkout` feature flag in every environment minus production. We need internal users to be able to test these new flows with the A8C proxy enabled.

#### Additional notes:

- `jetpack-cloud-horizon.json` was missing entries for `jetpack/siteless-checkout` and also for `jetpack/userless-checkout`, therefore I added them and set them to `true` as they should be.

#### Testing instructions

- Code review:  Verify that the `jetpack/siteless-checkout` feature flag is `true` in all environments, **_except not in Production environment_**


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: 1200479326344990-as-1200626189885429
Simple Jetpack.com checkout flow project thread: p1HpG7-cfR-p2