### PR TITLE
WIP: Update My Home: dismiss one of many cards

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -80,6 +80,7 @@ export const DotPager = ( {
 	const [ pagesStyle, setPagesStyle ] = useState();
 	const pagesRef = useRef();
 	const [ resizeObserver, sizes ] = useResizeObserver();
+	const numPages = Children.count( children );
 
 	useEffect( () => {
 		if ( ! hasDynamicHeight ) {
@@ -91,10 +92,11 @@ export const DotPager = ( {
 		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
 	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle, children ] );
 
-	const numPages = Children.count( children );
-	if ( currentPage >= numPages ) {
-		setCurrentPage( numPages - 1 );
-	}
+	useEffect( () => {
+		if ( currentPage >= numPages ) {
+			setCurrentPage( numPages - 1 );
+		}
+	}, [ numPages ] );
 
 	return (
 		<div className={ className } { ...props }>

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -91,13 +91,18 @@ export const DotPager = ( {
 		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
 	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle, children ] );
 
+	const numPages = Children.count( children );
+	if ( currentPage >= numPages ) {
+		setCurrentPage( numPages - 1 );
+	}
+
 	return (
 		<div className={ className } { ...props }>
 			{ resizeObserver }
 			<Controls
 				showControlLabels={ showControlLabels }
 				currentPage={ currentPage }
-				numberOfPages={ Children.count( children ) }
+				numberOfPages={ numPages }
 				setCurrentPage={ setCurrentPage }
 			/>
 			<div className="dot-pager__pages" ref={ pagesRef } style={ pagesStyle }>

--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -45,17 +45,17 @@ function useSkipCurrentViewMutation( siteId: number ): Result {
 				const cachedData: Record< string, unknown > | undefined = queryClient.getQueryData(
 					getCacheKey( siteId )
 				);
+
+				if ( ! cachedData?.primary?.indexOf || cachedData.primary.indexOf( card ) === -1 ) {
+					return;
+				}
+
 				const optimisticUpdate = {
 					...cachedData,
-					primary: cachedData.primary.filter( ( c ) => c !== card ),
+					primary: cachedData.primary.filter( ( v: string ) => v !== card ),
 				};
 
 				queryClient.setQueryData( getCacheKey( siteId ), optimisticUpdate );
-			},
-			onError(/* err, _data, cachedData */) {
-				// We can revert the change if there's an error here, but do
-				// we actually want to?
-				// queryClient.setQueryData( getCacheKey( siteId ), cachedData );
 			},
 			onSuccess( data ) {
 				queryClient.setQueryData( getCacheKey( siteId ), data );

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -22,13 +22,8 @@ const CelebrateNotice = ( {
 	tracksEventExtras = {},
 } ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
-	const [ isVisible, setIsVisible ] = useState( true );
 	const dispatch = useDispatch();
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
-
-	if ( ! isVisible ) {
-		return null;
-	}
 
 	const showNextTask = () => {
 		setIsLoading( true );
@@ -45,7 +40,7 @@ const CelebrateNotice = ( {
 	};
 
 	const skip = () => {
-		setIsVisible( false );
+		setIsLoading( true );
 		skipCurrentView();
 		onSkip && onSkip();
 

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -7,7 +7,6 @@ import fireworksIllustration from 'calypso/assets/images/customer-home/illustrat
 import Spinner from 'calypso/components/spinner';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { savePreference } from 'calypso/state/preferences/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const CelebrateNotice = ( {
@@ -31,8 +30,6 @@ const CelebrateNotice = ( {
 		return null;
 	}
 
-	const dismissalPreferenceKey = `dismissible-card-${ noticeId }-${ siteId }`;
-
 	const showNextTask = () => {
 		setIsLoading( true );
 		skipCurrentView();
@@ -49,7 +46,7 @@ const CelebrateNotice = ( {
 
 	const skip = () => {
 		setIsVisible( false );
-		dispatch( savePreference( dismissalPreferenceKey, true ) );
+		skipCurrentView();
 		onSkip && onSkip();
 
 		dispatch(

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -68,7 +68,7 @@ const Task = ( {
 	};
 
 	const skipTask = ( reminder = null ) => {
-		// setIsLoading( true );
+		setIsLoading( true );
 		setSkipOptionsVisible( false );
 
 		skipCard( taskId, reminder );

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -42,7 +42,7 @@ const Task = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const skipButtonRef = useRef( null );
-	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
+	const { skipCard } = useSkipCurrentViewMutation( siteId );
 	const instanceId = useInstanceId( Task );
 
 	useEffect( () => setIsLoading( forceIsLoading ), [ forceIsLoading ] );
@@ -54,7 +54,7 @@ const Task = ( {
 
 		if ( completeOnStart ) {
 			setIsLoading( true );
-			skipCurrentView();
+			skipCard( taskId );
 		}
 
 		dispatch(
@@ -68,10 +68,10 @@ const Task = ( {
 	};
 
 	const skipTask = ( reminder = null ) => {
-		setIsLoading( true );
+		// setIsLoading( true );
 		setSkipOptionsVisible( false );
 
-		skipCurrentView( reminder );
+		skipCard( taskId, reminder );
 
 		dispatch(
 			composeAnalytics(


### PR DESCRIPTION
This PR adds the logic for dismissing the currently viewed card when several are presented in the primary location along with an optimistic UI update.

#### Testing instructions

- Dismiss some specific cards and make sure the correct cards re-appear on refresh (use the `?view=VIEW_POST_LAUNCH` query param)
- Also make sure that single cards are dismissed correctly on sites with more than one eligible view (i.e. no query param).

Part of #54226