### PR TITLE
chore: migrate `packages/load-script` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -220,6 +220,7 @@ module.exports = {
 				'packages/language-picker/**/*',
 				'packages/languages/**/*',
 				'packages/launch/**/*',
+				'packages/load-script/**/*',
 				'packages/mocha-debug-reporter/**/*',
 				'packages/photon/**/*',
 				'packages/plans-grid/**/*',

--- a/packages/load-script/src/callback-handler.js
+++ b/packages/load-script/src/callback-handler.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 const debug = debugFactory( 'lib/load-script/callback-handler' );
 

--- a/packages/load-script/src/dom-operations.js
+++ b/packages/load-script/src/dom-operations.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-const debug = debugFactory( 'lib/load-script/dom-operations' );
-
-/**
- * Internal dependencies
- */
 import { handleRequestError, handleRequestSuccess } from './callback-handler';
+
+const debug = debugFactory( 'lib/load-script/dom-operations' );
 
 export function createScriptElement( url ) {
 	debug( `Creating script element for "${ url }"` );

--- a/packages/load-script/src/index.js
+++ b/packages/load-script/src/index.js
@@ -3,17 +3,11 @@
  *
  */
 
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-const debug = debugFactory( 'package/load-script' );
-
-/**
- * Internal dependencies
- */
 import { addScriptCallback, isLoading } from './callback-handler';
 import { createScriptElement, attachToHead } from './dom-operations';
+
+const debug = debugFactory( 'package/load-script' );
 
 // NOTE: This exists for compatibility.
 export { removeScriptCallback } from './callback-handler';

--- a/packages/load-script/test/callback-handler.js
+++ b/packages/load-script/test/callback-handler.js
@@ -1,9 +1,6 @@
 /**
  */
 
-/**
- * Internal dependencies
- */
 import {
 	addScriptCallback,
 	executeCallbacks,

--- a/packages/load-script/test/index.js
+++ b/packages/load-script/test/index.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { JQUERY_URL, loadjQueryDependentScript, loadScript } from '../src';
 import {
 	executeCallbacks,

--- a/packages/load-script/tsconfig.json
+++ b/packages/load-script/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/load-script` to use `import/order`

#### Testing instructions

N/A
