### PR TITLE
Fix/16440/dont share themes query results

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -371,6 +371,10 @@ export default class QueryManager {
 					return memo;
 				}
 
+				if ( ! isReceivedQueryKey && options.ownResultsOnly ) {
+					return memo;
+				}
+
 				// Found counts should not be adjusted for the received query if
 				// merging into existing items
 				const shouldAdjustFoundCount = ! isReceivedQueryKey;

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -253,6 +253,7 @@ export default class QueryManager {
 	 * @param  {boolean}        options.patch      Apply changes as partial
 	 * @param  {object}         options.query      Query set to set or replace
 	 * @param  {boolean}        options.mergeQuery Add to existing query set
+	 * @param  {boolean}        options.dontShareQueryResultsWhenQueriesAreDifferent When storing results for one query, results for that query should not be shared with different queries
 	 * @param  {number}         options.found      Total found items for query
 	 * @returns {QueryManager}                      New instance if changed, or
 	 *                                             same instance otherwise
@@ -371,7 +372,7 @@ export default class QueryManager {
 					return memo;
 				}
 
-				if ( ! isReceivedQueryKey && options.ownResultsOnly ) {
+				if ( ! isReceivedQueryKey && options.dontShareQueryResultsWhenQueriesAreDifferent ) {
 					return memo;
 				}
 

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -479,6 +479,32 @@ describe( 'QueryManager', () => {
 		} );
 	} );
 
+	describe( 'dontShareQueryResultsWhenQueriesAreDifferent', () => {
+		test( 'Query results should be independent', () => {
+			manager = manager.receive(
+				{ ID: 1 },
+				{ query: { a: true }, dontShareQueryResultsWhenQueriesAreDifferent: true, mergeQuery: true }
+			);
+			manager = manager.receive(
+				{ ID: 2 },
+				{ query: { b: true }, dontShareQueryResultsWhenQueriesAreDifferent: true, mergeQuery: true }
+			);
+			expect( manager.getItems( { a: true } ) ).toEqual( [ { ID: 1 } ] );
+			expect( manager.getItems( { b: true } ) ).toEqual( [ { ID: 2 } ] );
+		} );
+		test( 'Query results can still be shared for the same query', () => {
+			manager = manager.receive(
+				{ ID: 1 },
+				{ query: { a: true }, dontShareQueryResultsWhenQueriesAreDifferent: true, mergeQuery: true }
+			);
+			manager = manager.receive(
+				{ ID: 2 },
+				{ query: { a: true }, dontShareQueryResultsWhenQueriesAreDifferent: true, mergeQuery: true }
+			);
+			expect( manager.getItems( { a: true } ) ).toEqual( [ { ID: 1 }, { ID: 2 } ] );
+		} );
+	} );
+
 	describe( '.QueryKey', () => {
 		test( 'should include a .stringify() method', () => {
 			expect( typeof QueryManager.QueryKey.stringify ).toBe( 'function' );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -503,6 +503,13 @@ describe( 'QueryManager', () => {
 			);
 			expect( manager.getItems( { a: true } ) ).toEqual( [ { ID: 1 }, { ID: 2 } ] );
 		} );
+		test( 'Can still retrieve items without a query', () => {
+			manager = manager.receive(
+				{ ID: 1 },
+				{ dontShareQueryResultsWhenQueriesAreDifferent: true }
+			);
+			expect( manager.getItems() ).toEqual( [ { ID: 1 } ] );
+		} );
 	} );
 
 	describe( '.QueryKey', () => {

--- a/client/state/themes/actions/install-theme.js
+++ b/client/state/themes/actions/install-theme.js
@@ -9,6 +9,7 @@ import {
 } from 'calypso/state/themes/action-types';
 import { receiveTheme } from 'calypso/state/themes/actions/receive-theme';
 import { getWpcomParentThemeId } from 'calypso/state/themes/selectors';
+import { requestThemes } from 'calypso/state/themes/actions';
 
 import 'calypso/state/themes/init';
 
@@ -51,6 +52,7 @@ export function installTheme( themeId, siteId ) {
 					}
 				}
 			} )
+			.then( () => dispatch( requestThemes( siteId, {} ) ) )
 			.catch( ( error ) => {
 				dispatch( {
 					type: THEME_INSTALL_FAILURE,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -339,7 +339,12 @@ const queriesReducer = ( state = {}, action ) => {
 				// Always 'patch' to avoid overwriting existing fields when receiving
 				// from a less rich endpoint such as /mine
 				( m ) =>
-					m.receive( map( themes, fromApi ), { query, found, patch: true, ownResultsOnly: true } ),
+					m.receive( map( themes, fromApi ), {
+						query,
+						found,
+						patch: true,
+						dontShareQueryResultsWhenQueriesAreDifferent: true,
+					} ),
 				() => new ThemeQueryManager( null, { itemKey: 'id' } )
 			);
 		}

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -338,7 +338,8 @@ const queriesReducer = ( state = {}, action ) => {
 				siteId,
 				// Always 'patch' to avoid overwriting existing fields when receiving
 				// from a less rich endpoint such as /mine
-				( m ) => m.receive( map( themes, fromApi ), { query, found, patch: true } ),
+				( m ) =>
+					m.receive( map( themes, fromApi ), { query, found, patch: true, ownResultsOnly: true } ),
 				() => new ThemeQueryManager( null, { itemKey: 'id' } )
 			);
 		}


### PR DESCRIPTION
Our "QueryManager" merges results from multiple different queries together. But we don't have a way to intelligently determine which themes can be matched to which queries, so all queries results are cumulatively combined and all results are shared.

For example: Searching for premium themes, then free themes results in the "free themes" query results having premium themes in it, since it's cumulative.

Consider this second example:

```
Search: Free themes
What does free themes contain? Free themes

Search: Block based themes
Now what does free themes contain? Free themes and block based themes

Search: Full width themes
Now what does free themes contain? Free themes and block based themes and full width themes
````

Why does this happen?

The line of code which determines which themes match to which queries [might not be complete yet](https://github.com/Automattic/wp-calypso/blob/77108e4414894a996c8976fa368f36c1f72e463a/client/lib/query-manager/index.js#L120)

This pull request creates a new parameter: `dontShareQueryResultsWhenQueriesAreDifferent` which prevents query results from being shared. This parameter will be enabled for themes based queries.

This is probably a temporary solution, since QueryManager will probably be replaced when we use react-query.

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/10274366/126537676-f548233a-227a-4b07-a6fd-cdaa262fd89c.gif) | ![after](https://user-images.githubusercontent.com/10274366/126537702-3e0338d4-fb3a-403f-b833-d36b0f0d8ef3.gif) |

#### Testing instructions 

1. Go to the /themes page
2. Click the "premium" themes button
3. You should only see premium themes
3. Click the "all" themes button
4. You should see premium and free themes
4. Click the "premium" themes button
5. You should only see premium themes
6. Click the "all" themes button
7. Search for "feature:block-templates"
8. Note down which themes you see
9. Refresh the page
10. You should see the same themes