### PR TITLE
Theme Showcase: Set higher z-index on search bar

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -124,6 +124,7 @@ $z-layers: (
 		'.screen-options-tab': 179,
 		'.app-banner': 180,
 		'.masterbar': 180,
+		'.themes-magic-search': 180,
 		'.gdpr-banner': 185,
 		'.legal-updates-banner': 185,
 		'.detail-page__backdrop': 190,

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -3,6 +3,8 @@
  */
 .themes-magic-search {
 	margin-top: 24px;
+	position: relative;
+	z-index: z-index( 'root', '.themes-magic-search' );
 }
 
 .themes-magic-search-card {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Applies the fix @andres-blanco suggested and sets a higher z-index on the theme search bar to prevent overlap by the Screen options tab on scroll 

**Before**

<img width="1394" alt="Screen Shot 2021-07-29 at 4 22 22 PM" src="https://user-images.githubusercontent.com/2124984/127560600-e0eb1aa0-f188-418c-8c5b-9eed2ff0b581.png">

**After**

![2021-07-29 16 17 56](https://user-images.githubusercontent.com/2124984/127560527-3c401278-5609-4bba-9ce9-44e4468b638c.gif)


#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]`
* Scroll down the page until the search bar sticks to the top
* The Screen Options tab should be underneath the search bar
* You should still be able to access the search and filters as usual, both on desktop and mobile

Fixes #54252
