### PR TITLE
chore: migrate `packages/calypso-build` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,6 +206,7 @@ module.exports = {
 				'packages/babel-plugin-transform-wpcalypso-async/**/*',
 				'packages/browser-data-collector/**/*',
 				'packages/calypso-analytics/**/*',
+				'packages/calypso-build/**/*',
 				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-polyfills/**/*',

--- a/packages/calypso-build/bin/calypso-build.js
+++ b/packages/calypso-build/bin/calypso-build.js
@@ -5,9 +5,6 @@
  */
 /* eslint-disable import/no-nodejs-modules */
 
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
 const path = require( 'path' );
 

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -3,8 +3,8 @@
 /* eslint-disable import/no-nodejs-modules,no-console */
 
 // find all the packages
-const path = require( 'path' );
 const { execSync } = require( 'child_process' );
+const path = require( 'path' );
 
 const dir = process.cwd();
 const root = path.dirname( __dirname );

--- a/packages/calypso-build/jest-preset.js
+++ b/packages/calypso-build/jest-preset.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const path = require( 'path' );
 const { defaults } = require( 'jest-config' );
 

--- a/packages/calypso-build/jest/setup.js
+++ b/packages/calypso-build/jest/setup.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const { configure } = require( 'enzyme' );
 const Adapter = require( 'enzyme-adapter-react-16' );
 

--- a/packages/calypso-build/jest/transform/asset.js
+++ b/packages/calypso-build/jest/transform/asset.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const path = require( 'path' );
 
 module.exports = {

--- a/packages/calypso-build/jest/transform/babel.js
+++ b/packages/calypso-build/jest/transform/babel.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-const babelJest = require( 'babel-jest' ).default;
 const path = require( 'path' );
+const babelJest = require( 'babel-jest' ).default;
 
 module.exports = babelJest.createTransformer( {
 	presets: [

--- a/packages/calypso-build/tsconfig.json
+++ b/packages/calypso-build/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "./typescript/js-package.json",
+	"extends": "./typescript/js-package.json"
 }

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -3,23 +3,16 @@
  */
 /* eslint-disable import/no-nodejs-modules */
 
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
 const path = require( 'path' );
 const process = require( 'process' );
-const webpack = require( 'webpack' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
+const webpack = require( 'webpack' );
 const FileConfig = require( './webpack/file-loader' );
 const Minify = require( './webpack/minify' );
 const SassConfig = require( './webpack/sass' );
 const TranspileConfig = require( './webpack/transpile' );
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-
-/**
- * Internal dependencies
- */
 const { cssNameFromFilename, shouldTranspileDependency } = require( './webpack/util' );
 // const { workerCount } = require( './webpack.common' ); // todo: shard...
 

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -1,11 +1,8 @@
-/**
- * External Dependencies
- */
-const TerserPlugin = require( 'terser-webpack-plugin' );
-const browserslist = require( 'browserslist' );
 const babelPlugins = require( '@babel/compat-data/plugins' );
-const semver = require( 'semver' );
+const browserslist = require( 'browserslist' );
 const CssMinimizerPlugin = require( 'css-minimizer-webpack-plugin' );
+const semver = require( 'semver' );
+const TerserPlugin = require( 'terser-webpack-plugin' );
 
 const supportedBrowsers = browserslist();
 

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const WebpackRTLPlugin = require( '@automattic/webpack-rtl-plugin' );
-
-/**
- * Internal dependencies
- */
+const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const MiniCSSWithRTLPlugin = require( './mini-css-with-rtl' );
 
 /**

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const webpack = require( 'webpack' );
 
 /**


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-build` to use `import/order`

#### Testing instructions

N/A
