### PR TITLE
Emails: Fix Google Workspace inline layout for upsell and add mailbox.

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -139,44 +139,46 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 			className={ classNames( 'gsuite-new-user-list__new-user', { 'show-labels': showLabels } ) }
 		>
 			<FormFieldset>
-				<LabelWrapper label={ translate( 'First name' ) } showLabel={ showLabels }>
-					<FormTextInput
-						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-						placeholder={ translate( 'First name' ) }
-						value={ firstName }
-						maxLength={ 60 }
-						isError={ hasFirstNameError }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-							onUserValueChange( 'firstName', event.target.value, mailBoxFieldTouched );
-						} }
-						onBlur={ () => {
-							setFirstNameFieldTouched( wasValidated );
-						} }
-						onKeyUp={ onReturnKeyPress }
-					/>
-				</LabelWrapper>
+				<div className="gsuite-new-user-list__new-user-name-container">
+					<LabelWrapper label={ translate( 'First name' ) } showLabel={ showLabels }>
+						<FormTextInput
+							autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+							placeholder={ translate( 'First name' ) }
+							value={ firstName }
+							maxLength={ 60 }
+							isError={ hasFirstNameError }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+								onUserValueChange( 'firstName', event.target.value, mailBoxFieldTouched );
+							} }
+							onBlur={ () => {
+								setFirstNameFieldTouched( wasValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
+					</LabelWrapper>
 
-				{ hasFirstNameError && <FormInputValidation text={ firstNameError } isError /> }
-			</FormFieldset>
+					{ hasFirstNameError && <FormInputValidation text={ firstNameError } isError /> }
+				</div>
 
-			<FormFieldset>
-				<LabelWrapper label={ translate( 'Last name' ) } showLabel={ showLabels }>
-					<FormTextInput
-						placeholder={ translate( 'Last name' ) }
-						value={ lastName }
-						maxLength={ 60 }
-						isError={ hasLastNameError }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-							onUserValueChange( 'lastName', event.target.value );
-						} }
-						onBlur={ () => {
-							setLastNameFieldTouched( wasValidated );
-						} }
-						onKeyUp={ onReturnKeyPress }
-					/>
-				</LabelWrapper>
+				<div className="gsuite-new-user-list__new-user-name-container">
+					<LabelWrapper label={ translate( 'Last name' ) } showLabel={ showLabels }>
+						<FormTextInput
+							placeholder={ translate( 'Last name' ) }
+							value={ lastName }
+							maxLength={ 60 }
+							isError={ hasLastNameError }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+								onUserValueChange( 'lastName', event.target.value );
+							} }
+							onBlur={ () => {
+								setLastNameFieldTouched( wasValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
+					</LabelWrapper>
 
-				{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
+					{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
+				</div>
 
 				{ showTrashButton && (
 					<Button
@@ -197,28 +199,28 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 
 					{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
 				</div>
-			</FormFieldset>
 
-			<FormFieldset>
-				<LabelWrapper label={ translate( 'Password' ) } showLabel={ showLabels }>
-					<FormPasswordInput
-						autoCapitalize="off"
-						autoCorrect="off"
-						placeholder={ translate( 'Password' ) }
-						value={ password }
-						maxLength={ 100 }
-						isError={ hasPasswordError }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-							onUserValueChange( 'password', event.target.value );
-						} }
-						onBlur={ () => {
-							setPasswordFieldTouched( wasValidated );
-						} }
-						onKeyUp={ onReturnKeyPress }
-					/>
-				</LabelWrapper>
+				<div className="gsuite-new-user-list__new-user-password-container">
+					<LabelWrapper label={ translate( 'Password' ) } showLabel={ showLabels }>
+						<FormPasswordInput
+							autoCapitalize="off"
+							autoCorrect="off"
+							placeholder={ translate( 'Password' ) }
+							value={ password }
+							maxLength={ 100 }
+							isError={ hasPasswordError }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
+								onUserValueChange( 'password', event.target.value );
+							} }
+							onBlur={ () => {
+								setPasswordFieldTouched( wasValidated );
+							} }
+							onKeyUp={ onReturnKeyPress }
+						/>
+					</LabelWrapper>
 
-				{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+				</div>
 			</FormFieldset>
 		</div>
 	);

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -53,8 +53,6 @@
 .gsuite-new-user-list__new-user {
 	.form-fieldset .form-label {
 		color: var( --color-text );
-		margin-bottom: 1em;
-		margin-top: 0;
 
 		.form-text-input-with-affixes__suffix {
 			font-weight: normal;
@@ -121,36 +119,10 @@
 	}
 }
 
+.gsuite-new-user-list__new-user-email-container,
+.gsuite-new-user-list__new-user-password-container,
 .gsuite-new-user-list__new-user-name-container {
 	display: flex;
 	flex-direction: column;
 	margin-bottom: 15px;
-
-	@include breakpoint-deprecated( '>800px' ) {
-		margin-bottom: 20px;
-		width: 50%;
-	}
-}
-
-.gsuite-new-user-list__new-user-email-container,
-.gsuite-new-user-list__new-user-password-container {
-	@include breakpoint-deprecated( '>800px' ) {
-		margin-bottom: 0;
-	}
-}
-
-.gsuite-new-user-list__new-user-email-container {
-	@include breakpoint-deprecated( '>800px' ) {
-		width: 100%;
-	}
-}
-
-.gsuite-new-user-list__new-user-password-container {
-	margin-top: 15px;
-
-	@include breakpoint-deprecated( '>800px' ) {
-		margin-right: 0;
-		margin-top: 0;
-		width: 50%;
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of [previous development](https://github.com/Automattic/wp-calypso/pull/54349) we've removed spaces between HTML controls when upsell and add mailbox were removing the labels in the form.

This change fixes the empty gaps between those controls when not showing the labels. Plus It adds back the correct margin between controls in the main scenario when adding an email provider from emails home (very subtle)

#### Testing instructions

**Scenario 1: Upsell**

1. Go to upgrades -> domains
2. Add a domain
3. Check that there is a gap between HTML controls

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/127136893-a9f1eef0-25f5-42ea-9464-3b5a3f675ec7.png) | ![image](https://user-images.githubusercontent.com/5689927/127136637-9a68bc40-889f-4c12-b6ec-2168491930b3.png)

**Scenario 2: Add mailbox**

1. Go to upgrades -> emails
2. Add a mailbox to a Google Workspace account
3. Check that there is a gap between HTML controls

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/127138401-60f0f7c3-425a-41e8-8bfc-9604a3be0b80.png) | ![image](https://user-images.githubusercontent.com/5689927/127138125-0da1425e-3a09-4429-bcc2-f7b8dc25a1c3.png)

**Scenario 3: Purchase provider**

1. Go to upgrades -> emails
2. Without having a Google Workspace email provider, add one
3. Check that the form looks similar to the provided comparison

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/127139088-c9420c67-df0f-475e-9fd0-10256d7a0cf0.png) | ![image](https://user-images.githubusercontent.com/5689927/127138971-98cc7e1e-e49f-4b21-b4a1-429ef57efb84.png)



*

Related to [previous development](https://github.com/Automattic/wp-calypso/pull/54349) 
