### PR TITLE
Emails: Create checklist setup card for Professional Emails

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -3,6 +3,7 @@ import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
+import { emailManagement } from 'calypso/my-sites/email/paths';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
@@ -200,6 +201,18 @@ export const getTask = (
 				actionText: translate( 'Choose a theme' ),
 				isSkippable: false,
 				actionUrl: `/themes/${ siteSlug }`,
+			};
+			break;
+		case CHECKLIST_KNOWN_TASKS.PROFESSIONAL_EMAIL_MAILBOX_CREATED:
+			taskData = {
+				timing: 2,
+				title: translate( 'Set up your Professional Email' ),
+				description: translate(
+					'Complete your Professional Email setup to start sending and receiving emails from your custom domain today.'
+				),
+				actionText: translate( 'Complete setup' ),
+				isSkippable: false,
+				actionUrl: emailManagement( siteSlug, task.domain ),
 			};
 			break;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -37,6 +37,8 @@ const isTaskDisabled = (
 			return 'requesting' === emailVerificationStatus || ! isEmailUnverified;
 		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			return isDomainUnverified;
+		case CHECKLIST_KNOWN_TASKS.PROFESSIONAL_EMAIL_MAILBOX_CREATED:
+			return task.isCompleted;
 		default:
 			return false;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -3,7 +3,7 @@ import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
-import { emailManagement } from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetupMailbox } from 'calypso/my-sites/email/paths';
 import { requestSiteChecklistTaskUpdate } from 'calypso/state/checklist/actions';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
@@ -214,7 +214,7 @@ export const getTask = (
 				),
 				actionText: translate( 'Complete setup' ),
 				isSkippable: false,
-				actionUrl: emailManagement( siteSlug, task.domain ),
+				actionUrl: emailManagementTitanSetupMailbox( siteSlug, task.domain ),
 			};
 			break;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -25,6 +25,9 @@ import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
 import NavItem from './nav-item';
 
+/**
+ * Import Styles
+ */
 import './style.scss';
 
 const startTask = ( dispatch, task, siteId, advanceToNextIncompleteTask, isPodcastingSite ) => {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -28,6 +28,7 @@ export const CHECKLIST_KNOWN_TASKS = {
 	JETPACK_LAZY_IMAGES: 'jetpack_lazy_images',
 	JETPACK_VIDEO_HOSTING: 'jetpack_video_hosting',
 	JETPACK_SEARCH: 'jetpack_search',
+	PROFESSIONAL_EMAIL_MAILBOX_CREATED: 'professional_email_mailbox_created',
 };
 
 // Transform the response to a data / schema calypso understands, eg filter out unknown tasks


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add task to complete Professional email setup
![image](https://user-images.githubusercontent.com/5689927/127674312-af18c65e-1101-4070-a29b-20e6df116a13.png)



#### Testing instructions

1. Have a new site created from the onboarding steps
2. Go to dashboard
3. Check tasks lists
4. One of the tasks to complete should be "Setup your professional Email"
5. Complete the setup -> The task should be marked as completed.

A completed task looks like:
![image](https://user-images.githubusercontent.com/5689927/127674132-a4f0c6fe-4832-4fb8-8604-6977710f27c8.png)


Related to {1200182182542585-as-1200588428897562}
