### PR TITLE
Playwright: migrate `notifications` spec.

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -38,6 +38,16 @@ export function getCalypsoURL(
 }
 
 /**
+ * Wrapper around the `config.get` call.
+ *
+ * @param {string} key Top level key in the decrypted configuration file to get.
+ * @returns {[key: string]: any|string|null} Either a JSON dictionary or string matching the key if the key exists. Returns null otherwise.
+ */
+export function getConfig( key: string ): { [ key: string ]: any } | string | null {
+	return config.get( key );
+}
+
+/**
  * Returns the credential for a specified account from the secrets file.
  *
  * @param {string} accountType Type of the account for which the credentials are to be obtained.

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -2,6 +2,8 @@ import phrase from 'asana-phrase';
 import config from 'config';
 import { getViewportName } from './browser-helper';
 
+export { config };
+
 /**
  * Generate a pseudo-random integer, inclusive on the lower bound and exclusive on the upper bound.
  *
@@ -35,16 +37,6 @@ export function getCalypsoURL(
 	);
 
 	return url.toString();
-}
-
-/**
- * Wrapper around the `config.get` call.
- *
- * @param {string} key Top level key in the decrypted configuration file to get.
- * @returns {[key: string]: any|string|null} Either a JSON dictionary or string matching the key if the key exists. Returns null otherwise.
- */
-export function getConfig( key: string ): { [ key: string ]: any } | string | null {
-	return config.get( key );
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -31,9 +31,14 @@ export class CommentsComponent extends BaseContainer {
 		await this.page.waitForLoadState( 'networkidle' );
 		// To simulate user action first click on the field. This also exposes the
 		// submit comment button.
+		// const commentArea = await this.page.waitForSelector( selectors.commentTextArea)
+		// await commentArea.waitForElementState('stable');
 		await this.page.click( selectors.commentTextArea );
 		await this.page.fill( selectors.commentTextArea, comment );
-		await this.page.click( selectors.submitButton );
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.click( selectors.submitButton ),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -26,13 +26,16 @@ export class CommentsComponent extends BaseContainer {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async postComment( comment: string ): Promise< void > {
-		// Wait for the page to fully load. Otherwise, the Post Comment button may not
+		// Wait for all network connections to complete. Otherwise, the Post Comment button may not
 		// appear even if the text area is clicked on.
 		await this.page.waitForLoadState( 'networkidle' );
-		// To simulate user action first click on the field. This also exposes the
-		// submit comment button.
+		// Wait until the comment text area is fully stable on the page.
+		// This is to guard against long-loading pages (eg. notifications test) where all network
+		// requests may have completed but the page remains in a loading state.
 		const commentArea = await this.page.waitForSelector( selectors.commentTextArea );
 		await commentArea.waitForElementState( 'stable' );
+		// To simulate user action first click on the field. This also exposes the
+		// submit comment button.
 		await this.page.click( selectors.commentTextArea );
 		await this.page.fill( selectors.commentTextArea, comment );
 		await Promise.all( [

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -31,8 +31,8 @@ export class CommentsComponent extends BaseContainer {
 		await this.page.waitForLoadState( 'networkidle' );
 		// To simulate user action first click on the field. This also exposes the
 		// submit comment button.
-		// const commentArea = await this.page.waitForSelector( selectors.commentTextArea)
-		// await commentArea.waitForElementState('stable');
+		const commentArea = await this.page.waitForSelector( selectors.commentTextArea );
+		await commentArea.waitForElementState( 'stable' );
 		await this.page.click( selectors.commentTextArea );
 		await this.page.fill( selectors.commentTextArea, comment );
 		await Promise.all( [

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -4,3 +4,4 @@ export * from './sidebar-component';
 export * from './support-component';
 export * from './support-article-component';
 export * from './preview-component';
+export * from './notifications-component';

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -44,8 +44,11 @@ export class NavbarComponent extends BaseContainer {
 	async openNotificationsPanel( {
 		keyboard = false,
 	}: { keyboard?: boolean } = {} ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
-		await this.page.waitForSelector( selectors.notificationsButton );
+		await Promise.all( [
+			this.page.waitForURL( '**/home/**' ),
+			this.page.waitForLoadState( 'networkidle' ),
+		] );
+		await this.page.waitForSelector( selectors.notificationsButton, { state: 'visible' } );
 		if ( keyboard ) {
 			return await this.page.keyboard.press( 'n' );
 		}

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -38,12 +38,12 @@ export class NavbarComponent extends BaseContainer {
 	 * Optionally, set the `keyboard` parameter to trigger this action using keyboard shortcut.
 	 *
 	 * @param {{[key: string]: string}} [param0] Object assembled by the caller.
-	 * @param {string} param0.keyboard Set to true to use keyboard shortcut to open the notifications panel. Defaults to false.
+	 * @param {string} param0.useKeyboard Set to true to use keyboard shortcut to open the notifications panel. Defaults to false.
 	 * @returns {Promise<void>} No return value.
 	 */
 	async openNotificationsPanel( {
-		keyboard = false,
-	}: { keyboard?: boolean } = {} ): Promise< void > {
+		useKeyboard = false,
+	}: { useKeyboard?: boolean } = {} ): Promise< void > {
 		const notificationsButton = await this.page.waitForSelector( selectors.notificationsButton, {
 			state: 'visible',
 		} );
@@ -51,7 +51,7 @@ export class NavbarComponent extends BaseContainer {
 			this.page.waitForLoadState( 'networkidle' ),
 			notificationsButton.waitForElementState( 'stable' ),
 		] );
-		if ( keyboard ) {
+		if ( useKeyboard ) {
 			return await this.page.keyboard.type( 'n' );
 		}
 

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -3,6 +3,10 @@ import { BaseContainer } from '../base-container';
 const selectors = {
 	mySiteButton: 'text=My Site',
 	writeButton: '*css=a >> text=Write',
+	notificationsButton: 'a[href="/notifications"]',
+
+	// Notification pane
+	notificationsPane: '#wpnc-panel',
 };
 /**
  * Component representing the navbar/masterbar at top of WPCOM.
@@ -26,5 +30,25 @@ export class NavbarComponent extends BaseContainer {
 	 */
 	async clickMySites(): Promise< void > {
 		await this.page.click( selectors.mySiteButton );
+	}
+
+	/**
+	 * Opens the notification panel.
+	 *
+	 * Optionally, set the `keyboard` parameter to trigger this action using keyboard shortcut.
+	 *
+	 * @param {{[key: string]: string}} [param0] Object assembled by the caller.
+	 * @param {string} param0.keyboard Set to true to use keyboard shortcut to open the notifications panel. Defaults to false.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async openNotificationsPanel( {
+		keyboard = false,
+	}: { keyboard?: boolean } = {} ): Promise< void > {
+		await this.page.waitForSelector( selectors.notificationsButton );
+		if ( keyboard ) {
+			return await this.page.keyboard.press( 'n' );
+		}
+
+		await this.page.click( selectors.notificationsButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -44,6 +44,7 @@ export class NavbarComponent extends BaseContainer {
 	async openNotificationsPanel( {
 		keyboard = false,
 	}: { keyboard?: boolean } = {} ): Promise< void > {
+		await this.page.waitForLoadState( 'networkidle' );
 		await this.page.waitForSelector( selectors.notificationsButton );
 		if ( keyboard ) {
 			return await this.page.keyboard.press( 'n' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -44,13 +44,15 @@ export class NavbarComponent extends BaseContainer {
 	async openNotificationsPanel( {
 		keyboard = false,
 	}: { keyboard?: boolean } = {} ): Promise< void > {
+		const notificationsButton = await this.page.waitForSelector( selectors.notificationsButton, {
+			state: 'visible',
+		} );
 		await Promise.all( [
-			this.page.waitForURL( '**/home/**' ),
 			this.page.waitForLoadState( 'networkidle' ),
+			notificationsButton.waitForElementState( 'stable' ),
 		] );
-		await this.page.waitForSelector( selectors.notificationsButton, { state: 'visible' } );
 		if ( keyboard ) {
-			return await this.page.keyboard.press( 'n' );
+			return await this.page.keyboard.type( 'n' );
 		}
 
 		await this.page.click( selectors.notificationsButton );

--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -1,0 +1,54 @@
+import { ElementHandle } from 'playwright';
+import { BaseContainer } from '../base-container';
+
+const selectors = {
+	comment: '.wpnc__comment',
+	singleViewPanel: '.wpnc__single-view',
+};
+/**
+ * Component representing the notifications panel and notifications themselves.
+ *
+ * @augments {BaseContainer}
+ */
+export class NotificationsComponent extends BaseContainer {
+	/**
+	 * Locates and returns an ElementHandle to the notification.
+	 *
+	 * @param {string} text Text by which the notification should be located.
+	 * @returns {Promise<ElementHandle} Reference to the notification element.
+	 */
+	async getNotification( text: string ): Promise< ElementHandle > {
+		// Currently, only text selector is supported, but eventually it may make sense
+		// to implement a numerical selector as well.
+		const selector = `*css=${ selectors.comment } >> text=${ text }`;
+		return await this.page.waitForSelector( selector );
+	}
+
+	/**
+	 * Given a string of text, locate and click on the notification containing the text.
+	 *
+	 * @param {string} text Text contained in the notification.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async clickNotification( text: string ): Promise< void > {
+		const notification = await this.getNotification( text );
+		await notification.click();
+	}
+
+	/**
+	 * Given a string of text, click on the button in expanded single notification view to execute the action.
+	 *
+	 * eg. 'Trash' -> Clicks on the 'Trash' button when viewing a single notification.
+	 *
+	 * @param {string} action Predefined list of strings that are accepted.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async clickNotificationAction( action: 'Trash' ): Promise< void > {
+		const selector = `*css=button >> text=${ action }`;
+		await this.page.click( selector );
+
+		if ( action === 'Trash' ) {
+			await this.page.waitForSelector( ':text("Comment trashed")', { state: 'hidden' } );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/flows/login-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/login-flow.ts
@@ -56,11 +56,7 @@ export class LoginFlow {
 	 */
 	async logIn(): Promise< void > {
 		await this.page.goto( getCalypsoURL( 'log-in' ) );
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.waitForURL( '**/home/**' ),
-			this.baseflow(),
-		] );
+		await Promise.all( [ this.page.waitForNavigation(), this.baseflow() ] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/login-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/login-flow.ts
@@ -56,7 +56,11 @@ export class LoginFlow {
 	 */
 	async logIn(): Promise< void > {
 		await this.page.goto( getCalypsoURL( 'log-in' ) );
-		await Promise.all( [ this.page.waitForNavigation(), this.baseflow() ] );
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.waitForURL( '**/home/**' ),
+			this.baseflow(),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/login-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/login-flow.ts
@@ -56,7 +56,7 @@ export class LoginFlow {
 	 */
 	async logIn(): Promise< void > {
 		await this.page.goto( getCalypsoURL( 'log-in' ) );
-		await this.baseflow();
+		await Promise.all( [ this.page.waitForNavigation(), this.baseflow() ] );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -1,0 +1,67 @@
+import {
+	setupHooks,
+	BrowserManager,
+	DataHelper,
+	LoginFlow,
+	PublishedPostsListPage,
+	CommentsComponent,
+	NavbarComponent,
+	NotificationsComponent,
+} from '@automattic/calypso-e2e';
+
+describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
+	let page;
+	let publishedPostsListPage;
+	let notificationsComponent;
+
+	const commentingUser = 'commentingUser';
+	const notificationsUser = 'notificationsUser';
+	const comment = DataHelper.randomPhrase() + ' TBD';
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( `Log in as ${ commentingUser }`, async function () {
+		const loginFlow = new LoginFlow( page, commentingUser );
+		await loginFlow.logIn();
+	} );
+
+	it( 'View site', async function () {
+		const siteURL = `https://${ DataHelper.getConfig( 'testSiteForNotifications' ) }`;
+		await page.goto( siteURL );
+		publishedPostsListPage = await PublishedPostsListPage.Expect( page );
+	} );
+
+	it( 'View first post', async function () {
+		publishedPostsListPage.visitPost( 1 );
+	} );
+
+	it( 'Comment on the post', async function () {
+		const commentsComponent = await CommentsComponent.Expect( page );
+		await commentsComponent.postComment( comment );
+	} );
+
+	it( 'Clear cookies', async function () {
+		await BrowserManager.clearCookies( page );
+	} );
+
+	it( `Log in as ${ notificationsUser }`, async function () {
+		const loginFlow = new LoginFlow( page, notificationsUser );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Open notification using keyboard shortcut', async function () {
+		const navbarComponent = await NavbarComponent.Expect( page );
+		await navbarComponent.openNotificationsPanel( { keyboard: true } );
+		notificationsComponent = await NotificationsComponent.Expect( page );
+	} );
+
+	it( `See notification for the comment left by ${ commentingUser }`, async function () {
+		await notificationsComponent.clickNotification( comment );
+	} );
+
+	it( 'Delete comment from notification', async function () {
+		await notificationsComponent.clickNotificationAction( 'Trash' );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -54,10 +54,10 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	it( 'Open notification using keyboard shortcut', async function () {
 		const navbarComponent = await NavbarComponent.Expect( page );
 		await navbarComponent.openNotificationsPanel( { keyboard: true } );
-		notificationsComponent = await NotificationsComponent.Expect( page );
 	} );
 
 	it( `See notification for the comment left by ${ commentingUser }`, async function () {
+		notificationsComponent = await NotificationsComponent.Expect( page );
 		await notificationsComponent.clickNotification( comment );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -44,7 +44,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	} );
 
 	it( 'Clear cookies', async function () {
-		await BrowserManager.clearCookies( page );
+		await BrowserManager.clearAuthenticationState( page );
 	} );
 
 	it( `Log in as ${ notificationsUser }`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -29,7 +29,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	} );
 
 	it( 'View site', async function () {
-		const siteURL = `https://${ DataHelper.getConfig( 'testSiteForNotifications' ) }`;
+		const siteURL = `https://${ DataHelper.config.get( 'testSiteForNotifications' ) }`;
 		await page.goto( siteURL );
 		publishedPostsListPage = await PublishedPostsListPage.Expect( page );
 	} );
@@ -54,7 +54,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 
 	it( 'Open notification using keyboard shortcut', async function () {
 		const navbarComponent = await NavbarComponent.Expect( page );
-		await navbarComponent.openNotificationsPanel( { keyboard: true } );
+		await navbarComponent.openNotificationsPanel( { useKeyboard: true } );
 	} );
 
 	it( `See notification for the comment left by ${ commentingUser }`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -25,6 +25,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	it( `Log in as ${ commentingUser }`, async function () {
 		const loginFlow = new LoginFlow( page, commentingUser );
 		await loginFlow.logIn();
+		await page.waitForURL( '**/read' );
 	} );
 
 	it( 'View site', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to migrate the `notifications` spec.

Key changes:
- `wp-notifications-spec` migrated entirely to run under Playwright.
- additional reliability changes to `CommentsComponent` and `LoginFlow`.
- new method and objects to interact with notifications components.

Background Details:

The `notifications` spec is relatively straightforward, but the site/post used for this test revealed some problems with the way the `calypso-e2e` page objects were implemented.

For instance, `CommentsComponent.postComment` failed to reliably post comments against the test post used for notifications. This was due to the sheer number of comments on the post making the page quite heavy in loading terms; the browser would be less responsive, stuttering and pausing while the comments were loading. 

During the above, the load state events continue to fire prior to the page being fully ready - `domcontentloaded` and `load` fire quite soon after one another, and `networkidle` fires within 1s of the previous events. This means that from Playwright's perspective, the page is fully loaded and ready to interact; this is where problems begin.

The comment text area does not behave predictably if the page has not fully loaded and scripts executed. Clicking on the comment text area _should_ reveal the `Post Comment` button. For long-loading pages like the notifications test post, this behavior cannot be guaranteed.

The workaround is to ensure the stability of the comment text area's place in the DOM by waiting for the element state to be `stable`. 

#### Testing instructions

- [ ] no failures on TeamCity for notifications spec.


