### PR TITLE
Writing Settings: Refresh menu after changing content types

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -23,6 +23,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import SupportInfo from 'calypso/components/support-info';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 
 /**
  * Style dependencies
@@ -30,14 +31,20 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import './style.scss';
 
 class CustomContentTypes extends Component {
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		const {
 			activatingCustomContentTypesModule,
 			customContentTypesModuleActive,
 			fields,
+			isSavingSettings,
 			siteId,
 			siteIsJetpack,
 		} = this.props;
+
+		// Refresh menu after settings are saved in case CPTs have been registered or unregistered.
+		if ( ! isSavingSettings && prevProps.isSavingSettings ) {
+			this.props.requestAdminMenu( siteId );
+		}
 
 		if ( ! siteIsJetpack ) {
 			return;
@@ -245,5 +252,6 @@ export default connect(
 	},
 	{
 		activateModule,
+		requestAdminMenu,
 	}
 )( localize( CustomContentTypes ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/54314

#### Changes proposed in this Pull Request

Fetches the admin menu data after toggling a custom post type in the writing settings, so the sidebar menu is updated accordingly.

#### Testing instructions

- Go to Settings > Writing > Content types.
- Enable a custom post type (Testimonials or Portfolio projects).
- Make sure the relevant section shows up in the sidebar menu automatically.
- Disable a custom post type (Testimonials or Portfolio projects).
- Make sure the relevant section disappears from the sidebar menu automatically.
  - Note that because of #14912, if you're using a theme that supports the CPT you just disabled, the CPT would be registered anyway and thus the relevant section will remain in the sidebar menu.
