### PR TITLE
Refactor InlineSupportLink component to move context links to object

### DIFF
--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -1,15 +1,19 @@
 # Inline Support Link
 
-This component displays a link and icon. If `props.supportPostId` is supplied, when the link is clicked a SupportArticleDialog is opened with an `ExternalLink` to the `props.supportLink`. If no `props.supportPostId` is supplied, an `ExternalLink` to the `props.supportLink` is rendered.
+This component displays a link and icon. 
+
+If `props.supportPostId` is supplied, when the link is clicked a SupportArticleDialog is opened with an `ExternalLink` to the `props.supportLink`. If no `props.supportPostId` is supplied, an `ExternalLink` to the `props.supportLink` is rendered. These props are now stored in context-links.js; you should not need to provide them directly within the function anymore, see new example usage.
 
 The component's `children` prop will be used for the link text; if none is supplied, it will defaut to the text "Learn more". The `showText` property (default `true`) can be set to `false` in order to display no text.
 
-## Example Usage
+
+
+## Example Usage (deprecated)
 
 ```js
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
-function render() {
+function Link() {
 	const inlineSupportProps = {
 		supportLink: 'https://wordpress.com/support/audio/podcasting/',
 		supportPostId: 38147,
@@ -18,8 +22,31 @@ function render() {
 }
 ```
 
+## Example Usage
+
+```js
+import InlineSupportLink from 'calypso/components/inline-support-link';
+
+function Link() {
+	return <InlineSupportLink supportContext="purchases" showIcon={ false } />
+}
+```
+
+The `supportContext` is a combination of the `supportPostId` and `supportLink` found in _context-links.js_.
+
+```js
+const getContextLinks = () => ( {
+	purchases: {
+		link: 'https://wordpress.com/support/manage-purchases/',
+		post_id: 111349,
+	}
+} );
+```
+
+
 ## Props
 
+- `supportContext` - (string) The slug used to define the `supportPostId` and `supportLink` in _context-links.js_
 - `supportPostId` - (number) The postId of the support document.
 - `supportLink` - (string) The URL of the support document. If left out, no ExternalLink will be given.
 - `showText` - _optional_ (bool) Whether or not to display the link text. Default `true`.

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -1,12 +1,10 @@
 # Inline Support Link
 
-This component displays a link and icon. 
+This component displays a link and icon.
 
 If `props.supportPostId` is supplied, when the link is clicked a SupportArticleDialog is opened with an `ExternalLink` to the `props.supportLink`. If no `props.supportPostId` is supplied, an `ExternalLink` to the `props.supportLink` is rendered. These props are now stored in context-links.js; you should not need to provide them directly within the function anymore, see new example usage.
 
 The component's `children` prop will be used for the link text; if none is supplied, it will defaut to the text "Learn more". The `showText` property (default `true`) can be set to `false` in order to display no text.
-
-
 
 ## Example Usage (deprecated)
 
@@ -28,7 +26,7 @@ function Link() {
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 function Link() {
-	return <InlineSupportLink supportContext="purchases" showIcon={ false } />
+	return <InlineSupportLink supportContext="purchases" showIcon={ false } />;
 }
 ```
 
@@ -39,10 +37,9 @@ const getContextLinks = () => ( {
 	purchases: {
 		link: 'https://wordpress.com/support/manage-purchases/',
 		post_id: 111349,
-	}
+	},
 } );
 ```
-
 
 ## Props
 

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -1,0 +1,78 @@
+export const getContextLinks = () => ( {
+	pages: {
+		link: 'https://wordpress.com/support/pages/',
+		post_id: 86,
+	},
+	posts: {
+		link: 'https://wordpress.com/support/posts/',
+		post_id: 84,
+	},
+	stats: {
+		link: 'https://wordpress.com/support/stats/',
+		post_id: 4454,
+	},
+	domains: {
+		link: 'https://wordpress.com/support/domains/',
+		post_id: 1988,
+	},
+	emails: {
+		link: 'https://wordpress.com/support/add-email/',
+		post_id: 34087,
+	},
+	media: {
+		link: 'https://wordpress.com/support/media/',
+		post_id: 853,
+	},
+	portfolios: {
+		link: 'https://wordpress.com/support/portfolios/',
+		post_id: 84808,
+	},
+	testimonials: {
+		link: 'https://wordpress.com/support/testimonials/',
+		post_id: 97757,
+	},
+	comments: {
+		link: 'https://wordpress.com/support/comments/',
+		post_id: 113,
+	},
+	themes: {
+		link: 'https://wordpress.com/support/themes/',
+		post_id: 2278,
+	},
+	publicize: {
+		link: 'https://wordpress.com/support/publicize/',
+		post_id: 4789,
+	},
+	ads: {
+		link: 'https://wordpress.com/support/wordads-and-earn/',
+		post_id: 154292,
+	},
+	import: {
+		link: 'https://wordpress.com/support/import/',
+		post_id: 41,
+	},
+	export: {
+		link: 'https://wordpress.com/support/export/',
+		post_id: 2087,
+	},
+	team: {
+		link: 'https://wordpress.com/support/user-roles/',
+		post_id: 1221,
+	},
+	privacy: {
+		link: 'https://wordpress.com/support/settings/privacy-settings/',
+		post_id: 1507,
+	},
+	discussion: {
+		link: 'https://wordpress.com/support/settings/discussion-settings/',
+		post_id: 1504,
+	},
+	plugins: {
+		link: 'https://wordpress.com/support/plugins/',
+		post_id: 2108,
+	},
+	purchases: {
+		link: 'https://wordpress.com/support/manage-purchases/',
+		post_id: 111349,
+	},
+} );

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -22,6 +22,7 @@ import {
 	withAnalytics,
 } from 'calypso/state/analytics/actions';
 import { isDefaultLocale, localizeUrl } from 'calypso/lib/i18n-utils';
+import { getContextLinks } from './context-links';
 
 /**
  * Style dependencies
@@ -123,13 +124,6 @@ class InlineSupportLink extends Component {
 		);
 	}
 }
-
-const getContextLinks = () => ( {
-	pages: {
-		link: 'https://wordpress.com/support/pages/',
-		post_id: 86,
-	},
-} );
 
 const getLinkData = ( ownProps ) => {
 	const { supportContext } = ownProps;

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -39,6 +39,7 @@ class InlineSupportLink extends Component {
 		supportLink: PropTypes.string,
 		showText: PropTypes.bool,
 		showIcon: PropTypes.bool,
+		supportContext: PropTypes.string,
 		iconSize: PropTypes.number,
 		tracksEvent: PropTypes.string,
 		tracksOptions: PropTypes.object,
@@ -106,7 +107,7 @@ class InlineSupportLink extends Component {
 			<LinkComponent
 				className={ classnames( 'inline-support-link', className ) }
 				href={ url }
-				onClick={ openDialog }
+				onClick={ ( event ) => openDialog( event, supportPostId, supportLink ) }
 				onMouseEnter={
 					! isDefaultLocale( localeSlug ) && ! shouldLazyLoadAlternates
 						? this.loadAlternates
@@ -123,23 +124,37 @@ class InlineSupportLink extends Component {
 	}
 }
 
-const mapStateToProps = ( state ) => {
+const getContextLinks = () => ( {
+	pages: {
+		link: 'https://wordpress.com/support/pages/',
+		post_id: 86,
+	},
+} );
+
+const getLinkData = ( ownProps ) => {
+	const { supportContext } = ownProps;
+	const contextLinks = getContextLinks();
+	const linkData = contextLinks[ supportContext ];
+	if ( ! linkData ) {
+		return {};
+	}
+	return {
+		supportPostId: linkData.post_id,
+		supportLink: linkData.link,
+	};
+};
+
+const mapStateToProps = ( state, ownProps ) => {
 	return {
 		localeSlug: getCurrentLocaleSlug( state ),
+		...getLinkData( ownProps ),
 	};
 };
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {
-	const {
-		tracksEvent,
-		tracksOptions,
-		statsGroup,
-		statsName,
-		supportPostId,
-		supportLink,
-	} = ownProps;
+	const { tracksEvent, tracksOptions, statsGroup, statsName } = ownProps;
 	return {
-		openDialog: ( event ) => {
+		openDialog: ( event, supportPostId, supportLink ) => {
 			if ( ! supportPostId ) {
 				return;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The InlineSupportLink component originally hardcoded in the support documentation link and ID.

This change extracts the support documentation data into an object and allows you to pass a slug for the prop to pull the support page URL and ID into the InlineSupportLink component.

The reason for this change is to make adding support links to Calypso 'Learn More' components easier for non-developers/ Docs Guild.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Open https://wordpress.com/settings/writing/
- Go to Podcasting
- Click on Learn More
- Modal should open with Podcasting support documentation

(This should ensure the old format still works)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 428-gh-Automattic/payments-shilling