### PR TITLE
chore: migrate `client/data` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
 				'client/auth/**/*',
 				'client/boot/**/*',
 				'client/controller/**/*',
+				'client/data/**/*',
 				'client/document/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',

--- a/client/data/domains/nameservers/use-domain-nameservers-query.js
+++ b/client/data/domains/nameservers/use-domain-nameservers-query.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 
 const useDomainNameserversQuery = ( domainName ) =>

--- a/client/data/domains/nameservers/use-update-nameservers-mutation.js
+++ b/client/data/domains/nameservers/use-update-nameservers-mutation.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 
 function useUpdateNameserversMutation( domainName, queryOptions = {} ) {

--- a/client/data/emails/use-emails-query.js
+++ b/client/data/emails/use-emails-query.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export const getCacheKey = ( siteId, domain ) => [ 'emailAccounts', siteId, domain ];

--- a/client/data/emails/use-remove-titan-mailbox-mutation.js
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { getCacheKey } from './use-emails-query';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import wp from 'calypso/lib/wp';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getCacheKey } from './use-emails-query';
 
 const invalidationDelayTimeout = 5000;
 const noop = () => {};

--- a/client/data/followers/use-followers-query.js
+++ b/client/data/followers/use-followers-query.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useInfiniteQuery } from 'react-query';
 import { uniqueBy } from '@automattic/js-utils';
-
-/**
- * Internal dependencies
- */
+import { useInfiniteQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 const MAX_FOLLOWERS = 10; // means pages (= 1000 followers);

--- a/client/data/followers/use-remove-follower-mutation.js
+++ b/client/data/followers/use-remove-follower-mutation.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 
 function useRemoveFollowerMutation() {

--- a/client/data/happiness-engineers/use-happiness-engineers-query.js
+++ b/client/data/happiness-engineers/use-happiness-engineers-query.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 const useHappinessEngineersQuery = () =>

--- a/client/data/home/use-home-layout-query-params.ts
+++ b/client/data/home/use-home-layout-query-params.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useSelector } from 'react-redux';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
+import { useSelector } from 'react-redux';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 
 export interface HomeLayoutQueryParams {

--- a/client/data/home/use-home-layout-query.ts
+++ b/client/data/home/use-home-layout-query.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery, UseQueryResult, QueryKey } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 import { useHomeLayoutQueryParams, HomeLayoutQueryParams } from './use-home-layout-query-params';
 

--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient, UseMutationResult } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
-import { useHomeLayoutQueryParams } from './use-home-layout-query-params';
 import { fetchHomeLayout, getCacheKey } from './use-home-layout-query';
+import { useHomeLayoutQueryParams } from './use-home-layout-query-params';
 
 type ReminderDuration = '1d' | '1w' | null;
 

--- a/client/data/post-formats/use-post-formats-query.js
+++ b/client/data/post-formats/use-post-formats-query.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 const usePostFormatsQuery = ( siteId ) =>

--- a/client/data/site-roles/use-site-roles-query.js
+++ b/client/data/site-roles/use-site-roles-query.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 
 function useSiteRolesQuery( siteId, queryOptions = {} ) {

--- a/client/data/site-roles/with-site-roles.js
+++ b/client/data/site-roles/with-site-roles.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { createHigherOrderComponent } from '@wordpress/compose';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import useSiteRolesQuery from './use-site-roles-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useSiteRolesQuery from './use-site-roles-query';
 
 const withSiteRoles = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {

--- a/client/data/users/use-delete-user-mutation.js
+++ b/client/data/users/use-delete-user-mutation.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 
 function useDeleteUserMutation( siteId, queryOptions = {} ) {

--- a/client/data/users/use-update-user-mutation.js
+++ b/client/data/users/use-update-user-mutation.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 import { getCacheKey } from './use-user-query';
 

--- a/client/data/users/use-user-query.js
+++ b/client/data/users/use-user-query.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useQuery } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export const getCacheKey = ( siteId, login ) => [ 'user', siteId, login ];

--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useInfiniteQuery } from 'react-query';
 import { uniqueBy } from '@automattic/js-utils';
-
-/**
- * Internal dependencies
- */
+import { useInfiniteQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 export const defaults = {

--- a/client/data/viewers/use-remove-viewer-mutation.js
+++ b/client/data/viewers/use-remove-viewer-mutation.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
 
 function useRemoveViewer() {

--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useInfiniteQuery } from 'react-query';
 import { uniqueBy } from '@automattic/js-utils';
-
-/**
- * Internal dependencies
- */
+import { useInfiniteQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.viewers );


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/data` to use `import/order`

#### Testing instructions

N/A
