### PR TITLE
Sign up: Add free plan column to plans grid

### DIFF
--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -58,6 +58,10 @@ export class PlanFeaturesComparisonHeader extends Component {
 			isMonthlyPlan,
 		} = this.props;
 
+		if ( rawPrice === 0 ) {
+			return translate( 'Free forever' );
+		}
+
 		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
 			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
 			return translate( `Save %(discountRate)s%% by paying annually`, { args: { discountRate } } );
@@ -76,7 +80,17 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	getAnnualDiscount() {
-		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
+		const {
+			isMonthlyPlan,
+			rawPriceForMonthlyPlan,
+			annualPricePerMonth,
+			translate,
+			rawPrice,
+		} = this.props;
+
+		if ( rawPrice === 0 ) {
+			return null;
+		}
 
 		if ( ! isMonthlyPlan ) {
 			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -144,12 +144,12 @@ export class PlanFeaturesComparison extends Component {
 	}
 
 	handleUpgradeClick( singlePlanProperties ) {
-		const { onUpgradeClick: ownPropsOnUpgradeClick } = this.props;
+		const { onUpgradeClick } = this.props;
 		const { cartItemForPlan } = singlePlanProperties;
 
-		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop ) {
+		if ( onUpgradeClick && onUpgradeClick !== noop ) {
 			// cartItemForPlan can be null, which implies a free plan
-			ownPropsOnUpgradeClick( cartItemForPlan );
+			onUpgradeClick( cartItemForPlan );
 			return;
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -1013,17 +1013,17 @@ const ConnectedPlanFeatures = connect(
 					? getPlanDiscountedRawPrice( state, selectedSiteId, plan, isMonthlyObj )
 					: getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
+				const isFree = rawPrice === 0;
+
 				const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
 				if ( annualPlansOnlyFeatures.length > 0 ) {
 					planFeatures = planFeatures.map( ( feature ) => {
-						const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
-							feature.getSlug()
-						);
-
+						const availableOnlyForAnnualPlans =
+							! isFree && annualPlansOnlyFeatures.includes( feature.getSlug() );
 						return {
 							...feature,
 							availableOnlyForAnnualPlans,
-							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+							availableForCurrentPlan: isFree || ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
 						};
 					} );
 				}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -325,7 +325,7 @@ export class PlanFeatures extends Component {
 			forceDisplayButton = true;
 		}
 
-		return map( reorderedPlans, ( properties ) => {
+		return reorderedPlans.map( ( properties ) => {
 			const {
 				availableForPurchase,
 				currencyCode,
@@ -343,7 +343,7 @@ export class PlanFeatures extends Component {
 			} = properties;
 			const { rawPrice, discountPrice, isMonthlyPlan } = properties;
 			const planDescription = isInVerticalScrollingPlansExperiment
-				? planConstantObj.getShortDescription()
+				? planConstantObj.getShortDescription?.()
 				: planConstantObj.getDescription();
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
@@ -421,7 +421,7 @@ export class PlanFeatures extends Component {
 			isInVerticalScrollingPlansExperiment,
 		} = this.props;
 
-		return map( planProperties, ( properties ) => {
+		return planProperties.map( ( properties ) => {
 			const {
 				availableForPurchase,
 				currencyCode,
@@ -502,7 +502,7 @@ export class PlanFeatures extends Component {
 	renderPlanDescriptions() {
 		const { planProperties, withScroll } = this.props;
 
-		return map( planProperties, ( properties ) => {
+		return planProperties.map( ( properties ) => {
 			const { planName, planConstantObj, isPlaceholder } = properties;
 
 			const classes = classNames( 'plan-features__table-item', {
@@ -512,7 +512,7 @@ export class PlanFeatures extends Component {
 
 			let description = null;
 			if ( withScroll ) {
-				description = planConstantObj.getShortDescription();
+				description = planConstantObj.getShortDescription?.();
 			} else {
 				description = planConstantObj.getDescription();
 			}
@@ -618,7 +618,7 @@ export class PlanFeatures extends Component {
 			translate,
 		} = this.props;
 
-		return map( planProperties, ( properties ) => {
+		return planProperties.map( ( properties ) => {
 			let { availableForPurchase } = properties;
 			const {
 				current,
@@ -748,7 +748,7 @@ export class PlanFeatures extends Component {
 	renderPlanFeatureColumns( rowIndex ) {
 		const { planProperties, selectedFeature, withScroll } = this.props;
 
-		return map( planProperties, ( properties ) => {
+		return planProperties.map( ( properties ) => {
 			const { availableForPurchase, features, planName } = properties;
 
 			const featureKeys = Object.keys( features );
@@ -788,7 +788,7 @@ export class PlanFeatures extends Component {
 			purchaseId,
 		} = this.props;
 
-		return map( planProperties, ( properties ) => {
+		return planProperties.map( ( properties ) => {
 			let { availableForPurchase } = properties;
 			const {
 				current,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -547,7 +547,8 @@ export class PlanFeatures extends Component {
 			productSlug,
 		} = singlePlanProperties;
 
-		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop && cartItemForPlan ) {
+		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop ) {
+			// cartItemForPlan can be null, which implies a free plan
 			ownPropsOnUpgradeClick( cartItemForPlan );
 			return;
 		}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -25,9 +25,9 @@ $plan-features-sidebar-width: 272px;
 			align-items: center;
 
 			@media ( min-width: 660px ) and ( max-width: 1040px ) {
-				.plan-features__summary, .plan-features__description {
+				.plan-features__summary,
+				.plan-features__description {
 					padding: 16px 33px;
-
 				}
 				.plan-features--signup .plan-features__pricing {
 					padding: 0 7px;
@@ -42,6 +42,11 @@ $plan-features-sidebar-width: 272px;
 				border-top: solid 8px;
 				border-radius: 2px 2px 0 0;
 				padding-bottom: 12px;
+
+				&.is-free-plan {
+					border-color: var( --color-plan-blogger );
+					border-bottom: solid 2px var( --color-neutral-10 );
+				}
 
 				&.is-blogger-plan {
 					border-color: var( --color-plan-blogger );
@@ -69,7 +74,7 @@ $plan-features-sidebar-width: 272px;
 				}
 			}
 
-			 .plan-price {
+			.plan-price {
 				font-weight: 600;
 				margin-right: 10px;
 				font-size: $font-headline-large;
@@ -102,18 +107,17 @@ $plan-features-sidebar-width: 272px;
 
 			.plan-features__mobile-plan {
 				max-width: 408px;
+				width: 100%;
 			}
 		}
 	}
 }
-
 
 .plan-features--loading-container {
 	margin-top: 300px;
 }
 
 /******************************************/
-
 
 /* Breakpoints 1150px, */
 
@@ -359,6 +363,7 @@ $plan-features-sidebar-width: 272px;
 	width: 56px;
 	height: 56px;
 	margin-right: 15px;
+	// stylelint-disable-next-line declaration-property-unit-allowed-list
 	border-radius: 50%;
 }
 

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -33,14 +33,19 @@ export class PlanPrice extends Component {
 			translate,
 		} = this.props;
 
-		if ( ! currencyCode || ! rawPrice ) {
+		if ( ! currencyCode || typeof rawPrice === 'undefined' ) {
 			return null;
 		}
 
 		// "Normalize" the input price or price range.
-		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
-		if ( rawPriceRange.includes( 0 ) ) {
-			return null;
+		let rawPriceRange;
+		if ( Array.isArray( rawPrice ) ) {
+			rawPriceRange = rawPrice.slice( 0, 2 );
+			if ( rawPriceRange.includes( 0 ) ) {
+				return null;
+			}
+		} else {
+			rawPriceRange = [ rawPrice ];
 		}
 
 		const priceRange = rawPriceRange.map( ( item ) => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -340,6 +340,7 @@ export class PlansFeaturesMain extends Component {
 		if ( plansWithScroll ) {
 			return plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [
+					TYPE_FREE,
 					TYPE_BLOGGER,
 					TYPE_PERSONAL,
 					TYPE_PREMIUM,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -354,7 +354,13 @@ export class PlansFeaturesMain extends Component {
 
 		if ( isAllPaidPlansShown || withIntervalSelector ) {
 			return plans.filter( ( plan ) =>
-				isPlanOneOfType( plan, [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ] )
+				isPlanOneOfType( plan, [
+					TYPE_FREE,
+					TYPE_PERSONAL,
+					TYPE_PREMIUM,
+					TYPE_BUSINESS,
+					TYPE_ECOMMERCE,
+				] )
 			);
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -152,7 +152,7 @@ export class PlansStep extends Component {
 						planTypes={ planTypes }
 						flowName={ flowName }
 						showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-						isAllPaidPlansShown={ true }
+						isAllPaidPlansShown={ false }
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
 						isReskinned={ isReskinned }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -9,7 +9,6 @@ import { intersection } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
-import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -174,26 +173,7 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { hideFreePlan, subHeaderText, translate } = this.props;
-
-		if ( ! hideFreePlan ) {
-			if ( isDesktop() ) {
-				return translate(
-					"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
-					{
-						components: {
-							link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
-						},
-					}
-				);
-			}
-
-			return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
-				components: {
-					link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
-				},
-			} );
-		}
+		const { subHeaderText, translate } = this.props;
 
 		if ( isDesktop() ) {
 			return translate( "Pick one that's right for you and unlock features that help you grow." );

--- a/client/state/plans/selectors/get-plan-raw-price.js
+++ b/client/state/plans/selectors/get-plan-raw-price.js
@@ -24,7 +24,12 @@ export function getPlanRawPrice( state, productId, isMonthly = false ) {
 	if ( get( plan, 'raw_price', -1 ) < 0 ) {
 		return null;
 	}
+
 	const price = get( plan, 'orig_cost', 0 ) || plan.raw_price;
+
+	if ( price === 0 ) {
+		return 0;
+	}
 
 	return isMonthly ? calculateMonthlyPriceForPlan( plan.product_slug, price ) : price;
 }

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -932,10 +932,6 @@ export const PLANS_LIST = {
 		getPlanCompareFeatures: () => [
 			// pay attention to ordering, shared features should align on /plan page
 			FEATURE_WP_SUBDOMAIN,
-			FEATURE_JETPACK_ESSENTIAL,
-			FEATURE_COMMUNITY_SUPPORT,
-			FEATURE_FREE_THEMES,
-			FEATURE_BASIC_DESIGN,
 			FEATURE_3GB_STORAGE,
 		],
 		getSignupFeatures: () => [

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -29,21 +29,12 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 	}
 
 	async _selectPlan( level ) {
-		// We are switching from two separate designs for mobile and desktop plans to one. There will be two buttons -
-		// one visible and one hidden in control and only one button in the test variation.
-		const planLocator =
-			driverManager.currentScreenSize() === 'mobile'
-				? `.plan-features__mobile button.is-${ level }-plan, .plan-features-comparison__table button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`
-				: `.plan-features-comparison__table button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`;
+		const planLocator = `button.is-${ level }-plan`;
 
 		const locator = By.css( planLocator );
 
-		await driverHelper.waitUntilElementLocatedAndVisible(
-			this.driver,
-			By.css(
-				'.plan-features__mobile button.is-business-plan, .plan-features-comparison__table button.is-business-plan, .plan-features__table button.is-business-plan'
-			)
-		);
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, planLocator );
+
 		await this.scrollPlanInToView( level );
 
 		await driverHelper.clickWhenClickable( this.driver, locator );

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -29,13 +29,11 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 	}
 
 	async _selectPlan( level ) {
-		const planLocator = `button.is-${ level }-plan`;
+		const planLocator = `.button.is-${ level }-plan`;
 
 		const locator = By.css( planLocator );
 
-		console.error( 'locating', planLocator );
-		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, planLocator );
-		console.error( 'located', planLocator );
+		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, locator );
 
 		await this.scrollPlanInToView( level );
 

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -36,15 +36,8 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 				? `.plan-features__mobile button.is-${ level }-plan, .plan-features-comparison__table button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`
 				: `.plan-features-comparison__table button.is-${ level }-plan, .plan-features__table button.is-${ level }-plan`;
 
-		let locator = By.css( planLocator );
+		const locator = By.css( planLocator );
 
-		if ( level === 'free' ) {
-			if ( ! ( await driverHelper.isElementLocated( this.driver, locator ) ) ) {
-				locator = By.css(
-					'.plans-features-main__banner-content button, .formatted-header__subtitle button'
-				);
-			}
-		}
 		await driverHelper.waitUntilElementLocatedAndVisible(
 			this.driver,
 			By.css(

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -33,7 +33,9 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 
 		const locator = By.css( planLocator );
 
+		console.error( 'locating', planLocator );
 		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, planLocator );
+		console.error( 'located', planLocator );
 
 		await this.scrollPlanInToView( level );
 

--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -29,7 +29,7 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 	}
 
 	async _selectPlan( level ) {
-		const planLocator = `.button.is-${ level }-plan`;
+		const planLocator = `button.is-${ level }-plan`;
 
 		const locator = By.css( planLocator );
 


### PR DESCRIPTION
This PR adds a free plan column for a clearer comparison to the plan's grid in desktop and in mobile. But it only shows it when the user picks a free domain.

### Testing steps

1. Visit `/start` in production.
2. Pick a paid domain, you should **NOT** see a free plan column.
>>>
1. Visit `/start` using the live link of this branch.
2. Pick a free domain, you should see a free plan column.
3. Pick it, you should get a free site.

#### Launch

1. In My Home, go to Launch site.
2. Pick a **paid** domain.
3. Free plan should not be an option.
>>
1. In My Home, go to Launch site.
2. Pick a **free** domain.
3. Free plan should be an option.
4. Pick it. The site should launch seamlessly and without landing in checkout.

Please repeat the steps above on mobile (DevTools small viewport is sufficient).


Fixes: https://github.com/Automattic/wp-calypso/issues/54216