### PR TITLE
chore: migrate `packages/calypso-polyfills` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -195,6 +195,7 @@ module.exports = {
 				'packages/babel-plugin-i18n-calypso/**/*',
 				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',
+				'packages/calypso-polyfills/**/*',
 				'packages/calypso-products/**/*',
 				'packages/calypso-stripe/**/*',
 				'packages/components/**/*',

--- a/packages/calypso-polyfills/browser-evergreen.js
+++ b/packages/calypso-polyfills/browser-evergreen.js
@@ -4,8 +4,5 @@
 // avoid including polyfills for features that are supported acroll all target
 // browsers.
 
-/**
- * External dependencies
- */
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';

--- a/packages/calypso-polyfills/browser-fallback.js
+++ b/packages/calypso-polyfills/browser-fallback.js
@@ -4,9 +4,6 @@
 // avoid including polyfills for features that are supported acroll all target
 // browsers.
 
-/**
- * External dependencies
- */
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import svg4everybody from 'svg4everybody';

--- a/packages/calypso-polyfills/node.js
+++ b/packages/calypso-polyfills/node.js
@@ -1,8 +1,5 @@
 // Polyfills required for the server build of Calypso.
 
-/**
- * External dependencies
- */
 require( 'core-js/stable' );
 require( 'regenerator-runtime/runtime' );
 require( 'isomorphic-fetch' );

--- a/packages/calypso-polyfills/tsconfig.json
+++ b/packages/calypso-polyfills/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-polyfills` to use `import/order`

#### Testing instructions

N/A
