### PR TITLE
chore: migrate `packages/state-utils` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -239,6 +239,7 @@ module.exports = {
 				'packages/social-previews/**/*',
 				'packages/spec-junit-reporter/**/*',
 				'packages/spec-xunit-reporter/**/*',
+				'packages/state-utils/**/*',
 				'packages/tree-select/**/*',
 				'packages/viewport-react/**/*',
 				'packages/viewport/**/*',

--- a/packages/state-utils/src/create-selector/index.ts
+++ b/packages/state-utils/src/create-selector/index.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { memoize } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import warn from '@wordpress/warning';
+import { memoize } from 'lodash';
 
 /**
  * Constants

--- a/packages/state-utils/src/create-selector/test/index.js
+++ b/packages/state-utils/src/create-selector/test/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { filter } from 'lodash';
 import warn from '@wordpress/warning';
-
-/**
- * Internal dependencies
- */
+import { filter } from 'lodash';
 import createSelector from '../';
 
 jest.mock( '@wordpress/warning', () => jest.fn() );

--- a/packages/state-utils/src/extend-action/index.ts
+++ b/packages/state-utils/src/extend-action/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { merge } from 'lodash';
 import type { Action, AnyAction } from 'redux';
 import type { ThunkAction, ThunkDispatch } from 'redux-thunk';

--- a/packages/state-utils/src/extend-action/test/index.ts
+++ b/packages/state-utils/src/extend-action/test/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import extendAction from '..';
 
 describe( 'extendAction()', () => {

--- a/packages/state-utils/src/get-initial-state/index.ts
+++ b/packages/state-utils/src/get-initial-state/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { Reducer } from 'redux';
 
 export default function getInitialState< TState >( reducer: Reducer< TState > ): TState {

--- a/packages/state-utils/src/with-storage-key/index.ts
+++ b/packages/state-utils/src/with-storage-key/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { Reducer } from 'redux';
 
 type StorageKeyReducer< T extends Reducer > = T & {

--- a/packages/state-utils/src/with-storage-key/test/index.ts
+++ b/packages/state-utils/src/with-storage-key/test/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import withStorageKey from '..';
 
 describe( 'withStorageKey', () => {

--- a/packages/state-utils/tsconfig.json
+++ b/packages/state-utils/tsconfig.json
@@ -4,7 +4,7 @@
 		"declarationDir": "dist/types",
 		"outDir": "dist/esm",
 		"rootDir": "src",
-		"types": ["node"]
+		"types": [ "node" ]
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ]


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/state-utils` to use `import/order`

#### Testing instructions

N/A