### PR TITLE
chore: migrate `mailing-lists` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,6 +180,7 @@ module.exports = {
 				'apps/editing-toolkit/**/*',
 				'client/auth/**/*',
 				'client/incoming-redirect/**/*',
+				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/sections-filter.js',
 				'client/sections-helper.js',

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal Dependencies
- */
 import MainComponent from './main';
 
 export default {

--- a/client/mailing-lists/index.js
+++ b/client/mailing-lists/index.js
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import controller from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import controller from './controller';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function () {

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import { addSubscriber, deleteSubscriber } from './utils';
-import { Card } from '@automattic/components';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { preventWidows } from 'calypso/lib/formatting';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { addSubscriber, deleteSubscriber } from './utils';
 
 class MainComponent extends React.Component {
 	static displayName = 'MainComponent';

--- a/client/mailing-lists/utils.js
+++ b/client/mailing-lists/utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 function createSubscriberResourceUrl( category, emailAddress, method ) {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `mailing-lists` to use `import/order`

#### Testing instructions

N/A