### PR TITLE
Siteless checkout thank-you: Make form submit with Enter key pressed.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -87,25 +87,29 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 		[ translate, isFormDirty ]
 	);
 
-	const onUrlSubmit = useCallback( () => {
-		setIsFormDirty( true );
-		const siteUrl = addHttpIfMissing( siteInput );
-		setSiteInput( siteUrl );
+	const onUrlSubmit = useCallback(
+		( e ) => {
+			e.preventDefault();
+			setIsFormDirty( true );
+			const siteUrl = addHttpIfMissing( siteInput );
+			setSiteInput( siteUrl );
 
-		if ( ! resemblesUrl( siteUrl ) ) {
-			setError( translate( 'That is not a valid website URL.' ) );
-			return;
-		}
+			if ( ! resemblesUrl( siteUrl ) ) {
+				setError( translate( 'That is not a valid website URL.' ) );
+				return;
+			}
 
-		dispatch(
-			recordTracksEvent( 'calypso_siteless_checkout_submit_website_address', {
-				product_slug: productSlug,
-				site_url: siteUrl,
-				receipt_id: receiptId,
-			} )
-		);
-		dispatch( requestUpdateJetpackCheckoutSupportTicket( siteUrl, receiptId ) );
-	}, [ siteInput, dispatch, translate, productSlug, receiptId ] );
+			dispatch(
+				recordTracksEvent( 'calypso_siteless_checkout_submit_website_address', {
+					product_slug: productSlug,
+					site_url: siteUrl,
+					receipt_id: receiptId,
+				} )
+			);
+			dispatch( requestUpdateJetpackCheckoutSupportTicket( siteUrl, receiptId ) );
+		},
+		[ siteInput, dispatch, translate, productSlug, receiptId ]
+	);
 
 	const onScheduleClick = useCallback( () => {
 		if ( calendlyUrl !== null ) {
@@ -218,38 +222,41 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 									<br />
 									{ translate( 'Knowing this will allow us to jumpstart the activation process.' ) }
 								</p>
-								<FormLabel
-									className="jetpack-checkout-siteless-thank-you__form-label"
-									htmlFor="website-address-input"
-								>
-									Your website address:
-								</FormLabel>
-								<div className="jetpack-checkout-siteless-thank-you__form-group" role="group">
-									<FormTextInput
-										className={ classNames( 'jetpack-checkout-siteless-thank-you__form-input', {
-											'is-error': error,
-										} ) }
-										autoCapitalize="off"
-										value={ siteInput }
-										placeholder="https://yourjetpack.blog"
-										onChange={ onUrlChange }
-										autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
-									/>
-									<FormButton
-										className="jetpack-checkout-siteless-thank-you__form-submit"
-										disabled={ ! siteInput || supportTicketStatus === 'pending' }
-										busy={ supportTicketStatus === 'pending' }
-										onClick={ onUrlSubmit }
+								<form onSubmit={ onUrlSubmit }>
+									<FormLabel
+										className="jetpack-checkout-siteless-thank-you__form-label"
+										htmlFor="website-address-input"
 									>
-										{ translate( 'Continue' ) }
-									</FormButton>
-								</div>
-								{ error && (
-									<FormInputValidation
-										isError={ !! ( isFormDirty && error ) }
-										text={ error }
-									></FormInputValidation>
-								) }
+										Your website address:
+									</FormLabel>
+									<div className="jetpack-checkout-siteless-thank-you__form-group" role="group">
+										<FormTextInput
+											className={ classNames( 'jetpack-checkout-siteless-thank-you__form-input', {
+												'is-error': error,
+											} ) }
+											autoCapitalize="off"
+											value={ siteInput }
+											placeholder="https://yourjetpack.blog"
+											onChange={ onUrlChange }
+											autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+										/>
+										<FormButton
+											className="jetpack-checkout-siteless-thank-you__form-submit"
+											disabled={ ! siteInput || supportTicketStatus === 'pending' }
+											busy={ supportTicketStatus === 'pending' }
+										>
+											{ supportTicketStatus === 'pending'
+												? translate( 'Saving…' )
+												: translate( 'Continue' ) }
+										</FormButton>
+									</div>
+									{ error && (
+										<FormInputValidation
+											isError={ !! ( isFormDirty && error ) }
+											text={ error }
+										></FormInputValidation>
+									) }
+								</form>
 							</div>
 						</div>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the UX for the "Submit website Address" input form by allowing the form to be submitted by pressing the enter key.

Implementation notes:

- Removed the `onUrlSubmit()` off of the `<Button onClick={ onUrlSubmit }>` event and instead assigned it to the `<Form onSubmit={ onUrlSubmit }>` event. This captures the Form tags natural ability to submit the form using the Enter key, if you want.
- Also made the submit button text dynamic.  When submitting, button text is, "Saving...", otherwise button text is, "Continue".

#### Testing instructions

- Checkout and run this PR
- Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_scan
- Complete siteless checkout.
- On the "Thank you" page, test the "Submit website address" form:
    - Verify you can submit the form **using the enter key** or by pressing the button. 
    - Verify that when the form is submitting, the button text changes to, "Saving...", otherwise it says, "Continue".

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<!-- Related to # -->
