### PR TITLE
Shopping Cart: Remove leftover loading properties added by CartStore

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -455,7 +455,7 @@ class TransferDomainStep extends React.Component {
 			<div className={ 'transfer-domain-step__domain-availability' }>
 				<DomainRegistrationSuggestion
 					cart={ this.props.cart }
-					isCartPendingUpdate={ this.props.cart.hasPendingServerUpdates }
+					isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					key={ suggestion.domain_name }
 					onButtonClick={ this.registerSuggestedDomain }

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -52,7 +52,7 @@ interface Props {
 	onConfirm: ( purchases: Purchase[] ) => void;
 	submitButtonText?: string | TranslateResult;
 	showManagePurchaseLinks?: boolean;
-	getManagePurchaseUrlFor: ( siteSlug: string, purchaseId: number ) => string;
+	getManagePurchaseUrlFor?: ( siteSlug: string, purchaseId: number ) => string;
 }
 
 function getExpiresText(

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -39,6 +39,7 @@ import { getAllCartItems } from '../../../lib/cart-values/cart-items';
 class CartFreeUserPlanUpsell extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object,
+		isCartPendingUpdate: PropTypes.bool.isRequired,
 		addItemToCart: PropTypes.func.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		hasPaidPlan: PropTypes.bool,
@@ -53,8 +54,7 @@ class CartFreeUserPlanUpsell extends React.Component {
 	};
 
 	isLoading() {
-		const { cart } = this.props;
-		const isLoadingCart = ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates;
+		const { isCartPendingUpdate: isLoadingCart } = this.props;
 		const isLoadingPlans = this.props.isPlansListFetching;
 		const isLoadingSitePlans = this.props.isSitePlansListFetching;
 		return isLoadingCart || isLoadingPlans || isLoadingSitePlans;

--- a/client/my-sites/checkout/cart/cart-total.jsx
+++ b/client/my-sites/checkout/cart/cart-total.jsx
@@ -28,16 +28,6 @@ class CartTotal extends React.Component {
 	render() {
 		const cart = this.props.cart;
 
-		if ( cart.hasPendingServerUpdates ) {
-			return (
-				<div className="cart__total">
-					{ this.props.translate( 'Recalculating…', {
-						context: 'Upgrades: Updating cart cost in checkout',
-					} ) }
-				</div>
-			);
-		}
-
 		if ( ! cart.total_cost_display ) {
 			return <div className="cart__total" />;
 		}

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -27,7 +27,7 @@ import {
 } from 'calypso/state/purchases/selectors';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import type { Purchase } from 'calypso/lib/purchases/types';
-import { MockResponseCart } from 'calypso/my-sites/checkout/composite-checkout/components/secondary-cart-promotions';
+import { PartialCart } from 'calypso/my-sites/checkout/composite-checkout/components/secondary-cart-promotions';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const OtherPurchasesLink = styled.button`
@@ -55,7 +55,7 @@ interface SelectedSite {
 }
 
 interface Props {
-	cart: MockResponseCart;
+	cart: PartialCart;
 	addItemToCart: ( product: RequestCartProduct ) => void;
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -14,14 +14,10 @@ import CartFreeUserPlanUpsell from 'calypso/my-sites/checkout/cart/cart-free-use
 import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-renewals-reminder';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-type PartialCart = Pick< ResponseCart, 'products' >;
+export type PartialCart = Pick< ResponseCart, 'products' >;
 interface Props {
 	responseCart: PartialCart;
 	addItemToCart: ( item: RequestCartProduct ) => void;
-}
-
-export interface MockResponseCart extends PartialCart {
-	hasLoadedFromServer: boolean;
 }
 
 type DivProps = {
@@ -85,12 +81,6 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( { responseCart, ad
 		[ responseCart ]
 	);
 
-	// By this point we have definitely loaded the cart using useShoppingCart
-	// so we mock the loaded property the CartStore would inject.
-	const mockCart = useMemo( () => ( { ...responseCart, hasLoadedFromServer: true } ), [
-		responseCart,
-	] );
-
 	if (
 		config.isEnabled( 'upgrades/upcoming-renewals-notices' ) &&
 		isPurchaseRenewal &&
@@ -98,14 +88,14 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( { responseCart, ad
 	) {
 		return (
 			<UpsellWrapper>
-				<UpcomingRenewalsReminder cart={ mockCart } addItemToCart={ addItemToCart } />
+				<UpcomingRenewalsReminder cart={ responseCart } addItemToCart={ addItemToCart } />
 			</UpsellWrapper>
 		);
 	}
 
 	return (
 		<UpsellWrapper>
-			<CartFreeUserPlanUpsell cart={ mockCart } addItemToCart={ addItemToCart } />
+			<CartFreeUserPlanUpsell cart={ responseCart } addItemToCart={ addItemToCart } />
 		</UpsellWrapper>
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/secondary-cart-promotions.tsx
@@ -18,6 +18,7 @@ export type PartialCart = Pick< ResponseCart, 'products' >;
 interface Props {
 	responseCart: PartialCart;
 	addItemToCart: ( item: RequestCartProduct ) => void;
+	isCartPendingUpdate: boolean;
 }
 
 type DivProps = {
@@ -74,7 +75,11 @@ const UpsellWrapper = styled.div< DivProps >`
 	}
 `;
 
-const SecondaryCartPromotions: FunctionComponent< Props > = ( { responseCart, addItemToCart } ) => {
+const SecondaryCartPromotions: FunctionComponent< Props > = ( {
+	responseCart,
+	addItemToCart,
+	isCartPendingUpdate,
+} ) => {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
 	const isPurchaseRenewal = useMemo(
 		() => responseCart?.products?.some?.( ( product ) => product.is_renewal ),
@@ -95,7 +100,11 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( { responseCart, ad
 
 	return (
 		<UpsellWrapper>
-			<CartFreeUserPlanUpsell cart={ responseCart } addItemToCart={ addItemToCart } />
+			<CartFreeUserPlanUpsell
+				cart={ responseCart }
+				addItemToCart={ addItemToCart }
+				isCartPendingUpdate={ isCartPendingUpdate }
+			/>
 		</UpsellWrapper>
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -447,6 +447,7 @@ export default function WPCheckout( {
 						<SecondaryCartPromotions
 							responseCart={ responseCart }
 							addItemToCart={ addItemToCart }
+							isCartPendingUpdate={ isCartPendingUpdate }
 						/>
 						<CheckoutHelpLink />
 					</CheckoutSummaryBody>

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -1150,20 +1150,6 @@ describe( 'CompositeCheckout', () => {
 		const { getByText } = renderResult;
 		expect( getByText( 'Loading checkout' ) ).toBeInTheDocument();
 	} );
-
-	it( 'does not display loading when old cart store has pending updates and then they complete', async () => {
-		let renderResult;
-		let additionalProps = { cart: { hasLoadedFromServer: true, hasPendingServerUpdates: true } };
-		await act( async () => {
-			renderResult = render( <MyCheckout additionalProps={ additionalProps } />, container );
-		} );
-		const { queryByText, rerender } = renderResult;
-		additionalProps = { cart: { hasLoadedFromServer: true, hasPendingServerUpdates: false } };
-		await act( async () => {
-			rerender( <MyCheckout additionalProps={ additionalProps } />, container );
-		} );
-		expect( queryByText( 'Loading checkout' ) ).not.toBeInTheDocument();
-	} );
 } );
 
 async function mockSetCartEndpoint( _, requestCart ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the `CartStore` was removed (see the many PRs in https://github.com/Automattic/wp-calypso/issues/24019), the special cart properties `hasPendingServerUpdates` and `hasLoadedFromServer` were wholly removed, replaced by the `isPendingUpdate` and `isLoading` properties of the cart manager, respectively. However, there are several places in calypso where replacing these old properties was missed. This PR corrects these oversights.

#### Testing instructions

Places to test include:

##### Transfer domain step

- Visit `/start/domains/transfer`.
- Fill in a fake non-existent domain name in the transfer form field and press "Transfer".
- You should see a domain name suggestion appear below the field reading something like "XXXX is available!". 
- Click the "Select" button next to the suggestion.
- Verify that you are directed to the next page.

<img width="730" alt="Screen Shot 2021-07-31 at 4 44 35 PM" src="https://user-images.githubusercontent.com/2036909/127752074-f9e521e5-9f3d-4016-ac62-31a979f411bf.png">


##### Cart free plan upsell

- Add a domain to your cart (you can do this by visiting `/domains/add`) for a site that has no plan.
- Visit checkout and verify that the sidebar displays no upsell while the cart is loading.
- Once checkout has loaded, verify that you see a Personal Plan upsell in the sidebar. 

<img width="339" alt="Screen Shot 2021-07-31 at 4 45 47 PM" src="https://user-images.githubusercontent.com/2036909/127752076-eff4248d-101d-4c5f-86cb-0a8212536254.png">
