### PR TITLE
chore: migrate `client/root.js` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -186,6 +186,7 @@ module.exports = {
 				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/notifications/**/*',
+				'client/root.js',
 				'client/sections-filter.js',
 				'client/sections-helper.js',
 				'client/sections-middleware.js',

--- a/client/root.js
+++ b/client/root.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import page from 'page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { requestSite } from 'calypso/state/sites/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { requestSite } from 'calypso/state/sites/actions';
 import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 
 export default function () {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/root.js` to use `import/order`

#### Testing instructions

N/A