### PR TITLE
Checkout: Do not require cardholder name for existingCardProcessor

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -29,7 +29,7 @@ type ExistingCardTransactionRequest = Partial< Omit< TransactionRequest, 'paymen
 	Required<
 		Pick<
 			TransactionRequest,
-			'name' | 'storedDetailsId' | 'paymentMethodToken' | 'paymentPartnerProcessorId'
+			'storedDetailsId' | 'paymentMethodToken' | 'paymentPartnerProcessorId'
 		>
 	>;
 
@@ -58,6 +58,7 @@ export default async function existingCardProcessor(
 	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
+		name: transactionData.name ?? '',
 		siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
 		country: contactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode( contactDetails ),
@@ -110,9 +111,6 @@ function isValidTransactionData(
 	// a better localized error message than we can provide.
 	if ( ! data.storedDetailsId ) {
 		throw new Error( 'Transaction requires saved card information and none was provided' );
-	}
-	if ( ! data.name ) {
-		throw new Error( 'Transaction requires cardholder name and none was provided' );
 	}
 	if ( ! data.paymentMethodToken ) {
 		throw new Error( 'Transaction requires a Stripe token and none was provided' );

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -125,13 +125,6 @@ describe( 'existingCardProcessor', () => {
 		);
 	} );
 
-	it( 'throws an error if there is no name passed', async () => {
-		const submitData = { storedDetailsId: 'stored-details-id' };
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
-			/requires cardholder name and none was provided/
-		);
-	} );
-
 	it( 'throws an error if there is no paymentMethodToken passed', async () => {
 		const submitData = {
 			storedDetailsId: 'stored-details-id',
@@ -171,6 +164,31 @@ describe( 'existingCardProcessor', () => {
 			} )
 		).resolves.toStrictEqual( expected );
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'sends the correct data to the endpoint with no site and one product and no name', async () => {
+		const submitData = {
+			storedDetailsId: 'stored-details-id',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'IE',
+		};
+		const expected = { payload: 'success', type: 'SUCCESS' };
+		await expect(
+			existingCardProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} )
+		).resolves.toStrictEqual( expected );
+		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
+			...basicExpectedStripeRequest,
+			payment: {
+				...basicExpectedStripeRequest.payment,
+				name: '',
+			},
+		} );
 	} );
 
 	it( 'returns an explicit error response if the transaction fails', async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I think that there might be legitimate cases where a stored card does not have a `name` saved (eg: some Apple Pay cards?). This PR allows such cards to submit their data to the transactions endpoint safely. If the endpoint decides it does require a `name`, then it should return an appropriate error of its own (and possibly a better one since it will be localized).

#### Testing instructions

Unit tests are included.

To test this manually you'll need a saved card with no `name` property. You can fake this by applying the following patch on top of this PR.

<details>

```diff
diff --git a/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx b/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
index 795e34974d..df37920b30 100644
--- a/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
@@ -161,7 +161,7 @@ function ExistingCardPayButton( {
                                onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
                                onClick( 'existing-card', {
                                        items,
-                                       name: cardholderName,
+                                       // name: cardholderName,
                                        storedDetailsId,
                                        paymentMethodToken,
                                        paymentPartnerProcessorId,
```

</details>

1. Visit checkout with a product in your cart.
2. Select a saved card that has no cardholder name as your payment method.
3. Submit the payment and verify that the transaction is completed successfully.