### PR TITLE
Jetpack site-less Checkout: hide references to `siteless.jetpack.com` domain from Purchases section

### DIFF
--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -17,10 +17,19 @@ import {
 	isPlan,
 	isTheme,
 } from '@automattic/calypso-products';
+import { isJetpackTemporarySitePurchase } from '../utils';
 
 export function cancellationEffectHeadline( purchase, translate ) {
 	const { domain } = purchase;
 	const purchaseName = getName( purchase );
+
+	if ( isJetpackTemporarySitePurchase( purchase.domain ) ) {
+		return translate( 'Are you sure you want to cancel and remove %(purchaseName)s? ', {
+			args: {
+				purchaseName,
+			},
+		} );
+	}
 
 	if ( isRefundable( purchase ) ) {
 		return translate(

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -43,6 +43,7 @@ import {
 	canEditPaymentDetails,
 	getAddNewPaymentMethodPath,
 	getChangePaymentMethodPath,
+	isJetpackTemporarySitePurchase,
 } from '../utils';
 import {
 	getByPurchaseId,
@@ -132,6 +133,7 @@ class ManagePurchase extends Component {
 		hasLoadedPurchasesFromServer: PropTypes.bool.isRequired,
 		hasNonPrimaryDomainsFlag: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
+		isJetpackTemporarySite: PropTypes.bool,
 		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		purchase: PropTypes.object,
 		purchaseAttachedTo: PropTypes.object,
@@ -713,6 +715,7 @@ class ManagePurchase extends Component {
 		const {
 			purchase,
 			translate,
+			isJetpackTemporarySite,
 			isProductOwner,
 			getManagePurchaseUrlFor,
 			siteSlug,
@@ -793,7 +796,10 @@ class ManagePurchase extends Component {
 					! preventRenewal &&
 					renderMonthlyRenewalOption &&
 					this.renderRenewMonthlyNavItem() }
-				{ isProductOwner && ! preventRenewal && this.renderUpgradeNavItem() }
+				{ isProductOwner &&
+					! preventRenewal &&
+					! isJetpackTemporarySite &&
+					this.renderUpgradeNavItem() }
 				{ isProductOwner && this.renderEditPaymentMethodNavItem() }
 				{ isProductOwner && this.renderCancelPurchaseNavItem() }
 				{ isProductOwner && this.renderRemovePurchaseNavItem() }
@@ -938,5 +944,6 @@ export default connect( ( state, props ) => {
 		userId,
 		relatedMonthlyPlanSlug,
 		relatedMonthlyPlanPrice,
+		isJetpackTemporarySite: purchase && isJetpackTemporarySitePurchase( purchase.domain ),
 	};
 } )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -801,8 +801,8 @@ class ManagePurchase extends Component {
 					! isJetpackTemporarySite &&
 					this.renderUpgradeNavItem() }
 				{ isProductOwner && this.renderEditPaymentMethodNavItem() }
-				{ isProductOwner && this.renderCancelPurchaseNavItem() }
-				{ isProductOwner && this.renderRemovePurchaseNavItem() }
+				{ isProductOwner && ! isJetpackTemporarySite && this.renderCancelPurchaseNavItem() }
+				{ isProductOwner && ! isJetpackTemporarySite && this.renderRemovePurchaseNavItem() }
 			</Fragment>
 		);
 	}

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -25,6 +24,7 @@ import {
 } from 'calypso/lib/purchases';
 import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isJetpackTemporarySitePurchase } from '../../utils';
 
 export class PlanBillingPeriod extends Component {
 	static propTypes = {
@@ -95,6 +95,8 @@ export class PlanBillingPeriod extends Component {
 			return;
 		}
 
+		const isJetpackTemporarySite = isJetpackTemporarySitePurchase( purchase.domain );
+
 		return (
 			<React.Fragment>
 				<FormSettingExplanation>
@@ -105,7 +107,7 @@ export class PlanBillingPeriod extends Component {
 						</Button>
 					) }
 				</FormSettingExplanation>
-				{ ! site && (
+				{ ! site && ! isJetpackTemporarySite && (
 					<FormSettingExplanation>
 						{ translate(
 							'To manage your plan, please {{supportPageLink}}reconnect{{/supportPageLink}} your site.',

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -33,7 +33,7 @@ import AutoRenewToggle from './auto-renew-toggle';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import UserItem from 'calypso/components/user';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { canEditPaymentDetails } from '../utils';
+import { canEditPaymentDetails, isJetpackTemporarySitePurchase } from '../utils';
 import {
 	getPlan,
 	TERM_BIENNIALLY,
@@ -324,6 +324,10 @@ function RenewErrorMessage( { purchase, translate, site } ) {
 	}
 
 	const isJetpack = purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
+
+	if ( isJetpackTemporarySitePurchase( purchase.domain ) ) {
+		return null;
+	}
 
 	if ( isJetpack ) {
 		return (

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -448,6 +448,7 @@ PurchaseItem.propTypes = {
 	getManagePurchaseUrlFor: PropTypes.func,
 	isDisconnectedSite: PropTypes.bool,
 	isJetpack: PropTypes.bool,
+	isJetpackTemporarySite: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	purchase: PropTypes.object,
 	showSite: PropTypes.bool,

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -78,7 +78,7 @@ class PurchaseItem extends Component {
 		if ( isDisconnectedSite ) {
 			if ( isJetpackTemporarySite ) {
 				return (
-					<span className="purchase-item__is-error">{ translate( 'Waiting for site URL' ) }</span>
+					<span className="purchase-item__is-error">{ translate( 'Awaiting site URL' ) }</span>
 				);
 			}
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -55,7 +55,16 @@ class PurchaseItem extends Component {
 	}
 
 	getStatus() {
-		const { purchase, translate, locale, moment, name, isJetpack, isDisconnectedSite } = this.props;
+		const {
+			purchase,
+			translate,
+			locale,
+			moment,
+			name,
+			isJetpack,
+			isJetpackTemporarySite,
+			isDisconnectedSite,
+		} = this.props;
 		const expiry = moment( purchase.expiryDate );
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
@@ -67,6 +76,12 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isDisconnectedSite ) {
+			if ( isJetpackTemporarySite ) {
+				return (
+					<span className="purchase-item__is-error">{ translate( 'Waiting for site URL' ) }</span>
+				);
+			}
+
 			if ( isJetpack ) {
 				return (
 					<span className="purchase-item__is-error">
@@ -258,9 +273,20 @@ class PurchaseItem extends Component {
 	}
 
 	getPurchaseType() {
-		const { purchase, site, translate, slug, showSite, isDisconnectedSite } = this.props;
-		const productType = purchaseType( purchase );
+		const {
+			purchase,
+			site,
+			translate,
+			slug,
+			showSite,
+			isDisconnectedSite,
+			isJetpackTemporarySite,
+		} = this.props;
+		if ( isJetpackTemporarySite ) {
+			return null;
+		}
 
+		const productType = purchaseType( purchase );
 		if ( showSite && site ) {
 			if ( productType ) {
 				return translate( '%(purchaseType)s for {{button}}%(site)s{{/button}}', {

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -15,6 +14,7 @@ import { getSite } from 'calypso/state/sites/selectors';
 import QuerySites from 'calypso/components/data/query-sites';
 import Site from 'calypso/blocks/site';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import { isJetpackTemporarySitePurchase } from '../utils';
 
 /**
  * Style dependencies
@@ -23,6 +23,7 @@ import './header.scss';
 
 class PurchaseSiteHeader extends Component {
 	static propTypes = {
+		isJetpackTemporarySite: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		siteId: PropTypes.number,
 		name: PropTypes.string,
@@ -52,15 +53,21 @@ class PurchaseSiteHeader extends Component {
 	}
 
 	render() {
-		const { isPlaceholder, siteId, site, name, domain } = this.props;
+		const { isJetpackTemporarySite, isPlaceholder, siteId, site } = this.props;
 		let header;
+
+		// Both the domain and name of a Jetpack temporary site don't provide any
+		// meaningful information to the user.
+		if ( isJetpackTemporarySite ) {
+			return null;
+		}
 
 		if ( isPlaceholder ) {
 			header = <SitePlaceholder />;
 		} else if ( site ) {
 			header = <Site isCompact site={ site } indicator={ false } />;
 		} else {
-			header = this.renderFauxSite( name, domain );
+			header = this.renderFauxSite();
 		}
 
 		return (
@@ -72,6 +79,7 @@ class PurchaseSiteHeader extends Component {
 	}
 }
 
-export default connect( ( state, { siteId } ) => ( {
+export default connect( ( state, { domain, siteId } ) => ( {
 	site: getSite( state, siteId ),
+	isJetpackTemporarySite: isJetpackTemporarySitePurchase( domain ),
 } ) )( PurchaseSiteHeader );

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { isEnabled } from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
 import { getSite } from 'calypso/state/sites/selectors';
 import {
@@ -61,6 +62,9 @@ const PurchasesSite = ( {
 					isDisconnectedSite={ ! site }
 					purchase={ purchase }
 					isJetpack={ isJetpackPlan( purchase ) || isJetpackProduct( purchase ) }
+					isJetpackTemporarySite={
+						purchase.domain === 'siteless.jetpack.com' && isEnabled( 'jetpack/siteless-checkout' )
+					}
 					site={ site }
 					showSite={ showSite }
 					name={ name }

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isEnabled } from '@automattic/calypso-config';
+
+/**
  * Internal dependencies
  */
 import { addPaymentMethod, changePaymentMethod, addNewPaymentMethod } from './paths';
@@ -39,9 +44,14 @@ function getAddNewPaymentMethodPath() {
 	return addNewPaymentMethod;
 }
 
+function isJetpackTemporarySitePurchase( domain ) {
+	return 'siteless.jetpack.com' === domain && isEnabled( 'jetpack/siteless-checkout' );
+}
+
 export {
 	canEditPaymentDetails,
 	getChangePaymentMethodPath,
 	getAddNewPaymentMethodPath,
 	isDataLoading,
+	isJetpackTemporarySitePurchase,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove references to `siteless.jetpack.com` from the Purchases section that don't add useful information and might be confusing to some users.

#### Testing instructions

* Run this PR locally with `yarn start`.
* Sandbox `public-api.wordpress.com`.
* Enable `USE_STORE_SANDBOX` so you can use a fake credit card (using credits makes appear many other warnings in the Purchase section and we won't be dealing with them on this PR).
* Purchase a product and a plan.
* Visit the `/me/purchases` section.
* Make sure the purchases look like in the PR (you should not see any reference to `siteless.jetpack.com`).
* Visit the purchase records of both the product and the plan.
* Make sure the purchase records look like in the PR (you should not see any reference to `siteless.jetpack.com`).
* Go through the cancellation flow and make sure the last step looks like the capture below (no references to `siteless.jetpack.com`).

Related to 1200479326344990-as-1200641987599725

#### Demo

The images on the left correspond to how things look now in production, on the right how they look after these changes.

##### `/me/purchases`
<p align="center">
  <img src="https://user-images.githubusercontent.com/3418513/126832264-6453dee1-c0b1-4a98-9442-0e78e2325a72.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/3418513/126832288-5642fbc5-96ad-41fe-b09c-3c045b3b1da6.png" width="45%" />
</p>

##### `/me/purchases/siteless.jetpack.com/:purchaseId` – Product view
<p align="center">
  <img src="https://user-images.githubusercontent.com/3418513/126832712-6299477e-642e-468b-a8be-4aa8a121c43d.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/3418513/126832810-397c3f9c-4ac5-4763-89c9-6648ed3e1200.png" width="45%" />
</p>

##### `/me/purchases/siteless.jetpack.com/:purchaseId` – Plan view
<p align="center">
  <img src="https://user-images.githubusercontent.com/3418513/126832923-84942971-a8be-46ca-b5e3-5e95abd31d07.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/3418513/126832932-a7359613-d4b8-4230-a0d3-404cd506caba.png" width="45%" />
</p>

##### `/me/purchases/siteless.jetpack.com/:purchaseId` – Cancel product modal
<p align="center">
  <img src="https://user-images.githubusercontent.com/3418513/126833217-20a9e66b-9617-4eea-be0c-7c2b1ea1ae41.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/3418513/126833245-228eaad0-41bf-4a8a-be44-3ce3dbfbb12d.png" width="45%" />
</p>

##### `/me/purchases/siteless.jetpack.com/:purchaseId` – Cancel plan modal
<p align="center">
  <img src="https://user-images.githubusercontent.com/3418513/126833103-e9bda940-b650-4b62-b1c7-f3e7d2e17845.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/3418513/126833145-51da4959-6c9c-4ece-ba5b-0589e913a4ef.png" width="45%" />
</p>
