### PR TITLE
ci(e2e): Uses the new credentialsJSON token for e2e encryption key

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -61,7 +61,7 @@ project {
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
 		text("calypso.run_full_eslint", "false", label = "Run full eslint", description = "True will lint all files, empty/false will lint only changed files", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
-		password("CONFIG_E2E_ENCRYPTION_KEY", "credentialsJSON:16d15e36-f0f2-4182-8477-8d8072d0b5ec", display = ParameterDisplay.HIDDEN)
+		password("CONFIG_E2E_ENCRYPTION_KEY", "credentialsJSON:5af2a93b-bb28-4e29-ac23-a1ca51f399ec", display = ParameterDisplay.HIDDEN)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )
 		password("mc_auth_secret", "credentialsJSON:5b1903f9-4b03-43ff-bba8-4a7509d07088", display = ParameterDisplay.HIDDEN)
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses the new credentialsJSON token for e2e encryption key

Extracted from the UI:

![image](https://user-images.githubusercontent.com/975703/127457301-9e513b95-09cc-4556-a998-7913312db28a.png)

