### PR TITLE
chore: migrate `packages/social-previews` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -231,6 +231,7 @@ module.exports = {
 				'packages/request-external-access/**/*',
 				'packages/search/**/*',
 				'packages/shopping-cart/**/*',
+				'packages/social-previews/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
 				'packages/tree-select/**/*',

--- a/packages/social-previews/src/facebook-preview/index.jsx
+++ b/packages/social-previews/src/facebook-preview/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-
+import { compact } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { compact } from 'lodash';
 import { firstValid, hardTruncation, shortEnough, stripHtmlTags } from '../helpers';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const TITLE_LENGTH = 80;

--- a/packages/social-previews/src/helpers.js
+++ b/packages/social-previews/src/helpers.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { find } from 'lodash';
 
 export const shortEnough = ( limit ) => ( title ) => ( title.length <= limit ? title : false );

--- a/packages/social-previews/src/search-preview/index.jsx
+++ b/packages/social-previews/src/search-preview/index.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
@@ -12,9 +8,6 @@ import {
 	stripHtmlTags,
 } from '../helpers';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const URL_LENGTH = 68;

--- a/packages/social-previews/src/twitter-preview/index.jsx
+++ b/packages/social-previews/src/twitter-preview/index.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Tweet } from './tweet';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class TwitterPreview extends PureComponent {

--- a/packages/social-previews/src/twitter-preview/tweet.jsx
+++ b/packages/social-previews/src/twitter-preview/tweet.jsx
@@ -1,21 +1,11 @@
-/**
- * External dependencies
- */
+import { SandBox } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import moment from 'moment';
-import { __ } from '@wordpress/i18n';
-import { SandBox } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { firstValid, hardTruncation, shortEnough, stripHtmlTags } from '../helpers';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const DESCRIPTION_LENGTH = 200;

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -4,16 +4,9 @@
 
 /* eslint-disable jest/no-conditional-expect */
 
-/**
- * External dependencies
- */
-import React from 'react';
-import moment from 'moment';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import moment from 'moment';
+import React from 'react';
 import {
 	FacebookPreview as Facebook,
 	TwitterPreview as Twitter,

--- a/packages/social-previews/tsconfig.json
+++ b/packages/social-previews/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/social-previews` to use `import/order`

#### Testing instructions

N/A
