### PR TITLE
chore: migrate `client/login` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
 				'client/document/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',
+				'client/login/**/*',
 				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/notifications/**/*',

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
+import { includes } from 'lodash';
 import page from 'page';
 import React from 'react';
-import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
+import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
+import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
-import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
-import { getUrlParts } from '@automattic/calypso-url';
-import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
-import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 
 const enhanceContextWithLogin = ( context ) => {
 	const {

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -1,10 +1,7 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import webRouter from './index.web';
 import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
+import webRouter from './index.web';
 import redirectLoggedIn from './redirect-logged-in';
 
 /**

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,21 +1,7 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import {
-	login,
-	magicLogin,
-	magicLoginUse,
-	redirectJetpack,
-	redirectDefaultLocale,
-} from './controller';
-import { setShouldServerSideRenderLogin } from './ssr';
+import { RouteProvider } from 'calypso/components/route';
 import {
 	setLocaleMiddleware,
 	setSectionMiddleware,
@@ -23,8 +9,15 @@ import {
 } from 'calypso/controller/shared';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
-import { RouteProvider } from 'calypso/components/route';
+import {
+	login,
+	magicLogin,
+	magicLoginUse,
+	redirectJetpack,
+	redirectDefaultLocale,
+} from './controller';
 import redirectLoggedIn from './redirect-logged-in';
+import { setShouldServerSideRenderLogin } from './ssr';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { login, lostPassword } from 'calypso/lib/paths';
 import EmptyContent from 'calypso/components/empty-content';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
-import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
+import { login, lostPassword } from 'calypso/lib/paths';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
+import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { withEnhancers } from 'calypso/state/utils';
 
 class EmailedLoginLinkExpired extends React.Component {

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -1,25 +1,13 @@
-/**
- * External dependencies
- */
-
+import { useTranslate } from 'i18n-calypso';
 import React, { FC, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import checkEmailJetpackImage from 'calypso/assets/images/illustrations/check-email-jetpack.svg';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
 import { withEnhancers } from 'calypso/state/utils';
-
-/**
- * Image dependencies
- */
-import checkEmailJetpackImage from 'calypso/assets/images/illustrations/check-email-jetpack.svg';
 
 interface Props {
 	emailAddress: string;

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -1,33 +1,21 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { login } from 'calypso/lib/paths';
-import { Card } from '@automattic/components';
+import checkEmailImage from 'calypso/assets/images/illustrations/check-email.svg';
+import Gridicon from 'calypso/components/gridicon';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
-import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import { login } from 'calypso/lib/paths';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
-import { withEnhancers } from 'calypso/state/utils';
+import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Image dependencies
- */
-import checkEmailImage from 'calypso/assets/images/illustrations/check-email.svg';
+import { withEnhancers } from 'calypso/state/utils';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
 	static propTypes = {

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -1,35 +1,28 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import page from 'page';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import JetpackConnected from 'calypso/assets/images/jetpack/connected.svg';
 import EmptyContent from 'calypso/components/empty-content';
-import EmailedLoginLinkExpired from './emailed-login-link-expired';
 import { login } from 'calypso/lib/paths';
-import { LINK_EXPIRED_PAGE } from 'calypso/state/login/magic-login/constants';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
 import {
 	fetchMagicLoginAuthenticate,
 	showMagicLoginLinkExpiredPage,
 } from 'calypso/state/login/magic-login/actions';
-import { rebootAfterLogin } from 'calypso/state/login/actions';
-import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
-import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
-import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
-import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+import { LINK_EXPIRED_PAGE } from 'calypso/state/login/magic-login/constants';
 import {
 	getRedirectToOriginal,
 	getRedirectToSanitized,
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled,
 } from 'calypso/state/login/selectors';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import JetpackConnected from 'calypso/assets/images/jetpack/connected.svg';
+import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
+import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
+import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
+import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+import EmailedLoginLinkExpired from './emailed-login-link-expired';
 
 interface Props {
 	emailAddress: string;

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -1,46 +1,39 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
+import config from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
-import EmailedLoginLinkExpired from './emailed-login-link-expired';
-import config from '@automattic/calypso-config';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { login } from 'calypso/lib/paths';
-import { localize } from 'i18n-calypso';
-import { LINK_EXPIRED_PAGE } from 'calypso/state/login/magic-login/constants';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	wasImmediateLoginAttempted,
+	wasManualRenewalImmediateLoginAttempted,
+} from 'calypso/state/immediate-login/selectors';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
 import {
 	fetchMagicLoginAuthenticate,
 	showMagicLoginLinkExpiredPage,
 } from 'calypso/state/login/magic-login/actions';
-import { rebootAfterLogin } from 'calypso/state/login/actions';
-import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
-import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
-import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
-import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+import { LINK_EXPIRED_PAGE } from 'calypso/state/login/magic-login/constants';
 import {
 	getRedirectToOriginal,
 	getRedirectToSanitized,
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled,
 } from 'calypso/state/login/selectors';
-import {
-	wasImmediateLoginAttempted,
-	wasManualRenewalImmediateLoginAttempted,
-} from 'calypso/state/immediate-login/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
-import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
+import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
+import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
+import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
+import EmailedLoginLinkExpired from './emailed-login-link-expired';
 
 class HandleEmailedLinkForm extends React.Component {
 	static propTypes = {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,42 +1,31 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import React from 'react';
-import { connect } from 'react-redux';
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import page from 'page';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import { login } from 'calypso/lib/paths';
-import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
-import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
-import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import GlobalNotices from 'calypso/components/global-notices';
+import Gridicon from 'calypso/components/gridicon';
+import JetpackHeader from 'calypso/components/jetpack-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import Main from 'calypso/components/main';
+import { login } from 'calypso/lib/paths';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
+import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
+import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
 import { withEnhancers } from 'calypso/state/utils';
-import Main from 'calypso/components/main';
-import JetpackHeader from 'calypso/components/jetpack-header';
 import RequestLoginEmailForm from './request-login-email-form';
-import GlobalNotices from 'calypso/components/global-notices';
-import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class MagicLogin extends React.Component {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,39 +1,31 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
+import { defer, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { defer, get } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
-import EmailedLoginLinkSuccessfullyJetpackConnect from './emailed-login-link-successfully-jetpack-connect';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
-import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
-import getMagicLoginRequestedEmailSuccessfully from 'calypso/state/selectors/get-magic-login-requested-email-successfully';
-import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
-import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
-import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hideMagicLoginRequestNotice } from 'calypso/state/login/magic-login/actions';
+import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
 import {
 	getRedirectToOriginal,
 	getLastCheckedUsernameOrEmail,
 } from 'calypso/state/login/selectors';
-import { hideMagicLoginRequestNotice } from 'calypso/state/login/magic-login/actions';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import { sendEmailLogin } from 'calypso/state/auth/actions';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
+import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
+import getMagicLoginRequestedEmailSuccessfully from 'calypso/state/selectors/get-magic-login-requested-email-successfully';
+import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
+import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
+import EmailedLoginLinkSuccessfullyJetpackConnect from './emailed-login-link-successfully-jetpack-connect';
 
 class RequestLoginEmailForm extends React.Component {
 	static propTypes = {

--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export default function redirectLoggedIn( context, next ) {

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { intersection } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { isDefaultLocale } from 'calypso/lib/i18n-utils';
 
 /**

--- a/client/login/test/ssr.js
+++ b/client/login/test/ssr.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { setShouldServerSideRenderLogin } from '../ssr';
 
 function getSomeCleanLoginContext( queryValues, lang = 'en' ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,43 +1,33 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
+import LoginBlock from 'calypso/blocks/login';
 import AutomatticLogo from 'calypso/components/automattic-logo';
 import DocumentHead from 'calypso/components/data/document-head';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import Gridicon from 'calypso/components/gridicon';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
-import TranslatorInvite from 'calypso/components/translator-invite';
-import LoginBlock from 'calypso/blocks/login';
-import { isCrowdsignalOAuth2Client } from 'calypso/lib/oauth2-clients';
-import LoginLinks from './login-links';
 import Main from 'calypso/components/main';
-import PrivateSite from './private-site';
+import TranslatorInvite from 'calypso/components/translator-invite';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isCrowdsignalOAuth2Client } from 'calypso/lib/oauth2-clients';
 import {
 	recordPageViewWithClientId as recordPageView,
 	recordTracksEventWithClientId as recordTracksEvent,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { withEnhancers } from 'calypso/state/utils';
+import LoginLinks from './login-links';
+import PrivateSite from './private-site';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class Login extends React.Component {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -1,36 +1,29 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
+import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 import { getSignupUrl } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getUrlParts } from '@automattic/calypso-url';
+import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { login, lostPassword } from 'calypso/lib/paths';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
-import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {

--- a/client/login/wp-login/private-site.jsx
+++ b/client/login/wp-login/private-site.jsx
@@ -1,18 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
-
-/**
- * Image dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import privateImage from 'calypso/assets/images/illustrations/private.svg';
 
 export default function PrivateSite() {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/login` to use `import/order`

#### Testing instructions

N/A