### PR TITLE
Layout: use the `--masterbar-height` variable to determine top padding (+1px)

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -50,7 +50,7 @@
 	// displays at full height.
 	.is-section-preview & {
 		height: 100%;
-		padding: 47px 0 0 calc( var( --sidebar-width-max ) + 1px );
+		padding: calc( var( --masterbar-height ) + 1px ) 0 0 calc( var( --sidebar-width-max ) + 1px );
 	}
 
 	// Tablets
@@ -68,7 +68,7 @@
 		}
 
 		.is-section-preview & {
-			padding: 47px 0 0 ( 228px + 1px );
+			padding: calc( var( --masterbar-height ) + 1px ) 0 0 ( 228px + 1px );
 		}
 	}
 
@@ -76,14 +76,14 @@
 	@include breakpoint-deprecated( '<660px' ) {
 		margin-left: 0;
 		padding: 0;
-		padding-top: 47px;
+		padding-top: calc( var( --masterbar-height ) + 1px );
 
 		.has-no-sidebar & {
 			padding-left: 0;
 		}
 
 		.is-section-preview & {
-			padding: 47px 0 0;
+			padding: calc( var( --masterbar-height ) + 1px ) 0 0;
 		}
 	}
 }


### PR DESCRIPTION
I noticed that the layout content's top padding was off while using the site preview. This updates it to use the `--masterbar-height` variable.

Before: | After:
------------ | -------------
<img width="1507" alt="before" src="https://user-images.githubusercontent.com/942359/126804391-f0ec92d7-f594-490c-a768-2c56e2999d58.png"> | <img width="1507" alt="after" src="https://user-images.githubusercontent.com/942359/126804404-135a629d-d589-44e9-be37-c4382bad6ef0.png">
(red background added for effect)

**To test:**
- on desktop, visit a full-page Calypso component (like the site preview at `/view/{site}`)
- verify that the preview takes up the full content area
- verify that mobile breakpoint views are unchanged
- visit an non-full-page Calypso screen
- verify that visually the content area is unchanged