### PR TITLE
chore: migrate `packages/webpack-inline-constant-exports-plugin` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -222,6 +222,7 @@ module.exports = {
 				'packages/tree-select/**/*',
 				'packages/viewport/**/*',
 				'packages/webpack-config-flag-plugin/**/*',
+				'packages/webpack-inline-constant-exports-plugin/**/*',
 				'packages/whats-new/**/*',
 				'packages/wpcom-checkout/**/*',
 				'packages/wpcom-proxy-request/**/*',

--- a/packages/webpack-inline-constant-exports-plugin/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/index.js
@@ -1,6 +1,6 @@
+const ConstDependency = require( 'webpack/lib/dependencies/ConstDependency' );
 const HarmonyImportSideEffectDependency = require( 'webpack/lib/dependencies/HarmonyImportSideEffectDependency' );
 const HarmonyImportSpecifierDependency = require( 'webpack/lib/dependencies/HarmonyImportSpecifierDependency' );
-const ConstDependency = require( 'webpack/lib/dependencies/ConstDependency' );
 
 function addConstantExport( module, name, value ) {
 	if ( ! module.constantExports ) {

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -12,6 +12,20 @@ exports.modules = {
 
 \\"use strict\\";
 
+;// CONCATENATED MODULE: ./constants2.js
+/*
+ * The export is eligible for inlining, but the module is not used directly but re-exported from \`./export.js\`.
+ * Re-exporting is not supported, therefore no inlining should happen.
+ */
+const FOO = 'bar';
+
+;// CONCATENATED MODULE: ./paths.js
+/*
+ * The export is eligible for inlining, but the module is not specified in the plugin config.
+ * Therefore no inlining should happen.
+ */
+const HOME_PATH = '/';
+
 ;// CONCATENATED MODULE: ./plans.js
 /*
  * Export two plan constants and a a constant array of all plans. The array should not be inlined
@@ -21,24 +35,7 @@ const BLOGGER = 'BLOGGER_PLAN';
 const PREMIUM = 'PREMIUM_PLAN';
 /* harmony default export */ const plans = ([ BLOGGER, PREMIUM ]);
 
-;// CONCATENATED MODULE: ./paths.js
-/*
- * The export is eligible for inlining, but the module is not specified in the plugin config.
- * Therefore no inlining should happen.
- */
-const HOME_PATH = '/';
-
-;// CONCATENATED MODULE: ./constants2.js
-/*
- * The export is eligible for inlining, but the module is not used directly but re-exported from \`./export.js\`.
- * Re-exporting is not supported, therefore no inlining should happen.
- */
-const FOO = 'bar';
-
 ;// CONCATENATED MODULE: ./index.js
-/**
- * Internal dependencies
- */
 
 
 

--- a/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/index.js
@@ -1,11 +1,8 @@
-/**
- * Internal dependencies
- */
 import { PLANS_REQUEST, PLANS_RECEIVE } from './actions';
-import ALL_PLANS, { BLOGGER, PREMIUM } from './plans';
 import THE_ANSWER, { PI, YES, NO, NULL } from './constants';
-import { HOME_PATH } from './paths';
 import { FOO } from './export';
+import { HOME_PATH } from './paths';
+import ALL_PLANS, { BLOGGER, PREMIUM } from './plans';
 
 /* eslint-disable no-console */
 console.log( PLANS_REQUEST, PLANS_RECEIVE );

--- a/packages/webpack-inline-constant-exports-plugin/test/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
 const path = require( 'path' );
 const rimraf = require( 'rimraf' );

--- a/packages/webpack-inline-constant-exports-plugin/tsconfig.json
+++ b/packages/webpack-inline-constant-exports-plugin/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
 	"compilerOptions": {
-		"types": ["node"]
+		"types": [ "node" ]
 	}
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/webpack-inline-constant-exports-plugin` to use `import/order`

#### Testing instructions

N/A
