### PR TITLE
chore: migrate `client/incoming-redirect` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -179,6 +179,7 @@ module.exports = {
 			files: [
 				'apps/editing-toolkit/**/*',
 				'client/auth/**/*',
+				'client/incoming-redirect/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/sections-filter.js',
 				'client/sections-helper.js',

--- a/client/incoming-redirect/controller.js
+++ b/client/incoming-redirect/controller.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import TitanRedirector from 'calypso/my-sites/email/titan-redirector';
+import React from 'react';
 import EmptyContent from 'calypso/components/empty-content';
+import TitanRedirector from 'calypso/my-sites/email/titan-redirector';
 
 export default {
 	emailTitanAddMailboxes( pageContext, next ) {

--- a/client/incoming-redirect/index.js
+++ b/client/incoming-redirect/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import controller from './controller';
 import * as paths from './paths';
-import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page(


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/incoming-redirect` to use `import/order`

#### Testing instructions

N/A