### PR TITLE
Checkout: Add auto login to ecommerce setup flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -22,7 +22,7 @@ import {
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import wpcom from 'calypso/lib/wp';
-import { showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
+import { getSiteWooCommerceWizardUrl } from 'calypso/state/sites/selectors';
 
 const VERIFY_EMAIL_ERROR_NOTICE = 'ecommerce-verify-email-error';
 const RESEND_ERROR = 'RESEND_ERROR';
@@ -94,7 +94,7 @@ class AtomicStoreThankYouCard extends Component {
 	};
 
 	renderAction = () => {
-		const { isEmailVerified, site, translate } = this.props;
+		const { isEmailVerified, translate } = this.props;
 		const { resendStatus } = this.state;
 
 		if ( ! isEmailVerified ) {
@@ -116,7 +116,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ site.URL + '/wp-admin/admin.php?page=wc-admin&from-calypso&path=%2Fsetup-wizard' }
+					href={ this.props.siteWooCommerceWizardUrl }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>
@@ -175,6 +175,7 @@ export default connect(
 		const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : '';
 		const emailAddress = getCurrentUserEmail( state );
 		const isEmailVerified = isCurrentUserEmailVerified( state );
+		const siteWooCommerceWizardUrl = getSiteWooCommerceWizardUrl( state, siteId );
 
 		return {
 			siteId,
@@ -182,7 +183,8 @@ export default connect(
 			emailAddress,
 			isEmailVerified,
 			planClass,
+			siteWooCommerceWizardUrl,
 		};
 	},
-	{ errorNotice, fetchCurrentUser, removeNotice, showMasterbar }
+	{ errorNotice, fetchCurrentUser, removeNotice }
 )( localize( AtomicStoreThankYouCard ) );

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -116,7 +116,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ site.URL + '/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard' }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-admin&from-calypso&path=%2Fsetup-wizard' }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -94,7 +94,7 @@ class AtomicStoreThankYouCard extends Component {
 	};
 
 	renderAction = () => {
-		const { isEmailVerified, translate } = this.props;
+		const { isEmailVerified, translate, siteWooCommerceWizardUrl } = this.props;
 		const { resendStatus } = this.state;
 
 		if ( ! isEmailVerified ) {
@@ -116,7 +116,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ this.props.siteWooCommerceWizardUrl }
+					href={ siteWooCommerceWizardUrl }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -446,7 +446,7 @@ export class CheckoutThankYou extends React.Component {
 
 			return (
 				<Main className="checkout-thank-you">
-					{ this.props.transferComplete && (
+					{ this.props.transferComplete && this.props.isEmailVerified && (
 						<WpAdminAutoLogin
 							site={ { URL: `https://${ this.props.site?.wpcom_url }` } }
 							delay={ 0 }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -84,7 +84,7 @@ import { isRebrandCitiesSiteUrl } from 'calypso/lib/rebrand-cities';
 import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
-import { getSiteHomeUrl, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
@@ -440,18 +440,18 @@ export class CheckoutThankYou extends React.Component {
 		} else if ( wasEcommercePlanPurchased ) {
 			if ( ! this.props.transferComplete ) {
 				return (
-					<>
-						<TransferPending
-							orderId={ this.props.receiptId }
-							siteId={ this.props.selectedSite.ID }
-						/>
-						<WpAdminAutoLogin site={ this.props.selectedSite } />
-					</>
+					<TransferPending orderId={ this.props.receiptId } siteId={ this.props.selectedSite.ID } />
 				);
 			}
 
 			return (
 				<Main className="checkout-thank-you">
+					{ this.props.transferComplete && (
+						<WpAdminAutoLogin
+							site={ { URL: `https://${ this.props.site.wpcom_url }` } }
+							delay={ 0 }
+						/>
+					) }
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
@@ -683,6 +683,7 @@ export default connect(
 			selectedSiteSlug: getSiteSlug( state, siteId ),
 			siteHomeUrl: getSiteHomeUrl( state, siteId ),
 			customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId ),
+			site: getSite( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -448,7 +448,7 @@ export class CheckoutThankYou extends React.Component {
 				<Main className="checkout-thank-you">
 					{ this.props.transferComplete && (
 						<WpAdminAutoLogin
-							site={ { URL: `https://${ this.props.site.wpcom_url }` } }
+							site={ { URL: `https://${ this.props.site?.wpcom_url }` } }
 							delay={ 0 }
 						/>
 					) }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -440,13 +440,18 @@ export class CheckoutThankYou extends React.Component {
 		} else if ( wasEcommercePlanPurchased ) {
 			if ( ! this.props.transferComplete ) {
 				return (
-					<TransferPending orderId={ this.props.receiptId } siteId={ this.props.selectedSite.ID } />
+					<>
+						<TransferPending
+							orderId={ this.props.receiptId }
+							siteId={ this.props.selectedSite.ID }
+						/>
+						<WpAdminAutoLogin site={ this.props.selectedSite } />
+					</>
 				);
 			}
 
 			return (
 				<Main className="checkout-thank-you">
-					<WpAdminAutoLogin site={ this.props.selectedSite } delay={ 0 } />
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -92,6 +92,7 @@ import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customiz
 import getCheckoutUpgradeIntent from 'calypso/state/selectors/get-checkout-upgrade-intent';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors';
 import AsyncLoad from 'calypso/components/async-load';
+import WpAdminAutoLogin from 'calypso/components/wpadmin-auto-login';
 
 /**
  * Style dependencies
@@ -445,6 +446,7 @@ export class CheckoutThankYou extends React.Component {
 
 			return (
 				<Main className="checkout-thank-you">
+					<WpAdminAutoLogin site={ this.props.selectedSite } />
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -446,7 +446,7 @@ export class CheckoutThankYou extends React.Component {
 
 			return (
 				<Main className="checkout-thank-you">
-					<WpAdminAutoLogin site={ this.props.selectedSite } />
+					<WpAdminAutoLogin site={ this.props.selectedSite } delay={ 0 } />
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `WpAdminAutoLogin` to the checkout flow for an ecommerce site to fix https://github.com/Automattic/wp-calypso/issues/49064 (unauthorized error when opening the Woo setup wizard)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Purchase a new site with eCommerce plan at /new
2. Wait for the thank you page to load
3. Check for network requests to wp-login
3. Click on 'Create your store' button
4. Setup store page in WooCommerce loads
5. Regression: check other checkout flows, e.g. purchasing an upgrade to business.
6. Regression: check that we don't attempt wp-login if the user's email is unverified.

![image](https://user-images.githubusercontent.com/3747241/105133298-76357880-5b27-11eb-8889-887618b3924f.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/49064
