### PR TITLE
Added Backup Plugin to Backup Minimum Plugin reqs

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -19,6 +19,7 @@ import {
 	getSitePlan,
 	getSiteProducts,
 	isJetpackMinimumVersion,
+	getSiteOption,
 } from 'calypso/state/sites/selectors';
 import {
 	isPlanIncludingSiteBackup,
@@ -72,9 +73,19 @@ const PrePurchaseNotices = () => {
 	);
 
 	const BACKUP_MINIMUM_JETPACK_VERSION = '8.5';
-	const siteHasBackupMinimumPluginVersion = useSelector( ( state ) =>
-		isJetpackMinimumVersion( state, siteId, BACKUP_MINIMUM_JETPACK_VERSION )
-	);
+	const siteHasBackupMinimumPluginVersion = useSelector( ( state ) => {
+		const activeConnectedPlugins = getSiteOption(
+			state,
+			siteId,
+			'jetpack_connection_active_plugins'
+		);
+		const backupPluginActive =
+			Array.isArray( activeConnectedPlugins ) &&
+			activeConnectedPlugins.includes( 'jetpack-backup' );
+		return (
+			backupPluginActive || isJetpackMinimumVersion( state, siteId, BACKUP_MINIMUM_JETPACK_VERSION )
+		);
+	} );
 
 	// All these notices (and the selectors that drive them)
 	// require a site ID to work. We should *conceptually* always


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Includes the Backup Plugin in the check for minimum requirements when purchasing a backup plan

#### Testing instructions

* Create a jurassic.ninja site with the latest version of Jetpack and Jetpack Beta plugin
* Add a Backup Daily plan to your cart, but do not purchase it
* Ensure this patch shows no warning on the checkout screen
* Disable the Jetpack Plugin
* Use the Jetpack Beta plugin to Activate the Jetpack Backup Plugin
* Ensure this patch shows no warning on the checkout screen
* You can also visit checkout on wordpress.com to compare to the warning there
* Deactivate Jetpack Backup Plugin
* Install Jetpack 8.4 and ensure the warning appears indicating your current version and the minimum required version.

Before change - Jetpack Backup Plugin site
<img width="606" alt="Screen Shot 2021-07-26 at 12 51 07 PM" src="https://user-images.githubusercontent.com/1992658/127027846-c330027d-740e-4c94-8a6c-eaed2c1eb365.png">

After change - Jetpack Backup Plugin site
<img width="610" alt="Screen Shot 2021-07-26 at 12 53 57 PM" src="https://user-images.githubusercontent.com/1992658/127028225-80fa4451-51fe-4042-b0fe-77c00fd103e8.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1199658893173824-as-1200627212537886
