### PR TITLE
Fixes flaky test for shouldRenderMonthlyRenewalOption

### DIFF
--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -368,16 +368,16 @@ describe( 'index', () => {
 				expect(
 					shouldRenderMonthlyRenewalOption( {
 						...purchase,
-						...{ expiryStatus: 'expiring', expiryDate: moment().add( 90, 'days' ).format() },
+						...{ expiryStatus: 'expiring', expiryDate: moment().add( 89, 'days' ).format() },
 					} )
 				).toBe( true );
 			} );
 
-			test( 'when auto renew is on and plan is more than 30 days away from expiry', () => {
+			test( 'when auto renew is on and plan is less than 30 days away from expiry', () => {
 				expect(
 					shouldRenderMonthlyRenewalOption( {
 						...purchase,
-						...{ expiryDate: moment().add( 30, 'days' ).format() },
+						...{ expiryDate: moment().add( 29, 'days' ).format() },
 					} )
 				).toBe( true );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Context: p1626795613010300-slack-CDRRDATPS

* The test fails when the expiry date is exactly the same (at the millisecond level) as the current time. This PR changes the test values to avoid this failure.
* Also fixes the test description.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test Cases.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
