### PR TITLE
Remove usages of lodash/includes on array literals

### DIFF
--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment } from 'react';
 import getCaretCoordinates from 'textarea-caret';
-import { escapeRegExp, findIndex, get, includes, throttle, pick } from 'lodash';
+import { escapeRegExp, findIndex, get, throttle, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -88,12 +88,12 @@ export default ( WrappedComponent ) =>
 			const selectedIndex = this.getSelectedSuggestionIndex();
 
 			// Cancel Enter and Tab default actions so we can define our own in keyUp
-			if ( includes( [ keys.enter, keys.tab ], event.keyCode ) ) {
+			if ( [ keys.enter, keys.tab ].includes( event.keyCode ) ) {
 				event.preventDefault();
 				return false;
 			}
 
-			if ( ! includes( [ keys.upArrow, keys.downArrow ], event.keyCode ) || -1 === selectedIndex ) {
+			if ( ! [ keys.upArrow, keys.downArrow ].includes( event.keyCode ) || -1 === selectedIndex ) {
 				return;
 			}
 
@@ -117,15 +117,15 @@ export default ( WrappedComponent ) =>
 		};
 
 		handleKeyUp = ( event ) => {
-			if ( includes( [ keys.downArrow, keys.upArrow ], event.keyCode ) ) {
+			if ( [ keys.downArrow, keys.upArrow ].includes( event.keyCode ) ) {
 				return;
 			}
 
-			if ( includes( [ keys.spaceBar, keys.esc ], event.keyCode ) ) {
+			if ( [ keys.spaceBar, keys.esc ].includes( event.keyCode ) ) {
 				return this.hidePopover();
 			}
 
-			if ( includes( [ keys.enter, keys.tab ], event.keyCode ) ) {
+			if ( [ keys.enter, keys.tab ].includes( event.keyCode ) ) {
 				if ( ! this.state.showPopover || this.matchingSuggestions.length === 0 ) {
 					return;
 				}

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { filter, includes, isEmpty, last } from 'lodash';
+import { filter, isEmpty, last } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -19,7 +19,7 @@ function onKeydown( event ) {
 }
 
 function isInput( element ) {
-	return includes( [ 'INPUT', 'TEXTAREA' ], element.nodeName );
+	return [ 'INPUT', 'TEXTAREA' ].includes( element.nodeName );
 }
 
 function addKeydownListener() {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get, includes, times } from 'lodash';
+import { get, times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,18 +104,15 @@ class DomainSearchResults extends React.Component {
 		if (
 			domain &&
 			suggestions.length !== 0 &&
-			includes(
-				[
-					TRANSFERRABLE,
-					MAPPABLE,
-					MAPPED,
-					TLD_NOT_SUPPORTED,
-					TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE,
-					TLD_NOT_SUPPORTED_TEMPORARILY,
-					UNKNOWN,
-				],
-				lastDomainStatus
-			) &&
+			[
+				TRANSFERRABLE,
+				MAPPABLE,
+				MAPPED,
+				TLD_NOT_SUPPORTED,
+				TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE,
+				TLD_NOT_SUPPORTED_TEMPORARILY,
+				UNKNOWN,
+			].includes( lastDomainStatus ) &&
 			get( this.props, 'products.domain_map', false )
 		) {
 			// eslint-disable-next-line jsx-a11y/anchor-is-valid
@@ -123,8 +120,7 @@ class DomainSearchResults extends React.Component {
 
 			// If the domain is available we shouldn't offer to let people purchase mappings for it.
 			if (
-				includes(
-					[ TLD_NOT_SUPPORTED, TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE ],
+				[ TLD_NOT_SUPPORTED, TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE ].includes(
 					lastDomainStatus
 				)
 			) {
@@ -146,7 +142,7 @@ class DomainSearchResults extends React.Component {
 				offer = null;
 			}
 
-			let domainUnavailableMessage = includes( [ TLD_NOT_SUPPORTED, UNKNOWN ], lastDomainStatus )
+			let domainUnavailableMessage = [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus )
 				? translate(
 						'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
 						{

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes, get } from 'lodash';
+import { get } from 'lodash';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Button } from '@automattic/components';
 
@@ -247,8 +247,8 @@ class MapDomainStep extends React.Component {
 				}
 
 				if (
-					! includes( [ AVAILABILITY_CHECK_ERROR, NOT_REGISTRABLE ], status ) &&
-					includes( [ MAPPABLE, UNKNOWN ], mappableStatus )
+					! [ AVAILABILITY_CHECK_ERROR, NOT_REGISTRABLE ].includes( status ) &&
+					[ MAPPABLE, UNKNOWN ].includes( mappableStatus )
 				) {
 					this.props.onMapDomain( domain );
 					this.setState( { isPendingSubmit: false } );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -887,7 +887,7 @@ class RegisterDomainStep extends React.Component {
 						TRANSFERRABLE_PREMIUM,
 						UNKNOWN,
 					} = domainAvailability;
-					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+					const isDomainAvailable = [ AVAILABLE, UNKNOWN ].includes( status );
 					const isDomainTransferrable = TRANSFERRABLE === status;
 					const isDomainMapped = MAPPED === mappable;
 					const isAvailablePremiumDomain = AVAILABLE_PREMIUM === status;

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { camelCase, difference, filter, get, includes, isEmpty, keys, map, pick } from 'lodash';
+import { camelCase, difference, filter, get, isEmpty, keys, map, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -106,14 +106,13 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	};
 
 	isTradingNameRequired( registrantType ) {
-		return includes(
-			[ 'LTD', 'PLC', 'LLP', 'IP', 'RCHAR', 'FCORP', 'OTHER', 'FOTHER', 'STRA' ],
+		return [ 'LTD', 'PLC', 'LLP', 'IP', 'RCHAR', 'FCORP', 'OTHER', 'FOTHER', 'STRA' ].includes(
 			registrantType
 		);
 	}
 
 	isRegistrationNumberRequired( registrantType ) {
-		return includes( [ 'LTD', 'PLC', 'LLP', 'IP', 'SCH', 'RCHAR' ], registrantType );
+		return [ 'LTD', 'PLC', 'LLP', 'IP', 'SCH', 'RCHAR' ].includes( registrantType );
 	}
 
 	renderTradingNameField() {

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -234,7 +234,7 @@ export function formatNumber( inputNumber, country ) {
 	const { nationalNumber, prefix } = processNumber( inputNumber, country );
 
 	const patterns =
-		( includes( [ '+', '1' ], inputNumber[ 0 ] ) && country.internationalPatterns ) ||
+		( [ '+', '1' ].includes( inputNumber[ 0 ] ) && country.internationalPatterns ) ||
 		country.patterns ||
 		[];
 	const pattern = findPattern( nationalNumber, patterns );

--- a/client/extensions/wp-super-cache/components/advanced/caching.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/caching.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { includes, pick } from 'lodash';
+import { pick } from 'lodash';
 import { ToggleControl } from '@wordpress/components';
 
 /**
@@ -84,7 +84,7 @@ const Caching = ( {
 					<FormFieldset className="wp-super-cache__cache-type-fieldset">
 						<FormLabel>
 							<FormRadio
-								checked={ includes( [ 'PHP', 'wpcache' ], cache_type ) /* wpcache is legacy */ }
+								checked={ [ 'PHP', 'wpcache' ].includes( cache_type ) /* wpcache is legacy */ }
 								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
 								onChange={ handleRadio }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -272,7 +272,7 @@ export class JetpackAuthorize extends Component {
 		const { alreadyAuthorized, authApproved, from } = this.props.authQuery;
 		return (
 			this.isSso() ||
-			includes( [ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ], from ) || // Auto authorize the old WooCommerce setup wizard only.
+			[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ].includes( from ) || // Auto authorize the old WooCommerce setup wizard only.
 			( ! this.props.isAlreadyOnSitesList &&
 				! alreadyAuthorized &&
 				( this.props.calypsoStartedConnection || authApproved ) )
@@ -329,14 +329,11 @@ export class JetpackAuthorize extends Component {
 	isWooRedirect = ( props = this.props ) => {
 		const { from } = props.authQuery;
 		return (
-			includes(
-				[
-					'woocommerce-services-auto-authorize',
-					'woocommerce-setup-wizard',
-					'woocommerce-onboarding',
-				],
-				from
-			) || this.getWooDnaConfig( props ).isWooDnaFlow()
+			[
+				'woocommerce-services-auto-authorize',
+				'woocommerce-setup-wizard',
+				'woocommerce-onboarding',
+			].includes( from ) || this.getWooDnaConfig( props ).isWooDnaFlow()
 		);
 	};
 

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -5,7 +5,7 @@ import debugModule from 'debug';
 import React, { Component } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
-import { flowRight, get, includes, omit } from 'lodash';
+import { flowRight, get, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -115,7 +115,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 			}
 
 			if (
-				includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], status ) ||
+				[ NOT_JETPACK, NOT_ACTIVE_JETPACK ].includes( status ) ||
 				( status === NOT_CONNECTED_JETPACK && forceRemoteInstall )
 			) {
 				if ( ! isMobileAppFlow && ! skipRemoteInstall ) {

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import React, { Component, Fragment } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
-import { flowRight, includes } from 'lodash';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**
  * External dependencies
@@ -174,8 +174,7 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	isInvalidCreds() {
-		const { installError } = this.props;
-		return includes( [ INVALID_CREDENTIALS ], this.getError( installError ) );
+		return this.getError( this.props.installError ) === INVALID_CREDENTIALS;
 	}
 
 	isInvalidUsername() {

--- a/client/layout/guided-tours/docs/examples/selectors/has-selected-site-premium-or-business-plan.js
+++ b/client/layout/guided-tours/docs/examples/selectors/has-selected-site-premium-or-business-plan.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
@@ -25,5 +20,5 @@ export const hasSelectedSitePremiumOrBusinessPlan = ( state ) => {
 	if ( ! sitePlan ) {
 		return false;
 	}
-	return includes( [ PLAN_PREMIUM, PLAN_BUSINESS ], sitePlan.product_slug );
+	return [ PLAN_PREMIUM, PLAN_BUSINESS ].includes( sitePlan.product_slug );
 };

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -42,7 +42,7 @@ class MasterbarLoggedOut extends React.Component {
 
 	renderLoginItem() {
 		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
-		if ( includes( [ 'login' ], sectionName ) ) {
+		if ( sectionName === 'login' ) {
 			return null;
 		}
 
@@ -81,7 +81,7 @@ class MasterbarLoggedOut extends React.Component {
 		const { currentQuery, currentRoute, locale, sectionName, translate } = this.props;
 
 		// Hide for some sections
-		if ( includes( [ 'signup' ], sectionName ) ) {
+		if ( sectionName === 'signup' ) {
 			return null;
 		}
 

--- a/client/lib/domains/get-domain-product-slug.js
+++ b/client/lib/domains/get-domain-product-slug.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getTld } from './get-tld';
@@ -12,7 +7,7 @@ export function getDomainProductSlug( domain ) {
 	const tld = getTld( domain );
 	const tldSlug = tld.replace( /\./g, 'dot' );
 
-	if ( includes( [ 'com', 'net', 'org' ], tldSlug ) ) {
+	if ( [ 'com', 'net', 'org' ].includes( tldSlug ) ) {
 		return 'domain_reg';
 	}
 

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Given a domain object, does that domain have G Suite with us.
@@ -12,5 +12,5 @@ import { get, includes } from 'lodash';
 export function hasGSuiteWithUs( domain ) {
 	const defaultValue = '';
 	const domainStatus = get( domain, 'googleAppsSubscription.status', defaultValue );
-	return ! includes( [ defaultValue, 'no_subscription', 'other_provider' ], domainStatus );
+	return ! [ defaultValue, 'no_subscription', 'other_provider' ].includes( domainStatus );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,7 +3,7 @@
  */
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
-import { forEach, includes, throttle } from 'lodash';
+import { forEach, throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -66,7 +66,7 @@ export function getLanguagesInternalBasePath( targetBuild = 'evergreen' ) {
  * @returns {string} A language file URL.
  */
 export function getLanguageFileUrl( localeSlug, fileType = 'json', languageRevisions = {} ) {
-	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
+	if ( ! [ 'js', 'json' ].includes( fileType ) ) {
 		fileType = 'json';
 	}
 
@@ -141,7 +141,7 @@ export function getLanguageManifestFileUrl( {
 	targetBuild = 'evergreen',
 	hash = null,
 } = {} ) {
-	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
+	if ( ! [ 'js', 'json' ].includes( fileType ) ) {
 		fileType = 'json';
 	}
 
@@ -201,7 +201,7 @@ export function getTranslationChunkFileUrl( {
 	targetBuild = 'evergreen',
 	hash = null,
 } = {} ) {
-	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
+	if ( ! [ 'js', 'json' ].includes( fileType ) ) {
 		fileType = 'json';
 	}
 
@@ -463,7 +463,7 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		return;
 	}
 
-	if ( ! includes( [ 'current', 'waiting' ], translationStatus ) ) {
+	if ( ! [ 'current', 'waiting' ].includes( translationStatus ) ) {
 		return;
 	}
 

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -1,9 +1,3 @@
-/**
- * External dependencies
- */
-
-import { includes } from 'lodash';
-
 export const isAkismetOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client?.id === 973;
 };
@@ -18,10 +12,10 @@ export const isGravatarOAuth2Client = ( oauth2Client ) => {
 
 export const isWooOAuth2Client = ( oauth2Client ) => {
 	// 50019 => WooCommerce Dev, 50915 => WooCommerce Staging, 50916 => WooCommerce Production.
-	return oauth2Client && includes( [ 50019, 50915, 50916 ], oauth2Client.id );
+	return oauth2Client && [ 50019, 50915, 50916 ].includes( oauth2Client.id );
 };
 
 export const isJetpackCloudOAuth2Client = ( oauth2Client ) => {
 	// 68663 => Jetpack Cloud Dev,
-	return oauth2Client && includes( [ 68663, 69040, 69041 ], oauth2Client.id );
+	return oauth2Client && [ 68663, 69040, 69041 ].includes( oauth2Client.id );
 };

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, includes } from 'lodash';
+import { find } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n from 'i18n-calypso';
@@ -285,7 +285,7 @@ function isExpired( purchase ) {
 }
 
 function isExpiring( purchase ) {
-	return includes( [ 'manualRenew', 'expiring' ], purchase.expiryStatus );
+	return [ 'manualRenew', 'expiring' ].includes( purchase.expiryStatus );
 }
 
 function isIncludedWithPlan( purchase ) {
@@ -559,7 +559,7 @@ function isRenewal( purchase ) {
 }
 
 function isRenewing( purchase ) {
-	return includes( [ 'active', 'autoRenewing' ], purchase.expiryStatus );
+	return [ 'active', 'autoRenewing' ].includes( purchase.expiryStatus );
 }
 
 function isWithinIntroductoryOfferPeriod( purchase ) {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -7,7 +7,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, includes, isEmpty, isEqual } from 'lodash';
+import { find, get, isEmpty, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -380,7 +380,7 @@ class ActivityLog extends Component {
 
 		const disableRestore =
 			! enableRewind ||
-			includes( [ 'queued', 'running' ], get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
+			[ 'queued', 'running' ].includes( get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
@@ -531,7 +531,7 @@ class ActivityLog extends Component {
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
 		const rewindIsNotReady =
-			includes( [ 'uninitialized', 'awaitingCredentials' ], rewindState.state ) ||
+			[ 'uninitialized', 'awaitingCredentials' ].includes( rewindState.state ) ||
 			'vp_can_transfer' === rewindState.reason;
 
 		return (

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -103,7 +103,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const postId = get( comment, 'post.ID' );
 
 	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
-	const hasPermalink = includes( [ 'approved', 'unapproved' ], get( comment, 'status' ) );
+	const hasPermalink = [ 'approved', 'unapproved' ].includes( get( comment, 'status' ) );
 
 	return {
 		siteId,

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -4,7 +4,6 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import page from 'page';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -88,7 +87,7 @@ class Edit extends React.Component {
 		const { MAINTENANCE } = registrarNames;
 		const { REGISTERED, TRANSFER } = domainTypes;
 
-		if ( includes( [ REGISTERED, TRANSFER ], domain.type ) && domain.registrar === MAINTENANCE ) {
+		if ( [ REGISTERED, TRANSFER ].includes( domain.type ) && domain.registrar === MAINTENANCE ) {
 			return (
 				<MaintenanceCard
 					selectedDomainName={ this.props.selectedDomainName }

--- a/client/my-sites/importer/importer-logo.jsx
+++ b/client/my-sites/importer/importer-logo.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +18,7 @@ import SocialLogo from 'calypso/components/social-logo';
 import './importer-logo.scss';
 
 const ImporterLogo = ( { icon } ) => {
-	if ( includes( [ 'wordpress', 'blogger-alt', 'squarespace' ], icon ) ) {
+	if ( [ 'wordpress', 'blogger-alt', 'squarespace' ].includes( icon ) ) {
 		return <SocialLogo className="importer__service-icon" icon={ icon } size={ 48 } />;
 	}
 

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, flowRight, has, trim, sortBy } from 'lodash';
+import { isEmpty, flowRight, has, trim, sortBy } from 'lodash';
 import url from 'url'; // eslint-disable-line no-restricted-imports
 import moment from 'moment';
 
@@ -91,7 +91,7 @@ class SiteImporterInputPane extends React.Component {
 			site: { ID: siteId } = {},
 		} = this.props;
 
-		if ( ! includes( [ appStates.UPLOAD_SUCCESS ], importerState ) ) {
+		if ( importerState !== appStates.UPLOAD_SUCCESS ) {
 			this.props.cancelImport( siteId, importerId );
 			this.resetImport();
 		}

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { includes, truncate } from 'lodash';
+import { truncate } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
 
 /**
@@ -154,7 +154,7 @@ class UploadingPane extends React.PureComponent {
 		const { importerState } = this.props.importerStatus;
 		const { READY_FOR_UPLOAD, UPLOAD_FAILURE } = appStates;
 
-		return includes( [ READY_FOR_UPLOAD, UPLOAD_FAILURE ], importerState );
+		return [ READY_FOR_UPLOAD, UPLOAD_FAILURE ].includes( importerState );
 	}
 
 	openFileSelector = () => {

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
-import { get, includes, isEmpty, omit } from 'lodash';
+import { get, isEmpty, omit } from 'lodash';
 import moment from 'moment';
 import { Button, Card, CompactCard, ProgressBar } from '@automattic/components';
 
@@ -346,11 +346,11 @@ class SectionMigrate extends Component {
 	};
 
 	isInProgress = () => {
-		return includes( [ 'new', 'backing-up', 'restoring' ], this.state.migrationStatus );
+		return [ 'new', 'backing-up', 'restoring' ].includes( this.state.migrationStatus );
 	};
 
 	isFinished = () => {
-		return includes( [ 'done', 'error', 'unknown' ], this.state.migrationStatus );
+		return [ 'done', 'error', 'unknown' ].includes( this.state.migrationStatus );
 	};
 
 	isNonAtomicJetpack = () => {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
-import { get, includes, partial } from 'lodash';
+import { get, partial } from 'lodash';
 import { saveAs } from 'browser-filesaver';
 import classNames from 'classnames';
 
@@ -319,7 +319,7 @@ class Page extends Component {
 	getCopyPageItem() {
 		const { copyPagesModuleDisabled, wpAdminGutenberg, page: post, duplicateUrl } = this.props;
 		if (
-			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
+			! [ 'draft', 'future', 'pending', 'private', 'publish' ].includes( post.status ) ||
 			! userCan( 'edit_post', post ) ||
 			wpAdminGutenberg ||
 			copyPagesModuleDisabled

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -153,18 +153,18 @@ class InvitePeople extends React.Component {
 		} );
 
 		const filteredErrors = pickBy( errors, ( error, key ) => {
-			return includes( filteredTokens, key );
+			return filteredTokens.includes( key );
 		} );
 
 		const filteredSuccess = filter( success, ( successfulValidation ) => {
-			return includes( filteredTokens, successfulValidation );
+			return filteredTokens.includes( successfulValidation );
 		} );
 
 		this.setState( {
 			usernamesOrEmails: filteredTokens,
 			errors: filteredErrors,
 			success: filteredSuccess,
-			errorToDisplay: includes( filteredTokens, errorToDisplay ) && errorToDisplay,
+			errorToDisplay: filteredTokens.includes( errorToDisplay ) && errorToDisplay,
 		} );
 		this.validateInvitation( this.props.siteId, filteredTokens, role );
 
@@ -336,7 +336,7 @@ class InvitePeople extends React.Component {
 			has_custom_message: 'string' === typeof message && !! message.length,
 		} );
 
-		if ( includes( [ 'administrator', 'editor', 'author', 'contributor' ], role ) ) {
+		if ( [ 'administrator', 'editor', 'author', 'contributor' ].includes( role ) ) {
 			page( `/people/new/${ this.props.site.slug }/sent` );
 		}
 	};

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ function mergeProps( stateProps, dispatchProps, ownProps ) {
 	const pluginSlug = get( ownProps, 'plugin.slug' );
 	let overrides = {};
 
-	if ( includes( [ 'jetpack', 'vaultpress' ], pluginSlug ) && stateProps.isAutomatedTransfer ) {
+	if ( [ 'jetpack', 'vaultpress' ].includes( pluginSlug ) && stateProps.isAutomatedTransfer ) {
 		overrides = {
 			allowedActions: {
 				activation: false,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	onDuplicateClick,
 	siteId,
 } ) {
-	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
+	const validStatus = [ 'draft', 'future', 'pending', 'private', 'publish' ].includes( status );
 
 	if ( ! canEdit || ! validStatus || 'post' !== type || ! copyPostIsActive ) {
 		return <QueryJetpackModules siteId={ siteId } />;

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,7 +46,7 @@ class PostActionsEllipsisMenuPublish extends Component {
 
 	render() {
 		const { translate, status, canPublish } = this.props;
-		if ( ! canPublish || ! includes( [ 'pending', 'draft' ], status ) ) {
+		if ( ! canPublish || ! [ 'pending', 'draft' ].includes( status ) ) {
 			return null;
 		}
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -67,7 +66,7 @@ class PostActionsEllipsisMenuView extends Component {
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				{ includes( [ 'publish', 'private' ], status )
+				{ [ 'publish', 'private' ].includes( status )
 					? translate( 'View', { context: 'verb' } )
 					: translate( 'Preview', { context: 'verb' } ) }
 			</PopoverMenuItem>

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { compact, includes, omit, reduce, get, partial } from 'lodash';
+import { compact, omit, reduce, get, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
 
@@ -120,7 +120,7 @@ class SiteMenu extends PureComponent {
 	}
 
 	onNavigate = ( postType ) => () => {
-		if ( ! includes( [ 'post', 'page' ], postType ) ) {
+		if ( ! [ 'post', 'page' ].includes( postType ) ) {
 			bumpStat( 'calypso_publish_menu_click', postType );
 		}
 		this.props.recordTracksEvent( 'calypso_mysites_site_sidebar_item_clicked', {

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { compact, includes, partial } from 'lodash';
+import { compact, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -87,7 +87,7 @@ class ToolsMenu extends PureComponent {
 	}
 
 	onNavigate = ( postType ) => () => {
-		if ( ! includes( [ 'post', 'page' ], postType ) ) {
+		if ( ! [ 'post', 'page' ].includes( postType ) ) {
 			bumpStat( 'calypso_publish_menu_click', postType );
 		}
 		this.props.recordTracksEvent( 'calypso_mysites_tools_sidebar_item_clicked', {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { compact, includes, isEqual, property, snakeCase } from 'lodash';
+import { compact, isEqual, property, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -212,7 +212,7 @@ export const ConnectedThemesSelection = connect(
 		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
 		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
 		// Jetpack themes endpoint.
-		const number = ! includes( [ 'wpcom', 'wporg' ], sourceSiteId ) ? 2000 : 30;
+		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 30;
 		const query = {
 			search,
 			page,

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { flowRight, includes } from 'lodash';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { getUrlParts } from '@automattic/calypso-url';
 import Gridicon from 'calypso/components/gridicon';
@@ -115,7 +115,7 @@ export class EditorMediaModalDetailItem extends Component {
 
 		const mimePrefix = getMimePrefix( item );
 
-		if ( ! includes( [ 'image', 'video' ], mimePrefix ) ) {
+		if ( ! [ 'image', 'video' ].includes( mimePrefix ) ) {
 			return null;
 		}
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, isEmpty, includes, partial, some, values } from 'lodash';
+import { flow, get, isEmpty, partial, some, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -387,7 +387,7 @@ export class EditorMediaModal extends Component {
 	}
 
 	getModalButtons() {
-		if ( includes( [ ModalViews.IMAGE_EDITOR, ModalViews.VIDEO_EDITOR ], this.props.view ) ) {
+		if ( [ ModalViews.IMAGE_EDITOR, ModalViews.VIDEO_EDITOR ].includes( this.props.view ) ) {
 			return;
 		}
 
@@ -440,7 +440,7 @@ export class EditorMediaModal extends Component {
 	}
 
 	shouldClose() {
-		return ! includes( [ ModalViews.IMAGE_EDITOR, ModalViews.VIDEO_EDITOR ], this.props.view );
+		return ! [ ModalViews.IMAGE_EDITOR, ModalViews.VIDEO_EDITOR ].includes( this.props.view );
 	}
 
 	updateSettings = ( gallerySettings ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, get, includes, isEmpty } from 'lodash';
+import { defer, get, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import page from 'page';
 
@@ -650,7 +650,7 @@ class DomainsStep extends React.Component {
 		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';
 		const onboardingSubHeaderCopy =
 			siteType &&
-			includes( [ 'onboarding', 'ecommerce-onboarding' ], flowName ) &&
+			[ 'onboarding', 'ecommerce-onboarding' ].includes( flowName ) &&
 			getSiteTypePropertyValue( 'slug', siteType, subHeaderPropertyName );
 
 		if ( onboardingSubHeaderCopy ) {

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -5,7 +5,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -99,7 +99,7 @@ export default connect(
 		const rewindState = getRewindState( state, siteId );
 		return {
 			siteId,
-			rewindIsNowActive: includes( [ 'active', 'provisioning' ], rewindState.state ),
+			rewindIsNowActive: [ 'active', 'provisioning' ].includes( rewindState.state ),
 		};
 	},
 	{ submitSignupStep }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
-import { includes, isEmpty, omit, get } from 'lodash';
+import { isEmpty, omit, get } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -123,7 +123,7 @@ export class UserStep extends Component {
 
 		let subHeaderText = props.subHeaderText;
 
-		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
+		if ( [ 'wpcc', 'crowdsignal' ].includes( flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 				subHeaderText =
 					'cart' === wccomFrom
@@ -373,7 +373,7 @@ export class UserStep extends Component {
 			);
 		}
 
-		if ( includes( [ 'wpcc' ], flowName ) && oauth2Client ) {
+		if ( flowName === 'wpcc' && oauth2Client ) {
 			return translate( 'Sign up for %(clientTitle)s with a WordPress.com account', {
 				args: { clientTitle: oauth2Client.title },
 				comment:

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -74,7 +74,7 @@ export const queries = ( state = {}, action ) => {
 				COMMENTS_CHANGE_STATUS === action.type &&
 				'all' === status &&
 				includes( comments, action.commentId ) && // if the comment is not in the current view this is an undo
-				includes( [ 'approved', 'unapproved' ], action.status )
+				[ 'approved', 'unapproved' ].includes( action.status )
 			) {
 				// No-op when status changes from `approved` or `unapproved` in the All tab
 				return state;
@@ -82,7 +82,7 @@ export const queries = ( state = {}, action ) => {
 
 			if (
 				status === action.status ||
-				( status === 'all' && includes( [ 'approved', 'unapproved' ], action.status ) )
+				( status === 'all' && [ 'approved', 'unapproved' ].includes( action.status ) )
 			) {
 				//with undo, we should add this back to the list
 				const sortedList = [ action.commentId ]

--- a/client/state/comments/ui/utils.js
+++ b/client/state/comments/ui/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Creates a filters key to be used in the `comments.ui.queries` state.
  * E.g. `comments.ui.queries.${ siteId }.${ postId }.${ 'approved?s=foo' }.${ page }`
  *
@@ -15,7 +10,7 @@ import { includes } from 'lodash';
  */
 export const getFiltersKey = ( { order = 'DESC', search, status = 'all' } ) => {
 	const caseInsensitiveOrder = order.toUpperCase();
-	const orderFilter = includes( [ 'ASC', 'DESC' ], caseInsensitiveOrder )
+	const orderFilter = [ 'ASC', 'DESC' ].includes( caseInsensitiveOrder )
 		? caseInsensitiveOrder
 		: 'DESC';
 	const searchFilter = search ? `&s=${ search }` : '';

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, includes, mapValues } from 'lodash';
+import { filter, mapValues } from 'lodash';
 
 function validateAllFields( fieldValues, domainName ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -25,7 +25,7 @@ function validateField( { name, value, type, domainName } ) {
 		case 'data':
 			return isValidData( value, type );
 		case 'protocol':
-			return includes( [ 'tcp', 'udp', 'tls' ], value );
+			return [ 'tcp', 'udp', 'tls' ].includes( value );
 		case 'weight':
 		case 'aux':
 		case 'port': {
@@ -117,11 +117,11 @@ function isRootDomain( name, domainName ) {
 		'@.' + domainName,
 		'@.' + domainName + '.',
 	];
-	return ! name || includes( rootDomainVariations, name );
+	return ! name || rootDomainVariations.includes( name );
 }
 
 function canBeRootDomain( type ) {
-	return includes( [ 'A', 'MX', 'SRV', 'TXT' ], type );
+	return [ 'A', 'MX', 'SRV', 'TXT' ].includes( type );
 }
 
 function getFieldWithDot( field ) {

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, find, get, includes, some } from 'lodash';
+import { filter, find, get, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -81,14 +81,14 @@ export const isInstalling = function ( state, siteId, forPlugin = false ) {
 
 	// If any plugin is not done/waiting/error'd, it's in an installing state.
 	return some( pluginList, ( item ) => {
-		return ! includes( [ 'done', 'wait' ], item.status ) && item.error === null;
+		return ! [ 'done', 'wait' ].includes( item.status ) && item.error === null;
 	} );
 };
 
 export const getActivePlugin = function ( state, siteId, forPlugin = false ) {
 	const pluginList = getPluginsForSite( state, siteId, forPlugin );
 	const plugin = find( pluginList, ( item ) => {
-		return ! includes( [ 'done', 'wait' ], item.status ) && item.error === null;
+		return ! [ 'done', 'wait' ].includes( item.status ) && item.error === null;
 	} );
 	if ( typeof plugin === 'undefined' ) {
 		return false;

--- a/client/state/posts/utils/is-state-equal.js
+++ b/client/state/posts/utils/is-state-equal.js
@@ -1,16 +1,11 @@
-/**
- * External dependencies
- */
-import { includes } from 'lodash';
-
 export function isStatusEqual( localStatusEdit, savedStatus ) {
 	// When receiving a request to change the `status` attribute, the server
 	// treats `publish` and `future` as synonyms. It's really the post's `date`
 	// that determines the resulting status, not the requested value.
 	// Therefore, the `status` edit is considered saved and removed from the
 	// local edits even if the value returned by server is different.
-	if ( includes( [ 'publish', 'future' ], localStatusEdit ) ) {
-		return includes( [ 'publish', 'future' ], savedStatus );
+	if ( [ 'publish', 'future' ].includes( localStatusEdit ) ) {
+		return [ 'publish', 'future' ].includes( savedStatus );
 	}
 
 	// All other statuses (draft, private, pending) are 1:1. The only possible

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -1,11 +1,6 @@
 /**
  * Internal dependencies
  */
-import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import {
 	PLAN_ECOMMERCE,
@@ -213,7 +208,7 @@ describe( 'canUpgradeToPlan', () => {
 			sites: {
 				items: {
 					[ s ]: {
-						jetpack: includes( [ 'jetpack', 'atomic' ], siteType ),
+						jetpack: [ 'jetpack', 'atomic' ].includes( siteType ),
 						options: {
 							is_automated_transfer: siteType === 'atomic',
 						},

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, isEmpty, reduce, snakeCase } from 'lodash';
+import { isEmpty, reduce, snakeCase } from 'lodash';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 
 /**
@@ -50,7 +50,7 @@ function recordSubmitStep( stepName, providedDependencies ) {
 			}
 
 			// Ensure we don't capture identifiable user data we don't need.
-			if ( includes( [ 'email' ], propName ) ) {
+			if ( propName === 'email' ) {
 				propName = `user_entered_${ propName }`;
 				propValue = !! propValue;
 			}
@@ -61,7 +61,7 @@ function recordSubmitStep( stepName, providedDependencies ) {
 					.join( ',' );
 			}
 
-			if ( includes( [ 'selected_design' ], propName ) ) {
+			if ( propName === 'selected_design' ) {
 				propValue = propValue.slug;
 			}
 

--- a/client/state/ui/selectors/is-site-section.js
+++ b/client/state/ui/selectors/is-site-section.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getSectionGroup from './get-section-group';
@@ -15,5 +10,5 @@ import getSectionGroup from './get-section-group';
  * @returns {boolean}       Whether current section is site-specific
  */
 export default function isSiteSection( state ) {
-	return includes( [ 'sites', 'editor', 'gutenberg' ], getSectionGroup( state ) );
+	return [ 'sites', 'editor', 'gutenberg' ].includes( getSectionGroup( state ) );
 }


### PR DESCRIPTION
Removes usages of Lodash `includes` where the function is applied on an array literal, like:
```js
includes( [ A, B, C ], value )
```
it's obvious that this can be replaced with
```
[ A, B, C ].includes( value )
```
and that the array argument is never null here.

In most modules this removes all usages of `includes` and the import can be removed. But sometimes there are non-trivial usages left and `includes` remains a dependency. I didn't do the extra work to remove such usages completely.

In one case (`filteredTokens`), I figured that an array is produced by a `foo.map()` call few lines earlier and is therefore guaranteed to be a valid array. That's the only case where I replaced anything else than an array literal.

**How to test:**
Verify that all the changes are OK. Didn't I omit negation somewhere? I.e., replacing `! includes( a, v )` with `a.includes( v )` accidentally.