### PR TITLE
Tracking: Ignore replaceInnerBlocks tracking for Post Content block

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -396,7 +396,9 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 			// Template Part
 			name === 'core/template-part' ||
 			// Reusable Block
-			name === 'core/block'
+			name === 'core/block' ||
+			// Post Content
+			name === 'core/post-content'
 		) {
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Post Content block is producing a lot of unnecessary events, resulting in skewed stats. We've already fixed this for Template Parts and Reusable Blocks, looks like the same is happening for Post Content block. This PR takes care of it. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps to enable tracking debugging at PCYsg-nrf-p2
* Open Site Editor
* Edit a template which contains a Post Content block or add the block yourself.
* Save
* Refresh
* Confirm `replaceInnerBlocks` is triggered, but no events are tracked.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
