### PR TITLE
chore: migrate `packages/popup-monitor` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,6 +211,7 @@ module.exports = {
 				'packages/mocha-debug-reporter/**/*',
 				'packages/photon/**/*',
 				'packages/plans-grid/**/*',
+				'packages/popup-monitor/**/*',
 				'packages/shopping-cart/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',

--- a/packages/popup-monitor/src/emitter.js
+++ b/packages/popup-monitor/src/emitter.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { EventEmitter } from 'events';
 
 export default function ( prototype ) {

--- a/packages/popup-monitor/src/index.js
+++ b/packages/popup-monitor/src/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import Emitter from './emitter';
 
 /**

--- a/packages/popup-monitor/test/index.js
+++ b/packages/popup-monitor/test/index.js
@@ -2,14 +2,7 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import PopupMonitor from '../src';
 
 describe( 'PopupMonitor', () => {

--- a/packages/popup-monitor/tsconfig.json
+++ b/packages/popup-monitor/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/popup-monitor` to use `import/order`

#### Testing instructions

N/A