### PR TITLE
Update webpack config for wpcom.js website build

### DIFF
--- a/packages/wpcom.js/webapp/index.html
+++ b/packages/wpcom.js/webapp/index.html
@@ -74,8 +74,13 @@
 		</section>
 
 		<script>
+			var elVersion = document.getElementById( 'wpcom-version' );
+			if ( elVersion ) {
+				elVersion.innerHTML = pkg.version;
+			}
+
 			// create a client WPCOM instance
-			var wpcom = WPCOM();
+			var wpcom = WPCOM(); // TODO: provide a handler to make a successful request
 
 			// retrieve a listing of the most recent
 			// 5 posts on "en.blog.wordpress.com"
@@ -89,11 +94,6 @@
 					console.log( '  %d: "%s"', i+1, post.title );
 				} );
 			} );
-
-			var elVersion = document.getElementById( 'wpcom-version' );
-			if ( elVersion ) {
-				elVersion.innerHTML = pkg.version;
-			}
 		</script>
 	</body>
 </html>

--- a/packages/wpcom.js/webapp/main.js
+++ b/packages/wpcom.js/webapp/main.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import wpcomFactory from '../';
-import pkg from '../package';
+import wpcomFactory from '..';
+import pkg from '../package.json';
 
 /**
  * Expose globals

--- a/packages/wpcom.js/webapp/webpack.config.js
+++ b/packages/wpcom.js/webapp/webpack.config.js
@@ -1,33 +1,12 @@
 const path = require( 'path' );
 
 module.exports = {
+	mode: 'production',
 	entry: path.join( __dirname, 'main.js' ),
-
 	output: {
 		path: __dirname,
 		filename: 'webapp-bundle.js',
 		libraryTarget: 'var',
 		library: 'WPCOMWebApp',
 	},
-
-	module: {
-		loaders: [
-			{
-				test: /\.js$/,
-				exclude: /node_modules/,
-				loader: 'babel-loader',
-			},
-			{
-				test: /\.json$/,
-				exclude: /node_modules/,
-				loader: 'json-loader',
-			},
-		],
-	},
-
-	resolve: {
-		extensions: [ '', '.js', '.json' ],
-	},
-
-	devtool: 'sourcemap',
 };


### PR DESCRIPTION
Updates the webpack config for the wpcomjs.com website so that it works with the latest webpack.

The resulting website doesn't work 100%, because the `WPCOM` library is not initialized with a request handler (the default one was removed by @sgomes in #39142 to remove a questionable dependency) and will fail to actually issue a wpcom request. But other than that, the build works.

The webpack config is very simple: it doesn't need any loaders, as the `dist/esm` files are already transpiled. It just bundles existing JS files together and minifies them.

Inspired by discussion in #54831.

**How to test:**
- build the `wpcom.js` package with `cd packages/wpcom; yarn build`
- build the website with `cd website; webpack`
- open the site locally as `file:` URL with `open index.html` (on Mac)
- verify that the `webapp-bundle.js` script was loaded and that it updated the version number in the header
