### PR TITLE
Jetpack site-less Checkout: update ZD ticket after user schedules a call

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/utils.js
+++ b/client/my-sites/checkout/checkout-thank-you/utils.js
@@ -1,9 +1,25 @@
 /**
  * Internal dependencies
  */
-
+import { addQueryArgs } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 
 export function getDomainManagementUrl( { slug }, domain ) {
 	return domain ? domainManagementEdit( slug, domain ) : domainManagementList( slug );
+}
+
+/*
+ * Send a POST request to update the ZD ticket linked to the given receiptId.
+ *
+ * @param receiptId number – Receipt unique identifier.
+ */
+export async function addOnboardingCallInternalNote( receiptId ) {
+	return await wpcom.req.post( {
+		path: addQueryArgs(
+			{ receipt_id: receiptId },
+			'/jetpack-checkout/support-ticket/onboarding-call'
+		),
+		apiNamespace: 'wpcom/v2',
+	} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set up an event listener that sends a POST request to `/jetpack-checkout/support-ticket/onboarding-call` after a user schedules a call.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`.
* Visit `/checkout/jetpack/jetpack_scan_monthly` (the product doesn't really matter).
* Complete the purchase.
* Open in another tab, the post-purchase ZD ticket.
* On the Thank You page, click on the sidebar button to schedule a call (it should open a modal with a Calendly widget).
* Open the network tab.
* Schedule a Calendly call.
* Make sure that in the network tab, there is a reference to a successful POST request sent to `/jetpack-checkout/support-ticket/onboarding-call`.
* Go to your ZD ticket page, and make sure there is an internal note that reads `The user has scheduled an onboarding call.`.

Related to 1200479326344990-as-1200669355521606

#### Demo
![image](https://user-images.githubusercontent.com/3418513/127546683-a991c16c-87a3-43a4-867e-987ef76eb635.png)
![image](https://user-images.githubusercontent.com/3418513/127546732-8421ddba-6677-48d2-9c41-5b77d64bb146.png)
