### PR TITLE
Checkout: fix domain credit messages

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -210,8 +210,14 @@ function CheckoutSummaryFeaturesListDomainItem( {
 } ) {
 	const translate = useTranslate();
 
+	// If there's no plan in the cart, list the domain only.
 	if ( ! hasPlanInCart ) {
-		return null;
+		return (
+			<CheckoutSummaryFeaturesListItem isIncluded={ true }>
+				<WPCheckoutCheckIcon />
+				<strong>{ domain.meta }</strong>
+			</CheckoutSummaryFeaturesListItem>
+		);
 	}
 
 	const bundledText = translate( 'free for one year' );
@@ -225,29 +231,25 @@ function CheckoutSummaryFeaturesListDomainItem( {
 		},
 		comment: 'domain name and bundling message, separated by a dash',
 	} );
-	const annualPlanOnly = translate( '(annual plans only)', {
-		comment: 'Label attached to a feature',
-	} );
 
-	const isSupported = ! ( hasMonthlyPlan && nextDomainIsFree );
-	let label = <strong>{ domain.meta }</strong>;
-
-	if ( domain.is_bundled ) {
-		label = bundledDomain;
-	} else if ( hasMonthlyPlan && nextDomainIsFree ) {
-		label = (
-			<>
+	// Conditionally show if domain is included with current plan purchase
+	if ( ! ( hasMonthlyPlan && nextDomainIsFree ) && ! domain.is_bundled ) {
+		return (
+			<CheckoutSummaryFeaturesListItem isIncluded={ false }>
+				<WPCheckoutCrossIcon />
 				{ bundledDomain }
 				{ ` ` }
-				{ annualPlanOnly }
-			</>
+				{ translate( '(annual plans only)', {
+					comment: 'Label attached to a feature',
+				} ) }
+			</CheckoutSummaryFeaturesListItem>
 		);
 	}
 
 	return (
-		<CheckoutSummaryFeaturesListItem isSupported={ isSupported }>
-			{ isSupported ? <WPCheckoutCheckIcon /> : <WPCheckoutCrossIcon /> }
-			{ label }
+		<CheckoutSummaryFeaturesListItem isIncluded={ true }>
+			<WPCheckoutCheckIcon />
+			{ bundledDomain }
 		</CheckoutSummaryFeaturesListItem>
 	);
 }
@@ -274,14 +276,14 @@ function CheckoutSummaryPlanFeatures( { siteId } ) {
 	return (
 		<>
 			{ planFeatures.map( ( feature ) => {
-				const isSupported = ! feature.startsWith( '~~' );
-				if ( ! isSupported ) {
+				const isIncluded = ! feature.startsWith( '~~' );
+				if ( ! isIncluded ) {
 					feature = feature.substr( 2 );
 				}
 
 				return (
-					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isSupported={ isSupported }>
-						{ isSupported ? <WPCheckoutCheckIcon /> : <WPCheckoutCrossIcon /> }
+					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isIncluded={ isIncluded }>
+						{ isIncluded ? <WPCheckoutCheckIcon /> : <WPCheckoutCrossIcon /> }
 						{ feature }
 					</CheckoutSummaryFeaturesListItem>
 				);
@@ -358,7 +360,7 @@ const CheckoutSummaryFeaturesListItem = styled.li`
 	padding-left: 24px;
 	position: relative;
 	overflow-wrap: break-word;
-	color: ${ ( props ) => ( props.isSupported ? 'inherit' : 'var( --color-neutral-30 )' ) };
+	color: ${ ( props ) => ( props.isIncluded ? 'inherit' : 'var( --color-neutral-30 )' ) };
 
 	.rtl & {
 		padding-right: 24px;
@@ -366,7 +368,7 @@ const CheckoutSummaryFeaturesListItem = styled.li`
 	}
 `;
 CheckoutSummaryFeaturesListItem.defaultProps = {
-	isSupported: true,
+	isIncluded: true,
 };
 
 const CheckoutSummaryAmountWrapper = styled.div`

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -167,6 +167,7 @@ function CheckoutSummaryFeaturesList( props ) {
 					return (
 						<CheckoutSummaryFeaturesListDomainItem
 							domain={ domain }
+							hasPlanInCart={ hasPlanInCart }
 							key={ domain.uuid }
 							{ ...props }
 						/>
@@ -201,8 +202,18 @@ function SupportText( { hasPlanInCart, isJetpackNotAtomic } ) {
 	return <span>{ translate( 'Email support' ) }</span>;
 }
 
-function CheckoutSummaryFeaturesListDomainItem( { domain, hasMonthlyPlan, nextDomainIsFree } ) {
+function CheckoutSummaryFeaturesListDomainItem( {
+	domain,
+	hasMonthlyPlan,
+	hasPlanInCart,
+	nextDomainIsFree,
+} ) {
 	const translate = useTranslate();
+
+	if ( ! hasPlanInCart ) {
+		return null;
+	}
+
 	const bundledText = translate( 'free for one year' );
 	const bundledDomain = translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
 		components: {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -232,8 +232,8 @@ function CheckoutSummaryFeaturesListDomainItem( {
 		comment: 'domain name and bundling message, separated by a dash',
 	} );
 
-	// Conditionally show if domain is included with current plan purchase
-	if ( ! ( hasMonthlyPlan && nextDomainIsFree ) && ! domain.is_bundled ) {
+	// If the domain is not bundled or included with plan, display the "annual plans only" message.
+	if ( ! ( hasMonthlyPlan && nextDomainIsFree ) || ! domain.is_bundled ) {
 		return (
 			<CheckoutSummaryFeaturesListItem isIncluded={ false }>
 				<WPCheckoutCrossIcon />

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -213,7 +213,7 @@ function CheckoutSummaryFeaturesListDomainItem( {
 	// If there's no plan in the cart, list the domain only.
 	if ( ! hasPlanInCart ) {
 		return (
-			<CheckoutSummaryFeaturesListItem isIncluded={ true }>
+			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon />
 				<strong>{ domain.meta }</strong>
 			</CheckoutSummaryFeaturesListItem>
@@ -247,7 +247,7 @@ function CheckoutSummaryFeaturesListDomainItem( {
 	}
 
 	return (
-		<CheckoutSummaryFeaturesListItem isIncluded={ true }>
+		<CheckoutSummaryFeaturesListItem>
 			<WPCheckoutCheckIcon />
 			{ bundledDomain }
 		</CheckoutSummaryFeaturesListItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -766,13 +766,15 @@ function IntroductoryOfferCallout( {
 
 function DomainDiscountCallout( {
 	product,
+	hasPlanInCart,
 }: {
 	product: ResponseCartProduct;
+	hasPlanInCart: boolean;
 } ): JSX.Element | null {
 	const translate = useTranslate();
 
 	const isFreeBundledDomainRegistration = product.is_bundled && product.item_subtotal_integer === 0;
-	if ( isFreeBundledDomainRegistration && product.is_renewal ) {
+	if ( isFreeBundledDomainRegistration && ! hasPlanInCart ) {
 		return <DiscountCallout>{ translate( 'Domain credit applied' ) }</DiscountCallout>;
 	}
 
@@ -846,6 +848,7 @@ function WPLineItem( {
 	const id = product.uuid;
 	const translate = useTranslate();
 	const { responseCart } = useShoppingCart();
+	const hasPlanInCart = responseCart.products.some( isPlan );
 	const hasDomainsInCart = responseCart.products.some(
 		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
 	);
@@ -917,7 +920,7 @@ function WPLineItem( {
 			{ sublabel && (
 				<LineItemMeta>
 					<LineItemSublabelAndPrice product={ product } />
-					<DomainDiscountCallout product={ product } />
+					<DomainDiscountCallout product={ product } hasPlanInCart={ hasPlanInCart } />
 					<FirstTermDiscountCallout product={ product } />
 					<CouponDiscountCallout product={ product } />
 					<IntroductoryOfferCallout product={ product } />

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -772,6 +772,10 @@ function DomainDiscountCallout( {
 	const translate = useTranslate();
 
 	const isFreeBundledDomainRegistration = product.is_bundled && product.item_subtotal_integer === 0;
+	if ( isFreeBundledDomainRegistration && product.is_renewal ) {
+		return <DiscountCallout>{ translate( 'Domain credit applied' ) }</DiscountCallout>;
+	}
+
 	if ( isFreeBundledDomainRegistration ) {
 		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -774,8 +774,13 @@ function DomainDiscountCallout( {
 	const translate = useTranslate();
 
 	const isFreeBundledDomainRegistration = product.is_bundled && product.item_subtotal_integer === 0;
-	if ( isFreeBundledDomainRegistration && ! hasPlanInCart ) {
+
+	if ( isFreeBundledDomainRegistration && product.is_renewal ) {
 		return <DiscountCallout>{ translate( 'Domain credit applied' ) }</DiscountCallout>;
+	}
+
+	if ( isFreeBundledDomainRegistration && ! hasPlanInCart ) {
+		return <DiscountCallout>{ translate( 'First year free with your plan' ) }</DiscountCallout>;
 	}
 
 	if ( isFreeBundledDomainRegistration ) {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -1078,7 +1078,7 @@ describe( 'CompositeCheckout', () => {
 		} );
 		const { getAllByText } = renderResult;
 		expect( getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-		expect( getAllByText( 'foo.cash' ) ).toHaveLength( 3 );
+		expect( getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
@@ -1112,7 +1112,7 @@ describe( 'CompositeCheckout', () => {
 		const { getAllByText } = renderResult;
 		expect( getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
 		expect( getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-		expect( getAllByText( 'bar.com' ) ).toHaveLength( 5 );
+		expect( getAllByText( 'bar.com' ) ).toHaveLength( 4 );
 	} );
 
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -1078,7 +1078,7 @@ describe( 'CompositeCheckout', () => {
 		} );
 		const { getAllByText } = renderResult;
 		expect( getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-		expect( getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
+		expect( getAllByText( 'foo.cash' ) ).toHaveLength( 3 );
 	} );
 
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
@@ -1112,7 +1112,7 @@ describe( 'CompositeCheckout', () => {
 		const { getAllByText } = renderResult;
 		expect( getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
 		expect( getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-		expect( getAllByText( 'bar.com' ) ).toHaveLength( 4 );
+		expect( getAllByText( 'bar.com' ) ).toHaveLength( 5 );
 	} );
 
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {


### PR DESCRIPTION
When a domain is being renewed and a domain credit exists for the user, we should indicate that the credit is being used for the domain line item. Additionally when a plan isn't currently in the cart, the "free domain for one year" message in the "included with your purchase" sidebar items is inaccurate and shouldn't be shown.

Fixes: #54761

<img width="929" alt="Screen Shot 2021-07-21 at 12 07 41 PM" src="https://user-images.githubusercontent.com/942359/126522153-b9e10b88-78f6-45be-a1c3-61155d49b4c6.png">

**To test:**
- ~~apply D64500-code and sandbox `public-api.wordpress.com`~~
----
- add a domain and plan to your cart
- verify that under the domain line item "discount for first year" is shown
- verify that sidebar features include "{domain} - free for one year"
----
- on a site with an available domain credit
- add a domain to your cart
- verify that under the domain line item "discount for first year" is shown
- verify that sidebar features do not include "{domain} - free for one year"
----
- on a site with an available domain credit
- renew an existing domain
- verify that under the domain line item "domain credit applied" is shown
- verify that sidebar features do not include "{domain} - free for one year"
----
- on a site without an available domain credit
- add a domain to your cart
- verify that no first year discount or credit message is shown on the domain line item
- verify that no "included with your purchase" message is shown