### PR TITLE
chore: migrate `client/jetpack-cloud` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -189,6 +189,7 @@ module.exports = {
 				'client/document/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',
+				'client/jetpack-cloud/**/*',
 				'client/jetpack-connect/**/*',
 				'client/landing/**/*',
 				'client/login/**/*',

--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { NoJetpackSitesMessage } from 'calypso/components/jetpack/no-jetpack-sites-message';
 import { makeLayout, render as clientRender, setSectionMiddleware } from 'calypso/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
@@ -22,10 +15,6 @@ import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteId, getSiteSlug } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
-
-/**
- * Type dependencies
- */
 import type { UserData } from 'calypso/lib/user/user';
 import type PageJS from 'page';
 

--- a/client/jetpack-cloud/index.js
+++ b/client/jetpack-cloud/index.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import Debug from 'debug';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sites, siteSelection } from 'calypso/my-sites/controller';
-import { translate } from 'i18n-calypso';
-import Landing from './sections/landing';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getPrimarySiteIsJetpack from 'calypso/state/selectors/get-primary-site-is-jetpack';
+import Landing from './sections/landing';
 
 const debug = new Debug( 'calypso:jetpack-cloud:controller' );
 

--- a/client/jetpack-cloud/sections/auth/connect/index.tsx
+++ b/client/jetpack-cloud/sections/auth/connect/index.tsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Main from 'calypso/components/main';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
 import React from 'react';
 import store from 'store';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import Connect from './connect';
 
 const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';

--- a/client/jetpack-cloud/sections/auth/index.ts
+++ b/client/jetpack-cloud/sections/auth/index.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { connect, tokenRedirect } from './controller';
-import { makeLayout, render as clientRender } from 'calypso/controller';
 import config from '@automattic/calypso-config';
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { connect, tokenRedirect } from './controller';
 
 export default (): void => {
 	if ( config.isEnabled( 'jetpack-cloud' ) ) {

--- a/client/jetpack-cloud/sections/landing.tsx
+++ b/client/jetpack-cloud/sections/landing.tsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import { useSelector } from 'react-redux';
 import page from 'page';
 import React, { useEffect } from 'react';
-
-/**
- * Internal dependencies
- */
-import { AppState } from 'calypso/types';
+import { useSelector } from 'react-redux';
 import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
+import { AppState } from 'calypso/types';
 
 const siteIsEligible = ( state: AppState, siteId: number | null ) =>
 	siteId

--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React, { ReactElement } from 'react';
 import { useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import CardHeading from 'calypso/components/card-heading';
 import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function AddStoredCreditCard(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import { useTranslate } from 'i18n-calypso';
-import formatCurrency from '@automattic/format-currency';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import React, { ReactElement } from 'react';
+import Gridicon from 'calypso/components/gridicon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-
-/**
- * Style dependencies
- */
+import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
 import './style.scss';
 
 export default function BillingDetails(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
-import React, { ReactElement, useCallback, useRef, useState } from 'react';
-import { numberFormat, useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
-import Tooltip from 'calypso/components/tooltip';
+import formatCurrency from '@automattic/format-currency';
+import { numberFormat, useTranslate } from 'i18n-calypso';
+import React, { ReactElement, useCallback, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import Tooltip from 'calypso/components/tooltip';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-
-/**
- * Style dependencies
- */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useBillingDashboardQuery from 'calypso/state/partner-portal/licenses/hooks/use-billing-dashboard-query';
 import './style.scss';
 
 function CostTooltip(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -1,42 +1,35 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import page from 'page';
-import type PageJS from 'page';
-
-/**
- * Internal dependencies
- */
-import { addQueryArgs } from 'calypso/lib/route';
+import React from 'react';
+import BillingDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/billing-dashboard';
+import IssueLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license';
+import LandingPage from 'calypso/jetpack-cloud/sections/partner-portal/primary/landing-page';
+import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
+import PartnerAccess from 'calypso/jetpack-cloud/sections/partner-portal/primary/partner-access';
+import PaymentMethodAdd from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add';
+import PaymentMethodList from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-list';
+import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
+import TermsOfServiceConsent from 'calypso/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent';
+import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
 import {
-	getCurrentPartner,
-	hasActivePartnerKey,
-} from 'calypso/state/partner-portal/partner/selectors';
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import {
 	publicToInternalLicenseFilter,
 	publicToInternalLicenseSortField,
 	valueToEnum,
 	ensurePartnerPortalReturnUrl,
 } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import Header from './header';
 import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
-import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
-import PartnerAccess from 'calypso/jetpack-cloud/sections/partner-portal/primary/partner-access';
-import TermsOfServiceConsent from 'calypso/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent';
-import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
-import BillingDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/billing-dashboard';
-import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/licenses';
-import PaymentMethodList from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-list';
-import PaymentMethodAdd from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add';
-import IssueLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license';
-import LandingPage from 'calypso/jetpack-cloud/sections/partner-portal/primary/landing-page';
+import { addQueryArgs } from 'calypso/lib/route';
 import {
-	LicenseFilter,
-	LicenseSortDirection,
-	LicenseSortField,
-} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+	getCurrentPartner,
+	hasActivePartnerKey,
+} from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
+import Header from './header';
+import type PageJS from 'page';
 
 export function partnerContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/cvv-image.js
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/cvv-image.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
 
 function CVV( { className } ) {
 	const { __ } = useI18n();

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/payment-method-image.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/payment-method-image.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 export default function PaymentMethodImage() {

--- a/client/jetpack-cloud/sections/partner-portal/header/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/header/index.tsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import JetpackComMasterbar from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import FormattedHeader from 'calypso/components/formatted-header';
 import OlarkChat from 'calypso/components/olark-chat';
-import config from '@automattic/calypso-config';
+import JetpackComMasterbar from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import { preventWidows } from 'calypso/lib/formatting';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function Header() {

--- a/client/jetpack-cloud/sections/partner-portal/hooks.ts
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { useEffect } from 'react';
-import page from 'page';
 import { getQueryArg } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
+import page from 'page';
+import { useEffect } from 'react';
 import { ensurePartnerPortalReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 
 /**

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import page from 'page';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
+import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import * as controller from './controller';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function () {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -1,26 +1,15 @@
-/**
- * External dependencies
- */
-import React, { ReactElement, useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { APIProductFamily } from 'calypso/state/partner-portal/types';
-import { Button, Card } from '@automattic/components';
-import { addQueryArgs } from 'calypso/lib/url';
-import { errorNotice } from 'calypso/state/notices/actions';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
+import { errorNotice } from 'calypso/state/notices/actions';
+import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
 interface ProductOption {

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React, { ReactElement, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
+import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React, { ReactElement } from 'react';
+import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Gridicon from 'calypso/components/gridicon';
-import FormattedDate from 'calypso/components/formatted-date';
 import LicenseDetailsActions from 'calypso/jetpack-cloud/sections/partner-portal/license-details/actions';
-
-/**
- * Style dependencies
- */
+import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/license-list-context/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-context/index.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import {
 	LicenseFilter,
 	LicenseSortDirection,

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/index.tsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
-
-/**
- * Style dependencies
- */
+import classnames from 'classnames';
+import React, { ReactElement } from 'react';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import { useTranslate } from 'i18n-calypso';
-import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
-import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useTranslate } from 'i18n-calypso';
+import React, { ReactElement } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-
-/**
- * Style dependencies
- */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
@@ -1,30 +1,19 @@
-/**
- * External dependencies
- */
-import React, { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
-import { useDispatch } from 'react-redux';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React, { PropsWithChildren, ReactElement, useCallback, useContext } from 'react';
+import { useDispatch } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
-import Gridicon from 'calypso/components/gridicon';
-import { addQueryArgs } from 'calypso/lib/route';
 import { internalToPublicLicenseSortField } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function setSortingConfig(

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -1,36 +1,25 @@
-/**
- * External dependencies
- */
+import page from 'page';
 import React, { PropsWithChildren, ReactElement, useContext, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import page from 'page';
-import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
-
-/**
- * Internal dependencies
- */
-import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import TransitionGroup from 'react-transition-group/TransitionGroup';
+import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
+import Pagination from 'calypso/components/pagination';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty';
+import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header';
+import LicensePreview, {
+	LicensePreviewPlaceholder,
+} from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
 import { addQueryArgs } from 'calypso/lib/route';
-import { License, PaginatedItems } from 'calypso/state/partner-portal/types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
 import {
 	getPaginatedLicenses,
 	hasFetchedLicenses,
 	isFetchingLicenses,
 } from 'calypso/state/partner-portal/licenses/selectors';
-import LicensePreview, {
-	LicensePreviewPlaceholder,
-} from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
-import Pagination from 'calypso/components/pagination';
-import QueryJetpackPartnerPortalLicenses from 'calypso/components/data/query-jetpack-partner-portal-licenses';
-import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
-import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header';
-import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty';
-
-/**
- * Style dependencies
- */
+import { License, PaginatedItems } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
 function setPage( pageNumber: number ): void {

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -1,32 +1,21 @@
-/**
- * External dependencies
- */
-import React, { ReactElement, useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { getUrlParts } from '@automattic/calypso-url';
+import { Button } from '@automattic/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getUrlParts } from '@automattic/calypso-url';
-import { infoNotice } from 'calypso/state/notices/actions';
-import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import { Button } from '@automattic/components';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Gridicon from 'calypso/components/gridicon';
-import FormattedDate from 'calypso/components/formatted-date';
-import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
 import LicenseDetails from 'calypso/jetpack-cloud/sections/partner-portal/license-details';
-
-/**
- * Style dependencies
- */
+import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
+import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { infoNotice } from 'calypso/state/notices/actions';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -1,29 +1,17 @@
-/**
- * External dependencies
- */
-import React, { ReactElement, useContext } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React, { ReactElement, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-
-import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import SectionNav from 'calypso/components/section-nav';
-import NavTabs from 'calypso/components/section-nav/tabs';
-import NavItem from 'calypso/components/section-nav/item';
 import Count from 'calypso/components/count';
 import Search from 'calypso/components/search';
-import UrlSearch from 'calypso/lib/url-search';
-import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
-
-/**
- * Style dependencies
- */
+import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import UrlSearch from 'calypso/lib/url-search';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
 import { createStripeSetupIntent } from '@automattic/calypso-stripe';
-import type { Stripe, StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
-import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import { saveCreditCard } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { Stripe, StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 
 interface Props {
 	useAsPrimaryPaymentMethod?: boolean;

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/hooks/use-create-stored-credit-card.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/hooks/use-create-stored-credit-card.ts
@@ -1,11 +1,8 @@
-/**
- * External dependencies
- */
 import { useMemo } from 'react';
-import type { StripeConfiguration, Stripe, StripeLoadingError } from '@automattic/calypso-stripe';
-import type { PaymentMethod } from '@automattic/composite-checkout';
 import { createStoredCreditCardMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/stored-credit-card-method';
 import { createStoredCreditCardPaymentMethodStore } from 'calypso/state/partner-portal/payment-methods/';
+import type { StripeConfiguration, Stripe, StripeLoadingError } from '@automattic/calypso-stripe';
+import type { PaymentMethod } from '@automattic/composite-checkout';
 
 export function useCreateStoredCreditCardMethod( {
 	isStripeLoading,

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-credit-card-method.js
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-credit-card-method.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import CreditCardFields from 'calypso/jetpack-cloud/sections/partner-portal/credit-card-fields';
 import CreditCardPayButton from 'calypso/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-pay-button';
 

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import type { StripeConfiguration } from '@automattic/calypso-stripe';
-
-/**
- * Internal dependencies
- */
-import wpcomFactory from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcomFactory from 'calypso/lib/wp';
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
 
 const wpcom = wpcomFactory.undocumented();
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
+import React, { ReactElement } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
-import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
+import Main from 'calypso/components/main';
 import BillingDetails from 'calypso/jetpack-cloud/sections/partner-portal/billing-details';
+import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
-
-/**
- * Style dependencies
- */
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import './style.scss';
 
 export default function BillingDashboard(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { ReactElement, useEffect } from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
+import React, { ReactElement, useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import Main from 'calypso/components/main';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 
 export default function IssueLicense(): ReactElement {
 	const translate = useTranslate();

--- a/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/landing-page/index.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import page from 'page';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import { getActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
 
 export default function LandingPage(): React.ReactElement | null {

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,32 +1,21 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React, { ReactElement } from 'react';
 import { useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import Main from 'calypso/components/main';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
+import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
-import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
-import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/partner-access/index.tsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { PartnerKey } from 'calypso/state/partner-portal/types';
+import React, { ReactElement } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import CardHeading from 'calypso/components/card-heading';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import Main from 'calypso/components/main';
+import Spinner from 'calypso/components/spinner';
+import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isFetchingPartner,
 	getCurrentPartner,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
-import Main from 'calypso/components/main';
-import CardHeading from 'calypso/components/card-heading';
-import Spinner from 'calypso/components/spinner';
-import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { PartnerKey } from 'calypso/state/partner-portal/types';
 
 export default function PartnerAccess(): ReactElement | null {
 	const dispatch = useDispatch();

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
+import React, { ReactElement } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
-import { Card } from '@automattic/components';
 
 export default function PaymentMethodAdd(): ReactElement {
 	const translate = useTranslate();

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
-import { getAllStoredCards } from 'calypso/state/stored-cards/selectors';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
+import Main from 'calypso/components/main';
 import AddStoredCreditCard from 'calypso/jetpack-cloud/sections/partner-portal/add-stored-credit-card';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import StoredCreditCard from 'calypso/jetpack-cloud/sections/partner-portal/stored-credit-card';
-
-/**
- * Style dependencies
- */
+import { getAllStoredCards } from 'calypso/state/stored-cards/selectors';
 import './style.scss';
 
 export default function PaymentMethodList(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
@@ -1,15 +1,13 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { PartnerKey } from 'calypso/state/partner-portal/types';
+import React, { ReactElement } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import CardHeading from 'calypso/components/card-heading';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import Main from 'calypso/components/main';
+import Spinner from 'calypso/components/spinner';
+import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
 import {
 	isFetchingPartner,
@@ -17,16 +15,7 @@ import {
 	hasActivePartnerKey,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
-import Main from 'calypso/components/main';
-import CardHeading from 'calypso/components/card-heading';
-import Spinner from 'calypso/components/spinner';
-import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
-
-/**
- * Style dependencies
- */
+import { PartnerKey } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
 export default function SelectPartnerKey(): ReactElement | null {

--- a/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
@@ -1,36 +1,25 @@
-/**
- * External dependencies
- */
-import React, { ReactElement, useCallback, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React, { ReactElement, useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import CardHeading from 'calypso/components/card-heading';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import Gridicon from 'calypso/components/gridicon';
+import Main from 'calypso/components/main';
+import Spinner from 'calypso/components/spinner';
+import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import useTOSConsentMutation from 'calypso/state/partner-portal/licenses/hooks/use-tos-consent-mutation';
+import { receivePartner } from 'calypso/state/partner-portal/partner/actions';
 import {
 	getCurrentPartner,
 	hasFetchedPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
-import { receivePartner } from 'calypso/state/partner-portal/partner/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
-import Main from 'calypso/components/main';
-import CardHeading from 'calypso/components/card-heading';
-import Spinner from 'calypso/components/spinner';
-import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
-import useTOSConsentMutation from 'calypso/state/partner-portal/licenses/hooks/use-tos-consent-mutation';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import FormLabel from 'calypso/components/forms/form-label';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function TermsOfServiceConsent(): ReactElement | null {

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React, { ReactElement, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Dialog } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
-import { errorNotice } from 'calypso/state/notices/actions';
-import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
 import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown/index.tsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React, { ReactElement, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import SelectDropdown from 'calypso/components/select-dropdown';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
 import {
 	getActivePartnerKeyId,
 	getCurrentPartner,
 } from 'calypso/state/partner-portal/partner/selectors';
-import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import SelectDropdown from 'calypso/components/select-dropdown';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function SelectPartnerKeyDropdown(): ReactElement | null {

--- a/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
 import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function PartnerPortalSidebarNavigation(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { localize, translate as TranslateType } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, translate as TranslateType } from 'i18n-calypso';
-import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
-
-/**
- * Style dependencies
- */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import 'calypso/components/jetpack/sidebar/style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
-import React, { ReactElement } from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { PaymentLogo } from '@automattic/composite-checkout';
-
-/**
- * Style dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import React, { ReactElement } from 'react';
 import './style.scss';
 
 export default function StoredCreditCard( props ): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/text-placeholder/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/text-placeholder/index.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React, { ReactElement } from 'react';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function TextPlaceholder(): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	LicenseFilter,
 	LicenseSortField,

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { addQueryArgs } from 'calypso/lib/route';
 import { hideMasterbar } from 'calypso/state/ui/actions';
+import { setLocale } from 'calypso/state/ui/language/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
-import { setLocale } from 'calypso/state/ui/language/actions';
-import { addQueryArgs } from 'calypso/lib/route';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
 	const urlQueryArgs = context.query;

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import JetpackComMasterbar from '../jpcom-masterbar';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { preventWidows } from 'calypso/lib/formatting';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
-
-/**
- * Style dependencies
- */
+import { preventWidows } from 'calypso/lib/formatting';
+import JetpackComMasterbar from '../jpcom-masterbar';
 import './style.scss';
 
 const Header: React.FC< Props > = () => {

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,13 +1,6 @@
-/**
- * Internal dependencies
- */
-import { jetpackPricingContext } from './controller';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
-
-/**
- * Style dependencies
- */
+import { jetpackPricingContext } from './controller';
 import './style.scss';
 
 export default function (): void {

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SocialLogo from 'calypso/components/social-logo';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const AnAutomatticAirline = () => (

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -1,24 +1,12 @@
-/**
- * External dependencies
- */
-import React, { useCallback, useState } from 'react';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import React, { useCallback, useState } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import Gridicon from 'calypso/components/gridicon';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-
-/**
- * Style dependencies
- */
 import './style.scss';
-
 import antiSpamIcon from './assets/icons/anti-spam.svg';
 import backupIcon from './assets/icons/backup.svg';
 import boostIcon from './assets/icons/boost.svg';

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/connection-status.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/connection-status.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent } from 'react';
 

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/index.tsx
@@ -1,33 +1,22 @@
-/**
- * External dependencies
- */
-import { useDispatch } from 'react-redux';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useState, FormEventHandler } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import { FormState, FormMode, FormErrors, INITIAL_FORM_INTERACTION } from '../form';
-import { getHostInfoFromId } from '../host-info';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useDispatch } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormTextArea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextArea from 'calypso/components/forms/form-textarea';
 import Gridicon from 'calypso/components/gridicon';
 import InfoPopover from 'calypso/components/info-popover';
-import InlineInfo from './inline-info';
 import SegmentedControl from 'calypso/components/segmented-control';
-
-/**
- * Style dependencies
- */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { FormState, FormMode, FormErrors, INITIAL_FORM_INTERACTION } from '../form';
+import { getHostInfoFromId } from '../host-info';
+import InlineInfo from './inline-info';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/inline-info.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/credentials-form/inline-info.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { useDispatch } from 'react-redux';
 import React, { FunctionComponent, useEffect } from 'react';
-
-/**
- * Internal dependencies
- */
+import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import * as HostInfo from '../host-info';
 

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { TranslateResult, translate } from 'i18n-calypso';
 
 export enum FormMode {

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-info.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { translate, TranslateResult } from 'i18n-calypso';
 
 export interface LinkAndInfo {

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/host-selection/index.tsx
@@ -1,28 +1,17 @@
-/**
- * External dependencies
- */
-import { useDispatch, useSelector } from 'react-redux';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useEffect, useMemo } from 'react';
-import type { AnyAction } from 'redux';
-
-/**
- * Internal dependencies
- */
-import { getHttpData, requestHttpData, DataState } from 'calypso/state/data-layer/http-data';
-import { getProviderNameFromId, topHosts, otherHosts } from '../host-info';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useDispatch, useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Gridicon from 'calypso/components/gridicon';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getHttpData, requestHttpData, DataState } from 'calypso/state/data-layer/http-data';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getProviderNameFromId, topHosts, otherHosts } from '../host-info';
 import type { SiteId } from 'calypso/types';
-
-/**
- * Style dependencies
- */
+import type { AnyAction } from 'redux';
 import './style.scss';
 
 function getRequestHostingProviderGuessId( siteId: SiteId ) {

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/index.tsx
@@ -1,40 +1,29 @@
-/**
- * External dependencies
- */
-import { useSelector, useDispatch } from 'react-redux';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React, { FunctionComponent, useCallback, useMemo, useState, useEffect } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
-import { ConnectionStatus, StatusState } from './connection-status';
-import { FormMode, FormState, INITIAL_FORM_ERRORS, INITIAL_FORM_STATE, validate } from './form';
-import Verification from './verification';
-import { deleteCredentials, updateCredentials } from 'calypso/state/jetpack/credentials/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
-import CredentialsForm from './credentials-form';
+import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
+import Gridicon from 'calypso/components/gridicon';
+import Main from 'calypso/components/main';
+import StepProgress from 'calypso/components/step-progress';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import { JETPACK_CREDENTIALS_UPDATE_RESET } from 'calypso/state/action-types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { deleteCredentials, updateCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import getJetpackCredentialsUpdateError from 'calypso/state/selectors/get-jetpack-credentials-update-error';
 import getJetpackCredentialsUpdateStatus from 'calypso/state/selectors/get-jetpack-credentials-update-status';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
-import { JETPACK_CREDENTIALS_UPDATE_RESET } from 'calypso/state/action-types';
-import Gridicon from 'calypso/components/gridicon';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { ConnectionStatus, StatusState } from './connection-status';
+import CredentialsForm from './credentials-form';
+import { FormMode, FormState, INITIAL_FORM_ERRORS, INITIAL_FORM_STATE, validate } from './form';
 import HostSelection from './host-selection';
-import Main from 'calypso/components/main';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
-import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import StepProgress from 'calypso/components/step-progress';
-
-/**
- * Style dependencies
- */
+import Verification from './verification';
 import './style.scss';
 
 enum Step {

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/verification/index.tsx
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/verification/index.tsx
@@ -1,29 +1,18 @@
-/**
- * External dependencies
- */
-import { useSelector } from 'react-redux';
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent } from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useSelector } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { CredentialsTestProgress as Progress } from 'calypso/state/data-layer/wpcom/activity-log/update-credentials/vendor';
 import getJetpackCredentialsUpdateError, {
 	UpdateError,
 } from 'calypso/state/selectors/get-jetpack-credentials-update-error';
 import getJetpackCredentialsUpdateProgress from 'calypso/state/selectors/get-jetpack-credentials-update-progress';
-import { CredentialsTestProgress as Progress } from 'calypso/state/data-layer/wpcom/activity-log/update-credentials/vendor';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Style dependencies
- */
-import './style.scss';
 import getJetpackCredentialsUpdateStatus from 'calypso/state/selectors/get-jetpack-credentials-update-status';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import './style.scss';
 
 interface Props {
 	onFinishUp: () => void;

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';

--- a/client/jetpack-cloud/sections/settings/credentials/featured-provider.tsx
+++ b/client/jetpack-cloud/sections/settings/credentials/featured-provider.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React, { FunctionComponent } from 'react';
 
 interface Props {

--- a/client/jetpack-cloud/sections/settings/credentials/form.tsx
+++ b/client/jetpack-cloud/sections/settings/credentials/form.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
 
 const Form: FunctionComponent = () => {

--- a/client/jetpack-cloud/sections/settings/credentials/index.tsx
+++ b/client/jetpack-cloud/sections/settings/credentials/index.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React, { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import Form from './form';
 // import { isFeaturedProvider } from '../utils';
 

--- a/client/jetpack-cloud/sections/settings/empty-content.tsx
+++ b/client/jetpack-cloud/sections/settings/empty-content.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { preventWidows } from 'calypso/lib/formatting';

--- a/client/jetpack-cloud/sections/settings/has-site-credentials-switch.tsx
+++ b/client/jetpack-cloud/sections/settings/has-site-credentials-switch.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import React, { ReactNode, useCallback, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 import RenderSwitch from 'calypso/components/jetpack/render-switch';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';

--- a/client/jetpack-cloud/sections/settings/index.js
+++ b/client/jetpack-cloud/sections/settings/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	settings,
 	advancedCredentials,
 	showNotAuthorizedForNonAdmins,
 } from 'calypso/jetpack-cloud/sections/settings/controller';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
-import { isEnabled } from '@automattic/calypso-config';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 
 export default function () {
 	if ( isJetpackCloud() ) {

--- a/client/jetpack-cloud/sections/settings/loading/index.tsx
+++ b/client/jetpack-cloud/sections/settings/loading/index.tsx
@@ -1,8 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
 import './style.scss';
 
 const AdvancedCredentialsLoadingPlaceholder: React.FC = () => (

--- a/client/jetpack-cloud/sections/settings/loading/test/index.jsx
+++ b/client/jetpack-cloud/sections/settings/loading/test/index.jsx
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
+import { render } from 'config/testing-library';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-
-/**
- * Internal dependencies
- */
-import { render } from 'config/testing-library';
 import AdvancedCredentialsLoadingPlaceholder from '../index';
 
 describe( 'AdvancedCredentialsLoadingPlaceholder', () => {

--- a/client/jetpack-cloud/sections/settings/main.jsx
+++ b/client/jetpack-cloud/sections/settings/main.jsx
@@ -1,35 +1,24 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { localize, useTranslate } from 'i18n-calypso';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { localize, useTranslate } from 'i18n-calypso';
-import { Card } from '@automattic/components';
-
-/**
- * Internal dependencies
- */
+import connectedIcon from 'calypso/assets/images/jetpack/connected.svg';
+import disconnectedIcon from 'calypso/assets/images/jetpack/disconnected.svg';
 import DocumentHead from 'calypso/components/data/document-head';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
-import FoldableCard from 'calypso/components/foldable-card';
-import getRewindState from 'calypso/state/selectors/get-rewind-state';
-import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
-import getSiteCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
-import Main from 'calypso/components/main';
-import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import ExternalLink from 'calypso/components/external-link';
-
-/**
- * Style dependencies
- */
+import FoldableCard from 'calypso/components/foldable-card';
+import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import getSiteCredentials from 'calypso/state/selectors/get-jetpack-credentials';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
-import connectedIcon from 'calypso/assets/images/jetpack/connected.svg';
-import disconnectedIcon from 'calypso/assets/images/jetpack/disconnected.svg';
 
 const connectedProps = ( translate, connectedMessage ) => ( {
 	iconPath: connectedIcon,

--- a/client/jetpack-cloud/sections/settings/test/empty-content.jsx
+++ b/client/jetpack-cloud/sections/settings/test/empty-content.jsx
@@ -2,17 +2,10 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
+import { render } from 'config/testing-library';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-
-/**
- * Internal dependencies
- */
 import { JETPACK_PRICING_PAGE } from 'calypso/lib/url/support';
-import { render } from 'config/testing-library';
 import NoSitePurchasesMessage from '../empty-content';
 
 describe( 'NoSitePurchasesMessage', () => {

--- a/client/jetpack-cloud/style.tsx
+++ b/client/jetpack-cloud/style.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 import 'calypso/jetpack-cloud/style.scss';


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/jetpack-cloud` to use `import/order`

#### Testing instructions

N/A
