### PR TITLE
Conditionally set billing subheader for annual and biennial plans

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -19,6 +19,7 @@ import {
 	TYPE_FREE,
 	GROUP_WPCOM,
 	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
 	PLAN_P2_FREE,
 	PLAN_P2_PLUS,
 } from '@automattic/calypso-products';
@@ -248,8 +249,20 @@ export class PlanFeaturesHeader extends Component {
 			return translate( `Save %(discountRate)s%% by paying annually`, { args: { discountRate } } );
 		}
 
-		if ( ( isInSignup || isLoggedInMonthlyPricing ) && ! isMonthlyPlan ) {
+		if (
+			( isInSignup || isLoggedInMonthlyPricing ) &&
+			! isMonthlyPlan &&
+			planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } )
+		) {
 			return translate( 'billed annually' );
+		}
+
+		if (
+			( isInSignup || isLoggedInMonthlyPricing ) &&
+			! isMonthlyPlan &&
+			planMatches( planType, { group: GROUP_WPCOM, term: TERM_BIENNIALLY } )
+		) {
+			return translate( 'billed every two years' );
 		}
 
 		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -450,7 +450,7 @@ $plan-features-sidebar-width: 272px;
 	font-weight: 400;
 	color: var( --color-text-subtle );
 	line-height: normal;
-
+	display: flex;
 	&.is-placeholder {
 		@include placeholder( --color-neutral-10 );
 		width: 140px;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -451,6 +451,7 @@ $plan-features-sidebar-width: 272px;
 	color: var( --color-text-subtle );
 	line-height: normal;
 	display: flex;
+	align-items: baseline;
 	&.is-placeholder {
 		@include placeholder( --color-neutral-10 );
 		width: 140px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The billing subheader was written just for annual plans and is not accurate on biennial plans.

Before, biennial plan showed 'billed annually':
![image](https://user-images.githubusercontent.com/16580129/126716933-699ab4b8-08cc-4c0a-a59c-da84b9fef03d.png)

After, biennial plan correctly shows 'billed every two years':
![image](https://user-images.githubusercontent.com/16580129/126716970-eef35527-e860-4b81-8be8-7bb51d914292.png)


#### Testing instructions

Test the bug:
* Add plan to checkout
* Change to two year plan
* Proceed through checkout
* Go to https://wordpress.com/plans/[site]
* See billing subheader is stating as 'billed annual'

Test the fix:
* Do the above steps with this PR
* Verify that two year plan shows 'billed every two years' in billing subheader

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #54355
