### PR TITLE
Checkout: Move iDEAL payment method to wpcom-checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -6,8 +6,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
-	createIdealMethod,
-	createIdealPaymentMethodStore,
 	createSofortMethod,
 	createSofortPaymentMethodStore,
 } from '@automattic/composite-checkout';
@@ -23,6 +21,8 @@ import {
 	createEpsMethod,
 	createEpsPaymentMethodStore,
 	createPayPalMethod,
+	createIdealMethod,
+	createIdealPaymentMethodStore,
 } from '@automattic/wpcom-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { StripeConfiguration, Stripe, StripeLoadingError } from '@automattic/calypso-stripe';

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -44,7 +44,6 @@ import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processo
 import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
 import { createAlipayPaymentMethodStore, createAlipayMethod } from './lib/payment-methods/alipay';
-import { createIdealPaymentMethodStore, createIdealMethod } from './lib/payment-methods/ideal';
 import PaymentLogo from './lib/payment-methods/payment-logo';
 import { createSofortPaymentMethodStore, createSofortMethod } from './lib/payment-methods/sofort';
 import {
@@ -105,8 +104,6 @@ export {
 	checkoutTheme,
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
-	createIdealMethod,
-	createIdealPaymentMethodStore,
 	createRegistry,
 	createSofortMethod,
 	createSofortPaymentMethodStore,

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -11,6 +11,7 @@ export { default as Field } from './field';
 export { default as styled } from './styled';
 export * from './payment-methods/bancontact';
 export * from './payment-methods/giropay';
+export * from './payment-methods/ideal';
 export * from './payment-methods/p24';
 export * from './payment-methods/eps';
 export * from './use-is-web-payment-available';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the iDEAL payment method from the `@automattic/composite-checkout` package into the `@automattic/wpcom-checkout` package and converts it to TypeScript. This is similar to how Bancontact was moved in https://github.com/Automattic/wp-calypso/pull/51690, Giropay in https://github.com/Automattic/wp-calypso/pull/53346, and p24 in https://github.com/Automattic/wp-calypso/pull/53510 This is related to the refactoring of https://github.com/Automattic/wp-calypso/issues/52215

#### Background

The `composite-checkout` package is intended to be a fairly generic checkout-building toolkit. As part of this we originally envisioned it containing various payment methods, but that quickly became a problem as it became clear that the payment methods we use on WordPress.com are pretty specific to our platform. To reduce leaky abstractions, we moved many of our payment methods over to calypso, but some have remained because the cost of moving them seemed too high for the benefit.

As we prepare to publish version 1.0.0 of the `@automattic/composite-checkout` package on npm, I think it's a good time to clean up extraneous parts of the package. The payment methods are the only part of the package that are not fully TypeScript and are also still pretty specific to our WordPress.com infrastructure. Eventually it would be nice to convert them all to TypeScript and put them in a package like `@automattic/wpcom-checkout` (which is intended to be WordPress.com specific). This PR converts one such payment method and moves it there.

#### Testing instructions

- Apply D45029-code to your sandbox and sandbox the API to force iDEAL to be available.
- Set your user's currency to `EUR`.
- Visit checkout with a product in your cart.
- Verify that iDEAL shows up as an available payment method.
- Select iDEAL, fill in any string as the name and chose any bank.
- Click to submit the purchase.
- Verify that you're redirected to the Stripe test page.
- Verify that the information in the Stripe test page shows the correct total, name, and bank. (No need to confirm the payment.)