### PR TITLE
My Home/DotPager: Add animation to DotPager when content height changed

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import React, { Children, useState } from 'react';
+import React, { Children, useState, useEffect, useRef } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import classnames from 'classnames';
 import { Icon, arrowRight } from '@wordpress/icons';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Style dependencies
@@ -68,17 +69,40 @@ const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setC
 	);
 };
 
-export const DotPager = ( { showControlLabels = false, children, className, ...props } ) => {
+export const DotPager = ( {
+	showControlLabels = false,
+	hasDynamicHeight = false,
+	children,
+	className,
+	...props
+} ) => {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
+	const pagesRef = useRef();
+	const [ resizeObserver, sizes ] = useResizeObserver();
+
+	useEffect( () => {
+		if ( ! hasDynamicHeight ) {
+			return;
+		}
+
+		const targetHeight = pagesRef.current?.children[ currentPage ]?.offsetHeight;
+
+		pagesRef.current.style.setProperty(
+			'height',
+			targetHeight ? `${ targetHeight }px` : undefined
+		);
+	}, [ hasDynamicHeight, currentPage, sizes.width ] );
+
 	return (
 		<div className={ className } { ...props }>
+			{ resizeObserver }
 			<Controls
 				showControlLabels={ showControlLabels }
 				currentPage={ currentPage }
 				numberOfPages={ Children.count( children ) }
 				setCurrentPage={ setCurrentPage }
 			/>
-			<div className="dot-pager__pages">
+			<div className="dot-pager__pages" ref={ pagesRef }>
 				{ Children.map( children, ( child, index ) => (
 					<div
 						className={ classnames( 'dot-pager__page', {

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -77,6 +77,7 @@ export const DotPager = ( {
 	...props
 } ) => {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
+	const [ pagesStyle, setPagesStyle ] = useState();
 	const pagesRef = useRef();
 	const [ resizeObserver, sizes ] = useResizeObserver();
 
@@ -87,11 +88,8 @@ export const DotPager = ( {
 
 		const targetHeight = pagesRef.current?.children[ currentPage ]?.offsetHeight;
 
-		pagesRef.current.style.setProperty(
-			'height',
-			targetHeight ? `${ targetHeight }px` : undefined
-		);
-	}, [ hasDynamicHeight, currentPage, sizes.width ] );
+		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
+	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle ] );
 
 	return (
 		<div className={ className } { ...props }>
@@ -102,7 +100,7 @@ export const DotPager = ( {
 				numberOfPages={ Children.count( children ) }
 				setCurrentPage={ setCurrentPage }
 			/>
-			<div className="dot-pager__pages" ref={ pagesRef }>
+			<div className="dot-pager__pages" ref={ pagesRef } style={ pagesStyle }>
 				{ Children.map( children, ( child, index ) => (
 					<div
 						className={ classnames( 'dot-pager__page', {

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -3,7 +3,10 @@
 .dot-pager__pages {
 	overflow: hidden;
 	display: flex;
+	align-items: flex-start;
 	position: relative;
+	transition: height 0.5s ease-in-out;
+	@include reduce-motion( 'transition' );
 }
 
 .dot-pager__page {
@@ -17,7 +20,6 @@
 	&.is-prev,
 	&.is-next {
 		opacity: 0;
-		position: absolute;
 	}
 
 	&.is-prev {
@@ -65,7 +67,7 @@
 }
 
 .dot-pager__control-prev,
-.dot-pager__control-next, {
+.dot-pager__control-next {
 	display: inline-flex;
 
 	svg {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -79,7 +79,11 @@ const Primary = ( { cards, trackCards } ) => {
 	}
 
 	return (
-		<DotPager className="primary__customer-home-location-content" showControlLabels="true">
+		<DotPager
+			className="primary__customer-home-location-content"
+			showControlLabels="true"
+			hasDynamicHeight
+		>
 			{ cards.map(
 				( card, index ) =>
 					cardComponents[ card ] &&

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -38,7 +38,7 @@ const LearnGrow = () => {
 	}
 
 	return (
-		<DotPager className="learn-grow__content customer-home__card">
+		<DotPager className="learn-grow__content customer-home__card" hasDynamicHeight>
 			{ cards.map(
 				( card, index ) =>
 					cardComponents[ card ] &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Animate the change in DotPager height when switching between pages.

https://user-images.githubusercontent.com/13596067/127595201-a73f4c81-209f-4f1c-8814-a7c4a4760ded.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Home
* Add the `?view=VIEW_POST_LAUNCH` query param to the live branch
* Click around between the tabs.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55006
