### PR TITLE
My Home: Update CTA for when the "finish store setup" task is complete

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -132,7 +132,9 @@ export const getTask = (
 				description: translate(
 					'Add your store details, add products, configure shipping, so you can begin to collect orders!'
 				),
-				actionText: translate( 'Finish store setup' ),
+				actionText: task.isCompleted
+					? translate( 'Go to WooCommerce Home' )
+					: translate( 'Finish store setup' ),
 				actionUrl: taskUrls?.woocommerce_setup,
 				actionDisableOnComplete: false,
 				isSkippable: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the "Finish store setup" task is complete the main button label changes to "WooCommerce Home"

<img width="949" alt="Screenshot 2021-07-28 at 4 30 51 PM" src="https://user-images.githubusercontent.com/1500769/127264029-d139df58-3e67-4c31-bad7-7fcc7ef7ff57.png">

When the Woo checklist has been hidden/completed we can't take the user there because it no longer exists, so it felt like the CTA had to change. I was initially reluctant to add the "WooCommerce" name to the task list (was going to say something like "Store Dashboard") but that's what they call it everywhere in the UI, including Calypso. So figured it's best to just go with the official name. The user doesn't usually see the CTA for completed tasks anyway, only if they explicitly select it.

<img width="573" alt="Screenshot 2021-07-28 at 4 35 42 PM" src="https://user-images.githubusercontent.com/1500769/127264419-9d0a9a2d-90fa-4659-a55b-103ed82b3340.png">

Another option would be to disable the CTA when the task is done. That's what we do with the confirm email and launch tasks, since you literally can't do those tasks twice. The store CTA is just a navigation button though so perhaps it's useful to keep that button doing something.

@autumnfjeld since we discussed this in the team hangout.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D63486-code
* Test on an unlaunched, un-setup ecommerce site
* Complete (or hide) the store setup
* Check the CTA for the "Finish store setup" button

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
