### PR TITLE
Popover: prevent scroll when focusing on a popover

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -109,7 +109,7 @@ class PopoverMenu extends Component {
 		this._previouslyFocusedElement = document.activeElement;
 
 		if ( elementToFocus ) {
-			elementToFocus.focus();
+			elementToFocus.focus( { preventScroll: true } );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes an issue introduced in #54682 where scrolling down a page and opening a popover would cause the screen to jump back to the top of the viewport. Adding optional parameter `preventScroll` to the `focus()` method seems to prevent this, although I don't know if it affects a11y.

**Before**

![2021-07-23 10 36 08](https://user-images.githubusercontent.com/2124984/126798228-c0d49e87-1535-4155-86de-197ed3f3d1c7.gif)

**After**

![2021-07-23 10 35 00](https://user-images.githubusercontent.com/2124984/126798182-126f08e4-2c80-424c-9b5d-a67768563eb2.gif)

#### Testing instructions

* Switch to this PR, navigate to a longer page with a Popover component - like the theme showcase at `/themes` or a site with lots of `/posts`
* Scroll down the page and click on a popover
* The screen should remain in place
* All popover menu items should still be accessible
* The menu should also be accessible via keyboard

Related to #54803
