### PR TITLE
Move Calendly URL to config

### DIFF
--- a/client/lib/jetpack/get-calendly-url.ts
+++ b/client/lib/jetpack/get-calendly-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import config from '@automattic/calypso-config';
+
+const getCalendlyURL = (): string | null => {
+	const url = config< string >( 'calendly_jetpack_appointment_url' );
+
+	return url ? url : null;
+};
+
+export default getCalendlyURL;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-schedule-appointment.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-schedule-appointment.tsx
@@ -8,8 +8,9 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Main from 'calypso/components/main';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getCalendlyUrl from 'calypso/lib/jetpack/get-calendly-url';
+import Main from 'calypso/components/main';
 
 /**
  * Type dependencies
@@ -18,17 +19,25 @@ import type { UserData } from 'calypso/lib/user/user';
 
 const JetpackCheckoutScheduleAppointment: FunctionComponent = () => {
 	const currentUser = useSelector( ( state ) => getCurrentUser( state ) ) as UserData;
+	const calendlyUrl = getCalendlyUrl();
 
 	return (
 		<Main fullWidthLayout className="jetpack-checkout-schedule-appointment">
-			<InlineWidget
-				url="https://calendly.com/d/xfg8-3ykd/jetpack-com-onboarding-call"
-				pageSettings={ {
-					// --studio-jetpack-green
-					primaryColor: '069e08',
-				} }
-				prefill={ { email: currentUser?.email, name: currentUser?.display_name } }
-			/>
+			{ calendlyUrl ? (
+				<InlineWidget
+					url={ calendlyUrl }
+					pageSettings={ {
+						// --studio-jetpack-green
+						primaryColor: '069e08',
+					} }
+					prefill={ { email: currentUser?.email, name: currentUser?.display_name } }
+				/>
+			) : (
+				<div>
+					{ /* This is an extreme fallback that should not be user facing, so no translation */ }
+					<p>{ 'No Calendly URL set! Scheduling will not work without URL set in config.' }</p>
+				</div>
+			) }
 		</Main>
 	);
 };

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -11,22 +11,23 @@ import { Card } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import FormButton from 'calypso/components/forms/form-button';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import QueryProducts from 'calypso/components/data/query-products-list';
+import { cleanUrl } from 'calypso/jetpack-connect/utils.js';
 import {
 	isProductsListFetching as getIsProductListFetching,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
-import { cleanUrl } from 'calypso/jetpack-connect/utils.js';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestUpdateJetpackCheckoutSupportTicket } from 'calypso/state/jetpack-checkout/actions';
-import Main from 'calypso/components/main';
+import FormButton from 'calypso/components/forms/form-button';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import getCalendlyUrl from 'calypso/lib/jetpack/get-calendly-url';
 import getJetpackCheckoutSupportTicketStatus from 'calypso/state/selectors/get-jetpack-checkout-support-ticket-status';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryProducts from 'calypso/components/data/query-products-list';
 
 interface Props {
 	productSlug: string | 'no_product';
@@ -42,6 +43,8 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 	const productName = useSelector( ( state ) =>
 		hasProductInfo ? getProductName( state, productSlug ) : null
 	);
+
+	const hasCalendlyURL = getCalendlyUrl() !== null;
 
 	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
 
@@ -192,33 +195,38 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( { productSlug, receiptId 
 						</div>
 					) }
 				</div>
-				<div className="jetpack-checkout-siteless-thank-you__card-footer">
-					<div>
-						<h2>{ translate( 'Do you need help?' ) }</h2>
-						<p>
-							{ translate(
-								'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 minute call now{{/a}}.',
-								{
-									components: {
-										a: (
-											<a
-												className="jetpack-checkout-siteless-thank-you__link"
-												onClick={ () =>
-													dispatch(
-														recordTracksEvent( 'calypso_siteless_checkout_happiness_link_clicked', {
-															product_slug: productSlug,
-														} )
-													)
-												}
-												href={ happinessAppointmentLink }
-											/>
-										),
-									},
-								}
-							) }
-						</p>
+				{ hasCalendlyURL && (
+					<div className="jetpack-checkout-siteless-thank-you__card-footer">
+						<div>
+							<h2>{ translate( 'Do you need help?' ) }</h2>
+							<p>
+								{ translate(
+									'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 minute call now{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													className="jetpack-checkout-siteless-thank-you__link"
+													onClick={ () =>
+														dispatch(
+															recordTracksEvent(
+																'calypso_siteless_checkout_happiness_link_clicked',
+																{
+																	product_slug: productSlug,
+																}
+															)
+														)
+													}
+													href={ happinessAppointmentLink }
+												/>
+											),
+										},
+									}
+								) }
+							</p>
+						</div>
 					</div>
-				</div>
+				) }
 			</Card>
 		</Main>
 	);

--- a/config/development.json
+++ b/config/development.json
@@ -27,6 +27,7 @@
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,6 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"features": {
 		"automated-transfer": true,
 		"async-payments": false,

--- a/config/production.json
+++ b/config/production.json
@@ -15,6 +15,7 @@
 	"rebrand_cities_prefix": "rebrandcitiessite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
+	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"features": {
 		"ad-tracking": true,
 		"async-payments": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -14,6 +14,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move Calendly URL to config
* Add logic to suppress scheduling prompt in the event URL is not set

#### Testing instructions

1. Boot Branch in Calypso Blue
2. Navigate to `/checkout/jetpack/thank-you/no-site/jetpack_backup_daily`, verify the page matches staging.
3. Click the "Schedule call" link in the bottom right.
4. Verify that `/checkout/jetpack/schedule-happiness-appointment` works and matches staging
5. Remove the `calendly_jetpack_appointment_url` config from `development.json` & reboot the branch.
6. Navigate to `/checkout/jetpack/thank-you/no-site/jetpack_backup_daily` and verify the scheduling sidebar has been removed. ![calypso localhost_3000_checkout_jetpack_thank-you_no-site_jetpack_backup_daily_receiptId=59508518](https://user-images.githubusercontent.com/2810519/126696791-ceb8c299-823e-46f9-acbd-33a1052f4091.png)
7. Navigate to `/checkout/jetpack/schedule-happiness-appointment` and verify the error message shows. 
![calypso localhost_3000_checkout_jetpack_schedule-happiness-appointment](https://user-images.githubusercontent.com/2810519/126696915-d1089744-5784-46bc-b4d3-d1a5e9b74384.png)


