### PR TITLE
Playwright: additional sidebar reliability tweaks

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -666,7 +666,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
+					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-media__edit-spec.js; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -666,7 +666,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-media__edit-spec.js; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -12,6 +12,7 @@ const selectors = {
  */
 export class SidebarComponent {
 	private page: Page;
+	private gotoItemRetryCount: number;
 
 	/**
 	 * Constructs an instance of the component.
@@ -20,6 +21,7 @@ export class SidebarComponent {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		this.gotoItemRetryCount = 3;
 	}
 
 	/**
@@ -71,6 +73,12 @@ export class SidebarComponent {
 			} );
 			return;
 		} catch {
+			if ( this.gotoItemRetryCount === 0 ) {
+				throw new Error(
+					`Couldn't navigate to ${ item } > ${ subitem }: Expected (sub)item was not active.`
+				);
+			}
+			this.gotoItemRetryCount -= 1;
 			await this.page.reload();
 			return this.gotoMenu( { item, subitem } );
 		}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -70,13 +70,13 @@ export class SidebarComponent {
 			const selectedItemSelector = `${ selectors.sidebar } .selected :text("${ subitem || item }")`;
 			await this.page.waitForSelector( selectedItemSelector, {
 				timeout: 3000,
+				state: 'attached',
 			} );
 			return;
 		} catch {
 			if ( this.gotoItemRetryCount === 0 ) {
-				throw new Error(
-					`Couldn't navigate to ${ item } > ${ subitem }: Expected (sub)item was not active.`
-				);
+				const itemPath = subitem ? `${ item } > ${ subitem }` : item;
+				throw new Error( `Couldn't navigate to ${ itemPath }: Expected (sub)item was not active.` );
 			}
 			this.gotoItemRetryCount -= 1;
 			await this.page.reload();

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -3,17 +3,7 @@ import { getViewportName } from '../../browser-helper';
 import { NavbarComponent } from './navbar-component';
 
 const selectors = {
-	// Mobile view
-	layout: '.layout',
-
-	// Sidebar
 	sidebar: '.sidebar',
-	heading: '.sidebar > li',
-	subheading: '.sidebar__menu-item--child',
-	expandedMenu: '.sidebar__menu.is-toggle-open',
-
-	// Sidebar regions
-	currentSiteCard: '.card.current-site',
 };
 
 /**
@@ -33,7 +23,8 @@ export class SidebarComponent {
 	}
 
 	/**
-	 * Waits for the wrapper of the sidebar to be initialized on the page, then returns the element handle for that sidebar
+	 * Waits for the wrapper of the sidebar to be initialized on the page, then returns the element
+	 * handle for that sidebar.
 	 *
 	 * @returns the ElementHandle for the sidebar
 	 */
@@ -51,17 +42,17 @@ export class SidebarComponent {
 	 */
 	async gotoMenu( { item, subitem }: { item: string; subitem?: string } ): Promise< void > {
 		if ( getViewportName() === 'mobile' ) {
-			await this._openMobileSidebar();
+			await this.openMobileSidebar();
 		}
 
-		const itemSelector = `.sidebar :text("${ item }")`;
+		const itemSelector = `${ selectors.sidebar } :text("${ item }")`;
 		const itemElement = await this.scrollItemIntoViewIfNeeded( itemSelector );
 
 		if ( subitem ) {
 			// Click top-level item without waiting for navigation if targeting subitem.
 			await itemElement.click();
 
-			const subitemSelector = `.sidebar :text("${ subitem }"):below(${ itemSelector })`;
+			const subitemSelector = `${ selectors.sidebar } :text("${ subitem }"):below(${ itemSelector })`;
 			const subitemElement = await this.scrollItemIntoViewIfNeeded( subitemSelector );
 
 			await Promise.all( [ this.page.waitForNavigation(), subitemElement.click() ] );
@@ -74,7 +65,7 @@ export class SidebarComponent {
 		 * the lazy-loading nature of the sidenav items.
 		 */
 		try {
-			const selectedItemSelector = `.sidebar .selected >> text="${ subitem || item }"`;
+			const selectedItemSelector = `${ selectors.sidebar } .selected :text("${ subitem || item }")`;
 			await this.page.waitForSelector( selectedItemSelector, {
 				timeout: 3000,
 			} );
@@ -83,20 +74,6 @@ export class SidebarComponent {
 			await this.page.reload();
 			return this.gotoMenu( { item, subitem } );
 		}
-	}
-
-	/**
-	 * Opens the sidebar into view for mobile viewports.
-	 *
-	 * @returns {Promise<void>} No return value.
-	 */
-	async _openMobileSidebar(): Promise< void > {
-		await this.waitForSidebarInitialization();
-		const navbarComponent = new NavbarComponent( this.page );
-		await navbarComponent.clickMySites();
-		// `focus-sidebar` attribute is added once the sidebar is opened and focused in mobile view.
-		const layoutElement = await this.page.waitForSelector( `${ selectors.layout }.focus-sidebar` );
-		await layoutElement.waitForElementState( 'stable' );
 	}
 
 	/**
@@ -120,5 +97,19 @@ export class SidebarComponent {
 		}, elementHandle );
 
 		return elementHandle;
+	}
+
+	/**
+	 * Opens the sidebar into view for mobile viewports.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async openMobileSidebar(): Promise< void > {
+		await this.waitForSidebarInitialization();
+		const navbarComponent = new NavbarComponent( this.page );
+		await navbarComponent.clickMySites();
+		// `focus-sidebar` attribute is added once the sidebar is opened and focused in mobile view.
+		const layoutElement = await this.page.waitForSelector( '.layout.focus-sidebar' );
+		await layoutElement.waitForElementState( 'stable' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -31,7 +31,10 @@ export class SidebarComponent {
 	 * @returns the ElementHandle for the sidebar
 	 */
 	async waitForSidebarInitialization(): Promise< ElementHandle > {
-		return await this.page.waitForSelector( selectors.sidebar );
+		const sidebarElementHandle = await this.page.waitForSelector( selectors.sidebar );
+		await sidebarElementHandle.waitForElementState( 'stable' );
+
+		return sidebarElementHandle;
 	}
 
 	/**
@@ -46,14 +49,14 @@ export class SidebarComponent {
 			await this.openMobileSidebar();
 		}
 
-		const itemSelector = `${ selectors.sidebar } :text("${ item }")`;
+		const itemSelector = `${ selectors.sidebar } :text-is("${ item }"):visible`;
 		await this.scrollItemIntoViewIfNeeded( itemSelector );
 
 		if ( subitem ) {
 			// Click top-level item without waiting for navigation if targeting subitem.
 			await this.page.click( itemSelector );
 
-			const subitemSelector = `${ selectors.sidebar } :text("${ subitem }"):below(${ itemSelector })`;
+			const subitemSelector = `:text-is("${ subitem }"):visible:below(${ itemSelector })`;
 			await this.scrollItemIntoViewIfNeeded( subitemSelector );
 
 			await Promise.all( [ this.page.waitForNavigation(), this.page.click( subitemSelector ) ] );
@@ -66,7 +69,9 @@ export class SidebarComponent {
 		 * the lazy-loading nature of the sidenav items.
 		 */
 		try {
-			const selectedItemSelector = `${ selectors.sidebar } .selected :text("${ subitem || item }")`;
+			const selectedItemSelector = `${ selectors.sidebar } .selected :text-is("${
+				subitem || item
+			}")`;
 			await this.page.waitForSelector( selectedItemSelector, {
 				timeout: 3000,
 				state: 'attached',

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -48,18 +48,18 @@ export class SidebarComponent {
 		}
 
 		const itemSelector = `${ selectors.sidebar } :text("${ item }")`;
-		const itemElement = await this.scrollItemIntoViewIfNeeded( itemSelector );
+		await this.scrollItemIntoViewIfNeeded( itemSelector );
 
 		if ( subitem ) {
 			// Click top-level item without waiting for navigation if targeting subitem.
-			await itemElement.click();
+			await this.page.click( itemSelector );
 
 			const subitemSelector = `${ selectors.sidebar } :text("${ subitem }"):below(${ itemSelector })`;
-			const subitemElement = await this.scrollItemIntoViewIfNeeded( subitemSelector );
+			await this.scrollItemIntoViewIfNeeded( subitemSelector );
 
-			await Promise.all( [ this.page.waitForNavigation(), subitemElement.click() ] );
+			await Promise.all( [ this.page.waitForNavigation(), this.page.click( subitemSelector ) ] );
 		} else {
-			await Promise.all( [ this.page.waitForNavigation(), itemElement.click() ] );
+			await Promise.all( [ this.page.waitForNavigation(), this.page.click( itemSelector ) ] );
 		}
 
 		/**

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -34,6 +34,15 @@ export class SidebarComponent {
 	}
 
 	/**
+	 * Waits for the wrapper of the sidebar to be initialized on the page, then returns the element handle for that sidebar
+	 *
+	 * @returns the ElementHandle for the sidebar
+	 */
+	async waitForSidebarInitialization(): Promise< ElementHandle > {
+		return await this.page.waitForSelector( selectors.sidebar );
+	}
+
+	/**
 	 * Given heading and subheading, or any combination of the two, locate and click on the items on the sidebar.
 	 *
 	 * This method supports any of the following use cases:
@@ -62,7 +71,7 @@ export class SidebarComponent {
 		// Especially on mobile devices, there can be a race condition in clicking on "My Sites" button
 		// to slide in the sidebar, and that sidebar actually being initialized! So we want to wait
 		// and make sure the sidebar is actually in the DOM before proceeding.
-		await this.page.waitForSelector( selectors.sidebar );
+		await this.waitForSidebarInitialization();
 
 		// If mobile, sidebar is hidden by default and focus is on the content.
 		// The sidebar must be first brought into view.

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -35,14 +35,13 @@ export class SidebarComponent {
 	}
 
 	/**
-	 * Navigates to given (sub)item of the sidebar navigation.
+	 * Navigates to given (sub)item of the sidebar menu.
 	 *
-	 * @param {{[key: string]: string}} param0 Named object parameter.
-	 * @param {string} param0.item Plaintext representation of the top level heading.
-	 * @param {string} param0.subitem Plaintext representation of the child level heading.
+	 * @param {string} item Plaintext representation of the top level heading.
+	 * @param {string} subitem Plaintext representation of the child level heading.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async gotoMenu( { item, subitem }: { item: string; subitem?: string } ): Promise< void > {
+	async navigate( item: string, subitem?: string ): Promise< void > {
 		if ( getViewportName() === 'mobile' ) {
 			await this.openMobileSidebar();
 		}
@@ -80,7 +79,7 @@ export class SidebarComponent {
 			}
 			this.gotoItemRetryCount -= 1;
 			await this.page.reload();
-			return this.gotoMenu( { item, subitem } );
+			return this.navigate( item, subitem );
 		}
 	}
 

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -35,25 +35,25 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 				mediaPage = new MediaPage( page );
 			} );
 
-			// it( 'Show only images', async function () {
-			// 	await mediaPage.clickTab( 'Images' );
-			// } );
+			it( 'Show only images', async function () {
+				await mediaPage.clickTab( 'Images' );
+			} );
 
-			// it( 'Select the first image item', async function () {
-			// 	await mediaPage.selectItem( 1 );
-			// } );
+			it( 'Select the first image item', async function () {
+				await mediaPage.selectItem( 1 );
+			} );
 
-			// it( 'Click to edit selected image', async function () {
-			// 	await mediaPage.editImage();
-			// } );
+			it( 'Click to edit selected image', async function () {
+				await mediaPage.editImage();
+			} );
 
-			// it( 'Rotate image', async function () {
-			// 	await mediaPage.rotateImage();
-			// } );
+			it( 'Rotate image', async function () {
+				await mediaPage.rotateImage();
+			} );
 
-			// it( 'Cancel image edit', async function () {
-			// 	await mediaPage.cancelImageEdit();
-			// } );
+			it( 'Cancel image edit', async function () {
+				await mediaPage.cancelImageEdit();
+			} );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -35,25 +35,25 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 				mediaPage = new MediaPage( page );
 			} );
 
-			it( 'Show only images', async function () {
-				await mediaPage.clickTab( 'Images' );
-			} );
+			// it( 'Show only images', async function () {
+			// 	await mediaPage.clickTab( 'Images' );
+			// } );
 
-			it( 'Select the first image item', async function () {
-				await mediaPage.selectItem( 1 );
-			} );
+			// it( 'Select the first image item', async function () {
+			// 	await mediaPage.selectItem( 1 );
+			// } );
 
-			it( 'Click to edit selected image', async function () {
-				await mediaPage.editImage();
-			} );
+			// it( 'Click to edit selected image', async function () {
+			// 	await mediaPage.editImage();
+			// } );
 
-			it( 'Rotate image', async function () {
-				await mediaPage.rotateImage();
-			} );
+			// it( 'Rotate image', async function () {
+			// 	await mediaPage.rotateImage();
+			// } );
 
-			it( 'Cancel image edit', async function () {
-				await mediaPage.cancelImageEdit();
-			} );
+			// it( 'Cancel image edit', async function () {
+			// 	await mediaPage.cancelImageEdit();
+			// } );
 		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -28,7 +28,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 
 			it( 'Navigate to Media', async function () {
 				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.gotoMenu( { item: 'Media' } );
+				await sidebarComponent.navigate( 'Media' );
 			} );
 
 			it( 'See media gallery', async function () {

--- a/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
@@ -35,7 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 
 		it( 'Navigate to Media', async function () {
 			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.gotoMenu( { item: 'Media' } );
+			await sidebarComponent.navigate( 'Media' );
 		} );
 
 		it( 'See media gallery', async function () {

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -29,7 +29,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 
 		it( 'Navigate to Plans from sidebar', async function () {
 			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.gotoMenu( { item: 'Upgrades', subitem: 'Plans' } );
+			await sidebarComponent.navigate( 'Upgrades', 'Plans' );
 		} );
 
 		it( 'Click on the "My Plan" tab', async function () {

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -21,7 +21,7 @@ describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
 
 	it( 'Navigate to Tools > Marketing page', async function () {
 		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.gotoMenu( { item: 'Tools', subitem: 'Marketing' } );
+		await sidebarComponent.navigate( 'Tools', 'Marketing' );
 	} );
 
 	it( 'Click on Traffic tab', async function () {

--- a/test/e2e/specs/specs-playwright/wp-site-import__verify-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-site-import__verify-spec.ts
@@ -22,7 +22,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 
 	it( 'Navigate to Tools > Import', async function () {
 		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.gotoMenu( { item: 'Tools', subitem: 'Import' } );
+		await sidebarComponent.navigate( 'Tools', 'Import' );
 	} );
 
 	it.each( SiteImportPage.services )( 'Select service provider: %s', async function ( service ) {

--- a/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
@@ -26,7 +26,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 
 		it( 'Navigate to Stats', async function () {
 			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.gotoMenu( { item: 'Stats' } );
+			await sidebarComponent.navigate( 'Stats' );
 		} );
 
 		it( 'Click on Insights tab', async function () {

--- a/test/e2e/specs/specs-playwright/wp-support__popover-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-spec.js
@@ -27,7 +27,7 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 
 		it( 'Open Settings page', async function () {
 			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.gotoMenu( { item: 'Settings', subitem: 'General' } );
+			await sidebarComponent.navigate( 'Settings', 'General' );
 		} );
 
 		it( 'Open support popover', async function () {
@@ -82,7 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 
 		it( 'Open Settings page', async function () {
 			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.gotoMenu( { item: 'Settings', subitem: 'General' } );
+			await sidebarComponent.navigate( 'Settings', 'General' );
 		} );
 
 		it( 'Open support popover', async function () {

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -32,7 +32,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 
 	it( 'Navigate to Appearance > Themes', async function () {
 		sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
+		await sidebarComponent.navigate( 'Appearance', 'Themes' );
 	} );
 
 	it( `Choose test site ${ siteURL } if Site Selector is shown`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -29,7 +29,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 
 	it( 'Navigate to Themes', async function () {
 		sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
+		await sidebarComponent.navigate( 'Appearance', 'Themes' );
 	} );
 
 	it( `Choose test site ${ siteURL } if Site Selector is shown`, async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes additional reliability tweaks for sidebar interaction.

Key changes:
- check for the `boundingBox` of the Current Site card (at top of the sidebar) to remain stable prior to executing the click action on a sidebar element.

Background details:

After #54666 and #54745 it was hoped that sidebar interaction with (mostly) Atomic sites would be reliable. However, there are still fairly regular intermittent flakiness resulting from inability to reliable click on the menu item. 

I dug deeper and have come to the conclusion that the `_click` method will need to wait for sidebar elements to be stable prior to any clicks occurring. This can be dealt with in one of many ways, all of which have downsides:

- a hardcoded wait
- wait for `networkidle`
- force clicking using `dispatchEvent`

#### Testing instructions

- [ ] run Desktop Playwright E2E task at least 20 times repeatedly and ensure no failure resulting from sidebar interaction.
- [ ] run Mobile Playwright E2E task at least 20 times repeatedly and ensure no failure resulting from sidebar interaction.

Related to #54614
