### PR TITLE
Simplify the canCurrentUser and isSiteUpgradeable selectors

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -33,7 +33,7 @@ import Gridicon from 'calypso/components/gridicon';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -14,7 +14,7 @@ import QueryMediaStorage from 'calypso/components/data/query-media-storage';
 import { getMediaStorage } from 'calypso/state/sites/media-storage/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import {
 	FEATURE_UNLIMITED_STORAGE,
 	planHasFeature,

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -10,7 +10,7 @@ import formatCurrency from '@automattic/format-currency';
  */
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { findFirstSimilarPlanKey, TYPE_PREMIUM, TERM_ANNUALLY } from '@automattic/calypso-products';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -17,7 +17,7 @@ import FollowersCount from 'calypso/blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteOption } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from '@automattic/calypso-config';
 

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -23,7 +23,7 @@ import {
 import Banner from 'calypso/components/banner';
 import { addQueryArgs } from 'calypso/lib/url';
 import { hasFeature } from 'calypso/state/sites/plans/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -26,7 +26,7 @@ import {
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { Button, Card } from '@automattic/components';
 import DismissibleCard from 'calypso/blocks/dismissible-card';
 import PlanPrice from 'calypso/my-sites/plan-price';

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -12,7 +12,7 @@ import { backupPath, scanPath } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import getSiteScanProgress from 'calypso/state/selectors/get-site-scan-progress';

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -8,7 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -15,7 +15,7 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import FeatureExample from 'calypso/components/feature-example';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -17,7 +17,7 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { getCustomizerUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import AuthFormHeader from './auth-form-header';
 import { Button, Card } from '@automattic/components';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import config from '@automattic/calypso-config';
 import Disclaimer from './disclaimer';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -41,7 +41,7 @@ import {
 	storePlan,
 } from './persistence-utils';
 import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -11,7 +11,7 @@ import { Button } from '@automattic/components';
  * Internal dependencies
  */
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { preventWidows } from 'calypso/lib/formatting';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -21,7 +21,7 @@ import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import Gridicon from 'calypso/components/gridicon';
 import { getSitePlan } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
 import { preventWidows } from 'calypso/lib/formatting';

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -21,7 +21,7 @@ import CommentDeleteWarning from 'calypso/my-sites/comment/comment-delete-warnin
 import CommentListHeader from 'calypso/my-sites/comments/comment-list/comment-list-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteComment } from 'calypso/state/comments/selectors';
 import { getSiteId } from 'calypso/state/sites/selectors';
 

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -17,7 +17,7 @@ import ExternalLink from 'calypso/components/external-link';
 import Popover from 'calypso/components/popover';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { urlToDomainAndPath } from 'calypso/lib/url';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteComment } from 'calypso/state/comments/selectors';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import isAuthorsEmailBlocked from 'calypso/state/selectors/is-authors-email-blocked';

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -18,7 +18,7 @@ import CommentList from './comment-list';
 import CommentTree from './comment-tree';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { preventWidows } from 'calypso/lib/formatting';
 import config, { isEnabled } from '@automattic/calypso-config';
 import { NEWEST_FIRST } from './constants';

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -37,7 +37,7 @@ import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selec
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import {
 	domainManagementContactsPrivacy,

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -22,7 +22,7 @@ import {
 	hasDomainCredit,
 	isCurrentUserCurrentPlanOwner,
 } from 'calypso/state/sites/plans/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -28,7 +28,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import EmptyContent from 'calypso/components/empty-content';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -40,7 +40,7 @@ import {
 	isEcommerce,
 	isSecurityDaily,
 } from '@automattic/calypso-products';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isSiteWordadsUnsafe } from 'calypso/state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'calypso/state/wordads/status/schema';
 import {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -17,7 +17,7 @@ import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selecto
 import getSiteBySlug from 'calypso/state/sites/selectors/get-site-by-slug';
 import { hasFeature, getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
 import EmptyContent from 'calypso/components/empty-content';

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -11,7 +11,7 @@ import titleCase from 'to-title-case';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import DocumentHead from 'calypso/components/data/document-head';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import EmailHeader from 'calypso/my-sites/email/email-header';

--- a/client/my-sites/email/email-management/titan-management-iframe/index.jsx
+++ b/client/my-sites/email/email-management/titan-management-iframe/index.jsx
@@ -10,7 +10,7 @@ import titleCase from 'to-title-case';
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import DocumentHead from 'calypso/components/data/document-head';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import EmptyContent from 'calypso/components/empty-content';

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -18,7 +18,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -18,7 +18,7 @@ import { getSiteHomeUrl } from 'calypso/state/sites/selectors';
 import { requestKeyringServices } from 'calypso/state/sharing/services/actions';
 import { requestSiteKeyrings } from 'calypso/state/site-keyrings/actions';
 import { getSiteKeyringsForService } from 'calypso/state/site-keyrings/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 
 /**

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -13,7 +13,7 @@ import Gridicon from 'calypso/components/gridicon';
  */
 import ActionCard from 'calypso/components/action-card';
 import { Button, Card } from '@automattic/components';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import ExternalLink from 'calypso/components/external-link';

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -39,7 +39,7 @@ import {
 import { getSiteTitle } from 'calypso/state/sites/selectors';
 import Main from 'calypso/components/main';
 import JetpackImporter from 'calypso/my-sites/importer/jetpack-importer';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import EmptyContent from 'calypso/components/empty-content';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';

--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -21,7 +21,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { setExpandedService } from 'calypso/state/sharing/actions';
 
 export const redirectConnections = ( context ) => {

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -25,7 +25,7 @@ import RelatedPosts from 'calypso/my-sites/site-settings/related-posts';
 import Sitemaps from 'calypso/my-sites/site-settings/sitemaps';
 import Shortlinks from 'calypso/my-sites/site-settings/shortlinks';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -26,7 +26,7 @@ import {
 	MEDIA_IMAGE_THUMBNAIL,
 	SCALE_TOUCH_GRID,
 } from 'calypso/lib/media/constants';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import MediaLibraryHeader from './header';
 import MediaLibraryExternalHeader from './external-media-header';

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -19,7 +19,7 @@ import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import GooglePhotosIcon from './google-photos-icon';
 import config from '@automattic/calypso-config';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 export class MediaLibraryDataSource extends Component {
 	static propTypes = {

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -14,7 +14,7 @@ import { preventWidows } from 'calypso/lib/formatting';
  */
 import EmptyContent from 'calypso/components/empty-content';
 import { Button } from '@automattic/components';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class MediaLibraryListPlanPromo extends React.Component {

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'calypso/components/gridicon';
  */
 import { isFrontPage, isPostsPage } from 'calypso/state/pages/selectors';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getTheme } from 'calypso/state/themes/selectors';
 import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -47,7 +47,7 @@ import { getEditorDuplicatePostPath } from 'calypso/state/editor/selectors';
 import { updateSiteFrontPage } from 'calypso/state/sites/actions';
 import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import config from '@automattic/calypso-config';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -19,7 +19,7 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -28,7 +28,7 @@ import {
 	didInviteDeletionSucceed,
 } from 'calypso/state/invites/selectors';
 import { deleteInvite } from 'calypso/state/invites/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /**

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -23,7 +23,7 @@ import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import InvitesListEnd from './invites-list-end';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import {
 	isRequestingInvitesForSite,

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -13,7 +13,7 @@ import { isEnabled } from '@automattic/calypso-config';
  */
 import DocumentHead from 'calypso/components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import Main from 'calypso/components/main';
 import EmptyContent from 'calypso/components/empty-content';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -28,7 +28,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import PluginsBrowser from './plugins-browser';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import NoPermissionsError from './no-permissions-error';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import getUpdateableJetpackSites from 'calypso/state/selectors/get-updateable-jetpack-sites';

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -31,7 +31,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -24,7 +24,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import urlSearch from 'calypso/lib/url-search';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import getRecommendedPlugins from 'calypso/state/selectors/get-recommended-plugins';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -12,7 +12,7 @@ import { get } from 'lodash';
  */
 import PostLikesPopover from 'calypso/blocks/post-likes/popover';
 import { getNormalizedPost } from 'calypso/state/posts/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteSlug, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getRecentViewsForPost } from 'calypso/state/stats/recent-post-views/selectors';

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -14,7 +14,7 @@ import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getPost } from 'calypso/state/posts/selectors';
 import { savePost } from 'calypso/state/posts/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 class PostActionsEllipsisMenuPublish extends Component {
 	static propTypes = {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import { bumpStat as bumpAnalyticsStat } from 'calypso/state/analytics/actions';
 import { bumpStatGenerator } from './utils';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getPost } from 'calypso/state/posts/selectors';
 import { restorePost } from 'calypso/state/posts/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -15,7 +15,7 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'calypso/state/posts/selectors';
 import { toggleSharePanel } from 'calypso/state/ui/post-type-list/actions';
 import isPublicizeEnabled from 'calypso/state/selectors/is-publicize-enabled';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class PostActionsEllipsisMenuShare extends Component {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -13,7 +13,7 @@ import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { trashPost, deletePost } from 'calypso/state/posts/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getPost } from 'calypso/state/posts/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -15,7 +15,7 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteOption, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { addQueryArgs } from 'calypso/lib/route';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { Button } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -11,7 +11,7 @@ import { Button } from '@automattic/components';
  */
 import { addQueryArgs } from '@wordpress/url';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -12,7 +12,7 @@ import { requestAdminMenu } from '../../state/admin-menu/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import buildFallbackResponse from './static-data/fallback-menu';
 import allSitesMenu from './static-data/all-sites-menu';
 import jetpackMenu from './static-data/jetpack-fallback-menu';

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -36,7 +36,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { compact, omit, reduce, get, partial } from 'lodash';
+import { compact, omit, reduce, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
 
@@ -270,7 +270,7 @@ export default connect(
 	( state, { siteId } ) => ( {
 		allSingleSites: areAllSitesSingleUser( state ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
+		canCurrentUser: ( capability ) => canCurrentUserStateSelector( state, siteId, capability ),
 		isJetpack: isJetpackSite( state, siteId ),
 		isSiteAtomic: isSiteWpcomAtomic( state, siteId ),
 		isSingleUser: isSingleUserSite( state, siteId ),

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { compact, partial } from 'lodash';
+import { compact } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -144,9 +144,8 @@ export default connect(
 	( state, { siteId } ) => ( {
 		canManagePlugins: canCurrentUserManagePlugins( state ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
+		canCurrentUser: ( capability ) => canCurrentUserStateSelector( state, siteId, capability ),
 		isJetpack: isJetpackSite( state, siteId ),
-		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		isSiteWPForTeams: isSiteWPForTeams( state, siteId ),

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -22,7 +22,7 @@ import {
 } from 'calypso/state/analytics/actions';
 import QuerySiteConnectionStatus from 'calypso/components/data/query-site-connection-status';
 import { getUpdatesBySiteId, isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -22,7 +22,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -12,7 +12,7 @@ import { includes } from 'lodash';
  */
 import accept from 'calypso/lib/accept';
 import AuthorSelector from 'calypso/blocks/author-selector';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { Card } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -43,7 +43,7 @@ import QueryTerms from 'calypso/components/data/query-terms';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isRequestingTermsForQueryIgnoringPage } from 'calypso/state/terms/selectors';

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -7,7 +7,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import titlecase from 'to-title-case';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { sectionify } from 'calypso/lib/route';

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -47,7 +47,7 @@ class Sites extends Component {
 
 		// Plans are for not Jetpack or Jetpack upgradeable sites.
 		if ( /^\/plans/.test( path ) ) {
-			return ! site.jetpack || site.isSiteUpgradeable;
+			return ! site.jetpack || site.capabilities.manage_options;
 		}
 
 		if ( /^\/hosting-config/.test( path ) ) {

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -45,7 +45,7 @@ class Sites extends Component {
 			return ! site.jetpack || site.options.is_automated_transfer;
 		}
 
-		// Plans are for not Jetpack or Jetpack upgradeable sites.
+		// If a site is Jetpack, plans are available only when it is upgradeable.
 		if ( /^\/plans/.test( path ) ) {
 			return ! site.jetpack || site.capabilities.manage_options;
 		}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -45,7 +45,7 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import EmptyContent from 'calypso/components/empty-content';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import Banner from 'calypso/components/banner';
 import isVipSite from 'calypso/state/selectors/is-vip-site';

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -32,7 +32,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { canCurrentUserUseAds } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import PrivacyPolicyBanner from 'calypso/blocks/privacy-policy-banner';
 import StickyPanel from 'calypso/components/sticky-panel';

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -33,7 +33,7 @@ import {
 
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const identity = ( theme ) => theme;

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -20,7 +20,7 @@ import PostTypeFilter from 'calypso/my-sites/post-type-filter';
 import PostTypeList from 'calypso/my-sites/post-type-list';
 import PostTypeUnsupported from './post-type-unsupported';
 import PostTypeForbidden from './post-type-forbidden';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'calypso/state/post-types/selectors';
 import QueryPostTypes from 'calypso/components/data/query-post-types';

--- a/client/my-sites/types/post-type-unsupported/index.jsx
+++ b/client/my-sites/types/post-type-unsupported/index.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import EmptyContent from 'calypso/components/empty-content';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 /**

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -27,7 +27,7 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import { getMimePrefix, isItemBeingUploaded, isVideoPressItem } from 'calypso/lib/media/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import MediaLibraryListItem from 'calypso/my-sites/media-library/list-item';
 import EditorMediaModalGalleryCaption from './caption';
 import EditorMediaModalGalleryRemoveButton from './remove-button';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 class EditorMediaModalGalleryEditItem extends Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import { canUserDeleteItem } from 'calypso/lib/media/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { Button } from '@automattic/components';
 
 const noop = () => {};

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -133,25 +133,6 @@ export const getCurrentUserEmail = createCurrentUserSelector( 'email' );
 export const getCurrentUserDisplayName = createCurrentUserSelector( 'display_name' );
 
 /**
- * Returns true if the capability name is valid for the current user on a given
- * site, false if capabilities are known for the site but the name is invalid,
- * or null if capabilities are not known for the site.
- *
- * @param  {object}   state      Global state tree
- * @param  {number}   siteId     Site ID
- * @param  {string}   capability Capability name
- * @returns {?boolean}            Whether capability name is valid
- */
-export function isValidCapability( state, siteId, capability ) {
-	const capabilities = state.currentUser.capabilities[ siteId ];
-	if ( ! capabilities ) {
-		return null;
-	}
-
-	return capabilities.hasOwnProperty( capability );
-}
-
-/**
  * Returns true if the specified flag is enabled for the user
  *
  * @param  {object}   state      Global state tree

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -8,7 +8,6 @@ import {
 	getCurrentUserLocaleVariant,
 	getCurrentUserDate,
 	isUserLoggedIn,
-	isValidCapability,
 	getCurrentUserEmail,
 	isCurrentUserBootstrapped,
 } from '../selectors';
@@ -171,58 +170,6 @@ describe( 'selectors', () => {
 			} );
 
 			expect( currentUserDate ).toBeNull();
-		} );
-	} );
-
-	describe( 'isValidCapability()', () => {
-		test( 'should return null if the site is not known', () => {
-			const isValid = isValidCapability(
-				{
-					currentUser: {
-						capabilities: {},
-					},
-				},
-				2916284,
-				'manage_options'
-			);
-
-			expect( isValid ).toBeNull();
-		} );
-
-		test( 'should return true if the capability is valid', () => {
-			const isValid = isValidCapability(
-				{
-					currentUser: {
-						capabilities: {
-							2916284: {
-								manage_options: false,
-							},
-						},
-					},
-				},
-				2916284,
-				'manage_options'
-			);
-
-			expect( isValid ).toBe( true );
-		} );
-
-		test( 'should return false if the capability is invalid', () => {
-			const isValid = isValidCapability(
-				{
-					currentUser: {
-						capabilities: {
-							2916284: {
-								manage_options: false,
-							},
-						},
-					},
-				},
-				2916284,
-				'manage_foo'
-			);
-
-			expect( isValid ).toBe( false );
 		} );
 	} );
 

--- a/client/state/guided-tours/contexts/is-selected-site-customizable.js
+++ b/client/state/guided-tours/contexts/is-selected-site-customizable.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
 
 /**
  * Returns true if the current user can run customizer for the selected site
@@ -10,4 +11,4 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * @returns {boolean} True if user can run customizer, false otherwise.
  */
 export const isSelectedSiteCustomizable = ( state ) =>
-	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
+	canCurrentUser( state, getSelectedSite( state ), 'edit_theme_options' );

--- a/client/state/guided-tours/contexts/is-selected-site-customizable.js
+++ b/client/state/guided-tours/contexts/is-selected-site-customizable.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 /**
  * Returns true if the current user can run customizer for the selected site

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -41,7 +41,7 @@ import {
 } from 'calypso/lib/plugins/constants';
 import { getSite } from 'calypso/state/sites/selectors';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
 
 import 'calypso/state/plugins/init';

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -41,7 +41,7 @@ import {
 } from 'calypso/lib/plugins/constants';
 import { getSite } from 'calypso/state/sites/selectors';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
 
 import 'calypso/state/plugins/init';

--- a/client/state/selectors/can-current-user-for-sites.js
+++ b/client/state/selectors/can-current-user-for-sites.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 /**
  * Returns an object with a key/property for each site ID in the sites list.

--- a/client/state/selectors/can-current-user-manage-plugins.js
+++ b/client/state/selectors/can-current-user-manage-plugins.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { createSelector } from '@automattic/state-utils';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 /**
  * Returns true if user can manage plugins for at least one site and returns false otherwise

--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -1,14 +1,8 @@
 /**
- * Internal dependencies
- */
-
-import { isValidCapability } from 'calypso/state/current-user/selectors';
-
-/**
- * Returns true if the current user has the specified capability for the site,
- * false if the user does not have the capability or if the capability
- * cannot be determined (if the site is not currently known, or if specifying
- * an invalid capability).
+ * Returns:
+ * - `true` if the current user has the specified capability for the site;
+ * - `false` if the user does not have the capability, or if specifying an invalid capability;
+ * - `null` if the capability cannot be determined (the site is not currently known)
  *
  * @see https://codex.wordpress.org/Function_Reference/current_user_can
  *
@@ -17,12 +11,11 @@ import { isValidCapability } from 'calypso/state/current-user/selectors';
  * @param  {string}   capability Capability label
  * @returns {boolean}            Whether current user has capability
  */
-export const canCurrentUser = ( state, siteId, capability ) => {
-	if ( ! isValidCapability( state, siteId, capability ) ) {
-		return false;
+export default function canCurrentUser( state, siteId, capability ) {
+	const capabilities = state.currentUser.capabilities[ siteId ];
+	if ( ! capabilities ) {
+		return null;
 	}
 
-	return state.currentUser.capabilities[ siteId ][ capability ];
-};
-
-export default canCurrentUser;
+	return capabilities[ capability ] ?? false;
+}

--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -11,7 +11,7 @@
  * @param  {string}   capability Capability label
  * @returns {boolean}            Whether current user has capability
  */
-export default function canCurrentUser( state, siteId, capability ) {
+export function canCurrentUser( state, siteId, capability ) {
 	const capabilities = state.currentUser.capabilities[ siteId ];
 	if ( ! capabilities ) {
 		return null;

--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -17,5 +17,5 @@ export default function canCurrentUser( state, siteId, capability ) {
 		return null;
 	}
 
-	return capabilities[ capability ] ?? false;
+	return capabilities[ capability ] || false;
 }

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -3,7 +3,7 @@
  */
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 /**
  * Returns true if hosting section should be viewable

--- a/client/state/selectors/get-menus-url.js
+++ b/client/state/selectors/get-menus-url.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteAdminUrl, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 
 /**

--- a/client/state/selectors/get-selected-or-all-sites-jetpack-can-manage.js
+++ b/client/state/selectors/get-selected-or-all-sites-jetpack-can-manage.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { createSelector } from '@automattic/state-utils';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 

--- a/client/state/selectors/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/get-selected-or-all-sites-with-plugins.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { createSelector } from '@automattic/state-utils';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';

--- a/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';

--- a/client/state/selectors/is-site-upgradeable.js
+++ b/client/state/selectors/is-site-upgradeable.js
@@ -1,10 +1,7 @@
 /**
  * Internal dependencies
  */
-
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import getRawSite from 'calypso/state/selectors/get-raw-site';
 
 /**
  * Returns true if the site can be upgraded by the user, false if the
@@ -15,11 +12,6 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * @param  {number}   siteId Site ID
  * @returns {?boolean}        Whether site is upgradeable
  */
-export default function ( state, siteId ) {
-	// Cannot determine site upgradeability if there is no current user
-	if ( ! getCurrentUserId( state ) || ! getRawSite( state, siteId ) ) {
-		return null;
-	}
-
+export default function isSiteUpgradeable( state, siteId ) {
 	return canCurrentUser( state, siteId, 'manage_options' );
 }

--- a/client/state/selectors/is-site-upgradeable.js
+++ b/client/state/selectors/is-site-upgradeable.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 /**
  * Returns true if the site can be upgraded by the user, false if the

--- a/client/state/selectors/test/can-current-user.js
+++ b/client/state/selectors/test/can-current-user.js
@@ -1,15 +1,10 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
 
 describe( 'canCurrentUser()', () => {
-	test( 'should return false if the site is not known', () => {
+	test( 'should return null if the site is not known', () => {
 		const isCapable = canCurrentUser(
 			{
 				currentUser: {
@@ -20,7 +15,7 @@ describe( 'canCurrentUser()', () => {
 			'manage_options'
 		);
 
-		expect( isCapable ).to.be.false;
+		expect( isCapable ).toBeNull();
 	} );
 
 	test( 'should return the value for the specified capability', () => {
@@ -38,7 +33,7 @@ describe( 'canCurrentUser()', () => {
 			'manage_options'
 		);
 
-		expect( isCapable ).to.be.false;
+		expect( isCapable ).toBe( false );
 	} );
 
 	test( 'should return false if the capability is invalid', () => {
@@ -56,6 +51,6 @@ describe( 'canCurrentUser()', () => {
 			'manage_foo'
 		);
 
-		expect( isCapable ).to.be.false;
+		expect( isCapable ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/can-current-user.js
+++ b/client/state/selectors/test/can-current-user.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 describe( 'canCurrentUser()', () => {
 	test( 'should return null if the site is not known', () => {

--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -61,7 +61,6 @@ describe( 'getPublicSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
 				is_previewable: false,
 				options: {
 					unmapped_url: 'http://example.com',

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -60,7 +60,6 @@ describe( 'getVisibleSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
 				is_previewable: false,
 				options: {
 					unmapped_url: 'http://example.com',

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -7,12 +7,14 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import isEligibleForDomainToPaidPlanUpsell from '../is-eligible-for-domain-to-paid-plan-upsell';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
-jest.mock( 'calypso/state/selectors/can-current-user', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/can-current-user', () => ( {
+	canCurrentUser: require( 'sinon' ).stub(),
+} ) );
 jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
 jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
 jest.mock( 'calypso/state/selectors/is-vip-site', () => require( 'sinon' ).stub() );

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -6,14 +6,16 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isEligibleForFreeToPaidUpsell from '../is-eligible-for-free-to-paid-upsell';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
-jest.mock( 'calypso/state/selectors/can-current-user', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/can-current-user', () => ( {
+	canCurrentUser: require( 'sinon' ).stub(),
+} ) );
 jest.mock( 'calypso/state/sites/selectors', () => ( {
 	isJetpackSite: require( 'sinon' ).stub(),
 } ) );

--- a/client/state/selectors/test/is-site-upgradeable.js
+++ b/client/state/selectors/test/is-site-upgradeable.js
@@ -1,98 +1,23 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 
 describe( 'isSiteUpgradeable()', () => {
 	test( 'should return null if no siteId is given', () => {
-		const isUpgradeable = isSiteUpgradeable(
-			{
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							options: {
-								unmapped_url: 'https://example.wordpress.com',
-							},
-						},
-					},
-				},
-				currentUser: {
-					id: 123456,
-				},
-			},
-			null
-		);
-
-		expect( isUpgradeable ).to.be.null;
+		const isUpgradeable = isSiteUpgradeable( { currentUser: { capabilities: {} } }, null );
+		expect( isUpgradeable ).toBeNull();
 	} );
 
 	test( 'should return null if there is no site with that siteId', () => {
-		const isUpgradeable = isSiteUpgradeable(
-			{
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							options: {
-								unmapped_url: 'https://example.wordpress.com',
-							},
-						},
-					},
-				},
-				currentUser: {},
-			},
-			42
-		);
-
-		expect( isUpgradeable ).to.be.null;
-	} );
-
-	test( 'should return null if there is no current user', () => {
-		const isUpgradeable = isSiteUpgradeable(
-			{
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							options: {
-								unmapped_url: 'https://example.wordpress.com',
-							},
-						},
-					},
-				},
-				currentUser: {},
-			},
-			77203199
-		);
-
-		expect( isUpgradeable ).to.be.null;
+		const isUpgradeable = isSiteUpgradeable( { currentUser: { capabilities: {} } }, 42 );
+		expect( isUpgradeable ).toBeNull();
 	} );
 
 	test( 'should return false if the user cannot manage the site', () => {
 		const isUpgradeable = isSiteUpgradeable(
 			{
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							options: {
-								unmapped_url: 'https://example.wordpress.com',
-							},
-						},
-					},
-				},
 				currentUser: {
-					id: 123456,
 					capabilities: {
 						77203199: {
 							manage_options: false,
@@ -103,25 +28,13 @@ describe( 'isSiteUpgradeable()', () => {
 			77203199
 		);
 
-		expect( isUpgradeable ).to.be.false;
+		expect( isUpgradeable ).toBe( false );
 	} );
 
 	test( 'should return true if the user can manage the site', () => {
 		const isUpgradeable = isSiteUpgradeable(
 			{
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							options: {
-								unmapped_url: 'https://example.wordpress.com',
-							},
-						},
-					},
-				},
 				currentUser: {
-					id: 123456,
 					capabilities: {
 						77203199: {
 							manage_options: true,
@@ -132,6 +45,6 @@ describe( 'isSiteUpgradeable()', () => {
 			77203199
 		);
 
-		expect( isUpgradeable ).to.be.true;
+		expect( isUpgradeable ).toBe( true );
 	} );
 } );

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -7,7 +7,7 @@ import { filter, get } from 'lodash';
  * Internal dependencies
  */
 import { createSelector } from '@automattic/state-utils';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -7,7 +7,7 @@ import { filter } from 'lodash';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteGoogleMyBusinessEligible from 'calypso/state/selectors/is-site-google-my-business-eligible';

--- a/client/state/sites/selectors/can-current-user-manage-site-options.js
+++ b/client/state/sites/selectors/can-current-user-manage-site-options.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 /**
  * Whether the user can manage site options.

--- a/client/state/sites/selectors/can-current-user-upgrade-site.js
+++ b/client/state/sites/selectors/can-current-user-upgrade-site.js
@@ -3,7 +3,7 @@
  */
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isCurrentPlanPaid from './is-current-plan-paid';
 
 /**

--- a/client/state/sites/selectors/can-current-user-use-any-woocommerce-based-store.js
+++ b/client/state/sites/selectors/can-current-user-use-any-woocommerce-based-store.js
@@ -5,7 +5,7 @@ import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/sel
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';

--- a/client/state/sites/selectors/can-current-user-use-earn.js
+++ b/client/state/sites/selectors/can-current-user-use-earn.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSite from './get-site';
 

--- a/client/state/sites/selectors/get-jetpack-computed-attributes.js
+++ b/client/state/sites/selectors/get-jetpack-computed-attributes.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 import canJetpackSiteAutoUpdateFiles from './can-jetpack-site-auto-update-files';
 import canJetpackSiteUpdateFiles from './can-jetpack-site-update-files';
 import isJetpackSite from './is-jetpack-site';
@@ -17,6 +16,5 @@ export default function getJetpackComputedAttributes( state, siteId ) {
 		canUpdateFiles: canJetpackSiteUpdateFiles( state, siteId ),
 		isMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
 		isSecondaryNetworkSite: isJetpackSiteSecondaryNetworkSite( state, siteId ),
-		isSiteUpgradeable: isSiteUpgradeable( state, siteId ),
 	};
 }

--- a/client/state/sites/selectors/get-site-computed-attributes.js
+++ b/client/state/sites/selectors/get-site-computed-attributes.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { withoutHttp } from 'calypso/lib/url';
-import canCurrentUser from 'calypso/state/selectors/can-current-user';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSiteDomain from './get-site-domain';
 import getSiteOption from './get-site-option';
@@ -29,7 +28,6 @@ export default function getSiteComputedAttributes( state, siteId ) {
 	const computedAttributes = {
 		domain: getSiteDomain( state, siteId ),
 		hasConflict: isSiteConflicting( state, siteId ),
-		is_customizable: canCurrentUser( state, siteId, 'edit_theme_options' ),
 		is_previewable: !! isSitePreviewable( state, siteId ),
 		options: getSiteOptions( state, siteId ),
 		slug: getSiteSlug( state, siteId ),

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -130,14 +130,12 @@ describe( 'selectors', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
 				is_previewable: true,
 				jetpack: true,
 				canAutoupdateFiles: true,
 				canUpdateFiles: true,
 				isMainNetworkSite: false,
 				isSecondaryNetworkSite: false,
-				isSiteUpgradeable: false,
 				options: {
 					jetpack_version: '8.0',
 					unmapped_url: 'https://example.wordpress.com',
@@ -200,7 +198,6 @@ describe( 'selectors', () => {
 				slug: 'example.wordpress.com',
 				hasConflict: true,
 				jetpack: false,
-				is_customizable: false,
 				is_previewable: true,
 				options: {
 					unmapped_url: 'https://example.wordpress.com',
@@ -3256,7 +3253,6 @@ describe( 'selectors', () => {
 			chaiExpect( noNewAttributes.canUpdateFiles ).to.equal( undefined );
 			chaiExpect( noNewAttributes.isMainNetworkSite ).to.equal( undefined );
 			chaiExpect( noNewAttributes.isSecondaryNetworkSite ).to.equal( undefined );
-			chaiExpect( noNewAttributes.isSiteUpgradeable ).to.equal( undefined );
 		} );
 
 		test( 'should return exists for attributes if a site is Jetpack', () => {
@@ -3283,7 +3279,6 @@ describe( 'selectors', () => {
 			chaiExpect( noNewAttributes.canUpdateFiles ).to.have.property;
 			chaiExpect( noNewAttributes.isMainNetworkSite ).to.have.property;
 			chaiExpect( noNewAttributes.isSecondaryNetworkSite ).to.have.property;
-			chaiExpect( noNewAttributes.isSiteUpgradeable ).to.have.property;
 		} );
 	} );
 	describe( 'getSiteComputedAttributes()', () => {
@@ -3317,7 +3312,6 @@ describe( 'selectors', () => {
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
 				is_previewable: false,
-				is_customizable: false,
 				hasConflict: false,
 				domain: 'example.wordpress.com',
 				slug: 'example.wordpress.com',
@@ -3357,7 +3351,6 @@ describe( 'selectors', () => {
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
 				is_previewable: true,
-				is_customizable: false,
 				hasConflict: true,
 				domain: 'unmapped-url.wordpress.com',
 				slug: 'unmapped-url.wordpress.com',

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -55,7 +55,6 @@ describe( 'selectors', () => {
 				URL: 'https://example.com',
 				domain: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
 				is_previewable: false,
 				options: {},
 				slug: 'example.com',


### PR DESCRIPTION
Simplifies a few selectors that work with user capabilities.

First, I'm inlining the `isValidCapability` selector into `canCurrentUser` because it's used only there. The `isValidCapability` selector gets removed including its tests, because the `canCurrentUser` unit tests already test the same behavior.

The `canCurrentUser` now returns `null` when the `siteId` doesn't exist, instead of `false`. That's inline with how other selectors behave.

The `isSiteUpgradeable` selector doesn't need to call `getCurrentUser` or `getRawSite`. It can be just a wrapper around `canCurrentUser` and the return values don't change. If the user is logged out, the sites it gets from the anonymous `/sites` endpoints won't have the `capabilities` field, and `canCurrentUser` will return `null`. If the site doesn't exist, there won't be a `state.currentUser.capabilities[ siteId ]` record and again, the return value is `null`.

Finally, I'm removing the `is_customizable` and `isSiteUpgradeable` computed attributes on site objects. `is_customizable` is not used anywhere, and `isSiteUpgradeable` had just one usage that I replaced with `site.capabilities.manage_options` check.

**How to test:**
Verify that the changes are reasonable. Verify that the `site.isSiteUpgradeable` computed attribute is indeed never used. As it has the same name as the `isSiteUpgradeable` Redux selector, it's not easy to check.