### PR TITLE
[E2E] DRY the `insertBlockOrPatternViaBlockAppender` function

### DIFF
--- a/test/e2e/lib/components/abstract-editor-component.js
+++ b/test/e2e/lib/components/abstract-editor-component.js
@@ -1,0 +1,47 @@
+import { By } from 'selenium-webdriver';
+import AsyncBaseContainer from '../async-base-container';
+import * as driverHelper from '../driver-helper';
+
+/**
+ * Abstract class containing shared code for editor-related classes.
+ */
+export default class AbstractEditorComponent extends AsyncBaseContainer {
+	/**
+	 * Insert a child block into a parent block using the inline block inserter.
+	 *
+	 * @param {string} name the name of the block to insert as a child.
+	 * @param {string} container the name of the container block to insert the child block into.
+	 */
+	async insertBlockOrPatternViaBlockAppender( name, container = 'Group' ) {
+		const containerBlockId = await this.addBlock( container );
+		await this.runInCanvas( async () => {
+			const blockAppenderLocator = By.css(
+				`#${ containerBlockId } .block-editor-button-block-appender`
+			);
+			await driverHelper.clickWhenClickable( this.driver, blockAppenderLocator );
+		} );
+
+		const quickInserterSearchInputLocator = By.css(
+			`.block-editor-inserter__quick-inserter .components-search-control__input`
+		);
+
+		const patternItemLocator = By.css(
+			'.block-editor-inserter__quick-inserter .block-editor-block-types-list__item, .block-editor-inserter__quick-inserter .block-editor-block-patterns-list__item'
+		);
+
+		await driverHelper.setWhenSettable( this.driver, quickInserterSearchInputLocator, name );
+		await driverHelper.clickWhenClickable( this.driver, patternItemLocator );
+	}
+
+	/**
+	 * Set the running context for operating on the DOM, i.e switch to the right
+	 * iframe. By default, it's defined here as a noop, but can be overriden in
+	 * subclasses with a proper implementation, if needed.
+	 *
+	 * @param {Function} cb  The callback setting the right document context.
+	 * @returns {*} depends on the return value of the cb function.
+	 */
+	async runInCanvas( cb ) {
+		return await cb();
+	}
+}

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -1,10 +1,10 @@
 import { By } from 'selenium-webdriver';
-import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
+import AbstractEditorComponent from './abstract-editor-component';
 
-export default class SiteEditorComponent extends AsyncBaseContainer {
+export default class SiteEditorComponent extends AbstractEditorComponent {
 	constructor( driver, url, editorType = 'iframe' ) {
 		super( driver, By.css( '.edit-site-header' ), url );
 		this.editorType = editorType;
@@ -243,27 +243,6 @@ export default class SiteEditorComponent extends AsyncBaseContainer {
 		}
 
 		await driverHelper.waitUntilElementNotLocated( this.driver, snackbarNoticeLocator );
-	}
-
-	async insertBlockOrPatternViaBlockAppender( name, container = 'Group' ) {
-		const containerBlockId = await this.addBlock( container );
-		await this.runInCanvas( async () => {
-			const blockAppenderLocator = By.css(
-				`#${ containerBlockId } .block-editor-button-block-appender`
-			);
-			await driverHelper.clickWhenClickable( this.driver, blockAppenderLocator );
-		} );
-
-		const quickInserterSearchInputLocator = By.css(
-			`.block-editor-inserter__quick-inserter .components-search-control__input`
-		);
-
-		const patternItemLocator = By.css(
-			'.block-editor-inserter__quick-inserter .block-editor-block-types-list__item, .block-editor-inserter__quick-inserter .block-editor-block-patterns-list__item'
-		);
-
-		await driverHelper.setWhenSettable( this.driver, quickInserterSearchInputLocator, name );
-		await driverHelper.clickWhenClickable( this.driver, patternItemLocator );
 	}
 
 	async toggleNavigationSidebar() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -1,6 +1,6 @@
 import { kebabCase } from 'lodash';
 import webdriver, { By } from 'selenium-webdriver';
-import AsyncBaseContainer from '../async-base-container';
+import AbstractEditorComponent from '../components/abstract-editor-component';
 import GuideComponent from '../components/guide-component.js';
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager.js';
@@ -9,7 +9,7 @@ import { FileBlockComponent } from './blocks/file-block-component';
 import { ImageBlockComponent } from './blocks/image-block-component';
 import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
 
-export default class GutenbergEditorComponent extends AsyncBaseContainer {
+export default class GutenbergEditorComponent extends AbstractEditorComponent {
 	constructor( driver, url, editorType = 'iframe' ) {
 		super( driver, By.css( '.edit-post-header' ), url );
 		this.editorType = editorType;
@@ -713,24 +713,5 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const notices = await this.driver.findElements( locator );
 		await Promise.all( notices.map( ( notice ) => notice.click() ) );
 		await driverHelper.waitUntilElementNotLocated( this.driver, locator );
-	}
-
-	async insertBlockOrPatternViaBlockAppender( name, container = 'Group' ) {
-		const containerBlockId = await this.addBlock( container );
-		const blockAppenderLocator = By.css(
-			`#${ containerBlockId } .block-editor-button-block-appender`
-		);
-		await driverHelper.clickWhenClickable( this.driver, blockAppenderLocator );
-
-		const quickInserterSearchInputLocator = By.css(
-			`.block-editor-inserter__quick-inserter .components-search-control__input`
-		);
-
-		const patternItemLocator = By.css(
-			'.block-editor-inserter__quick-inserter .block-editor-block-types-list__item, .block-editor-inserter__quick-inserter .block-editor-block-patterns-list__item'
-		);
-
-		await driverHelper.setWhenSettable( this.driver, quickInserterSearchInputLocator, name );
-		await driverHelper.clickWhenClickable( this.driver, patternItemLocator );
 	}
 }


### PR DESCRIPTION
The main goal for this changeset is to DRY the `insertBlockOrPatternViaBlockAppender`, inspired [by this PR](https://github.com/Automattic/wp-calypso/pull/54780) and the subsequent [comment](https://github.com/Automattic/wp-calypso/pull/54780/files#r674598397) by @david-szabo97. However, It also introduces a new base class for the editor component. We can start drying further in subsequent PRs. I'll do that as time allows.

Inheritance was simpler than composing it, due to the two existing editor classes and the fact we might move more common aspects to it.



#### Changes proposed in this Pull Request

- Introduce a new `AbstractEditorComponent` class to be used as base class for editor components;
- The `GutenbergEditorComponent` and `SiteEditorComponent` now inherit from this abstract class;
- The class provides a noop `runInCanvas` instance method and lets subclasses override the implementation;
- The abstract class can be used to DRY other functions, too, later.

#### Testing instructions

* Tests should pass.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/54780
