### PR TITLE
Enable checkoutBackUrl from jetpack.com

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -421,8 +421,14 @@ export function redirectToSiteLessCheckout( context, next ) {
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 
+	const urlQueryArgs = context.query;
+
 	if ( config.isEnabled( 'jetpack/siteless-checkout' ) ) {
-		page( addQueryArgs( context.query, `/checkout/jetpack/${ planSlug }` ) );
+		if ( ! urlQueryArgs?.checkoutBackUrl ) {
+			urlQueryArgs.checkoutBackUrl = 'https://jetpack.com';
+		}
+
+		page( addQueryArgs( urlQueryArgs, `/checkout/jetpack/${ planSlug }` ) );
 		return;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -18,7 +18,12 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 			return undefined;
 		}
 
-		const allowedHosts = [ 'jetpack.cloud.localhost', 'cloud.jetpack.com', siteSlug ];
+		const allowedHosts = [
+			'jetpack.com',
+			'jetpack.cloud.localhost',
+			'cloud.jetpack.com',
+			siteSlug,
+		];
 
 		let parsedUrl;
 		try {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For the Simple Checkout on Jetpack.com project, this PR allows the redirect back to Jetpack.com when closing the siteless checkout window. (see screencast below)

Related to: 1200479326344990-as-1200641986671529

#### Testing instructions

1.  Login to your sandbox. `cd public_html/wp-content/themes/a8c`. Apply patch D64569-code
1. Sandbox `jetpack.com` and `jetpackme.wordpress.com`
1. From `chrome://net-internals/#hsts` do “Delete domain security policies” for `jetpack.com`. (Im not actually certain this is necessary, but I read about it here: p6TEKc-4EZ-p2)
1. Open jetpack.com in chrome.  You will get a http untrusted page.  Type: `thisisunsafe` and press enter.  Jetpack.com sandboxed should now open.
1. Checkout and run this PR (`git checkout add/checkout-backurl-jetpack-com && yarn start`)
1. Go to jetpack.com, select any product page, and select the CTA to get the product.
1. Verify you are redirected to `wordpress.com/checkout/jetpack/:product` and verify there is a `checkoutBackUrl` query arg in the url.
1. In the url, replace `https://wordpress.com` with `https://calypso.localhost:3000` and press enter to reload the page in your local dev environment.
1. Click the X in the upper left corner of the checkout window and verify you are redirected back to the jetpack.com page you initially came from.

#### Screencast

https://user-images.githubusercontent.com/11078128/126774909-fa52b3bf-ec01-4544-aa83-3db661d74633.mov


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->