### PR TITLE
Plugin Builds: Merge trunk before running build

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -59,6 +59,21 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """
+				# Merge the trunk branch first. This way, our builds and tests
+				# include the latest merged version of the plugin being built.
+				# Otherwise, we can get into a situation where the current plugin
+				# build appears "different", but that's just because it's older.
+				if [[ "%teamcity.build.branch.is_default%" != "true" ]] ; then
+					# git operations will fail if no user is set.
+					git config --local user.email "tcbuildagent@example.com"
+					git config --local user.name "TeamCity Build Agent"
+					# Note that `trunk` is already up-to-date from the `teamcity.git.fetchAllHeads`
+					# parameter in the project settings.
+					git merge trunk
+					# See if the trunk commit shows up:
+					git --no-pager log --oneline -n 5
+				fi
+
 				# Update composer
 				composer install
 

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -69,7 +69,10 @@ open class PluginBaseBuild : Template({
 					git config --local user.name "TeamCity Build Agent"
 					# Note that `trunk` is already up-to-date from the `teamcity.git.fetchAllHeads`
 					# parameter in the project settings.
-					git merge trunk
+					if ! git merge trunk ; then
+						echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Rebase on trunk to resolve this problem.' identity='merge_conflict']]"
+						exit
+					fi
 					# See if the trunk commit shows up:
 					git --no-pager log --oneline -n 5
 				fi

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -18,7 +18,9 @@ object WPComPlugins : Project({
 		param("build.prefix", "1")
 		param("normalize_files", "")
 		param("build_env", "production")
+		param("teamcity.git.fetchAllHeads", "true")
 	}
+
 	buildType(EditingToolkit)
 	buildType(WpcomBlockEditor)
 	buildType(Notifications)
@@ -44,7 +46,6 @@ object WPComPlugins : Project({
 		}
 	}
 })
-
 
 private object EditingToolkit : BuildType({
 	id("WPComPlugins_EditorToolKit")


### PR DESCRIPTION
### Changes proposed in this Pull Request
This PR tests how we would merge trunk before running plugin builds in TeamCity. The goal would be to reduce the number of false-positive for "changed" builds which are caused by out-of-date branches.

The main downside to this approach is that the release artifact will no longer match your local development copy. Theoretically, we could do two builds to account for this, but I'm not sure if it's worth the effort. (Plus, we'd be effectively doubling the build time by doing that.) So this trade off might be okay to accept.

### Testing instructions
1. In the commit log shown under the "prepare environment" step, note that the merge of trunk is the most recent commit.
2. When installing to your sandbox, note that the output displays the commit of your branch (not of the merge commit). This makes sense to me, as it's useful for comparing to the current branch. Showing the merge commit number, which will never appear in VCS, would be confusing.

To test this solves the notification problem, I think we need to have:
1. A branch which will not change ETK at all.
2. A release build of ETK merged to trunk after that branch is created.
3. The branch remains out of date of trunk, but a new commit is pushed.
4. In this case we should _not_ get a notification, but would have previously.