### PR TITLE
Domains: Update domain suggestions cards layout

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -132,21 +132,23 @@ class DomainProductPrice extends React.Component {
 	renderSalePrice() {
 		const { price, salePrice, translate } = this.props;
 
-		const className = classnames( 'domain-product-price', 'is-free-domain', {
+		const className = classnames( 'domain-product-price', 'is-free-domain', 'is-sale-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
 		} );
 
 		return (
 			<div className={ className }>
 				<div className="domain-product-price__sale-price">
-					{ translate( '%(salePrice)s for the first year', {
+					{ translate( '%(salePrice)s {{small}}for the first year{{/small}}', {
 						args: { salePrice },
+						components: { small: <small /> },
 					} ) }
 				</div>
 				<div className="domain-product-price__renewal-price">
-					{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
+					{ translate( '%(cost)s {{small}}/year{{/small}}', {
 						args: { cost: price },
 						components: { small: <small /> },
+						comment: '%(cost)s is the annual renewal price of a domain currently on sale',
 					} ) }
 				</div>
 			</div>

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -138,7 +138,11 @@ class DomainProductPrice extends React.Component {
 
 		return (
 			<div className={ className }>
-				<div className="domain-product-price__sale-price">{ salePrice }</div>
+				<div className="domain-product-price__sale-price">
+					{ translate( '%(salePrice)s for the first year', {
+						args: { salePrice },
+					} ) }
+				</div>
 				<div className="domain-product-price__renewal-price">
 					{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
 						args: { cost: price },

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -24,31 +24,22 @@ class DomainProductPrice extends React.Component {
 	};
 
 	renderFreeWithPlanText() {
-		const { isMappingProduct, showStrikedOutPrice, translate } = this.props;
+		const { isMappingProduct, translate } = this.props;
 
 		let message;
 		switch ( this.props.rule ) {
 			case 'FREE_WITH_PLAN':
-				message = translate( 'First year free with your plan' );
 				if ( isMappingProduct ) {
 					message = translate( 'Free with your plan' );
+				} else {
+					return this.renderReskinFreeWithPlanText();
 				}
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				if ( showStrikedOutPrice ) {
-					message = translate( 'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free{{/span}}', {
-						args: { cost: this.props.price },
-						components: {
-							del: <del />,
-							span: <span className="domain-product-price__free-price" />,
-						},
-					} );
-				} else {
-					message = translate( 'First year included in paid plans' );
-				}
-
 				if ( isMappingProduct ) {
 					message = translate( 'Included in paid plans' );
+				} else {
+					return this.renderReskinFreeWithPlanText();
 				}
 				break;
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
@@ -63,17 +54,7 @@ class DomainProductPrice extends React.Component {
 		if ( this.props.isMappingProduct ) {
 			return;
 		}
-
-		const priceText = this.props.showStrikedOutPrice
-			? this.props.translate( 'Renews at %(cost)s / year', {
-					args: { cost: this.props.price },
-			  } )
-			: this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
-					args: { cost: this.props.price },
-					components: { small: <small /> },
-			  } );
-
-		return <div className="domain-product-price__price">{ priceText }</div>;
+		return this.renderReskinDomainPrice();
 	}
 
 	renderReskinFreeWithPlanText() {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -10,14 +10,6 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-end;
 		font-size: $font-body;
-
-		.featured-domain-suggestions & {
-			align-items: flex-start;
-		}
-
-		&.domain-product-price__domain-step-signup-flow {
-			align-items: flex-start;
-		}
 	}
 	
 	@include breakpoint-deprecated( '<660px' ) {
@@ -42,7 +34,7 @@
 	.is-section-domains & {
 		@include breakpoint-deprecated( '>800px' ) {
 			padding-left: 1em;
-			padding-right: 2em;
+			padding-right: 1em;
 		}
 	}
 
@@ -83,7 +75,7 @@
 
 		.domain-product-price__price,
 		.domain-product-price__renewal-price {
-			font-size: 80%;
+			font-size: 80%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: var( --color-text-subtle );
 		}
 

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -104,6 +104,10 @@
 
 		.domain-product-price__renewal-price {
 			text-decoration: line-through;
+
+			small {
+				font-size: $font-body-small;
+			}
 		}
 
 		@include breakpoint-deprecated( '>660px' ) {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -15,7 +15,7 @@
 			align-items: flex-start;
 		}
 	}
-	
+
 	@include breakpoint-deprecated( '<660px' ) {
 		display: inline-block;
 		font-size: $font-body-small;
@@ -54,6 +54,11 @@
 	.domain-product-price__sale-price {
 		color: var( --color-neutral-60 );
 		display: block;
+	}
+
+	.domain-product-price__sale-price {
+		color: var( --studio-orange-50 );
+		font-weight: 600;
 	}
 
 	&.no-price .domain-product-price__free-text,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -68,6 +68,14 @@
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 	}
 
+	.domain-product-price__price {
+		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+
+		small {
+			font-size: $font-body-small;
+		}
+	}
+
 	.domain-product-price__price,
 	.domain-product-price__renewal-price {
 		margin: auto 0;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -10,6 +10,10 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-end;
 		font-size: $font-body;
+
+		.is-white-signup & {
+			align-items: flex-start;
+		}
 	}
 	
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -59,6 +59,10 @@
 	.domain-product-price__sale-price {
 		color: var( --studio-orange-50 );
 		font-weight: 600;
+		small {
+			color: var( --studio-orange-50 );
+			font-size: $font-body-small;
+		}
 	}
 
 	&.no-price .domain-product-price__free-text,
@@ -71,10 +75,11 @@
 	.domain-product-price__free-price {
 		color: var( --studio-green-60 );
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-size: $font-body-small;
 	}
 
 	.domain-product-price__price {
-		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-weight: 400;
 
 		small {
 			font-size: $font-body-small;
@@ -95,6 +100,10 @@
 		.domain-product-price__renewal-price {
 			font-size: $font-body-small;
 			color: var( --color-text-subtle );
+		}
+
+		.domain-product-price__renewal-price {
+			text-decoration: line-through;
 		}
 
 		@include breakpoint-deprecated( '>660px' ) {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -64,7 +64,8 @@
 	}
 
 	.domain-product-price__free-price {
-		color: var( --color-success );
+		color: var( --studio-green-60 );
+		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 	}
 
 	.domain-product-price__price,
@@ -79,7 +80,7 @@
 
 		.domain-product-price__price,
 		.domain-product-price__renewal-price {
-			font-size: 80%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-body-small;
 			color: var( --color-text-subtle );
 		}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -224,7 +224,6 @@ class DomainRegistrationSuggestion extends React.Component {
 
 	renderDomain() {
 		const {
-			isFeatured,
 			showHstsNotice,
 			suggestion: { domain_name: domain },
 			translate,
@@ -240,8 +239,6 @@ class DomainRegistrationSuggestion extends React.Component {
 		let title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
 		title = this.renderDomainParts( domain );
 
-		const infoPopoverSize = isFeatured ? 22 : 18;
-
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain':
 				this.props.showStrikedOutPrice && ! this.props.isFeatured,
@@ -249,40 +246,52 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		return (
 			<div className={ titleWrapperClassName }>
-				<h3 className="domain-registration-suggestion__title">{ title }</h3>
+				<h3 className="domain-registration-suggestion__title">
+					{ title } { showHstsNotice && this.renderInfoBubble() }
+				</h3>
 				{ this.renderBadges() }
-				{ showHstsNotice && (
-					<InfoPopover
-						className="domain-registration-suggestion__hsts-tooltip"
-						iconSize={ infoPopoverSize }
-						position={ 'right' }
-					>
-						{ translate(
-							'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
-								'to host a website. When you host this domain at WordPress.com an SSL ' +
-								'certificate is included. {{a}}Learn more{{/a}}.',
-							{
-								args: {
-									tld: '.' + getTld( domain ),
-								},
-								components: {
-									a: (
-										<a
-											href={ HTTPS_SSL }
-											target="_blank"
-											rel="noopener noreferrer"
-											onClick={ ( event ) => {
-												event.stopPropagation();
-											} }
-										/>
-									),
-									strong: <strong />,
-								},
-							}
-						) }
-					</InfoPopover>
-				) }
 			</div>
+		);
+	}
+
+	renderInfoBubble() {
+		const {
+			isFeatured,
+			suggestion: { domain_name: domain },
+			translate,
+		} = this.props;
+
+		const infoPopoverSize = isFeatured ? 22 : 18;
+		return (
+			<InfoPopover
+				className="domain-registration-suggestion__hsts-tooltip"
+				iconSize={ infoPopoverSize }
+				position={ 'right' }
+			>
+				{ translate(
+					'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
+						'to host a website. When you host this domain at WordPress.com an SSL ' +
+						'certificate is included. {{a}}Learn more{{/a}}.',
+					{
+						args: {
+							tld: '.' + getTld( domain ),
+						},
+						components: {
+							a: (
+								<a
+									href={ HTTPS_SSL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ ( event ) => {
+										event.stopPropagation();
+									} }
+								/>
+							),
+							strong: <strong />,
+						},
+					}
+				) }
+			</InfoPopover>
 		);
 	}
 
@@ -297,9 +306,17 @@ class DomainRegistrationSuggestion extends React.Component {
 		const badges = [];
 
 		if ( isRecommended && isFeatured ) {
-			badges.push( <Badge type="info-green">{ translate( 'Recommended' ) }</Badge> );
+			badges.push(
+				<Badge key="recommended" type="info-green">
+					{ translate( 'Recommended' ) }
+				</Badge>
+			);
 		} else if ( isBestAlternative && isFeatured ) {
-			badges.push( <Badge type="info-purple">{ translate( 'Best Alternative' ) }</Badge> );
+			badges.push(
+				<Badge key="best-alternative" type="info-purple">
+					{ translate( 'Best Alternative' ) }
+				</Badge>
+			);
 		}
 
 		const paidDomain = isPaidDomain( this.getPriceRule() );
@@ -307,11 +324,13 @@ class DomainRegistrationSuggestion extends React.Component {
 			const saleBadgeText = translate( 'Sale', {
 				comment: 'Shown next to a domain that has a special discounted sale price',
 			} );
-			badges.push( <Badge>{ saleBadgeText }</Badge> );
+			badges.push( <Badge key="sale">{ saleBadgeText }</Badge> );
 		}
 
 		if ( isPremium ) {
-			badges.push( <PremiumBadge restrictedPremium={ premiumDomain?.is_price_limit_exceeded } /> );
+			badges.push(
+				<PremiumBadge key="premium" restrictedPremium={ premiumDomain?.is_price_limit_exceeded } />
+			);
 		}
 
 		if ( badges.length > 0 ) {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -230,7 +230,6 @@ class DomainRegistrationSuggestion extends React.Component {
 			premiumDomain,
 			suggestion: { domain_name: domain, is_premium: isPremium },
 			translate,
-			isReskinned,
 		} = this.props;
 
 		let isAvailable = false;
@@ -241,9 +240,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		let title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
-		if ( isReskinned ) {
-			title = this.renderDomainParts( domain );
-		}
+		title = this.renderDomainParts( domain );
 
 		const paidDomain = isPaidDomain( this.getPriceRule() );
 		const saleBadgeText = translate( 'Sale', {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -166,8 +166,10 @@ class DomainRegistrationSuggestion extends React.Component {
 			buttonContent = translate( 'Unavailable', {
 				context: 'Domain suggestion is not available for registration',
 			} );
-		} else if ( pendingCheckSuggestion || this.props.isCartPendingUpdate ) {
+		} else if ( pendingCheckSuggestion?.domain_name === domain ) {
 			buttonStyles = { ...buttonStyles, busy: true, disabled: true };
+		} else if ( pendingCheckSuggestion || this.props.isCartPendingUpdate ) {
+			buttonStyles = { ...buttonStyles, disabled: true };
 		}
 		return {
 			buttonContent,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -1,4 +1,3 @@
-import { ProgressBar } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, includes } from 'lodash';
@@ -9,8 +8,6 @@ import { connect } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import {
 	parseMatchReasons,
-	SLD_EXACT_MATCH,
-	TLD_EXACT_MATCH,
 	VALID_MATCH_REASONS,
 } from 'calypso/components/domains/domain-registration-suggestion/utility';
 import DomainSuggestion from 'calypso/components/domains/domain-suggestion';
@@ -22,11 +19,6 @@ import {
 	hasDomainInCart,
 	isPaidDomain,
 } from 'calypso/lib/cart-values/cart-items';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	parseMatchReasons,
-	VALID_MATCH_REASONS,
-} from 'calypso/components/domains/domain-registration-suggestion/utility';
 import { getDomainPrice, getDomainSalePrice, getTld, isHstsRequired } from 'calypso/lib/domains';
 import { HTTPS_SSL } from 'calypso/lib/url/support';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -356,7 +356,7 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	renderMatchReason() {
-		if ( this.props.showStrikedOutPrice ) {
+		if ( this.props.isReskinned ) {
 			return null;
 		}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -304,7 +304,6 @@ class DomainRegistrationSuggestion extends React.Component {
 			suggestion: { isRecommended, isBestAlternative },
 			translate,
 			isFeatured,
-			showStrikedOutPrice,
 		} = this.props;
 
 		if ( ! isFeatured ) {
@@ -313,7 +312,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title;
 		if ( isRecommended ) {
-			title = showStrikedOutPrice ? translate( 'Recommended' ) : translate( 'Best Match' );
+			title = translate( 'Recommended' );
 		}
 
 		if ( isBestAlternative ) {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -336,7 +336,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		if ( badges.length > 0 ) {
-			return <div className="domain-registration-suggestion__progress-bar">{ badges }</div>;
+			return <div className="domain-registration-suggestion__badges">{ badges }</div>;
 		}
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -226,9 +226,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const {
 			isFeatured,
 			showHstsNotice,
-			productSaleCost,
-			premiumDomain,
-			suggestion: { domain_name: domain, is_premium: isPremium },
+			suggestion: { domain_name: domain },
 			translate,
 		} = this.props;
 
@@ -242,10 +240,6 @@ class DomainRegistrationSuggestion extends React.Component {
 		let title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
 		title = this.renderDomainParts( domain );
 
-		const paidDomain = isPaidDomain( this.getPriceRule() );
-		const saleBadgeText = translate( 'Sale', {
-			comment: 'Shown next to a domain that has a special discounted sale price',
-		} );
 		const infoPopoverSize = isFeatured ? 22 : 18;
 
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
@@ -257,10 +251,6 @@ class DomainRegistrationSuggestion extends React.Component {
 			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
 				{ this.renderBadges() }
-				{ isPremium && (
-					<PremiumBadge restrictedPremium={ premiumDomain?.is_price_limit_exceeded } />
-				) }
-				{ productSaleCost && paidDomain && <Badge>{ saleBadgeText }</Badge> }
 				{ showHstsNotice && (
 					<InfoPopover
 						className="domain-registration-suggestion__hsts-tooltip"
@@ -298,35 +288,34 @@ class DomainRegistrationSuggestion extends React.Component {
 
 	renderBadges() {
 		const {
-			suggestion: { isRecommended, isBestAlternative },
+			suggestion: { isRecommended, isBestAlternative, is_premium: isPremium },
 			translate,
 			isFeatured,
+			productSaleCost,
+			premiumDomain,
 		} = this.props;
+		const badges = [];
 
-		if ( ! isFeatured ) {
-			return null;
+		if ( isRecommended && isFeatured ) {
+			badges.push( <Badge type="info-green">{ translate( 'Recommended' ) }</Badge> );
+		} else if ( isBestAlternative && isFeatured ) {
+			badges.push( <Badge type="info-purple">{ translate( 'Best Alternative' ) }</Badge> );
 		}
 
-		let title;
-		if ( isRecommended ) {
-			title = translate( 'Recommended' );
-		}
-
-		if ( isBestAlternative ) {
-			title = translate( 'Best Alternative' );
-		}
-
-		if ( title ) {
-			const badgeClassName = classNames( '', {
-				'info-green': isRecommended,
-				'info-purple': isBestAlternative,
+		const paidDomain = isPaidDomain( this.getPriceRule() );
+		if ( productSaleCost && paidDomain ) {
+			const saleBadgeText = translate( 'Sale', {
+				comment: 'Shown next to a domain that has a special discounted sale price',
 			} );
+			badges.push( <Badge>{ saleBadgeText }</Badge> );
+		}
 
-			return (
-				<div className="domain-registration-suggestion__progress-bar">
-					<Badge type={ badgeClassName }>{ title }</Badge>
-				</div>
-			);
+		if ( isPremium ) {
+			badges.push( <PremiumBadge restrictedPremium={ premiumDomain?.is_price_limit_exceeded } /> );
+		}
+
+		if ( badges.length > 0 ) {
+			return <div className="domain-registration-suggestion__progress-bar">{ badges }</div>;
 		}
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -256,7 +256,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		return (
 			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
-				{ isReskinned && this.renderProgressBar() }
+				{ this.renderProgressBar() }
 				{ isPremium && (
 					<PremiumBadge restrictedPremium={ premiumDomain?.is_price_limit_exceeded } />
 				) }
@@ -302,7 +302,6 @@ class DomainRegistrationSuggestion extends React.Component {
 			translate,
 			isFeatured,
 			showStrikedOutPrice,
-			isReskinned,
 		} = this.props;
 
 		if ( ! isFeatured ) {
@@ -316,11 +315,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		let title;
 		let progressBarProps;
 		if ( isRecommended ) {
-			title = showStrikedOutPrice ? translate( 'Our Recommendation' ) : translate( 'Best Match' );
-
-			if ( isReskinned ) {
-				title = translate( 'Recommended' );
-			}
+			title = showStrikedOutPrice ? translate( 'Recommended' ) : translate( 'Best Match' );
 
 			progressBarProps = {
 				color: NOTICE_GREEN,
@@ -340,10 +335,8 @@ class DomainRegistrationSuggestion extends React.Component {
 		if ( title ) {
 			if ( showStrikedOutPrice ) {
 				const badgeClassName = classNames( '', {
-					success: isRecommended && ! isReskinned,
-					'info-blue': isBestAlternative && ! isReskinned,
-					'info-green': isRecommended && isReskinned,
-					'info-purple': isBestAlternative && isReskinned,
+					'info-green': isRecommended,
+					'info-purple': isBestAlternative,
 				} );
 
 				return (
@@ -425,7 +418,6 @@ class DomainRegistrationSuggestion extends React.Component {
 				isReskinned={ isReskinned }
 			>
 				{ this.renderDomain() }
-				{ ! isReskinned && this.renderProgressBar() }
 				{ this.renderMatchReason() }
 			</DomainSuggestion>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -34,7 +34,6 @@ class DomainSuggestion extends React.Component {
 			salePrice,
 			isSignupStep,
 			showStrikedOutPrice,
-			isReskinned,
 		} = this.props;
 
 		if ( hidePrice ) {
@@ -52,7 +51,7 @@ class DomainSuggestion extends React.Component {
 				rule={ priceRule }
 				isSignupStep={ isSignupStep }
 				showStrikedOutPrice={ showStrikedOutPrice }
-				isReskinned={ isReskinned }
+				isReskinned={ true }
 			/>
 		);
 	}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -57,7 +57,14 @@ class DomainSuggestion extends React.Component {
 	}
 
 	render() {
-		const { children, extraClasses, isAdded, isFeatured, showStrikedOutPrice } = this.props;
+		const {
+			children,
+			extraClasses,
+			isAdded,
+			isFeatured,
+			showStrikedOutPrice,
+			isReskinned,
+		} = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',
@@ -85,9 +92,9 @@ class DomainSuggestion extends React.Component {
 			>
 				<div className={ contentClassName }>
 					{ children }
-					{ ! isFeatured && this.renderPrice() }
+					{ ( isReskinned || ! isFeatured ) && this.renderPrice() }
 				</div>
-				{ isFeatured && (
+				{ ! isReskinned && isFeatured && (
 					<div className="domain-suggestion__price-container">{ this.renderPrice() }</div>
 				) }
 				<div className="domain-suggestion__action-container">

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -86,8 +86,11 @@ class DomainSuggestion extends React.Component {
 			>
 				<div className={ contentClassName }>
 					{ children }
-					{ this.renderPrice() }
+					{ ! isFeatured && this.renderPrice() }
 				</div>
+				{ isFeatured && (
+					<div className="domain-suggestion__price-container">{ this.renderPrice() }</div>
+				) }
 				<div className="domain-suggestion__action-container">
 					<Button className="domain-suggestion__action" { ...this.props.buttonStyles }>
 						{ this.props.buttonContent }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -58,14 +58,7 @@ class DomainSuggestion extends React.Component {
 	}
 
 	render() {
-		const {
-			children,
-			extraClasses,
-			isAdded,
-			isFeatured,
-			showStrikedOutPrice,
-			isReskinned,
-		} = this.props;
+		const { children, extraClasses, isAdded, isFeatured, showStrikedOutPrice } = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',
@@ -81,13 +74,6 @@ class DomainSuggestion extends React.Component {
 			'domain-suggestion__content-domain': showStrikedOutPrice && ! isFeatured,
 		} );
 
-		const wrapDivActionContainer = ( contentElement ) =>
-			isReskinned ? (
-				<div className="domain-suggestion__action-container">{ contentElement }</div>
-			) : (
-				contentElement
-			);
-
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		/* eslint-disable jsx-a11y/interactive-supports-focus */
 		return (
@@ -102,11 +88,11 @@ class DomainSuggestion extends React.Component {
 					{ children }
 					{ this.renderPrice() }
 				</div>
-				{ wrapDivActionContainer(
+				<div className="domain-suggestion__action-container">
 					<Button className="domain-suggestion__action" { ...this.props.buttonStyles }>
 						{ this.props.buttonContent }
 					</Button>
-				) }
+				</div>
 				{ this.props.showChevron && (
 					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
 				) }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -34,6 +34,7 @@ class DomainSuggestion extends React.Component {
 			salePrice,
 			isSignupStep,
 			showStrikedOutPrice,
+			isReskinned,
 		} = this.props;
 
 		if ( hidePrice ) {
@@ -51,7 +52,7 @@ class DomainSuggestion extends React.Component {
 				rule={ priceRule }
 				isSignupStep={ isSignupStep }
 				showStrikedOutPrice={ showStrikedOutPrice }
-				isReskinned={ true }
+				isReskinned={ isReskinned }
 			/>
 		);
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -148,6 +148,7 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
+	margin-bottom: 8px;
 
 	&.domain-registration-suggestion__title-domain {
 		@include breakpoint-deprecated( '>480px' ) {
@@ -288,9 +289,7 @@
 
 .domain-registration-suggestion__progress-bar {
 	align-self: center;
-	margin-left: 0;
-	margin-top: 0;
-	margin-bottom: 10px;
+	margin: 0 0 0 4px;
 
 	.badge {
 		border-radius: 4px; /* stylelint-disable-line */

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -9,6 +9,10 @@
 		align-items: center;
 	}
 
+	.domain-suggestion__content-domain {
+		justify-content: space-between;
+	}
+
 	&.is-clickable {
 		cursor: pointer;
 
@@ -74,10 +78,6 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		justify-content: space-between;
-
-		&.domain-suggestion__content-domain {
-			justify-content: initial;
-		}
 	}
 
 	.notice.is-compact {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -340,7 +340,6 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.domain-registration-suggestion__progress-bar {
-		align-self: center;
 		margin-left: 0;
 		margin-top: 0;
 		margin-bottom: 10px;
@@ -352,6 +351,7 @@ body.is-section-signup.is-white-signup {
 		}
 
 		@include break-xlarge {
+			align-self: center;
 			margin-left: 12px;
 			margin-bottom: 0;
 		}
@@ -372,6 +372,10 @@ body.is-section-signup.is-white-signup {
 
 		@include break-large {
 			margin: 0;
+		}
+
+		button.info-popover {
+			padding: 0;
 		}
 
 		& .domain-suggestion__content-domain {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -7,6 +7,10 @@
 	@include break-mobile {
 		flex-direction: row;
 		align-items: center;
+
+		.badge {
+			margin-left: 4px;
+		}
 	}
 
 	.domain-suggestion__content-domain {
@@ -26,6 +30,13 @@
 	}
 
 	.domain-registration-suggestion__domain-title-tld {
+		font-weight: 500; /* stylelint-disable-line */
+	}
+
+	.badge {
+		margin-left: 0;
+		border-radius: 4px; /* stylelint-disable-line */
+		font-size: 0.75rem;
 		font-weight: 500; /* stylelint-disable-line */
 	}
 }
@@ -298,12 +309,6 @@
 .domain-registration-suggestion__progress-bar {
 	align-self: center;
 	margin: 0 0 10px;
-
-	.badge {
-		border-radius: 4px; /* stylelint-disable-line */
-		font-size: 0.75rem;
-		font-weight: 500; /* stylelint-disable-line */
-	}
 
 	@include break-mobile {
 		margin: 0 0 0 4px;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -7,6 +7,7 @@
 	@include break-mobile {
 		flex-direction: row;
 		align-items: center;
+		padding: 15px 20px;
 	}
 
 	.domain-suggestion__content-domain {
@@ -29,10 +30,6 @@
 .domain-suggestion:not( .featured-domain-suggestion ) {
 	display: flex;
 	flex-direction: column;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		padding: 15px 20px;
-	}
 
 	.is-section-signup & {
 		@include breakpoint-deprecated( '>480px' ) {
@@ -202,6 +199,10 @@
 	@include break-mobile {
 		width: auto;
 	}
+}
+
+.domain-suggestion__price-container {
+	padding-right: 1em;
 }
 
 .button.domain-suggestion__action {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -2,6 +2,13 @@
 @import '@wordpress/base-styles/mixins';
 
 .domain-suggestion {
+	flex-direction: column;
+
+	@include break-mobile {
+		flex-direction: row;
+		align-items: center;
+	}
+
 	&.is-clickable {
 		cursor: pointer;
 
@@ -187,12 +194,26 @@
 	}
 }
 
+.domain-suggestion__action-container {
+	flex: 0 0 auto;
+	width: 100%;
+
+	@include break-mobile {
+		width: auto;
+	}
+}
+
 .button.domain-suggestion__action {
+	width: 100%;
 	min-width: 66px;
 	text-align: center;
 	margin-top: 16px;
 	padding: 0.25em 3em;
 	transition: all 0.1s linear;
+
+	@include break-mobile {
+		width: auto;
+	}
 
 	&.is-primary {
 		@include breakpoint-deprecated( '>480px' ) {
@@ -372,10 +393,6 @@ body.is-section-signup.is-white-signup {
 
 			.domain-product-price__price:not( .domain-product-price__free-price ) {
 				font-size: $font-body-small;
-			}
-
-			.domain-suggestion__action-container {
-				flex: 0 0 auto;
 			}
 
 			.domain-suggestion__action:not( .is-borderless ) {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -7,10 +7,6 @@
 	@include break-mobile {
 		flex-direction: row;
 		align-items: center;
-
-		.badge {
-			margin-left: 4px;
-		}
 	}
 
 	.domain-suggestion__content-domain {
@@ -38,6 +34,10 @@
 		border-radius: 4px; /* stylelint-disable-line */
 		font-size: 0.75rem;
 		font-weight: 500; /* stylelint-disable-line */
+
+		@include break-mobile {
+			margin-left: 4px;
+		}
 	}
 }
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -43,9 +43,10 @@
 		border-radius: 4px; /* stylelint-disable-line */
 		font-size: 0.75rem;
 		font-weight: 500; /* stylelint-disable-line */
+		margin-right: 4px;
 
-		@include break-mobile {
-			margin-left: 4px;
+		&.badge--warning {
+			background-color: var( --color-warning-10 );
 		}
 	}
 }
@@ -170,8 +171,12 @@
 
 .domain-registration-suggestion__title-wrapper {
 	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
+	flex-direction: column-reverse;
+	flex-wrap: nowrap;
+
+	@include break-xlarge {
+		flex-direction: row;
+	}
 
 	&.domain-registration-suggestion__title-domain {
 		@include breakpoint-deprecated( '>480px' ) {
@@ -316,15 +321,22 @@
 }
 
 .domain-registration-suggestion__progress-bar {
-	align-self: center;
 	margin: 0 0 10px;
+	display: flex;
+	align-items: center;
 
 	@include break-mobile {
 		margin: 0 0 0 4px;
+		align-self: center;
 	}
 }
 
 body.is-section-signup.is-white-signup {
+	svg {
+		padding-top: 0;
+		margin-right: 0;
+	}
+
 	.domain-registration-suggestion__progress-bar {
 		align-self: center;
 		margin-left: 0;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -196,6 +196,7 @@
 		width: auto;
 		max-width: 100%;
 		padding-right: 0.2em;
+		display: flex;
 	}
 
 	.badge {
@@ -206,6 +207,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		margin-left: 4px;
 	}
 
 	body.is-section-signup .layout:not( .dops ) & {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -293,12 +293,16 @@
 
 .domain-registration-suggestion__progress-bar {
 	align-self: center;
-	margin: 0 0 0 4px;
+	margin: 0 0 10px;
 
 	.badge {
 		border-radius: 4px; /* stylelint-disable-line */
 		font-size: 0.75rem;
 		font-weight: 500; /* stylelint-disable-line */
+	}
+
+	@include break-mobile {
+		margin: 0 0 0 4px;
 	}
 }
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -25,8 +25,17 @@
 		}
 	}
 
-	.domain-registration-suggestion__domain-title-tld {
-		font-weight: 500; /* stylelint-disable-line */
+	.domain-registration-suggestion__domain-title {
+		font-size: $font-body;
+
+		.domain-registration-suggestion__domain-title-name {
+			color: var( --studio-gray-60 );
+		}
+
+		.domain-registration-suggestion__domain-title-tld {
+			font-weight: 500; /* stylelint-disable-line */
+			color: var( --studio-gray-90 );
+		}
 	}
 
 	.badge {
@@ -163,7 +172,6 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	margin-bottom: 8px;
 
 	&.domain-registration-suggestion__title-domain {
 		@include breakpoint-deprecated( '>480px' ) {
@@ -232,6 +240,7 @@
 
 .button.domain-suggestion__action {
 	width: 100%;
+	height: 40px;
 	min-width: 66px;
 	text-align: center;
 	margin-top: 16px;
@@ -433,6 +442,7 @@ body.is-section-signup.is-white-signup {
 
 			.domain-suggestion__action:not( .is-borderless ) {
 				width: 100%;
+				height: auto;
 				line-height: 20px;
 				padding: 0.57em 1.17em;
 				font-weight: 500; /* stylelint-disable-line */
@@ -465,6 +475,7 @@ body.is-section-signup.is-white-signup {
 				$cod-grey: #2b2d2f;
 
 				.domain-suggestion__action {
+					height: auto;
 					color: $cod-grey;
 					text-decoration-line: underline;
 				}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -194,6 +194,7 @@
 	}
 }
 
+.domain-suggestion__price-container,
 .domain-suggestion__action-container {
 	flex: 0 0 auto;
 	width: 100%;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -24,6 +24,10 @@
 			z-index: z-index( 'root', '.domain-suggestion.is-clickable:hover' );
 		}
 	}
+
+	.domain-registration-suggestion__domain-title-tld {
+		font-weight: 500; /* stylelint-disable-line */
+	}
 }
 
 .domain-suggestion:not( .featured-domain-suggestion ) {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -418,6 +418,7 @@ body.is-section-signup.is-white-signup {
 
 		& .domain-product-price__free-price {
 			font-size: $font-body-small;
+			font-weight: initial;
 			color: var( --studio-green-60 );
 			line-height: 20px;
 			letter-spacing: 0.2px;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -213,6 +213,10 @@
 
 .domain-suggestion__price-container {
 	padding-right: 1em;
+	margin-top: 10px;
+	@include break-mobile {
+		margin-top: 0;
+	}
 }
 
 .button.domain-suggestion__action {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -372,6 +372,7 @@ body.is-section-signup.is-white-signup {
 
 		.domain-product-price__price {
 			font-size: $font-body-small;
+			font-weight: initial;
 
 			&:not( .domain-product-price__free-price ) {
 				color: var( --color-neutral-40 );

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -7,7 +7,6 @@
 	@include break-mobile {
 		flex-direction: row;
 		align-items: center;
-		padding: 15px 20px;
 	}
 
 	.domain-suggestion__content-domain {
@@ -30,6 +29,12 @@
 .domain-suggestion:not( .featured-domain-suggestion ) {
 	display: flex;
 	flex-direction: column;
+
+	@include break-mobile {
+		flex-direction: row;
+		align-items: center;
+		padding: 15px 20px;
+	}
 
 	.is-section-signup & {
 		@include breakpoint-deprecated( '>480px' ) {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -322,7 +322,7 @@
 	}
 }
 
-.domain-registration-suggestion__progress-bar {
+.domain-registration-suggestion__badges {
 	margin: 0 0 10px;
 	display: flex;
 	align-items: center;
@@ -339,7 +339,7 @@ body.is-section-signup.is-white-signup {
 		margin-right: 0;
 	}
 
-	.domain-registration-suggestion__progress-bar {
+	.domain-registration-suggestion__badges {
 		margin-left: 0;
 		margin-top: 0;
 		margin-bottom: 10px;
@@ -357,7 +357,7 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 
-	.featured-domain-suggestion--is-placeholder .domain-registration-suggestion__progress-bar {
+	.featured-domain-suggestion--is-placeholder .domain-registration-suggestion__badges {
 		margin-left: 0;
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -279,6 +279,19 @@
 	}
 }
 
+.domain-registration-suggestion__progress-bar {
+	align-self: center;
+	margin-left: 0;
+	margin-top: 0;
+	margin-bottom: 10px;
+
+	.badge {
+		border-radius: 4px; /* stylelint-disable-line */
+		font-size: 0.75rem;
+		font-weight: 500; /* stylelint-disable-line */
+	}
+}
+
 body.is-section-signup.is-white-signup {
 	.domain-registration-suggestion__progress-bar {
 		align-self: center;

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -113,7 +113,7 @@ export class FeaturedDomainSuggestions extends Component {
 						uiPosition={ index }
 						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( suggestion ) }
-						buttonStyles={ 0 === index || { primary: true } }
+						buttonStyles={ { primary: true } }
 						isReskinned={ this.props.isReskinned }
 						{ ...childProps }
 					/>

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -113,7 +113,7 @@ export class FeaturedDomainSuggestions extends Component {
 						uiPosition={ index }
 						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( suggestion ) }
-						buttonStyles={ 0 === index || this.props.isReskinned ? { primary: true } : {} }
+						buttonStyles={ 0 === index || { primary: true } }
 						isReskinned={ this.props.isReskinned }
 						{ ...childProps }
 					/>

--- a/client/components/domains/featured-domain-suggestions/placeholder.jsx
+++ b/client/components/domains/featured-domain-suggestions/placeholder.jsx
@@ -9,7 +9,7 @@ export default function FeaturedDomainSuggestionsPlaceholder() {
 			<div className="domain-suggestion__content">
 				<div className="domain-registration-suggestion__title" />
 				<div className="domain-product-price" />
-				<div className="domain-registration-suggestion__progress-bar" />
+				<div className="domain-registration-suggestion__badges" />
 				<div className="domain-registration-suggestion__match-reasons" />
 			</div>
 			<div className="domain-suggestion__action" />

--- a/client/components/domains/featured-domain-suggestions/placeholder.scss
+++ b/client/components/domains/featured-domain-suggestions/placeholder.scss
@@ -3,7 +3,7 @@
 	min-height: 222px;
 
 	.domain-registration-suggestion__title,
-	.domain-registration-suggestion__progress-bar,
+	.domain-registration-suggestion__badges,
 	.domain-registration-suggestion__match-reasons,
 	.domain-suggestion__action {
 		animation: loading-fade 1.6s ease-in-out infinite;
@@ -23,7 +23,7 @@
 	.domain-product-price {
 		height: 18px;
 	}
-	.domain-registration-suggestion__progress-bar {
+	.domain-registration-suggestion__badges {
 		height: 22px;
 	}
 	.domain-registration-suggestion__match-reasons {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -90,6 +90,8 @@
 		}
 
 		.domain-registration-suggestion__domain-title {
+			font-size: $font-title-small;
+
 			@include break-mobile {
 				font-size: $font-title-medium;
 			}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -78,10 +78,6 @@
 		width: 100%;
 	}
 
-	.domain-registration-suggestion__progress-bar {
-		align-self: initial;
-	}
-
 	.domain-registration-suggestion__title-wrapper {
 		margin-bottom: 8px;
 	}
@@ -131,10 +127,15 @@
 	}
 
 	.domain-registration-suggestion__progress-bar {
+		align-self: flex-start;
 		align-items: center;
 		display: flex;
 		font-size: $font-body-extra-small;
 		order: 2;
+
+		@include break-mobile {
+			align-self: center;
+		}
 
 		.progress-bar {
 			width: 25%;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -101,10 +101,14 @@
 			@include break-mobile {
 				font-size: $font-title-medium;
 			}
-		}
 
-		.domain-registration-suggestion__domain-title-tld {
-			font-weight: normal;
+			.domain-registration-suggestion__domain-title-name {
+				color: var( --studio-gray-90 );
+			}
+
+			.domain-registration-suggestion__domain-title-tld {
+				font-weight: normal;
+			}
 		}
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -175,13 +175,14 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	align-items: center;
 	background: #ffffff;
 	border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
-	padding: 16px 24px;
+	padding: 16px;
 
 	@include break-mobile {
 		margin-bottom: 12px;
 		box-sizing: border-box;
 		border: 1px solid #e2e4e7;
 		background: var( --color-surface );
+		padding: 16px 24px;
 	}
 
 	.domain-suggestion__action-container {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -80,6 +80,10 @@
 		width: 100%;
 	}
 
+	.domain-registration-suggestion__progress-bar {
+		align-self: initial;
+	}
+
 	.domain-registration-suggestion__title-wrapper .domain-registration-suggestion__title {
 		width: auto;
 	}
@@ -210,6 +214,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	.domain-registration-suggestion__title-wrapper {
 		flex-wrap: nowrap;
 		flex-direction: column-reverse;
+		margin-bottom: initial;
 
 		@include break-xlarge {
 			flex-direction: row;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -64,7 +64,7 @@
 		display: flex;
 		flex-basis: auto;
 		flex-direction: column;
-		justify-content: flex-start;
+		justify-content: center;
 		flex-grow: 1;
 		margin-top: 0;
 	}
@@ -78,10 +78,6 @@
 		width: 100%;
 	}
 
-	.domain-registration-suggestion__title-wrapper {
-		margin-bottom: 8px;
-	}
-
 	.domain-registration-suggestion__title {
 		font-size: $font-title-small;
 		font-weight: 400;
@@ -90,7 +86,7 @@
 		width: auto;
 
 		@include break-mobile {
-			margin-bottom: 0.125em;
+			margin-bottom: 0;
 		}
 
 		.domain-registration-suggestion__domain-title {
@@ -137,6 +133,7 @@
 	}
 
 	.domain-registration-suggestion__match-reasons {
+		margin-top: 8px;
 		order: 3;
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -49,7 +49,6 @@
 	.button.domain-suggestion__action {
 		flex-grow: 0;
 		margin-left: 0;
-		margin-top: 1em;
 		text-align: center;
 		padding: 0.5em 3em;
 		transition: all 0.1s linear;
@@ -121,7 +120,6 @@
 		align-items: center;
 		display: flex;
 		font-size: $font-body-extra-small;
-		margin-top: 10px;
 		order: 2;
 
 		.progress-bar {
@@ -151,6 +149,17 @@
 		.domain-registration-suggestion__progress-bar,
 		.domain-registration-suggestion__match-reasons {
 			display: none;
+		}
+	}
+}
+
+.featured-domain-suggestion.card {
+	.domain-registration-suggestion__title-wrapper {
+		flex-wrap: nowrap;
+		flex-direction: column-reverse;
+
+		@include break-xlarge {
+			flex-direction: row;
 		}
 	}
 }

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -102,6 +102,7 @@
 		justify-content: flex-start;
 
 		body.is-section-signup.is-white-signup & {
+			align-items: flex-start;
 			margin-top: 12px;
 		}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -42,6 +42,10 @@
 	margin-top: 0;
 	width: 100%;
 
+	@include break-mobile {
+		flex-direction: row;
+	}
+
 	.button.domain-suggestion__action {
 		flex-grow: 0;
 		margin-left: 0;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -4,6 +4,7 @@
 .featured-domain-suggestions {
 	display: flex;
 	flex-direction: column;
+	flex-wrap: wrap;
 
 	&.featured-domain-suggestions--has-match-reasons .featured-domain-suggestion {
 		.domain-registration-suggestion__match-reasons {
@@ -235,12 +236,6 @@ body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	}
 }
 
-@include breakpoint-deprecated( '<660px' ) {
-	.featured-domain-suggestions {
-		flex-flow: wrap;
-	}
-}
-
 @include breakpoint-deprecated( '>660px' ) {
 	.domain-registration-suggestion__title {
 		.featured-domain-suggestions--title-in-18em & {
@@ -261,8 +256,6 @@ body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	}
 
 	.featured-domain-suggestions--title-causes-overflow {
-		flex-wrap: wrap;
-
 		.featured-domain-suggestion {
 			margin-top: 0;
 		}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -70,7 +70,7 @@
 	}
 
 	.domain-registration-suggestion__title,
-	.domain-registration-suggestion__progress-bar,
+	.domain-registration-suggestion__badges,
 	.domain-product-price,
 	.domain-registration-suggestion__match-reasons {
 		flex: 0 0 auto;
@@ -126,7 +126,7 @@
 		}
 	}
 
-	.domain-registration-suggestion__progress-bar {
+	.domain-registration-suggestion__badges {
 		align-self: flex-start;
 		align-items: center;
 		display: flex;
@@ -161,7 +161,7 @@
 	}
 
 	&.is-unavailable {
-		.domain-registration-suggestion__progress-bar,
+		.domain-registration-suggestion__badges,
 		.domain-registration-suggestion__match-reasons {
 			display: none;
 		}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -82,8 +82,8 @@
 		align-self: initial;
 	}
 
-	.domain-registration-suggestion__title-wrapper .domain-registration-suggestion__title {
-		width: auto;
+	.domain-registration-suggestion__title-wrapper {
+		margin-bottom: 8px;
 	}
 
 	.domain-registration-suggestion__title {
@@ -91,10 +91,16 @@
 		font-weight: 400;
 		line-height: 1.2;
 		margin-bottom: 0.25em;
+		width: auto;
 
-		@include breakpoint-deprecated( '>480px' ) {
-			font-size: $font-title-medium;
+		@include break-mobile {
 			margin-bottom: 0.125em;
+		}
+
+		.domain-registration-suggestion__domain-title {
+			@include break-mobile {
+				font-size: $font-title-medium;
+			}
 		}
 
 		.domain-registration-suggestion__domain-title-tld {
@@ -138,7 +144,7 @@
 
 	.domain-registration-suggestion__match-reason {
 		color: var( --color-text-subtle );
-		font-size: $font-body-extra-small;
+		font-size: $font-body-small;
 		padding: 0.125em 0;
 		display: flex;
 		align-items: center;
@@ -199,6 +205,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		border-radius: 4px; /* stylelint-disable-line */
 		box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 		font-size: 0.875rem;
+		height: auto;
 
 		@include break-mobile {
 			margin-top: 0;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -12,12 +12,6 @@
 		}
 	}
 
-	&.featured-domain-suggestions__is-domain-management .featured-domain-suggestion {
-		.domain-suggestion__action {
-			font-size: $font-body;
-		}
-	}
-
 	.is-section-signup & {
 		@include breakpoint-deprecated( '>480px' ) {
 			flex-direction: row;
@@ -44,6 +38,10 @@
 
 	@include break-mobile {
 		flex-direction: row;
+		/* using .is-compact to increase specificity */
+		&.is-compact {
+			padding: 15px 20px;
+		}
 	}
 
 	.button.domain-suggestion__action {
@@ -173,6 +171,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	align-items: center;
 	background: #ffffff;
 	border-bottom: 1px solid rgba( 220, 220, 222, 0.64 );
+	padding: 16px 24px;
 
 	@include break-mobile {
 		margin-bottom: 12px;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -96,6 +96,10 @@
 			font-size: $font-title-medium;
 			margin-bottom: 0.125em;
 		}
+
+		.domain-registration-suggestion__domain-title-tld {
+			font-weight: normal;
+		}
 	}
 
 	// .card used to increase specificity

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -117,13 +117,6 @@
 			align-items: flex-start;
 			margin-top: 12px;
 		}
-
-		&.is-free-domain,
-		&.is-sale-domain {
-			small {
-				font-size: 0.9em; /* stylelint-disable-line */
-			}
-		}
 	}
 
 	.domain-registration-suggestion__badges {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -48,11 +48,8 @@
 
 	.button.domain-suggestion__action {
 		flex-grow: 0;
-		margin-left: 0;
 		text-align: center;
-		padding: 0.5em 3em;
 		transition: all 0.1s linear;
-		width: 100%;
 
 		.is-placeholder & {
 			animation: loading-fade 1.6s ease-in-out infinite;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1453,9 +1453,7 @@ class RegisterDomainStep extends React.Component {
 				offerUnavailableOption={ this.props.offerUnavailableOption }
 				placeholderQuantity={ PAGE_SIZE }
 				isSignupStep={ this.props.isSignupStep }
-				showStrikedOutPrice={
-					this.props.isSignupStep && ! this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-				}
+				showStrikedOutPrice={ ! this.props.forceHideFreeDomainExplainerAndStrikeoutUi }
 				railcarId={ this.state.railcarId }
 				fetchAlgo={ this.getFetchAlgo() }
 				cart={ this.props.cart }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1453,7 +1453,9 @@ class RegisterDomainStep extends React.Component {
 				offerUnavailableOption={ this.props.offerUnavailableOption }
 				placeholderQuantity={ PAGE_SIZE }
 				isSignupStep={ this.props.isSignupStep }
-				showStrikedOutPrice={ ! this.props.forceHideFreeDomainExplainerAndStrikeoutUi }
+				showStrikedOutPrice={
+					this.props.isSignupStep && ! this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+				}
 				railcarId={ this.state.railcarId }
 				fetchAlgo={ this.getFetchAlgo() }
 				cart={ this.props.cart }

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -241,7 +241,9 @@ class DomainSearch extends Component {
 							<FormattedHeader
 								brandFont
 								headerText={
-									isManagingAllDomains ? translate( 'All Domains' ) : translate( 'Site Domains' )
+									isManagingAllDomains
+										? translate( 'All Domains' )
+										: translate( 'Search for a domain' )
 								}
 								align="left"
 							/>

--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -70,7 +70,9 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 
 	async skipSuggestion() {
 		// currently used in 'launch-site' signup flow
-		const skipSuggestion = By.css( '.domain-skip-suggestion > .button.domain-suggestion__action' );
+		const skipSuggestion = By.css(
+			'.domain-skip-suggestion > div > .button.domain-suggestion__action'
+		);
 		await driverHelper.scrollIntoView( this.driver, skipSuggestion );
 		return await driverHelper.clickWhenClickable(
 			this.driver,

--- a/test/e2e/lib/pages/domains-page.js
+++ b/test/e2e/lib/pages/domains-page.js
@@ -4,7 +4,7 @@ import * as driverHelper from '../driver-helper.js';
 
 export default class DomainsPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.domain-management-list__items' ) );
+		super( driver, By.css( '.empty-domains-list-card' ) );
 	}
 
 	async clickAddDomain() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the layout of domain suggestions cards in the domain registration search page. This corresponds to task 8 of pcYYhz-e4-p2, which is part of a redesign of domains pages.

The main updates in this PR are:

- Featured domain suggestions are always shown in a full-width row - previously, they could be shown as two side-by-side cards if the searched domain name was short enough
- The colored bars indicating the quality of the suggestion ("Best match" or "Best alternative") were removed. They were replaced by badges with "Recommended" and "Best alternative" texts
- Both featured domain suggestions have the "Selected" button colored as primary now
- The "Sale" badge was reskinned to have the same format as the "Recommended" and "Best alternative" ones

This is what the domain suggestions page looked like before:

<img width="1055" alt="Screen Shot 2021-08-02 at 20 00 14" src="https://user-images.githubusercontent.com/5324818/127934732-3c1cf44d-d9df-4259-b5f3-e6dad631a315.png">

And what it looks like with this update:

<img width="1055" alt="Screen Shot 2021-08-11 at 12 35 25" src="https://user-images.githubusercontent.com/5324818/129059585-e55515d5-3ced-4bd0-b089-2e45e5c04ff6.png">

Mobile view before:

<img width="417" alt="Screen Shot 2021-08-02 at 20 02 44" src="https://user-images.githubusercontent.com/5324818/127934845-5bf52beb-88b3-494f-a216-8a2e1fa37725.png">

Mobile view after:

<img width="429" alt="Screen Shot 2021-08-11 at 12 36 42" src="https://user-images.githubusercontent.com/5324818/129059616-983ab796-92ed-4779-9ce8-b6414f6d72ac.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use the live Calypso link and navigate to the domain name search page (Upgrades > Domains > Add a domain > To this site). Do a few domain searches with different names and TLDs and ensure everything looks alright. Please test both desktop and mobile views to ensure both are OK.

It would also be great if you could take a look at the signup flow (`<calypso live URL>/start`) and check that the domain search there looks OK too, because it uses the same components that were updated here. 🙇‍♂️ It was a little tricky to not change things in that page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
