### PR TITLE
Shopping Cart: Always prevent refetch-on-focus for temporary cart keys

### DIFF
--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -14,8 +14,7 @@ import type { RequestCart } from '@automattic/shopping-cart';
  * Internal Dependencies
  */
 import wp from 'calypso/lib/wp';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import getCartKey from './get-cart-key';
+import useCartKey from './use-cart-key';
 import CartMessages from 'calypso/my-sites/checkout/cart/cart-messages';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -31,8 +30,6 @@ export default function CalypsoShoppingCartProvider( {
 }: {
 	children: React.ReactNode;
 } ): JSX.Element {
-	const selectedSite = useSelector( getSelectedSite );
-	const cartKeysThatDoNotAllowRefetch = [ 'no-site', 'no-user' ];
 	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
 	const currentUrlPath = window.location.pathname;
 	const searchParams = new URLSearchParams( window.location.search );
@@ -50,23 +47,18 @@ export default function CalypsoShoppingCartProvider( {
 
 	const getCart = isLoggedOutCart || isNoSiteCart ? () => Promise.resolve( emptyCart ) : undefined;
 
-	const finalCartKey = getCartKey( { selectedSite, isLoggedOutCart, isNoSiteCart } );
-
-	const refetchOnWindowFocus: boolean =
-		Boolean( selectedSite?.ID ) &&
-		Boolean( finalCartKey ) &&
-		! cartKeysThatDoNotAllowRefetch.includes( String( finalCartKey ) );
+	const defaultCartKey = useCartKey();
 
 	const options = useMemo(
 		() => ( {
-			refetchOnWindowFocus,
+			refetchOnWindowFocus: true,
 		} ),
-		[ refetchOnWindowFocus ]
+		[]
 	);
 
 	return (
 		<ShoppingCartProvider
-			cartKey={ finalCartKey }
+			cartKey={ defaultCartKey }
 			getCart={ getCart || wpcomGetCart }
 			setCart={ wpcomSetCart }
 			options={ options }

--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -11,7 +11,7 @@ export default function getCartKey( {
 	selectedSite: SiteData | undefined | null;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
-} ): string | number | undefined {
+} ): string | undefined {
 	if ( ! selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
 		return 'no-user';
 	}
@@ -21,6 +21,8 @@ export default function getCartKey( {
 	if ( selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
 		return selectedSite.slug;
 	}
-
-	return selectedSite?.ID ?? 'no-site';
+	if ( selectedSite?.ID ) {
+		return String( selectedSite.ID );
+	}
+	return 'no-site';
 }

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCartKey from './get-cart-key';
+
+export default function useCartKey(): ReturnType< typeof getCartKey > {
+	const selectedSite = useSelector( getSelectedSite );
+	const isLoggedOutCart = ! useSelector( isUserLoggedIn );
+	const currentUrlPath = window.location.pathname;
+	const searchParams = new URLSearchParams( window.location.search );
+	const jetpackPurchaseToken = searchParams.has( 'purchasetoken' );
+	const jetpackPurchaseNonce = searchParams.has( 'purchaseNonce' );
+	const isJetpackCheckout =
+		currentUrlPath.includes( '/checkout/jetpack' ) &&
+		isLoggedOutCart &&
+		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
+	const isNoSiteCart =
+		isJetpackCheckout ||
+		( ! isLoggedOutCart &&
+			currentUrlPath.includes( '/checkout/no-site' ) &&
+			'no-user' === searchParams.get( 'cart' ) );
+
+	return getCartKey( { selectedSite, isLoggedOutCart, isNoSiteCart } );
+}

--- a/packages/shopping-cart/src/shopping-cart-provider.tsx
+++ b/packages/shopping-cart/src/shopping-cart-provider.tsx
@@ -10,7 +10,7 @@ export default function ShoppingCartProvider( {
 	options,
 	children,
 }: {
-	cartKey: string | number | null | undefined;
+	cartKey: string | undefined;
 	setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
 	options?: ShoppingCartManagerOptions;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -11,7 +11,7 @@ import type { Dispatch } from 'react';
 export * from './shopping-cart-endpoint';
 
 export interface ShoppingCartManagerArguments {
-	cartKey: string | number | null | undefined;
+	cartKey: string | undefined;
 	setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
 	options?: ShoppingCartManagerOptions;

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -8,6 +8,8 @@ const debug = debugFactory( 'shopping-cart:use-refetch-on-focus' );
 // automatic refetch on focus.
 const minimumFetchInterval = 60;
 
+const cartKeysThatDoNotAllowRefetch = [ 'no-site', 'no-user' ];
+
 function convertMsToSecs( ms: number ): number {
 	return Math.floor( ms / 1000 );
 }
@@ -22,6 +24,13 @@ export default function useRefetchOnFocus(
 		if ( ! options.refetchOnWindowFocus ) {
 			return;
 		}
+		if ( ! cartKey ) {
+			return;
+		}
+		if ( cartKeysThatDoNotAllowRefetch.includes( cartKey ) ) {
+			return;
+		}
+
 		// Refresh only if the cart is not pending any other operations
 		if ( cacheStatus !== 'valid' && cacheStatus !== 'error' ) {
 			return;

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -15,6 +15,7 @@ function convertMsToSecs( ms: number ): number {
 }
 
 export default function useRefetchOnFocus(
+	cartKey: string | undefined,
 	options: ShoppingCartManagerOptions,
 	cacheStatus: CacheStatus,
 	lastCart: ResponseCart,
@@ -83,5 +84,11 @@ export default function useRefetchOnFocus(
 			window.removeEventListener( 'focus', handleFocusChange );
 			window.removeEventListener( 'online', handleFocusChange );
 		};
-	}, [ options.refetchOnWindowFocus, lastCart.cart_generated_at_timestamp, refetch, cacheStatus ] );
+	}, [
+		cartKey,
+		options.refetchOnWindowFocus,
+		lastCart.cart_generated_at_timestamp,
+		refetch,
+		cacheStatus,
+	] );
 }

--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -158,6 +158,7 @@ export default function useShoppingCartManager( {
 
 	// Refetch when the window is refocused
 	useRefetchOnFocus(
+		cartKey,
 		options ?? {},
 		cacheStatus,
 		responseCartWithoutTempProducts,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `ShoppingCartProvider` component has an option, `refetchOnFocus`, that will cause it to automatically refetch the shopping cart when the window is refocused (if it hasn't been fetched recently). There are some cases, however, where we want to prevent refetching, notably when there is no cart key or when the cart key is a special type that will create a temporary cart. To handle those situations, the calypso wrapper for `ShoppingCartProvider`, called `CalypsoShoppingCartProvider`, sets `refetchOnFocus` only if the appropriate conditions are met.

However, these conditions (not refetching on special cart keys or no cart key) are not specific to calypso; they are specific to the shopping cart implementation, which is the whole purpose of the `shopping-cart` package. In this PR, we move that logic from `CalypsoShoppingCartProvider` into `ShoppingCartProvider` itself (or rather, its `useRefetchOnFocus` hook). This greatly simplifies the responsibilities of `CalypsoShoppingCartProvider`.

The logic for generating the cart key used by `CalypsoShoppingCartProvider` is already in its own function, `getCartKey`, but the data it requires is stored in Redux. So to further simplify `CalypsoShoppingCartProvider`, this PR also moves the logic which generates the cart key to a custom hook, `useCartKey`, which then has the ability to fetch its own data.

These changes will make it easier to refactor the `shopping-cart` package to use a singleton cart manager in https://github.com/Automattic/wp-calypso/pull/54667 since we'll need to provide the cart key (and therefore also the decision about whether to refetch) to every use of `useShoppingCart` instead of inside `CalypsoShoppingCartProvider`.

#### Testing instructions

First test that the cart refresh still works for normal keys.

- Add any product to your cart for a site and visit checkout in a window or tab; let's call it "tab A".
- Open a second window or tab and load checkout there also for the same site; let's call this "tab B".
- In tab B, click to modify the cart in some way. The simplest option is to delete the item in the cart, but you could also change the tax location, change the product variant, or click an upsell. Make sure you've been on tab B for more than 60 seconds.
- Return to tab A and verify that the cart now looks identical to tab B, with the change complete. (You may see the form briefly disable while it is updating, but it can be quite fast.)

Now test that the refresh does not occur for a special key.

- Visit http://calypso.localhost:3000/checkout/jetpack/jetpack_scan (you must be logged in to WordPress.com but no site is required).
- Open a second window or tab to anywhere and wait for a bit longer than 60 seconds.
- Return to the checkout tab and verify that the cart does not refresh and everything looks as it did before you left it.