### PR TITLE
Jetpack site-less Checkout: Add site-less redirect to the product purchase route

### DIFF
--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -27,7 +27,6 @@ import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
-	isJetpackProductSlug,
 } from '@automattic/calypso-products';
 import { addQueryArgs } from 'calypso/lib/route';
 
@@ -117,7 +116,10 @@ export function redirectToSitelessCheckout( context, next ) {
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 
-	if ( config.isEnabled( 'jetpack/siteless-checkout' ) && isJetpackProductSlug( planSlug ) ) {
+	if (
+		config.isEnabled( 'jetpack/siteless-checkout' ) &&
+		[ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( planSlug )
+	) {
 		page( addQueryArgs( context.query, `/checkout/jetpack/${ planSlug }` ) );
 		return;
 	}

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -27,7 +27,9 @@ import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
+	isJetpackProductSlug,
 } from '@automattic/calypso-products';
+import { addQueryArgs } from 'calypso/lib/route';
 
 /**
  * Module variables
@@ -107,5 +109,18 @@ export function purchase( context, next ) {
 			url={ query.url }
 		/>
 	);
+	next();
+}
+
+export function redirectToSitelessCheckout( context, next ) {
+	const { type, interval } = context.params;
+
+	const planSlug = getPlanSlugFromFlowType( type, interval );
+
+	if ( config.isEnabled( 'jetpack/siteless-checkout' ) && isJetpackProductSlug( planSlug ) ) {
+		page( addQueryArgs( context.query, `/checkout/jetpack/${ planSlug }` ) );
+		return;
+	}
+
 	next();
 }

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -17,6 +17,7 @@ import '../../jetpack-connect/style.scss';
 export default function () {
 	page(
 		'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
+		controller.redirectToSitelessCheckout,
 		controller.redirectToLogin,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `/purchase-product/jetpack_search/monthly|yearly` -> `/checkout/jetpack/jetpack_search_monthly|jetpack_search`

#### Testing instructions

1. Boot branch
2. Verify navigating to `/purchase-product/jetpack_search/monthly` redirects to `/checkout/jetpack/jetpack_search_monthly`
3. Verify navigating to `/purchase-product/jetpack_search/yearly` redirects to `/checkout/jetpack/jetpack_search`
4. Verify `/purchase-product/wpcom_search/yearly` and `/purchase-product/wpcom_search/monthly` do not redirect

