### PR TITLE
TC: Delete comments when the release status changes

### DIFF
--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -148,7 +148,7 @@ open class PluginBaseBuild : Template({
 					fi
 				else
 					# If the current build is the same as trunk, remove any related comments posted to the PR.
-					%teamcity.build.checkoutDir%/bin/add-pr-comment.sh "%teamcity.build.branch%" "$pluginSlug" "delete" <<< ""
+					%teamcity.build.checkoutDir%/bin/add-pr-comment.sh "%teamcity.build.branch%" "$pluginSlug" "delete" <<< "" || true
 				fi
 
 				# 4. Create metadata file with info for the download script.

--- a/.teamcity/_self/PluginBaseBuild.kt
+++ b/.teamcity/_self/PluginBaseBuild.kt
@@ -100,6 +100,10 @@ open class PluginBaseBuild : Template({
 		bashNodeScript {
 			name = "Process Artifact"
 			scriptContent = """
+				# Prepare pr commenter script.
+				export GH_TOKEN="%matticbot_oauth_token%"
+				chmod +x ./bin/add-pr-comment.sh
+
 				cd $workingDir
 				cp README.md $archiveDir
 
@@ -124,17 +128,13 @@ open class PluginBaseBuild : Template({
 
 					# On normal PRs, post a message about WordPress.com deployments.
 					if [[ "%teamcity.build.branch.is_default%" != "true" ]] ; then
-						cd %teamcity.build.checkoutDir%
-						export GH_TOKEN="%matticbot_oauth_token%"
-						chmod +x ./bin/add-pr-comment.sh
-						./bin/add-pr-comment.sh "%teamcity.build.branch%" "$pluginSlug" <<- EOF || true
+						%teamcity.build.checkoutDir%/bin/add-pr-comment.sh "%teamcity.build.branch%" "$pluginSlug" <<- EOF || true
 						**This PR modifies the release build for $pluginSlug**
 
 						To test your changes on WordPress.com, run \`install-plugin.sh $pluginSlug %teamcity.build.branch%\` on your sandbox.
 						
 						To deploy your changes after merging, see the documentation: %docs_link%
 						EOF
-						cd $workingDir
 					fi
 
 					# Ping commit merger in Slack if we're on the main branch and the build has changed.
@@ -146,6 +146,9 @@ open class PluginBaseBuild : Template({
 						ping_response=`curl -s -d "${'$'}payload" -X POST -H "TEAMCITY_SIGNATURE: ${'$'}signature" %mc_post_root%?plugin-deploy-reminder`
 						echo -e "Slack ping status: ${'$'}ping_response\n"
 					fi
+				else
+					# If the current build is the same as trunk, remove any related comments posted to the PR.
+					%teamcity.build.checkoutDir%/bin/add-pr-comment.sh "%teamcity.build.branch%" "$pluginSlug" "delete" <<< ""
 				fi
 
 				# 4. Create metadata file with info for the download script.

--- a/bin/add-pr-comment.sh
+++ b/bin/add-pr-comment.sh
@@ -27,15 +27,36 @@ function post() {
 		-X POST "${url}" --data "${data}"
 }
 
+function delete() {
+	url="${1}"
+	curl --fail --silent --show-error --location \
+		--header "Accept: application/vnd.github.v3+json" \
+		--header "Authorization: token ${GH_TOKEN}" \
+		-X DELETE "${url}"
+}
+
+# Returns the commentID if one exists in the given PR with the given watermark.
+function get_existing_comment() {
+	prNumber="${1}"
+	watermark="${2}"
+	# `-watermark:apr@v1` is used to avod collisions with other script that use watermarks.
+	get "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments?per_page=100" | jq ". | map(select(.body | contains(\"${watermark}\")))[0] | .id"
+}
+
 # Sanitize parameters
 branch="${1:-}"
 watermarkName="${2:-}"
+operation="${3:-}"
 message="$(cat - | jq -Rs .)"
+
 if [[ -z "$branch" ]]; then
-	echo "Usage: ${0} <branch-name> [watermark]"
+	echo "Usage: ${0} <branch-name> [watermark] [operation]"
 	echo ""
 	echo "The script will find a PR for <branch-name> and add a message to it. If [watermark] is"
 	echo "supplied, it will update any existing message created with the same [watermark]."
+	echo ""
+	echo "If 'delete' is provided as the operation and an existing comment on the PR matches the"
+	echo "watermark, that comment will be deleted."
 	echo ""
 	echo "The content of the message will be read from STDIN."
 	exit 1
@@ -48,16 +69,29 @@ if [[ -z "${prNumber}" ]]; then
 	exit 1
 fi
 
+if [[ ${operation} == "delete" ]]; then
+	if [[ -z "$watermarkName" ]]; then
+		echo "A watermark is required for deleting comments."
+		exit 1
+	fi
+	watermark="<!--${watermarkName}-watermark:apr@v1-->"
+	commentId=$(get_existing_comment $prNumber $watermark)
+	if [[ -z "${commentId}" || "${commentId}" == "null" ]]; then
+		echo "No comment found to delete."
+		exit
+	fi
+	echo "Deleting comment"
+	delete "https://api.github.com/repos/Automattic/wp-calypso/issues/comments/${commentId}"
+	exit
+fi
+
 if [[ -z "$watermarkName" ]]; then
 	echo "Creating comment"
 	post "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments" "{\"body\":${message}}" > /dev/null
 else
-	echo "Getting comments in the PR #${prNumber}..."
-	# `-watermark:apr@v1` is used to avod collisions with other script that use watermarks.
 	watermark="<!--${watermarkName}-watermark:apr@v1-->"
-	commentId=$(get "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments?per_page=100" | jq ". | map(select(.body | contains(\"${watermark}\")))[0] | .id")
-
 	watermarkedMessage="${message/%\"/${watermark}\"}"
+	commentId=$(get_existing_comment $prNumber $watermark)
 	if [[ -z "${commentId}" || "${commentId}" == "null" ]]; then
 		echo "Creating comment"
 		post "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments" "{\"body\":${watermarkedMessage}}" > /dev/null

--- a/bin/add-pr-comment.sh
+++ b/bin/add-pr-comment.sh
@@ -78,7 +78,7 @@ if [[ ${operation} == "delete" ]]; then
 	commentId=$(get_existing_comment $prNumber $watermark)
 	if [[ -z "${commentId}" || "${commentId}" == "null" ]]; then
 		echo "No comment found to delete."
-		exit
+		exit 1
 	fi
 	echo "Deleting comment"
 	delete "https://api.github.com/repos/Automattic/wp-calypso/issues/comments/${commentId}"

--- a/bin/add-pr-comment.sh
+++ b/bin/add-pr-comment.sh
@@ -39,7 +39,6 @@ function delete() {
 function get_existing_comment() {
 	prNumber="${1}"
 	watermark="${2}"
-	# `-watermark:apr@v1` is used to avod collisions with other script that use watermarks.
 	get "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments?per_page=100" | jq ". | map(select(.body | contains(\"${watermark}\")))[0] | .id"
 }
 
@@ -74,6 +73,7 @@ if [[ "$operation" == "delete" ]]; then
 		echo "A watermark is required for deleting comments."
 		exit 1
 	fi
+	# `-watermark:apr@v1` is used to avod collisions with other script that use watermarks.
 	watermark="<!--${watermarkName}-watermark:apr@v1-->"
 	commentId=$(get_existing_comment "$prNumber" "$watermark")
 	if [[ -z "${commentId}" || "${commentId}" == "null" ]]; then
@@ -89,6 +89,7 @@ if [[ -z "$watermarkName" ]]; then
 	echo "Creating comment"
 	post "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments" "{\"body\":${message}}" > /dev/null
 else
+	# `-watermark:apr@v1` is used to avod collisions with other script that use watermarks.
 	watermark="<!--${watermarkName}-watermark:apr@v1-->"
 	watermarkedMessage="${message/%\"/${watermark}\"}"
 	commentId=$(get_existing_comment "$prNumber" "$watermark")

--- a/bin/add-pr-comment.sh
+++ b/bin/add-pr-comment.sh
@@ -69,13 +69,13 @@ if [[ -z "${prNumber}" ]]; then
 	exit 1
 fi
 
-if [[ ${operation} == "delete" ]]; then
+if [[ "$operation" == "delete" ]]; then
 	if [[ -z "$watermarkName" ]]; then
 		echo "A watermark is required for deleting comments."
 		exit 1
 	fi
 	watermark="<!--${watermarkName}-watermark:apr@v1-->"
-	commentId=$(get_existing_comment $prNumber $watermark)
+	commentId=$(get_existing_comment "$prNumber" "$watermark")
 	if [[ -z "${commentId}" || "${commentId}" == "null" ]]; then
 		echo "No comment found to delete."
 		exit 1
@@ -91,7 +91,7 @@ if [[ -z "$watermarkName" ]]; then
 else
 	watermark="<!--${watermarkName}-watermark:apr@v1-->"
 	watermarkedMessage="${message/%\"/${watermark}\"}"
-	commentId=$(get_existing_comment $prNumber $watermark)
+	commentId=$(get_existing_comment "$prNumber" "$watermark")
 	if [[ -z "${commentId}" || "${commentId}" == "null" ]]; then
 		echo "Creating comment"
 		post "https://api.github.com/repos/Automattic/wp-calypso/issues/${prNumber}/comments" "{\"body\":${watermarkedMessage}}" > /dev/null


### PR DESCRIPTION
### Changes proposed in this Pull Request
We currently add comments to PRs when we detect a change in wpcom plugins. However, it's possible for a PR to change such that it no longer makes a change to one of those plugins. In that case, the comment will stick around, but it won't be true any more.

This PR fixes that by automatically removing comments in the following situation:
- There were no changes to the plugin build artifact
- A comment with the plugin watermark already existed on the PR


### Testing instructions
When I first created this branch, it was out of date with trunk. As a result, there were comments about ETK and notifications because the build on this branch was "stale" (This will be fixed in #54809):

<img width="1490" alt="Screen Shot 2021-07-23 at 1 42 46 PM" src="https://user-images.githubusercontent.com/6265975/126839925-d0c91f3e-45dc-4bbb-8b82-6c7e0e17baa8.png">

After rebasing on trunk, the comments were deleted, since the stale builds were no longer considered different:

<img width="1446" alt="Screen Shot 2021-07-23 at 1 47 44 PM" src="https://user-images.githubusercontent.com/6265975/126839953-83d1e9ff-dd0e-4f35-8bab-48eacec7fb20.png">
