### PR TITLE
PopupMenu: Prevent unwanted scroll by ensuring menu is visible before focusing first element

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -35,9 +35,15 @@ class PopoverMenu extends Component {
 
 	menu = React.createRef();
 
+	delayedFocus = null;
+
 	componentWillUnmount() {
 		// Make sure we don't hold on to reference to the DOM reference
 		this._previouslyFocusedElement = null;
+
+		if ( this.delayedFocus !== null ) {
+			window.clearTimeout( this.delayedFocus );
+		}
 	}
 
 	render() {
@@ -109,7 +115,14 @@ class PopoverMenu extends Component {
 		this._previouslyFocusedElement = document.activeElement;
 
 		if ( elementToFocus ) {
-			elementToFocus.focus();
+			// Defer the focus a bit to make sure that the popover already has the final position.
+			// Initially, after first render, the popover is positioned outside the screen, at
+			// { top: -9999, left: -9999 } where it already has dimensions. These dimensions are measured
+			// and used to calculate the final position.
+			// Focusing the element while it's off the screen would cause unwanted scrolling.
+			this.delayedFocus = setTimeout( () => {
+				elementToFocus.focus();
+			}, 1 );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Delays focusing the first element in `<PopoverMenu>` until it's in its final position on screen ([implementation taken from `<Popup>` component](https://github.com/automattic/wp-calypso/blob/6d4b10dc7fb3619cfc30a8f1d79d23502d50cb13/client/components/popover/index.jsx#L198))

This is an alternative to #54843, which are both attempts to fix a bug introduced by #54682 and reported in #54803.

Rational for why I'm proposing this fix over #54843: https://github.com/Automattic/wp-calypso/pull/54843#pullrequestreview-714366498

**Before**

![2021-07-23 10 36 08](https://user-images.githubusercontent.com/2124984/126798228-c0d49e87-1535-4155-86de-197ed3f3d1c7.gif)

**After**

![2021-07-23 10 35 00](https://user-images.githubusercontent.com/2124984/126798182-126f08e4-2c80-424c-9b5d-a67768563eb2.gif)

#### Testing instructions

* Switch to this PR, navigate to a longer page with a Popover component - like the theme showcase at `/themes` or a site with lots of `/posts`
* Scroll down the page and click on a popover
* The screen should remain in place
* All popover menu items should still be accessible
* The menu should also be accessible via keyboard

Related to #54803

