### PR TITLE
Display FSE theme tab when current enabled theme supports FSE

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -30,6 +30,7 @@ import ThemesSearchCard from './themes-magic-search-card';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import {
 	getActiveTheme,
+	getCanonicalTheme,
 	getThemeFilterTerms,
 	getThemeFilterToTermTable,
 	getThemeShowcaseDescription,
@@ -80,16 +81,14 @@ class ThemeShowcase extends React.Component {
 				key: 'recommended',
 				text: props.translate( 'Recommended' ),
 				order: 1,
-				show: true,
 			},
-			TRENDING: { key: 'trending', text: props.translate( 'Trending' ), order: 2, show: true },
+			TRENDING: { key: 'trending', text: props.translate( 'Trending' ), order: 2 },
 			MYTHEMES: {
 				key: 'my-themes',
 				text: props.translate( 'My Themes' ),
 				order: 3,
-				show: this.props.isJetpackSite,
 			},
-			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4, show: true },
+			ALL: { key: 'all', text: props.translate( 'All Themes' ), order: 4 },
 			FSE: {
 				key: 'fse',
 				text: (
@@ -101,7 +100,6 @@ class ThemeShowcase extends React.Component {
 					</span>
 				),
 				order: 5,
-				show: config.isEnabled( 'gutenboarding/site-editor' ),
 			},
 		};
 		this.state = {
@@ -266,6 +264,25 @@ class ThemeShowcase extends React.Component {
 		);
 	};
 
+	shouldShowTab = ( key ) => {
+		switch ( key ) {
+			case this.tabFilters.RECOMMENDED.key:
+			case this.tabFilters.TRENDING.key:
+			case this.tabFilters.ALL.key:
+				return true;
+			case this.tabFilters.MYTHEMES.key:
+				return this.props.isJetpackSite;
+			case this.tabFilters.FSE.key:
+				// Display FSE tab if feature flag is enabled or if current theme is already FSE-enabled.
+				return (
+					config.isEnabled( 'gutenboarding/site-editor' ) ||
+					this.props.currentTheme?.taxonomies?.theme_feature?.some(
+						( f ) => f.slug === 'block-templates'
+					)
+				);
+		}
+	};
+
 	render() {
 		const {
 			siteId,
@@ -384,7 +401,7 @@ class ThemeShowcase extends React.Component {
 									.sort( ( a, b ) => a.order - b.order )
 									.map(
 										( tabFilter ) =>
-											tabFilter.show && (
+											this.shouldShowTab( tabFilter.key ) && (
 												<NavItem
 													key={ tabFilter.key }
 													onClick={ () => this.onFilterClick( tabFilter ) }
@@ -415,16 +432,21 @@ class ThemeShowcase extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
-	currentThemeId: getActiveTheme( state, siteId ),
-	isLoggedIn: isUserLoggedIn( state ),
-	siteSlug: getSiteSlug( state, siteId ),
-	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
-	title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
-	subjects: getThemeFilterTerms( state, 'subject' ) || {},
-	filterString: prependThemeFilterKeys( state, filter ),
-	filterToTermTable: getThemeFilterToTermTable( state ),
-	themesBookmark: getThemesBookmark( state ),
-} );
+const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
+	const currentThemeId = getActiveTheme( state, siteId );
+	const currentTheme = getCanonicalTheme( state, siteId, currentThemeId );
+	return {
+		currentThemeId,
+		currentTheme,
+		isLoggedIn: isUserLoggedIn( state ),
+		siteSlug: getSiteSlug( state, siteId ),
+		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
+		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
+		subjects: getThemeFilterTerms( state, 'subject' ) || {},
+		filterString: prependThemeFilterKeys( state, filter ),
+		filterToTermTable: getThemeFilterToTermTable( state ),
+		themesBookmark: getThemesBookmark( state ),
+	};
+};
 
 export default connect( mapStateToProps, null )( localize( ThemeShowcase ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the logic which checks when to display which tabs on the Theme Showcase search bar. Specifically, it enables the "Full Site Editing (Beta)" tab in two scenarios instead of just one; in addition to showing it when the `gutenboarding/site-editor` feature flag is enabled (which was already the case), it also displays the tab when the site's current theme is already FSE-enabled.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/themes/{SITE_URL}` on a site which does not have an FSE-enabled theme active.
* Verify that "Full Site Editing" tab does not exist in search bar.
* Enable the FSE feature flag by updating the URL to `/themes/{SITE_URL}?flags=gutenboarding/site-editor`
* Verify that "Full Site Editing" tab is now shown.
* Use "Full Site Editing" tab to enable an FSE theme on your site.
* In a new tab, navigate to `/themes/{SITE_URL}` (no feature flag) for the same site.
* Verify that, now that the site has an FSE theme enabled, the tab displays regardless of the flag.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54820
