### PR TITLE
Mailchimp: Update "List" copy to say "Audience"

### DIFF
--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -52,7 +52,9 @@ const MailchimpSettings = ( {
 				follower_list_id: event.target.value,
 				keyring_id: keyringConnections[ 0 ].ID,
 			},
-			translate( 'Subscriber emails will be saved to the %s Mailchimp list', { args: list.name } )
+			translate( 'Subscriber emails will be saved to the %s Mailchimp audience', {
+				args: list.name,
+			} )
 		);
 	};
 	const common = (
@@ -62,7 +64,7 @@ const MailchimpSettings = ( {
 			<div className="sharing-connections__mailchimp-gutenberg_explanation">
 				<p>
 					{ translate(
-						'Start building your mailing list by adding the Mailchimp block to your posts and pages. '
+						'Start building your audience by adding the Mailchimp block to your posts and pages. '
 					) }
 					<a
 						href={ localizeUrl( 'https://wordpress.com/support/mailchimp-block/' ) }
@@ -95,12 +97,12 @@ const MailchimpSettings = ( {
 		<div>
 			<QueryMailchimpLists siteId={ siteId } />
 			<QueryMailchimpSettings siteId={ siteId } />
-			<p>{ translate( 'What Mailchimp list should subscribers be added to?' ) }</p>
+			<p>{ translate( 'What Mailchimp audience should subscribers be added to?' ) }</p>
 			{ Array.isArray( mailchimpLists ) && mailchimpLists.length === 0 && (
 				<Notice
 					status="is-info"
 					text={ translate(
-						"Looks like you've not set up any Mailchimp lists yet. Head to your Mailchimp admin to add a list."
+						"Looks like you've not set up any Mailchimp audiences yet. Head to your Mailchimp admin to add an audience."
 					) }
 					showDismiss={ false }
 				>
@@ -111,7 +113,7 @@ const MailchimpSettings = ( {
 				<Notice
 					status="is-warning"
 					text={ translate(
-						'Subscribers will not be added to Mailchimp for this site. Please select a list to sign them up for your Mailchimp content'
+						'Subscribers will not be added to Mailchimp for this site. Please select an audience to sign them up for your Mailchimp content'
 					) }
 					showDismiss={ false }
 				/>

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -73,15 +73,15 @@ class SharingServiceDescription extends Component {
 			mailchimp: function () {
 				if ( this.props.numberOfConnections > 0 ) {
 					return this.props.translate(
-						'Allow users to sign up to your Mailchimp mailing list.',
-						'Allow users to sign up to your Mailchimp mailing lists.',
+						'Allow users to sign up to your Mailchimp mailing audience.',
+						'Allow users to sign up to your Mailchimp mailing audiences.',
 						{
 							count: this.props.numberOfConnections,
 						}
 					);
 				}
 
-				return this.props.translate( 'Allow users to sign up to your Mailchimp mailing list.' );
+				return this.props.translate( 'Allow users to sign up to your Mailchimp mailing audience.' );
 			},
 			linkedin: function () {
 				if ( this.props.numberOfConnections > 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Mailchimp has changed their "Lists" to "Audiences" - this PR updates the copy on the connection page to reduce confusion. 

This PR doesn't update the screenshot on the Connections page. It probably should, but after scouring the Mailchimp dashboard, I'm honestly sure what screenshot would be best or what our image requirements are.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proofread
* Regression test the Mailchimp connection.
* Any translation concerns?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to an issue opened in the Jetpack repo: https://github.com/Automattic/jetpack/issues/20452
Jetpack PR for the Mailchimp block: https://github.com/Automattic/jetpack/pull/20453
