### PR TITLE
Remove http to https rewrite from logmein

### DIFF
--- a/client/lib/logmein/index.ts
+++ b/client/lib/logmein/index.ts
@@ -10,9 +10,8 @@ import { Store } from 'redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 
-// Used as placeholder / default domain to detect when we're looking at a relative url,
-// Note: also prevents exceptions from being raised
-const INVALID_URL = `https://__domain__.invalid`;
+// Used as default domain to detect when we're looking at a relative or invalid url
+const INVALID_URL = 'https://__domain__.invalid';
 
 type Host = string;
 
@@ -41,6 +40,11 @@ export function logmeinUrl( url: string, redirectTo = '' ): string {
 		return url;
 	}
 
+	// logmein doesn't work with http.
+	if ( newurl.protocol !== 'https:' ) {
+		return url;
+	}
+
 	const sites = Object.values( getSitesItems( reduxStore.getState() ) );
 
 	// We only want to logmein into valid sites that belong to the user (for now that is mapped simple sites)
@@ -52,9 +56,6 @@ export function logmeinUrl( url: string, redirectTo = '' ): string {
 	if ( ! isValid ) {
 		return url;
 	}
-
-	// logmein doesn't work with http.
-	newurl.protocol = 'https:';
 
 	// Set the param
 	newurl.searchParams.set( 'logmein', 'direct' );

--- a/client/lib/logmein/index.ts
+++ b/client/lib/logmein/index.ts
@@ -40,11 +40,6 @@ export function logmeinUrl( url: string, redirectTo = '' ): string {
 		return url;
 	}
 
-	// logmein doesn't work with http.
-	if ( newurl.protocol !== 'https:' ) {
-		return url;
-	}
-
 	const sites = Object.values( getSitesItems( reduxStore.getState() ) );
 
 	// We only want to logmein into valid sites that belong to the user (for now that is mapped simple sites)

--- a/client/lib/logmein/test/index.js
+++ b/client/lib/logmein/test/index.js
@@ -188,8 +188,8 @@ describe( 'logmein', () => {
 			expect( logmeinUrl( 'https://wpcom.store' ) ).toBe( 'https://wpcom.store' );
 		} );
 
-		it( 'replaces http urls with https', () => {
-			expect( logmeinUrl( 'http://test.blog' ) ).toBe( 'https://test.blog/?logmein=direct' );
+		it( 'fallsback on url input when given http urls and does not replace http urls with https', () => {
+			expect( logmeinUrl( 'http://test.blog' ) ).toBe( 'http://test.blog' );
 		} );
 
 		it( 'fallsback on url input when given relative urls', () => {

--- a/client/lib/logmein/test/index.js
+++ b/client/lib/logmein/test/index.js
@@ -47,6 +47,10 @@ describe( 'logmein', () => {
 			expect( logmeinUrl( 'https://test.blog' ) ).toBe( 'https://test.blog/?logmein=direct' );
 		} );
 
+		it( 'respects protocol', () => {
+			expect( logmeinUrl( 'http://test.blog' ) ).toBe( 'http://test.blog/?logmein=direct' );
+		} );
+
 		it( 'works with other params', () => {
 			expect( logmeinUrl( 'https://test.blog/?test=1' ) ).toBe(
 				'https://test.blog/?test=1&logmein=direct'
@@ -186,10 +190,6 @@ describe( 'logmein', () => {
 			expect( logmeinUrl( 'https://atomic.domain' ) ).toBe( 'https://atomic.domain' );
 			expect( logmeinUrl( 'https://redirecting.domain' ) ).toBe( 'https://redirecting.domain' );
 			expect( logmeinUrl( 'https://wpcom.store' ) ).toBe( 'https://wpcom.store' );
-		} );
-
-		it( 'fallsback on url input when given http urls and does not replace http urls with https', () => {
-			expect( logmeinUrl( 'http://test.blog' ) ).toBe( 'http://test.blog' );
 		} );
 
 		it( 'fallsback on url input when given relative urls', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Some (<500) sites don't have https,
* Remove http to https rewrite from logmein
* More context in pMz3w-dvF-p2

#### Testing instructions

* Check logmein works as expected on http links
* http://calypso.localhost:3000/home/c3polikes.blog (or the calypso-live link: https://container-sad-saha.calypso.live/home/automattic.com)
* Right click the `Visit Site` button and observe the link url is changed from `http://c3polikes.blog` to `http://c3polikes.blog?logmein=direct`
* Without the PR it would rewrite to `https://c3polikes.blog?logmein=direct`

#### Before (right click + hover over "Visit Site" in top right)
![https-before](https://user-images.githubusercontent.com/811776/131281288-2cda7d21-0381-4318-974a-2fcdaf321b6b.png)

#### After (forced https removed)
![https-after](https://user-images.githubusercontent.com/811776/131281292-69de96fa-837a-4eef-942e-397b6bf5a78c.png)

Related to #53443, D64872-code

D64872-code is not required for this PR but is required for solving a related issue with logmein on the serverside.