### PR TITLE
Theme Showcase: Fix FSE Beta badge size

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -85,6 +85,8 @@
 .section-nav__mobile-header-text .theme-showcase__badge-beta,
 .section-nav-tab__text .theme-showcase__badge-beta {
 	margin-left: 6px;
-    line-height: 12px;
-    height: 13px;
+	line-height: 12px;
+	height: 13px;
+	padding-left: 10px;
+	padding-right: 10px;
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -87,6 +87,6 @@
 	margin-left: 6px;
 	line-height: 12px;
 	height: 13px;
-	padding-left: 10px;
-	padding-right: 10px;
+	padding-left: 8px;
+	padding-right: 8px;
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -82,6 +82,9 @@
 	}
 }
 
-.theme-showcase__badge-beta {
+.section-nav__mobile-header-text .theme-showcase__badge-beta,
+.section-nav-tab__text .theme-showcase__badge-beta {
 	margin-left: 6px;
+    line-height: 12px;
+    height: 13px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
|Device | Before  | After |
|-- | ------------- | ------------- |
| Desktop| ![image](https://user-images.githubusercontent.com/375980/127011031-39f5999a-d167-4cf3-948f-467e32b64c6a.png)  | ![image](https://user-images.githubusercontent.com/375980/127011242-03d7d382-7732-48e6-9eb9-92e11bea5013.png)  |
| Mobile | ![image](https://user-images.githubusercontent.com/375980/127011162-c8806b09-5cc2-414a-a1d4-c2814ccd4257.png)  | ![image](https://user-images.githubusercontent.com/375980/127011203-3f2a183c-7bce-42c4-9a9a-f7e5517aa4ad.png)  |

#### Testing instructions
1. Go to your local dev environment 
2. Navigate to http://calypso.localhost:3000/themes/[YOUR_SITE]?flags=gutenboarding/site-editor
3. Verify the size of the beta badge on the tab
4. Go to mobile view and verify that the selected FSE tab looks correct

https://github.com/Automattic/wp-calypso/issues/54825
