### PR TITLE
Fix enabled check in bilmur utils

### DIFF
--- a/client/document/utils/bilmur.js
+++ b/client/document/utils/bilmur.js
@@ -13,7 +13,7 @@ export function isBilmurEnabled() {
 export function getBilmurUrl() {
 	const baseUrl = config( 'bilmur_url' );
 
-	if ( ! isBilmurEnabled || ! baseUrl ) {
+	if ( ! isBilmurEnabled() || ! baseUrl ) {
 		return undefined;
 	}
 


### PR DESCRIPTION
This fixes a bug in the `getBilmurUrl` util, which fails to correctly check whether `bilmur-script` is enabled.

It doesn't currently translate into an actual bug in production (or any other environment), since there's a redundant check in the one place that `getBilmurUrl` gets used, but it should of course be fixed in case that code is ever refactored.

Discovered in https://github.com/Automattic/wp-calypso/pull/54757#discussion_r674728111

#### Changes proposed in this Pull Request

* Fix a bug in the `getBilmurUrl` util, which prevents checking whether the `bilmur-script` feature is enabled

#### Testing instructions

No testing should be necessary, as the bug doesn't manifest in production or any other environment. Checking whether this doesn't break anything further could make sense, but the change is so small and easy to grok that it's likely unnecessary.
