### PR TITLE
chore: migrate `client/test-helpers` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -190,6 +190,7 @@ module.exports = {
 				'client/sections-preloaders.js',
 				'client/sections.js',
 				'client/support/**/*',
+				'client/test-helpers/**/*',
 				'client/types.ts',
 				'client/webpack.config.desktop.js',
 				'client/webpack.config.js',

--- a/client/test-helpers/config/index.js
+++ b/client/test-helpers/config/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 export const setFeatureFlag = ( feature, val ) => {

--- a/client/test-helpers/config/testing-library.jsx
+++ b/client/test-helpers/config/testing-library.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { render as rtlRender } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
-import { render as rtlRender } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
 import initialReducer from 'calypso/state/reducer';
 
 const render = ( ui, { initialState, store, reducers, ...renderOptions } = {} ) => {

--- a/client/test-helpers/use-nock/index.js
+++ b/client/test-helpers/use-nock/index.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
 import debug from 'debug';
-import nock from 'nock';
 import { partial } from 'lodash';
+import nock from 'nock';
 
 export { nock };
 

--- a/client/test-helpers/use-nock/integration/index.js
+++ b/client/test-helpers/use-nock/integration/index.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { nock, useNock } from '../index.js';
 
 describe( 'useNock', () => {

--- a/client/test-helpers/use-sinon/index.js
+++ b/client/test-helpers/use-sinon/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import sinon from 'sinon';
 
 const noop = () => {};


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/test-helpers` to use `import/order`

#### Testing instructions

N/A
