### PR TITLE
Theme Showcase: Remember viewport position on tab change

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -233,6 +233,7 @@ class ThemeShowcase extends React.Component {
 	};
 
 	onFilterClick = ( tabFilter ) => {
+		const scrollPos = window.pageYOffset;
 		trackClick( 'section nav filter', tabFilter );
 		this.setState( { tabFilter } );
 
@@ -240,7 +241,10 @@ class ThemeShowcase extends React.Component {
 		// In this state: tabFilter = [ Recommended | ##All(1)## ]  tier = [ All(2) | Free | ##Premium## ]
 		// Clicking "Recommended" forces tier to be "all", since Recommend themes cannot filter on tier.
 		if ( tabFilter.key !== this.tabFilters.ALL.key && 'all' !== this.props.tier ) {
-			callback = () => this.onTierSelect( { value: 'all' } );
+			callback = () => {
+				this.onTierSelect( { value: 'all' } );
+				window.scrollTo( 0, scrollPos );
+			};
 		}
 		this.setState( { tabFilter }, callback );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remember the browser's scroll position when clicking a tab in the tab filter, and scroll to that position after triggering the state change.
* This feels a bit hacky? I'm open to other suggestions. 
* I believe scroll position is preserved for "All themes" because it uses Infinite Scroll, which has built-in memory. The other queries don't use infinite scroll.

Fixes #54651

**Before**

![2021-07-29 15 57 14](https://user-images.githubusercontent.com/2124984/127558192-58df846a-c9e2-4ab1-bcf1-7db3173a1ea8.gif)

**After**

![2021-07-29 15 56 41](https://user-images.githubusercontent.com/2124984/127558240-d9ca4aa5-6470-4be0-975a-a522f6b4b35c.gif)


#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]`
* Scroll down a little before clicking on any of the tabs
* Your scroll position should stay the same regardless of which tab you click on