### PR TITLE
Domains: Add professional email upsell route

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -20,8 +20,8 @@ import {
 } from 'calypso/state/ui/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import DomainSearch from './domain-search';
-import SiteRedirect from './domain-search/site-redirect';
 import EmailProvidersUpsell from './email-providers-upsell';
+import SiteRedirect from './domain-search/site-redirect';
 import MapDomain from 'calypso/my-sites/domains/map-domain';
 import TransferDomain from 'calypso/my-sites/domains/transfer-domain';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -222,7 +222,7 @@ const emailUpsellForDomainRegistration = ( context, next ) => {
 			/>
 			<DocumentHead
 				title={ translate( 'Register %(domain)s', {
-					args: { domain: context.params.registerDomain },
+					args: { domain: context.params.domain },
 				} ) }
 			/>
 			<EmailProvidersUpsell domain={ context.params.domain } />

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -21,6 +21,7 @@ import {
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import DomainSearch from './domain-search';
 import SiteRedirect from './domain-search/site-redirect';
+import EmailProvidersUpsell from './email-providers-upsell';
 import MapDomain from 'calypso/my-sites/domains/map-domain';
 import TransferDomain from 'calypso/my-sites/domains/transfer-domain';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
@@ -39,7 +40,6 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import EmailProvidersUpsell from './email-providers-upsell';
 
 const noop = () => {};
 const domainsAddHeader = ( context, next ) => {
@@ -213,6 +213,25 @@ const googleAppsWithRegistration = ( context, next ) => {
 	next();
 };
 
+const emailWithRegistration = ( context, next ) => {
+	context.primary = (
+		<Main wideLayout>
+			<PageViewTracker
+				path="/domains/add/:domain/email/:site"
+				title="Domain Search > Domain Registration > Email"
+			/>
+			<DocumentHead
+				title={ translate( 'Register %(domain)s', {
+					args: { domain: context.params.registerDomain },
+				} ) }
+			/>
+			<EmailProvidersUpsell domain={ context.params.domain } />
+		</Main>
+	);
+
+	next();
+};
+
 const redirectIfNoSite = ( redirectTo ) => {
 	return ( context, next ) => {
 		const state = context.store.getState();
@@ -273,25 +292,6 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	} else {
 		next();
 	}
-};
-
-const emailWithRegistration = ( context, next ) => {
-	context.primary = (
-		<Main wideLayout>
-			<PageViewTracker
-				path="/domains/add/:domain/email/:site"
-				title="Domain Search > Domain Registration > Email"
-			/>
-			<DocumentHead
-				title={ translate( 'Register %(domain)s', {
-					args: { domain: context.params.registerDomain },
-				} ) }
-			/>
-			<EmailProvidersUpsell domain={ context.params.domain } />
-		</Main>
-	);
-
-	next();
 };
 
 export default {

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -213,7 +213,7 @@ const googleAppsWithRegistration = ( context, next ) => {
 	next();
 };
 
-const emailWithRegistration = ( context, next ) => {
+const emailUpsellForDomainRegistration = ( context, next ) => {
 	context.primary = (
 		<Main wideLayout>
 			<PageViewTracker
@@ -298,7 +298,7 @@ export default {
 	domainsAddHeader,
 	domainsAddRedirectHeader,
 	domainSearch,
-	emailWithRegistration,
+	emailUpsellForDomainRegistration,
 	jetpackNoDomainsWarning,
 	siteRedirect,
 	mapDomain,

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -39,6 +39,7 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import EmailProvidersUpsell from './email-providers-upsell';
 
 const noop = () => {};
 const domainsAddHeader = ( context, next ) => {
@@ -274,10 +275,30 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	}
 };
 
+const emailWithRegistration = ( context, next ) => {
+	context.primary = (
+		<Main wideLayout>
+			<PageViewTracker
+				path="/domains/add/:domain/email/:site"
+				title="Domain Search > Domain Registration > Email"
+			/>
+			<DocumentHead
+				title={ translate( 'Register %(domain)s', {
+					args: { domain: context.params.registerDomain },
+				} ) }
+			/>
+			<EmailProvidersUpsell domain={ context.params.domain } />
+		</Main>
+	);
+
+	next();
+};
+
 export default {
 	domainsAddHeader,
 	domainsAddRedirectHeader,
 	domainSearch,
+	emailWithRegistration,
 	jetpackNoDomainsWarning,
 	siteRedirect,
 	mapDomain,

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import HeaderCake from 'calypso/components/header-cake';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+
+export default function EmailProvidersUpsell( { domain } ) {
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
+
+	const handleGoBack = () => {
+		page( `/domains/add/${ selectedSiteSlug }` );
+	};
+
+	const translateArgs = {
+		args: {
+			domainName: 'example.com',
+		},
+		comment: '%(domainName)s is the domain name, e.g example.com',
+	};
+
+	const image = {
+		path: emailIllustration,
+		align: 'right',
+	};
+
+	return (
+		<>
+			<HeaderCake onClick={ handleGoBack }>
+				{ translate( 'Register %(domain)s', { args: { domain } } ) }
+			</HeaderCake>
+
+			<PromoCard
+				isPrimary
+				title={ translate( 'Add a professional email address to %(domainName)s', translateArgs ) }
+				image={ image }
+				className="email-providers-upsell__action-panel"
+			>
+				<p>{ translate( 'No setup or software required. Easy to manage from your dashboard.' ) }</p>
+			</PromoCard>
+		</>
+	);
+}

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -17,13 +17,14 @@ import PromoCard from 'calypso/components/promo-section/promo-card';
  * Style dependencies
  */
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import { domainAddNew } from '../paths';
 
 export default function EmailProvidersUpsell( { domain } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
 	const handleGoBack = () => {
-		page( `/domains/add/${ selectedSiteSlug }` );
+		page( domainAddNew( selectedSiteSlug ) );
 	};
 
 	const translateArgs = {

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import page from 'page';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -12,6 +12,10 @@ import { useTranslate } from 'i18n-calypso';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import HeaderCake from 'calypso/components/header-cake';
 import PromoCard from 'calypso/components/promo-section/promo-card';
+
+/**
+ * Style dependencies
+ */
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
 
 export default function EmailProvidersUpsell( { domain } ) {
@@ -35,7 +39,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 	};
 
 	return (
-		<>
+		<Fragment>
 			<HeaderCake onClick={ handleGoBack }>
 				{ translate( 'Register %(domain)s', { args: { domain } } ) }
 			</HeaderCake>
@@ -48,6 +52,6 @@ export default function EmailProvidersUpsell( { domain } ) {
 			>
 				<p>{ translate( 'No setup or software required. Easy to manage from your dashboard.' ) }</p>
 			</PromoCard>
-		</>
+		</Fragment>
 	);
 }

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import HeaderCake from 'calypso/components/header-cake';
 import PromoCard from 'calypso/components/promo-section/promo-card';
@@ -17,7 +18,6 @@ import PromoCard from 'calypso/components/promo-section/promo-card';
  * Style dependencies
  */
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
-import { domainAddNew } from '../paths';
 
 export default function EmailProvidersUpsell( { domain } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import page from 'page';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -40,7 +40,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 	};
 
 	return (
-		<Fragment>
+		<>
 			<HeaderCake onClick={ handleGoBack }>
 				{ translate( 'Register %(domain)s', { args: { domain } } ) }
 			</HeaderCake>
@@ -53,6 +53,6 @@ export default function EmailProvidersUpsell( { domain } ) {
 			>
 				<p>{ translate( 'No setup or software required. Easy to manage from your dashboard.' ) }</p>
 			</PromoCard>
-		</Fragment>
+		</>
 	);
 }

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -28,7 +28,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 
 	const translateArgs = {
 		args: {
-			domainName: 'example.com',
+			domainName: domain,
 		},
 		comment: '%(domainName)s is the domain name, e.g example.com',
 	};

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -27,13 +27,6 @@ export default function EmailProvidersUpsell( { domain } ) {
 		page( domainAddNew( selectedSiteSlug ) );
 	};
 
-	const translateArgs = {
-		args: {
-			domainName: domain,
-		},
-		comment: '%(domainName)s is the domain name, e.g example.com',
-	};
-
 	const image = {
 		path: emailIllustration,
 		align: 'right',
@@ -47,7 +40,12 @@ export default function EmailProvidersUpsell( { domain } ) {
 
 			<PromoCard
 				isPrimary
-				title={ translate( 'Add a professional email address to %(domainName)s', translateArgs ) }
+				title={ translate( 'Add a professional email address to %(domainName)s', {
+					args: {
+						domainName: domain,
+					},
+					comment: '%(domainName)s is the domain name, e.g example.com',
+				} ) }
 				image={ image }
 				className="email-providers-upsell__action-panel"
 			>

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -231,6 +231,17 @@ export default function () {
 		);
 
 		page(
+			'/domains/add/:domain/email/:siteSlug',
+			siteSelection,
+			navigation,
+			domainsController.redirectIfNoSite( '/domains/add' ),
+			domainsController.jetpackNoDomainsWarning,
+			domainsController.emailWithRegistration,
+			makeLayout,
+			clientRender
+		);
+
+		page(
 			'/domains/add/suggestion/:suggestion/:domain',
 			siteSelection,
 			navigation,
@@ -312,21 +323,6 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
-
-		const domainPurchaseFlowEnabled = true;
-
-		if ( domainPurchaseFlowEnabled ) {
-			page(
-				'/domains/add/:domain/email/:siteSlug',
-				siteSelection,
-				navigation,
-				domainsController.redirectIfNoSite( '/domains/add' ),
-				domainsController.jetpackNoDomainsWarning,
-				domainsController.emailWithRegistration,
-				makeLayout,
-				clientRender
-			);
-		}
 	}
 
 	page(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -236,7 +236,7 @@ export default function () {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.jetpackNoDomainsWarning,
-			domainsController.emailWithRegistration,
+			domainsController.emailUpsellForDomainRegistration,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -312,6 +312,21 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
+
+		const domainPurchaseFlowEnabled = true;
+
+		if ( domainPurchaseFlowEnabled ) {
+			page(
+				'/domains/add/:domain/email/:siteSlug',
+				siteSelection,
+				navigation,
+				domainsController.redirectIfNoSite( '/domains/add' ),
+				domainsController.jetpackNoDomainsWarning,
+				domainsController.emailWithRegistration,
+				makeLayout,
+				clientRender
+			);
+		}
 	}
 
 	page(

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -60,6 +60,10 @@ export function domainAddNew( siteName, searchTerm ) {
 	return path;
 }
 
+export function domainAddEmailUpsell( siteName, domainName ) {
+	return `/domains/add/${ siteName }/email/${ domainName }`;
+}
+
 export function domainManagementAllRoot() {
 	return '/domains/manage/all';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is the first step to proposed changes in domain purchase flow. It adds a new route for the professional email upsell page at:

```
http://wordpress.com/domains/add/:domain/email/:siteName
```

The content for this page will be added in an upcoming PR based on this one.

Side note: I referred to @daledupreez's previous approach at #50152 and @stephanethomas's work on #53712 to come up with this.

#### Testing instructions

1. Run git checkout `add/titan-email-upsell-route` and start your server
2. Log into a WordPress.com account that has a site
3. Open the _Domains_ page (replace `yoursite` with a site slug that you have): `http://calypso.localhost:3000/domains/manage/yoursite.wordpress.com`
4. Click Add _Domain button > to this site_ from the popover
5. Search for a domain or choose one of the suggestions by clicking _Select button_
5. Once the page loads, replace `google-workspace` in the domain with `email`. For example:
    If the URL shown is:
    ```
    http://calypso.localhost:3000/domains/add/example.in/google-workspace/example.wordpress.com
    ```
   
    replace it with:

    ```
    http://calypso.localhost:3000/domains/add/example.in/email/example.wordpress.com
    ```
6. Verify that the new route loads and renders without errors

#### Screenshots

![GOwwpLwluM](https://user-images.githubusercontent.com/2759499/127220102-720e8c40-3a9e-4b1e-a8c6-689f99f8c55a.gif)