### PR TITLE
chore: migrate `packages/whats-new` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,6 +211,7 @@ module.exports = {
 				'packages/tree-select/**/*',
 				'packages/viewport/**/*',
 				'packages/webpack-config-flag-plugin/**/*',
+				'packages/whats-new/**/*',
 				'packages/wpcom-checkout/**/*',
 				'test/e2e/**/*',
 			],

--- a/packages/whats-new/src/index.js
+++ b/packages/whats-new/src/index.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import { Guide } from '@wordpress/components';
-import proxyRequest from 'wpcom-proxy-request';
-import React, { useEffect, useState } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
 import { useLocale } from '@automattic/i18n-utils';
+import { Guide } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import React, { useEffect, useState } from 'react';
 import wpcom from 'wpcom';
-
-/**
- * Internal dependencies
- */
-import './style.scss';
+import proxyRequest from 'wpcom-proxy-request';
 import WhatsNewPage from './whats-new-page';
+import './style.scss';
 
 const WhatsNewGuide = ( { onClose } ) => {
 	const [ whatsNewData, setWhatsNewData ] = useState( null );

--- a/packages/whats-new/src/whats-new-page.js
+++ b/packages/whats-new/src/whats-new-page.js
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import { Button, GuidePage } from '@wordpress/components';
-import React, { useEffect } from 'react';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, GuidePage } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import React, { useEffect } from 'react';
 
 function WhatsNewPage( { description, heading, imageSrc, isLastPage, link, pageNumber } ) {
 	const __ = useI18n().__;

--- a/packages/whats-new/tsconfig.json
+++ b/packages/whats-new/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/whats-new` to use `import/order`

#### Testing instructions

N/A