### PR TITLE
Revert "Revert "Jetpack Backup plugin skip the plans page on auth""

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -243,7 +243,8 @@ export class JetpackAuthorize extends Component {
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber' ||
 			this.isJetpackUpgradeFlow() ||
-			this.isFromJetpackConnectionManager()
+			this.isFromJetpackConnectionManager() ||
+			this.isFromJetpackBackupPlugin()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -324,6 +325,11 @@ export class JetpackAuthorize extends Component {
 	isFromJetpackConnectionManager( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'connection-ui' );
+	}
+
+	isFromJetpackBackupPlugin( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-backup' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -257,6 +257,30 @@ describe( 'JetpackAuthorize', () => {
 		} );
 	} );
 
+	describe( 'isFromJetpackBackupPlugin', () => {
+		const isFromJetpackBackupPlugin = new JetpackAuthorize().isFromJetpackBackupPlugin;
+
+		test( 'is from backup plugin', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-backup',
+				},
+			};
+
+			expect( isFromJetpackBackupPlugin( props ) ).toBe( true );
+		} );
+
+		test( 'is not from backup plugin', () => {
+			const props = {
+				authQuery: {
+					from: 'not-jetpack-backup',
+				},
+			};
+
+			expect( isFromJetpackBackupPlugin( props ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'isFromJetpackBoost', () => {
 		const isFromJetpackBoost = new JetpackAuthorize().isFromJetpackBoost;
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#54696

- This is to disable the plan purchase from the Connect / Auth flow
- The reason we're re-reverting is because currently the purchase flow goes to WordPress.com, that won't currently support the Jetpack Backup plugin, without an option to go to cloud.jetpack.com