### PR TITLE
Jetpack site-less Checkout: add link to schedule a call

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -39,7 +39,7 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } 
 
 	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
 
-	const contactSupportLink = 'https://wordpress.com/help/contact';
+	const happinessAppointmentLink = '/checkout/jetpack/schedule-happiness-appointment';
 
 	return (
 		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">
@@ -70,26 +70,26 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } 
 						) }
 					</p>
 					<p>
-						{ translate( '{{a}}Contact us{{/a}} at any time if you need assistance with Jetpack.', {
-							components: {
-								a: (
-									<a
-										className="jetpack-checkout-siteless-thank-you-completed__link"
-										onClick={ () =>
-											dispatch(
-												recordTracksEvent(
-													'calypso_siteless_checkout_completed_support_link_clicked',
-													{
+						{ translate(
+							'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 minute call now{{/a}}.',
+							{
+								components: {
+									a: (
+										<a
+											className="jetpack-checkout-siteless-thank-you-completed__link"
+											onClick={ () =>
+												dispatch(
+													recordTracksEvent( 'calypso_siteless_checkout_happiness_link_clicked', {
 														product_slug: productSlug,
-													}
+													} )
 												)
-											)
-										}
-										href={ contactSupportLink }
-									/>
-								),
-							},
-						} ) }
+											}
+											href={ happinessAppointmentLink }
+										/>
+									),
+								},
+							}
+						) }
 					</p>
 				</div>
 			</Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a link to schedule a call to the page that comes right after a user has submitted a URL.

#### Testing instructions

* Download this PR.
* Complete a site-less purchase.
* Submit a URL.
* Make sure you see a link to schedule a call.
* Click on the link.
* Verify that you're redirected to the Calendly page.

Related to 1200479326344990-as-1200641986671520

#### Demo

https://user-images.githubusercontent.com/3418513/126813712-9343103f-a8af-4744-8b2e-bf43355a05da.mp4

