### PR TITLE
chore: migrate `packages/calypso-url` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,6 +211,7 @@ module.exports = {
 				'packages/calypso-polyfills/**/*',
 				'packages/calypso-products/**/*',
 				'packages/calypso-stripe/**/*',
+				'packages/calypso-url/**/*',
 				'packages/components/**/*',
 				'packages/composite-checkout/**/*',
 				'packages/create-calypso-config/**/*',

--- a/packages/calypso-url/src/format.ts
+++ b/packages/calypso-url/src/format.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { determineUrlType, URL_TYPE } from './url-type';
 
 const BASE_URL = 'http://__domain__.invalid/';

--- a/packages/calypso-url/src/index.ts
+++ b/packages/calypso-url/src/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 export { URL_TYPE, determineUrlType } from './url-type';
 export { default as format } from './format';
 export { getUrlParts, getUrlFromParts } from './url-parts';

--- a/packages/calypso-url/src/url-parts.ts
+++ b/packages/calypso-url/src/url-parts.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { determineUrlType, URL_TYPE } from './url-type';
 
 const BASE_URL = `http://__domain__.invalid`;

--- a/packages/calypso-url/test/format.js
+++ b/packages/calypso-url/test/format.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { format } from '../src';
 
 describe( 'getUrlType', () => {

--- a/packages/calypso-url/test/url-parts.js
+++ b/packages/calypso-url/test/url-parts.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { getUrlParts, getUrlFromParts } from '../src';
 
 function convertParamsToObject( searchParams ) {

--- a/packages/calypso-url/test/url-type.js
+++ b/packages/calypso-url/test/url-type.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { determineUrlType } from '../src';
 
 test( 'should detect the correct type for absolute URLs', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `packages/calypso-url` to use `import/order`

#### Testing instructions

N/A
