### PR TITLE
Enable signup/professional-email-step feature in dev and wpcalypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/professional-email-step": true,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,6 +116,7 @@
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/professional-email-step": true,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change enables the `signup/professional-email-step` feature flag added in #54641 in the development and wpcalypso environments.

#### Testing instructions

* Run this branch locally and via the live branch
* Navigate to `/start`
* Search for and select a domain name
* Verify that you see the email step

Related to #54641
