### PR TITLE
Avoid zoom in 5x for LoginForm

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -95,7 +95,7 @@ export class LoginForm extends Component {
 		const { disableAutoFocus } = this.props;
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isFormDisabledWhileLoading: false }, () => {
-			! disableAutoFocus && this.usernameOrEmail && this.usernameOrEmail.focus();
+			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
 		} );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* iPhone safari will automatically zoom in if font size of input is smaller than **16px**. However, even if the font size of text input in our login has font size 1rem (which is equal to 16px in our site), it still zoom in. Besides, the `window.visualViewport.scale` value is 1.4 normally but it becomes 5 in our login form. I'm not sure the truly reason, so I just use `defer` to avoid this problem. Any ideas?

Before

https://user-images.githubusercontent.com/13596067/127646629-b37b2197-8acb-405e-9941-efe9f19251cf.mp4

After

https://user-images.githubusercontent.com/13596067/127646671-892c1a84-cbf5-4829-b97d-07ecc5de4bb9.mp4

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.localhost:3000 on iPhone safari
* Click **Log In**
* Check the view is zooming in or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
