### PR TITLE
ci: Do not run automatically builds that have been failing for weeks

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -327,19 +327,6 @@ fun jetpackBuildType(screenSize: String): BuildType {
 				}
 			}
 		}
-
-		triggers {
-			schedule {
-				schedulingPolicy = daily {
-					hour = 2
-				}
-				branchFilter = """
-					+:trunk
-				""".trimIndent()
-				triggerBuild = always()
-				withPendingChangesOnly = false
-			}
-		}
 	}
 }
 
@@ -413,19 +400,6 @@ private object VisualRegressionTests : BuildType({
 			buildFailedToStart = true
 			firstSuccessAfterFailure = true
 			buildProbablyHanging = true
-		}
-	}
-
-	triggers {
-		schedule {
-			schedulingPolicy = daily {
-				hour = 3
-			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
-			triggerBuild = always()
-			withPendingChangesOnly = false
 		}
 	}
 })


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable automatic trigger of Visual Regressions build, as it has been failing for weeks (p1627024845209700-slack-CQD1HH4MA)
* Disable automatic trigger of Jetpack builds, as they have been failing for weeks (p1627025010252600-slack-CBG1CP4EN)
