### PR TITLE
chore: migrate `client/server` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,6 +198,7 @@ module.exports = {
 				'client/sections-middleware.js',
 				'client/sections-preloaders.js',
 				'client/sections.js',
+				'client/server/**/*',
 				'client/support/**/*',
 				'client/test-helpers/**/*',
 				'client/types.ts',

--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import express from 'express';
-
-/**
- * Internal dependencies
- */
-import pkgJson from '../../package.json';
 import config from '@automattic/calypso-config';
+import express from 'express';
+import pkgJson from '../../package.json';
 import signInWithApple from './sign-in-with-apple';
 
 const { version } = pkgJson;

--- a/client/server/api/integration/index.js
+++ b/client/server/api/integration/index.js
@@ -1,15 +1,8 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "localRequest.*.expect"] }] */
 
-/**
- * External dependencies
- */
+import unmodifiedConfig from '@automattic/calypso-config';
 import request from 'superagent';
 import supertest from 'supertest';
-import unmodifiedConfig from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'api', () => {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import bodyParser from 'body-parser';
 import qs from 'qs';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 
 function loginEndpointData() {

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
 import path from 'path';
 import chalk from 'chalk';
-import express from 'express';
 import cookieParser from 'cookie-parser';
+import express from 'express';
 import userAgent from 'express-useragent';
-
-/**
- * Internal dependencies
- */
-import analytics from 'calypso/server/lib/analytics';
-import config from 'calypso/server/config';
 import api from 'calypso/server/api';
+import config from 'calypso/server/config';
+import analytics from 'calypso/server/lib/analytics';
+import loggerMiddleware from 'calypso/server/middleware/logger';
 import pages from 'calypso/server/pages';
 import pwa from 'calypso/server/pwa';
-import loggerMiddleware from 'calypso/server/middleware/logger';
 
 /**
  * Returns the server HTTP request handler "app".

--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -1,16 +1,10 @@
-/**
- * External dependencies
- */
-
-const webpackMiddleware = require( 'webpack-dev-middleware' );
-const webpack = require( 'webpack' );
-const hotMiddleware = require( 'webpack-hot-middleware' );
-
-const chalk = require( 'chalk' );
-const webpackConfig = require( 'calypso/webpack.config' );
 const { execSync } = require( 'child_process' );
-
 const config = require( '@automattic/calypso-config' );
+const chalk = require( 'chalk' );
+const webpack = require( 'webpack' );
+const webpackMiddleware = require( 'webpack-dev-middleware' );
+const hotMiddleware = require( 'webpack-hot-middleware' );
+const webpackConfig = require( 'calypso/webpack.config' );
 
 const protocol = config( 'protocol' );
 const host = config( 'hostname' );

--- a/client/server/bundler/utils.js
+++ b/client/server/bundler/utils.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const crypto = require( 'crypto' );
 const fs = require( 'fs' );
 const qs = require( 'qs' );

--- a/client/server/config/index.js
+++ b/client/server/config/index.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
 const configPath = require( 'path' ).resolve( __dirname, '..', '..', '..', 'config' );
-const parser = require( './parser' );
 const { default: createConfig } = require( '@automattic/create-calypso-config' );
+const parser = require( './parser' );
 
 const { serverData, clientData } = parser( configPath, {
 	env: process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development',

--- a/client/server/config/parser.js
+++ b/client/server/config/parser.js
@@ -2,13 +2,10 @@
  * WARNING: ES5 code only here. Used by un-transpiled script!
  */
 
-/**
- * Module dependencies
- */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { assignWith } = require( 'lodash' );
 const debug = require( 'debug' )( 'config' );
+const { assignWith } = require( 'lodash' );
 
 function getDataFromFile( file ) {
 	let fileData = {};

--- a/client/server/config/test/parser.js
+++ b/client/server/config/test/parser.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import mockFs from 'mock-fs';
 import parser from '@automattic/calypso-config/parser';
+import mockFs from 'mock-fs';
 
 function setValidSecrets() {
 	mockFs( {

--- a/client/server/devdocs/index.js
+++ b/client/server/devdocs/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import express from 'express';
 import fs from 'fs';
 import fspath from 'path';
-import marked from 'marked';
-import lunr from 'lunr';
+import config from '@automattic/calypso-config';
+import express from 'express';
 import { escapeRegExp, find, escape as escapeHTML, once } from 'lodash';
+import lunr from 'lunr';
+import marked from 'marked';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-scss';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import searchSelectors from './selectors';
 
 const loadSearchIndex = once( async () => {

--- a/client/server/devdocs/selectors/index.js
+++ b/client/server/devdocs/selectors/index.js
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import { once } from 'lodash';
 import fs from 'fs';
 import path from 'path';
 import Fuse from 'fuse.js';
+import { once } from 'lodash';
 
 const loadSearchIndex = once( async () => {
 	const searchIndexPath = path.resolve(

--- a/client/server/index.js
+++ b/client/server/index.js
@@ -8,12 +8,8 @@ import '@automattic/calypso-polyfills';
  * External dependencies.
  */
 import fs from 'fs';
-
-/**
- * Internal dependencies
- */
-import boot from './boot';
 import config from '@automattic/calypso-config';
+import boot from './boot';
 import { getLogger } from './lib/logger';
 
 const logger = getLogger();

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
-
-/**
- * Internal dependencies
- */
-import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
 import { setSectionMiddleware } from 'calypso/controller';
+import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
 import { setRoute } from 'calypso/state/route/actions';
 
 export function serverRouter( expressApp, setUpRoute, section ) {

--- a/client/server/isomorphic-routing/test/index.js
+++ b/client/server/isomorphic-routing/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getNormalizedPath } from '..';
 
 describe( 'getNormalizedPath', () => {

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import { omit, get, has } from 'lodash';
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
-import { omit, get, has } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
 const URL = require( 'url' );
 

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import superagent from 'superagent';
-
-/**
- * Internal dependencies
- */
 import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
 import analytics from '../index';
-import config from '@automattic/calypso-config';
 jest.mock( '@automattic/calypso-config', () => require( 'sinon' ).stub() );
 jest.mock( 'calypso/lib/analytics/statsd-utils', () => ( {
 	statsdTimingUrl: require( 'sinon' ).stub(),

--- a/client/server/lib/logger/index.js
+++ b/client/server/lib/logger/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import bunyan from 'bunyan';
 
 let logger;

--- a/client/server/lib/logger/test/index.js
+++ b/client/server/lib/logger/test/index.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import fs from 'fs';
 import { mockProcessStdout } from 'jest-mock-process';
 import mockFs from 'mock-fs';
-import fs from 'fs';
 
 let mockStdout;
 let getLogger;

--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import fs from 'fs';
 import path from 'path';
 import { defaults, groupBy, flatten } from 'lodash';

--- a/client/server/middleware/build-target.js
+++ b/client/server/middleware/build-target.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { matchesUA } from 'browserslist-useragent';
 
 /**

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import uaParser from 'ua-parser-js';
 import { v4 as uuidv4 } from 'uuid';
-
-/**
- * Internal dependencies
- */
 import { getLogger } from 'calypso/server/lib/logger';
-import config from '@automattic/calypso-config';
 
 const NS_TO_MS = 1e-6;
 

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import EventEmitter from 'events';
-
-/**
- * Internal dependencies
- */
-import loggerMiddleware from '../logger';
 import config from '@automattic/calypso-config';
+import loggerMiddleware from '../logger';
 
 const requestLogger = {
 	info: jest.fn(),

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { throttle } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import { throttle } from 'lodash';
 import analytics from '../lib/analytics';
 
 // Compute the number of milliseconds between each call to recordTiming

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 import events from 'events';
+import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
-import analytics from '../../lib/analytics';
 import { logSectionResponse } from 'calypso/server/pages/analytics';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
+import analytics from '../../lib/analytics';
 
 const TWO_SECONDS = 2000;
 const noop = () => {};

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1,4 +1,7 @@
 import { IncomingMessage } from 'http';
+import cloneDeep from 'lodash/cloneDeep';
+import mockFs from 'mock-fs';
+import sections from 'calypso/sections';
 
 jest.mock( 'browserslist-useragent', () => ( {
 	matchesUA: jest.fn(),
@@ -24,6 +27,7 @@ jest.mock( 'calypso/server/bundler/utils', () => ( {
 } ) );
 
 jest.mock( 'calypso/sections', () => {
+	// eslint-disable-next-line no-shadow
 	const sections = jest.requireActual( 'calypso/sections' );
 	sections
 		.filter( ( section ) => section.isomorphic )
@@ -113,17 +117,6 @@ jest.mock( 'calypso/landing/gutenboarding/section', () => ( {
 		enableLoggedOut: true,
 	},
 } ) );
-
-/**
- * External dependencies
- */
-import mockFs from 'mock-fs';
-import cloneDeep from 'lodash/cloneDeep';
-
-/**
- * Internal dependencies
- */
-import sections from 'calypso/sections';
 
 /**
  * Builds an app for an specific environment.

--- a/client/server/pwa/index.js
+++ b/client/server/pwa/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import path from 'path';
 import express from 'express';
-
-/**
- * Internal dependencies
- */
 import manifest from './manifest';
 
 export default () => {

--- a/client/server/pwa/manifest.js
+++ b/client/server/pwa/manifest.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import querystring from 'querystring';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 const getWordPressOptions = ( environmentUrlSuffix ) => ( {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -1,37 +1,30 @@
-/**
- * External dependencies
- */
+import fs from 'fs';
+import path from 'path';
+import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
+import { get, pick } from 'lodash';
+import Lru from 'lru';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
-import Lru from 'lru';
-import { get, pick } from 'lodash';
-import debugFactory from 'debug';
-import path from 'path';
-import fs from 'fs';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import { isDefaultLocale, isLocaleRtl, isTranslatedIncompletely } from 'calypso/lib/i18n-utils';
 import {
 	getLanguageFileUrl,
 	getLanguageManifestFileUrl,
 	getTranslationChunkFileUrl,
 } from 'calypso/lib/i18n-utils/switch-locale';
+import { getNormalizedPath } from 'calypso/server/isomorphic-routing';
+import stateCache from 'calypso/server/state-cache';
 import {
 	getDocumentHeadFormattedTitle,
 	getDocumentHeadMeta,
 	getDocumentHeadLink,
 } from 'calypso/state/document-head/selectors';
+import { logToLogstash } from 'calypso/state/logstash/actions';
+import initialReducer from 'calypso/state/reducer';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
-import initialReducer from 'calypso/state/reducer';
 import { serialize } from 'calypso/state/utils';
-import { logToLogstash } from 'calypso/state/logstash/actions';
-import stateCache from 'calypso/server/state-cache';
-import { getNormalizedPath } from 'calypso/server/isomorphic-routing';
 
 const debug = debugFactory( 'calypso:server-render' );
 const HOUR_IN_MS = 3600000;

--- a/client/server/render/test/index.js
+++ b/client/server/render/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { shouldServerSideRender, setShouldServerSideRender } from '..';
 
 /**

--- a/client/server/sanitize/test/index.js
+++ b/client/server/sanitize/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { jsonStringifyForHtml } from '..';
 
 describe( 'jsonStringifyForHtml', () => {

--- a/client/server/state-cache/index.js
+++ b/client/server/state-cache/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import Lru from 'lru';
 
 const HOUR_IN_MS = 3600000;

--- a/client/server/user-bootstrap/index.js
+++ b/client/server/user-bootstrap/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import superagent from 'superagent';
-import debugFactory from 'debug';
 import crypto from 'crypto';
-
-/**
- * Internal dependencies
- */
-import { filterUserObject } from 'calypso/lib/user/shared-utils';
 import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
+import superagent from 'superagent';
+import { filterUserObject } from 'calypso/lib/user/shared-utils';
 
 const debug = debugFactory( 'calypso:bootstrap' );
 const AUTH_COOKIE_NAME = 'wordpress_logged_in';


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/server` to use `import/order`

#### Testing instructions

N/A

Note: there's preexisting eslint failures in `client/server/pwa/manifest.js`
