### PR TITLE
Theme Showcase: Fix logic so 'All' tab highlights correctly on theme search card

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -386,7 +386,7 @@ class ThemesMagicSearchCard extends React.Component {
 						{ isPremiumThemesEnabled && showTierThemesControl && (
 							<SimplifiedSegmentedControl
 								key={ this.props.tier }
-								initialSelected={ this.props.tier }
+								initialSelected={ this.props.tier ? this.props.tier : 'all' }
 								options={ tiers }
 								onSelect={ this.props.select }
 								className={ classNames( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes broken behavior in the Theme Showcase "Magic Search Card" which was causing the 'All' filter tab to not be highlighted when it was selected. (The reason for this was that the `tier` value passed as a prop from further up the component tree is an empty string, not null, when All is selected; therefore, the existing `defaultProps` value was not being applied. So I updated the prop being passed to the `SimplifiedSegmentedControl` so that its selected value falls back to 'All' any time that the passed `tier` prop is generally falsy.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/themes/{SITE_URL}`
* Navigate between All, Free, Premium tabs on the segmented search control and verify that "All" is correctly highlighted when it is selected.
* Select the All Themes tab on the tab bar, then the Free tab on the segmented control, then click "Trending" on the tab bar. Verify that the segmented control returns back to having "All" highlighted.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54805
