### PR TITLE
chore: Refactor `packages/design-picker` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,6 +204,7 @@ module.exports = {
 				'packages/composite-checkout/**/*',
 				'packages/create-calypso-config/**/*',
 				'packages/data-stores/**/*',
+				'packages/design-picker/**/*',
 				'packages/domain-picker/**/*',
 				'packages/eslint-plugin-wpcalypso/**/*',
 				'packages/explat-client-react-helpers/**/*',

--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
+import * as React from 'react';
 import DesignPicker from '../components';
 import { getAvailableDesigns } from '../utils';
-import type { Design } from '../types';
 import type { DesignPickerProps } from '../components';
+import type { Design } from '../types';
 
 jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn().mockImplementation( ( feature: string ) => {

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,19 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
+import { isEnabled } from '@automattic/calypso-config';
 import { Tooltip } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { isEnabled } from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import MShotsImage from './mshots-image';
-export { default as MShotsImage } from './mshots-image';
+import classnames from 'classnames';
+import React from 'react';
 import {
 	getAvailableDesigns,
 	getDesignImageUrl,
@@ -21,11 +12,10 @@ import {
 	mShotOptions,
 	isBlankCanvasDesign,
 } from '../utils';
+import MShotsImage from './mshots-image';
+export { default as MShotsImage } from './mshots-image';
 import type { Design } from '../types';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;

--- a/packages/design-picker/src/components/mshots-image/index.tsx
+++ b/packages/design-picker/src/components/mshots-image/index.tsx
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-import React, { useState, useEffect, useRef } from 'react';
-import classnames from 'classnames';
 import { addQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
 import debugFactory from 'debug';
+import React, { useState, useEffect, useRef } from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface MShotsImageProps {

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { Font } from './types';
 
 export const FONT_TITLES: Partial< Record< Font, string > > = {

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 export { default } from './components';
 
 export { default as MShotsImage } from './components/mshots-image';

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import type { ValuesType } from 'utility-types';
-
-/**
- * Internal dependencies
- */
 import type { FONT_PAIRINGS } from './constants';
+import type { ValuesType } from 'utility-types';
 
 export type Font = ValuesType< ValuesType< typeof FONT_PAIRINGS > >;
 

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import '@automattic/calypso-config';
 
-/**
- * Internal dependencies
- */
 import '../../constants';
 import { getDesignUrl, getDesignImageUrl, getAvailableDesigns } from '../available-designs';
 import { availableDesignsConfig } from '../available-designs-config';
 import { shuffleArray } from '../shuffle';
-
 import type { Design } from '../../types';
 
 jest.mock( '@automattic/calypso-config', () => ( {

--- a/packages/design-picker/src/utils/__tests__/font.test.ts
+++ b/packages/design-picker/src/utils/__tests__/font.test.ts
@@ -1,9 +1,5 @@
-/**
- * Internal dependencies
- */
 import '../../constants';
 import { getFontTitle } from '../fonts';
-
 import type { Font } from '../../types';
 
 jest.mock( '../../constants', () => ( {

--- a/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
+++ b/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isBlankCanvasDesign } from '../available-designs';
 
 jest.mock( '@automattic/calypso-config', () => ( {

--- a/packages/design-picker/src/utils/__tests__/shuffle.test.ts
+++ b/packages/design-picker/src/utils/__tests__/shuffle.test.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { shuffleArray } from '../shuffle';
 
 const TEST_ARRAY_EMPTY = [];

--- a/packages/design-picker/src/utils/available-designs-config.ts
+++ b/packages/design-picker/src/utils/available-designs-config.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import rawAvailableDesignsConfig from '../available-designs-config.json';
 import type { Design } from '../types';
 

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { addQueryArgs } from '@wordpress/url';
 import { isEnabled } from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import { availableDesignsConfig } from './available-designs-config';
+import { addQueryArgs } from '@wordpress/url';
 import { DESIGN_IMAGE_FOLDER } from '../constants';
+import { availableDesignsConfig } from './available-designs-config';
 import { shuffleArray } from './shuffle';
 import type { MShotsOptions } from '../components/mshots-image';
 import type { Design } from '../types';

--- a/packages/design-picker/src/utils/fonts.ts
+++ b/packages/design-picker/src/utils/fonts.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { FONT_TITLES } from '../constants';
 import type { Font } from '../types';
 


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/design-picker` to use `import/order`

#### Testing instructions

N/A