### PR TITLE
chore: Refactor `packages/shopping-cart` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -205,6 +205,7 @@ module.exports = {
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
 				'packages/plans-grid/**/*',
+				'packages/shopping-cart/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
 				'packages/wpcom-checkout/**/*',

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import { getEmptyResponseCart } from './empty-carts';
 import type { TempResponseCart } from './shopping-cart-endpoint';
 import type {

--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { RequestCartProduct, MinimalRequestCartProduct } from './shopping-cart-endpoint';
 
 export default function createRequestCartProduct(

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { ResponseCart, ResponseCartProduct } from './shopping-cart-endpoint';
 
 export function getEmptyResponseCart(): ResponseCart {

--- a/packages/shopping-cart/src/shopping-cart-context.ts
+++ b/packages/shopping-cart/src/shopping-cart-context.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { createContext } from 'react';
-
-/**
- * Internal dependencies
- */
 import type { ShoppingCartManager } from './types';
 
 const ShoppingCartContext = createContext< ShoppingCartManager | undefined >( undefined );

--- a/packages/shopping-cart/src/shopping-cart-provider.tsx
+++ b/packages/shopping-cart/src/shopping-cart-provider.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import type { RequestCart, ResponseCart, ShoppingCartManagerOptions } from './types';
-import useShoppingCartManager from './use-shopping-cart-manager';
 import ShoppingCartContext from './shopping-cart-context';
+import useShoppingCartManager from './use-shopping-cart-manager';
+import type { RequestCart, ResponseCart, ShoppingCartManagerOptions } from './types';
 
 export default function ShoppingCartProvider( {
 	cartKey,

--- a/packages/shopping-cart/src/sync.ts
+++ b/packages/shopping-cart/src/sync.ts
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-import type { Dispatch } from 'react';
-
-/**
- * Internal dependencies
- */
 import {
 	convertResponseCartToRequestCart,
 	convertRawResponseCartToResponseCart,
@@ -18,6 +10,7 @@ import type {
 	ShoppingCartAction,
 	ShoppingCartMiddleware,
 } from './types';
+import type { Dispatch } from 'react';
 
 const debug = debugFactory( 'shopping-cart:sync' );
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -1,11 +1,3 @@
-/**
- * External dependencies
- */
-import type { Dispatch } from 'react';
-
-/**
- * Internal dependencies
- */
 import type {
 	TempResponseCart,
 	ResponseCart,
@@ -14,6 +6,7 @@ import type {
 	CartLocation,
 	MinimalRequestCartProduct,
 } from './shopping-cart-endpoint';
+import type { Dispatch } from 'react';
 
 export * from './shopping-cart-endpoint';
 

--- a/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
+++ b/packages/shopping-cart/src/use-cart-update-and-revalidate.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { useEffect } from 'react';
 import debugFactory from 'debug';
-import type { Dispatch } from 'react';
-
-/**
- * Internal dependencies
- */
+import { useEffect } from 'react';
 import type { CacheStatus, ShoppingCartAction } from './types';
+import type { Dispatch } from 'react';
 
 const debug = debugFactory( 'shopping-cart:use-cart-update-and-revalidate' );
 

--- a/packages/shopping-cart/src/use-initialize-cart-from-server.ts
+++ b/packages/shopping-cart/src/use-initialize-cart-from-server.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useEffect, useRef } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { useEffect, useRef } from 'react';
 import { convertRawResponseCartToResponseCart } from './cart-functions';
 import type { ResponseCart, RequestCart, CacheStatus, ShoppingCartAction } from './types';
 

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useEffect } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { useEffect } from 'react';
 import type { CacheStatus, ShoppingCartManagerOptions, ResponseCart } from './types';
 
 const debug = debugFactory( 'shopping-cart:use-refetch-on-focus' );

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -1,12 +1,12 @@
-/**
- * External dependencies
- */
-import { useCallback, useMemo, useEffect, useRef } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { useCallback, useMemo, useEffect, useRef } from 'react';
+import { convertTempResponseCartToResponseCart } from './cart-functions';
+import { createRequestCartProducts } from './create-request-cart-product';
+import { createCartSyncMiddleware } from './sync';
+import useCartUpdateAndRevalidate from './use-cart-update-and-revalidate';
+import useInitializeCartFromServer from './use-initialize-cart-from-server';
+import useRefetchOnFocus from './use-refetch-on-focus';
+import useShoppingCartReducer from './use-shopping-cart-reducer';
 import type {
 	TempResponseCart,
 	ResponseCart,
@@ -27,13 +27,6 @@ import type {
 	CartValidCallback,
 	DispatchAndWaitForValid,
 } from './types';
-import { convertTempResponseCartToResponseCart } from './cart-functions';
-import useShoppingCartReducer from './use-shopping-cart-reducer';
-import useInitializeCartFromServer from './use-initialize-cart-from-server';
-import useCartUpdateAndRevalidate from './use-cart-update-and-revalidate';
-import { createRequestCartProducts } from './create-request-cart-product';
-import useRefetchOnFocus from './use-refetch-on-focus';
-import { createCartSyncMiddleware } from './sync';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-manager' );
 

--- a/packages/shopping-cart/src/use-shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-reducer.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useReducer, useEffect, Dispatch, useCallback, useRef } from 'react';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { useReducer, useEffect, Dispatch, useCallback, useRef } from 'react';
 import {
 	removeItemFromResponseCart,
 	addItemsToResponseCart,
@@ -18,6 +11,7 @@ import {
 	doesCartLocationDifferFromResponseCartLocation,
 	doesResponseCartContainProductMatching,
 } from './cart-functions';
+import { getEmptyResponseCart } from './empty-carts';
 import type {
 	ResponseCart,
 	ShoppingCartState,
@@ -26,7 +20,6 @@ import type {
 	CacheStatus,
 	ShoppingCartMiddleware,
 } from './types';
-import { getEmptyResponseCart } from './empty-carts';
 
 const debug = debugFactory( 'shopping-cart:use-shopping-cart-reducer' );
 const emptyResponseCart = getEmptyResponseCart();

--- a/packages/shopping-cart/src/use-shopping-cart.ts
+++ b/packages/shopping-cart/src/use-shopping-cart.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { useContext } from 'react';
-
-/**
- * Internal dependencies
- */
-import type { ShoppingCartManager } from './types';
 import ShoppingCartContext from './shopping-cart-context';
+import type { ShoppingCartManager } from './types';
 
 export default function useShoppingCart(): ShoppingCartManager {
 	const manager = useContext( ShoppingCartContext );

--- a/packages/shopping-cart/src/with-shopping-cart.tsx
+++ b/packages/shopping-cart/src/with-shopping-cart.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import useShoppingCart from './use-shopping-cart';
 
 export default function withShoppingCart< P >( Component: React.ComponentType< P > ) {

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -1,11 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-import '@automattic/calypso-polyfills';
-
-/**
- * External dependencies
- */
-import React, { useEffect, useRef } from 'react';
-import '@testing-library/jest-dom/extend-expect';
 import {
 	screen,
 	render,
@@ -13,12 +5,9 @@ import {
 	fireEvent,
 	waitForElementToBeRemoved,
 } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
-import { useShoppingCart, ShoppingCartProvider } from '../src/index';
+import React, { useEffect, useRef } from 'react';
 import { getEmptyResponseCart } from '../src/empty-carts';
+import { useShoppingCart, ShoppingCartProvider } from '../src/index';
 import type {
 	RequestCartProduct,
 	ResponseCartProduct,
@@ -26,6 +15,10 @@ import type {
 	ResponseCart,
 	MinimalRequestCartProduct,
 } from '../src/types';
+
+// This is required to fix the "regeneratorRuntime is not defined" error
+import '@automattic/calypso-polyfills';
+import '@testing-library/jest-dom/extend-expect';
 
 const planOne: ResponseCartProduct = {
 	time_added_to_cart: Date.now(),

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	removeItemFromResponseCart,
 	addCouponToResponseCart,


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/shopping-cart` to use `import/order`

#### Testing instructions

N/A