### PR TITLE
Display translated strings in cloud pricing page nav

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
-import { translate } from 'i18n-calypso';
-import React, { useCallback, useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import React, { useCallback, useMemo, useState } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -18,95 +18,99 @@ import searchIcon from './assets/icons/search.svg';
 import securityIcon from './assets/icons/security.svg';
 
 const JETPACK_COM_BASE_URL = 'https://jetpack.com';
-const MENU_ITEMS = [
-	{
-		label: translate( 'Products' ),
-		items: [
-			{
-				category: {
-					label: translate( 'Security' ),
-					description: translate( 'Protect your site' ),
-					href: '/features/security/',
-					icon: securityIcon,
-				},
-				items: [
-					{
-						label: translate( 'Backup' ),
-						description: translate( 'Save every change' ),
-						href: '/upgrade/backup/',
-						icon: backupIcon,
-					},
-					{
-						label: translate( 'Scan' ),
-						description: translate( 'Stay one step ahead of threats' ),
-						href: '/upgrade/scan/',
-						icon: scanIcon,
-					},
-					{
-						label: translate( 'Anti-spam' ),
-						description: translate( 'Stop comment and form spam' ),
-						href: '/upgrade/anti-spam/',
-						icon: antiSpamIcon,
-					},
-				],
-			},
-			{
-				category: {
-					label: translate( 'Performance' ),
-					description: translate( 'Speed up your site' ),
-					href: '/features/performance/',
-					icon: performanceIcon,
-				},
-				items: [
-					{
-						label: translate( 'Site Search' ),
-						description: translate( 'Help them find what they need' ),
-						href: '/upgrade/search/',
-						icon: searchIcon,
-					},
-					{
-						label: translate( 'Boost' ),
-						description: translate( 'Instant speed and SEO' ),
-						href: '/boost/',
-						icon: boostIcon,
-					},
-				],
-			},
-			{
-				category: {
-					label: translate( 'Growth' ),
-					description: translate( 'Grow your audience' ),
-					href: '/features/growth/',
-					icon: growthIcon,
-				},
-				items: [
-					{
-						label: translate( 'CRM' ),
-						description: translate( 'Connect with your people' ),
-						href: 'https://jetpackcrm.com/',
-						icon: crmIcon,
-					},
-				],
-			},
-		],
-	},
-	{
-		label: translate( 'Pricing' ),
-		href: '/pricing/',
-	},
-	{
-		label: translate( 'Support' ),
-		href: '/support/',
-	},
-	{
-		label: translate( 'Blog' ),
-		href: '/blog/',
-	},
-];
-
-const bp = 960; // Breakpoint defined in stylesheet
+const BP = 960; // Breakpoint defined in stylesheet
 
 const JetpackComMasterbar: React.FC = () => {
+	const translate = useTranslate();
+	const menuItems = useMemo(
+		() => [
+			{
+				label: translate( 'Products' ),
+				items: [
+					{
+						category: {
+							label: translate( 'Security' ),
+							description: translate( 'Protect your site' ),
+							href: '/features/security/',
+							icon: securityIcon,
+						},
+						items: [
+							{
+								label: translate( 'Backup' ),
+								description: translate( 'Save every change' ),
+								href: '/upgrade/backup/',
+								icon: backupIcon,
+							},
+							{
+								label: translate( 'Scan' ),
+								description: translate( 'Stay one step ahead of threats' ),
+								href: '/upgrade/scan/',
+								icon: scanIcon,
+							},
+							{
+								label: translate( 'Anti-spam' ),
+								description: translate( 'Stop comment and form spam' ),
+								href: '/upgrade/anti-spam/',
+								icon: antiSpamIcon,
+							},
+						],
+					},
+					{
+						category: {
+							label: translate( 'Performance' ),
+							description: translate( 'Speed up your site' ),
+							href: '/features/performance/',
+							icon: performanceIcon,
+						},
+						items: [
+							{
+								label: translate( 'Site Search' ),
+								description: translate( 'Help them find what they need' ),
+								href: '/upgrade/search/',
+								icon: searchIcon,
+							},
+							{
+								label: translate( 'Boost' ),
+								description: translate( 'Instant speed and SEO' ),
+								href: '/boost/',
+								icon: boostIcon,
+							},
+						],
+					},
+					{
+						category: {
+							label: translate( 'Growth' ),
+							description: translate( 'Grow your audience' ),
+							href: '/features/growth/',
+							icon: growthIcon,
+						},
+						items: [
+							{
+								label: translate( 'CRM' ),
+								description: translate( 'Connect with your people' ),
+								href: 'https://jetpackcrm.com/',
+								icon: crmIcon,
+							},
+						],
+					},
+				],
+			},
+			{
+				label: translate( 'Pricing' ),
+				href: '/pricing/',
+			},
+			{
+				label: translate( 'Support' ),
+				href: '/support/',
+			},
+			{
+				label: translate( 'Blog' ),
+				href: '/blog/',
+			},
+		],
+		[ translate ]
+	);
+
 	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
 
 	const toggleMenu = () => {
@@ -123,7 +127,7 @@ const JetpackComMasterbar: React.FC = () => {
 	}, [] );
 	const onSubmenuClick = useCallback(
 		( e ) => {
-			if ( window.innerWidth <= bp ) {
+			if ( window.innerWidth <= BP ) {
 				toggleSubmenu( e.currentTarget );
 			}
 		},
@@ -133,7 +137,7 @@ const JetpackComMasterbar: React.FC = () => {
 		( e ) => {
 			const key = e.code || e.key;
 
-			if ( key.indexOf( 'Enter' ) > -1 && window.innerWidth <= bp ) {
+			if ( key.indexOf( 'Enter' ) > -1 && window.innerWidth <= BP ) {
 				toggleSubmenu( e.currentTarget );
 			}
 		},
@@ -173,7 +177,7 @@ const JetpackComMasterbar: React.FC = () => {
 				</Button>
 
 				<ul className={ classNames( 'jpcom-masterbar__nav', { 'is-open': isMenuOpen } ) }>
-					{ MENU_ITEMS.map( ( { label, href, items }, index ) => (
+					{ menuItems.map( ( { label, href, items }, index ) => (
 						<li
 							className={ classNames( 'jpcom-masterbar__nav-item', { 'with-submenu': ! href } ) }
 							key={ index }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes sure that the translated strings are displayed in the navigation of the Jetpack cloud pricing page.

Fixes 1196108640073826-as-1200693763409406

### Implementation notes

Translated strings were moved into the navigation component.

### Testing instructions

- Download the PR and run cloud
- Visit `/pricing`
- Check that the navigation looks as it does in production
- Visit the same page in a different language, e.g. `/fr/pricing`
- Check that the text elements in the navigation are shown in the proper language

_Note: the text briefly shows in english first. This is another issue that this PR doesn't address._