### PR TITLE
Themes Showcase: Removed theme options from "InstallThemeButton"

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  */
 
 import siteCanUploadThemesOrPlugins from 'calypso/state/sites/selectors/can-upload-themes-or-plugins';
-import { connectOptions } from './theme-options';
 import { translate } from 'i18n-calypso';
 import { trackClick } from './helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -37,51 +36,49 @@ function getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) {
 	return `/themes/upload/${ siteSlug }`;
 }
 
-const InstallThemeButton = connectOptions(
-	( {
-		isMultisite,
-		jetpackSite,
-		isLoggedIn,
-		siteSlug,
-		dispatchTracksEvent,
-		canUploadThemesOrPlugins,
-		atomicSite,
-	} ) => {
-		if ( ! isLoggedIn || isMultisite ) {
-			return null;
-		}
-
-		let siteType = null;
-		if ( ! isLoggedIn ) {
-			siteType = 'logged_out';
-		} else if ( atomicSite ) {
-			siteType = 'atomic';
-		} else if ( jetpackSite ) {
-			siteType = 'jetpack';
-		} else if ( siteSlug ) {
-			siteType = 'simple';
-		}
-
-		const clickHandler = () => {
-			trackClick( 'upload theme' );
-			dispatchTracksEvent( {
-				tracksEventProps: {
-					site_type: siteType,
-				},
-			} );
-		};
-
-		return (
-			<Button
-				className="themes__upload-button"
-				onClick={ clickHandler }
-				href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
-			>
-				{ translate( 'Install theme' ) }
-			</Button>
-		);
+const InstallThemeButton = ( {
+	isMultisite,
+	jetpackSite,
+	isLoggedIn,
+	siteSlug,
+	dispatchTracksEvent,
+	canUploadThemesOrPlugins,
+	atomicSite,
+} ) => {
+	if ( ! isLoggedIn || isMultisite ) {
+		return null;
 	}
-);
+
+	let siteType = null;
+	if ( ! isLoggedIn ) {
+		siteType = 'logged_out';
+	} else if ( atomicSite ) {
+		siteType = 'atomic';
+	} else if ( jetpackSite ) {
+		siteType = 'jetpack';
+	} else if ( siteSlug ) {
+		siteType = 'simple';
+	}
+
+	const clickHandler = () => {
+		trackClick( 'upload theme' );
+		dispatchTracksEvent( {
+			tracksEventProps: {
+				site_type: siteType,
+			},
+		} );
+	};
+
+	return (
+		<Button
+			className="themes__upload-button"
+			onClick={ clickHandler }
+			href={ getInstallThemeSlug( siteSlug, canUploadThemesOrPlugins ) }
+		>
+			{ translate( 'Install theme' ) }
+		</Button>
+	);
+};
 
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );


### PR DESCRIPTION
#### Testing Instructions Simple

1. Open the /themes page on a simple site
2. Click the "Install theme" button
3. You should be brought to https://wordpress.com/themes/upload/SITE_SLUG

#### Testing Instructions Atomic

1. Open the /themes page on an atomic site
2. Click the "Install theme" button
3. You should be brought to the wp-admin version of the themes page for your site

Both of these should have created a tracks event: calypso_click_theme_upload.
