### PR TITLE
Add better error when email is removed from the cart

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -105,6 +105,16 @@ function getBlockedPurchaseErrorMessage( {
 	);
 }
 
+function getNoDomainMappingForEmailErrorMessage( {
+	translate,
+}: {
+	translate: ReturnType< typeof useTranslate >;
+} ) {
+	return translate(
+		'We have removed an email product from your cart because you no longer have the domain it was using.'
+	);
+}
+
 function getInvalidMultisitePurchaseErrorMessage( {
 	translate,
 	message,
@@ -141,6 +151,9 @@ function getMessagePrettifier(
 
 			case 'invalid-product-multisite':
 				return getInvalidMultisitePurchaseErrorMessage( { translate, message: message.message } );
+
+			case 'no-domain-mapping':
+				return getNoDomainMappingForEmailErrorMessage( { translate } );
 
 			default:
 				return message.message;

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -111,7 +111,7 @@ function getNoDomainMappingForEmailErrorMessage( {
 	translate: ReturnType< typeof useTranslate >;
 } ) {
 	return translate(
-		'We have removed an email product from your cart because you no longer have the domain it was using.'
+		'We have removed an email product from your cart because you no longer have the domain it depends on.'
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that we show a more meaningful error message when we encounter a `no-domain-mapping` error code from the server, as that represents a situation where the server has removed an email product (either Google Workspace or Professional Email) due to the domain for the subscription being removed.

#### Testing instructions

* Run this branch locally or access the live branch link in [this comment](https://github.com/Automattic/wp-calypso/pull/54986#issuecomment-888614119)
* Navigate to `/start`
* Search for and select a paid domain name
* Click on "Add" in the email step
* Select a paid plan in the plans step
* When checkout is displayed, verify that you have a plan, domain, and email product listed
* Remove only the domain registration from the cart
* Verify that the Professional Email product is removed from the cart and you see the new error message: `We have removed an email product from your cart because you no longer have the domain it depends on.`

#### Screenshot

<img width="1293" alt="Screenshot 2021-08-02 at 15 11 33" src="https://user-images.githubusercontent.com/3376401/127867513-53a09142-b079-45b2-8df8-fc8de69ad00c.png">