### PR TITLE
[GB 11.1.0][E2E] Remove deprecated GB v11.0 fallback CSS selectors

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -254,14 +254,8 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 			await driverHelper.clickWhenClickable( this.driver, blockAppenderLocator );
 		} );
 
-		// @todo Remove this fallback and its reference below in the `By.css` call
-		// once Gutenberg v11.1.0 is in production. This is here to support GB
-		// versions < 11.1.0, which is still the case at the moment as v11.1.0 is
-		// on edge sites.
-		const quickInserterSearchInputDeprecatedSelector =
-			'.block-editor-inserter__quick-inserter .block-editor-inserter__search-input';
 		const quickInserterSearchInputLocator = By.css(
-			`.block-editor-inserter__quick-inserter .components-search-control__input, ${ quickInserterSearchInputDeprecatedSelector }`
+			`.block-editor-inserter__quick-inserter .components-search-control__input`
 		);
 
 		const patternItemLocator = By.css(

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -248,14 +248,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await this.openBlockInserter();
 
-		// @todo Remove this fallback and its reference below in the `By.css` call
-		// once Gutenberg v11.1.0 is in production. This is here to support GB
-		// versions < 11.1.0, which is still the case at the moment as v11.1.0 is
-		// on edge sites.
-		const inserterSearchInputDeprecatedSelector = 'input.block-editor-inserter__search-input';
-		const inserterSearchInputLocator = By.css(
-			`input.components-search-control__input, ${ inserterSearchInputDeprecatedSelector }`
-		);
+		const inserterSearchInputLocator = By.css( `input.components-search-control__input` );
 
 		await driverHelper.setWhenSettable( this.driver, inserterSearchInputLocator, searchTerm );
 	}
@@ -729,14 +722,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 		await driverHelper.clickWhenClickable( this.driver, blockAppenderLocator );
 
-		// @todo Remove this fallback and its reference below in the `By.css` call
-		// once Gutenberg v11.1.0 is in production. This is here to support GB
-		// versions < 11.1.0, which is still the case at the moment as v11.1.0 is
-		// on edge sites.
-		const quickInserterSearchInputDeprecatedSelector =
-			'.block-editor-inserter__quick-inserter .block-editor-inserter__search-input';
 		const quickInserterSearchInputLocator = By.css(
-			`.block-editor-inserter__quick-inserter .components-search-control__input, ${ quickInserterSearchInputDeprecatedSelector }`
+			`.block-editor-inserter__quick-inserter .components-search-control__input`
 		);
 
 		const patternItemLocator = By.css(


### PR DESCRIPTION
Remove (now deprecated) fallback CSS selectors in E2E tests that were introduced in https://github.com/Automattic/wp-calypso/pull/54780. These are not needed anymore now that GB 11.1.0 has been shipped to all simple sites.

Tracking issues: https://github.com/Automattic/wp-calypso/issues/54393, https://github.com/Automattic/wp-calypso/issues/54859.