### PR TITLE
chore: migrate `test/(client|server)` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -212,7 +212,9 @@ module.exports = {
 				'packages/viewport/**/*',
 				'packages/webpack-config-flag-plugin/**/*',
 				'packages/wpcom-checkout/**/*',
+				'test/client/**/*',
 				'test/e2e/**/*',
+				'test/server/**/*',
 			],
 			rules: {
 				'wpcalypso/import-docblock': 'off',

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const nock = require( 'nock' );
 
 // Disables all network requests for all tests.

--- a/test/server/setup-test-framework.js
+++ b/test/server/setup-test-framework.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import * as nock from 'nock';
 import chai from 'chai';
+import * as nock from 'nock';
 import sinonChai from 'sinon-chai';
 
 chai.use( sinonChai );


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `test/client` and `text/server` to use `import/order`

#### Testing instructions

N/A
