### PR TITLE
Activity Log: Only show 'Share this event' for backups

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -114,6 +114,7 @@ class ActivityCardList extends Component {
 					<div className="activity-card-list__date-group-content">
 						{ dateLogs.map( ( activity ) => (
 							<ActivityCard
+								shareable={ isActivityBackup( activity ) }
 								activity={ activity }
 								className={
 									isActivityBackup( activity )

--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -101,7 +101,7 @@
 	width: calc( 100% - 32px - 16px );
 
 	// scooch secondary card elements over
-	> .activity-card__time,
+	> .activity-card__header,
 	> .card {
 		transform: translateX( 32px );
 	}

--- a/client/components/activity-card/index.jsx
+++ b/client/components/activity-card/index.jsx
@@ -36,6 +36,7 @@ class ActivityCard extends Component {
 		allowRestore: PropTypes.bool.isRequired,
 		applySiteOffset: PropTypes.func,
 		className: PropTypes.string,
+		shareable: PropTypes.bool,
 		moment: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
@@ -45,6 +46,7 @@ class ActivityCard extends Component {
 
 	static defaultProps = {
 		summarize: false,
+		shareable: false,
 	};
 
 	constructor( props ) {
@@ -56,7 +58,15 @@ class ActivityCard extends Component {
 	}
 
 	render() {
-		const { activity, allowRestore, applySiteOffset, className, siteId, summarize } = this.props;
+		const {
+			activity,
+			shareable,
+			allowRestore,
+			applySiteOffset,
+			className,
+			siteId,
+			summarize,
+		} = this.props;
 
 		const backupTimeDisplay = applySiteOffset
 			? applySiteOffset( activity.activityTs ).format( 'LT' )
@@ -81,7 +91,7 @@ class ActivityCard extends Component {
 							<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />
 							<div className="activity-card__time-text">{ backupTimeDisplay }</div>
 						</div>
-						{ isEnabled( 'jetpack/activity-log-sharing' ) && (
+						{ isEnabled( 'jetpack/activity-log-sharing' ) && shareable && (
 							<ShareActivity siteId={ siteId } activity={ activity } />
 						) }
 					</div>

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -59,10 +59,6 @@
 	justify-content: space-between;
 	column-gap: 16px;
 	margin: 24px 0 8px;
-
-	.activity-card-list__secondary-card & {
-		transform: translateX( 32px );
-	}
 }
 
 .activity-card__time {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the 'Share this event' button visible only on "primary" (i.e., backup) Activity cards.
* Adjust alignment so that the activity timestamp on "secondary" (i.e. nested, non-backup) Activity cards lines up with the left border of the card.

#### Testing instructions

1. Open Calypso Green, selecting a site (probably with Backup Real-time) that has non-backup events in its Activity Log.
2. Visit the Activity Log page.
3. Verify that the 'Share this event' button (see reference screenshot) only appears on cards for full backup events.
4. Verify that the timestamp on non-backup event cards is aligned with the left edge of the card, not centered on the top-to-bottom timeline.

#### Reference screenshots (before / after)

##### Mobile

<img width="361" alt="image" src="https://user-images.githubusercontent.com/670067/127047966-3b776b31-03f3-4084-ae4d-0156c898f058.png"> <img width="360" alt="image" src="https://user-images.githubusercontent.com/670067/127048007-d1ca15e0-1e9c-4e36-aa11-9fcb5b27a428.png">

##### Desktop

<img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/127047099-176ec9a1-027a-449a-bf9d-ac87af879c31.png"> <img width="325" alt="image" src="https://user-images.githubusercontent.com/670067/127047204-10b9ec5b-dce7-450f-8663-2c27d0ff1bd2.png">