### PR TITLE
chore: migrate `controller` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -179,6 +179,7 @@ module.exports = {
 			files: [
 				'apps/editing-toolkit/**/*',
 				'client/auth/**/*',
+				'client/controller/**/*',
 				'client/incoming-redirect/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/sections-filter.js',

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { makeLayoutMiddleware } from './shared.js';
-import { ssrSetupLocaleMiddleware } from './ssr-setup-locale.js';
-import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
-import LayoutLoggedOut from 'calypso/layout/logged-out';
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
+import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
+import { makeLayoutMiddleware } from './shared.js';
+import { ssrSetupLocaleMiddleware } from './ssr-setup-locale.js';
 
 /**
  * Re-export

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,31 +1,27 @@
 /**
- * External dependencies
- */
-import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
-import page from 'page';
-import { QueryClient, QueryClientProvider } from 'react-query';
-
-/**
  * Internal Dependencies
  */
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import Layout from 'calypso/layout';
-import LayoutLoggedOut from 'calypso/layout/logged-out';
-import EmptyContent from 'calypso/components/empty-content';
+import page from 'page';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
+import EmptyContent from 'calypso/components/empty-content';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
-import { login } from 'calypso/lib/paths';
+import Layout from 'calypso/layout';
+import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { getLanguageSlugs } from 'calypso/lib/i18n-utils';
-import { makeLayoutMiddleware } from './shared.js';
+import { login } from 'calypso/lib/paths';
+import { getSiteFragment } from 'calypso/lib/route';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
 	getImmediateLoginLocale,
 } from 'calypso/state/immediate-login/selectors';
-import { getSiteFragment } from 'calypso/lib/route';
+import { makeLayoutMiddleware } from './shared.js';
 import { render, hydrate } from './web-util.js';
 
 /**

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import React from 'react';
+import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSection } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
-import { isTranslatedIncompletely } from 'calypso/lib/i18n-utils/utils';
 
 const noop = () => {};
 

--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 /* eslint-disable import/no-nodejs-modules */
 import { readFile } from 'fs/promises';
 /* eslint-enable import/no-nodejs-modules */
-
-/**
- * Internal dependencies
- */
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import { getLanguage } from 'calypso/lib/i18n-utils';
-import { setLocaleRawData } from 'calypso/state/ui/language/actions';
 import config from 'calypso/server/config';
+import { setLocaleRawData } from 'calypso/state/ui/language/actions';
 
 export function ssrSetupLocaleMiddleware() {
 	const translationsCache = {};

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import ReactDom from 'react-dom';
 
 export function render( context ) {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/controller` to use `import/order`

#### Testing instructions

N/A

Note: there are preexisting eslint failures in one of the changed files.
