### PR TITLE
chore: migrate `client/notifications` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -184,6 +184,7 @@ module.exports = {
 				'client/incoming-redirect/**/*',
 				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',
+				'client/notifications/**/*',
 				'client/sections-filter.js',
 				'client/sections-helper.js',
 				'client/sections-middleware.js',

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -11,34 +11,24 @@
  * @module notifications
  */
 
-/**
- * External dependencies
- */
-import debugFactory from 'debug';
-import React, { Component } from 'react';
-import classNames from 'classnames';
-import page from 'page';
-import { connect } from 'react-redux';
+import config from '@automattic/calypso-config';
 import NotificationsPanel, {
 	refreshNotes,
 } from '@automattic/notifications/src/panel/Notifications';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
+import classNames from 'classnames';
+import debugFactory from 'debug';
+import page from 'page';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import config from '@automattic/calypso-config';
+import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { didForceRefresh } from 'calypso/state/notifications-panel/actions';
+import { shouldForceRefresh } from 'calypso/state/notifications-panel/selectors';
+import { setUnseenCount } from 'calypso/state/notifications/actions';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
-import { setUnseenCount } from 'calypso/state/notifications/actions';
-import { shouldForceRefresh } from 'calypso/state/notifications-panel/selectors';
-import { didForceRefresh } from 'calypso/state/notifications-panel/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/notifications` to use `import/order`

#### Testing instructions

N/A
