### PR TITLE
chore: migrate `packages/search` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -215,6 +215,7 @@ module.exports = {
 				'packages/photon/**/*',
 				'packages/plans-grid/**/*',
 				'packages/popup-monitor/**/*',
+				'packages/search/**/*',
 				'packages/shopping-cart/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -1,8 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
 import Search from './search';
 
 export default { title: 'Search', component: Search };

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
 
+import { Button, Spinner } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { close, search, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
+import { debounce } from 'lodash';
 import React, { useEffect } from 'react';
+import { useUpdateEffect } from './utils';
 import type {
 	ReactNode,
 	Ref,
@@ -15,23 +17,7 @@ import type {
 	KeyboardEvent,
 	MouseEvent,
 } from 'react';
-import { debounce } from 'lodash';
 
-/**
- * WordPress dependencies
- */
-import { Button, Spinner } from '@wordpress/components';
-import { close, search, Icon } from '@wordpress/icons';
-import { useInstanceId } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import { useUpdateEffect } from './utils';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { act } from 'react-dom/test-utils';
-
-/**
- * Internal dependencies
- */
 import Search from '..';
 
 describe( 'search', () => {

--- a/packages/search/src/utils.ts
+++ b/packages/search/src/utils.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 /**


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/search` to use `import/order`

#### Testing instructions

N/A
