### PR TITLE
Playwright: Revert changes from #54858 relevant to the LoginPage and LoginFlow.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/login-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/login-flow.ts
@@ -56,7 +56,7 @@ export class LoginFlow {
 	 */
 	async logIn(): Promise< void > {
 		await this.page.goto( getCalypsoURL( 'log-in' ) );
-		await this.baseflow();
+		await Promise.all( [ this.page.waitForNavigation(), this.baseflow() ] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -53,10 +53,7 @@ export class LoginPage extends BaseContainer {
 		await this.page.fill( selectors.username, username );
 		await this.page.keyboard.press( 'Enter' );
 		await this.page.fill( selectors.password, password );
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.loginButton ),
-		] );
+		await this.page.click( selectors.loginButton );
 		// make sure after logging in that everything stablizes, so we can continue with the next action!
 		await this.page.waitForLoadState( 'load' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts the behavior of LoginFlow and LoginPage to pre-#54858 state.

Key changes:
- apply `waitForNavigation()` to LoginFlow.logIn method instead of LoginPage.login.

Backgrond details:

After #54858 was merged into `trunk`, I noticed more frequent failures of the `wp-likes__post` spec, specifically relating to the last step (like as logged out user). 

It turns out the application of the `page.waitForNavigation` call to the `LoginPage.login` method leads to a navigation error being thrown by Playwright when the `LoginFlow.logInFromPopup` method is used. This is because the popup window, which is used to perform the login action, closes instead of navigating. 

#### Testing instructions

- [x] TeamCity does not show failure of the `wp-likes__post` test suite.


