### PR TITLE
Playwright: sidebar click tweaks, part 2

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -125,29 +125,27 @@ export class SidebarComponent extends BaseContainer {
 	async _click( selector: string ): Promise< void > {
 		// Wait for these promises in no particular order. We simply want to ensure the sidebar
 		// and the page is not animating and is ready to accept inputs.
-		await Promise.all( [
-			this.page.waitForLoadState( 'load' ),
-			this.sidebar.waitForElementState( 'stable' ),
-		] );
+		await this.page.waitForLoadState( 'load' );
 
-		const elementHandle = await this.page.waitForSelector( selector );
+		// await Promise.all( [
+		// 	this.sidebar.waitForElementState( 'stable' ),
+		// ] );
 
-		// Scroll to reveal the element fully using a page function if required.
+		await this.page.waitForSelector( selector, { state: 'attached' } );
+
+		// Scroll to reveal the target element fully using a page function if required.
 		// This workaround is necessary as the sidebar is 'sticky' in calypso, so a traditional
 		// scroll behavior does not adequately expose the sidebar element.
-		await this.page.evaluate(
-			( [ element ] ) => {
-				const elementBottom = element.getBoundingClientRect().bottom;
-				const isOutsideViewport = window.innerHeight < elementBottom;
+		await this.page.$eval( selector, ( element ) => {
+			const elementBottom = element.getBoundingClientRect().bottom;
+			const isOutsideViewport = window.innerHeight < elementBottom;
 
-				if ( isOutsideViewport ) {
-					window.scrollTo( 0, elementBottom - window.innerHeight );
-				}
-			},
-			[ elementHandle ]
-		);
+			if ( isOutsideViewport ) {
+				window.scrollTo( 0, elementBottom - window.innerHeight );
+			}
+		} );
 
-		await elementHandle.click();
+		await this.page.click( selector );
 
 		await this.page.waitForLoadState( 'domcontentloaded' );
 	}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -123,28 +123,30 @@ export class SidebarComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async _click( selector: string ): Promise< void > {
-		// Wait for these promises in no particular order. We simply want to ensure the sidebar
-		// and the page is not animating and is ready to accept inputs.
 		await this.page.waitForLoadState( 'load' );
 
-		// await Promise.all( [
-		// 	this.sidebar.waitForElementState( 'stable' ),
-		// ] );
-
-		await this.page.waitForSelector( selector, { state: 'attached' } );
+		const elementHandle = await this.page.waitForSelector( selector, { state: 'attached' } );
 
 		// Scroll to reveal the target element fully using a page function if required.
 		// This workaround is necessary as the sidebar is 'sticky' in calypso, so a traditional
 		// scroll behavior does not adequately expose the sidebar element.
-		await this.page.$eval( selector, ( element ) => {
-			const elementBottom = element.getBoundingClientRect().bottom;
-			const isOutsideViewport = window.innerHeight < elementBottom;
+		await this.page.evaluate(
+			( [ element ] ) => {
+				const elementBottom = element.getBoundingClientRect().bottom;
+				const isOutsideViewport = window.innerHeight < elementBottom;
 
-			if ( isOutsideViewport ) {
-				window.scrollTo( 0, elementBottom - window.innerHeight );
-			}
-		} );
+				if ( isOutsideViewport ) {
+					window.scrollTo( 0, elementBottom - window.innerHeight );
+				}
+			},
+			[ elementHandle ]
+		);
 
+		// Use page.click since if the ElementHandle moves or otherwise disappears from the original
+		// location in the DOM, it is no longer valid and will throw an error.
+		// For Atomic sites, sidebar items often shift soon after initial rendering as Atomic-specific
+		// features are loaded.
+		// See https://github.com/microsoft/playwright/issues/6244#issuecomment-824384845.
 		await this.page.click( selector );
 
 		await this.page.waitForLoadState( 'domcontentloaded' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is yet another attempt to make the sidebar interaction more reliable. 

Current code runs into a problem described in [this issue on microsoft/playwright](https://github.com/microsoft/playwright/issues/6244) and I believe this is applicable to our situation with the sidebar.

What I have narrowed down so far:

- error `Element is not attached to DOM` only ever occurs on Atomic sites.
- heading items on Atomic sidebar shifts after it has been initially rendered on the page.

Using this, I have come to the conclusion that the current code, which does the following:

```
get reference to the target sidebar menu item once it shows

scroll into view if necessary

menu item.click
```

According to the linked issue, this is not a recommended pattern as the element could move or disappear between the initial retrieval and the action calls, thereby throwing the `Element is not attache to DOM` error.

#### Testing instructions

- [ ] run Playwright E2E tests several times on the feature branch.
- [ ] ensure no intermittent failures from tests that run on atomic that interact with sidebar (eg. `media-edit`)

Related to #
