### PR TITLE
Help: Fix Error when Detecting Site with "JSON API Module Failure"

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -330,17 +330,17 @@ export class HelpContactForm extends React.PureComponent {
 			( userDeclaredUrl &&
 				siteData &&
 				siteData.ID &&
-				( ! siteData.jetpack || siteData.is_wpcom_atomic ) ) ||
+				( ( ! siteData.jetpack && ! siteData.jetpack_connection ) || siteData.is_wpcom_atomic ) ) ||
 			( helpSite &&
 				! userDeclaresUnableToSeeSite &&
 				helpSite &&
 				helpSite.ID &&
-				( ! helpSite.jetpack || helpSite.is_wpcom_atomic ) ) ||
+				( ( ! helpSite.jetpack && ! helpSite.jetpack_connection ) || helpSite.is_wpcom_atomic ) ) ||
 			( userDeclaredUrl && errorData && errorData === 'unauthorized' );
 
 		// Returns true for self-hosted sites, irrespective of Jetpack connection status, and non-WordPress sites.
 		const isNonWpComHostedSite =
-			( userDeclaredUrl && siteData && siteData.jetpack ) ||
+			( userDeclaredUrl && siteData && ( siteData.jetpack || siteData.jetpack_connection ) ) ||
 			( userDeclaredUrl &&
 				errorData &&
 				( errorData === 'unknown_blog' || errorData === 'jetpack_error' ) ) ||

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -294,7 +294,7 @@ class HelpContact extends React.Component {
 		if ( site || userDeclaredUrl ) {
 			const siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
 
-			blogHelpMessage = this.translateForForums( 'Site: %s.', {
+			blogHelpMessage = this.translateForForums( 'Site: %s', {
 				args: [ userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl ],
 			} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sometimes when a site fails to reliably access data from the API, it's because the `requestSite` function tries the API endpoint again with `force=wpcom` - according to #44049, this happens when there is a JSON API module failure. In this condition, the detection of a self-hosted site in the Help section is inaccurate.

This can be resolved though by checking for `jetpack_connection` and `jetpack` in the API response - previously, I assumed they would always be the same, but it turns out that isn't always the case. I think this only applies when a Jetpack site has been disconnected.

#### Testing instructions

You might need to switch this to always return the default in order to test this.

https://github.com/Automattic/wp-calypso/blob/73bfc7141d33081b4e5f25ada256aea2d96a68cd/client/me/help/help-contact/index.jsx#L384

However, once you've done that, you can go to `/help/contact` and enter the site `https://growupwithme.org` into the input - verify it's marked as a self-hosted one rather than a WordPress.com one.

<img width="838" alt="Screenshot 2021-07-28 at 08 11 17" src="https://user-images.githubusercontent.com/43215253/127280529-ed99d0ca-7370-4af3-abe9-8df348fa4725.png">

cc @sixhours

Fixes https://github.com/Automattic/wp-calypso/pull/52979#issuecomment-887470288