### PR TITLE
Domains: Fix organization field error message when the field is optional

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -319,9 +319,7 @@ export class ManagedContactDetailsFormFields extends Component {
 							label: translate( 'Organization' ),
 							text: translate( '+ Add organization name' ),
 							toggled:
-								form.organization?.value ||
-								this.props.getIsFieldRequired?.( 'organization' ) ||
-								undefined,
+								form.organization?.value || this.props.getIsFieldRequired?.( 'organization' ),
 						},
 						{
 							customErrorMessage: this.props.contactDetailsErrors?.organization,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -175,9 +175,12 @@ export default function WPCheckout( {
 
 	const contactInfo: ManagedContactDetails =
 		useSelect( ( sel ) => sel( 'wpcom' ).getContactInfo() ) || {};
-	const { setSiteId, touchContactFields, applyDomainContactValidationResults } = useDispatch(
-		'wpcom'
-	);
+	const {
+		setSiteId,
+		touchContactFields,
+		applyDomainContactValidationResults,
+		clearDomainContactErrorMessages,
+	} = useDispatch( 'wpcom' );
 
 	const [
 		shouldShowContactDetailsValidationErrors,
@@ -243,6 +246,7 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod?.id ?? '',
 				validationResult,
 				applyDomainContactValidationResults,
+				clearDomainContactErrorMessages,
 			} );
 			const isSignupValidationValid = isContactValidationResponseValid(
 				validationResult,
@@ -263,6 +267,7 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod?.id ?? '',
 				validationResult,
 				applyDomainContactValidationResults,
+				clearDomainContactErrorMessages,
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( contactDetailsType === 'domain' ) {
@@ -277,6 +282,7 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod?.id ?? '',
 				validationResult,
 				applyDomainContactValidationResults,
+				clearDomainContactErrorMessages,
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( contactDetailsType === 'gsuite' ) {
@@ -291,6 +297,7 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod?.id ?? '',
 				validationResult,
 				applyDomainContactValidationResults,
+				clearDomainContactErrorMessages,
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		}

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -61,6 +61,7 @@ export function handleContactValidationResult( {
 	paymentMethodId,
 	validationResult,
 	applyDomainContactValidationResults,
+	clearDomainContactErrorMessages,
 } ) {
 	recordEvent( {
 		type: 'VALIDATE_DOMAIN_CONTACT_INFO',
@@ -82,9 +83,13 @@ export function handleContactValidationResult( {
 			)
 		);
 	}
-	applyDomainContactValidationResults(
-		formatDomainContactValidationResponse( validationResult ?? {} )
-	);
+	if ( validationResult?.success ) {
+		clearDomainContactErrorMessages();
+	} else {
+		applyDomainContactValidationResults(
+			formatDomainContactValidationResponse( validationResult ?? {} )
+		);
+	}
 }
 
 export function isContactValidationResponseValid( data, contactDetails ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -36,6 +36,7 @@ type WpcomStoreAction =
 	| { type: 'UPDATE_POSTAL_CODE'; payload: string }
 	| { type: 'UPDATE_REQUIRED_DOMAIN_FIELDS'; payload: ManagedContactDetailsRequiredMask }
 	| { type: 'TOUCH_CONTACT_DETAILS' }
+	| { type: 'CLEAR_DOMAIN_CONTACT_ERROR_MESSAGES' }
 	| { type: 'UPDATE_COUNTRY_CODE'; payload: string }
 	| { type: 'LOAD_COUNTRY_CODE_FROM_GEOIP'; payload: string }
 	| {
@@ -80,6 +81,8 @@ export function useWpcomStore(
 				return updaters.updateCountryCode( state, action.payload );
 			case 'APPLY_DOMAIN_CONTACT_VALIDATION_RESULTS':
 				return updaters.setErrorMessages( state, action.payload );
+			case 'CLEAR_DOMAIN_CONTACT_ERROR_MESSAGES':
+				return updaters.clearErrorMessages( state );
 			case 'TOUCH_CONTACT_DETAILS':
 				return updaters.touchContactFields( state );
 			case 'LOAD_COUNTRY_CODE_FROM_GEOIP':
@@ -135,6 +138,10 @@ export function useWpcomStore(
 				payload: ManagedContactDetailsErrors
 			): WpcomStoreAction {
 				return { type: 'APPLY_DOMAIN_CONTACT_VALIDATION_RESULTS', payload };
+			},
+
+			clearDomainContactErrorMessages(): WpcomStoreAction {
+				return { type: 'CLEAR_DOMAIN_CONTACT_ERROR_MESSAGES' };
 			},
 
 			setSiteId( payload: string ): WpcomStoreAction {

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -261,6 +261,10 @@ function touchField( oldData: ManagedValue ): ManagedValue {
 	return { ...oldData, isTouched: true };
 }
 
+function clearFieldErrors( oldData: ManagedValue ): ManagedValue {
+	return { ...oldData, errors: [] };
+}
+
 function touchIfDifferent(
 	newValue: undefined | string,
 	oldData: ManagedValue | undefined
@@ -768,6 +772,10 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		errors: ManagedContactDetailsErrors
 	): ManagedContactDetails => {
 		return setManagedContactDetailsErrors( errors, oldDetails );
+	},
+
+	clearErrorMessages: ( oldDetails: ManagedContactDetails ): ManagedContactDetails => {
+		return mapManagedContactDetailsShape( clearFieldErrors, oldDetails );
 	},
 
 	populateCountryCodeFromGeoIP: (

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -21,8 +21,11 @@ export class HiddenInput extends PureComponent {
 	}
 
 	static getDerivedStateFromProps( props, state ) {
-		if ( props.toggled !== undefined && state.toggled !== props.toggled ) {
-			return { ...state, toggled: props.toggled };
+		if ( props.toggled === undefined ) return null;
+
+		const toggled = !! props.toggled;
+		if ( state.toggled !== toggled ) {
+			return { ...state, toggled };
 		}
 
 		return null;

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -14,7 +14,7 @@ export class HiddenInput extends PureComponent {
 	constructor( props, context ) {
 		super( props, context );
 		this.state = {
-			wasClicked: false,
+			wasClicked: ! isEmpty( props.value ),
 			toggled: ! isEmpty( props.value ),
 		};
 		this.inputField = null;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -360,6 +360,7 @@ export type ManagedContactDetailsUpdaters = {
 		arg0: ManagedContactDetails,
 		arg1: ManagedContactDetailsErrors
 	) => ManagedContactDetails;
+	clearErrorMessages: ( arg0: ManagedContactDetails ) => ManagedContactDetails;
 	populateCountryCodeFromGeoIP: (
 		arg0: ManagedContactDetails,
 		arg1: string


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes https://github.com/Automattic/wp-calypso/issues/54980. It removes the error message from the organization field when changing the registrant type value. 

#### Testing instructions
- For .ca domain chose "Canadian corporation" and try to save the contact info with an empty organization field;
- Switch back to "Canadian citizen" and click save;
- Click on the edit button for the contact information:
  - Previously, the form would render an error message: "An organization name is required for Canadian corporations", even though we just saved the contact info with "Canadian citizen".
  - Check that the error message is not displayed anymore and that the field is hidden (since it had no value when we saved it).
  - Check that both organization and registrant type fields behave properly when having their values changed.

#### Preview
##### Before
https://user-images.githubusercontent.com/18705930/127409536-16f5601d-dfa1-410f-83de-d3779a438adc.mov

##### After
https://user-images.githubusercontent.com/18705930/127409539-4d4fe7b9-6a01-40a0-b7db-2e15794bcb96.mov