### PR TITLE
chore: migrate `client/jetpack-connect` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -188,6 +188,7 @@ module.exports = {
 				'client/document/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',
+				'client/jetpack-connect/**/*',
 				'client/landing/**/*',
 				'client/login/**/*',
 				'client/mailing-lists/**/*',

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -1,24 +1,17 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
-import FormattedHeader from 'calypso/components/formatted-header';
-import safeImageUrl from 'calypso/lib/safe-image-url';
 import Site from 'calypso/blocks/site';
-import versionCompare from 'calypso/lib/version-compare';
-import { authQueryPropTypes } from './utils';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { decodeEntities } from 'calypso/lib/formatting';
-import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors';
+import safeImageUrl from 'calypso/lib/safe-image-url';
+import versionCompare from 'calypso/lib/version-compare';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getAuthorizationData } from 'calypso/state/jetpack-connect/selectors';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
+import { authQueryPropTypes } from './utils';
 
 export class AuthFormHeader extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1,70 +1,29 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import debugModule from 'debug';
-import { connect } from 'react-redux';
-import { flowRight, get, includes, startsWith } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AuthFormHeader from './auth-form-header';
-import { Button, Card } from '@automattic/components';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import config from '@automattic/calypso-config';
-import Disclaimer from './disclaimer';
+import { Button, Card } from '@automattic/components';
+import debugModule from 'debug';
+import { localize } from 'i18n-calypso';
+import { flowRight, get, includes, startsWith } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserConnection from 'calypso/components/data/query-user-connection';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import Gravatar from 'calypso/components/gravatar';
 import Gridicon from 'calypso/components/gridicon';
-import HelpButton from './help-button';
-import isVipSite from 'calypso/state/selectors/is-vip-site';
-import JetpackConnectHappychatButton from './happychat-button';
-import JetpackConnectNotices from './jetpack-connect-notices';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import MainWrapper from './main-wrapper';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import QueryUserConnection from 'calypso/components/data/query-user-connection';
 import Spinner from 'calypso/components/spinner';
-import { redirectToLogout } from 'calypso/state/current-user/actions';
-import { addQueryArgs } from 'calypso/lib/route';
-import { navigate } from 'calypso/lib/navigate';
-import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'calypso/lib/formatting';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import {
-	isFetchingSitePurchases,
-	siteHasJetpackProductPurchase,
-} from 'calypso/state/purchases/selectors';
-import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
-import { OFFER_RESET_FLOW_TYPES } from './flow-types';
+import { navigate } from 'calypso/lib/navigate';
 import { login } from 'calypso/lib/paths';
-import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { addQueryArgs } from 'calypso/lib/route';
 import { urlToSlug } from 'calypso/lib/url';
-import {
-	ALREADY_CONNECTED,
-	ALREADY_CONNECTED_BY_OTHER_USER,
-	DEFAULT_AUTHORIZE_ERROR,
-	RETRY_AUTH,
-	RETRYING_AUTH,
-	SECRET_EXPIRED,
-	SITE_BLOCKED,
-	USER_IS_ALREADY_CONNECTED_TO_SITE,
-	XMLRPC_ERROR,
-} from './connection-notice-types';
-import {
-	clearPlan,
-	isCalypsoStartedConnection,
-	isSsoApproved,
-	retrieveMobileRedirect,
-	retrievePlan,
-} from './persistence-utils';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
 	authorize as authorizeAction,
 	retryAuth as retryAuthAction,
@@ -78,8 +37,42 @@ import {
 	isRemoteSiteOnSitesList,
 	isSiteBlockedError as isSiteBlockedSelector,
 } from 'calypso/state/jetpack-connect/selectors';
+import {
+	isFetchingSitePurchases,
+	siteHasJetpackProductPurchase,
+} from 'calypso/state/purchases/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPartnerIdFromQuery from 'calypso/state/selectors/get-partner-id-from-query';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import AuthFormHeader from './auth-form-header';
+import {
+	ALREADY_CONNECTED,
+	ALREADY_CONNECTED_BY_OTHER_USER,
+	DEFAULT_AUTHORIZE_ERROR,
+	RETRY_AUTH,
+	RETRYING_AUTH,
+	SECRET_EXPIRED,
+	SITE_BLOCKED,
+	USER_IS_ALREADY_CONNECTED_TO_SITE,
+	XMLRPC_ERROR,
+} from './connection-notice-types';
+import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
+import Disclaimer from './disclaimer';
+import { OFFER_RESET_FLOW_TYPES } from './flow-types';
+import JetpackConnectHappychatButton from './happychat-button';
+import HelpButton from './help-button';
+import JetpackConnectNotices from './jetpack-connect-notices';
+import MainWrapper from './main-wrapper';
+import {
+	clearPlan,
+	isCalypsoStartedConnection,
+	isSsoApproved,
+	retrieveMobileRedirect,
+	retrievePlan,
+} from './persistence-utils';
+import { authQueryPropTypes, getRoleFromScope } from './utils';
 import wooDnaConfig from './woo-dna-config';
 
 /**

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -1,50 +1,4 @@
-/**
- * External Dependencies
- */
-import React from 'react';
-import Debug from 'debug';
-import page from 'page';
-import { get, some } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import { recordPageView } from 'calypso/lib/analytics/page-view';
 import config from '@automattic/calypso-config';
-import InstallInstructions from './install-instructions';
-import JetpackAuthorize from './authorize';
-import JetpackConnect from './main';
-import JetpackSignup from './signup';
-import JetpackSsoForm from './sso';
-import NoDirectAccessError from './no-direct-access-error';
-import OrgCredentialsForm from './remote-credentials';
-import SearchPurchase from './search';
-import StoreHeader from './store-header';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getLocaleFromPath, removeLocaleFromPath } from 'calypso/lib/i18n-utils';
-import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
-import { OFFER_RESET_FLOW_TYPES } from './flow-types';
-import {
-	ALLOWED_MOBILE_APP_REDIRECT_URL_LIST,
-	CALYPSO_PLANS_PAGE,
-	CALYPSO_REDIRECTION_PAGE,
-	JETPACK_ADMIN_PATH,
-} from './constants';
-import { login } from 'calypso/lib/paths';
-import { parseAuthorizationQuery } from './utils';
-import {
-	clearPlan,
-	isCalypsoStartedConnection,
-	persistMobileRedirect,
-	retrieveMobileRedirect,
-	retrievePlan,
-	storePlan,
-} from './persistence-utils';
-import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -67,8 +21,47 @@ import {
 	getProductFromSlug,
 	getJetpackProductDisplayName,
 } from '@automattic/calypso-products';
+import Debug from 'debug';
+import { get, some } from 'lodash';
+import page from 'page';
+import React from 'react';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { getLocaleFromPath, removeLocaleFromPath } from 'calypso/lib/i18n-utils';
 import { navigate } from 'calypso/lib/navigate';
+import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
+import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import JetpackAuthorize from './authorize';
+import {
+	ALLOWED_MOBILE_APP_REDIRECT_URL_LIST,
+	CALYPSO_PLANS_PAGE,
+	CALYPSO_REDIRECTION_PAGE,
+	JETPACK_ADMIN_PATH,
+} from './constants';
+import { OFFER_RESET_FLOW_TYPES } from './flow-types';
+import InstallInstructions from './install-instructions';
+import JetpackConnect from './main';
+import NoDirectAccessError from './no-direct-access-error';
+import {
+	clearPlan,
+	isCalypsoStartedConnection,
+	persistMobileRedirect,
+	retrieveMobileRedirect,
+	retrievePlan,
+	storePlan,
+} from './persistence-utils';
+import OrgCredentialsForm from './remote-credentials';
+import SearchPurchase from './search';
+import JetpackSignup from './signup';
+import JetpackSsoForm from './sso';
+import StoreHeader from './store-header';
+import { parseAuthorizationQuery } from './utils';
 
 /**
  * Module variables

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class JetpackConnectDisclaimer extends PureComponent {

--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 
 const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } ) => {
 	return (

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 
 const JetpackConnectExampleConnect = ( { url, translate, onClick } ) => {
 	return (

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 
 const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 	return (

--- a/client/jetpack-connect/flow-types.js
+++ b/client/jetpack-connect/flow-types.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { JETPACK_RESET_PLANS, JETPACK_PRODUCTS_LIST } from '@automattic/calypso-products';
 import { UPSELL_PRODUCT_MATRIX } from 'calypso/my-sites/plans/jetpack-plans/constants';
 

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import Gridicon from 'calypso/components/gridicon';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
 import HappychatButton from 'calypso/components/happychat/button';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
-import { isEnabled } from '@automattic/calypso-config';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
-import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -1,23 +1,13 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import * as controller from './controller';
-import { siteSelection } from 'calypso/my-sites/controller';
+import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
-import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import { OFFER_RESET_FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
+import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { siteSelection } from 'calypso/my-sites/controller';
+import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
+import * as controller from './controller';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function () {

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import FormattedHeader from 'calypso/components/formatted-header';
+import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import { navigate } from 'calypso/lib/navigate';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { confirmJetpackInstallStatus } from 'calypso/state/jetpack-connect/actions';
+import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
+import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
 import HelpButton from './help-button';
 import JetpackInstallStep from './install-step';
-import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
 import { addCalypsoEnvQueryArg } from './utils';
-import { confirmJetpackInstallStatus } from 'calypso/state/jetpack-connect/actions';
-import { navigate } from 'calypso/lib/navigate';
-import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
 
 class InstallInstructions extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
-import JetpackExampleInstall from './example-components/jetpack-install';
 import JetpackExampleActivate from './example-components/jetpack-activate';
 import JetpackExampleConnect from './example-components/jetpack-connect';
+import JetpackExampleInstall from './example-components/jetpack-install';
 
 const noop = () => {};
 

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -1,13 +1,8 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import {
 	ALREADY_CONNECTED,
 	ALREADY_CONNECTED_BY_OTHER_USER,
@@ -31,8 +26,6 @@ import {
 	WORDPRESS_DOT_COM,
 	XMLRPC_ERROR,
 } from './connection-notice-types';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 
 export class JetpackConnectNotices extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -1,32 +1,20 @@
-/**
- * External dependencies
- */
+import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import debugModule from 'debug';
-import React, { Component } from 'react';
-import page from 'page';
-import { connect } from 'react-redux';
-import { flowRight, get, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import { flowRight, get, omit } from 'lodash';
+import page from 'page';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import { JETPACK_ADMIN_PATH } from 'calypso/jetpack-connect/constants';
-import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
-import versionCompare from 'calypso/lib/version-compare';
-import { addQueryArgs } from 'calypso/lib/route';
 import { navigate } from 'calypso/lib/navigate';
+import { addQueryArgs } from 'calypso/lib/route';
+import versionCompare from 'calypso/lib/version-compare';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { clearPlan, retrieveMobileRedirect, retrievePlan, storePlan } from './persistence-utils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import HelpButton from './help-button';
-import JetpackConnectNotices from './jetpack-connect-notices';
-import { redirect } from './utils';
-import { IS_DOT_COM_GET_SEARCH, MINIMUM_JETPACK_VERSION } from './constants';
 import {
 	ALREADY_CONNECTED,
 	IS_DOT_COM,
@@ -39,6 +27,11 @@ import {
 	SITE_BLOCKED,
 	WORDPRESS_DOT_COM,
 } from './connection-notice-types';
+import { IS_DOT_COM_GET_SEARCH, MINIMUM_JETPACK_VERSION } from './constants';
+import HelpButton from './help-button';
+import JetpackConnectNotices from './jetpack-connect-notices';
+import { clearPlan, retrieveMobileRedirect, retrievePlan, storePlan } from './persistence-utils';
+import { redirect } from './utils';
 
 const debug = debugModule( 'calypso:jetpack-connect:main' );
 

--- a/client/jetpack-connect/jetpack-remote-install-notices.jsx
+++ b/client/jetpack-connect/jetpack-remote-install-notices.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { addQueryArgs } from 'calypso/lib/route';
-import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
 import {
 	ACTIVATION_FAILURE,
 	ACTIVATION_RESPONSE_ERROR,

--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -1,15 +1,3 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { concat } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import FormattedHeader from 'calypso/components/formatted-header';
 import {
 	getPlan,
 	JETPACK_RESET_PLANS,
@@ -18,6 +6,11 @@ import {
 	getJetpackProductDescription,
 	PRODUCTS_LIST,
 } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import { concat } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
 
 class JetpackConnectMainHeader extends Component {

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
-import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
+import { connect } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
 import JetpackHeader from 'calypso/components/jetpack-header';
 import Main from 'calypso/components/main';
-import DocumentHead from 'calypso/components/data/document-head';
+import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 import { retrieveMobileRedirect } from './persistence-utils';
 
 export class JetpackConnectMainWrapper extends PureComponent {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -1,29 +1,22 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { concat, flowRight, includes } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { concat, flowRight, includes } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { checkUrl } from 'calypso/state/jetpack-connect/actions';
+import { getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import jetpackConnection from './jetpack-connection';
 import MainHeader from './main-header';
 import MainWrapper from './main-wrapper';
+import { persistSession } from './persistence-utils';
 import SiteUrlInput from './site-url-input';
 import { cleanUrl } from './utils';
-import { checkUrl } from 'calypso/state/jetpack-connect/actions';
-import { FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
-import { getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { persistSession } from './persistence-utils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import jetpackConnection from './jetpack-connection';
 
 export class JetpackConnectMain extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/no-direct-access-error.js
+++ b/client/jetpack-connect/no-direct-access-error.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
-import HelpButton from './help-button';
-import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import Main from 'calypso/components/main';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import JetpackConnectHappychatButton from './happychat-button';
+import HelpButton from './help-button';
 
 class NoDirectAccessError extends PureComponent {
 	static propTypes = {

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import cookie from 'cookie';
-
-/**
- * Internal dependencies
- */
-import { JETPACK_CONNECT_TTL_SECONDS } from 'calypso/state/jetpack-connect/constants';
 import { urlToSlug } from 'calypso/lib/url';
+import { JETPACK_CONNECT_TTL_SECONDS } from 'calypso/state/jetpack-connect/constants';
 
 export const SESSION_STORAGE_SELECTED_PLAN = 'jetpack_connect_selected_plan';
 

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -1,32 +1,27 @@
 /**
  * Component which handle remote credentials for installing Jetpack
  */
-import classnames from 'classnames';
-import React, { Component, Fragment } from 'react';
-import page from 'page';
-import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
-import { localize } from 'i18n-calypso';
-/**
- * External dependencies
- */
 import { Button, Card } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
+import page from 'page';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import Gridicon from 'calypso/components/gridicon';
-import HelpButton from './help-button';
-import JetpackConnectNotices from './jetpack-connect-notices';
-import JetpackRemoteInstallNotices from './jetpack-remote-install-notices';
-import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
-import MainWrapper from './main-wrapper';
+import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import Spinner from 'calypso/components/spinner';
-import { addCalypsoEnvQueryArg } from './utils';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import { addQueryArgs } from 'calypso/lib/route';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
 import {
 	jetpackRemoteInstall,
 	jetpackRemoteInstallUpdateError,
@@ -34,9 +29,6 @@ import {
 import getJetpackRemoteInstallErrorCode from 'calypso/state/selectors/get-jetpack-remote-install-error-code';
 import getJetpackRemoteInstallErrorMessage from 'calypso/state/selectors/get-jetpack-remote-install-error-message';
 import isJetpackRemoteInstallComplete from 'calypso/state/selectors/is-jetpack-remote-install-complete';
-import { getConnectingSite } from 'calypso/state/jetpack-connect/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { REMOTE_PATH_AUTH } from './constants';
 import {
 	ACTIVATION_FAILURE,
 	ACTIVATION_RESPONSE_ERROR,
@@ -45,7 +37,12 @@ import {
 	INVALID_PERMISSIONS,
 	UNKNOWN_REMOTE_INSTALL_ERROR,
 } from './connection-notice-types';
-import WordPressLogo from 'calypso/components/wordpress-logo';
+import { REMOTE_PATH_AUTH } from './constants';
+import HelpButton from './help-button';
+import JetpackConnectNotices from './jetpack-connect-notices';
+import JetpackRemoteInstallNotices from './jetpack-remote-install-notices';
+import MainWrapper from './main-wrapper';
+import { addCalypsoEnvQueryArg } from './utils';
 
 export class OrgCredentialsForm extends Component {
 	state = {

--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -1,37 +1,29 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { concat, flowRight } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
-import HelpButton from './help-button';
+import { localize } from 'i18n-calypso';
+import { concat, flowRight } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import MainHeader from './main-header';
-import MainWrapper from './main-wrapper';
-import page from 'page';
-import SiteUrlInput from './site-url-input';
-import { cleanUrl } from './utils';
+import searchSites from 'calypso/components/search-sites';
+import { urlToSlug } from 'calypso/lib/url';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { checkUrl, dismissUrl } from 'calypso/state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'calypso/state/jetpack-connect/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { persistSession, retrieveMobileRedirect } from './persistence-utils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { urlToSlug } from 'calypso/lib/url';
-import searchSites from 'calypso/components/search-sites';
-import jetpackConnection from './jetpack-connection';
-
+import { ALREADY_CONNECTED } from './connection-notice-types';
 import { IS_DOT_COM_GET_SEARCH } from './constants';
 import { FLOW_TYPES } from './flow-types';
-import { ALREADY_CONNECTED } from './connection-notice-types';
+import HelpButton from './help-button';
+import jetpackConnection from './jetpack-connection';
+import MainHeader from './main-header';
+import MainWrapper from './main-wrapper';
+import { persistSession, retrieveMobileRedirect } from './persistence-utils';
+import SiteUrlInput from './site-url-input';
+import { cleanUrl } from './utils';
 
 export class SearchPurchase extends Component {
 	static propTypes = {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -6,55 +6,48 @@
  * and redirection.
  */
 
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, Card } from '@wordpress/components';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import { flowRight, get, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, includes } from 'lodash';
-import { localize } from 'i18n-calypso';
-import { Button, Card } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import AuthFormHeader from './auth-form-header';
-import HelpButton from './help-button';
+import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
+import LoginBlock from 'calypso/blocks/login';
+import SignupForm from 'calypso/blocks/signup-form';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Gridicon from 'calypso/components/gridicon';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import MainWrapper from './main-wrapper';
-import SignupForm from 'calypso/blocks/signup-form';
-import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
-import { addQueryArgs } from 'calypso/lib/route';
-import { authQueryPropTypes } from './utils';
-import {
-	errorNotice as errorNoticeAction,
-	warningNotice as warningNoticeAction,
-} from 'calypso/state/notices/actions';
-import { isEnabled } from '@automattic/calypso-config';
+import { decodeEntities } from 'calypso/lib/formatting';
 import { login, lostPassword } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/route';
+import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { sendEmailLogin as sendEmailLoginAction } from 'calypso/state/auth/actions';
 import {
 	createAccount as createAccountAction,
 	createSocialAccount as createSocialAccountAction,
 } from 'calypso/state/jetpack-connect/actions';
-import LoginBlock from 'calypso/blocks/login';
-import Gridicon from 'calypso/components/gridicon';
-import { decodeEntities } from 'calypso/lib/formatting';
+import { resetAuthAccountType as resetAuthAccountTypeAction } from 'calypso/state/login/actions';
 import {
 	getRequestError,
 	getLastCheckedUsernameOrEmail,
 	getAuthAccountType,
 	getRedirectToOriginal,
 } from 'calypso/state/login/selectors';
-import { resetAuthAccountType as resetAuthAccountTypeAction } from 'calypso/state/login/actions';
-import FormattedHeader from 'calypso/components/formatted-header';
+import {
+	errorNotice as errorNoticeAction,
+	warningNotice as warningNoticeAction,
+} from 'calypso/state/notices/actions';
+import AuthFormHeader from './auth-form-header';
+import HelpButton from './help-button';
+import MainWrapper from './main-wrapper';
+import { authQueryPropTypes } from './utils';
 import wooDnaConfig from './woo-dna-config';
-import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 const noop = () => {};
@@ -177,7 +170,6 @@ export class JetpackSignup extends Component {
 	 * Handle Social service authentication flow result (OAuth2 or OpenID Connect)
 	 *
 	 * @see client/signup/steps/user/index.jsx
-	 *
 	 * @param {string} service      The name of the social service
 	 * @param {string} access_token An OAuth2 acccess token
 	 * @param {string} id_token     (Optional) a JWT id_token which contains the signed user info

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 import Spinner from 'calypso/components/spinner';
 import SuggestionSearch from 'calypso/components/suggestion-search';
 import { localizeUrl } from 'calypso/lib/i18n-utils';

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -1,41 +1,34 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { Button, Card, CompactCard, Dialog } from '@automattic/components';
 import debugModule from 'debug';
-import Gridicon from 'calypso/components/gridicon';
+import { localize } from 'i18n-calypso';
+import { flowRight, get, map } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, map } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { addQueryArgs } from 'calypso/lib/route';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { Button, Card, CompactCard, Dialog } from '@automattic/components';
-import config from '@automattic/calypso-config';
+import Site from 'calypso/blocks/site';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Gravatar from 'calypso/components/gravatar';
-import HelpButton from './help-button';
-import JetpackConnectHappychatButton from './happychat-button';
+import Gridicon from 'calypso/components/gridicon';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import Main from 'calypso/components/main';
-import MainWrapper from './main-wrapper';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import Site from 'calypso/blocks/site';
-import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { decodeEntities } from 'calypso/lib/formatting';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getSSO } from 'calypso/state/jetpack-connect/selectors';
 import { login } from 'calypso/lib/paths';
-import { persistSsoApproved } from './persistence-utils';
+import { addQueryArgs } from 'calypso/lib/route';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { validateSSONonce, authorizeSSO } from 'calypso/state/jetpack-connect/actions';
+import { getSSO } from 'calypso/state/jetpack-connect/selectors';
+import JetpackConnectHappychatButton from './happychat-button';
+import HelpButton from './help-button';
+import MainWrapper from './main-wrapper';
+import { persistSsoApproved } from './persistence-utils';
 
 /*
  * Module variables

--- a/client/jetpack-connect/store-footer.tsx
+++ b/client/jetpack-connect/store-footer.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import JetpackFAQ from 'calypso/my-sites/plans/jetpack-plans/faq';
 
 // We can use this later if more iterations of the FAQ component show up

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackHeader from 'calypso/components/jetpack-header';
-import DocumentHead from 'calypso/components/data/document-head';
-import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 
 import './style.scss';
 

--- a/client/jetpack-connect/test/auth-form-header.js
+++ b/client/jetpack-connect/test/auth-form-header.js
@@ -2,17 +2,10 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
-import { AuthFormHeader } from '../auth-form-header';
+import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { AuthFormHeader } from '../auth-form-header';
 import wooDnaConfig from '../woo-dna-config';
 
 const CLIENT_ID = 98765;

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { JetpackAuthorize } from '../authorize';
 
 const noop = () => {};

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -1,15 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
-import React from 'react';
-import { shallow } from 'enzyme';
 
-/**
- * Internal dependencies
- */
+import { shallow } from 'enzyme';
+import React from 'react';
 import { JetpackConnectNotices } from '../jetpack-connect-notices';
 
 const terminalErrorNoticeType = 'siteBlocked';

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -4,17 +4,10 @@
 
 jest.mock( 'calypso/components/data/document-head', () => 'DocumentHead' );
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
-import { JetpackConnectMainWrapper } from '../main-wrapper';
+import React from 'react';
 import Main from 'calypso/components/main';
+import { JetpackConnectMainWrapper } from '../main-wrapper';
 
 describe( 'JetpackConnectMainWrapper', () => {
 	const translate = ( string ) => string;

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -2,19 +2,12 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { JetpackSignup } from '../signup.js';
-import FormattedHeader from 'calypso/components/formatted-header';
 
 const noop = () => {};
 const CLIENT_ID = 98765;

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -1,15 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
+
 import page from 'page';
 import { navigate } from 'calypso/lib/navigate';
-
-/**
- * Internal dependencies
- */
+import { JPC_PATH_PLANS, JPC_PATH_REMOTE_INSTALL, REMOTE_PATH_AUTH } from '../constants';
 import {
 	addCalypsoEnvQueryArg,
 	cleanUrl,
@@ -17,8 +12,6 @@ import {
 	parseAuthorizationQuery,
 	redirect,
 } from '../utils';
-
-import { JPC_PATH_PLANS, JPC_PATH_REMOTE_INSTALL, REMOTE_PATH_AUTH } from '../constants';
 
 jest.mock( '@automattic/calypso-config', () => ( input ) => {
 	const lookupTable = {

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
+import config, { isCalypsoLive } from '@automattic/calypso-config';
 import { includes, isEmpty } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import config, { isCalypsoLive } from '@automattic/calypso-config';
+import PropTypes from 'prop-types';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
-import { addQueryArgs, untrailingslashit } from 'calypso/lib/route';
 import { navigate } from 'calypso/lib/navigate';
+import { addQueryArgs, untrailingslashit } from 'calypso/lib/route';
 import { urlToSlug } from 'calypso/lib/url';
 import {
 	JPC_PATH_PLANS,


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/jetpack-connect` to use `import/order`

#### Testing instructions

N/A

Note: there are a few preexisting eslint failures

