### PR TITLE
chore: migrate `packages/languages` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -205,6 +205,7 @@ module.exports = {
 				'packages/format-currency/**/*',
 				'packages/js-utils/**/*',
 				'packages/language-picker/**/*',
+				'packages/languages/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
 				'packages/plans-grid/**/*',

--- a/packages/languages/bin/download.js
+++ b/packages/languages/bin/download.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-const https = require( 'https' );
 const fs = require( 'fs' );
+const https = require( 'https' );
 const path = require( 'path' );
 
 const LANGUAGES_META_URL = 'https://widgets.wp.com/languages/calypso/languages-meta.json';

--- a/packages/languages/src/index.ts
+++ b/packages/languages/src/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import data from './languages-meta.json';
 
 type LanguageSlug = string;

--- a/packages/languages/test/index.js
+++ b/packages/languages/test/index.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import languages from '../src';
 
 describe( 'languages', () => {

--- a/packages/languages/tsconfig.json
+++ b/packages/languages/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",
-		"rootDir": "src",
+		"rootDir": "src"
 	},
 	"include": [ "src", "src/*.json" ]
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/languages` to use `import/order`

#### Testing instructions

N/A
