### PR TITLE
Global Styles: Add more robust support for multiple font weights for some font families

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -483,18 +483,11 @@ class Global_Styles {
 		}
 
 		if ( count( $font_list ) > 0 ) {
-			$expanded_font_list = array( 'Montserrat', 'Work Sans', 'Roboto' );
-			$font_list_str      = '';
+			$font_list_str = '';
 			foreach ( $font_list as $font ) {
-				// Some fonts have more available styles than others,
-				// so return those if available.
-				if ( in_array( $font, $expanded_font_list, true ) ) {
-					$font_list_str = $font_list_str . $font . ':thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|';
-				} else {
-					// Some fonts lack italic variants,
-					// the API will return only the regular and bold CSS for those.
-					$font_list_str = $font_list_str . $font . ':regular,bold,italic,bolditalic|';
-				}
+				// Some fonts lack italic variants,
+				// the API will return only the regular and bold CSS for those.
+				$font_list_str = $font_list_str . $font . ':thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|';
 			}
 			$result = $result . "@import url('https://fonts.googleapis.com/css?family=" . $font_list_str . "');";
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -483,11 +483,18 @@ class Global_Styles {
 		}
 
 		if ( count( $font_list ) > 0 ) {
-			$font_list_str = '';
+			$expanded_font_list = array( 'Montserrat', 'Work Sans', 'Roboto' );
+			$font_list_str      = '';
 			foreach ( $font_list as $font ) {
-				// Some fonts lack italic variants,
-				// the API will return only the regular and bold CSS for those.
-				$font_list_str = $font_list_str . $font . ':regular,bold,italic,bolditalic|';
+				// Some fonts have more available styles than others,
+				// so return those if available.
+				if ( in_array( $font, $expanded_font_list, true ) ) {
+					$font_list_str = $font_list_str . $font . ':thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|';
+				} else {
+					// Some fonts lack italic variants,
+					// the API will return only the regular and bold CSS for those.
+					$font_list_str = $font_list_str . $font . ':regular,bold,italic,bolditalic|';
+				}
 			}
 			$result = $result . "@import url('https://fonts.googleapis.com/css?family=" . $font_list_str . "');";
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This may not be do-able, but I thought I'd open the PR so we can figure out if it is!
* In #54535 it's noted that changing the font weight on a single block when a global font style other than the system font is applied has no effect unless the weight is regular or bold.
* This PR adds support to all listed font families for weights like thin, light, semibold, etc. to match the list of available font weights presented in the menu.
* Not all fonts are created equal. Some font families do not have the full range of weights, and therefore the block-level font weight styles will not apply. Ideally we could tie into the core font weight system to determine what weights show, but I didn't see an easy way to hook into that.
* This does not include support for even more variations, like the `italic` versions of the extended weights (if they exist).
* Is there any drawback to requesting font weights from the API that don't exist? 🤔  In researching the font sets we offer I found that the majority do offer a wide range of weights, so I think it makes sense to apply that as the default case here.

**Before**

<img width="1311" alt="Screen Shot 2021-07-29 at 3 08 29 PM" src="https://user-images.githubusercontent.com/2124984/127551576-3b63c693-76e9-42eb-a63e-34286fd5429c.png">

**After**

<img width="1330" alt="Screen Shot 2021-07-29 at 3 07 19 PM" src="https://user-images.githubusercontent.com/2124984/127551493-371affd4-19ab-42f7-ad30-3d83c9558726.png">


#### Testing instructions

* Switch to this PR, run `yarn`, and `yarn dev --sync` to your sandbox
* Open the editor, go to Global Styles, apply a variable font to the heading (Montserrat, Fira Sans, Work Sans, etc). Publish to save your changes.
* Create a new heading in the post and select it. It should use the font you chose in step two.
* Change the weight of the font; it should change to correspond to each of the available weights (in most cases :))
