### PR TITLE
chore: migrate `client/document` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
 				'client/auth/**/*',
 				'client/boot/**/*',
 				'client/controller/**/*',
+				'client/document/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',
 				'client/mailing-lists/**/*',

--- a/client/document/404.jsx
+++ b/client/document/404.jsx
@@ -1,17 +1,8 @@
-/**
- * External dependencies
- *
- */
-
-import React from 'react';
-import classNames from 'classnames';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import Head from 'calypso/components/head';
+import classNames from 'classnames';
+import React from 'react';
 import EmptyContent from 'calypso/components/empty-content';
+import Head from 'calypso/components/head';
 import { chunkCssLinks } from './utils';
 
 function NotFound( { entrypoint } ) {

--- a/client/document/500.jsx
+++ b/client/document/500.jsx
@@ -1,17 +1,8 @@
-/**
- * External dependencies
- *
- */
-
-import React from 'react';
-import classNames from 'classnames';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import Head from 'calypso/components/head';
+import classNames from 'classnames';
+import React from 'react';
 import EmptyContent from 'calypso/components/empty-content';
+import Head from 'calypso/components/head';
 import { chunkCssLinks } from './utils';
 
 function ServerError( { entrypoint } ) {

--- a/client/document/browsehappy.jsx
+++ b/client/document/browsehappy.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import Head from 'calypso/components/head';
 import EmptyContent from 'calypso/components/empty-content';
+import Head from 'calypso/components/head';
 import { chunkCssLinks } from './utils';
 
 function Browsehappy( { entrypoint, dashboardUrl } ) {

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -1,19 +1,10 @@
-/**
- * External dependencies
- *
- */
-
-import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import EnvironmentBadge, { Branch, DevDocsLink } from 'calypso/components/environment-badge';
 import Head from 'calypso/components/head';
-import { chunkCssLinks } from './utils';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
+import { chunkCssLinks } from './utils';
 
 class Desktop extends React.Component {
 	render() {

--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -1,17 +1,8 @@
-/**
- * External dependencies
- *
- */
-
-import React from 'react';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import Head from 'calypso/components/head';
-import { chunkCssLinks } from './utils';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
+import { chunkCssLinks } from './utils';
 
 function DomainsLanding( {
 	branchName,

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -1,16 +1,7 @@
-/**
- * External dependencies
- *
- */
-import React from 'react';
-import classNames from 'classnames';
 import path from 'path';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import Head from 'calypso/components/head';
+import classNames from 'classnames';
+import React from 'react';
 import EnvironmentBadge, {
 	Branch,
 	AuthHelper,
@@ -18,11 +9,12 @@ import EnvironmentBadge, {
 	PreferencesHelper,
 	FeaturesHelper,
 } from 'calypso/components/environment-badge';
-import { chunkCssLinks } from './utils/chunk';
-import { isBilmurEnabled, getBilmurUrl } from './utils/bilmur';
+import Head from 'calypso/components/head';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
+import { isBilmurEnabled, getBilmurUrl } from './utils/bilmur';
+import { chunkCssLinks } from './utils/chunk';
 
 class Document extends React.Component {
 	render() {

--- a/client/document/support-user.jsx
+++ b/client/document/support-user.jsx
@@ -1,13 +1,4 @@
-/**
- * External dependencies
- *
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 
 function supportUserFn( { user, token, path, authorized } ) {
 	const url = window.location.toString();

--- a/client/document/utils/bilmur.js
+++ b/client/document/utils/bilmur.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 export function isBilmurEnabled() {

--- a/client/document/utils/chunk.jsx
+++ b/client/document/utils/chunk.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 export function chunkCssLinks( chunkAssets, isRTL = false ) {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/document` to use `import/order`

#### Testing instructions

N/A
