### PR TITLE
chore: migrate `client/auth` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,6 +178,7 @@ module.exports = {
 		{
 			files: [
 				'apps/editing-toolkit/**/*',
+				'client/auth/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/sections-filter.js',
 				'client/sections-helper.js',

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import store from 'store';
 
 // Store token into local storage

--- a/client/auth/index.js
+++ b/client/auth/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import page from 'page';
 import { storeToken } from './controller';
 
 export default () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/auth` to use `import/order`

#### Testing instructions

N/A