### PR TITLE
chore: migrate `packages/onboarding` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -221,6 +221,7 @@ module.exports = {
 				'packages/languages/**/*',
 				'packages/launch/**/*',
 				'packages/mocha-debug-reporter/**/*',
+				'packages/onboarding/**/*',
 				'packages/photon/**/*',
 				'packages/plans-grid/**/*',
 				'packages/popup-monitor/**/*',

--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
-import classnames from 'classnames';
 import { Button } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
+import * as React from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface ActionButtonsProps {

--- a/packages/onboarding/src/feature-icon/index.tsx
+++ b/packages/onboarding/src/feature-icon/index.tsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import { SVG, Path } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
+import * as React from 'react';
 import type { WPCOMFeatures } from '@automattic/data-stores';
 
 export const iconList: Record< WPCOMFeatures.FeatureId, React.ReactElement > = {

--- a/packages/onboarding/src/scroll-to-top/index.tsx
+++ b/packages/onboarding/src/scroll-to-top/index.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 

--- a/packages/onboarding/src/scroll-to-top/test/index.tsx
+++ b/packages/onboarding/src/scroll-to-top/test/index.tsx
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import { render } from '@testing-library/react';
-import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-/**
- * Internal dependencies
- */
+import * as React from 'react';
+import { Router } from 'react-router-dom';
 import ScrollToTop from '../';
 
 describe( 'ScrollToTop', () => {

--- a/packages/onboarding/src/titles/index.tsx
+++ b/packages/onboarding/src/titles/index.tsx
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
 import classnames from 'classnames';
+import * as React from 'react';
 
 import './styles.scss';
 


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/onboarding` to use `import/order`

#### Testing instructions

N/A
