### PR TITLE
chore: migrate `packages/language-picker` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -203,6 +203,7 @@ module.exports = {
 				'packages/data-stores/**/*',
 				'packages/domain-picker/**/*',
 				'packages/js-utils/**/*',
+				'packages/language-picker/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
 				'packages/plans-grid/**/*',

--- a/packages/language-picker/src/constants.ts
+++ b/packages/language-picker/src/constants.ts
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { LanguageGroup } from './Language';
 import { I18n } from '@wordpress/i18n';
+import { LanguageGroup } from './Language';
 
 export const createLanguageGroups = ( __: I18n[ '__' ] ): LanguageGroup[] => [
 	{

--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -1,26 +1,13 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-import type { ReactNode } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+
 import Search from '@automattic/search';
-
-/**
- * WordPress dependencies
- */
 import { Button, CustomSelectControl, Flex, FlexBlock, FlexItem } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import type { Language, LanguageGroup } from './Language';
+import { useI18n } from '@wordpress/react-i18n';
+import React, { useState } from 'react';
 import { getSearchedLanguages, LocalizedLanguageNames } from './search';
+import type { Language, LanguageGroup } from './Language';
+import type { ReactNode } from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 type Props< TLanguage extends Language > = {

--- a/packages/language-picker/src/search.ts
+++ b/packages/language-picker/src/search.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { Language } from './Language';
 
 type SearchableFields = string[];


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/language-picker` to use `import/order`

#### Testing instructions

N/A
