### PR TITLE
chore: migrate `packages/wpcom-proxy-request` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -216,6 +216,7 @@ module.exports = {
 				'packages/webpack-config-flag-plugin/**/*',
 				'packages/whats-new/**/*',
 				'packages/wpcom-checkout/**/*',
+				'packages/wpcom-proxy-request/**/*',
 				'test/client/**/*',
 				'test/e2e/**/*',
 				'test/server/**/*',

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
+import debugFactory from 'debug';
+import ProgressEvent from 'progress-event';
 import { v4 as uuidv4 } from 'uuid';
 import WPError from 'wp-error';
-import ProgressEvent from 'progress-event';
-import debugFactory from 'debug';
 
 /**
  * debug instance

--- a/packages/wpcom-proxy-request/test/index.js
+++ b/packages/wpcom-proxy-request/test/index.js
@@ -1,13 +1,6 @@
 /* eslint-disable no-console */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import proxy, { reloadProxy } from '../';
 
 /**

--- a/packages/wpcom-proxy-request/tsconfig.json
+++ b/packages/wpcom-proxy-request/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/wpcom-proxy-request` to use `import/order`

#### Testing instructions

N/A
