### PR TITLE
chore: migrate `client/gutenberg` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
 				'client/auth/**/*',
 				'client/boot/**/*',
 				'client/controller/**/*',
+				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',
 				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -1,21 +1,42 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
-import { map, partial, pickBy, flowRight } from 'lodash';
+
 /* eslint-disable no-restricted-imports */
 import url from 'url';
+import config from '@automattic/calypso-config';
+import { getQueryArg } from '@wordpress/url';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import type { RequestCart } from '@automattic/shopping-cart';
+import { map, partial, pickBy, flowRight } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import WebPreview from 'calypso/components/web-preview';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { navigate } from 'calypso/lib/navigate';
+import {
+	withStopPerformanceTrackingProp,
+	PerformanceTrackProps,
+} from 'calypso/lib/performance-tracking';
+import { protectForm, ProtectedFormProps } from 'calypso/lib/protect-form';
+import { addQueryArgs } from 'calypso/lib/route';
+import wpcom from 'calypso/lib/wp';
+import EditorDocumentHead from 'calypso/post-editor/editor-document-head';
+import { setEditorIframeLoaded, startEditingPost } from 'calypso/state/editor/actions';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
+import { selectMediaItems } from 'calypso/state/media/actions';
+import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
+import { editPost, trashPost } from 'calypso/state/posts/actions';
+import { openPostRevisionsDialog } from 'calypso/state/posts/revisions/actions';
+import { clearLastNonEditorRoute, setRoute } from 'calypso/state/route/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import getPostTypeTrashUrl from 'calypso/state/selectors/get-post-type-trash-url';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import getSiteUrl from 'calypso/state/selectors/get-site-url';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import { updateSiteFrontPage } from 'calypso/state/sites/actions';
 import {
 	getCustomizerUrl,
 	getSiteOption,
@@ -24,47 +45,13 @@ import {
 	isJetpackSite,
 	getSite,
 } from 'calypso/state/sites/selectors';
-import { addQueryArgs } from 'calypso/lib/route';
-import { getQueryArg } from '@wordpress/url';
-import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
-import { clearLastNonEditorRoute, setRoute } from 'calypso/state/route/actions';
-import { updateSiteFrontPage } from 'calypso/state/sites/actions';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import getPostTypeTrashUrl from 'calypso/state/selectors/get-post-type-trash-url';
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
-import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
-import wpcom from 'calypso/lib/wp';
-import { openPostRevisionsDialog } from 'calypso/state/posts/revisions/actions';
-import { setEditorIframeLoaded, startEditingPost } from 'calypso/state/editor/actions';
-import { Placeholder } from './placeholder';
-import WebPreview from 'calypso/components/web-preview';
-import { editPost, trashPost } from 'calypso/state/posts/actions';
-import { getEditorPostId } from 'calypso/state/editor/selectors';
-import { protectForm, ProtectedFormProps } from 'calypso/lib/protect-form';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import getSiteUrl from 'calypso/state/selectors/get-site-url';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import config from '@automattic/calypso-config';
-import EditorDocumentHead from 'calypso/post-editor/editor-document-head';
-import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import {
-	withStopPerformanceTrackingProp,
-	PerformanceTrackProps,
-} from 'calypso/lib/performance-tracking';
-import { selectMediaItems } from 'calypso/state/media/actions';
-import { fetchMediaItem, getMediaItem } from 'calypso/state/media/thunks';
-import { navigate } from 'calypso/lib/navigate';
-import Iframe from './iframe';
-
-/**
- * Types
- */
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
+import Iframe from './iframe';
+import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
+import { Placeholder } from './placeholder';
+import type { RequestCart } from '@automattic/shopping-cart';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,37 +1,29 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { isEnabled } from '@automattic/calypso-config';
 import { get, has } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
-import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import CalypsoifyIframe from './calypsoify-iframe';
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import React from 'react';
+import { makeLayout, render } from 'calypso/controller';
 import { addQueryArgs } from 'calypso/lib/route';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { getAdminMenu, getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import { stopEditingPost } from 'calypso/state/editor/actions';
 import { requestSelectedEditor } from 'calypso/state/selected-editor/actions';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
+import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
+import { requestSite } from 'calypso/state/sites/actions';
 import {
 	getSiteUrl,
 	getSiteOption,
 	isJetpackSite,
 	isSSOEnabled,
 } from 'calypso/state/sites/selectors';
-import { isEnabled } from '@automattic/calypso-config';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import CalypsoifyIframe from './calypsoify-iframe';
 import { Placeholder } from './placeholder';
-
-import { makeLayout, render } from 'calypso/controller';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
-import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import { requestSite } from 'calypso/state/sites/actions';
-import { stopEditingPost } from 'calypso/state/editor/actions';
-import { getAdminMenu, getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
-import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 
 const noop = () => {};
 

--- a/client/gutenberg/editor/iframe.tsx
+++ b/client/gutenberg/editor/iframe.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React, { forwardRef, useEffect, DetailedHTMLProps, IframeHTMLAttributes } from 'react';
 
 type IframeProps = DetailedHTMLProps<

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
 import { authenticate, post, redirect, siteEditor, exitPost } from './controller';
-import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page(

--- a/client/gutenberg/editor/media-utils.js
+++ b/client/gutenberg/editor/media-utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { get, includes, reduce } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import { parseWithAttributeSchema } from '@wordpress/blocks';
+import { get, includes, reduce } from 'lodash';
 
 /**
  * Convert the Calypso Media Modal output to the format expected by Gutenberg

--- a/client/gutenberg/editor/placeholder.jsx
+++ b/client/gutenberg/editor/placeholder.jsx
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
-/**
- * Internal dependencies
- */
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/gutenberg` to use `import/order`

#### Testing instructions

N/A