### PR TITLE
build: Add action to create temporary calypso.live links

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Build calypso.live link.
         run: |
-          echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/commit:${{ github.event.pull_request.head.sha }}'
+          echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}'
         id: build_link
 
       - name: Post comment on PR

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   calypso-live:
-    name: 'Launch a Calypso.live instance for your branch'
+    name: 'Links to a calypso.live instance for your branch'
     runs-on: ubuntu-latest
     # We only offer the Calypso.live link to PRs created from the Automattic organization.
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10
     steps:
-      - name: Build Calypso.live link.
+      - name: Build calypso.live link.
         run: |
           echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/commit:${{ github.event.pull_request.head.sha }}'
         id: build_link

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -26,10 +26,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '
-              <!--calypso-live-watermark:apr@v1-->
-              Link to Calypso live: ${{ steps.build_link.outputs.LINK }}
-              Link to Jetpack Cloud live: ${{ steps.build_link.outputs.LINK }}&env=jetpack
-              _(These links may take a few minutes to be available)_
-              '
+              body: '<!--calypso-live-watermark:apr@v1-->\nLink to Calypso live: ${{ steps.build_link.outputs.LINK }}\nLink to Jetpack Cloud live: ${{ steps.build_link.outputs.LINK }}&env=jetpack\n_(These links may take a few minutes to be available)_'
             })

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -1,0 +1,35 @@
+name: Calypso Live
+
+on:
+  pull_request:
+    types: ['opened']
+
+jobs:
+  calypso-live:
+    name: 'Launch a Calypso.live instance for your branch'
+    runs-on: ubuntu-latest
+    # We only offer the Calypso.live link to PRs created from the Automattic organization.
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 10
+    steps:
+      - name: Build Calypso.live link.
+        run: |
+          echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/commit:${{ github.event.pull_request.head.sha }}'
+        id: build_link
+
+      - name: Post comment on PR
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '
+              <!--calypso-live-watermark:apr@v1-->
+              Link to Calypso live: ${{ steps.build_link.outputs.LINK }}
+              Link to Jetpack Cloud live: ${{ steps.build_link.outputs.LINK }}&env=jetpack
+              _(These links may take a few minutes to be available)_
+              '
+            })


### PR DESCRIPTION
#### Background

We have a TeamCity build that post links to calypso.live in a PR. However, it only works if the PR exists prior building the branch associated with that PR.

#### Changes proposed in this Pull Request

Create a GH Action to comment on a PR with temporary links to calypso.live. This will help in the situation where the developer creates the branch, TC builds it but doesn't post the link because there is no PR yet, and then the developer creates the PR.

There are a few scenarios at play here, depending on the order of a few steps:

##### Flow 1
1. Dev pushes a new branch
2. Dev creates a PR
3. TeamCity build completes

As long as (2) is done before (3), TeamCity will post a message with the links to calypso.live.

##### Flow 2
1. Dev pushes a new branch
2. TeamCity build completes
3. Dev creates a PR

In this scenario, the action (runs on step 3) will post the links to calypso.live.

##### Flow 3
1. Dev pushes a new branch
2. TeamCity starts
3. Dev creates a PR
4. TeamCity build completes

In this case, when the action post the links (step 3), they will point to an image that doesn't exists yet and they will throw a 304. Currently the build takes ~5:30 minutes on average, so the window in which this scenario can occur is not huge.
As soon as TeamCity build is complete it will post the correct links, as we are effectively back to Flow 1.

Note that this action only run when the PR is created, not when it is updated. When a PR is updated we'll always be in Flow 1 by definition. As the action and TeamCity uses the same message watermark, they will actually update the same message, we won't get double posting.

#### Testing instructions

N/A