### PR TITLE
import-order.sh script removes Image and Style dependencies comments

### DIFF
--- a/bin/import-order.sh
+++ b/bin/import-order.sh
@@ -13,7 +13,7 @@ set -eou pipefail
 DIR="$1"
 
 function removeComments {
-	perl -0777 -pi -e "s/\/\*\*\n \* (External|Internal|WordPress|Module|Type) dependencies\n \*\///g" "$1"
+	perl -0777 -pi -e "s/\/\*\*\n \* (External|Internal|WordPress|Module|Type|Image|Style) dependencies\n \*\///g" "$1"
 }
 
 function prettify {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `import-order.sh` script now removes these common import comments blocks too

```
/**
 * Style dependencies
 */

/**
 * Image dependencies
 */
```


Related to #54448