### PR TITLE
Nav Unification: Use post type for checking preferred editor view

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -192,8 +192,8 @@ export const redirect = async ( context, next ) => {
 		return next();
 	}
 
-	if ( ! shouldLoadGutenframe( state, siteId ) ) {
-		const postType = determinePostType( context );
+	const postType = determinePostType( context );
+	if ( ! shouldLoadGutenframe( state, siteId, postType ) ) {
 		const postId = getPostID( context );
 
 		const url =

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -771,7 +771,7 @@ const mapState = ( state, props ) => {
 		copyPagesModuleDisabled:
 			! isJetpackModuleActive( state, pageSiteId, 'copy-post' ) &&
 			isJetpackSite( state, pageSiteId ),
-		wpAdminGutenberg: ! shouldLoadGutenframe( state, pageSiteId ),
+		wpAdminGutenberg: ! shouldLoadGutenframe( state, pageSiteId, 'page' ),
 		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
 		isFullSiteEditing: isSiteUsingFullSiteEditing( state, pageSiteId ),
 		canManageOptions: canCurrentUser( state, pageSiteId, 'manage_options' ),

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -9,7 +9,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
 export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	if ( ! shouldLoadGutenframe( state, siteId ) ) {
+	if ( ! shouldLoadGutenframe( state, siteId, postType ) ) {
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
 		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
 

--- a/client/state/selectors/get-preferred-editor-view.js
+++ b/client/state/selectors/get-preferred-editor-view.js
@@ -4,7 +4,7 @@
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 
-export const getPreferredEditorView = ( state, siteId ) => {
+export const getPreferredEditorView = ( state, siteId, postType = 'post' ) => {
 	if ( ! isNavUnificationEnabled( state ) ) {
 		return 'default';
 	}
@@ -13,7 +13,11 @@ export const getPreferredEditorView = ( state, siteId ) => {
 	if ( ! menu ) {
 		return 'default';
 	}
-	const postsMenuItem = menu.find( ( item ) => item.slug === 'edit-php' );
+	let menuSlug = 'edit-php';
+	if ( postType !== 'post' ) {
+		menuSlug += `post_type${ postType }`;
+	}
+	const postsMenuItem = menu.find( ( item ) => item.slug === menuSlug );
 	if ( ! postsMenuItem ) {
 		return 'default';
 	}

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -4,7 +4,8 @@
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import { getPreferredEditorView } from 'calypso/state/selectors/get-preferred-editor-view';
 
-export const shouldLoadGutenframe = ( state, siteId ) =>
-	isEligibleForGutenframe( state, siteId ) && getPreferredEditorView( state, siteId ) === 'default';
+export const shouldLoadGutenframe = ( state, siteId, postType = 'post' ) =>
+	isEligibleForGutenframe( state, siteId ) &&
+	getPreferredEditorView( state, siteId, postType ) === 'default';
 
 export default shouldLoadGutenframe;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/55057

#### Changes proposed in this Pull Request

We're mistakenly checking the preferred view for Posts when deciding which editor view should be loaded for other posts types such as Pages. To fix that, this PR ensures that the preferred view for the given post type is checked.

#### Testing instructions

- Use the Calypso live link below.
- Go to Posts > All posts.
- Open the "Screen Options" tab and switch to the "Classic View".
- You'll be in WP Admin, so use again the Calypso link below.
- Go to Pages > All pages
- Make sure you’re using the Default View.
- Edit any page.
- Make sure the Calypso editor is loaded.
