### PR TITLE
chore: migrate `packages/i18n-calypso-cli` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -215,6 +215,7 @@ module.exports = {
 				'packages/explat-client-react-helpers/**/*',
 				'packages/explat-client/**/*',
 				'packages/format-currency/**/*',
+				'packages/i18n-calypso-cli/**/*',
 				'packages/i18n-utils/**/*',
 				'packages/js-utils/**/*',
 				'packages/language-picker/**/*',

--- a/packages/i18n-calypso-cli/cli.js
+++ b/packages/i18n-calypso-cli/cli.js
@@ -2,17 +2,10 @@
 
 /* eslint-disable no-console */
 
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
-const globby = require( 'globby' );
 const path = require( 'path' );
 const program = require( 'commander' );
-
-/**
- * Internal dependencies
- */
+const globby = require( 'globby' );
 const i18n = require( '.' );
 
 function collect( val, memo ) {

--- a/packages/i18n-calypso-cli/index.js
+++ b/packages/i18n-calypso-cli/index.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const Xgettext = require( 'xgettext-js' );
 const debug = require( 'debug' )( 'i18n-calypso' );
-
-/**
- * Internal dependencies
- */
-const preProcessXGettextJSMatch = require( './preprocess-xgettextjs-match.js' );
+const Xgettext = require( 'xgettext-js' );
 const formatters = require( './formatters' );
+const preProcessXGettextJSMatch = require( './preprocess-xgettextjs-match.js' );
 
 module.exports = function i18nCalypso( config ) {
 	const keywords = config.keywords || [ 'translate' ];

--- a/packages/i18n-calypso-cli/test/i18n.js
+++ b/packages/i18n-calypso-cli/test/i18n.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 const path = require( 'path' );
-
-/**
- * Internal dependencies
- */
 const i18n = require( '..' );
 
 // generate allowed file

--- a/packages/i18n-calypso-cli/test/multiline.js
+++ b/packages/i18n-calypso-cli/test/multiline.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 const multiline = require( '../formatters/multiline' );
 
 describe( 'multiline', function () {

--- a/packages/i18n-calypso-cli/tsconfig.json
+++ b/packages/i18n-calypso-cli/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }

--- a/packages/i18n-calypso-cli/util.js
+++ b/packages/i18n-calypso-cli/util.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
 
 /**


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/i18n-calypso-cli` to use `import/order`

#### Testing instructions

N/A
