### PR TITLE
chore: migrate `packages/calypso-codemods` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -208,6 +208,7 @@ module.exports = {
 				'packages/browser-data-collector/**/*',
 				'packages/calypso-analytics/**/*',
 				'packages/calypso-build/**/*',
+				'packages/calypso-codemods/**/*',
 				'packages/calypso-config/**/*',
 				'packages/calypso-e2e/**/*',
 				'packages/calypso-polyfills/**/*',

--- a/packages/calypso-codemods/api.js
+++ b/packages/calypso-codemods/api.js
@@ -1,21 +1,13 @@
 #!/usr/bin/env node
 
-/**
- * External dependencies
- */
-const fs = require( 'fs' );
-const path = require( 'path' );
 const child_process = require( 'child_process' );
-
-/**
- * Internal dependencies
- */
-const config = require( path.join( __dirname, 'config' ) );
-const transformsDir = path.join( __dirname, './transforms' );
-
+const fs = require( 'fs' );
 const jscodeshiftBin = require( 'module' )
 	.createRequireFromPath( require.resolve( 'jscodeshift' ) )
 	.resolve( require( 'jscodeshift/package.json' ).bin.jscodeshift );
+const path = require( 'path' );
+const config = require( path.join( __dirname, 'config' ) );
+const transformsDir = path.join( __dirname, './transforms' );
 
 function getLocalCodemodFileNames() {
 	const jsFiles = fs

--- a/packages/calypso-codemods/index.js
+++ b/packages/calypso-codemods/index.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-/**
- * Internal dependencies
- */
 const api = require( './api' );
 
 function main() {

--- a/packages/calypso-codemods/tests/combine-reducer-with-persistence/__snapshots__/codemod.spec.js.snap
+++ b/packages/calypso-codemods/tests/combine-reducer-with-persistence/__snapshots__/codemod.spec.js.snap
@@ -1,12 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic.js 1`] = `
-"/**
- * Internal dependencies
- */
-import hello from 'internal/lib';
-
-import { combineReducers } from \\"state/utils\\";
+"import hello from 'internal/lib';
 
 "
 `;

--- a/packages/calypso-codemods/tests/combine-reducer-with-persistence/basic.js
+++ b/packages/calypso-codemods/tests/combine-reducer-with-persistence/basic.js
@@ -1,6 +1,3 @@
 import { combineReducers } from 'redux';
 
-/**
- * Internal dependencies
- */
 import hello from 'internal/lib';

--- a/packages/calypso-codemods/tests/sort-imports/incorrect-docblocks.js
+++ b/packages/calypso-codemods/tests/sort-imports/incorrect-docblocks.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import chickenLibrary from 'chicken';
 import okapiMe from 'okapi-me';
 

--- a/packages/calypso-codemods/transforms/single-tree-rendering.js
+++ b/packages/calypso-codemods/transforms/single-tree-rendering.js
@@ -23,16 +23,9 @@
  *   from `my-sites/controller`.
  */
 
-/**
- * External dependencies
- */
-const _ = require( 'lodash' );
 const fs = require( 'fs' );
 const repl = require( 'repl' );
-
-/**
- * Internal dependencies
- */
+const _ = require( 'lodash' );
 const config = require( './config' );
 
 export default function transformer( file, api ) {

--- a/packages/calypso-codemods/transforms/sort-imports.js
+++ b/packages/calypso-codemods/transforms/sort-imports.js
@@ -5,13 +5,10 @@
  * It is smart enough to retain whether or not a docblock should keep a prettier/formatter pragma
  */
 
-/**
- * External dependencies
- */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const _ = require( 'lodash' );
 const nodeJsDeps = require( 'repl' )._builtinLibs;
+const _ = require( 'lodash' );
 
 function findPkgJson( target ) {
 	let root = path.dirname( target );

--- a/packages/calypso-codemods/tsconfig.json
+++ b/packages/calypso-codemods/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"extends": "@automattic/calypso-build/typescript/js-package.json"
 }


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-codemods` to use `import/order`

#### Testing instructions

N/A
