### PR TITLE
Use the isUserLoggedIn selector whenever we just want the boolean

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSection } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
 import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
@@ -19,7 +19,7 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 		const { store, section, pathname, query, primary, secondary } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
-		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
+		if ( ! ( context.isServerSide && isUserLoggedIn( context.store.getState() ) ) ) {
 			context.layout = (
 				<LayoutComponent
 					store={ store }

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -20,7 +20,7 @@ import DevWelcome from './welcome';
 import Sidebar from './sidebar';
 import EmptyContent from 'calypso/components/empty-content';
 import WizardComponent from './wizard-component';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const devdocs = {
 	/*
@@ -138,7 +138,7 @@ const devdocs = {
 
 	pleaseLogIn: function ( context, next ) {
 		const redirectTo = window.location.origin + '/devdocs/welcome';
-		if ( ! getCurrentUserId( context.store.getState() ) ) {
+		if ( ! isUserLoggedIn( context.store.getState() ) ) {
 			context.primary = React.createElement( EmptyContent, {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -20,7 +20,7 @@ import NoDirectAccessError from './no-direct-access-error';
 import OrgCredentialsForm from './remote-credentials';
 import SearchPurchase from './search';
 import StoreHeader from './store-header';
-import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath } from 'calypso/lib/i18n-utils';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
@@ -189,7 +189,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 
 export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 	debug( 'controller: redirectWithoutLocaleIfLoggedIn', context.params );
-	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 	if ( isLoggedIn && getLocaleFromPath( context.path ) ) {
 		const urlWithoutLocale = removeLocaleFromPath( context.path );
 		debug( 'redirectWithoutLocaleIfLoggedIn to %s', urlWithoutLocale );
@@ -230,11 +230,11 @@ export function loginBeforeJetpackSearch( context, next ) {
 	debug( 'controller: loginBeforeJetpackSearch', context.params );
 	const { params, path } = context;
 	const { type } = params;
-	const isLoggedOut = ! getCurrentUserId( context.store.getState() );
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 
 	// Log in to WP.com happens at the start of the flow for Search products
 	// ( to facilitate site selection ).
-	if ( JETPACK_SEARCH_PRODUCTS.includes( type ) && isLoggedOut ) {
+	if ( JETPACK_SEARCH_PRODUCTS.includes( type ) && ! isLoggedIn ) {
 		return page( login( { isJetpack: true, redirectTo: path } ) );
 	}
 	next();
@@ -321,7 +321,7 @@ export function signupForm( context, next ) {
 		}
 	);
 
-	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
 		// Force login for mobile app flow. App will intercept this request and prompt native login.
 		return window.location.replace( login( { redirectTo: context.path } ) );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -19,7 +19,7 @@ import { cleanUrl } from './utils';
 import { checkUrl } from 'calypso/state/jetpack-connect/actions';
 import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
 import { getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { persistSession } from './persistence-utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -150,7 +150,7 @@ const connectComponent = connect(
 		return {
 			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 			getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
-			isLoggedIn: !! getCurrentUserId( state ),
+			isLoggedIn: isUserLoggedIn( state ),
 			isRequestingSites: isRequestingSites( state ),
 		};
 	},

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -15,7 +15,7 @@ import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { getUrlParts } from '@automattic/calypso-url';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
-import { getCurrentUser, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 
 const enhanceContextWithLogin = ( context ) => {
 	const {
@@ -137,7 +137,7 @@ export function redirectDefaultLocale( context, next ) {
 
 	// Do not redirect if user bootrapping is disabled
 	if (
-		! getCurrentUser( context.store.getState() ) &&
+		! isUserLoggedIn( context.store.getState() ) &&
 		! config.isEnabled( 'wpcom-user-bootstrap' )
 	) {
 		return next();

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -34,7 +34,7 @@ import {
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import canCurrentUser from 'calypso/state/selectors/can-current-user';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const identity = ( theme ) => theme;
 
@@ -52,7 +52,7 @@ function getAllThemeOptions( { translate } ) {
 				getUrl: getThemePurchaseUrl,
 				hideForTheme: ( state, themeId, siteId ) =>
 					isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
-					! getCurrentUser( state ) || // Not logged in
+					! isUserLoggedIn( state ) || // Not logged in
 					! isThemePremium( state, themeId ) || // Not a premium theme
 					isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
 					isThemeActive( state, themeId, siteId ), // Already active
@@ -75,7 +75,7 @@ function getAllThemeOptions( { translate } ) {
 					getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ),
 				hideForTheme: ( state, themeId, siteId ) =>
 					! isJetpackSite( state, siteId ) ||
-					! getCurrentUser( state ) ||
+					! isUserLoggedIn( state ) ||
 					! isThemePremium( state, themeId ) ||
 					isThemeActive( state, themeId, siteId ) ||
 					isPremiumThemeAvailable( state, themeId, siteId ),
@@ -90,7 +90,7 @@ function getAllThemeOptions( { translate } ) {
 		} ),
 		action: activateAction,
 		hideForTheme: ( state, themeId, siteId ) =>
-			! getCurrentUser( state ) ||
+			! isUserLoggedIn( state ) ||
 			isJetpackSiteMultiSite( state, siteId ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ),
@@ -127,7 +127,7 @@ function getAllThemeOptions( { translate } ) {
 		} ),
 		action: tryAndCustomizeAction,
 		hideForTheme: ( state, themeId, siteId ) =>
-			! getCurrentUser( state ) ||
+			! isUserLoggedIn( state ) ||
 			( siteId &&
 				( ! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 					( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) ) ) ) ||
@@ -153,7 +153,7 @@ function getAllThemeOptions( { translate } ) {
 		label: signupLabel,
 		extendedLabel: signupLabel,
 		getUrl: getThemeSignupUrl,
-		hideForTheme: ( state ) => getCurrentUser( state ),
+		hideForTheme: ( state ) => isUserLoggedIn( state ),
 	};
 
 	const separator = {
@@ -199,7 +199,7 @@ function getAllThemeOptions( { translate } ) {
 const connectOptionsHoc = connect(
 	( state, props ) => {
 		const { siteId, origin = siteId, locale } = props;
-		const isLoggedOut = ! getCurrentUser( state );
+		const isLoggedOut = ! isUserLoggedIn( state );
 		let mapGetUrl = identity;
 		let mapHideForTheme = identity;
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -18,7 +18,7 @@ import { addTracking, trackClick, localizeThemesPath } from './helpers';
 import DocumentHead from 'calypso/components/data/document-head';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
@@ -386,7 +386,7 @@ class ThemeShowcase extends React.Component {
 
 const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	currentThemeId: getActiveTheme( state, siteId ),
-	isLoggedIn: !! getCurrentUserId( state ),
+	isLoggedIn: isUserLoggedIn( state ),
 	siteSlug: getSiteSlug( state, siteId ),
 	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
 	title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -15,7 +15,7 @@ import QueryThemes from 'calypso/components/data/query-themes';
 import ThemesList from 'calypso/components/themes-list';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getPremiumThemePrice,
 	getThemesForQueryIgnoringPage,
@@ -237,7 +237,7 @@ export const ConnectedThemesSelection = connect(
 			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
 			isRequesting: isRequestingThemesForQuery( state, sourceSiteId, query ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
-			isLoggedIn: !! getCurrentUserId( state ),
+			isLoggedIn: isUserLoggedIn( state ),
 			isThemeActive: bindIsThemeActive( state, siteId ),
 			isInstallingTheme: bindIsInstallingTheme( state, siteId ),
 			// Note: This component assumes that purchase and plans data is already present in the state tree

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -12,7 +12,7 @@ import { get, isEmpty } from 'lodash';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { getDomainProductSlug } from 'calypso/lib/domains';
@@ -200,7 +200,7 @@ export default connect(
 		const productsLoaded = ! isEmpty( productsList );
 
 		return {
-			isLoggedIn: !! getCurrentUserId( state ),
+			isLoggedIn: isUserLoggedIn( state ),
 			productsList,
 			productsLoaded,
 		};


### PR DESCRIPTION
Changes usages of the `getCurrentUser` selector to `isUserLoggedIn` whenever we're interested just in the "is logged in" boolean and not any particular attribute of the user object. A straightforward cleanup.