### PR TITLE
chore: Force @wordpress/base-styles resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,5 +330,8 @@
 		"bunyan": "^1.8.15",
 		"chokidar": "^3.5.1",
 		"eslint-nibble": "^7.0.0"
+	},
+	"resolutions": {
+		"**/newspack-components/@wordpress/base-styles": "3.4.3"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3577,6 +3577,11 @@
     resolve-from "^5.0.0"
     store2 "^2.7.1"
 
+"@stripe/stripe-js@^1.15.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.16.0.tgz#73bce24fb7f47d719caa6b151e58e49b4167d463"
+  integrity sha512-ZSHbiwTrISoaTbpercmYGuY7QTg7HxfFyNgbJBaYbwHWbzMhpEdGTsmMpaBXIU6iiqwEEDaIyD8O6yJ+H5DWCg==
+
 "@stylelint/postcss-css-in-js@^0.37.2":
   version "0.37.2"
   resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz#7e5a84ad181f4234a2480803422a47b8749af3d2"
@@ -4957,7 +4962,7 @@
     "@wordpress/warning" "^1.4.2"
     core-js "^3.6.4"
 
-"@wordpress/base-styles@^3.4.3":
+"@wordpress/base-styles@3.4.3", "@wordpress/base-styles@^3.4.3", "@wordpress/base-styles@^3.5.1":
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/@wordpress/base-styles/-/base-styles-3.4.3.tgz#389ca7740588bf77a5cac76a9873d776a5fc5b8b"
   integrity sha512-HabpKnrXN2CEC10IvQrZWjg6hQDxPt1jhARl7DCZBKqUTYmdbRYxQ6ZKoPnJcgbk2O6iIjBGXe8i4Gz+84I4Xw==
@@ -5130,7 +5135,7 @@
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-3.0.3.tgz#9d8599b2745f871f0da3bb94d768906c84a0d357"
   integrity sha512-hbGJt0+EKiVaa1VhVnm4nwWEzXH7/KMJVsEwk3IZjoYTqKLOWw3zQa6E7eh+jdJifEFrPkQNZs4QcICv6Z+1kQ==
 
-"@wordpress/components@^12.0.8":
+"@wordpress/components@^12.0.6", "@wordpress/components@^12.0.8":
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-12.0.8.tgz#5d6997e9184b3ecd20d173a62e325fb9c056e91f"
   integrity sha512-sq0vs7Bm9yoF0Li3XpXUN6z7ggf72pPmqJd0u+DrAg0ZaPxYfCNCdazOHRXrc/0psyHF+xSTb5J8XpsE1DiWLQ==
@@ -5447,7 +5452,7 @@
     react-autosize-textarea "^7.1.0"
     rememo "^3.0.0"
 
-"@wordpress/element@^2.14.0", "@wordpress/element@^2.19.1", "@wordpress/element@^2.20.3":
+"@wordpress/element@^2.14.0", "@wordpress/element@^2.19.0", "@wordpress/element@^2.19.1", "@wordpress/element@^2.20.3":
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.20.3.tgz#a86a20e90be41d6fe4ea1f0ce580f7f2f1d839e7"
   integrity sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==
@@ -5562,7 +5567,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/i18n@^3.18.0", "@wordpress/i18n@^3.19.2", "@wordpress/i18n@^3.20.0", "@wordpress/i18n@^3.7.0":
+"@wordpress/i18n@^3.17.0", "@wordpress/i18n@^3.18.0", "@wordpress/i18n@^3.19.2", "@wordpress/i18n@^3.20.0", "@wordpress/i18n@^3.7.0":
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.20.0.tgz#dc9b04b9e8c359c1b0dbae78b99b32ef2c0b4729"
   integrity sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==
@@ -19874,6 +19879,7 @@ new-github-issue-url@^0.2.1:
   version "1.30.0"
   resolved "https://codeload.github.com/Automattic/newspack-blocks/tar.gz/396703aa237b5811f25a29334503b7de58219f0a"
   dependencies:
+    "@stripe/stripe-js" "^1.15.0"
     "@wordpress/a11y" "^2.9.0"
     "@wordpress/compose" "^3.9.0"
     "@wordpress/data" "^4.11.0"
@@ -19888,6 +19894,7 @@ new-github-issue-url@^0.2.1:
     "@wordpress/keycodes" "^2.9.0"
     "@wordpress/plugins" "^2.12.0"
     lodash "^4.17.20"
+    newspack-components "^1.6.1"
     react "^16.12.0"
     redux "^4.0.5"
     redux-saga "^1.1.3"
@@ -19895,6 +19902,21 @@ new-github-issue-url@^0.2.1:
     swiper "4.5.1"
   optionalDependencies:
     fsevents "^1.2.11"
+
+newspack-components@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/newspack-components/-/newspack-components-1.6.1.tgz#26fdf419d61f7b16cea22c46c283f27705770e91"
+  integrity sha512-ZdlCzAFxIfKt08A9jfTCYSiFL77Kx3yyB5fTiBmIOxFQvF00ZAioFEbOSEnyiMMY4JKepNq1JuCQB/e3i/d+9w==
+  dependencies:
+    "@wordpress/base-styles" "^3.5.1"
+    "@wordpress/components" "^12.0.6"
+    "@wordpress/element" "^2.19.0"
+    "@wordpress/i18n" "^3.17.0"
+    "@wordpress/icons" "^4.0.1"
+    classnames "^2.2.6"
+    lodash "^4.17.20"
+    qs "^6.9.6"
+    react-router-dom "^5.2.0"
 
 next-tick@1:
   version "1.1.0"
@@ -22884,7 +22906,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.1.0, qs@^6.4.0, qs@^6.5.1, qs@^6.5.2, qs@^6.6.0, qs@^6.9.1:
+qs@^6.1.0, qs@^6.4.0, qs@^6.5.1, qs@^6.5.2, qs@^6.6.0, qs@^6.9.1, qs@^6.9.6:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -23409,7 +23431,7 @@ react-resize-aware@^3.1.0:
   resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.1.0.tgz#fa1da751d1d72f90c3b79969d05c2c577dfabd92"
   integrity sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA==
 
-react-router-dom@^5.1.2:
+react-router-dom@^5.1.2, react-router-dom@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
   integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==


### PR DESCRIPTION
#### Background

See the discussion in #54923.

In a nutshell: we have an incomplete `yarn.lock` in `trunk`. The entry `newspack-blocks@github:Automattic/newspack-blocks#v1.30.0` is missing some dependencies like `newspack-components` (those dependencies does exist in the package repo).

When adding those dependencies, it pulls in `@wordpress/base-styles@3.6.0` which is not compatible with other `@wordpress/*` packages in our repo.

#### Changes proposed in this Pull Request

Use yarn resolutions to force a downgrade from `@wordpress/base-styles@3.6.0` to `@wordpress/base-styles@3.4.3`. This should fix `yarn.lock` without forcing us to move to modern `@wordpress/*` packages.

I'm not sure if this will break `newspack-components` though. cc @dkoo @adekbadek

