### PR TITLE
chore: migrate `packages/viewport-react` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,6 +226,7 @@ module.exports = {
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
 				'packages/tree-select/**/*',
+				'packages/viewport-react/**/*',
 				'packages/viewport/**/*',
 				'packages/webpack-config-flag-plugin/**/*',
 				'packages/webpack-inline-constant-exports-plugin/**/*',

--- a/packages/viewport-react/src/index.js
+++ b/packages/viewport-react/src/index.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { forwardRef, useState, useEffect } from 'react';
-import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
 import {
 	isWithinBreakpoint,
 	subscribeIsWithinBreakpoint,
 	MOBILE_BREAKPOINT,
 	DESKTOP_BREAKPOINT,
 } from '@automattic/viewport';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import React, { forwardRef, useState, useEffect } from 'react';
 
 /**
  * React hook for getting the status for a breakpoint and keeping it updated.

--- a/packages/viewport-react/test/index.js
+++ b/packages/viewport-react/test/index.js
@@ -4,9 +4,6 @@
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["runComponentTests", "expect"] }] */
 
-/**
- * External dependencies
- */
 import 'regenerator-runtime';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/viewport-react/tsconfig.json
+++ b/packages/viewport-react/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/viewport-react` to use `import/order`

#### Testing instructions

N/A
