### PR TITLE
Use authenticated error logging

### DIFF
--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -4,6 +4,8 @@
 import TraceKit from 'tracekit';
 import debug from 'debug';
 
+import wpcom from 'calypso/lib/wp';
+
 /**
  * Module variables
  */
@@ -119,17 +121,24 @@ export default class ErrorLogger {
 	}
 
 	sendToApi( error ) {
-		const body = new window.FormData();
-		body.append( 'error', JSON.stringify( error ) );
-
-		try {
-			window.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
-				method: 'POST',
-				body,
-			} );
-		} catch {
+		const onUnableToRecordError = () => {
 			// eslint-disable-next-line no-console
 			console.error( 'Error: Unable to record the error in Logstash.' );
+		};
+
+		try {
+			wpcom.req.post(
+				{
+					path: '/js-error',
+					apiNamespace: 'rest/v1.1',
+					body: {
+						error: JSON.stringify( error ),
+					},
+				},
+				( err ) => err && onUnableToRecordError()
+			);
+		} catch {
+			onUnableToRecordError();
 		}
 	}
 }

--- a/client/lib/explat/internals/log-error.ts
+++ b/client/lib/explat/internals/log-error.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import wpcom from 'calypso/lib/wp';
+
+/**
  * Internal dependencies
  */
 import { getLogger } from 'calypso/server/lib/logger';
@@ -42,14 +47,16 @@ export const logError = ( error: Record< string, string > & { message: string } 
 			// eslint-disable-next-line no-console
 			console.error( '[ExPlat] ', error.message, error );
 		} else {
-			const body = new window.FormData();
-			body.append( 'error', JSON.stringify( logStashError ) );
-			window
-				.fetch( 'https://public-api.wordpress.com/rest/v1.1/js-error', {
-					method: 'POST',
-					body,
-				} )
-				.catch( onError );
+			wpcom.req.post(
+				{
+					path: '/js-error',
+					apiNamespace: 'rest/v1.1',
+					body: {
+						error: JSON.stringify( logStashError ),
+					},
+				},
+				( err: unknown ) => err && onError( err )
+			);
 		}
 	} catch ( e ) {
 		onError( e );

--- a/client/lib/explat/internals/test/log-error.ts
+++ b/client/lib/explat/internals/test/log-error.ts
@@ -1,8 +1,11 @@
 /**
  * Internal dependencies
  */
+import wpcom from 'calypso/lib/wp';
 import * as Logger from 'calypso/server/lib/logger';
 import { logError } from '../log-error';
+
+jest.mock( 'calypso/lib/wp' );
 
 jest.mock( 'calypso/server/lib/logger', () => {
 	const logger = jest.fn();
@@ -58,16 +61,17 @@ describe( 'logError', () => {
 	} );
 	it( 'should log to the server in the browser', () => {
 		logError( { message: 'asdf', foo: 'bar' } );
-		expect( mockWindow.fetch.mock.calls ).toMatchInlineSnapshot( `
+		expect( wpcom.req.post.mock.calls ).toMatchInlineSnapshot( `
 		Array [
 		  Array [
-		    "https://public-api.wordpress.com/rest/v1.1/js-error",
 		    Object {
-		      "body": FormData {
+		      "apiNamespace": "rest/v1.1",
+		      "body": Object {
 		        "error": "{\\"message\\":\\"asdf\\",\\"properties\\":{\\"foo\\":\\"bar\\",\\"context\\":\\"explat\\",\\"explat_client\\":\\"calypso\\",\\"message\\":\\"asdf\\"}}",
 		      },
-		      "method": "POST",
+		      "path": "/js-error",
 		    },
+		    [Function],
 		  ],
 		]
 	` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds authenticated error logging in both general Calypso and ExPlat, giving us more information when investigating errors. 

Part of https://github.com/Automattic/experimentation-platform/issues/651

- Requires `lib/wpcom` as a dependency.
- Using `wpcom.req` is a bit more fragile, I was considering creating a fallback to window.fetch, but decided against the complexity of having to detect and determine which request failure should be resent via the fallback.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Manually tested against my sandbox to ensure the logged data contains `userIds`.
* Updated AT for ExPlat

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

