### PR TITLE
chore: migrate `packages/photon` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -207,6 +207,7 @@ module.exports = {
 				'packages/language-picker/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
+				'packages/photon/**/*',
 				'packages/plans-grid/**/*',
 				'packages/shopping-cart/**/*',
 				'packages/spec-junit-reporter/**/*',

--- a/packages/photon/src/index.js
+++ b/packages/photon/src/index.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
 import crc32 from 'crc32';
-import seed from 'seed-random';
 import debugFactory from 'debug';
+import seed from 'seed-random';
 
 const debug = debugFactory( 'photon' );
 

--- a/packages/photon/test/index.js
+++ b/packages/photon/test/index.js
@@ -1,8 +1,5 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectHostedOnPhoton", "expectHostedOnPhotonInsecurely", "expectPathname", "expectQuery", "expect"] }] */
 
-/**
- * Internal dependencies
- */
 import photon from '../src';
 
 function expectHostedOnPhoton( url ) {

--- a/packages/photon/tsconfig.json
+++ b/packages/photon/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/photon` to use `import/order`

#### Testing instructions

N/A
