### PR TITLE
chore: Prepare for releasing @automattic/calypso-live 9.0.0

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -91,7 +91,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -44,7 +44,7 @@
 		"wpcom-xhr-request": "^1.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"webpack": "^5.46.0",

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -22,7 +22,7 @@
 		"build": "BROWSERSLIST_ENV=wpcom calypso-build"
 	},
 	"dependencies": {
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@wordpress/api-fetch": "^4.0.0",
 		"@wordpress/base-styles": "^3.4.3",
 		"@wordpress/block-editor": "^5.3.3",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -50,7 +50,7 @@
 		"tinymce": "^4.9.6"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^3.1.2",
 		"enzyme": "^3.11.0",
 		"npm-run-all": "^4.1.5"

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
 		"@automattic/accessible-focus": "^1.0.0-alpha.0",
 		"@automattic/browser-data-collector": "^0.0.1",
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 	"dependencies": {
 		"@automattic/babel-plugin-i18n-calypso": "^1.2.0",
 		"@automattic/babel-plugin-transform-wpcalypso-async": "^1.0.1",
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-doctor": "^0.1.0",
 		"@automattic/calypso-polyfills": "^1.0.0",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,21 +2,48 @@
 
 ## trunk
 
+## 9.0.0
+
+- Added new, extensible TypeScript config for modern TS and JS packages in `./typescript/[tj]-package.json`
 - Breaking: Changed `webpack/file-loader` to internally use the new `asset/resource` modules (the former is deprecated in
   webpack 5). The semantics of the options have changed, now the final asset URL is `${publichPath}${outputPath}/${fileName}`,
   before it didn't include the `outputPath` part.
-- Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files.
-  - Removed dependency `node-sass`
-  - Added dependency `sass ^1.32.13`
-- Updated dependencies
+- Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files:
+- Removed dependencies:
+  - node-sass
+  - file-loader
+- Added dependencies:
+  - sass ^1.32.13
+- Updated dependencies:
+  - @babel/cli to ^7.14.8
+  - @babel/compat-data to ^7.14.7
+  - @babel/core to ^7.14.8
+  - @babel/helpers to ^7.14.8
+  - @babel/plugin-proposal-class-properties to ^7.14.5
+  - @babel/plugin-transform-react-jsx to ^7.14.5
+  - @babel/plugin-transform-runtime to ^7.14.5
+  - @babel/preset-env to ^7.14.8
+  - @babel/preset-react to ^7.14.5
+  - @babel/preset-typescript to ^7.14.5
+  - @types/webpack-env to ^1.16.2
+  - @wordpress/babel-plugin-import-jsx-pragma to ^3.0.3
+  - @wordpress/browserslist-config to ^3.0.3
+  - @wordpress/dependency-extraction-webpack-plugin to ^3.1.2
   - autoprefixer to ^10.2.5
+  - babel-jest to ^27.0.6
   - css-loader to ^5.2.4
+  - jest-config to ^27.0.6
   - mini-css-extract-plugin to ^1.6.0
-  - node-sass to ^6.0.0
-  - postcss to ^8.2.15
   - postcss-loader to ^5.3.0
+  - sass to ^1.32.13
   - sass-loader to ^11.1.1
   - thread-loader to ^3.0.4
+  - typescript to ^4.3.5
+  - webpack-cli to ^4.7.2
+- Updated peer dependencies:
+  - jest to >=27.0.6
+  - postcss to ^8.2.15
+  - webpack to ^5.46.0
 
 ## 8.0.0
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "8.0.0",
+	"version": "9.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -48,7 +48,7 @@
 		"react-stripe-elements": "^4.0.2"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "^8.0.0",
+		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-polyfills": "^1.0.0",
 		"@storybook/addon-actions": "^6.1.10",
 		"@storybook/preset-scss": "^1.0.3",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update CHANGELOG with the changes since 8.0.0
* Bump calypso-build version
* Use the new version everywhere in our repo
