### PR TITLE
chore: migrate `client/post-editor` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,6 +194,7 @@ module.exports = {
 				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',
 				'client/notifications/**/*',
+				'client/post-editor/**/*',
 				'client/root.js',
 				'client/sections-filter.js',
 				'client/sections-helper.js',

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
 import { isWithinBreakpoint } from '@automattic/viewport';
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
-import { debounce, filter, get, has, last, map, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { debounce, filter, get, has, last, map, throttle } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { getPostRevision } from 'calypso/state/posts/selectors/get-post-revision';
-import { getPostRevisionsDiffView } from 'calypso/state/posts/selectors/get-post-revisions-diff-view';
 import TextDiff from 'calypso/components/text-diff';
 import scrollTo from 'calypso/lib/scroll-to';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
+import { getPostRevision } from 'calypso/state/posts/selectors/get-post-revision';
+import { getPostRevisionsDiffView } from 'calypso/state/posts/selectors/get-post-revisions-diff-view';
 import './style.scss';
 
 const getCenterOffset = ( node ) =>

--- a/client/post-editor/editor-document-head/index.jsx
+++ b/client/post-editor/editor-document-head/index.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryPostTypes from 'calypso/components/data/query-post-types';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getEditorPostId, isEditorNewPost } from 'calypso/state/editor/selectors';
-import { getEditedPostValue } from 'calypso/state/posts/selectors';
 import { getPostType } from 'calypso/state/post-types/selectors';
+import { getEditedPostValue } from 'calypso/state/posts/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function EditorDocumentHead( { translate, siteId, type, typeObject, newPost } ) {
 	let title;

--- a/client/post-editor/editor-media-modal/index.jsx
+++ b/client/post-editor/editor-media-modal/index.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import { partial, map, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { partial, map, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import MediaModal from 'calypso/post-editor/media-modal';
 import { generateGalleryShortcode } from 'calypso/lib/media/utils';
+import MediaModal from 'calypso/post-editor/media-modal';
 import markup from 'calypso/post-editor/media-modal/markup';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const EditorRevisionsListHeader = ( { numRevisions, translate } ) => {
 	return (

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -1,26 +1,15 @@
-/**
- * External dependencies
- */
-import ReactDom from 'react-dom';
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 import { get, isEmpty, last, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import EditorRevisionsListHeader from './header';
-import EditorRevisionsListViewButtons from './view-buttons';
-import EditorRevisionsListNavigation from './navigation';
-import EditorRevisionsListItem from './item';
-import { selectPostRevision } from 'calypso/state/posts/revisions/actions';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
-
-/**
- * Style dependencies
- */
+import { selectPostRevision } from 'calypso/state/posts/revisions/actions';
+import EditorRevisionsListHeader from './header';
+import EditorRevisionsListItem from './item';
+import EditorRevisionsListNavigation from './navigation';
+import EditorRevisionsListViewButtons from './view-buttons';
 import './style.scss';
 
 class EditorRevisionsList extends PureComponent {

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
-import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import TimeSince from 'calypso/components/time-since';
 import { selectPostRevision } from 'calypso/state/posts/revisions/actions';
 import { getPostRevisionAuthor } from 'calypso/state/posts/revisions/authors/selectors';
 import { isSingleUserSite } from 'calypso/state/sites/selectors';
-import TimeSince from 'calypso/components/time-since';
 
 class EditorRevisionsListItem extends PureComponent {
 	selectRevision = () => {

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ButtonGroup from 'calypso/components/button-group';
+import Gridicon from 'calypso/components/gridicon';
 
 const EditorRevisionsListNavigation = ( {
 	nextIsDisabled,

--- a/client/post-editor/editor-revisions-list/view-buttons.jsx
+++ b/client/post-editor/editor-revisions-list/view-buttons.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import SegmentedControl from 'calypso/components/segmented-control';
 import {
 	splitPostRevisionsDiffView,

--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -1,27 +1,20 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import { Dialog } from '@automattic/components';
-
-/**
- * Internal dependencies
- */
-import { getPostRevisionsSelectedRevision } from 'calypso/state/posts/selectors/get-post-revisions-selected-revision';
-import { isPostRevisionsDialogVisible } from 'calypso/state/posts/selectors/is-post-revisions-dialog-visible';
-import { getEditorPostId } from 'calypso/state/editor/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import CloseOnEscape from 'calypso/components/close-on-escape';
+import EditorRevisions from 'calypso/post-editor/editor-revisions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
 import {
 	closePostRevisionsDialog,
 	selectPostRevision,
 } from 'calypso/state/posts/revisions/actions';
-import EditorRevisions from 'calypso/post-editor/editor-revisions';
-import CloseOnEscape from 'calypso/components/close-on-escape';
+import { getPostRevisionsSelectedRevision } from 'calypso/state/posts/selectors/get-post-revisions-selected-revision';
+import { isPostRevisionsDialogVisible } from 'calypso/state/posts/selectors/is-post-revisions-dialog-visible';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class PostRevisionsDialog extends PureComponent {
 	static propTypes = {

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -1,30 +1,19 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import QueryPostRevisionAuthors from 'calypso/components/data/query-post-revision-authors';
+import QueryPostRevisions from 'calypso/components/data/query-post-revisions';
+import EditorDiffViewer from 'calypso/post-editor/editor-diff-viewer';
+import EditorRevisionsList from 'calypso/post-editor/editor-revisions-list';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEditorPostId } from 'calypso/state/editor/selectors';
 import { getPostRevisions } from 'calypso/state/posts/selectors/get-post-revisions';
 import { getPostRevisionsAuthorsId } from 'calypso/state/posts/selectors/get-post-revisions-authors-id';
 import { getPostRevisionsComparisons } from 'calypso/state/posts/selectors/get-post-revisions-comparisons';
 import { getPostRevisionsSelectedRevisionId } from 'calypso/state/posts/selectors/get-post-revisions-selected-revision-id';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import EditorDiffViewer from 'calypso/post-editor/editor-diff-viewer';
-import EditorRevisionsList from 'calypso/post-editor/editor-revisions-list';
-import QueryPostRevisions from 'calypso/components/data/query-post-revisions';
-import QueryPostRevisionAuthors from 'calypso/components/data/query-post-revision-authors';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class EditorRevisions extends Component {

--- a/client/post-editor/media-modal/content.jsx
+++ b/client/post-editor/media-modal/content.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Style dependencies
- */
+import React from 'react';
 import './content.scss';
 
 export default ( { children, className } ) => (

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -1,29 +1,22 @@
-/**
- * External dependencies
- */
-import ReactDom from 'react-dom';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { debounce, get, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { debounce, get, noop } from 'lodash';
-import { localize } from 'i18n-calypso';
+import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import TrackInputChanges from 'calypso/components/track-input-changes';
+import { FormCheckbox } from 'calypso/devdocs/design/playground-scope';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getMimePrefix, url } from 'calypso/lib/media/utils';
-import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
-import FormTextarea from 'calypso/components/forms/form-textarea';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import TrackInputChanges from 'calypso/components/track-input-changes';
-import EditorMediaModalFieldset from '../fieldset';
 import { updateMedia } from 'calypso/state/media/thunks';
-import FormLabel from 'calypso/components/forms/form-label';
-import { FormCheckbox } from 'calypso/devdocs/design/playground-scope';
-import classnames from 'classnames';
-import FormRadio from 'calypso/components/forms/form-radio';
+import EditorMediaModalFieldset from '../fieldset';
 
 class EditorMediaModalDetailFields extends Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { playtime } from 'calypso/lib/media/utils';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { playtime } from 'calypso/lib/media/utils';
 
 class EditorMediaModalDetailFileInfo extends React.Component {
 	static displayName = 'EditorMediaModalDetailFileInfo';

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -1,35 +1,28 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
 
+import { getUrlParts } from '@automattic/calypso-url';
+import { Button, ScreenReaderText } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { flowRight } from 'lodash';
-import { localize } from 'i18n-calypso';
-import { getUrlParts } from '@automattic/calypso-url';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import EditorMediaModalContent from '../content';
-import EditorMediaModalDetailFields from './detail-fields';
-import EditorMediaModalDetailFileInfo from './detail-file-info';
-import EditorMediaModalDetailPreviewImage from './detail-preview-image';
-import EditorMediaModalDetailPreviewVideo from './detail-preview-video';
-import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
-import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
-import { Button, ScreenReaderText } from '@automattic/components';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import Gridicon from 'calypso/components/gridicon';
 import { getMimePrefix, isItemBeingUploaded, isVideoPressItem } from 'calypso/lib/media/utils';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EditorMediaModalContent from '../content';
+import EditorMediaModalDetailFields from './detail-fields';
+import EditorMediaModalDetailFileInfo from './detail-file-info';
+import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
+import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
+import EditorMediaModalDetailPreviewImage from './detail-preview-image';
+import EditorMediaModalDetailPreviewVideo from './detail-preview-video';
 
 const noop = () => {};
 

--- a/client/post-editor/media-modal/detail/detail-preview-audio.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-audio.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import EditorMediaModalDetailPreviewMediaFile from './detail-preview-media-file';
 
 export default class extends React.Component {

--- a/client/post-editor/media-modal/detail/detail-preview-document.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-document.jsx
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-import classNames from 'classnames';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalDetailPreviewDocument';

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import Spinner from 'calypso/components/spinner';
-import MediaImage from 'calypso/my-sites/media-library/media-image';
 import { url, isItemBeingUploaded } from 'calypso/lib/media/utils';
+import MediaImage from 'calypso/my-sites/media-library/media-image';
 
 const noop = () => {};
 

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React, { useState } from 'react';
 import { url } from 'calypso/lib/media/utils';
 import MediaFile from 'calypso/my-sites/media-library/media-file';
 

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { isVideoPressItem } from 'calypso/lib/media/utils';
-import EditorMediaModalDetailItemVideoPress from './detail-preview-videopress';
 import EditorMediaModalDetailPreviewMediaFile from './detail-preview-media-file';
+import EditorMediaModalDetailItemVideoPress from './detail-preview-videopress';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalDetailPreviewAudio';

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { get, keys } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, keys } from 'lodash';
-import classNames from 'classnames';
 
 /**
  * Module variables

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -1,25 +1,15 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { partial } from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { partial } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import DetailItem from './detail-item';
-import { getMimePrefix, filterItemsByMimePrefix, url } from 'calypso/lib/media/utils';
 import HeaderCake from 'calypso/components/header-cake';
-import preloadImage from '../preload-image';
-import { ModalViews } from 'calypso/state/ui/media-modal/constants';
+import { getMimePrefix, filterItemsByMimePrefix, url } from 'calypso/lib/media/utils';
 import { setEditorMediaModalView } from 'calypso/state/editor/actions';
+import { ModalViews } from 'calypso/state/ui/media-modal/constants';
+import preloadImage from '../preload-image';
+import DetailItem from './detail-item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -2,18 +2,11 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
 
 jest.mock( 'calypso/post-editor/media-modal/detail/detail-fields', () =>
 	require( 'calypso/components/empty-component' )

--- a/client/post-editor/media-modal/dialog.jsx
+++ b/client/post-editor/media-modal/dialog.jsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { Dialog } from '@automattic/components';
-
-/**
- * Style dependencies
- */
+import classNames from 'classnames';
+import React from 'react';
 import './dialog.scss';
 
 export default ( { additionalClassNames, ...props } ) => (

--- a/client/post-editor/media-modal/fieldset.jsx
+++ b/client/post-editor/media-modal/fieldset.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-
-/**
- * Style dependencies
- */
 import './fieldset.scss';
 
 export default class extends React.Component {

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -1,25 +1,18 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import Popover from 'calypso/components/popover';
-import FormLabel from 'calypso/components/forms/form-label';
+import QueryPreferences from 'calypso/components/data/query-preferences';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
-import { Button } from '@automattic/components';
+import FormLabel from 'calypso/components/forms/form-label';
+import Gridicon from 'calypso/components/gridicon';
+import Popover from 'calypso/components/popover';
 import { setPreference, savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
-import QueryPreferences from 'calypso/components/data/query-preferences';
 
 class EditorMediaModalGalleryHelp extends React.PureComponent {
 	static displayName = 'EditorMediaModalGalleryHelp';

--- a/client/post-editor/media-modal/gallery/caption.jsx
+++ b/client/post-editor/media-modal/gallery/caption.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { updateMedia } from 'calypso/state/media/thunks';
 

--- a/client/post-editor/media-modal/gallery/drop-zone.jsx
+++ b/client/post-editor/media-modal/gallery/drop-zone.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
-import MediaLibraryDropZone from 'calypso/my-sites/media-library/drop-zone';
 import { filterItemsByMimePrefix } from 'calypso/lib/media/utils';
+import MediaLibraryDropZone from 'calypso/my-sites/media-library/drop-zone';
 import { selectMediaItems } from 'calypso/state/media/actions';
+import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
 
 class EditorMediaModalGalleryDropZone extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import MediaLibraryListItem from 'calypso/my-sites/media-library/list-item';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import EditorMediaModalGalleryCaption from './caption';
 import EditorMediaModalGalleryRemoveButton from './remove-button';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 
 class EditorMediaModalGalleryEditItem extends Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
+import { map, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, sortBy } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import SortableList from 'calypso/components/forms/sortable-list';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import EditorMediaModalGalleryEditItem from './edit-item';
 
 const noop = () => {};

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
+import { includes, times } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { includes, times } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import EditorMediaModalFieldset from '../fieldset';
-import SelectDropdown from 'calypso/components/select-dropdown';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'calypso/lib/media/constants';
 import { isModuleActive } from 'calypso/lib/site/utils';
+import EditorMediaModalFieldset from '../fieldset';
 
 const noop = () => {};
 

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -1,29 +1,18 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { omitBy, some, isEqual, partial } from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { omitBy, some, isEqual, partial } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import HeaderCake from 'calypso/components/header-cake';
+import { GalleryDefaultAttrs } from 'calypso/lib/media/constants';
+import { isModuleActive } from 'calypso/lib/site/utils';
+import { setEditorMediaModalView } from 'calypso/state/editor/actions';
+import getMediaItem from 'calypso/state/media/thunks/get-media-item';
+import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 import EditorMediaModalContent from '../content';
 import EditorMediaModalGalleryDropZone from './drop-zone';
 import EditorMediaModalGalleryFields from './fields';
 import EditorMediaModalGalleryPreview from './preview';
-import { GalleryDefaultAttrs } from 'calypso/lib/media/constants';
-import { ModalViews } from 'calypso/state/ui/media-modal/constants';
-import { setEditorMediaModalView } from 'calypso/state/editor/actions';
-import { isModuleActive } from 'calypso/lib/site/utils';
-import getMediaItem from 'calypso/state/media/thunks/get-media-item';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/post-editor/media-modal/gallery/preview-individual.jsx
+++ b/client/post-editor/media-modal/gallery/preview-individual.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import markup from '../markup';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import markup from '../markup';
 
 class EditorMediaModalGalleryPreviewIndividual extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/preview-shortcode.jsx
+++ b/client/post-editor/media-modal/gallery/preview-shortcode.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { some } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { some } from 'lodash';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { generateGalleryShortcode } from 'calypso/lib/media/utils';
 import GalleryShortcode from 'calypso/components/gallery-shortcode';
+import { generateGalleryShortcode } from 'calypso/lib/media/utils';
 
 export default class EditorMediaModalGalleryPreviewShortcode extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import Notice from 'calypso/components/notice';
 import SegmentedControl from 'calypso/components/segmented-control';
 import EditorMediaModalGalleryEdit from './edit';
-import EditorMediaModalGalleryPreviewShortcode from './preview-shortcode';
 import EditorMediaModalGalleryPreviewIndividual from './preview-individual';
+import EditorMediaModalGalleryPreviewShortcode from './preview-shortcode';
 
 const noop = () => {};
 

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
+import { ScreenReaderText } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { reject } from 'lodash';
+import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { reject } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { ScreenReaderText } from '@automattic/components';
-import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
 import { selectMediaItems } from 'calypso/state/media/actions';
+import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -1,40 +1,29 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { flow, get, isEmpty, partial, some, values } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import MediaLibrary from 'calypso/my-sites/media-library';
-import { bumpStat as mcBumpStat } from 'calypso/lib/analytics/mc';
-import { recordEditorEvent, recordEditorStat } from 'calypso/state/posts/stats';
-import MediaModalGallery from './gallery';
-import * as MediaUtils from 'calypso/lib/media/utils';
-import CloseOnEscape from 'calypso/components/close-on-escape';
-import accept from 'calypso/lib/accept';
-import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
-import { getMediaModalView } from 'calypso/state/ui/media-modal/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
-import { getEditorPostId } from 'calypso/state/editor/selectors';
-import { resetMediaModalView } from 'calypso/state/ui/media-modal/actions';
-import { setEditorMediaModalView } from 'calypso/state/editor/actions';
-import { ModalViews } from 'calypso/state/ui/media-modal/constants';
-import { editMedia, deleteMedia, addExternalMedia } from 'calypso/state/media/thunks';
-import { changeMediaSource, selectMediaItems, setQuery } from 'calypso/state/media/actions';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import ImageEditor from 'calypso/blocks/image-editor';
 import VideoEditor from 'calypso/blocks/video-editor';
-import MediaModalDialog from './dialog';
-import MediaModalDetail from './detail';
+import CloseOnEscape from 'calypso/components/close-on-escape';
+import accept from 'calypso/lib/accept';
+import { bumpStat as mcBumpStat } from 'calypso/lib/analytics/mc';
+import * as MediaUtils from 'calypso/lib/media/utils';
+import MediaLibrary from 'calypso/my-sites/media-library';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
+import { setEditorMediaModalView } from 'calypso/state/editor/actions';
+import { getEditorPostId } from 'calypso/state/editor/selectors';
+import { changeMediaSource, selectMediaItems, setQuery } from 'calypso/state/media/actions';
+import { editMedia, deleteMedia, addExternalMedia } from 'calypso/state/media/thunks';
+import { recordEditorEvent, recordEditorStat } from 'calypso/state/posts/stats';
+import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
+import { getSite } from 'calypso/state/sites/selectors';
+import { resetMediaModalView } from 'calypso/state/ui/media-modal/actions';
+import { ModalViews } from 'calypso/state/ui/media-modal/constants';
+import { getMediaModalView } from 'calypso/state/ui/media-modal/selectors';
+import MediaModalDetail from './detail';
+import MediaModalDialog from './dialog';
+import MediaModalGallery from './gallery';
 import './index.scss';
 
 const noop = () => {};

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import ReactDomServer from 'react-dom/server';
-import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { parse, stringify } from 'calypso/lib/shortcode';
-import * as MediaUtils from 'calypso/lib/media/utils';
+import React from 'react';
+import ReactDomServer from 'react-dom/server';
 import { deserialize } from 'calypso/lib/media-serialization';
+import * as MediaUtils from 'calypso/lib/media/utils';
+import { parse, stringify } from 'calypso/lib/shortcode';
 
 /**
  * Module variables

--- a/client/post-editor/media-modal/preload-image.js
+++ b/client/post-editor/media-modal/preload-image.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { memoize } from 'lodash';
 
 export default memoize( function ( src ) {

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { canUserDeleteItem } from 'calypso/lib/media/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { Button } from '@automattic/components';
 
 const noop = () => {};
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -2,21 +2,14 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { translate } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { EditorMediaModal } from '../';
 import accept from 'calypso/lib/accept';
 import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { EditorMediaModal } from '../';
 
 jest.mock( 'component-closest', () => {} );
 jest.mock(

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import ReactDomServer from 'react-dom/server';
-
-/**
- * Internal dependencies
- */
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import markup from '../markup';
 

--- a/client/post-editor/media-modal/test/preload-image.js
+++ b/client/post-editor/media-modal/test/preload-image.js
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import preloadImage from '../preload-image';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import preloadImage from '../preload-image';
 
 describe( '#preloadImage()', () => {
 	let sandbox;


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/post-editor` to use `import/order`

#### Testing instructions

N/A

