### PR TITLE
chore: Migrate packages/wpcom.js to use import/order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -243,6 +243,7 @@ module.exports = {
 				'packages/whats-new/**/*',
 				'packages/wpcom-checkout/**/*',
 				'packages/wpcom-proxy-request/**/*',
+				'packages/wpcom.js/**/*',
 				'test/client/**/*',
 				'test/e2e/**/*',
 				'test/server/**/*',

--- a/packages/wpcom.js/examples/media-editor/source.js
+++ b/packages/wpcom.js/examples/media-editor/source.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import proxy from 'wpcom-proxy-request';
-import wpcomOAuthFactory from 'wpcom-oauth-cors';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import wpcomOAuthFactory from 'wpcom-oauth-cors';
+import proxy from 'wpcom-proxy-request';
 import wpcomFactory from '../../';
 
 const debug = debugFactory( 'media-editor' );

--- a/packages/wpcom.js/examples/server/index.js
+++ b/packages/wpcom.js/examples/server/index.js
@@ -1,15 +1,6 @@
-/**
- * Module dependencies.
- */
-
-const express = require( 'express' );
 const path = require( 'path' );
+const express = require( 'express' );
 const WPCOM = require( '../../' );
-
-/**
- * wpcon app data
- */
-
 const wpapp = require( '../../test/config' );
 
 /**

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
 import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
 import Batch from './lib/batch';
 import Domain from './lib/domain';
 import Domains from './lib/domains';
 import Marketing from './lib/marketing';
 import Me from './lib/me';
-import Pinghub from './lib/util/pinghub';
 import Plans from './lib/plans';
-import Request from './lib/util/request';
 import Site from './lib/site';
 import Users from './lib/users';
+import Pinghub from './lib/util/pinghub';
+import Request from './lib/util/request';
 import sendRequest from './lib/util/send-request';
 
 /**

--- a/packages/wpcom.js/src/lib/domain.js
+++ b/packages/wpcom.js/src/lib/domain.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import DomainEmail from './domain.email';
 import DomainDns from './domain.dns';
+import DomainEmail from './domain.email';
 
 const root = '/domains/';
 

--- a/packages/wpcom.js/src/lib/marketing.js
+++ b/packages/wpcom.js/src/lib/marketing.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import MarketingSurvey from './marketing.survey';
 
 export default class Marketing {

--- a/packages/wpcom.js/src/lib/me.js
+++ b/packages/wpcom.js/src/lib/me.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import MeKeyringConnection from './me.keyring-connection';
 import MeConnectedApp from './me.connected-application';
+import MeKeyringConnection from './me.keyring-connection';
 import MePublicizeConnection from './me.publicize-connection';
 import MeSettings from './me.settings';
 import MeTwoStep from './me.two-step';

--- a/packages/wpcom.js/src/lib/me.settings.js
+++ b/packages/wpcom.js/src/lib/me.settings.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import MeProfileLinks from './me.settings.profile-links';
 import MeSettingsPassword from './me.settings.password';
+import MeProfileLinks from './me.settings.profile-links';
 
 /**
  * `MeSettings` constructor.

--- a/packages/wpcom.js/src/lib/me.two-step.js
+++ b/packages/wpcom.js/src/lib/me.two-step.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import MeTwoStepSMS from './me.two-step.sms';
 
 const root = '/me/two-step/';

--- a/packages/wpcom.js/src/lib/site.comment.js
+++ b/packages/wpcom.js/src/lib/site.comment.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import commentLike from './site.comment.like';
 
 /**

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import siteGetMethods from './runtime/site.get';
 import Category from './site.category';
 import Comment from './site.comment';
+import SiteCreditVouchers from './site.credit-vouchers';
+import SiteDomain from './site.domain';
 import Follow from './site.follow';
 import Media from './site.media';
-import Post from './site.post';
-import Tag from './site.tag';
-import SitePostType from './site.post-type';
-import SiteDomain from './site.domain';
 import SitePlugin from './site.plugin';
+import Post from './site.post';
+import SitePostType from './site.post-type';
 import SiteSettings from './site.settings';
+import Tag from './site.tag';
 import SiteTaxonomy from './site.taxonomy';
-import SiteCreditVouchers from './site.credit-vouchers';
 import SiteWordAds from './site.wordads';
 import SiteWPComPlugin from './site.wpcom-plugin';
-import siteGetMethods from './runtime/site.get';
 import runtimeBuilder from './util/runtime-builder';
 
 /**

--- a/packages/wpcom.js/src/lib/site.media.js
+++ b/packages/wpcom.js/src/lib/site.media.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import { createReadStream } from './util/fs';
 
 const debug = debugFactory( 'wpcom:media' );

--- a/packages/wpcom.js/src/lib/site.post.js
+++ b/packages/wpcom.js/src/lib/site.post.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import sitePostGetMethods from './runtime/site.post.get';
+import Comment from './site.comment';
 import Like from './site.post.like';
 import Reblog from './site.post.reblog';
-import Comment from './site.comment';
 import Subscriber from './site.post.subscriber';
 import runtimeBuilder from './util/runtime-builder';
-import sitePostGetMethods from './runtime/site.post.get';
 
 /**
  * Module vars

--- a/packages/wpcom.js/src/lib/site.taxonomy.js
+++ b/packages/wpcom.js/src/lib/site.taxonomy.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import SiteTaxonomyTerm from './site.taxonomy.term';
 
 /**

--- a/packages/wpcom.js/src/lib/site.wordads.js
+++ b/packages/wpcom.js/src/lib/site.wordads.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import SiteWordAdsSettings from './site.wordads.settings';
 import SiteWordAdsEarnings from './site.wordads.earnings';
+import SiteWordAdsSettings from './site.wordads.settings';
 import SiteWordAdsTOS from './site.wordads.tos';
 
 /**

--- a/packages/wpcom.js/src/lib/util/fs.js
+++ b/packages/wpcom.js/src/lib/util/fs.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import fs from 'fs';
 
 export function createReadStream( ...args ) {

--- a/packages/wpcom.js/src/lib/util/pinghub.js
+++ b/packages/wpcom.js/src/lib/util/pinghub.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'wpcom:pinghub' );

--- a/packages/wpcom.js/src/lib/util/request.js
+++ b/packages/wpcom.js/src/lib/util/request.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import sendRequest from './send-request';
 
 /**

--- a/packages/wpcom.js/src/lib/util/runtime-builder.js
+++ b/packages/wpcom.js/src/lib/util/runtime-builder.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 
 /**

--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import qs from 'qs';
 import debugFactory from 'debug';
+import qs from 'qs';
 
 const debug = debugFactory( 'wpcom:send-request' );
 const debug_res = debugFactory( 'wpcom:send-request:res' );


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/wpcom.js` to use `import/order`

#### Testing instructions

N/A