### PR TITLE
Playwright: use correct env var name

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -958,7 +958,7 @@ object RunCalypsoPlaywrightE2eMobileTests : BuildType({
 				COUNTER=0
 
 				# Transform an URL like https://calypso.live?image=... into https://<container>.calypso.live
-				while [[ ${'$'}COUNTER -le ${'$'}MfAX_LOOP ]]; do
+				while [[ ${'$'}COUNTER -le ${'$'}MAX_LOOP ]]; do
 					COUNTER=${'$'}((COUNTER+1))
 					REDIRECT=${'$'}(curl --output /dev/null --silent --show-error  --write-out "%{http_code} %{redirect_url}" "${'$'}{IMAGE_URL}")
 					read HTTP_STATUS URL <<< "${'$'}{REDIRECT}"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -835,7 +835,7 @@ object RunCalypsoPlaywrightE2eDesktopTests : BuildType({
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				export VIEWPORT_SIZE=desktop
+				export VIEWPORT_NAME=desktop
 				export LOCALE=en
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export DEBUG=pw:api
@@ -958,7 +958,7 @@ object RunCalypsoPlaywrightE2eMobileTests : BuildType({
 				COUNTER=0
 
 				# Transform an URL like https://calypso.live?image=... into https://<container>.calypso.live
-				while [[ ${'$'}COUNTER -le ${'$'}MAX_LOOP ]]; do
+				while [[ ${'$'}COUNTER -le ${'$'}MfAX_LOOP ]]; do
 					COUNTER=${'$'}((COUNTER+1))
 					REDIRECT=${'$'}(curl --output /dev/null --silent --show-error  --write-out "%{http_code} %{redirect_url}" "${'$'}{IMAGE_URL}")
 					read HTTP_STATUS URL <<< "${'$'}{REDIRECT}"
@@ -986,7 +986,7 @@ object RunCalypsoPlaywrightE2eMobileTests : BuildType({
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 				# Run the test
-				export VIEWPORT_SIZE=mobile
+				export VIEWPORT_NAME=mobile
 				export LOCALE=en
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export DEBUG=pw:api

--- a/test/e2e/specs/specs-playwright/wp-support__search-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__search-spec.js
@@ -27,7 +27,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( page );
 			const sidebarComponent = await SidebarComponent.Expect( page );
-			await sidebarComponent.gotoMenu( { item: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings', subitem: 'General' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -82,7 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( page );
 			const sidebarComponent = await SidebarComponent.Expect( page );
-			await sidebarComponent.gotoMenu( { item: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings', subitem: 'General' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -125,7 +125,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( page );
 			const sidebarComponent = await SidebarComponent.Expect( page );
-			await sidebarComponent.gotoMenu( { item: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings', subitem: 'General' } );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -161,7 +161,7 @@ describe( DataHelper.createSuiteTitle( 'Support' ), function () {
 		it( 'Open Settings page', async function () {
 			await MyHomePage.Expect( page );
 			const sidebarComponent = await SidebarComponent.Expect( page );
-			await sidebarComponent.gotoMenu( { item: 'Settings' } );
+			await sidebarComponent.gotoMenu( { item: 'Settings', subitem: 'General' } );
 		} );
 
 		it( 'Open support popover', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR corrects the environment variable name used in Playwright tasks.

Key changes:
- switch from VIEWPORT_SIZE to VIEWPORT_NAME.

#### Testing instructions

- [x] ensure TeamCity tasks for both mobile and desktop Playwright passes.
- [x] introduce a failure in a spec and confirm screen size in the recorded video.

Related to #
