### PR TITLE
Gutenboarding: Store products in localStorage rather than sending to cart directly

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -4,8 +4,7 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createRequestCartProduct } from '@automattic/shopping-cart';
-import type { RequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
-import wp from '../../../lib/wp';
+import type { RequestCartProduct } from '@automattic/shopping-cart';
 
 /**
  * Internal dependencies
@@ -18,15 +17,15 @@ import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
 import { useOnboardingFlow } from '../path';
-
-const wpcom = wp.undocumented();
+import doesValueExist from 'calypso/my-sites/checkout/composite-checkout/lib/does-value-exist';
+import { addCartItemsToLocalStorage } from 'calypso/my-sites/checkout/composite-checkout/lib/cart-local-storage';
 
 /**
  * After a new site has been created there are 3 scenarios to cover:
  * 1. The user explicitly selected a paid plan using PlansGrid => redirect to checkout with that plan + any selected paid domain in cart
  * 2. The user selected a paid domain using DomainPicker (Premium Plan appears in top-right corner) => show PlansGrid as the last step of Gutenboarding => scenario 1
  * 3. The user is still seeing 'Free Plan' label on PlansButton => redirect to editor
- **/
+ */
 
 export default function useOnSiteCreation(): void {
 	const { domain } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
@@ -85,11 +84,7 @@ export default function useOnSiteCreation(): void {
 
 				const go = async () => {
 					if ( planProduct || domainProduct ) {
-						const cart: ResponseCart = await wpcom.getCart( newSite.blogid );
-						await wpcom.setCart( newSite.blogid, {
-							...cart,
-							products: [ ...cart.products, planProduct, domainProduct ].filter( Boolean ),
-						} );
+						addCartItemsToLocalStorage( [ planProduct, domainProduct ].filter( doesValueExist ) );
 					}
 					resetOnboardStore();
 					clearLastNonEditorRoute();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

One of two remaining places in calypso which does not use the `@automattic/shopping-cart` package to interact with the `/me/shopping-cart` endpoint is gutenboarding. This PR modifies the gutenboarding `go` method so that instead of saving cart items directly, it saves them to localStorage temporarily from which checkout will extract them when it loads (which is functionality that already exists for siteless carts).

This provides consistency with other cart management in calypso and separates the cart logic away from the gutenboarding infrastructure.

Since localStorage is not available in some environments (eg: Safari private browsing mode), this also has a fallback singleton storage that should act like a session storage for the same purpose.

Depends on https://github.com/Automattic/wp-calypso/pull/54262 and will require a rebase when that is merged.

#### Testing instructions

- Visit `/new` and add a domain and a paid plan.
- Verify there are no errors.
- Verify that when you reach checkout, both the domain and the plan are in your cart.