### PR TITLE
chore: migrate `packages/calypso-analytics` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -203,6 +203,7 @@ module.exports = {
 				'packages/babel-plugin-i18n-calypso/**/*',
 				'packages/babel-plugin-transform-wpcalypso-async/**/*',
 				'packages/browser-data-collector/**/*',
+				'packages/calypso-analytics/**/*',
 				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-polyfills/**/*',

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -1,20 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/**
- * External dependencies
- */
-import { includes, omitBy, times } from 'lodash';
-import cookie from 'cookie';
 import { EventEmitter } from 'events';
 import { loadScript } from '@automattic/load-script';
-
-/**
- * Internal Dependencies
- */
-import { getCurrentUser, setCurrentUser } from './utils/current-user';
-import getDoNotTrack from './utils/do-not-track';
+import cookie from 'cookie';
+import { includes, omitBy, times } from 'lodash';
 import { getPageViewParams } from './page-view-params';
+import { getCurrentUser, setCurrentUser } from './utils/current-user';
 import debug from './utils/debug';
+import getDoNotTrack from './utils/do-not-track';
 
 declare global {
 	interface Window {

--- a/packages/calypso-analytics/src/utils/current-user.ts
+++ b/packages/calypso-analytics/src/utils/current-user.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import hashPii from './hash-pii';
 
 /**

--- a/packages/calypso-analytics/src/utils/debug.ts
+++ b/packages/calypso-analytics/src/utils/debug.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 
 /**

--- a/packages/calypso-analytics/src/utils/do-not-track.ts
+++ b/packages/calypso-analytics/src/utils/do-not-track.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import debug from './debug';
 
 /**

--- a/packages/calypso-analytics/src/utils/hash-pii.ts
+++ b/packages/calypso-analytics/src/utils/hash-pii.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import sha256 from 'hash.js/lib/hash/sha/256';
 
 /**

--- a/packages/calypso-analytics/tsconfig.json
+++ b/packages/calypso-analytics/tsconfig.json
@@ -4,7 +4,7 @@
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",
 		"rootDir": "src",
-		"types": ["node"]
+		"types": [ "node" ]
 	},
 	"include": [ "src" ]
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-analytics` to use `import/order`

#### Testing instructions

N/A
