### PR TITLE
chore: migrate `apps/o2-blocks` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -179,6 +179,7 @@ module.exports = {
 			files: [
 				'apps/editing-toolkit/**/*',
 				'apps/notifications/**/*',
+				'apps/o2-blocks/**/*',
 				'client/auth/**/*',
 				'client/boot/**/*',
 				'client/controller/**/*',

--- a/apps/o2-blocks/src/category.js
+++ b/apps/o2-blocks/src/category.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { getCategories, setCategories } from '@wordpress/blocks';
 
 setCategories( [

--- a/apps/o2-blocks/src/editor-notes/editor.js
+++ b/apps/o2-blocks/src/editor-notes/editor.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { registerBlockType } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 

--- a/apps/o2-blocks/src/editor.js
+++ b/apps/o2-blocks/src/editor.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import './category';
 import './editor-notes/editor';
 import './p2-autocomplete/editor';

--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -1,12 +1,9 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { TextControl, TextareaControl } from '@wordpress/components';
-import * as createIssueUrl from 'new-github-issue-url';
+import { __ } from '@wordpress/i18n';
 import { SVG, Rect, Path } from '@wordpress/primitives';
 import classNames from 'classnames';
+import * as createIssueUrl from 'new-github-issue-url';
 
 import './editor.scss';
 

--- a/apps/o2-blocks/src/github-issue-template/view.js
+++ b/apps/o2-blocks/src/github-issue-template/view.js
@@ -1,5 +1,1 @@
-/**
- * Internal dependencies
- */
-
 import './style.scss';

--- a/apps/o2-blocks/src/p2-autocomplete/editor.js
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import apiFetch from '@wordpress/api-fetch';
 import { addFilter } from '@wordpress/hooks';
 import { map, unescape } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import './editor.scss';
 
 /*

--- a/apps/o2-blocks/src/prev-next/editor.jsx
+++ b/apps/o2-blocks/src/prev-next/editor.jsx
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
-import { registerBlockType } from '@wordpress/blocks';
 import { URLInput } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
 import './editor.scss';
 
 const blockAttributes = {

--- a/apps/o2-blocks/src/project-status/editor.tsx
+++ b/apps/o2-blocks/src/project-status/editor.tsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
-import type { BlockAttributes, SelectAttributes } from './types';
-
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import type { BlockEditProps } from '@wordpress/blocks';
 import { CustomSelectControl, PanelBody, TextControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import React, { FunctionComponent } from 'react';
+import type { BlockAttributes, SelectAttributes } from './types';
+import type { BlockEditProps } from '@wordpress/blocks';
 
 import './editor.scss';
 

--- a/apps/o2-blocks/src/project-status/icon.js
+++ b/apps/o2-blocks/src/project-status/icon.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Path, SVG } from '@wordpress/components';
 
 export default (

--- a/apps/o2-blocks/src/project-status/index.tsx
+++ b/apps/o2-blocks/src/project-status/index.tsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { BlockDeprecation, registerBlockType } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import edit from './editor';
-import save from './save';
 import icon from './icon';
-
+import save from './save';
 import type { BlockAttributesV1, BlockAttributes } from './types';
 
 const v1deprecation: BlockDeprecation< BlockAttributesV1 > = {

--- a/apps/o2-blocks/src/project-status/save.tsx
+++ b/apps/o2-blocks/src/project-status/save.tsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
 import React, { FunctionComponent } from 'react';
-
-/**
- * WordPress dependencies
- */
-import type { BlockSaveProps } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
 import type { BlockAttributes } from './types';
+import type { BlockSaveProps } from '@wordpress/blocks';
 
 const save: FunctionComponent< BlockSaveProps< BlockAttributes > > = ( { attributes } ) => {
 	const { allTasks, pendingTasks, completedTasks, estimate, team } = attributes;

--- a/apps/o2-blocks/src/spoiler/editor.jsx
+++ b/apps/o2-blocks/src/spoiler/editor.jsx
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
 
 const blockAttributes = {
 	summary: {

--- a/apps/o2-blocks/src/task/editor.js
+++ b/apps/o2-blocks/src/task/editor.js
@@ -1,13 +1,3 @@
-/**
- * External dependencies
- */
-import classnames from 'classnames';
-import moment from 'moment';
-
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { RichText, InspectorControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
@@ -19,6 +9,9 @@ import {
 	TextControl,
 	PanelBody,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import moment from 'moment';
 
 import './editor.scss';
 const name = 'a8c/task';

--- a/apps/o2-blocks/src/task/icon.js
+++ b/apps/o2-blocks/src/task/icon.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Path, SVG } from '@wordpress/components';
 
 export default (

--- a/apps/o2-blocks/src/task/index.js
+++ b/apps/o2-blocks/src/task/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import edit from './editor';
-import save from './save';
 import icon from './icon';
+import save from './save';
 
 export function registerBlock() {
 	registerBlockType( 'a8c/task', {

--- a/apps/o2-blocks/src/task/save.js
+++ b/apps/o2-blocks/src/task/save.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import classnames from 'classnames';
 
 const save = ( { attributes } ) => {

--- a/apps/o2-blocks/src/todo/editor.js
+++ b/apps/o2-blocks/src/todo/editor.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import classnames from 'classnames';
-import { __ } from '@wordpress/i18n';
-import { Button, Dashicon } from '@wordpress/components';
-import { Component } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
+import { Button, Dashicon } from '@wordpress/components';
 import { RichText } from '@wordpress/editor';
-
-/**
- * Internal dependencies
- */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { ItemEditor } from './item';
 
 import './editor.scss';

--- a/apps/o2-blocks/src/todo/item.js
+++ b/apps/o2-blocks/src/todo/item.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
 import { Button, Dashicon } from '@wordpress/components';
-import { Component } from '@wordpress/element';
 import { RichText } from '@wordpress/editor';
+import { Component } from '@wordpress/element';
 
 export const ItemEditor = class extends Component {
 	constructor() {

--- a/apps/o2-blocks/src/view.js
+++ b/apps/o2-blocks/src/view.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './github-issue-template/view';

--- a/apps/o2-blocks/webpack.config.js
+++ b/apps/o2-blocks/webpack.config.js
@@ -3,9 +3,6 @@
  */
 /* eslint-disable import/no-nodejs-modules */
 
-/**
- * External dependencies
- */
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 
 module.exports = () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `apps/o2-blocks` to use `import/order`

#### Testing instructions

N/A

Please note there are preexisting lint failures in some of the files changed.