### PR TITLE
Domains: Remove duplicate "organization" text input in the contact information section on checkout

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -318,6 +318,8 @@ export class ManagedContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Organization' ),
 							text: translate( '+ Add organization name' ),
+							toggled:
+								form.organization?.value || this.props.getIsFieldRequired?.( 'organization' ),
 						},
 						{
 							customErrorMessage: this.props.contactDetailsErrors?.organization,

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -319,7 +319,9 @@ export class ManagedContactDetailsFormFields extends Component {
 							label: translate( 'Organization' ),
 							text: translate( '+ Add organization name' ),
 							toggled:
-								form.organization?.value || this.props.getIsFieldRequired?.( 'organization' ),
+								form.organization?.value ||
+								this.props.getIsFieldRequired?.( 'organization' ) ||
+								undefined,
 						},
 						{
 							customErrorMessage: this.props.contactDetailsErrors?.organization,

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -19,7 +19,6 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import { Input } from 'calypso/my-sites/domains/components/form';
 import { disableSubmitButton } from './with-contact-details-validation';
 import wp from 'calypso/lib/wp';
 
@@ -138,20 +137,18 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	};
 
 	handleChangeEvent = ( event ) => {
-		const { value, name, checked, type, id } = event.target;
+		const { value, checked, type, id } = event.target;
 		const newContactDetails = {};
 
-		if ( name === 'organization' ) {
-			newContactDetails[ name ] = value;
-			this.validateContactDetails( {
-				...this.props.contactDetails,
-				[ name ]: value,
+		if ( id === 'legal-type' ) {
+			this.props.updateRequiredDomainFields( {
+				organization: this.isCorporationLegalType( value ),
 			} );
-		} else {
-			newContactDetails.extra = {
-				ca: { [ camelCase( id ) ]: type === 'checkbox' ? checked : value },
-			};
 		}
+
+		newContactDetails.extra = {
+			ca: { [ camelCase( id ) ]: type === 'checkbox' ? checked : value },
+		};
 
 		this.props.updateContactDetailsCache( { ...newContactDetails } );
 
@@ -160,8 +157,12 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		}
 	};
 
+	isCorporationLegalType( legalType ) {
+		return legalType === 'CCO';
+	}
+
 	needsOrganization() {
-		return get( this.props.ccTldDetails, 'legalType' ) === 'CCO';
+		return this.isCorporationLegalType( get( this.props.ccTldDetails, 'legalType' ) );
 	}
 
 	organizationFieldIsValid() {
@@ -189,28 +190,6 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		}
 
 		return this.props.translate( 'Required' );
-	}
-
-	renderOrganizationField() {
-		const { translate, contactDetails } = this.props;
-		const label = {
-			label: translate( 'Organization' ),
-			...( this.needsOrganization() ? {} : { labelProps: { optional: true } } ),
-		};
-
-		return (
-			<FormFieldset>
-				<Input
-					name="organization"
-					className="registrant-extra-info__organization"
-					value={ contactDetails.organization || '' }
-					isError={ ! this.organizationFieldIsValid() }
-					errorMessage={ this.getOrganizationErrorMessage() }
-					{ ...label }
-					onChange={ this.handleChangeEvent }
-				/>
-			</FormFieldset>
-		);
 	}
 
 	render() {
@@ -266,7 +245,6 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 						) }
 					</FormLabel>
 				</FormFieldset>
-				{ this.renderOrganizationField() }
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { camelCase, debounce, difference, get, isEmpty, keys, map, pick } from 'lodash';
+import { camelCase, difference, get, isEmpty, keys, map, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,9 +20,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import { disableSubmitButton } from './with-contact-details-validation';
-import wp from 'calypso/lib/wp';
 
-const wpcom = wp.undocumented();
 const ciraAgreementUrl = 'https://cira.ca/agree';
 const defaultValues = {
 	lang: 'EN',
@@ -94,7 +92,6 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		this.state = {
 			errorMessages: {},
 		};
-		this.validateContactDetails = debounce( this.validateContactDetails, 333 );
 	}
 
 	componentDidMount() {
@@ -123,18 +120,6 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		this.props.updateContactDetailsCache( payload );
 		this.props.onContactDetailsChange?.( payload );
 	}
-
-	validateContactDetails = ( contactDetails ) => {
-		wpcom.validateDomainContactInformation(
-			contactDetails,
-			this.props.getDomainNames(),
-			( error, data ) => {
-				this.setState( {
-					errorMessages: ( data && data.messages ) || {},
-				} );
-			}
-		);
-	};
 
 	handleChangeEvent = ( event ) => {
 		const { value, checked, type, id } = event.target;

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -162,7 +162,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	}
 
 	needsOrganization() {
-		return this.isCorporationLegalType( get( this.props.ccTldDetails, 'legalType' ) );
+		return this.isCorporationLegalType( this.props.ccTldDetails?.legalType );
 	}
 
 	organizationFieldIsValid() {

--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelect, useDispatch } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
-import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
+import type { DomainContactDetailsErrors, ManagedValue } from '@automattic/wpcom-checkout';
 
 /**
  * Internal dependencies
@@ -47,6 +48,11 @@ export default function DomainContactDetails( {
 	const getIsFieldDisabled = () => isDisabled;
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
+	const { updateRequiredDomainFields } = useDispatch( 'wpcom' );
+	const contactInfo = useSelect< Record< string, ManagedValue > >( ( select ) =>
+		select( 'wpcom' ).getContactInfo()
+	);
+	const getIsFieldRequired = ( field: string ) => contactInfo[ field ].isRequired;
 
 	return (
 		<React.Fragment>
@@ -58,6 +64,7 @@ export default function DomainContactDetails( {
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 				}
 				onContactDetailsChange={ updateDomainContactFields }
+				getIsFieldRequired={ getIsFieldRequired }
 				getIsFieldDisabled={ getIsFieldDisabled }
 				isLoggedOutCart={ isLoggedOutCart }
 				emailOnly={ emailOnly }
@@ -67,6 +74,7 @@ export default function DomainContactDetails( {
 					contactDetails={ contactDetails }
 					ccTldDetails={ contactDetails?.extra?.ca ?? {} }
 					onContactDetailsChange={ updateDomainContactFields }
+					updateRequiredDomainFields={ updateRequiredDomainFields }
 					contactDetailsValidationErrors={
 						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 					}

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -14,13 +14,14 @@ export class HiddenInput extends PureComponent {
 	constructor( props, context ) {
 		super( props, context );
 		this.state = {
+			wasClicked: false,
 			toggled: ! isEmpty( props.value ),
 		};
 		this.inputField = null;
 	}
 
 	static getDerivedStateFromProps( props, state ) {
-		if ( props.toggled !== undefined ) {
+		if ( props.toggled !== undefined && state.toggled !== props.toggled ) {
 			return { ...state, toggled: props.toggled };
 		}
 
@@ -33,6 +34,7 @@ export class HiddenInput extends PureComponent {
 		this.setState(
 			{
 				toggled: true,
+				wasClicked: true,
 			},
 			() => {
 				this.inputField && this.inputField.focus();
@@ -48,7 +50,7 @@ export class HiddenInput extends PureComponent {
 	};
 
 	render() {
-		if ( this.state.toggled ) {
+		if ( this.state.toggled || this.state.wasClicked ) {
 			return <Input ref={ this.assignInputFieldRef } { ...this.props } />;
 		}
 

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * External dependencies
  */
@@ -16,6 +17,14 @@ export class HiddenInput extends PureComponent {
 			toggled: ! isEmpty( props.value ),
 		};
 		this.inputField = null;
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		if ( props.toggled !== undefined ) {
+			return { ...state, toggled: props.toggled };
+		}
+
+		return null;
 	}
 
 	handleClick = ( event ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When trying to buy a .ca domain, you need to provide a few extra values: 
- Your Canadian presence;
- The confirmation you read and agreed to the CIRA agreement;
- An organization **(Only required if you chose "Canadian Corporation" as Canadian presence. Otherwise, it's optional)**

If you select "Canadian Corporation", then a **second** organization field is shown in the contact information form. 
This PR fixes it by using only the default organization text input for .ca domains.

#### Testing instructions
- Add a .ca domain to the cart;
- Go to the checkout page; 
- If you select "Canadian Corporation" on the "Canadian presence" input:
  - Check that the organization input gets toggled and required;
  - Check that a single input is shown;
- If you select any other value, just check that the organization field behaves the same as before.

#### Screenshot
##### Before (2 fields)
![image](https://user-images.githubusercontent.com/18705930/127044304-ce1ac891-25a2-4a67-b3a1-19740d93767d.png)

##### After (a single field)
![image](https://user-images.githubusercontent.com/18705930/127044392-2bdad4fd-9768-4612-a517-a6f49b2219de.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->