### PR TITLE
Siteless Checkout - Limit cart to only one product.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -156,6 +156,7 @@ export default function CompositeCheckout( {
 		createAnalyticsEventHandler( reduxDispatch ),
 		[]
 	);
+	const isJetpackSitelessCheckout = isJetpackCheckout && ! jetpackSiteSlug;
 	const updatedSiteSlug = isJetpackCheckout ? jetpackSiteSlug : siteSlug;
 
 	const showErrorMessage = useCallback(
@@ -231,6 +232,7 @@ export default function CompositeCheckout( {
 		applyCoupon,
 		updateLocation,
 		replaceProductInCart,
+		replaceProductsInCart,
 		isLoading: isLoadingCart,
 		isPendingUpdate: isCartPendingUpdate,
 		responseCart,
@@ -247,11 +249,13 @@ export default function CompositeCheckout( {
 	const isInitialCartLoading = useAddProductsFromUrl( {
 		isLoadingCart,
 		isCartPendingUpdate,
+		isJetpackSitelessCheckout,
 		productsForCart,
 		areCartProductsPreparing,
 		couponCodeFromUrl: couponCodeFromUrl || maybeJetpackIntroCouponCode,
 		applyCoupon,
 		addProductsToCart,
+		replaceProductsInCart,
 	} );
 
 	useRecordCartLoaded( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the siteless checkout flow, the backend does not support checking out with multiple products yet, so therefore we need to only allow one product in the shopping cart.

This PR will limit the cart to only the most recently selected product when going through the siteless checkout flow.

#### Testing instructions

1. Checkout and run this PR
1. Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_scan
1. Verify that **only** "Jetpack Scan" is in the cart.
1. Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_daily
1. Verify that **only** "Jetpack Backup Daily" is in the cart.
1. Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_security_daily
1. Verify that **only** "Jetpack Security Daily" is in the cart.
1. Verify the FRESHPACK coupon stays applied, on each product change.

To see the current unwanted cart behavior, go to the url's above except on wordpress.com instead of your local Calypso dev url. 

Task: 1200479326344990-as-1200631299519219
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->