### PR TITLE
Revert "Theme Showcase: Set higher z-index on search bar"

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -124,7 +124,6 @@ $z-layers: (
 		'.screen-options-tab': 179,
 		'.app-banner': 180,
 		'.masterbar': 180,
-		'.themes-magic-search': 180,
 		'.gdpr-banner': 185,
 		'.legal-updates-banner': 185,
 		'.detail-page__backdrop': 190,

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -3,8 +3,6 @@
  */
 .themes-magic-search {
 	margin-top: 24px;
-	position: relative;
-	z-index: z-index( 'root', '.themes-magic-search' );
 }
 
 .themes-magic-search-card {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#55042

In the theme showcase, we raised the z-index of the search bar to fix a problem with the "Screen Options" tab overlapping it after you scrolled down:

![overlap-screen-options](https://user-images.githubusercontent.com/937354/127700231-ac654871-291f-4429-b171-7080dc7480ea.png)

Unfortunately, this raised a new problem of sidebar menus falling under the search bar:

![overlap-menu](https://user-images.githubusercontent.com/937354/127700108-a70901b5-a142-4090-8d3e-93df7e8fa154.png)

In my testing it looks like the left menu hover is z=175, and the "screen options" is z=179, so there's no way to be over "screen options" but under the menu. So I believe it's better to to reintroduce the "screen options" overlap as it's a lesser problem.
