### PR TITLE
Add new InlineSupportLink format to Calypso sections

### DIFF
--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -44,6 +44,7 @@ import {
 } from 'calypso/me/concierge/constants';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import titles from 'calypso/me/purchases/titles';
 import PurchasesListHeader from './purchases-list-header';
 
@@ -180,7 +181,14 @@ class PurchasesList extends Component {
 				<FormattedHeader
 					brandFont
 					headerText={ titles.sectionTitle }
-					subHeaderText={ translate( 'View, manage, or cancel your plan and other purchases.' ) }
+					subHeaderText={ translate(
+						'View, manage, or cancel your plan and other purchases. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
+							},
+						}
+					) }
 					align="left"
 				/>
 				<PurchasesNavigation section="activeUpgrades" />

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -71,7 +72,12 @@ export class CommentsManagement extends Component {
 						className="comments__page-heading"
 						headerText={ translate( 'Comments' ) }
 						subHeaderText={ translate(
-							'View, reply to, and manage all the comments across your site.'
+							'View, reply to, and manage all the comments across your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: <InlineSupportLink supportContext="comments" showIcon={ false } />,
+								},
+							}
 						) }
 						align="left"
 						hasScreenOptions

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -12,6 +12,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import { type } from 'calypso/lib/domains/constants';

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -119,13 +119,7 @@ export class List extends React.Component {
 							'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 							{
 								components: {
-									learnMoreLink: (
-										<InlineSupportLink
-											supportLink="https://wordpress.com/support/domains/"
-											supportPostId={ 1988 }
-											showIcon={ false }
-										/>
-									),
+									learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
 								},
 							}
 						) }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -115,7 +115,20 @@ export class List extends React.Component {
 						brandFont
 						className="domain-management__page-heading"
 						headerText={ translate( 'Site Domains' ) }
-						subHeaderText={ translate( 'Manage the domains connected to your site.' ) }
+						subHeaderText={ translate(
+							'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: (
+										<InlineSupportLink
+											supportLink="https://wordpress.com/support/domains/"
+											supportPostId={ 1988 }
+											showIcon={ false }
+										/>
+									),
+								},
+							}
+						) }
 						align="left"
 					/>
 					<div className="domains__header-buttons">

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -194,7 +195,14 @@ class EarningsMain extends Component {
 					brandFont
 					className="earn__page-header"
 					headerText={ translate( 'Earn' ) }
-					subHeaderText={ translate( 'Explore tools to earn money with your site.' ) }
+					subHeaderText={ translate(
+						'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="ads" showIcon={ false } />,
+							},
+						}
+					) }
 					align="left"
 				/>
 				{ this.getHeaderCake() }

--- a/client/my-sites/email/email-header/index.js
+++ b/client/my-sites/email/email-header/index.js
@@ -19,13 +19,7 @@ function EmailHeader( { currentRoute, selectedSite } ) {
 					'Your home base for accessing, setting up, and managing your emails. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
-							learnMoreLink: (
-								<InlineSupportLink
-									supportLink="https://wordpress.com/support/add-email/"
-									supportPostId={ 34087 }
-									showIcon={ false }
-								/>
-							),
+							learnMoreLink: <InlineSupportLink supportContext="emails" showIcon={ false } />,
 						},
 					}
 				) }

--- a/client/my-sites/email/email-header/index.js
+++ b/client/my-sites/email/email-header/index.js
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 
 import './style.scss';
@@ -15,7 +16,18 @@ function EmailHeader( { currentRoute, selectedSite } ) {
 				brandFont
 				headerText={ translate( 'Emails' ) }
 				subHeaderText={ translate(
-					'Your home base for accessing, setting up, and managing your emails.'
+					'Your home base for accessing, setting up, and managing your emails. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink
+									supportLink="https://wordpress.com/support/add-email/"
+									supportPostId={ 34087 }
+									showIcon={ false }
+								/>
+							),
+						},
+					}
 				) }
 				align="left"
 			/>

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import ExporterContainer from 'calypso/my-sites/exporter/container';
@@ -46,7 +47,14 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 					brandFont
 					className="exporter__section-header"
 					headerText={ translate( 'Export Content' ) }
-					subHeaderText={ translate( 'Back up or move your content to another site or platform.' ) }
+					subHeaderText={ translate(
+						'Back up or move your content to another site or platform. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="export" showIcon={ false } />,
+							},
+						}
+					) }
 					align="left"
 					hasScreenOptions
 				/>

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -8,6 +8,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionHeader from 'calypso/components/section-header';
@@ -287,7 +288,14 @@ class SectionImport extends Component {
 					brandFont
 					className="importer__page-heading"
 					headerText={ translate( 'Import Content' ) }
-					subHeaderText={ translate( 'Import content from another website or platform.' ) }
+					subHeaderText={ translate(
+						'Import content from another website or platform. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="import" showIcon={ false } />,
+							},
+						}
+					) }
 					align="left"
 					hasScreenOptions
 				/>

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -18,7 +18,7 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => (
 		{ ! isP2Hub && (
 			<SharingServicesGroup
 				type="publicize"
-				title={ translate( 'Publicize posts {{learnMoreLink}}{{/learnMoreLink}}', {
+				title={ translate( 'Publicize posts {{learnMoreLink/}}', {
 					components: {
 						learnMoreLink: <InlineSupportLink supportContext="publicize" showText={ false } />,
 					},

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -4,6 +4,7 @@ import QueryKeyringConnections from 'calypso/components/data/query-keyring-conne
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryP2Connections from 'calypso/components/data/query-p2-connections';
 import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import SharingServicesGroup from './services-group';
 
@@ -15,7 +16,14 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => (
 		{ ! isP2Hub && <QueryKeyringConnections /> }
 		{ ! isP2Hub && <QueryPublicizeConnections selectedSite /> }
 		{ ! isP2Hub && (
-			<SharingServicesGroup type="publicize" title={ translate( 'Publicize posts' ) } />
+			<SharingServicesGroup
+				type="publicize"
+				title={ translate( 'Publicize posts {{learnMoreLink}}{{/learnMoreLink}}', {
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="publicize" showText={ false } />,
+					},
+				} ) }
+			/>
 		) }
 
 		<QueryKeyringServices />

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -140,7 +140,7 @@ const SharingServicesGroup = ( {
 SharingServicesGroup.propTypes = {
 	isFetching: PropTypes.bool,
 	services: PropTypes.array,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.node.isRequired,
 	type: PropTypes.string.isRequired,
 	expandedService: PropTypes.string,
 };

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -368,13 +368,7 @@ class Media extends Component {
 						'Manage all the media on your site, including images, video, and more. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
-								learnMoreLink: (
-									<InlineSupportLink
-										supportLink="https://wordpress.com/support/media/"
-										supportPostId={ 853 }
-										showIcon={ false }
-									/>
-								),
+								learnMoreLink: <InlineSupportLink supportContext="media" showIcon={ false } />,
 							},
 						}
 					) }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -8,6 +8,7 @@ import VideoEditor from 'calypso/blocks/video-editor';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMedia from 'calypso/components/data/query-media';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import accept from 'calypso/lib/accept';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -364,7 +365,18 @@ class Media extends Component {
 					className="media__page-heading"
 					headerText={ translate( 'Media' ) }
 					subHeaderText={ translate(
-						'Manage all the media on your site, including images, video, and more.'
+						'Manage all the media on your site, including images, video, and more. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink
+										supportLink="https://wordpress.com/support/media/"
+										supportPostId={ 853 }
+										showIcon={ false }
+									/>
+								),
+							},
+						}
 					) }
 					align="left"
 					hasScreenOptions

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -10,6 +10,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { Experiment } from 'calypso/lib/explat';
 import { mapPostStatus } from 'calypso/lib/route';
 import urlSearch from 'calypso/lib/url-search';
 import PostTypeFilter from 'calypso/my-sites/post-type-filter';

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -6,10 +6,10 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { Experiment } from 'calypso/lib/explat';
 import { mapPostStatus } from 'calypso/lib/route';
 import urlSearch from 'calypso/lib/url-search';
 import PostTypeFilter from 'calypso/my-sites/post-type-filter';
@@ -91,8 +91,34 @@ class PagesMain extends React.Component {
 					headerText={ translate( 'Pages' ) }
 					subHeaderText={
 						siteId
-							? translate( 'Create, edit, and manage the pages on your site.' )
-							: translate( 'Create, edit, and manage the pages on your sites.' )
+							? translate(
+									'Create, edit, and manage the pages on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+									{
+										components: {
+											learnMoreLink: (
+												<InlineSupportLink
+													supportLink="https://wordpress.com/support/pages/"
+													supportPostId={ 86 }
+													showIcon={ false }
+												/>
+											),
+										},
+									}
+							  )
+							: translate(
+									'Create, edit, and manage the pages on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+									{
+										components: {
+											learnMoreLink: (
+												<InlineSupportLink
+													supportLink="https://wordpress.com/support/pages/"
+													supportPostId={ 86 }
+													showIcon={ false }
+												/>
+											),
+										},
+									}
+							  )
 					}
 					align="left"
 					hasScreenOptions

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -65,7 +65,7 @@ class PagesMain extends React.Component {
 	render() {
 		const { siteId, search, status, translate, queryType, author } = this.props;
 		const postStatus = mapPostStatus( status );
-
+		const allSites = siteId ? 1 : 2;
 		const query = {
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			search,
@@ -89,37 +89,16 @@ class PagesMain extends React.Component {
 					brandFont
 					className="pages__page-heading"
 					headerText={ translate( 'Pages' ) }
-					subHeaderText={
-						siteId
-							? translate(
-									'Create, edit, and manage the pages on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-									{
-										components: {
-											learnMoreLink: (
-												<InlineSupportLink
-													supportLink="https://wordpress.com/support/pages/"
-													supportPostId={ 86 }
-													showIcon={ false }
-												/>
-											),
-										},
-									}
-							  )
-							: translate(
-									'Create, edit, and manage the pages on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-									{
-										components: {
-											learnMoreLink: (
-												<InlineSupportLink
-													supportLink="https://wordpress.com/support/pages/"
-													supportPostId={ 86 }
-													showIcon={ false }
-												/>
-											),
-										},
-									}
-							  )
-					}
+					subHeaderText={ translate(
+						'Create, edit, and manage the pages on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Create, edit, and manage the pages on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							count: allSites,
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="pages" showIcon={ false } />,
+							},
+						}
+					) }
 					align="left"
 					hasScreenOptions
 				/>

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -65,7 +65,8 @@ class PagesMain extends React.Component {
 	render() {
 		const { siteId, search, status, translate, queryType, author } = this.props;
 		const postStatus = mapPostStatus( status );
-		const allSites = siteId ? 1 : 2;
+		/* Check if All Sites Mode */
+		const isAllSites = siteId ? 1 : 0;
 		const query = {
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			search,
@@ -93,7 +94,7 @@ class PagesMain extends React.Component {
 						'Create, edit, and manage the pages on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						'Create, edit, and manage the pages on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
-							count: allSites,
+							count: isAllSites,
 							components: {
 								learnMoreLink: <InlineSupportLink supportContext="pages" showIcon={ false } />,
 							},

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -47,7 +48,14 @@ class People extends React.Component {
 			case 'email-followers':
 				return translate( 'People who have subscribed to your site using their email address.' );
 			default:
-				return translate( 'Invite contributors to your site and manage their access settings.' );
+				return translate(
+					'Invite contributors to your site and manage their access settings. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="team" showIcon={ false } />,
+						},
+					}
+				);
 		}
 	}
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -8,6 +8,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
@@ -406,7 +407,14 @@ export class PluginsMain extends Component {
 							headerText={ this.props.translate( 'Plugins' ) }
 							align="left"
 							subHeaderText={ this.props.translate(
-								'Add new functionality and integrations to your site with plugins.'
+								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="plugins" showIcon={ false } />
+										),
+									},
+								}
 							) }
 						/>
 						<div className="plugins__main-buttons">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -21,6 +21,7 @@ import QuerySiteRecommendedPlugins from 'calypso/components/data/query-site-reco
 import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -489,7 +490,14 @@ export class PluginsBrowser extends Component {
 							headerText={ this.props.translate( 'Plugins' ) }
 							align="left"
 							subHeaderText={ this.props.translate(
-								'Add new functionality and integrations to your site with plugins.'
+								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="plugins" showIcon={ false } />
+										),
+									},
+								}
 							) }
 						/>
 						<div className="plugins-browser__main-buttons">

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -48,6 +48,7 @@ class PostsMain extends React.Component {
 	render() {
 		const { author, category, search, siteId, statusSlug, tag, translate } = this.props;
 		const status = mapPostStatus( statusSlug );
+		const allSites = siteId ? 1 : 2;
 		const query = {
 			author,
 			category,
@@ -77,37 +78,16 @@ class PostsMain extends React.Component {
 					brandFont
 					className="posts__page-heading"
 					headerText={ translate( 'Posts' ) }
-					subHeaderText={
-						siteId
-							? translate(
-									'Create, edit, and manage the posts on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-									{
-										components: {
-											learnMoreLink: (
-												<InlineSupportLink
-													supportLink="https://wordpress.com/support/posts/"
-													supportPostId={ 84 }
-													showIcon={ false }
-												/>
-											),
-										},
-									}
-							  )
-							: translate(
-									'Create, edit, and manage the posts on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-									{
-										components: {
-											learnMoreLink: (
-												<InlineSupportLink
-													supportLink="https://wordpress.com/support/posts/"
-													supportPostId={ 84 }
-													showIcon={ false }
-												/>
-											),
-										},
-									}
-							  )
-					}
+					subHeaderText={ translate(
+						'Create, edit, and manage the posts on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Create, edit, and manage the posts on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							count: allSites,
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="posts" showIcon={ false } />,
+							},
+						}
+					) }
 					align="left"
 					hasScreenOptions
 				/>

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -78,8 +79,34 @@ class PostsMain extends React.Component {
 					headerText={ translate( 'Posts' ) }
 					subHeaderText={
 						siteId
-							? translate( 'Create, edit, and manage the posts on your site.' )
-							: translate( 'Create, edit, and manage the posts on your sites.' )
+							? translate(
+									'Create, edit, and manage the posts on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+									{
+										components: {
+											learnMoreLink: (
+												<InlineSupportLink
+													supportLink="https://wordpress.com/support/posts/"
+													supportPostId={ 84 }
+													showIcon={ false }
+												/>
+											),
+										},
+									}
+							  )
+							: translate(
+									'Create, edit, and manage the posts on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+									{
+										components: {
+											learnMoreLink: (
+												<InlineSupportLink
+													supportLink="https://wordpress.com/support/posts/"
+													supportPostId={ 84 }
+													showIcon={ false }
+												/>
+											),
+										},
+									}
+							  )
 					}
 					align="left"
 					hasScreenOptions

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -48,7 +48,8 @@ class PostsMain extends React.Component {
 	render() {
 		const { author, category, search, siteId, statusSlug, tag, translate } = this.props;
 		const status = mapPostStatus( statusSlug );
-		const allSites = siteId ? 1 : 2;
+		/* Check if All Sites Mode */
+		const isAllSites = siteId ? 1 : 0;
 		const query = {
 			author,
 			category,
@@ -82,7 +83,7 @@ class PostsMain extends React.Component {
 						'Create, edit, and manage the posts on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						'Create, edit, and manage the posts on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
-							count: allSites,
+							count: isAllSites,
 							components: {
 								learnMoreLink: <InlineSupportLink supportContext="posts" showIcon={ false } />,
 							},

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -17,6 +17,7 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import Gridicon from 'calypso/components/gridicon';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import LanguagePicker from 'calypso/components/language-picker';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -568,7 +569,12 @@ export class SiteSettingsFormGeneral extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Privacy', { context: 'Privacy Settings header' } ) }
+					title={ translate( 'Privacy {{learnMoreLink}}{{/learnMoreLink}}', {
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="privacy" showText={ false } />,
+						},
+						context: 'Privacy Settings header',
+					} ) }
 				/>
 				<Card>
 					<form> { this.visibilityOptionsComingSoon() }</form>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -573,7 +573,7 @@ export class SiteSettingsFormGeneral extends Component {
 						components: {
 							learnMoreLink: <InlineSupportLink supportContext="privacy" showText={ false } />,
 						},
-						context: 'Privacy Settings header',
+						comment: 'Privacy Settings header',
 					} ) }
 				/>
 				<Card>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -569,7 +569,7 @@ export class SiteSettingsFormGeneral extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Privacy {{learnMoreLink}}{{/learnMoreLink}}', {
+					title={ translate( 'Privacy {{learnMoreLink/}}', {
 						components: {
 							learnMoreLink: <InlineSupportLink supportContext="privacy" showText={ false } />,
 						},

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -21,7 +22,14 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 			brandFont
 			className="settings-discussion__page-heading"
 			headerText={ translate( 'Discussion Settings' ) }
-			subHeaderText={ translate( 'Control how people interact with your site through comments.' ) }
+			subHeaderText={ translate(
+				'Control how people interact with your site through comments. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="discussion" showIcon={ false } />,
+					},
+				}
+			) }
 			align="left"
 			hasScreenOptions
 		/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -194,13 +194,7 @@ class StatsSite extends Component {
 						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
 						{
 							components: {
-								learnMoreLink: (
-									<InlineSupportLink
-										supportLink="https://wordpress.com/support/stats/"
-										supportPostId={ 4454 }
-										showIcon={ false }
-									/>
-								),
+								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
 							},
 						}
 					) }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -16,6 +16,7 @@ import QueryKeyringConnections from 'calypso/components/data/query-keyring-conne
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import StickyPanel from 'calypso/components/sticky-panel';
@@ -190,7 +191,18 @@ class StatsSite extends Component {
 					headerText={ translate( 'Stats and Insights' ) }
 					align="left"
 					subHeaderText={ translate(
-						"Learn more about the activity and behavior of your site's visitors."
+						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink
+										supportLink="https://wordpress.com/support/stats/"
+										supportPostId={ 4454 }
+										showIcon={ false }
+									/>
+								),
+							},
+						}
 					) }
 				/>
 				<StatsNavigation

--- a/client/my-sites/themes/themes-header.jsx
+++ b/client/my-sites/themes/themes-header.jsx
@@ -1,6 +1,7 @@
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import InstallThemeButton from './install-theme-button';
 
@@ -14,7 +15,14 @@ const ThemesHeader = () => {
 				brandFont
 				className="themes__page-heading"
 				headerText={ translate( 'Themes' ) }
-				subHeaderText={ translate( 'Select or update the visual design for your site.' ) }
+				subHeaderText={ translate(
+					'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
+						},
+					}
+				) }
 				align="left"
 				hasScreenOptions
 			/>

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -35,13 +35,7 @@ function Types( {
 			'Create and manage all the testimonials on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 			{
 				components: {
-					learnMoreLink: (
-						<InlineSupportLink
-							supportLink="https://wordpress.com/support/testimonials/"
-							supportPostId={ 97757 }
-							showIcon={ false }
-						/>
-					),
+					learnMoreLink: <InlineSupportLink supportContext="testimonials" showIcon={ false } />,
 				},
 			}
 		);
@@ -50,13 +44,7 @@ function Types( {
 			'Create, edit, and manage the portfolio projects on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 			{
 				components: {
-					learnMoreLink: (
-						<InlineSupportLink
-							supportLink="https://wordpress.com/support/portfolios/"
-							supportPostId={ 84808 }
-							showIcon={ false }
-						/>
-					),
+					learnMoreLink: <InlineSupportLink supportContext="portfolios" showIcon={ false } />,
 				},
 			}
 		);

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryPostTypes from 'calypso/components/data/query-post-types';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -30,9 +31,35 @@ function Types( {
 } ) {
 	let subHeaderText = '';
 	if ( 'Testimonials' === get( postType, 'label', '' ) ) {
-		subHeaderText = translate( 'Create and manage all the testimonials on your site.' );
+		subHeaderText = translate(
+			'Create and manage all the testimonials on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink: (
+						<InlineSupportLink
+							supportLink="https://wordpress.com/support/testimonials/"
+							supportPostId={ 97757 }
+							showIcon={ false }
+						/>
+					),
+				},
+			}
+		);
 	} else if ( 'Projects' === get( postType, 'label', '' ) ) {
-		subHeaderText = translate( 'Create, edit, and manage the portfolio projects on your site.' );
+		subHeaderText = translate(
+			'Create, edit, and manage the portfolio projects on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink: (
+						<InlineSupportLink
+							supportLink="https://wordpress.com/support/portfolios/"
+							supportPostId={ 84808 }
+							showIcon={ false }
+						/>
+					),
+				},
+			}
+		);
 	}
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the new `supportContext` format for the InlineSupportLinks component across various Calypso screens. 

#### Deprecated usage:
```js
import InlineSupportLink from 'calypso/components/inline-support-link';
function Link() {
	const inlineSupportProps = {
		supportLink: 'https://wordpress.com/support/audio/podcasting/',
		supportPostId: 38147,
}
```

#### New Example Usage

```js
import InlineSupportLink from 'calypso/components/inline-support-link';
function Link() {
	return <InlineSupportLink supportContext="purchases" showIcon={ false } />
}
```

The `supportContext` is a combination of the `supportPostId` and `supportLink` now found in _context-links.js_.

```js
const getContextLinks = () => ( {
	purchases: {
		link: 'https://wordpress.com/support/manage-purchases/',
		post_id: 111349,
	}
} );
```

#### Testing instructions

This PR relies on the merger of #54991, once merged please test the following:
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test that the existing deprecated format still works:

- Open https://wordpress.com/settings/writing/
- Go to Podcasting
- Click on Learn More
- Modal should load with Podcasting support documentation

Test that the new format works too:
- Go to Posts or Pages
- Click on Learn More at the top of the section
- Modal should load with respective support documentation

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### For translators

Strings that look like:

`Create, edit, and manage the posts on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.`

Will render as a subheader:
![image](https://user-images.githubusercontent.com/16580129/128423872-89ae0721-38ac-4df0-a613-742b23a2eec4.png)

Strings that look like (omit the Learn More text):

`Publicize posts {{learnMoreLink/}}`

Will render as an icon:
![image](https://user-images.githubusercontent.com/16580129/128424013-b9455f61-a836-4e35-8fe5-3fa2417b0a3a.png)


Related to #54991
