### PR TITLE
chore: migrate `packages/format-currency` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -201,6 +201,7 @@ module.exports = {
 				'packages/create-calypso-config/**/*',
 				'packages/data-stores/**/*',
 				'packages/domain-picker/**/*',
+				'packages/format-currency/**/*',
 				'packages/js-utils/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',

--- a/packages/format-currency/src/index.js
+++ b/packages/format-currency/src/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { numberFormat } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { getCurrencyDefaults } from './currencies';
 export { getCurrencyDefaults };
 

--- a/packages/format-currency/test/index.js
+++ b/packages/format-currency/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import formatCurrency, { getCurrencyDefaults, getCurrencyObject } from '../src';
 
 describe( 'formatCurrency', () => {

--- a/packages/format-currency/tsconfig.json
+++ b/packages/format-currency/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/format-currency` to use `import/order`

#### Testing instructions

N/A