### PR TITLE
Add action to create temporary calypso.live links

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   calypso-live:
-    name: 'Launch a Calypso.live instance for your branch'
+    name: 'Links to a calypso.live instance for your branch'
     runs-on: ubuntu-latest
     # We only offer the Calypso.live link to PRs created from the Automattic organization.
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10
     steps:
-      - name: Build Calypso.live link.
+      - name: Build calypso.live link.
         run: |
           echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/commit:${{ github.event.pull_request.head.sha }}'
         id: build_link

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -26,10 +26,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '
-              <!--calypso-live-watermark:apr@v1-->
-              Link to Calypso live: ${{ steps.build_link.outputs.LINK }}
-              Link to Jetpack Cloud live: ${{ steps.build_link.outputs.LINK }}&env=jetpack
-              _(These links may take a few minutes to be available)_
-              '
+              body: '<!--calypso-live-watermark:apr@v1-->\nLink to Calypso live: ${{ steps.build_link.outputs.LINK }}\nLink to Jetpack Cloud live: ${{ steps.build_link.outputs.LINK }}&env=jetpack\n_(These links may take a few minutes to be available)_'
             })

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -1,0 +1,35 @@
+name: Calypso Live
+
+on:
+  pull_request:
+    types: ['opened']
+
+jobs:
+  calypso-live:
+    name: 'Launch a Calypso.live instance for your branch'
+    runs-on: ubuntu-latest
+    # We only offer the Calypso.live link to PRs created from the Automattic organization.
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 10
+    steps:
+      - name: Build Calypso.live link.
+        run: |
+          echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/commit:${{ github.event.pull_request.head.sha }}'
+        id: build_link
+
+      - name: Post comment on PR
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '
+              <!--calypso-live-watermark:apr@v1-->
+              Link to Calypso live: ${{ steps.build_link.outputs.LINK }}
+              Link to Jetpack Cloud live: ${{ steps.build_link.outputs.LINK }}&env=jetpack
+              _(These links may take a few minutes to be available)_
+              '
+            })


### PR DESCRIPTION
#### Background

We have a TeamCity build that post links to calypso.live in a PR. However, it only works if the PR exists prior building the branch associated with that PR.

#### Changes proposed in this Pull Request

Create a GH Action to comment on a PR with temporary links to calypso.live.

This will help in the situation where the developer creates the branch, TC builds it but doesn't post the link because there is no PR yet, and then the developer creates the PR.

Note that because we are using the same watermark, once the PR is create and built (either because the build is re-run or because there is a new commit in the branch), TeamCity will "take over" and update the message accordingly.

It is worth mentioning that there is no guarantee that the links posted by this GH Action work: there are is small window after a PR is created (a few minutes) where the Action will post a link that points to an image that is still being built. In that scenario, once the image finished, TeamCity will post the correct link.


#### Testing instructions

N/A