### PR TITLE
Jetpack site-less Checkout: bypass call to `siteSelection` controller

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -355,8 +355,9 @@ export function noSite( context, next ) {
 	const currentUser = getCurrentUser( getState() );
 	const hasSite = currentUser && currentUser.visible_site_count >= 1;
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
+	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
 
-	if ( ! isDomainOnlyFlow && hasSite ) {
+	if ( ! isDomainOnlyFlow && ! isJetpackCheckoutFlow && hasSite ) {
 		siteSelection( context, next );
 	} else {
 		context.store.dispatch( setSelectedSiteId( null ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `noSite` controller calls the `siteSelection` controller if the user has at least one site, which breaks the Jetpack site-less checkout flow because the `siteSeleciton` controller appends the user's primary site URL to the URL. So, the URL goes from `/checkout/jetpack/:product` to `/checkout/jetpack/:product:site` which makes Calypso use the wrong controller.

#### Testing instructions

Prerequisite:
* A WP.com account with only one Jetpack site.

**Let's confirm there is a bug**
* Visit `wordpress.com/checkout/jetpack/jetpack_scan`.
* Verify that you see the Site Selection page.

**Let's test the solution**
* Download this PR.
* Start Calypso with `yarn start`.
* Visit `calypso.localhost:3000/checkout/jetpack/jetpack_scan`.
* Verify that you see the Checkout page.

Related to 1200479326344990-as-1200660344242712

#### Demo – before

https://user-images.githubusercontent.com/3418513/127020153-b28fb225-8503-492e-95ea-e02b9cceefbd.mp4

#### Demo – after 

https://user-images.githubusercontent.com/3418513/127020121-33f13dcb-0dcd-45a4-be81-a3a6ec6aa480.mp4

