### PR TITLE
Jetpack Cloud: enable Search section

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -22,8 +22,6 @@ import QueryScanState from 'calypso/components/data/query-jetpack-scan';
 import ScanBadge from 'calypso/components/jetpack/scan-badge';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isEnabled } from '@automattic/calypso-config';
 
 export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
@@ -91,19 +89,17 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
 				</SidebarItem>
 			) }
-			{ ( ! isJetpackCloud() || isEnabled( 'jetpack-cloud/search' ) ) && (
-				<SidebarItem
-					tipTarget="jetpack-search"
-					icon={ showIcons ? 'search' : undefined }
-					label={ translate( 'Search', {
-						comment: 'Jetpack sidebar menu item',
-					} ) }
-					link={ `/jetpack-search/${ siteSlug }` }
-					onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
-					selected={ currentPathMatches( `/jetpack-search/${ siteSlug }` ) }
-					expandSection={ expandSection }
-				/>
-			) }
+			<SidebarItem
+				tipTarget="jetpack-search"
+				icon={ showIcons ? 'search' : undefined }
+				label={ translate( 'Search', {
+					comment: 'Jetpack sidebar menu item',
+				} ) }
+				link={ `/jetpack-search/${ siteSlug }` }
+				onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
+				selected={ currentPathMatches( `/jetpack-search/${ siteSlug }` ) }
+				expandSection={ expandSection }
+			/>
 		</>
 	);
 };

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -38,7 +38,6 @@
 		"ive/use-external-assignment": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud/connect": false,
-		"jetpack-cloud/search": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/backups-date-picker": true,
 		"jetpack/only-realtime-products": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -63,8 +63,9 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"scan": true,
-		"jetpack-connect": true
+		"jetpack-connect": true,
+		"jetpack-search": true,
+		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud"

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -66,6 +66,7 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
+		"jetpack-search": true,
 		"scan": true
 	},
 	"site_filter": [ "jetpack" ],

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -69,8 +69,9 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud": true,
-		"scan": true,
-		"jetpack-connect": true
+		"jetpack-connect": true,
+		"jetpack-search": true,
+		"scan": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the 'Search' menu item to Jetpack Cloud. This section shows the same information as Jetpack > Search in Calypso blue.

<img width="708" alt="Screen Shot 2021-07-29 at 14 32 37" src="https://user-images.githubusercontent.com/17325/127422519-30e81692-a490-4e5b-9f99-d896aa7c53cd.png">

Fixes https://github.com/Automattic/wp-calypso/issues/53689.

#### Testing instructions

1. Run locally with `CALYPSO_ENV=jetpack-cloud-development yarn start` and map `jetpack.cloud.localhost` to 127.0.0.1 in your “hosts” file.
2. Visit http://jetpack.cloud.localhost:3000/ and choose the 'Search' item in the sidebar.
3. Try to access a site that is currently connected to Jetpack. Make sure the search enabled status reflects whether Search is currently enabled on the site.
4. Try to access a site that is disconnected from Jetpack (like an old jurassic.ninja site). It should look like this:

<img width="769" alt="Screen Shot 2021-05-24 at 16 00 17" src="https://user-images.githubusercontent.com/17325/119295009-e278e200-bca9-11eb-9b72-84e125fdf2d8.png">

4. Stop Calypso and restart with the regular environment (`yarn start`) and access via http://calypso.localhost:3000.
5. Visit the same sites in Calypso blue via Jetpack > Search and ensure the experience is consistent.