### PR TITLE
chore: migrate `packages/explat-client-react-helpers` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -205,6 +205,7 @@ module.exports = {
 				'packages/data-stores/**/*',
 				'packages/domain-picker/**/*',
 				'packages/eslint-plugin-wpcalypso/**/*',
+				'packages/explat-client-react-helpers/**/*',
 				'packages/explat-client/**/*',
 				'packages/format-currency/**/*',
 				'packages/js-utils/**/*',

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React, { useState, useEffect } from 'react';
-
-/**
- * WordPress dependencies
- */
 import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
 
 interface ExperimentOptions {

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -2,23 +2,12 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
-import { renderHook, act as actReactHooks } from '@testing-library/react-hooks';
-import { render, act as actReact, waitFor } from '@testing-library/react';
-
-/**
- * WordPress dependencies
- */
-import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
 import { validExperimentAssignment } from '@automattic/explat-client/src/internal/test-common';
-
-/**
- * Internal dependencies
- */
+import { render, act as actReact, waitFor } from '@testing-library/react';
+import { renderHook, act as actReactHooks } from '@testing-library/react-hooks';
+import React from 'react';
 import createExPlatClientReactHelpers from '../index';
+import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
 
 const createMockExPlatClient = ( isDevelopmentMode = false ): ExPlatClient => ( {
 	loadExperimentAssignment: jest.fn(),


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/explat-client-react-helpers` to use `import/order`

#### Testing instructions

N/A
