### PR TITLE
chore: migrate `apps/wpcom-block-editor` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,6 +180,7 @@ module.exports = {
 				'apps/editing-toolkit/**/*',
 				'apps/notifications/**/*',
 				'apps/o2-blocks/**/*',
+				'apps/wpcom-block-editor/**/*',
 				'client/auth/**/*',
 				'client/boot/**/*',
 				'client/controller/**/*',

--- a/apps/wpcom-block-editor/src/calypso/editor.js
+++ b/apps/wpcom-block-editor/src/calypso/editor.js
@@ -1,9 +1,3 @@
-/**
- * Internal dependencies
- */
 import './features/iframe-bridge-server';
 
-/**
- * Style dependencies
- */
 import './editor.scss';

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1,32 +1,24 @@
 /* global calypsoifyGutenberg, Image, MessageChannel, MessagePort, requestAnimationFrame */
 
-/**
- * External dependencies
- */
-import $ from 'jquery';
-import { filter, find, forEach, get, map, partialRight } from 'lodash';
-import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse } from '@wordpress/blocks';
-import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
-import { registerPlugin } from '@wordpress/plugins';
-import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import {
 	Button,
 	__experimentalNavigationBackButton as NavigationBackButton,
 } from '@wordpress/components';
+import { dispatch, select, subscribe, use } from '@wordpress/data';
+import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
+import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+import { registerPlugin } from '@wordpress/plugins';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import debugFactory from 'debug';
+import $ from 'jquery';
+import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { Component, useEffect, useState } from 'react';
 import tinymce from 'tinymce/tinymce';
-import debugFactory from 'debug';
 import { STORE_KEY as NAV_SIDEBAR_STORE_KEY } from '../../../../editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants';
-
-/**
- * Internal dependencies
- */
 import { inIframe, isEditorReadyWithBlocks, sendMessage, getPages } from '../../utils';
-
 /**
  * Conditional dependency.  We cannot use the standard 'import' since this package is
  * not available in the post editor and causes WSOD in that case.  Instead, we can

--- a/apps/wpcom-block-editor/src/calypso/features/tinymce.js
+++ b/apps/wpcom-block-editor/src/calypso/features/tinymce.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import tinymce from 'tinymce/tinymce';
-
-/**
- * Internal dependencies
- */
 import { inIframe, sendMessage } from '../../utils';
 
 function replaceMediaModalOnClassicBlocks() {

--- a/apps/wpcom-block-editor/src/calypso/tinymce.js
+++ b/apps/wpcom-block-editor/src/calypso/tinymce.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './features/tinymce';

--- a/apps/wpcom-block-editor/src/default/editor.js
+++ b/apps/wpcom-block-editor/src/default/editor.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './features/rich-text';

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -1,8 +1,5 @@
 /* global wpcomGutenberg */
 
-/**
- * External dependencies
- */
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch, select, subscribe } from '@wordpress/data';
 import { RichTextToolbarButton } from '@wordpress/editor';

--- a/apps/wpcom-block-editor/src/default/view.js
+++ b/apps/wpcom-block-editor/src/default/view.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
 import './view.scss';

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { select, subscribe } from '@wordpress/data';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -1,24 +1,11 @@
-/**
- * WordPress dependencies
- */
-
 import { registerPlugin } from '@wordpress/plugins';
-
-/**
- * Internal dependencies
- */
 import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
 import './features/tracking';
 import './features/use-classic-block-guide';
-
-/**
- * Style dependencies
- */
-import './editor.scss';
-
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
+import './editor.scss';
 
 registerPlugin( 'track-inserter-menu-events', {
 	render() {

--- a/apps/wpcom-block-editor/src/wpcom/features/deprecate-coblocks-buttons.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/deprecate-coblocks-buttons.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { select, dispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
+import { select, dispatch } from '@wordpress/data';
 import { isEditorReadyWithBlocks } from '../../utils';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/images.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/images.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { __ } from '@wordpress/i18n';
 
 export const ClassicBlockImage = ( props ) => (

--- a/apps/wpcom-block-editor/src/wpcom/features/reorder-block-categories.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/reorder-block-categories.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { getCategories, setCategories } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
 import { use, select } from '@wordpress/data';
-import { registerPlugin } from '@wordpress/plugins';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { find, isEqual } from 'lodash';
+import { registerPlugin } from '@wordpress/plugins';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import tracksRecordEvent from './tracking/track-record-event';
+import { find, isEqual } from 'lodash';
 import delegateEventTracking, {
 	registerSubscriber as registerDelegateEventSubscriber,
 } from './tracking/delegate-event-tracking';
+import tracksRecordEvent from './tracking/track-record-event';
 import { trackGlobalStylesTabSelected } from './tracking/wpcom-block-editor-global-styles-tab-selected';
 import {
 	buildGlobalStylesContentEvents,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -1,27 +1,20 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import wpcomBlockDonationsPlanUpgrade from './wpcom-block-donations-plan-upgrade';
+import wpcomBlockDonationsStripeConnect from './wpcom-block-donations-stripe-connect';
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomBlockEditorDetailsOpen from './wpcom-block-editor-details-open';
 import wpcomBlockEditorGlobalStylesTabSelected from './wpcom-block-editor-global-styles-tab-selected';
-import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
-import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
-import wpcomBlockDonationsPlanUpgrade from './wpcom-block-donations-plan-upgrade';
-import wpcomBlockDonationsStripeConnect from './wpcom-block-donations-stripe-connect';
+import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
+import wpcomBlockEditorTemplatePartDetachBlocks from './wpcom-block-editor-template-part-detach-blocks';
 import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-plan-upgrade';
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
+import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
+import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
+import wpcomTemplatePartChooseExisting from './wpcom-template-part-choose-existing';
 import {
 	wpcomTemplatePartReplaceCapture,
 	wpcomTemplatePartReplaceBubble,
 } from './wpcom-template-part-replace';
-import wpcomTemplatePartChooseExisting from './wpcom-template-part-choose-existing';
-import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
-import wpcomBlockEditorTemplatePartDetachBlocks from './wpcom-block-editor-template-part-detach-blocks';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { omitBy } from 'lodash';
-import debug from 'debug';
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import debug from 'debug';
+import { omitBy } from 'lodash';
 import { isE2ETest } from '../../../utils';
 import { getEditorType } from '../utils';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-plan-upgrade.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-plan-upgrade.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-stripe-connect.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-stripe-connect.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-close-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-close-click.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-details-open.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-details-open.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-tab-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-tab-selected.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 const getTabNameFromId = ( id ) => ( id?.endsWith?.( '-block' ) ? 'block-type' : 'root' );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-list-view-select.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-template-part-detach-blocks.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-template-part-detach-blocks.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { getFlattenedBlockNames } from '../utils';
-
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-plan-upgrade.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-plan-upgrade.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
-import { debounce, get } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { debounce, get } from 'lodash';
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import {
 	__unstableInserterMenuExtension,
 	__experimentalInserterMenuExtension,
 } from '@wordpress/block-editor';
-
-/**
- * Internal dependencies
- */
+import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { debounce } from 'lodash';
 import tracksRecordEvent from './track-record-event';
 
 // InserterMenuExtension has been made unstable in this PR: https://github.com/WordPress/gutenberg/pull/31417 / Gutenberg v10.7.0-rc.1.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-tab-panel-selected.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 // Curiously, the numeric ids of the tabs increment every time you close and

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-template-part-choose-existing.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-template-part-choose-existing.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-template-part-replace.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-template-part-replace.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import tracksRecordEvent from './track-record-event';
 
 // Used to store data between capture and bubble handlers.

--- a/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import { createInterpolateElement, useState } from '@wordpress/element';
+import url from 'url'; // eslint-disable-line no-restricted-imports
 import { Guide } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement, useState } from '@wordpress/element';
 // Disabling lint rule while trying to make an urgent fix -- feel free to update to lib/url later!
-import url from 'url'; // eslint-disable-line no-restricted-imports
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-
-/**
- * Internal dependencies
- */
 import { ClassicBlockImage, InserterImage, InserterIconImage } from './images';
 
 const parsedEditorUrl = url.parse( globalThis.location.href, true );

--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -1,12 +1,8 @@
 /**
  * External Dependencies
  */
-import { isEqual, some, debounce } from 'lodash';
 import { select } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
+import { isEqual, some, debounce } from 'lodash';
 import tracksRecordEvent from './tracking/track-record-event';
 
 /**

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -3,12 +3,9 @@
  */
 /* eslint-disable import/no-nodejs-modules */
 
-/**
- * External dependencies
- */
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 
 /**
  * Internal variables


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `apps/wpcom-block-editor` to use `import/order`

#### Testing instructions

N/A
