### PR TITLE
Remove the legacy Gutenframe error handler

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -78,7 +78,7 @@ function handlePostTrash( calypsoPort ) {
 				 * More context:
 				 * - https://github.com/WordPress/gutenberg/issues/27088;
 				 * - https://github.com/WordPress/gutenberg/pull/32153.
-				 **/
+				 */
 				const namespace = store.name ?? store;
 				const actions = { ...registry.dispatch( namespace ) };
 
@@ -1050,27 +1050,6 @@ function getCalypsoUrlInfo( calypsoPort ) {
 	);
 }
 
-/**
- * Passes uncaught errors in window.onerror to Calypso for logging.
- *
- * @param {MessagePort} calypsoPort Port used for communication with parent frame.
- */
-function handleUncaughtErrors( calypsoPort ) {
-	window.onerror = ( ...error ) => {
-		// Since none of Error's properties are enumerable, JSON.stringify does not work on it.
-		// We therefore stringify the error with a custom replacer containing the object's properties.
-		const errorObject = error[ 4 ]; // the 5th argument is the error object
-		error[ 4 ] =
-			errorObject && JSON.stringify( errorObject, Object.getOwnPropertyNames( errorObject ) );
-
-		// The other parameters don't need encoded since they are numbers or strings.
-		calypsoPort.postMessage( {
-			action: 'logError',
-			payload: { error },
-		} );
-	};
-}
-
 async function handleEditorLoaded( calypsoPort ) {
 	await isEditorReadyWithBlocks();
 	const isNew = select( 'core/editor' ).isCleanNewPost();
@@ -1269,8 +1248,6 @@ function initPort( message ) {
 		getNavSidebarLabels( calypsoPort );
 
 		getCalypsoUrlInfo( calypsoPort );
-
-		handleUncaughtErrors( calypsoPort );
 
 		handleEditorLoaded( calypsoPort );
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -128,7 +128,6 @@ enum EditorActions {
 	GetTemplateEditorUrl = 'getTemplateEditorUrl',
 	OpenTemplatePart = 'openTemplatePart',
 	GetCloseButtonUrl = 'getCloseButtonUrl',
-	LogError = 'logError',
 	GetGutenboardingStatus = 'getGutenboardingStatus',
 	ToggleInlineHelpButton = 'toggleInlineHelpButton',
 	GetNavSidebarLabels = 'getNavSidebarLabels',
@@ -487,16 +486,6 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 				origin: window.location.origin,
 				siteSlug: this.props.siteSlug,
 			} );
-		}
-
-		// Pipes errors in the iFrame context to the Calypso error handler if it exists:
-		if ( EditorActions.LogError === action ) {
-			const { error } = payload;
-			if ( Array.isArray( error ) && error.length > 4 && window.onerror ) {
-				const errorObject = error[ 4 ];
-				error[ 4 ] = errorObject && JSON.parse( errorObject );
-				window.onerror( ...error );
-			}
 		}
 
 		if ( EditorActions.PostStatusChange === action ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This reverts https://github.com/Automattic/wp-calypso/pull/36345. 

@fullofcaffeine Has been working on better error handlers for our Gutenberg integration. These work entirely in the wp-admin context and do not need a connection to Calypso. I originally added this code to use Calypso's error handler to handle Gutenframe errors as well. 

It is now causing problems because it overwrites `window.onerror`, which our new error handler, Sentry, uses as well. We currently think that Sentry sets up [its error handler](https://github.com/getsentry/sentry-javascript/blob/b024902fe5194a1591fe5e778ab21c9471c3eb4c/packages/browser/src/loader.js#L192), and then this code loads and overwrites that in most cases.

Given that no one every really used this data (to my knowledge), and I'm unsure if it even works, I think we should remove it entirely in favor of the new error handlers.

#### Testing instructions

1. Run `install-plugin.sh wpcom-block-editor remove/legacy-gutenframe-error-handler` on your sandbox
2. Sandbox `widgets.wp.com`
3. Test #54257, with a focus on Calypso Gutenframe editor views
4. Manual errors from those testing steps should now work
