### PR TITLE
Setup Mailbox: Redirect to new Thank You page on successful creation

### DIFF
--- a/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
+++ b/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
@@ -18,16 +18,16 @@ import {
 	decorateMailboxWithAvailabilityError,
 	validateMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
-import { emailManagement } from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetupThankYouPage } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-const getMailboxDomainName = ( mailbox ) => mailbox?.domain?.value;
-const getMailboxUserName = ( mailbox ) => mailbox?.mailbox?.value;
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
 import { useCreateTitanMailboxMutation } from 'calypso/data/emails/use-create-titan-mailbox-mutation';
 import { useGetTitanMailboxAvailability } from 'calypso/data/emails/use-get-titan-mailbox-availability';
+
+const getMailboxDomainName = ( mailbox ) => mailbox?.domain?.value;
+const getMailboxUserName = ( mailbox ) => mailbox?.mailbox?.value;
 
 const recordCompleteSetupClickEvent = ( canContinue, mailbox ) => {
 	return recordTracksEvent(
@@ -51,11 +51,15 @@ const useHandleSetupAction = (
 	const mailbox = mailboxes[ 0 ];
 
 	const selectedSite = useSelector( getSelectedSite );
-	const currentRoute = useSelector( getCurrentRoute );
 
-	const goToThankYouPage = () => {
-		// TODO: Change the destination to the Thank You page once it's ready
-		page( emailManagement( selectedSite?.slug ?? null, selectedDomainName, currentRoute ) );
+	const goToThankYouPage = ( emailAddress ) => {
+		page(
+			emailManagementTitanSetupThankYouPage(
+				selectedSite?.slug ?? null,
+				selectedDomainName,
+				emailAddress
+			)
+		);
 	};
 
 	const {
@@ -126,7 +130,11 @@ const useHandleSetupAction = (
 		try {
 			await createTitanMailbox();
 
-			goToThankYouPage();
+			const emailAddress = `${ getMailboxUserName( mailbox ) }@${ getMailboxDomainName(
+				mailbox
+			) }`;
+
+			goToThankYouPage( emailAddress );
 		} catch ( createError ) {
 			dispatch( errorNotice( createError.message ) );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a follow up to #54934. It changes the success destination URL to the new Thank You page once a mailbox has been successfully created. That page was still a WIP when #54934 merged.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The tests for #54934 can be adapted here. However ...

* Confirm that you are redirected to the new Thank You page, rather than the Email Plan page once a mailbox has been successfully created.


