### PR TITLE
Show prices in LTR direction in cloud pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -172,19 +172,29 @@ const DisplayPrice = ( {
 			{ currencyCode && originalPrice ? (
 				<>
 					{ displayFrom && <span className="jetpack-product-card__price-from">from</span> }
-					<PlanPrice
-						original
-						className="jetpack-product-card__original-price"
-						rawPrice={
-							( billingTerm === TERM_ANNUALLY ? originalPrice : couponOriginalPrice ) as number
-						}
-						currencyCode={ currencyCode }
-					/>
-					<PlanPrice
-						discounted
-						rawPrice={ couponDiscountedPrice as number }
-						currencyCode={ currencyCode }
-					/>
+					{ /*
+					 * Price should be displayed from left-to-right, even in right-to-left
+					 * languages. `PlanPrice` seems to keep the ltr direction no matter
+					 * what when seen in the dev docs page, but somehow it doesn't in
+					 * the pricing page.
+					 */ }
+					<span dir="ltr">
+						<PlanPrice
+							original
+							className="jetpack-product-card__original-price"
+							rawPrice={
+								( billingTerm === TERM_ANNUALLY ? originalPrice : couponOriginalPrice ) as number
+							}
+							currencyCode={ currencyCode }
+						/>
+					</span>
+					<span dir="ltr">
+						<PlanPrice
+							discounted
+							rawPrice={ couponDiscountedPrice as number }
+							currencyCode={ currencyCode }
+						/>
+					</span>
 					{ tooltipText && (
 						<InfoPopover position="top" className="jetpack-product-card__price-tooltip">
 							{ tooltipText }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR shows the prices in the cloud pricing page from left-to-right, even in right-to-left languages.

Fixes 1164141197617539-as-1200697332102700

### Implementation notes

At first, my intention was to apply the fix directly to the `PlanPrice` component. But I visualized it in the dev docs, updated the `dir` attribute in the `html` tag to `rtl`, and the prices were displayed as expected.

I didn't uncover why this behaviour was not kept in the pricing page.

### Testing instructions

- Download the PR and run cloud
- Visit the pricing page in a right-to-left language, e.g. `/he/pricing`
- Check that the prices parts are shown in this order, from left-to-right: currency, integer, decimal

Note that the language switch glitch is not meant to be fixed by this PR.

### Screenshots

**Notice the prices only**

_Before_
![image-7-1](https://user-images.githubusercontent.com/1620183/127703290-0ed42650-e1c9-4bb0-898a-eaf34aae2d8c.png)

_After_
<img width="1067" alt="Screen Shot 2021-07-30 at 3 22 23 PM" src="https://user-images.githubusercontent.com/1620183/127703279-bf373a0c-9cdd-415c-a0e2-7b4a31e48593.png">
