### PR TITLE
Theme Showcase: Fix alignment of search autocomplete

### DIFF
--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -6,6 +6,8 @@
 	margin-left: -1px;
 	overflow-y: auto;
 	max-height: 50vh;
+    border: 1px solid var( --color-neutral-10 );
+    border-top: 0;
 }
 
 .keyed-suggestions__suggestions {
@@ -15,8 +17,8 @@
 
 .keyed-suggestions__category {
 	background-color: var( --color-neutral-0 );
-	border: 1px solid var( --color-neutral-5 );
-	border-top: 0;
+	border: 0;
+	border-bottom: 1px solid var( --color-neutral-5 );
 	padding: 4px 8px;
 	font-size: $font-body-small;
 	display: flex;
@@ -44,8 +46,8 @@
 	display: flex;
 	padding: 10px;
 	background: var( --color-surface );
-	border: 1px solid var( --color-neutral-5 );
-	border-top: 0;
+    border: 0;
+	border-bottom: 1px solid var( --color-neutral-5 );
 	font-size: $font-body;
 	cursor: pointer;
 

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -6,8 +6,8 @@
 	margin-left: -1px;
 	overflow-y: auto;
 	max-height: 50vh;
-    border: 1px solid var( --color-neutral-10 );
-    border-top: 0;
+	border: 1px solid var( --color-neutral-10 );
+	border-top: 0;
 }
 
 .keyed-suggestions__suggestions {
@@ -46,7 +46,7 @@
 	display: flex;
 	padding: 10px;
 	background: var( --color-surface );
-    border: 0;
+	border: 0;
 	border-bottom: 1px solid var( --color-neutral-5 );
 	font-size: $font-body;
 	cursor: pointer;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/127048805-2251d085-073d-4c73-99ba-22dd04f95a43.png)  | ![image](https://user-images.githubusercontent.com/375980/127048957-22c0acc3-607f-44ef-8f52-b29c89cd907e.png) |

~~Note that the color of the search box is different from the border of the suggestion box, but that should be fixed after merging this: https://github.com/Automattic/wp-calypso/pull/54898~~ (already merged)

#### Testing instructions
Verify that the search box is aligned

https://github.com/Automattic/wp-calypso/issues/54823
