### PR TITLE
Remove yoast hard coded references to Yoast

### DIFF
--- a/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
+++ b/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
@@ -23,11 +23,13 @@ export const productGroups: IProductGroupCollection = {
 	[ YOAST ]: {
 		products: {
 			[ YOAST_PREMIUM ]: {
+				productName: 'Yoast Premium',
 				defaultPluginSlug: 'wordpress-seo',
 				pluginsToBeInstalled: [ 'wordpress-seo-premium', 'wordpress-seo', 'yoast-test-helper' ],
 				isPurchasableProduct: true,
 			},
 			[ YOAST_FREE ]: {
+				productName: 'Yoast Free',
 				defaultPluginSlug: 'wordpress-seo',
 				pluginsToBeInstalled: [ 'wordpress-seo' ],
 				isPurchasableProduct: false,
@@ -35,6 +37,11 @@ export const productGroups: IProductGroupCollection = {
 		},
 	},
 };
+
+export const getAllProducts = (): IProductCollection =>
+	Object.values( productGroups )
+		.map( ( productGroup ) => productGroup.products )
+		.reduce( ( productsMap, curr ) => ( { ...productsMap, ...curr } ), {} );
 
 /**
  * Provides the plugin that needs to be installed for a given product
@@ -100,6 +107,23 @@ export function getProductDefinition(
 		marketplaceDebugger(
 			`Product does not exist for provided parameters: ${ productGroupSlug }, ${ productSlug }`
 		);
+		return null;
+	}
+	return productDefinition;
+}
+
+/**
+ * Do a simple search of all the products for a given product slug
+ *
+ * @param {string} productSlug The product slug
+ * @returns {string} The product details
+ */
+export function findProductDefinition(
+	productSlug: keyof IProductCollection
+): IProductDefinition | null {
+	const productDefinition = getAllProducts()[ productSlug ];
+	if ( ! productDefinition ) {
+		marketplaceDebugger( `Product does not exist for provided parameters: ${ productSlug }` );
 		return null;
 	}
 	return productDefinition;

--- a/client/my-sites/marketplace/marketplace-product-definitions/test/marketplace-product-definitions.ts
+++ b/client/my-sites/marketplace/marketplace-product-definitions/test/marketplace-product-definitions.ts
@@ -12,6 +12,7 @@ import {
 	getDefaultProductInProductGroup,
 	getProductDefinition,
 	productGroups,
+	findProductDefinition,
 } from '../index';
 import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 
@@ -61,5 +62,20 @@ describe( 'Constants and product related utilities test', () => {
 			'NON_EXISTENT_PRODUCT'
 		);
 		expect( receivedForNonExistentProduct ).toEqual( null );
+	} );
+
+	test( 'findProductDefinition returns the correct product details, given an an available product slug', () => {
+		const received = findProductDefinition( YOAST_FREE );
+		expect( received ).toEqual( {
+			productName: 'Yoast Free',
+			defaultPluginSlug: 'wordpress-seo',
+			isPurchasableProduct: false,
+			pluginsToBeInstalled: [ 'wordpress-seo' ],
+		} );
+	} );
+
+	test( 'findProductDefinition returns null, given a product slug that does not exist', () => {
+		const received = findProductDefinition( 'PRODUCT_SLUG_THAT_DOES_NOT_EXIST' );
+		expect( received ).toEqual( null );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-domain-upsell/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-domain-upsell/index.tsx
@@ -158,7 +158,7 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 							: page(
 									`/marketplace/product/details/wordpress-seo${
 										selectedSite?.slug ? `/${ selectedSite.slug }` : ''
-									}?flags=marketplace-yoast`
+									}`
 							  )
 					}
 					tooltip={ translate( 'Close Domain Selection' ) }

--- a/client/my-sites/marketplace/pages/marketplace-product-details/test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-details/test/index.tsx
@@ -7,6 +7,7 @@
  */
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -15,9 +16,9 @@ import PurchaseArea from '../purchase-area';
 
 const onNavigateToCheckoutMockFunction = jest.fn();
 const onNavigateToDomainsSelectionMockFunction = jest.fn();
-const onAddYoastPremiumToCart = jest.fn();
+const onAddMarketplaceProductToCart = jest.fn();
 const onRemoveEverythingFromCart = jest.fn();
-const onInstallPluginManually = jest.fn();
+const onInstallProductManually = jest.fn();
 
 describe( '<PurchaseArea/> Plugin details next step tests', () => {
 	const wpcomDomain = { isWpcomStagingDomain: true, domain: 'awesomecustomdomain.wordpress.com' };
@@ -27,88 +28,111 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
-	test( 'If user has a primary custom domain and purchases a paid product, redirects to checkout', async () => {
+	test( 'If user has a primary custom domain and purchases a paid product, should redirect to checkout', async () => {
 		const marketplacePluginDetails = render(
 			<PurchaseArea
+				productSlug={ YOAST_PREMIUM }
 				siteDomains={ [ wpcomDomain, primaryCustomDomain ] }
-				isProductListLoading={ false }
 				displayCost="$ 100"
-				wporgPluginName={ 'Yoast SEO' }
-				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
+				onAddMarketplaceProductToCart={ onAddMarketplaceProductToCart }
 				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
 				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
 				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
-				onInstallPluginManually={ onInstallPluginManually }
+				onInstallProductManually={ onInstallProductManually }
 			/>
 		);
-		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
+		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Add Yoast Premium' );
 		await fireEvent.click( yoastPremiumButton );
 		// onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise for the following mocks to be called
 		await Promise.resolve();
 
-		expect( onAddYoastPremiumToCart ).toHaveBeenCalled();
+		expect( onAddMarketplaceProductToCart ).toHaveBeenCalledWith(
+			YOAST_PREMIUM,
+			customDomain.domain
+		);
 		expect( onNavigateToCheckoutMockFunction ).toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).not.toHaveBeenCalled();
-		expect( onInstallPluginManually ).not.toHaveBeenCalled();
+		expect( onInstallProductManually ).not.toHaveBeenCalled();
 	} );
 
-	test( '<PurchaseArea/> If user has no custom domain and purchases any product, redirects to domains step', async () => {
+	test( '<PurchaseArea/> If user has no custom domain and adds a paid product, should redirect to domains step', async () => {
 		const marketplacePluginDetails = render(
 			<PurchaseArea
+				productSlug={ YOAST_PREMIUM }
 				siteDomains={ [ primaryWpcomDomain ] }
-				isProductListLoading={ false }
 				displayCost="$ 100"
-				wporgPluginName={ 'Yoast SEO' }
-				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
+				onAddMarketplaceProductToCart={ onAddMarketplaceProductToCart }
 				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
 				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
 				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
-				onInstallPluginManually={ onInstallPluginManually }
+				onInstallProductManually={ onInstallProductManually }
 			/>
 		);
-		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
+		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Add Yoast Premium' );
 		await fireEvent.click( yoastPremiumButton );
 		// onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise for the following mocks to be called
 		await Promise.resolve();
 
-		expect( onAddYoastPremiumToCart ).toHaveBeenCalled();
+		expect( onAddMarketplaceProductToCart ).toHaveBeenCalled();
 		expect( onNavigateToCheckoutMockFunction ).not.toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).toHaveBeenCalled();
-		await onAddYoastPremiumToCart.mockReset();
-		await onNavigateToCheckoutMockFunction.mockReset();
-		await onNavigateToDomainsSelectionMockFunction.mockReset();
+	} );
 
+	test( '<PurchaseArea/> If user has no custom domain and adds a free product, should redirect to domains step', async () => {
+		const marketplacePluginDetails = render(
+			<PurchaseArea
+				productSlug={ YOAST_FREE }
+				siteDomains={ [ primaryWpcomDomain ] }
+				displayCost="$ 100"
+				onAddMarketplaceProductToCart={ onAddMarketplaceProductToCart }
+				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
+				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
+				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
+				onInstallProductManually={ onInstallProductManually }
+			/>
+		);
 		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
 		await fireEvent.click( yoastFreeButton );
 		//onAddPlugin call in the PurchaseArea component is async so we have to queue and await a promise  for the following mocks to be called
 		await Promise.resolve();
 
-		expect( onAddYoastPremiumToCart ).not.toHaveBeenCalled();
+		expect( onAddMarketplaceProductToCart ).not.toHaveBeenCalled();
 		expect( onNavigateToCheckoutMockFunction ).not.toHaveBeenCalled();
 		expect( onNavigateToDomainsSelectionMockFunction ).toHaveBeenCalled();
 	} );
 
-	test( 'Remove all other products from basket when adding a marketplace plugin', async () => {
+	test( 'Remove all other products from basket when adding a paid marketplace plugin', async () => {
 		const marketplacePluginDetails = render(
 			<PurchaseArea
+				productSlug={ YOAST_PREMIUM }
 				siteDomains={ [ primaryWpcomDomain ] }
-				isProductListLoading={ false }
 				displayCost="$ 100"
-				wporgPluginName={ 'Yoast SEO' }
-				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
+				onAddMarketplaceProductToCart={ onAddMarketplaceProductToCart }
 				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
 				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
 				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
-				onInstallPluginManually={ onInstallPluginManually }
+				onInstallProductManually={ onInstallProductManually }
 			/>
 		);
-		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
-		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
-
+		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Add Yoast Premium' );
 		await fireEvent.click( yoastPremiumButton );
 		expect( onRemoveEverythingFromCart ).toHaveBeenCalled();
-		await onRemoveEverythingFromCart.mockReset();
+	} );
 
+	test( 'Remove all other products from basket when adding a free marketplace plugin', async () => {
+		const marketplacePluginDetails = render(
+			<PurchaseArea
+				productSlug={ YOAST_FREE }
+				siteDomains={ [ primaryWpcomDomain ] }
+				displayCost="$ 100"
+				onAddMarketplaceProductToCart={ onAddMarketplaceProductToCart }
+				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
+				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
+				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
+				onInstallProductManually={ onInstallProductManually }
+			/>
+		);
+		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
 		await fireEvent.click( yoastFreeButton );
 		expect( onRemoveEverythingFromCart ).toHaveBeenCalled();
 	} );
@@ -116,25 +140,21 @@ describe( '<PurchaseArea/> Plugin details next step tests', () => {
 	test( 'On installation of free plugin trigger callback to install plugin manually', async () => {
 		const marketplacePluginDetails = render(
 			<PurchaseArea
+				productSlug={ YOAST_FREE }
 				siteDomains={ [ primaryWpcomDomain ] }
-				isProductListLoading={ false }
 				displayCost="$ 100"
-				wporgPluginName={ 'Yoast SEO' }
-				onAddYoastPremiumToCart={ onAddYoastPremiumToCart }
+				onAddMarketplaceProductToCart={ onAddMarketplaceProductToCart }
 				onNavigateToCheckout={ onNavigateToCheckoutMockFunction }
 				onNavigateToDomainsSelection={ onNavigateToDomainsSelectionMockFunction }
 				onRemoveEverythingFromCart={ onRemoveEverythingFromCart }
-				onInstallPluginManually={ onInstallPluginManually }
+				onInstallProductManually={ onInstallProductManually }
 			/>
 		);
-		const yoastPremiumButton = await marketplacePluginDetails.findByText( 'Buy Yoast Premium' );
 		const yoastFreeButton = await marketplacePluginDetails.findByText( 'Add Yoast Free' );
-
-		await fireEvent.click( yoastPremiumButton );
-		expect( onInstallPluginManually ).not.toHaveBeenCalledWith();
-		await onInstallPluginManually.mockReset();
-
 		await fireEvent.click( yoastFreeButton );
-		expect( onInstallPluginManually ).toHaveBeenCalledWith( primaryWpcomDomain.domain );
+		expect( onInstallProductManually ).toHaveBeenCalledWith(
+			YOAST_FREE,
+			primaryWpcomDomain.domain
+		);
 	} );
 } );

--- a/client/my-sites/marketplace/types.ts
+++ b/client/my-sites/marketplace/types.ts
@@ -8,12 +8,26 @@ import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
  */
 import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 export interface IProductDefinition {
+	productName: string;
+
 	/**
-	 * defaultPluginSlug : Some plugins may not be available in the calypso product library so we specify a default plugin that is accessible in the product library
+	 * Some plugins may not be available in the calypso product library ( i.e. wordpress-seo-premium ) so we specify a default plugin that is accessible in the product library
 	 * so that relevant details can be shown
 	 * */
 	defaultPluginSlug: string;
+
+	/**
+	 * While this array is not in use right now, it indicates the plugins that need to be installed as part of the product
+	 * Eventually when moving this logic to the backend this can be part of the Market Place product entity
+	 * */
 	pluginsToBeInstalled: string[];
+
+	/**
+	 * Some products like yoast free do not require a product purchase. In these instances the "product_slug" does not exist in our backend billing daddy configurations.
+	 * We have however introduced dummy products in the calypso product library so that we can maintain a product details in declarative data structure.
+	 * Hence the product is not purchasable ( and is a dummy product i.e. yoast_free ) we maintain a flag to indicate this.
+	 *
+	 * */
 	isPurchasableProduct: boolean;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove all references to yoast in code
* Depended completely on the marketplace product data structure for the flow
* Updated tests 
* Load only one product per url

| Premium      | Free |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/3422709/126641446-feee1be7-f632-4ad2-9b9d-70328043df35.png)     |  ![image](https://user-images.githubusercontent.com/3422709/126641682-467ecdbf-6625-4b82-ab08-950c6c7088e0.png)       |



#### Testing instructions
- Make sure,  Flow 1,2 in decision grid, before and after atomic should work.
- All unit tests should work


