### PR TITLE
Fix padding and line height on theme showcase tabs

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -59,7 +59,9 @@
 	border-top: 0;
 	.section-nav-tab__link {
 		@include breakpoint-deprecated( '>480px' ) {
-			padding-top: 8px;
+			height: 60px;
+			line-height: 36px;
+			padding: 12px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change fixes alignment issues which were causing tabs in the theme showcase to look vertically off-center and the FSE beta tab to look misaligned from the others.

Before:
<img width="709" alt="CleanShot 2021-07-27 at 13 40 12@2x" src="https://user-images.githubusercontent.com/13437011/127209739-929b36f5-413e-4361-98c3-b0594e11e0e8.png">


After:
![image](https://user-images.githubusercontent.com/13437011/127209612-2425f837-cb5d-4aed-a7ef-a292bdab88ca.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/themes/{SITE_URL}?flags=gutenboarding/site-editor` on an atomic/Jetpack site (so all currently available tabs appear).
* Verify that all tabs appear properly aligned with each other and with their container bar (including when hovered.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54822, #54804
