### PR TITLE
Added domain credit information in plans faq

### DIFF
--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -34,7 +34,8 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						' domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. Does not apply to premium domains. Domain name should be' +
 						' registered within one year of the purchase of the plan to use this promotion. Registered' +
-						' domain names will renew at regular prices. {{a}}Find out more about domains.{{/a}}',
+						' domain names will renew at regular prices. The domain credit for a free domain for the' +
+						' first year is only included with the annual or two-year plans. {{a}}Find out more about domains.{{/a}}',
 					{
 						components: {
 							a: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a line mentioned in the issue in the appropriate file `wpcom-faq.jsx`. 

#### Testing instructions
1. Run calypso locally
2. Go to 'https://wordpress.com/plans/SITEADDRESS'
3. Scroll down to FAQ
4. There you will find a new line added under **Do you sell domains?**
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54718
cc @stephanethomas
