### PR TITLE
chore: migrate `packages/page-pattern-modal` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -230,6 +230,7 @@ module.exports = {
 				'packages/load-script/**/*',
 				'packages/mocha-debug-reporter/**/*',
 				'packages/onboarding/**/*',
+				'packages/page-pattern-modal/**/*',
 				'packages/photon/**/*',
 				'packages/plans-grid/**/*',
 				'packages/popup-monitor/**/*',

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
+import { BlockInstance, parse as parseBlocks } from '@wordpress/blocks';
+import { Button, MenuItem, Modal, NavigableMenu, VisuallyHidden } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { memoize } from 'lodash';
-import { __ } from '@wordpress/i18n';
-import { Button, MenuItem, Modal, NavigableMenu, VisuallyHidden } from '@wordpress/components';
-import { Component } from '@wordpress/element';
-import { BlockInstance, parse as parseBlocks } from '@wordpress/blocks';
-import { withInstanceId } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import PatternSelectorControl from './pattern-selector-control';
-import { trackDismiss, trackSelection, trackView } from '../utils/tracking';
-import replacePlaceholders from '../utils/replace-placeholders';
-import mapBlocksRecursively from '../utils/map-blocks-recursively';
 import containsMissingBlock from '../utils/contains-missing-block';
 import { sortGroupNames } from '../utils/group-utils';
+import mapBlocksRecursively from '../utils/map-blocks-recursively';
+import replacePlaceholders from '../utils/replace-placeholders';
+import { trackDismiss, trackSelection, trackView } from '../utils/tracking';
+import PatternSelectorControl from './pattern-selector-control';
 import type { PatternCategory, PatternDefinition } from '../pattern-definition';
 
 interface PagePatternModalProps {

--- a/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
@@ -1,15 +1,8 @@
-/**
- * WordPress dependencies
- */
 import { BaseControl } from '@wordpress/components';
-import { memo } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import PatternSelectorItem from './pattern-selector-item';
-import replacePlaceholders from '../utils/replace-placeholders';
 import { withInstanceId } from '@wordpress/compose';
+import { memo } from '@wordpress/element';
+import replacePlaceholders from '../utils/replace-placeholders';
+import PatternSelectorItem from './pattern-selector-item';
 import type { PatternDefinition } from '../pattern-definition';
 
 const noop = () => undefined;

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { MShotsImage } from '@automattic/design-picker';
 
 interface PatternSelectorItemProps {

--- a/packages/page-pattern-modal/src/components/test/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/test/page-pattern-modal.tsx
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { render, fireEvent, screen } from '@testing-library/react';
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PagePatternModal from '../page-pattern-modal';
 
 const noop = () => undefined;

--- a/packages/page-pattern-modal/src/utils/contains-missing-block.ts
+++ b/packages/page-pattern-modal/src/utils/contains-missing-block.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import type { BlockInstance } from '@wordpress/blocks';
 
 // Once parsed, missing Blocks have a name prop of `core/missing`.

--- a/packages/page-pattern-modal/src/utils/map-blocks-recursively.ts
+++ b/packages/page-pattern-modal/src/utils/map-blocks-recursively.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { BlockInstance, cloneBlock } from '@wordpress/blocks';
 
 type Writeable< T > = { -readonly [ P in keyof T ]: T[ P ] };

--- a/packages/page-pattern-modal/src/utils/replace-placeholders.ts
+++ b/packages/page-pattern-modal/src/utils/replace-placeholders.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { _x } from '@wordpress/i18n';
 
 const PLACEHOLDER_DEFAULTS = {

--- a/packages/page-pattern-modal/src/utils/test/group-utils.ts
+++ b/packages/page-pattern-modal/src/utils/test/group-utils.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { sortGroupNames } from '../group-utils';
 
 describe( 'sortGroupNames', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/page-pattern-modal` to use `import/order`

#### Testing instructions

N/A