### PR TITLE
chore: migrate `packages/request-external-access` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -221,6 +221,7 @@ module.exports = {
 				'packages/photon/**/*',
 				'packages/plans-grid/**/*',
 				'packages/popup-monitor/**/*',
+				'packages/request-external-access/**/*',
 				'packages/search/**/*',
 				'packages/shopping-cart/**/*',
 				'packages/spec-junit-reporter/**/*',

--- a/packages/request-external-access/src/index.js
+++ b/packages/request-external-access/src/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import PopupMonitor from '@automattic/popup-monitor';
 
 /**

--- a/packages/request-external-access/test/index.js
+++ b/packages/request-external-access/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import PopupMonitor from '@automattic/popup-monitor';
-
-/**
- * Internal dependencies
- */
 import requestExternalAccess from '../src';
 
 jest.mock( '@automattic/popup-monitor' );

--- a/packages/request-external-access/tsconfig.json
+++ b/packages/request-external-access/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/request-external-access` to use `import/order`

#### Testing instructions

N/A
