### PR TITLE
Emails: Enable new signup step for Professional Email in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,6 +98,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"sign-in-with-apple": false,
+		"signup/professional-email-step": true,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -107,6 +107,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/professional-email-step": true,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,6 +109,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/professional-email-step": true,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,


### PR DESCRIPTION
This pull request, which is a follow up of https://github.com/Automattic/wp-calypso/pull/54641, enables the new signup step that offers Professional Email to users in `horizon`, `staging`, and `production`:

![Screenshot](https://user-images.githubusercontent.com/3376401/126254419-3428a893-6444-4c39-877f-ef106974c410.png)


#### Testing instructions

None, as this is not testable.