### PR TITLE
Fix issues with Activity Log on Jetpack Multi-Site Secondary Sites

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/to-update.jsx
@@ -41,7 +41,7 @@ export default ( WrappedComponent ) => {
 			return {
 				plugins:
 					nextProps.siteId === prevState.siteId
-						? unionBySlug( nextProps.plugins, prevState.plugins )
+						? unionBySlug( nextProps.plugins ?? [], prevState?.plugins ?? [] )
 						: emptyList,
 				siteId: nextProps.siteId,
 			};
@@ -61,7 +61,7 @@ export default ( WrappedComponent ) => {
 	}
 	return connect( ( state, { siteId } ) => {
 		const alertsData = requestSiteAlerts( siteId );
-		let pluginsWithUpdates = null;
+		let pluginsWithUpdates = emptyList;
 		if ( ! isJetpackSiteSecondaryNetworkSite( state, siteId ) ) {
 			pluginsWithUpdates = getPluginsWithUpdates( state, [ siteId ] );
 		}

--- a/client/my-sites/activity/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/to-update.jsx
@@ -41,7 +41,7 @@ export default ( WrappedComponent ) => {
 			return {
 				plugins:
 					nextProps.siteId === prevState.siteId
-						? unionBySlug( nextProps.plugins ?? [], prevState?.plugins ?? [] )
+						? unionBySlug( nextProps.plugins ?? [], prevState.plugins ?? [] )
 						: emptyList,
 				siteId: nextProps.siteId,
 			};

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -47,7 +47,12 @@ import {
 	siteHasScanProductPurchase,
 } from 'calypso/state/purchases/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug, getSiteTitle, isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	getSiteSlug,
+	getSiteTitle,
+	isJetpackSite,
+	isJetpackSiteSecondaryNetworkSite as getIsJetpackSiteSecondaryNetworkSite,
+} from 'calypso/state/sites/selectors';
 import {
 	recordTracksEvent as recordTracksEventAction,
 	withAnalytics,
@@ -126,6 +131,7 @@ class ActivityLog extends Component {
 		// localize
 		moment: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
+		isJetpackSiteSecondaryNetworkSite: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -376,6 +382,7 @@ class ActivityLog extends Component {
 			isAtomic,
 			isJetpack,
 			isIntroDismissed,
+			isJetpackSiteSecondaryNetworkSite,
 		} = this.props;
 
 		const disableRestore =
@@ -439,7 +446,9 @@ class ActivityLog extends Component {
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
 				<IntroBanner siteId={ siteId } />
-				{ siteHasNoLog && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
+				{ siteHasNoLog && isIntroDismissed && ! isJetpackSiteSecondaryNetworkSite && (
+					<UpgradeBanner siteId={ siteId } />
+				) }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }
 				{ this.renderActionProgress() }
@@ -599,6 +608,7 @@ export default connect(
 			timezone,
 			siteHasNoLog,
 			isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
+			isJetpackSiteSecondaryNetworkSite: getIsJetpackSiteSecondaryNetworkSite( state, siteId ),
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix errors caused by using`/activity-log` for a multisite
* Remove unusable `UpgradeBanner` on `/activity-log` for a multisite

#### Testing instructions

1. Setup a jurassic.ninja or test multisite
 a. Setup a jurassic.ninja multisite via the "Want more options?" link
 b. Connect the new site to your test WordPress.com account
 c. Add a new "secondary"  site by navigating to `your-site.jurassic.ninja/wp-admin/network/sites.php` and clicking "Add New"
 d. Install Jetpack on that new site and connect it to your test WordPress.com account
2. Navigate to activity log for your new`/activity-log/your-site.jurassic.ninja::multisite`
3. Verify the Activity Log appears and works as expected
4. Verify the Upsell banner does NOT appear

<img width="1507" alt="Screen Shot 2021-07-28 at 10 31 39 AM" src="https://user-images.githubusercontent.com/2810519/127372200-a2f798d7-6557-467c-b2b9-15cb48705c9f.png">

fixes 6789-gh-Automattic/jpop-issues
