### PR TITLE
Notifications: Fix Slideshow block images

### DIFF
--- a/apps/notifications/src/panel/templates/body.jsx
+++ b/apps/notifications/src/panel/templates/body.jsx
@@ -114,6 +114,31 @@ export class NoteBody extends React.Component {
 					);
 					break;
 				case 'post':
+					let slideCount = 0;
+					for ( i = 0; i < block.block.ranges.length; i++ ) {
+						if ( block.block.ranges[ i ].type === 'figcaption' ) {
+							block.block.ranges[ i ].style += 'display:none;';
+						}
+
+						if (
+							block.block.ranges[ i ].class &&
+							block.block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_slide' )
+						) {
+							slideCount++;
+							block.block.ranges[ i ].style = 'display:flex;height:100%;width:100%;padding:2px;';
+							if ( slideCount > 4 ) {
+								block.block.ranges[ i ].style += 'display:none;';
+							}
+						}
+
+						if (
+							block.block.ranges[ i ].class &&
+							block.block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_container' )
+						) {
+							block.block.ranges[ i ].style = 'width:100%';
+						}
+					}
+
 					body.push(
 						<Post key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
 					);

--- a/apps/notifications/src/panel/templates/body.jsx
+++ b/apps/notifications/src/panel/templates/body.jsx
@@ -84,6 +84,7 @@ export class NoteBody extends React.Component {
 		for ( i = 0; i < blocks.length; i++ ) {
 			const block = blocks[ i ];
 			const blockKey = 'block-' + this.props.note.id + '-' + i;
+			let slideCount = 0;
 
 			if ( block.block.actions && 'user' !== block.signature.type ) {
 				actions = (
@@ -114,7 +115,7 @@ export class NoteBody extends React.Component {
 					);
 					break;
 				case 'post':
-					let slideCount = 0;
+					slideCount = 0;
 					for ( i = 0; i < block.block.ranges.length; i++ ) {
 						if ( block.block.ranges[ i ].type === 'figcaption' ) {
 							block.block.ranges[ i ].style += 'display:none;';

--- a/apps/notifications/src/panel/templates/body.jsx
+++ b/apps/notifications/src/panel/templates/body.jsx
@@ -7,7 +7,7 @@ import NoteActions from './actions';
 import Comment from './block-comment';
 import Post from './block-post';
 import User from './block-user';
-import { p, zipWithSignature } from './functions';
+import { p, zipWithSignature, fixBlockFormatting } from './functions';
 import NotePreface from './preface';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -84,7 +84,6 @@ export class NoteBody extends React.Component {
 		for ( i = 0; i < blocks.length; i++ ) {
 			const block = blocks[ i ];
 			const blockKey = 'block-' + this.props.note.id + '-' + i;
-			let slideCount = 0;
 
 			if ( block.block.actions && 'user' !== block.signature.type ) {
 				actions = (
@@ -115,33 +114,12 @@ export class NoteBody extends React.Component {
 					);
 					break;
 				case 'post':
-					slideCount = 0;
-					for ( i = 0; i < block.block.ranges.length; i++ ) {
-						if ( block.block.ranges[ i ].type === 'figcaption' ) {
-							block.block.ranges[ i ].style += 'display:none;';
-						}
-
-						if (
-							block.block.ranges[ i ].class &&
-							block.block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_slide' )
-						) {
-							slideCount++;
-							block.block.ranges[ i ].style = 'display:flex;height:100%;width:100%;padding:2px;';
-							if ( slideCount > 4 ) {
-								block.block.ranges[ i ].style += 'display:none;';
-							}
-						}
-
-						if (
-							block.block.ranges[ i ].class &&
-							block.block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_container' )
-						) {
-							block.block.ranges[ i ].style = 'width:100%';
-						}
-					}
-
 					body.push(
-						<Post key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+						<Post
+							key={ blockKey }
+							block={ fixBlockFormatting( block.block ) }
+							meta={ this.props.note.meta }
+						/>
 					);
 					break;
 				case 'reply':

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -297,27 +297,25 @@ export const linkProps = ( note, block ) => {
 export function fixBlockFormatting( block ) {
 	let slideCount = 0;
 	let i = 0;
+	let range;
+
 	for ( i = 0; i < block.ranges.length; i++ ) {
-		if ( block.ranges[ i ].type === 'figcaption' ) {
-			block.ranges[ i ].style += 'display:none;';
+		range = block.ranges[ i ];
+
+		if ( range.type === 'figcaption' ) {
+			range.style += 'display:none;';
 		}
 
-		if (
-			block.ranges[ i ].class &&
-			block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_slide' )
-		) {
+		if ( range.class && range.class.includes( 'wp-block-jetpack-slideshow_slide' ) ) {
 			slideCount++;
-			block.ranges[ i ].style = 'display:flex;height:100%;width:100%;padding:2px;';
+			range.style = 'display:flex;height:100%;width:100%;padding:2px;';
 			if ( slideCount > 4 ) {
-				block.ranges[ i ].style += 'display:none;';
+				range.style += 'display:none;';
 			}
 		}
 
-		if (
-			block.ranges[ i ].class &&
-			block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_container' )
-		) {
-			block.ranges[ i ].style = 'width:100%';
+		if ( range.class && range.class.includes( 'wp-block-jetpack-slideshow_container' ) ) {
+			range.style = 'width:100%';
 		}
 	}
 

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -293,3 +293,33 @@ export const linkProps = ( note, block ) => {
 			return {};
 	}
 };
+
+export function fixBlockFormatting( block ) {
+	let slideCount = 0;
+	let i = 0;
+	for ( i = 0; i < block.ranges.length; i++ ) {
+		if ( block.ranges[ i ].type === 'figcaption' ) {
+			block.ranges[ i ].style += 'display:none;';
+		}
+
+		if (
+			block.ranges[ i ].class &&
+			block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_slide' )
+		) {
+			slideCount++;
+			block.ranges[ i ].style = 'display:flex;height:100%;width:100%;padding:2px;';
+			if ( slideCount > 4 ) {
+				block.ranges[ i ].style += 'display:none;';
+			}
+		}
+
+		if (
+			block.ranges[ i ].class &&
+			block.ranges[ i ].class.includes( 'wp-block-jetpack-slideshow_container' )
+		) {
+			block.ranges[ i ].style = 'width:100%';
+		}
+	}
+
+	return block;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Slideshow block images are not displayed in the post notifications:
https://github.com/Automattic/wp-calypso/issues/46964

The proposed code address this issue by overriding the Slideshow block CSS.

We also make sure the notification displays a maximum of four Slideshow images.

This is due to limited notification space.

#### Testing instructions

1. Make sure there is a subscriber on your site that can receive notifications on newly published posts.

Notification settings are located in the subscriber's account at `/following/manage` → ⚙️ Settings → "Notify me of new posts" (toggle):

![Markup_on_2021-07-29_at_15_35_56](https://user-images.githubusercontent.com/25105483/127670085-0ca7a053-6f1f-4122-9610-9f8692f1c5ad.png)

2. Log in to the account of the user that can publish posts on the site.
3. Create and publish a new post that has the Slideshow block with multiple images in it.
4. Review the notification in the subscriber's account. The Slideshow images should display:

![Markup on 2021-07-30 at 16:45:13](https://user-images.githubusercontent.com/25105483/127670341-83f3640f-af19-4bc2-a5fb-0c7b90e5f3af.png)

Please note that the proposed change is work in progress.