### PR TITLE
[GH tracking issue template] Add link to create a new tracking issue in the task

### DIFF
--- a/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
+++ b/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
@@ -38,7 +38,7 @@ As you complete the tasks in this list, please update the relevant lines with di
     - [ ] P2: wpcomhappy
  - [ ] Clean up unused releases
  - [ ] Add log entry to the Gutenberg Upgrade Log (######-p2)
- - [ ] Open a new issue for the next upgrade, transfer remaining tasks, close this issue.
+ - [ ] [Open a new issue](https://github.com/Automattic/wp-calypso/issues/new?assignees=&labels=gutenberg-upgrade%2C+%5BType%5D+Task&template=gutenberg-plugin-upgrade.md&title=Gutenberg%3A+%5Bv%23.%23.%23%5D+plugin+upgrade) for the next upgrade, transfer remaining tasks, close this issue.
 
  ### Blockers 🤷‍♀️
 


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/54819.

Add a convenience link to create a new tracking issue using the template in the corresponding task.

### How to test
1. [View](https://github.com/Automattic/wp-calypso/blob/601a63579028db9728c3788528cf3e40234fd7c4/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md) the modified .md file in Github;
2. Click the `Open a new issue` link and verify that it correctly creates a new issue with the right template.