### PR TITLE
chore: migrate `packages/eslint-plugin-wpcalypso` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,6 +202,7 @@ module.exports = {
 				'packages/create-calypso-config/**/*',
 				'packages/data-stores/**/*',
 				'packages/domain-picker/**/*',
+				'packages/eslint-plugin-wpcalypso/**/*',
 				'packages/format-currency/**/*',
 				'packages/js-utils/**/*',
 				'packages/language-picker/**/*',

--- a/packages/eslint-plugin-wpcalypso/lib/configs/index.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/index.js
@@ -1,5 +1,5 @@
-const configRecommended = require( './recommended' );
 const configReact = require( './react' );
+const configRecommended = require( './recommended' );
 
 module.exports = {
 	recommended: configRecommended,

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-classname-namespace.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-classname-namespace.js
@@ -9,9 +9,9 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require( '../jsx-classname-namespace' );
-const formatMessage = require( '../../../test-utils/format-message' );
 const { RuleTester } = require( 'eslint' );
+const formatMessage = require( '../../../test-utils/format-message' );
+const rule = require( '../jsx-classname-namespace' );
 
 //------------------------------------------------------------------------------
 // Constants

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-unsafe-wp-apis.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { RuleTester } from 'eslint';
-
-/**
- * Internal dependencies
- */
 import rule from '../no-unsafe-wp-apis';
 
 const ruleTester = new RuleTester( {

--- a/packages/eslint-plugin-wpcalypso/lib/util/test/get-i18n-string-from-node.js
+++ b/packages/eslint-plugin-wpcalypso/lib/util/test/get-i18n-string-from-node.js
@@ -6,8 +6,8 @@
  */
 
 const assert = require( 'assert' );
-const getTextContentFromNode = require( '../../../lib/util/get-text-content-from-node.js' );
 const parser = require( '@babel/eslint-parser' );
+const getTextContentFromNode = require( '../../../lib/util/get-text-content-from-node.js' );
 
 function parseCode( code ) {
 	const programNode = parser.parse( code, {

--- a/packages/eslint-plugin-wpcalypso/tsconfig.json
+++ b/packages/eslint-plugin-wpcalypso/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/eslint-plugin-wpcalypso` to use `import/order`

#### Testing instructions

N/A
