### PR TITLE
Jetpack site-less Checkout: send both the receipt and the event id to `/onboarding-call`

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/utils.js
+++ b/client/my-sites/checkout/checkout-thank-you/utils.js
@@ -13,11 +13,12 @@ export function getDomainManagementUrl( { slug }, domain ) {
  * Send a POST request to update the ZD ticket linked to the given receiptId.
  *
  * @param receiptId number – Receipt unique identifier.
+ * @param eventId number – Calendly event unique identifier.
  */
-export async function addOnboardingCallInternalNote( receiptId ) {
+export async function addOnboardingCallInternalNote( receiptId, eventId ) {
 	return await wpcom.req.post( {
 		path: addQueryArgs(
-			{ receipt_id: receiptId },
+			{ receipt_id: receiptId, event_id: eventId },
 			'/jetpack-checkout/support-ticket/onboarding-call'
 		),
 		apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Send the event ID as a query parameter.

#### Testing instructions

* Download this PR.
* Run Calypso with `yarn start`.
* Open the network tab.
* Schedule an onboarding call.
* On the network tab, search for a call to `/support-ticket/onboarding-call`.
* Make sure the request the `event_id` query parameter with a string value.

Related to 1200479326344990-as-1200693956107463

#### Demo
![image](https://user-images.githubusercontent.com/3418513/127673373-0b49ef49-41e2-4275-aeaa-6ff3650d07fe.png)
