### PR TITLE
chore: migrate `packages/i18n-calypso` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -222,6 +222,7 @@ module.exports = {
 				'packages/explat-client/**/*',
 				'packages/format-currency/**/*',
 				'packages/i18n-calypso-cli/**/*',
+				'packages/i18n-calypso/**/*',
 				'packages/i18n-utils/**/*',
 				'packages/js-utils/**/*',
 				'packages/language-picker/**/*',

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import debugFactory from 'debug';
-import interpolateComponents from 'interpolate-components';
-import Tannin from 'tannin';
-import LRU from 'lru';
-import sha1 from 'hash.js/lib/hash/sha/1';
 import { EventEmitter } from 'events';
 import sprintf from '@tannin/sprintf';
-
-/**
- * Internal dependencies
- */
+import debugFactory from 'debug';
+import sha1 from 'hash.js/lib/hash/sha/1';
+import interpolateComponents from 'interpolate-components';
+import LRU from 'lru';
+import Tannin from 'tannin';
 import numberFormat from './number-format';
 
 /**

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -1,10 +1,7 @@
-/**
- * Internal dependencies
- */
 import I18N from './i18n';
 import localizeFactory from './localize';
-import translateHookFactory from './use-translate';
 import rtlFactory from './rtl';
+import translateHookFactory from './use-translate';
 
 // Export the `I18N` class
 export { I18N };

--- a/packages/i18n-calypso/src/localize.js
+++ b/packages/i18n-calypso/src/localize.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 /**

--- a/packages/i18n-calypso/src/rtl.js
+++ b/packages/i18n-calypso/src/rtl.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import { createHigherOrderComponent } from '@wordpress/compose';
 import React, { forwardRef } from 'react';
 import { useSubscription } from 'use-subscription';
-import { createHigherOrderComponent } from '@wordpress/compose';
 
 export default function rtlFactory( i18n ) {
 	// Subscription object (adapter) for the `useSubscription` hook

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 export default function ( i18n ) {

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
-
-/**
- * Internal dependencies
- */
-import data from './data';
 import i18n, { numberFormat, translate } from '../src';
+import data from './data';
 
 /**
  * Pass in a react-generated html string to remove react-specific attributes

--- a/packages/i18n-calypso/test/localize.js
+++ b/packages/i18n-calypso/test/localize.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
-
-/**
- * Internal dependencies
- */
 import i18n, { localize } from '../src';
 
 describe( 'localize()', () => {

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -1,16 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-
-/**
- * Internal dependencies
- */
 import i18n, { useTranslate } from '../src';
 
 function Label() {

--- a/packages/i18n-calypso/tsconfig.json
+++ b/packages/i18n-calypso/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -1,9 +1,6 @@
 // Type definitions for i18n-calypso
 // Project: i18n-calypso
 
-/**
- * External dependencies
- */
 import * as React from 'react';
 
 declare namespace i18nCalypso {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/i18n-calypso` to use `import/order`

#### Testing instructions

N/A