### PR TITLE
Change the notice in case you search for a domain that's already registered

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -145,22 +145,32 @@ class DomainSearchResults extends React.Component {
 			}
 
 			let domainUnavailableMessage = [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus )
-				? translate( '.%(tld)s domains are not available for registration on WordPress.com.', {
-						args: { tld: getTld( domain ) },
-				  } )
-				: translate( '%(domain)s is already registered. {{a}}Do you own it?{{/a}}', {
-						args: { domain },
-						components: {
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-is-valid
-								<a
-									href="#"
-									onClick={ this.props.onClickUseYourDomain }
-									data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-								/>
-							),
-						},
-				  } );
+				? translate(
+						'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
+						{
+							args: { tld: getTld( domain ) },
+							components: {
+								strong: <strong />,
+							},
+						}
+				  )
+				: translate(
+						'{{strong}}%(domain)s{{/strong}} is already registered. {{a}}Do you own it?{{/a}}',
+						{
+							args: { domain },
+							components: {
+								strong: <strong />,
+								a: (
+									// eslint-disable-next-line jsx-a11y/anchor-is-valid
+									<a
+										href="#"
+										onClick={ this.props.onClickUseYourDomain }
+										data-tracks-button-click-source={ this.props.tracksButtonClickSource }
+									/>
+								),
+							},
+						}
+				  );
 
 			if ( TLD_NOT_SUPPORTED_TEMPORARILY === lastDomainStatus ) {
 				domainUnavailableMessage = translate(
@@ -177,14 +187,18 @@ class DomainSearchResults extends React.Component {
 				if ( this.props.siteDesignType !== DESIGN_TYPE_STORE && lastDomainIsTransferrable ) {
 					availabilityElement = (
 						<CompactCard className="domain-search-results__domain-available-notice">
-							<MaterialIcon icon="info" />
+							<span className="domain-search-results__domain-available-notice-icon">
+								<MaterialIcon icon="info" />
+							</span>
 							<span>{ domainUnavailableMessage }</span>
 						</CompactCard>
 					);
 				} else if ( lastDomainStatus !== MAPPED ) {
 					availabilityElement = (
 						<CompactCard className="domain-search-results__domain-available-notice">
-							<MaterialIcon icon="info" />
+							<span className="domain-search-results__domain-available-notice-icon">
+								<MaterialIcon icon="info" />
+							</span>
 							<span>
 								{ domainUnavailableMessage } { offer }
 							</span>

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -17,7 +17,7 @@ import DomainSuggestion from 'calypso/components/domains/domain-suggestion';
 import FeaturedDomainSuggestions from 'calypso/components/domains/featured-domain-suggestions';
 import { isDomainMappingFree, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import Notice from 'calypso/components/notice';
-import { Card, ScreenReaderText } from '@automattic/components';
+import { CompactCard, ScreenReaderText } from '@automattic/components';
 import { getTld } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
@@ -25,6 +25,8 @@ import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
 import { hideSitePreview } from 'calypso/state/signup/preview/actions';
 import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
 import DomainSkipSuggestion from 'calypso/components/domains/domain-skip-suggestion';
+import MaterialIcon from 'calypso/components/material-icon';
+
 /**
  * Style dependencies
  */
@@ -150,9 +152,18 @@ class DomainSearchResults extends React.Component {
 							components: { strong: <strong /> },
 						}
 				  )
-				: translate( '{{strong}}%(domain)s{{/strong}} is taken.', {
+				: translate( '%(domain)s is already registered. {{a}}Do you own it?{{/a}}', {
 						args: { domain },
-						components: { strong: <strong /> },
+						components: {
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-is-valid
+								<a
+									href="#"
+									onClick={ this.props.onClickUseYourDomain }
+									data-tracks-button-click-source={ this.props.tracksButtonClickSource }
+								/>
+							),
+						},
 				  } );
 
 			if ( TLD_NOT_SUPPORTED_TEMPORARILY === lastDomainStatus ) {
@@ -169,30 +180,10 @@ class DomainSearchResults extends React.Component {
 			if ( this.props.offerUnavailableOption ) {
 				if ( this.props.siteDesignType !== DESIGN_TYPE_STORE && lastDomainIsTransferrable ) {
 					availabilityElement = (
-						<Card className="domain-search-results__transfer-card" highlight="info">
-							<div className="domain-search-results__transfer-card-copy">
-								<div>{ domainUnavailableMessage }</div>
-								<p>
-									{ translate(
-										'If you already own this domain you can use it for your WordPress.com site.'
-									) }
-								</p>
-							</div>
-							<div className="domain-search-results__transfer-card-link">
-								{ translate( '{{a}}Yes, I own this domain{{/a}}', {
-									components: {
-										a: (
-											// eslint-disable-next-line jsx-a11y/anchor-is-valid
-											<a
-												href="#"
-												onClick={ this.props.onClickUseYourDomain }
-												data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-											/>
-										),
-									},
-								} ) }
-							</div>
-						</Card>
+						<CompactCard className="domain-search-results__domain-available-notice">
+							<MaterialIcon icon="info" />
+							<span>{ domainUnavailableMessage }</span>
+						</CompactCard>
 					);
 				} else if ( lastDomainStatus !== MAPPED ) {
 					availabilityElement = (

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -118,7 +118,7 @@ class DomainSearchResults extends React.Component {
 			get( this.props, 'products.domain_map', false )
 		) {
 			// eslint-disable-next-line jsx-a11y/anchor-is-valid
-			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
+			const components = { a: <a href="#" onClick={ this.handleAddMapping } /> };
 
 			// If the domain is available we shouldn't offer to let people purchase mappings for it.
 			if (
@@ -128,12 +128,12 @@ class DomainSearchResults extends React.Component {
 			) {
 				if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
 					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for free.{{/small}}',
+						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} for free.',
 						{ args: { domain }, components }
 					);
 				} else {
 					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.{{/small}}',
+						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.',
 						{ args: { domain }, components }
 					);
 				}
@@ -145,13 +145,9 @@ class DomainSearchResults extends React.Component {
 			}
 
 			let domainUnavailableMessage = [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus )
-				? translate(
-						'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
-						{
-							args: { tld: getTld( domain ) },
-							components: { strong: <strong /> },
-						}
-				  )
+				? translate( '.%(tld)s domains are not available for registration on WordPress.com.', {
+						args: { tld: getTld( domain ) },
+				  } )
 				: translate( '%(domain)s is already registered. {{a}}Do you own it?{{/a}}', {
 						args: { domain },
 						components: {
@@ -187,9 +183,12 @@ class DomainSearchResults extends React.Component {
 					);
 				} else if ( lastDomainStatus !== MAPPED ) {
 					availabilityElement = (
-						<Notice status="is-warning" showDismiss={ false }>
-							{ domainUnavailableMessage } { offer }
-						</Notice>
+						<CompactCard className="domain-search-results__domain-available-notice">
+							<MaterialIcon icon="info" />
+							<span>
+								{ domainUnavailableMessage } { offer }
+							</span>
+						</CompactCard>
 					);
 				}
 			} else {

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -67,9 +67,10 @@ body.is-section-signup.is-white-signup {
 .domain-search-results__domain-available-notice {
 	display: flex;
 	.domain-search-results__domain-available-notice-icon {
-		margin-top: 2px;
 		margin-right: 8px;
 		svg {
+			display: block;
+			margin: 0 auto;
 			fill: var( --color-neutral-20 );
 			width: 20px;
 			height: 20px;

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -63,3 +63,22 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 }
+
+.domain-search-results__domain-available-notice {
+	display: flex;
+	span {
+		font-size: $font-body-small;
+		color: var( --color-text-subtle );
+		a {
+			color: var( --color-text );
+			text-decoration: underline;
+		}
+	}
+	svg {
+		fill: var( --color-neutral-20 );
+		margin-right: 8px;
+		width: 20px;
+		height: 20px;
+		margin-top: 2px;
+	}
+}

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -66,20 +66,22 @@ body.is-section-signup.is-white-signup {
 
 .domain-search-results__domain-available-notice {
 	display: flex;
+	.domain-search-results__domain-available-notice-icon {
+		margin-top: 2px;
+		margin-right: 8px;
+		svg {
+			fill: var( --color-neutral-20 );
+			width: 20px;
+			height: 20px;
+		}
+	}
 	span {
 		font-size: $font-body-small;
 		color: var( --color-text-subtle );
 		a {
 			color: var( --color-text );
 			text-decoration: underline;
-			font-weight: 400;
+			font-weight: 600;
 		}
-	}
-	svg {
-		fill: var( --color-neutral-20 );
-		margin-right: 8px;
-		width: 20px;
-		height: 20px;
-		margin-top: 2px;
 	}
 }

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -72,6 +72,7 @@ body.is-section-signup.is-white-signup {
 		a {
 			color: var( --color-text );
 			text-decoration: underline;
+			font-weight: 400;
 		}
 	}
 	svg {


### PR DESCRIPTION
Change the domain is already registered notice to a more subtle one

#### Changes proposed in this Pull Request

* I'm removing the existing notice and switching to a more subtle one.

Before:
<img width="1065" alt="Screenshot 2021-07-27 at 15 40 27" src="https://user-images.githubusercontent.com/1355045/127155441-1ffb2516-22c2-4260-b58e-c3b9ae63c99b.png">

After:
<img width="1057" alt="Screenshot 2021-07-28 at 21 09 09" src="https://user-images.githubusercontent.com/1355045/127374262-13cb24e3-4659-4c66-a130-38ad245bd0ab.png">
<img width="1057" alt="Screenshot 2021-07-28 at 21 09 19" src="https://user-images.githubusercontent.com/1355045/127374265-18ba40bc-df71-4700-8e7b-ace852894a4d.png">
<img width="417" alt="Screenshot 2021-07-28 at 21 09 39" src="https://user-images.githubusercontent.com/1355045/127374267-50e2deb1-0dae-4640-83a0-23145b4ce22d.png">
<img width="423" alt="Screenshot 2021-07-28 at 21 09 49" src="https://user-images.githubusercontent.com/1355045/127374270-61d91094-4ea1-42f3-a22c-b25198a13aa8.png">

#### Testing instructions

* Go to a site and then click on the "Add a domain to this site" button. Search for a domain that is already registered and verify that you see the new version of the info notice.
