### PR TITLE
WIP: Show the App Banner immediately

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -24,7 +24,6 @@ import { isOffline } from 'calypso/state/application/selectors';
 import {
 	getSelectedSiteId,
 	masterbarIsVisible,
-	getSelectedSite,
 	getSidebarIsCollapsed,
 } from 'calypso/state/ui/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -51,7 +50,7 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { withCurrentRoute } from 'calypso/components/route';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
-import { getShouldShowAppBanner, handleScroll } from './utils';
+import { handleScroll } from './utils';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { isWithinBreakpoint } from '@automattic/viewport';
@@ -264,7 +263,6 @@ class Layout extends Component {
 				bodyClass,
 			};
 		};
-		const { shouldShowAppBanner } = this.props;
 
 		const loadInlineHelp = this.shouldLoadInlineHelp();
 
@@ -357,7 +355,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
 					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 				) }
-				{ shouldShowAppBanner && config.isEnabled( 'layout/app-banner' ) && (
+				{ config.isEnabled( 'layout/app-banner' ) && (
 					<AsyncLoad require="calypso/blocks/app-banner" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'gdpr-banner' ) && (
@@ -377,7 +375,6 @@ export default compose(
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
-		const shouldShowAppBanner = getShouldShowAppBanner( getSelectedSite( state ) );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 		const isJetpack =
@@ -422,7 +419,6 @@ export default compose(
 			sectionGroup,
 			sectionName,
 			sectionJitmPath,
-			shouldShowAppBanner,
 			isOffline: isOffline( state ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			chatIsOpen: isHappychatOpen( state ),

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,20 +1,3 @@
-const HOUR_IN_MS = 60 * 60 * 1000;
-
-/**
- * Returns false if the site is unlaunched or is younger than 1 hour
- *
- * @param site the site object
- */
-export function getShouldShowAppBanner( site: any ): boolean {
-	if ( site && site.options ) {
-		const olderThanAnHour = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
-		const isLaunched = site.launch_status !== 'unlaunched';
-
-		return olderThanAnHour && isLaunched;
-	}
-	return true;
-}
-
 let lastScrollPosition = 0; // Used for calculating scroll direction.
 let sidebarTop = 0; // Current sidebar top position.
 let pinnedSidebarTop = true; // We pin sidebar to the top by default.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow the new spec to remove the condition that the site must be launched and show the App Banner immediately after site creation
  <img width="300px" src="https://user-images.githubusercontent.com/13596067/127317923-79ab2983-487f-490a-bbb5-1a8c8c04b80f.png" />

* Besides, I found that the onboarding guide UI is broken on mobile and the user cannot click the “Next” button to finish the guide. So I issued a PR to fix the problem. See: https://github.com/WordPress/gutenberg/pull/33728
  <img width="300px" src="https://user-images.githubusercontent.com/13596067/127317758-1a638077-8c73-41a5-888c-3b53c624769d.png" />

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open My Home
* Add a new site
* Finish the site creation flow
* You should see the App Banner immediately

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/54948

#### TODO

- [ ] Check the final behavior
- [ ] Update `@wordpress/components` after the fixed PR is merged
