### PR TITLE
Restore unit tests to calypso e2e tsconfig for type checking

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -32,7 +32,6 @@
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist && npx rimraf tsconfig.test.tsbuildinfo",
 		"build": "tsc --build ./tsconfig.json",
-		"pretest": "tsc --project ./tsconfig.test.json",
 		"test": "yarn jest"
 	}
 }

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -30,7 +30,7 @@
 		"mockdate": "^3.0.5"
 	},
 	"scripts": {
-		"clean": "yarn build --clean && npx rimraf dist && npx rimraf tsconfig.test.tsbuildinfo",
+		"clean": "yarn build --clean && npx rimraf dist",
 		"build": "tsc --build ./tsconfig.json",
 		"test": "yarn jest"
 	}

--- a/packages/calypso-e2e/tsconfig.json
+++ b/packages/calypso-e2e/tsconfig.json
@@ -4,5 +4,5 @@
 		"outDir": "dist/esm",
 		"declarationDir": "dist/types"
 	},
-	"include": [ "src" ]
+	"include": [ "src", "test" ]
 }

--- a/packages/calypso-e2e/tsconfig.test.json
+++ b/packages/calypso-e2e/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-	"extends": "@automattic/calypso-build/typescript/ts-package.json",
-	"compilerOptions": {
-		"noEmit": true // just type checking, no output. The output is handled by babel.
-	},
-	"include": [ "src", "test" ]
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This effectively reverts part of the changes in PR #54734, namely the removal of unit tests from the tsconfig to get the tests out of the `dist` output. 

Because we currently do type-checking holistically for packages, and those scripts all have hard assumptions on everything being in one tsconfig, this means that most of our various scripts and CI pipelines wouldn't do type checking for this packages unit tests. 

In the current setup, you basically have to choose between a tradeoff of type checking for your unit tests vs having potential clutter in your `dist` output. For this package, because it's only consumed internally, it makes the most sense for now to favor the type checking. See [this comment](https://github.com/Automattic/wp-calypso/pull/54734#issuecomment-884637006) for more background.

We will tackle the broader issue of how to better support TypeScript Jest unit tests in packages in a separate issue (#54801), and make those changes all at once for the different packages in the repo!

#### Testing instructions

- [x] Unit tests should still pass
- [x] To check type checking, you can add something like `const x: string = 42;` to one of the unit tests in the `calypso-e2e` repo. If you then run "yarn tsc --build packages/*/tsconfig.json", you should see the type error get reported

