### PR TITLE
chore: migrate `packages/i18n-utils` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -213,6 +213,7 @@ module.exports = {
 				'packages/explat-client-react-helpers/**/*',
 				'packages/explat-client/**/*',
 				'packages/format-currency/**/*',
+				'packages/i18n-utils/**/*',
 				'packages/js-utils/**/*',
 				'packages/language-picker/**/*',
 				'packages/languages/**/*',

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
-import React, { createContext, useContext, useEffect, useState } from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import * as i18n from '@wordpress/i18n';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 export const localeContext = createContext< string | null >( null );
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useCallback } from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
+import React, { useCallback } from 'react';
 import { useLocale } from './locale-context';
 import {
 	localesWithBlog,

--- a/packages/i18n-utils/src/test/locale-context.tsx
+++ b/packages/i18n-utils/src/test/locale-context.tsx
@@ -1,18 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
-import React from 'react';
-import { act, renderHook } from '@testing-library/react-hooks';
-import { render } from '@testing-library/react';
-import { getLocaleData, subscribe } from '@wordpress/i18n';
-import '@testing-library/jest-dom/extend-expect';
 
-/**
- * Internal dependencies
- */
+import { render } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { getLocaleData, subscribe } from '@wordpress/i18n';
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
 import { LocaleProvider, useLocale, withLocale } from '../locale-context';
 
 jest.mock( '@wordpress/i18n', () => ( {

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -1,13 +1,6 @@
 /* eslint-disable no-shadow -- shadowing localizeUrl makes tests readable */
 
-/**
- * External dependencies
- */
 import { renderHook } from '@testing-library/react-hooks';
-
-/**
- * Internal dependencies
- */
 import { localizeUrl, useLocalizeUrl } from '../';
 
 jest.mock( '../locale-context', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/i18n-utils` to use `import/order`

#### Testing instructions

N/A
