### PR TITLE
Jetpack site-less Checkout: add button to cancel and refund a subscription back

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -801,7 +801,7 @@ class ManagePurchase extends Component {
 					! isJetpackTemporarySite &&
 					this.renderUpgradeNavItem() }
 				{ isProductOwner && this.renderEditPaymentMethodNavItem() }
-				{ isProductOwner && ! isJetpackTemporarySite && this.renderCancelPurchaseNavItem() }
+				{ isProductOwner && this.renderCancelPurchaseNavItem() }
 				{ isProductOwner && ! isJetpackTemporarySite && this.renderRemovePurchaseNavItem() }
 			</Fragment>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On 3d4243b, I made the mistake of hiding the button to cancel and refund a subscription when the site is a temporary Jetpack site. We need to put this button back since users might want to ask for a refund before their subscription is transferred to another site.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Sandbox public-api.wordpress.com.
* Enable USE_STORE_SANDBOX so you can use a fake credit card (using credits makes appear many other warnings in the Purchase section, and we won't be dealing with them on this PR).
* Purchase a product and a plan separately (you should own two temporary sites after this).
* Visit the /me/purchases section.
* Verify that you see two entries associated with the two purchases you just made.
* Click on any of them.
* Verify that at the bottom of the page appears a button called `Cancel Subscription and Refund`.
* Go back and verify the same behavior in the other product/plan.

#### Demo of a product subscription
<p align="center">
<img src="https://user-images.githubusercontent.com/3418513/127060984-f6e8ed2d-6c0c-4993-ba9d-c534acb7a2a1.png" width="47%" />
<img src="https://user-images.githubusercontent.com/3418513/127060966-53222651-bad5-447c-a5bb-a4241af4d13e.png" width="47%" />
</p>

#### Demo of a plan subscription
<p align="center">
<img src="https://user-images.githubusercontent.com/3418513/127061177-0d797701-ce04-430f-b006-324145a3f07c.png" width="47%" />
<img src="https://user-images.githubusercontent.com/3418513/127061162-c0cbae5a-5f7e-4b35-8a8d-2b593862a525.png" width="47%" />
</p>
