### PR TITLE
DotPager: Ignore non-current pages when sizing DotPager

### DIFF
--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -3,6 +3,7 @@
 .dot-pager__pages {
 	overflow: hidden;
 	display: flex;
+	position: relative;
 }
 
 .dot-pager__page {

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -16,6 +16,7 @@
 	&.is-prev,
 	&.is-next {
 		opacity: 0;
+		position: absolute;
 	}
 
 	&.is-prev {


### PR DESCRIPTION
This PR modifies the DotPager component to resize based on the content of the current page.

Currently, the DotPager component accommodates the largest page, leaving significant whitespace at the bottom of shorter ones:

![Minha_página_inicial_‹_A_Test_Site_—_WordPress_com_and_Minha_página_inicial_‹_A_Test_Site_—_WordPress_com_and_Minha_página_inicial_‹_Título_do_site_—_WordPress_com](https://user-images.githubusercontent.com/5952255/127439939-e30d39a6-235f-4266-b18d-d0366ef75dfc.jpg)

This does mean that content below the pager moves around a bit. (We hope to improve this with animation in a followup, but we think it's in improvement already):

![resizing-cards](https://user-images.githubusercontent.com/5952255/127440050-3c23a132-9f3d-40ef-aef8-a7dd1f22f2fe.gif)

#### Testing instructions

Add the `?view=VIEW_POST_LAUNCH` query param to the live branch and click around between the tabs.

Be sure to check out the narrower mobile layouts too. They should work the same, just a bit simpler (the wider formats have an additional concern with hiding the overflow as the cards animate out).

Addresses one part of #54226
