### PR TITLE
chore: migrate `packages/wp-babel-makepot` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -246,6 +246,7 @@ module.exports = {
 				'packages/webpack-config-flag-plugin/**/*',
 				'packages/webpack-inline-constant-exports-plugin/**/*',
 				'packages/whats-new/**/*',
+				'packages/wp-babel-makepot/**/*',
 				'packages/wpcom-checkout/**/*',
 				'packages/wpcom-proxy-request/**/*',
 				'packages/wpcom.js/**/*',

--- a/packages/wp-babel-makepot/cli.js
+++ b/packages/wp-babel-makepot/cli.js
@@ -1,20 +1,13 @@
 #!/usr/bin/env node
 
-/**
- * External dependencies
- */
-const program = require( 'commander' );
-const process = require( 'process' );
-const glob = require( 'glob' );
 const os = require( 'os' );
-
-/**
- * Internal dependencies
- */
-const makePot = require( './index' );
+const process = require( 'process' );
+const program = require( 'commander' );
+const glob = require( 'glob' );
+const version = require( './package.json' ).version;
 const presets = require( './presets' );
 const concatPot = require( './utils/concat-pot' );
-const version = require( './package.json' ).version;
+const makePot = require( './index' );
 
 const presetsKeys = Object.keys( presets );
 

--- a/packages/wp-babel-makepot/index.js
+++ b/packages/wp-babel-makepot/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 const babel = require( '@babel/core' );
-
-/**
- * Internal dependencies
- */
 const defaultPreset = require( './presets' ).default;
 
 /**

--- a/packages/wp-babel-makepot/presets/index.js
+++ b/packages/wp-babel-makepot/presets/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 const path = require( 'path' );
-
-/**
- * Internal dependencies
- */
 const defaultPreset = require( './default' );
 
 /**

--- a/packages/wp-babel-makepot/test/__snapshots__/index.js.snap
+++ b/packages/wp-babel-makepot/test/__snapshots__/index.js.snap
@@ -12,7 +12,7 @@ msgid \\"Prop string\\"
 msgstr \\"\\"
 
 #: test/examples/translate-1.js:2
-#: test/examples/translate-2.js:7
+#: test/examples/translate-2.js:4
 #: test/examples/wordpress-i18n.js:2
 #. Second occurrence of \`Simple string\` should also be extracted.
 msgid \\"Simple string\\"
@@ -35,27 +35,27 @@ msgid_plural \\"Plural with comment\\"
 msgstr[0] \\"\\"
 msgstr[1] \\"\\"
 
-#: test/examples/translate-2.js:11
-#: test/examples/translate-2.js:12
+#: test/examples/translate-2.js:8
+#: test/examples/translate-2.js:9
 #. First comment
 #. Second comment
 msgid \\"Stack comments\\"
 msgstr \\"\\"
 
+#: test/examples/translate-2.js:12
 #: test/examples/translate-2.js:15
-#: test/examples/translate-2.js:18
 #. Extract from leading comment first
 #. Extract from leading comment second
 msgid \\"Extract from leading comment\\"
 msgstr \\"\\"
 
-#: test/examples/translate-2.js:20
+#: test/examples/translate-2.js:17
 msgid \\"Exrract _x as alias for translate\\"
 msgid_plural \\"Second param should be extracted as plural instead of context\\"
 msgstr[0] \\"\\"
 msgstr[1] \\"\\"
 
-#: test/examples/typescript-react.tsx:11
+#: test/examples/typescript-react.tsx:8
 msgid \\"Typescript react component string\\"
 msgstr \\"\\"
 
@@ -88,7 +88,7 @@ msgid \\"\\"
 msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 
 #: test/examples/translate-1.js:2
-#: test/examples/translate-2.js:7
+#: test/examples/translate-2.js:4
 #: test/examples/wordpress-i18n.js:2
 #. Second occurrence of \`Simple string\` should also be extracted.
 msgid \\"Simple string\\"
@@ -184,26 +184,26 @@ exports[`makePot pot files should match their snapshots 5`] = `
 "msgid \\"\\"
 msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 
-#: test/examples/translate-2.js:7
+#: test/examples/translate-2.js:4
 #. Second occurrence of \`Simple string\` should also be extracted.
 msgid \\"Simple string\\"
 msgstr \\"\\"
 
-#: test/examples/translate-2.js:11
-#: test/examples/translate-2.js:12
+#: test/examples/translate-2.js:8
+#: test/examples/translate-2.js:9
 #. First comment
 #. Second comment
 msgid \\"Stack comments\\"
 msgstr \\"\\"
 
+#: test/examples/translate-2.js:12
 #: test/examples/translate-2.js:15
-#: test/examples/translate-2.js:18
 #. Extract from leading comment first
 #. Extract from leading comment second
 msgid \\"Extract from leading comment\\"
 msgstr \\"\\"
 
-#: test/examples/translate-2.js:20
+#: test/examples/translate-2.js:17
 msgid \\"Exrract _x as alias for translate\\"
 msgid_plural \\"Second param should be extracted as plural instead of context\\"
 msgstr[0] \\"\\"
@@ -214,7 +214,7 @@ exports[`makePot pot files should match their snapshots 6`] = `
 "msgid \\"\\"
 msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 
-#: test/examples/typescript-react.tsx:11
+#: test/examples/typescript-react.tsx:8
 msgid \\"Typescript react component string\\"
 msgstr \\"\\""
 `;

--- a/packages/wp-babel-makepot/test/examples/translate-2.js
+++ b/packages/wp-babel-makepot/test/examples/translate-2.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { translate as _x } from 'i18n-calypso';
 
 function test() {

--- a/packages/wp-babel-makepot/test/examples/typescript-react.tsx
+++ b/packages/wp-babel-makepot/test/examples/typescript-react.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 interface Props {

--- a/packages/wp-babel-makepot/test/index.js
+++ b/packages/wp-babel-makepot/test/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
-const glob = require( 'glob' );
 const path = require( 'path' );
+const glob = require( 'glob' );
 const rimraf = require( 'rimraf' );
-
-/**
- * Internal dependencies
- */
 const makePot = require( '..' );
 const concatPot = require( '../utils/concat-pot' );
 

--- a/packages/wp-babel-makepot/tsconfig.json
+++ b/packages/wp-babel-makepot/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "@automattic/calypso-build/typescript/js-package.json",
-	"include": ["**/*.js", "package.json"]
+	"include": [ "**/*.js", "package.json" ]
 }

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
-const glob = require( 'glob' );
 const path = require( 'path' );
 const { po } = require( 'gettext-parser' );
+const glob = require( 'glob' );
 const merge = require( 'lodash.mergewith' );
 
 const mergeDeep = ( left, right, key ) => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/wp-babel-makepot` to use `import/order`

#### Testing instructions

N/A