### PR TITLE
Jetpack siteless checkout thank-you: Update Jetpack installation instructions link.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -66,7 +66,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 	);
 
 	const jetpackInstallInstructionsLink =
-		'https://jetpack.com/support/getting-started-with-jetpack/';
+		'https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/';
 
 	const [ siteInput, setSiteInput ] = useState( '' );
 	const [ isFormDirty, setIsFormDirty ] = useState( false );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Jetpack installation instructions link on the Jetpack siteless checkout Thank-you page.  The link should point to: https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/

#### Testing instructions

- Checkout and run this PR
- Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_scan
- Complete siteless checkout.
- On the "Thank you" page, Under step 1, verify that the "instructions we put together here." link points to: https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/

#### Screenshot:

<img width="1118" alt="Markup 2021-07-27 at 07 42 31" src="https://user-images.githubusercontent.com/11078128/127148008-4c16d985-daae-4865-a8a3-8a44e098fce0.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1200479326344990-as-1200660344242695