### PR TITLE
Theme Showcase: Fix logic that checks if recommended/trending tab are loading.

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -199,7 +199,19 @@ function bindGetPremiumThemePrice( state, siteId ) {
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
 export const ConnectedThemesSelection = connect(
-	( state, { filter, page, search, tier, vertical, siteId, source } ) => {
+	(
+		state,
+		{
+			filter,
+			page,
+			search,
+			tier,
+			vertical,
+			siteId,
+			source,
+			isLoading: isCustomizedThemeListLoading,
+		}
+	) => {
 		const isJetpack = isJetpackSite( state, siteId );
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
@@ -220,14 +232,14 @@ export const ConnectedThemesSelection = connect(
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};
-
 		return {
 			query,
 			source: sourceSiteId,
 			siteSlug: getSiteSlug( state, siteId ),
 			themes: getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [],
 			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
-			isRequesting: isRequestingThemesForQuery( state, sourceSiteId, query ),
+			isRequesting:
+				isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: isUserLoggedIn( state ),
 			isThemeActive: bindIsThemeActive( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This was a rather gnarly one to figure out. This PR updates the connected Redux component for `ThemesShowcase` to properly set the `isRequesting` value by checking not only if we have a live "All Themes" query in the themes query state value, but also by checking the value of the `isLoading` props passed by the "Recommended" and "Trending" theme tabs. (These were not being checked, and consequently the ThemesShowcase component thought that they were not loading when they were, and displayed a "No Themes Found" message instead of a loading indicator until the query was complete.)

Before:
![theme-loading-before](https://user-images.githubusercontent.com/13437011/127375385-aaa64adf-4a6b-482e-ba2b-565f2f51a66d.gif)

After:
![theme-loading-after](https://user-images.githubusercontent.com/13437011/127375831-7a754813-1654-472c-89df-62ba54963460.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/themes/{SITE_URL}`
* Verify that "Recommended" theme tab does not briefly show a "No themes found" message while loading in.
* Switch to "Trending" theme tab and verify that it also does not show a "No themes found" message while loading.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54821
