### PR TITLE
Theme Showcase: fix 'no themes found' when clicking on trending tab

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -174,7 +174,7 @@ class ThemesSelection extends Component {
 					isActive={ this.props.isThemeActive }
 					getPrice={ this.props.getPremiumThemePrice }
 					isInstalling={ this.props.isInstallingTheme }
-					loading={ this.props.isRequesting }
+					loading={ this.props.isLoading }
 					emptyContent={ this.props.emptyContent }
 					placeholderCount={ this.props.placeholderCount }
 					bookmarkRef={ this.props.bookmarkRef }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When you click on "Trending" tab you see a "No themes found" message before seeing the themes. This PR fixes that.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes`
* Click on `Trending` tab
* Verify you do not see the `Sorry, no themes found` message before getting the actual list of themes:
![image](https://user-images.githubusercontent.com/375980/127384932-9601d283-25a6-4088-a820-71c2162e1dd2.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54807 
