### PR TITLE
chore: Refactor `my-sites/customer-home` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,6 +178,7 @@ module.exports = {
 		{
 			files: [
 				'apps/editing-toolkit/**/*',
+				'client/my-sites/customer-home/**/*',
 				'client/sections-filter.js',
 				'client/sections-helper.js',
 				'client/sections-middleware.js',

--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
-import MaterialIcon from 'calypso/components/material-icon';
+import classnames from 'classnames';
+import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
+import MaterialIcon from 'calypso/components/material-icon';
 
 const ActionBox = ( {
 	href,

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,42 +1,28 @@
-/**
- * External dependencies
- */
+import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import ActionBox from './action-box';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
+import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import FoldableCard from 'calypso/components/foldable-card';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { hasPaidEmailWithUs } from 'calypso/lib/emails';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	getSiteFrontPage,
 	getCustomizerUrl,
 	getSiteOption,
 	isNewSite,
 } from 'calypso/state/sites/selectors';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { hasPaidEmailWithUs } from 'calypso/lib/emails';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
-import { savePreference } from 'calypso/state/preferences/actions';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import ActionBox from './action-box';
 
-/**
- * Image dependencies
- */
-import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
-import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export const QuickLinks = ( {

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -1,31 +1,21 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FoldableCard from 'calypso/components/foldable-card';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
 import {
 	getSiteFrontPage,
 	getCustomizerUrl,
 	getSiteOption,
 	isNewSite,
 } from 'calypso/state/sites/selectors';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ActionBox from '../quick-links/action-box';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference } from 'calypso/state/preferences/selectors';
 
-/**
- * Style dependencies
- */
 import '../quick-links/style.scss';
 
 export const QuickLinks = ( {

--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -1,21 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import EducationalContent from '../educational-content';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-export const EDUCATION_EARN = 'home-education-earn';
-
-/**
- * Image dependencies
- */
 import earnCardPrompt from 'calypso/assets/images/customer-home/illustration--secondary-earn.svg';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import EducationalContent from '../educational-content';
+
+export const EDUCATION_EARN = 'home-education-earn';
 
 const EducationEarn = ( { siteSlug } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { isDesktop } from '@automattic/viewport';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import ExternalLink from 'calypso/components/external-link';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Gridicon from 'calypso/components/gridicon';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import MaterialIcon from 'calypso/components/material-icon';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function trackNavigation( url, cardName ) {

--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import EducationalContent from '../educational-content';
-import { EDUCATION_FREE_PHOTO_LIBRARY } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import freePhotoLibraryVideoPrompt from 'calypso/assets/images/customer-home/illustration--secondary-free-photo-library.svg';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { EDUCATION_FREE_PHOTO_LIBRARY } from 'calypso/my-sites/customer-home/cards/constants';
+import EducationalContent from '../educational-content';
 
 const FreePhotoLibrary = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import EducationalContent from '../educational-content';
-import { EDUCATION_GUTENBERG } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import gutenbergIllustration from 'calypso/assets/images/customer-home/illustration--secondary-gutenberg.svg';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { EDUCATION_GUTENBERG } from 'calypso/my-sites/customer-home/cards/constants';
+import EducationalContent from '../educational-content';
 
 const MasteringGutenberg = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
+++ b/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
-import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
-
-/**
- * Internal dependencies
- */
-import InlineSupportLink from 'calypso/components/inline-support-link';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { FEATURE_QUICK_START_VIDEO } from 'calypso/my-sites/customer-home/cards/constants';
-import MaterialIcon from 'calypso/components/material-icon';
-
-/**
- * Style dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 import quickStartVideoImage from 'calypso/assets/images/customer-home/quick-start-video-ss.png';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import MaterialIcon from 'calypso/components/material-icon';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { FEATURE_QUICK_START_VIDEO } from 'calypso/my-sites/customer-home/cards/constants';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/education/webinars/index.jsx
+++ b/client/my-sites/customer-home/cards/education/webinars/index.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import EducationalContent from '../educational-content';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import webinarIllustration from 'calypso/assets/images/customer-home/illustration-webinars.svg';
+import EducationalContent from '../educational-content';
 
 const Webinars = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
+++ b/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { getLocaleSlug } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import EducationalContent from '../educational-content';
-import { EDUCATION_WPCOURSES } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
+import { getLocaleSlug } from 'i18n-calypso';
+import React from 'react';
 import freePhotoLibraryVideoPrompt from 'calypso/assets/images/customer-home/illustration--secondary-wp-courses.svg';
+import { EDUCATION_WPCOURSES } from 'calypso/my-sites/customer-home/cards/constants';
+import EducationalContent from '../educational-content';
 
 const WpCourses = () => {
 	const isEnglish = config( 'english_locales' ).includes( getLocaleSlug() );

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
-import { Card, Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import { Card, Button } from '@automattic/components';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
 import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
-import userAgent from 'calypso/lib/user-agent';
 import CardHeading from 'calypso/components/card-heading';
-import { sendEmailLogin } from 'calypso/state/auth/actions';
+import userAgent from 'calypso/lib/user-agent';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export const GoMobile = ( { email, sendMobileLoginEmail } ) => {

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -1,31 +1,21 @@
-/**
- * External dependencies
- */
 import { Card } from '@automattic/components';
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import CardHeading from 'calypso/components/card-heading';
-import Gridicon from 'calypso/components/gridicon';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import HelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
-import HelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
-import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
 import {
 	RESULT_ARTICLE,
 	RESULT_LINK,
 	RESULT_TOUR,
 	RESULT_TYPE,
 } from 'calypso/blocks/inline-help/constants';
+import HelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
+import HelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
+import CardHeading from 'calypso/components/card-heading';
+import Gridicon from 'calypso/components/gridicon';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
+import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const HELP_COMPONENT_LOCATION = 'customer-home';

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
 import { Button, Card } from '@automattic/components';
-import { connect } from 'react-redux';
-import 'moment-timezone';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import HappinessEngineersTray from 'calypso/components/happiness-engineers-tray';
+import React from 'react';
+import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
-import { composeAnalytics, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
-import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
+import HappinessEngineersTray from 'calypso/components/happiness-engineers-tray';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-
-/**
- * Style dependencies
- */
+import { composeAnalytics, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
+import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import 'moment-timezone';
 import './style.scss';
 
 const QuickStart = ( { nextSession, reschedule, siteId, siteSlug, viewDetails } ) => {

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -1,22 +1,16 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { numberFormat, useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import React, { useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { numberFormat, useTranslate } from 'i18n-calypso';
-import { Card } from '@automattic/components';
-import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import CardHeading from 'calypso/components/card-heading';
 import Chart from 'calypso/components/chart';
-import Spinner from 'calypso/components/spinner';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
+import Spinner from 'calypso/components/spinner';
 import { preventWidows } from 'calypso/lib/formatting';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSiteOption } from 'calypso/state/sites/selectors';
@@ -28,11 +22,7 @@ import {
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import classnames from 'classnames';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const placeholderChartData = Array.from( { length: 7 }, () => ( {

--- a/client/my-sites/customer-home/cards/features/support/index.jsx
+++ b/client/my-sites/customer-home/cards/features/support/index.jsx
@@ -1,32 +1,18 @@
-/**
- * External dependencies
- */
 import { Card } from '@automattic/components';
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import happinessIllustration from 'calypso/assets/images/customer-home/happiness.png';
 import CardHeading from 'calypso/components/card-heading';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { composeAnalytics, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
-
-/**
- * Image dependencies
- */
-import happinessIllustration from 'calypso/assets/images/customer-home/happiness.png';
 
 const Support = ( { trackContactAction, trackDocsAction } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-import { connect, useDispatch } from 'react-redux';
 import { Button } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React, { useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import fireworksIllustration from 'calypso/assets/images/customer-home/illustration--fireworks-v2.svg';
 import Spinner from 'calypso/components/spinner';
+import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
+import { composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
-
-/**
- * Image dependencies
- */
-import fireworksIllustration from 'calypso/assets/images/customer-home/illustration--fireworks-v2.svg';
 
 const CelebrateNotice = ( {
 	actionText,

--- a/client/my-sites/customer-home/cards/notices/celebrate-site-creation/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-creation/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
 import { NOTICE_CELEBRATE_SITE_CREATION } from 'calypso/my-sites/customer-home/cards/constants';
+import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
 
 const CelebrateSiteCreation = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
@@ -1,28 +1,17 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect, useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import launchedIllustration from 'calypso/assets/images/customer-home/illustration--rocket.svg';
+import {
+	NOTICE_CELEBRATE_SITE_LAUNCH,
+	NOTICE_CELEBRATE_SITE_SETUP_COMPLETE,
+} from 'calypso/my-sites/customer-home/cards/constants';
+import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import getSiteTaskList from 'calypso/state/selectors/get-site-task-list';
 import isSiteChecklistComplete from 'calypso/state/selectors/is-site-checklist-complete';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
-import {
-	NOTICE_CELEBRATE_SITE_LAUNCH,
-	NOTICE_CELEBRATE_SITE_SETUP_COMPLETE,
-} from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
-import launchedIllustration from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 
 const CelebrateSiteLaunch = ( { isSiteSetupComplete, pendingSiteSetupTasks, siteId } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/notices/celebrate-site-migration/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-migration/index.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
-import { NOTICE_CELEBRATE_SITE_MIGRATION } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
 import migrationIllustration from 'calypso/assets/images/customer-home/illustration--import-complete.svg';
+import { NOTICE_CELEBRATE_SITE_MIGRATION } from 'calypso/my-sites/customer-home/cards/constants';
+import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
 
 const CelebrateSiteMigration = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/notices/celebrate-site-setup-complete/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-setup-complete/index.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
-import { NOTICE_CELEBRATE_SITE_SETUP_COMPLETE } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
 import checklistIllustration from 'calypso/assets/images/customer-home/illustration--checklist-complete.svg';
+import { NOTICE_CELEBRATE_SITE_SETUP_COMPLETE } from 'calypso/my-sites/customer-home/cards/constants';
+import CelebrateNotice from 'calypso/my-sites/customer-home/cards/notices/celebrate-notice';
 
 const CelebrateSiteSetupComplete = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/cloudflare/index.js
+++ b/client/my-sites/customer-home/cards/tasks/cloudflare/index.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_CLOUDFLARE } from 'calypso/my-sites/customer-home/cards/constants';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import growthSummitIllustration from 'calypso/assets/images/customer-home/illustration--task-cloudflare.svg';
+import { TASK_CLOUDFLARE } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const Cloudflare = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/connect-accounts/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/connect-accounts/index.jsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { isMobile } from '@automattic/viewport';
-
-/**
- * Internal dependencies
- */
-import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_CONNECT_ACCOUNTS } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
 import connectSocialAccountsIllustration from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
+import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
+import { TASK_CONNECT_ACCOUNTS } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const ConnectAccountsTask = ( { siteSlug } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/earn-features/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/earn-features/index.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
+import { TASK_EARN_FEATURES } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { TASK_EARN_FEATURES } from 'calypso/my-sites/customer-home/cards/constants';
-import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 
 const EarnFeatures = ( { siteSlug } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { preventWidows } from 'calypso/lib/formatting';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_FIND_DOMAIN } from 'calypso/my-sites/customer-home/cards/constants';
-
-/**
- * Image dependencies
- */
 import findDomainIllustration from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
+import { preventWidows } from 'calypso/lib/formatting';
+import { TASK_FIND_DOMAIN } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const FindDomain = ( { siteSlug } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
+++ b/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { preventWidows } from 'calypso/lib/formatting';
+import React from 'react';
 import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
+import { preventWidows } from 'calypso/lib/formatting';
 import {
 	TASK_GO_MOBILE_ANDROID,
 	TASK_GO_MOBILE_IOS,
 } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const GoMobile = ( { isIos } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/growth-summit/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/growth-summit/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_GROWTH_SUMMIT } from 'calypso/my-sites/customer-home/cards/constants';
+import React from 'react';
 import growthSummitIllustration from 'calypso/assets/images/customer-home/illustration--growth-summit.svg';
+import { TASK_GROWTH_SUMMIT } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const GrowthSummit = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/podcasting/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_PODCASTING } from 'calypso/my-sites/customer-home/cards/constants';
+import React from 'react';
 import podcastingIllustration from 'calypso/assets/images/customer-home/illustration--task-podcasting.svg';
+import { TASK_PODCASTING } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const Podcasting = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/renew/index.js
+++ b/client/my-sites/customer-home/cards/tasks/renew/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_RENEW_EXPIRED_PLAN } from 'calypso/my-sites/customer-home/cards/constants';
 import expiredIllustration from 'calypso/assets/images/customer-home/disconnected-dark.svg';
 import expiringIllustration from 'calypso/assets/images/customer-home/disconnected.svg';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { TASK_RENEW_EXPIRED_PLAN } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const Renew = ( { card, moment, purchases, site, siteSlug } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce/index.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSiteUrl } from 'calypso/state/sites/selectors';
-import { TASK_SITE_SETUP_CHECKLIST_ECOMMERCE } from 'calypso/my-sites/customer-home/cards/constants';
+import React from 'react';
+import { connect } from 'react-redux';
 import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
+import { TASK_SITE_SETUP_CHECKLIST_ECOMMERCE } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { getSiteUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const SiteSetupListEcommerce = ( { siteUrl } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { translate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import { translate } from 'i18n-calypso';
+import React from 'react';
 import Badge from 'calypso/components/badge';
 import Gridicon from 'calypso/components/gridicon';
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
-import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 
 const getTaskDescription = ( task, { isDomainUnverified } ) => {
 	switch ( task.id ) {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -1,40 +1,30 @@
-/**
- * External dependencies
- */
 import { Card } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
 import React, { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import CardHeading from 'calypso/components/card-heading';
 import Spinner from 'calypso/components/spinner';
+import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { getTaskList } from 'calypso/lib/checklist';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
 import { resetVerifyEmailState } from 'calypso/state/current-user/email-verification/actions';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
+import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
+import getMenusUrl from 'calypso/state/selectors/get-menus-url';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import getMenusUrl from 'calypso/state/selectors/get-menus-url';
 import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
-import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import NavItem from './nav-item';
 import CurrentTaskItem from './current-task-item';
-import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import { getTask } from './get-task';
-import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
+import NavItem from './nav-item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const startTask = ( dispatch, task, siteId, advanceToNextIncompleteTask, isPodcastingSite ) => {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useDispatch } from 'react-redux';
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -1,28 +1,18 @@
-/**
- * External dependencies
- */
-import React, { useEffect, useRef, useState } from 'react';
-import { useTranslate } from 'i18n-calypso';
-import { connect, useDispatch } from 'react-redux';
 import { Button } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import React, { useEffect, useRef, useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Gridicon from 'calypso/components/gridicon';
 import PopoverMenu from 'calypso/components/popover/menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import Spinner from 'calypso/components/spinner';
+import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const Task = ( {

--- a/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import { TASK_UPSELL_TITAN } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_UPSELL_TITAN } from 'calypso/my-sites/customer-home/cards/constants';
 
 const TitanBanner = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/verify-email/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/verify-email/index.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import { TASK_VERIFY_EMAIL } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
-import { TASK_VERIFY_EMAIL } from 'calypso/my-sites/customer-home/cards/constants';
 
 const VerifyEmail = (): React.ReactElement => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_WEBINARS } from 'calypso/my-sites/customer-home/cards/constants';
+import React from 'react';
 import webinarsIllustration from 'calypso/assets/images/customer-home/illustration-webinars.svg';
+import { TASK_WEBINARS } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const Webinars = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/tasks/wp-courses/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/wp-courses/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { TASK_WP_COURSES } from 'calypso/my-sites/customer-home/cards/constants';
 import coursesLogo from 'calypso/assets/images/customer-home/courses-logo.png';
+import { TASK_WP_COURSES } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const WPCourses = () => {
 	return (

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import page from 'page';
-
-/**
- * Internal Dependencies
- */
-import CustomerHome from './main';
-import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import React from 'react';
 import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import CustomerHome from './main';
 
 export default async function ( context, next ) {
 	const state = await context.store.getState();

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import home, { maybeRedirect } from './controller';
-import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page( '/home', siteSelection, sites, makeLayout, clientRender );

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -1,29 +1,6 @@
-/**
- * External dependencies
- */
 import React, { useEffect } from 'react';
-
-/**
- * Internal dependencies
- */
-import ConnectAccounts from 'calypso/my-sites/customer-home/cards/tasks/connect-accounts';
-import EarnFeatures from 'calypso/my-sites/customer-home/cards/tasks/earn-features';
-import FindDomain from 'calypso/my-sites/customer-home/cards/tasks/find-domain';
-import GoMobile from 'calypso/my-sites/customer-home/cards/tasks/go-mobile';
-import GrowthSummit from 'calypso/my-sites/customer-home/cards/tasks/growth-summit';
-import Podcasting from 'calypso/my-sites/customer-home/cards/tasks/podcasting';
-import Renew from 'calypso/my-sites/customer-home/cards/tasks/renew';
-import SiteSetupList from 'calypso/my-sites/customer-home/cards/tasks/site-setup-list';
-import SiteSetupListEcommerce from 'calypso/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce';
-import TitanBanner from 'calypso/my-sites/customer-home/cards/tasks/titan-banner';
-import Webinars from 'calypso/my-sites/customer-home/cards/tasks/webinars';
-import WPCourses from 'calypso/my-sites/customer-home/cards/tasks/wp-courses';
-import Cloudflare from 'calypso/my-sites/customer-home/cards/tasks/cloudflare';
-import VerifyEmail from 'calypso/my-sites/customer-home/cards/tasks/verify-email';
-import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-creation';
-import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
-import CelebrateSiteMigration from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-migration';
-import CelebrateSiteSetupComplete from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-setup-complete';
+import { connect } from 'react-redux';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import {
 	NOTICE_CELEBRATE_SITE_CREATION,
 	NOTICE_CELEBRATE_SITE_LAUNCH,
@@ -46,9 +23,25 @@ import {
 	TASK_WEBINARS,
 	TASK_WP_COURSES,
 } from 'calypso/my-sites/customer-home/cards/constants';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-creation';
+import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
+import CelebrateSiteMigration from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-migration';
+import CelebrateSiteSetupComplete from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-setup-complete';
+import Cloudflare from 'calypso/my-sites/customer-home/cards/tasks/cloudflare';
+import ConnectAccounts from 'calypso/my-sites/customer-home/cards/tasks/connect-accounts';
+import EarnFeatures from 'calypso/my-sites/customer-home/cards/tasks/earn-features';
+import FindDomain from 'calypso/my-sites/customer-home/cards/tasks/find-domain';
+import GoMobile from 'calypso/my-sites/customer-home/cards/tasks/go-mobile';
+import GrowthSummit from 'calypso/my-sites/customer-home/cards/tasks/growth-summit';
+import Podcasting from 'calypso/my-sites/customer-home/cards/tasks/podcasting';
+import Renew from 'calypso/my-sites/customer-home/cards/tasks/renew';
+import SiteSetupListEcommerce from 'calypso/my-sites/customer-home/cards/tasks/site-setup-checklist-ecommerce';
+import SiteSetupList from 'calypso/my-sites/customer-home/cards/tasks/site-setup-list';
+import TitanBanner from 'calypso/my-sites/customer-home/cards/tasks/titan-banner';
+import VerifyEmail from 'calypso/my-sites/customer-home/cards/tasks/verify-email';
+import Webinars from 'calypso/my-sites/customer-home/cards/tasks/webinars';
+import WPCourses from 'calypso/my-sites/customer-home/cards/tasks/wp-courses';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { connect } from 'react-redux';
 
 const cardComponents = {
 	[ NOTICE_CELEBRATE_SITE_CREATION ]: CelebrateSiteCreation,

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
-import QuickStartVideo from 'calypso/my-sites/customer-home/cards/education/quick-start-video';
-import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
-import LearnGrow from './learn-grow';
 import {
 	FEATURE_STATS,
 	SECTION_LEARN_GROW,
 	FEATURE_QUICK_START_VIDEO,
 	FEATURE_SUPPORT,
 } from 'calypso/my-sites/customer-home/cards/constants';
+import QuickStartVideo from 'calypso/my-sites/customer-home/cards/education/quick-start-video';
+import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
+import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
+import LearnGrow from './learn-grow';
 
 const cardComponents = {
 	[ FEATURE_STATS ]: Stats,

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -1,27 +1,20 @@
-/**
- * External dependencies
- */
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import FreePhotoLibrary from 'calypso/my-sites/customer-home/cards/education/free-photo-library';
-// eslint-disable-next-line inclusive-language/use-inclusive-words
-import MasteringGutenberg from 'calypso/my-sites/customer-home/cards/education/mastering-gutenberg';
-import EducationEarn from 'calypso/my-sites/customer-home/cards/education/earn';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import DotPager from 'calypso/components/dot-pager';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import {
 	EDUCATION_FREE_PHOTO_LIBRARY,
 	EDUCATION_GUTENBERG,
 	EDUCATION_EARN,
 	EDUCATION_WPCOURSES,
 } from 'calypso/my-sites/customer-home/cards/constants';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import EducationEarn from 'calypso/my-sites/customer-home/cards/education/earn';
+import FreePhotoLibrary from 'calypso/my-sites/customer-home/cards/education/free-photo-library';
+// eslint-disable-next-line inclusive-language/use-inclusive-words
+import MasteringGutenberg from 'calypso/my-sites/customer-home/cards/education/mastering-gutenberg';
 import WpCourses from 'calypso/my-sites/customer-home/cards/education/wpcourses';
-import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
-import DotPager from 'calypso/components/dot-pager';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const cardComponents = {
 	[ EDUCATION_FREE_PHOTO_LIBRARY ]: FreePhotoLibrary,

--- a/client/my-sites/customer-home/locations/tertiary/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import ManageSite from './manage-site';
 import { SECTION_MANAGE_SITE } from 'calypso/my-sites/customer-home/cards/constants';
+import ManageSite from './manage-site';
 
 const cardComponents = {
 	[ SECTION_MANAGE_SITE ]: ManageSite,

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import GoMobile from 'calypso/my-sites/customer-home/cards/features/go-mobile';
-import QuickStart from 'calypso/my-sites/customer-home/cards/features/quick-start';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import QuickLinks from 'calypso/my-sites/customer-home/cards/actions/quick-links';
-import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import WpForTeamsQuickLinks from 'calypso/my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	ACTION_QUICK_LINKS,
 	ACTION_WP_FOR_TEAMS_QUICK_LINKS,
@@ -20,8 +10,11 @@ import {
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
 } from 'calypso/my-sites/customer-home/cards/constants';
+import GoMobile from 'calypso/my-sites/customer-home/cards/features/go-mobile';
+import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
+import QuickStart from 'calypso/my-sites/customer-home/cards/features/quick-start';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: GoMobile,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,38 +1,28 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import EmptyContent from 'calypso/components/empty-content';
-import Main from 'calypso/components/main';
-import { preventWidows } from 'calypso/lib/formatting';
-import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { canCurrentUserUseCustomerHome, getSiteOption } from 'calypso/state/sites/selectors';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import { preventWidows } from 'calypso/lib/formatting';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
-import config from '@automattic/calypso-config';
-import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import { canCurrentUserUseCustomerHome, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const Home = ( { canUserUseCustomerHome, site, siteId, trackViewSiteAction, noticeType } ) => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `my-sites/customer-home` to use `import/order`

```
/**
 * Style dependencies
 */
```
and
```
/**
 * Image dependencies
 */
```

comments have also been removed (mentioning because they're not as standard).

#### Testing instructions

N/A