### PR TITLE
Make Jetpack product card button handle long strings

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -275,13 +275,14 @@
 
 .jetpack-product-card__button {
 	width: 100%;
-	height: 45px;
+	padding: 0.875rem 1rem;
 
 	border-radius: ( 2px * 2 );
 	margin-block-start: 32px;
 	margin-block-end: 24px;
 
 	font-size: 1rem;
+	line-height: 1;
 
 	em {
 		font-style: normal;

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -275,14 +275,13 @@
 
 .jetpack-product-card__button {
 	width: 100%;
-	padding: 0.875rem 1rem;
+	padding: 0.625rem 1rem;
 
 	border-radius: ( 2px * 2 );
 	margin-block-start: 32px;
 	margin-block-end: 24px;
 
 	font-size: 1rem;
-	line-height: 1;
 
 	em {
 		font-style: normal;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes the button of the Jetpack product card handle long strings properly. Button label was cut in the pricing page for some languages.

We took advantage of this to center the label vertically too.

Fixes 1164141197617539-as-1200697105068326

### Testing instructions

- Download the PR and run cloud
- Visit `/pricing`
- Check that the label of the product card buttons is centered vertically
- Edit the label of one of the buttons with the inspector, so that it takes multiple lines, and verify that the text isn't cut

### Screenshots

#### Vertically centered

_Before_
<img width="311" alt="Screen Shot 2021-07-30 at 2 35 55 PM" src="https://user-images.githubusercontent.com/1620183/127697822-056baccb-f832-4581-b20b-38390568c20c.png">

_After_
<img width="306" alt="Screen Shot 2021-07-30 at 2 36 15 PM" src="https://user-images.githubusercontent.com/1620183/127697847-9bc55b44-d649-4e9f-a606-74a2af536841.png">


#### Long text

_Before_
<img width="300" alt="Screen Shot 2021-07-30 at 2 35 32 PM" src="https://user-images.githubusercontent.com/1620183/127697866-b4e525de-f637-47a8-a3a8-b4dd7143bbdd.png">

_After_
<img width="294" alt="Screen Shot 2021-07-30 at 2 36 42 PM" src="https://user-images.githubusercontent.com/1620183/127697885-1224859c-c670-4d47-822c-3e52db479034.png">