### PR TITLE
Fix minor typo in README

### DIFF
--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -10,7 +10,7 @@ It is designed in a way that in its simplest form is very easy to invoke, with v
 
 ## Usage
 
-Add add `@automattic/calypso-build` to your project's `devDependencies` by running
+Add `@automattic/calypso-build` to your project's `devDependencies` by running
 
 ```
 yarn add --dev @automattic/calypso-build


### PR DESCRIPTION
Thanks for taking a look at this PR. It's very minor 🙇 

#### Changes proposed in this Pull Request

* Remove a duplicate `Add` from the `calypso-build` packages README

```diff
- Add add @automattic/calypso-build to your project's devDependencies by running
+ Add @automattic/calypso-build to your project's devDependencies by running
```

You can see the typo on `npm` here: https://www.npmjs.com/package/@automattic/calypso-build

#### Testing instructions

* The duplicate "Add" in the [Usage](https://github.com/LL782/wp-calypso/blob/patch-1/packages/calypso-build/README.md#usage) section of the `calypos-build` README should be fixed

* There should be no other changes 🙂 
