### PR TITLE
Theme Search: Magic welcome click clears previous unfinished attribute searches

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -231,6 +231,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	updateInput = ( updatedInput ) => {
 		this.setState( { searchInput: updatedInput } );
+		this.findTextForSuggestions( updatedInput );
 		this.searchInputRef.clear();
 	};
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -186,12 +186,6 @@ class ThemesMagicSearchCard extends React.Component {
 		return tokens.join( '' );
 	};
 
-	insertTextAtCursor = ( text ) => {
-		const input = this.state.searchInput;
-		const position = this.state.cursorPosition;
-		return input.slice( 0, position ) + text + input.slice( position );
-	};
-
 	onSearchChange = ( input ) => {
 		this.findTextForSuggestions( input );
 		this.setState( { searchInput: input } );
@@ -245,19 +239,23 @@ class ThemesMagicSearchCard extends React.Component {
 		this.updateInput( updatedInput );
 	};
 
+	// User has clicked on an item in the "Magic Welcome Bar" to add something like
+	// "feature:" to their search text, which causes autocompletions to display.
 	welcomeBarAddText = ( text ) => {
-		if ( config.isEnabled( 'theme/showcase-revamp' ) ) {
-			// Add an extra leading space sometimes. If the user has "abcd" in
-			// their bar and they click to add "feature:", we want "abcd feature:",
-			// not "abcdfeature:".
-			const { searchInput, cursorPosition } = this.state;
-			if ( searchInput[ cursorPosition - 1 ] !== ' ' ) {
-				text = ' ' + text;
-			}
+		let { searchInput } = this.state;
+		// Since we are adding an unfinished feature to the search, like "feature:" or "column:",
+		// remove other unfinished features from the search. The user doesn't want to have their
+		// search bar reading "feature: column:" after clicking feature, then column.
+		searchInput = searchInput.replace( /(feature|column|subject):(\s|$)/i, '' );
+
+		// Add an extra leading space sometimes. If the user has "abcd" in
+		// their bar and they click to add "feature:", we want "abcd feature:",
+		// not "abcdfeature:".
+		if ( searchInput.length > 0 && searchInput.slice( -1 ) !== ' ' ) {
+			text = ' ' + text;
 		}
 
-		const updatedInput = this.insertTextAtCursor( text );
-		this.updateInput( updatedInput );
+		this.updateInput( searchInput + text );
 		this.setState( { isPopoverVisible: false } );
 	};
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -157,21 +157,29 @@ class ThemesMagicSearchCard extends React.Component {
 	findTextForSuggestions = ( input ) => {
 		const val = input;
 		window.requestAnimationFrame( () => {
-			this.setState( {
-				cursorPosition: val.slice( 0, this.searchInputRef.searchInput.selectionStart ).length,
-			} );
-			const tokens = input.split( /(\s+)/ );
-
-			// Get rid of empty match at end
-			tokens[ tokens.length - 1 ] === '' && tokens.splice( tokens.length - 1, 1 );
-			if ( tokens.length === 0 ) {
-				this.setState( { editedSearchElement: '' } );
-				return;
-			}
-			const tokenIndex = this.findEditedTokenIndex( tokens, this.state.cursorPosition );
-			const text = tokens[ tokenIndex ].trim();
-			this.setState( { editedSearchElement: text } );
+			const selectionStart = this.searchInputRef.searchInput.selectionStart;
+			const [ editedSearchElement, cursorPosition ] = this.computeEditedSearchElement(
+				val,
+				selectionStart
+			);
+			this.setState( { editedSearchElement, cursorPosition } );
 		} );
+	};
+
+	computeEditedSearchElement = ( searchText, selectionStart ) => {
+		const cursorPosition = searchText.slice( 0, selectionStart ).length;
+		const tokens = searchText.split( /(\s+)/ );
+
+		let editedSearchElement = '';
+
+		// Get rid of empty match at end
+		tokens[ tokens.length - 1 ] === '' && tokens.splice( tokens.length - 1, 1 );
+		if ( tokens.length === 0 ) {
+			return [ editedSearchElement, cursorPosition ];
+		}
+		const tokenIndex = this.findEditedTokenIndex( tokens, cursorPosition );
+		editedSearchElement = tokens[ tokenIndex ].trim();
+		return [ editedSearchElement, cursorPosition ];
 	};
 
 	insertSuggestion = ( suggestion ) => {
@@ -231,7 +239,6 @@ class ThemesMagicSearchCard extends React.Component {
 
 	updateInput = ( updatedInput ) => {
 		this.setState( { searchInput: updatedInput } );
-		this.findTextForSuggestions( updatedInput );
 		this.searchInputRef.clear();
 	};
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -267,6 +267,7 @@ class ThemesMagicSearchCard extends React.Component {
 	suggest = ( suggestion ) => {
 		const updatedInput = this.insertSuggestion( suggestion );
 		this.updateInput( updatedInput );
+		this.focusOnInput();
 	};
 
 	// User has clicked on an item in the "Magic Welcome Bar" to add something like

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -265,6 +265,10 @@ class ThemesMagicSearchCard extends React.Component {
 		}
 
 		this.updateInput( searchInput + text );
+		// Workaround for a strange bug: sometimes after clicking in the magic
+		// welcome bar, when findTextForSuggestions() was running, it would
+		// think the cursor is at the beginning of the input, causing no
+		// suggestions to appear. Delaying this state transition seems to fix it.
 		setTimeout( () => this.setState( { isPopoverVisible: false } ), 100 );
 	};
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -60,7 +60,6 @@ class ThemesMagicSearchCard extends React.Component {
 			cursorPosition: 0,
 			searchInput: this.props.search,
 			isPopoverVisible: false,
-			log: [ '...', '...', '...', '...', '...', '...' ],
 		};
 	}
 
@@ -157,16 +156,13 @@ class ThemesMagicSearchCard extends React.Component {
 
 	findTextForSuggestions = ( input ) => {
 		const val = input;
-		this.addLog( `findTextForSuggestions: queued up RAF` );
 		window.requestAnimationFrame( () => {
 			const selectionStart = this.searchInputRef.searchInput.selectionStart;
 			const [ editedSearchElement, cursorPosition ] = this.computeEditedSearchElement(
 				val,
 				selectionStart
 			);
-			this.setState( { editedSearchElement, cursorPosition }, () => {
-				this.addLog( `RAF setState finished` );
-			} );
+			this.setState( { editedSearchElement, cursorPosition } );
 		} );
 	};
 
@@ -179,26 +175,11 @@ class ThemesMagicSearchCard extends React.Component {
 		// Get rid of empty match at end
 		tokens[ tokens.length - 1 ] === '' && tokens.splice( tokens.length - 1, 1 );
 		if ( tokens.length === 0 ) {
-			this.logCompute( searchText, selectionStart, cursorPosition, editedSearchElement );
 			return [ editedSearchElement, cursorPosition ];
 		}
 		const tokenIndex = this.findEditedTokenIndex( tokens, cursorPosition );
 		editedSearchElement = tokens[ tokenIndex ].trim();
-		this.logCompute( searchText, selectionStart, cursorPosition, editedSearchElement );
 		return [ editedSearchElement, cursorPosition ];
-	};
-
-	logCompute = ( searchText, selectionStart, cursorPosition, editedSearchElement ) => {
-		const text = `[${ searchText }] [${ selectionStart }] -> [${ cursorPosition }] [${ editedSearchElement }]`;
-		this.addLog( text );
-	};
-
-	addLog = ( text ) => {
-		const ts = new Date().toISOString().slice( 11, -1 );
-		const newText = `${ ts } ${ text }`;
-		const { log } = this.state;
-		log.push( newText );
-		this.setState( { log } );
 	};
 
 	insertSuggestion = ( suggestion ) => {
@@ -257,10 +238,7 @@ class ThemesMagicSearchCard extends React.Component {
 	};
 
 	updateInput = ( updatedInput ) => {
-		// this.addLog( `Update Input setState: [${ updatedInput }]` );
-		this.setState( { searchInput: updatedInput }, () => {
-			this.addLog( `Update Input Setstate finished: [${ updatedInput }]` );
-		} );
+		this.setState( { searchInput: updatedInput } );
 		this.searchInputRef.clear();
 	};
 
@@ -405,17 +383,6 @@ class ThemesMagicSearchCard extends React.Component {
 		return (
 			<div className={ magicSearchClass }>
 				<StickyPanel>
-					<div>
-						Search Input: [{ this.state.searchInput }] | Edited Search Element: [
-						{ this.state.editedSearchElement }]
-					</div>
-					<div>
-						{ this.state.log.slice( -12 ).map( ( logText, i ) => (
-							<div style={ { fontSize: '12px' } } key={ i }>
-								{ logText }
-							</div>
-						) ) }
-					</div>
 					<div
 						className={ themesSearchCardClass }
 						role="presentation"

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -287,7 +287,7 @@ class ThemesMagicSearchCard extends React.Component {
 		}
 
 		this.updateInput( searchInput + text );
-		this.setState( { isPopoverVisible: false } );
+		setTimeout( () => this.setState( { isPopoverVisible: false } ), 100 );
 	};
 
 	focusOnInput = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Theme Search: Magic welcome click clears previous unfinished attribute searches

Observe the contents of the search bar after I make several clicks in the magic welcome bar.

https://user-images.githubusercontent.com/937354/126552165-6f78dc67-9c42-4af8-9707-bdc674662a17.mp4

^ Before / Prod


https://user-images.githubusercontent.com/937354/126552149-0a2384f7-d20d-4a2f-b8e2-736587aedc18.mp4

^ After / This Branch

Finished attribute searches like "feature:author-bio", or non-attribute searches like "yellow" should not be cleared and will work the same as before.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the theme showcase, then try different combinations of the magic welcome bar (click "Filters"), using autocomplete feature searches, and regular searches.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/54727
