### PR TITLE
ci(e2e): Make e2e test compatible with Chrome 92

### DIFF
--- a/packages/mocha-debug-reporter/tsconfig.json
+++ b/packages/mocha-debug-reporter/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@automattic/calypso-build/typescript/ts-package.json",
 	"compilerOptions": {
 		"module": "CommonJS",
+		"allowJs": true,
 		"declarationDir": "dist/types",
 		"outDir": "dist/cjs",
 		"rootDir": "src",

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -214,6 +214,7 @@ export async function startBrowser( {
 				}
 
 				options.addArguments( '--app=https://www.wordpress.com' );
+				options.addArguments( '--v=2' );
 
 				// eslint-disable-next-line no-case-declarations
 				const service = new chrome.ServiceBuilder( chromedriver.path )

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -215,6 +215,7 @@ export async function startBrowser( {
 
 				options.addArguments( '--app=https://www.wordpress.com' );
 				options.addArguments( '--v=2' );
+				options.addArguments( '--disable-gpu' );
 
 				// eslint-disable-next-line no-case-declarations
 				const service = new chrome.ServiceBuilder( chromedriver.path )


### PR DESCRIPTION
#### Background

The latest `ci-e2e` docker image uses Chrome 92 instead of Chrome 91. Since then, all e2e tests across all branches have been failing. The error suggest Chrome is not starting or crashing.

#### Changes proposed in this Pull Request

After some trial and error I fond a fix: disabling GPU seems to help. While working on this I did another two fixes to improve logs:

- Increase verbosity from Chrome logs
- Fix `@automattic/mocha-debug-reporter` to export a CJS module.

#### Testing instructions

- Verify e2e tests pass
- Verify that e2e capture a file called `mocha.log` for each test and it contains a JSON dump of mocha test lifecycle (hook starting, test starting, test done, etc).