### PR TITLE
chore: migrate `packages/babel-plugin-transform-wpcalypso-async` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,6 +197,7 @@ module.exports = {
 				'desktop/webpack.config.js',
 				'packages/accessible-focus/**/*',
 				'packages/babel-plugin-i18n-calypso/**/*',
+				'packages/babel-plugin-transform-wpcalypso-async/**/*',
 				'packages/browser-data-collector/**/*',
 				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',

--- a/packages/babel-plugin-transform-wpcalypso-async/index.js
+++ b/packages/babel-plugin-transform-wpcalypso-async/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 const kebabCase = require( 'lodash' ).kebabCase;
 
 module.exports = ( { types: t } ) => {

--- a/packages/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/packages/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const babel = require( '@babel/core' );
 
 describe( 'babel-plugin-transform-wpcalypso-async', () => {

--- a/packages/babel-plugin-transform-wpcalypso-async/tsconfig.json
+++ b/packages/babel-plugin-transform-wpcalypso-async/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/babel-plugin-transform-wpcalypso-async` to use `import/order`

#### Testing instructions

N/A
