### PR TITLE
Same colors on filters and search bar borders

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -28,7 +28,7 @@
 		flex: 0 1 auto;
 		margin: 0 5px 0 10px;
 		height: 36px;
-		border: solid 1px var( --color-border-subtle );
+		border: solid 1px var( --color-neutral-10 );
 
 		&.has-focus,
 		&.has-focus:hover {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/127027841-7e8fa9ef-b217-432b-a3a3-33d5baca365e.png) | ![image](https://user-images.githubusercontent.com/375980/127027705-edf4ba8b-e4be-4386-b35f-869e526fbf51.png) |

#### Testing instructions
* Verify that the border colors of the search bar and the filters match

https://github.com/Automattic/wp-calypso/issues/54824