### PR TITLE
chore: migrate `client/devdocs` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
 				'client/boot/**/*',
 				'client/controller/**/*',
 				'client/data/**/*',
+				'client/devdocs/**/*',
 				'client/document/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { stringify } from 'qs';
 import { debounce } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { stringify } from 'qs';
+import React from 'react';
+import EmptyContent from 'calypso/components/empty-content';
+import { login } from 'calypso/lib/paths';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 // This is a custom AsyncLoad component for devdocs that includes a
 // `props.component`-aware placeholder. It still needs to be imported as
 // `AsyncLoad` though–see https://github.com/Automattic/babel-plugin-transform-wpcalypso-async/blob/HEAD/index.js#L12
 import AsyncLoad from './devdocs-async-load';
-import DocsComponent from './main';
-import { login } from 'calypso/lib/paths';
 import SingleDocComponent from './doc';
-import DevWelcome from './welcome';
+import DocsComponent from './main';
 import Sidebar from './sidebar';
-import EmptyContent from 'calypso/components/empty-content';
+import DevWelcome from './welcome';
 import WizardComponent from './wizard-component';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const devdocs = {
 	/*

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -1,83 +1,72 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import { trim } from 'lodash';
-import { slugToCamelCase } from 'calypso/devdocs/docs-example/util';
-
-/**
- * Internal dependencies
- */
-import Collection from 'calypso/devdocs/design/search-collection';
-import DocumentHead from 'calypso/components/data/document-head';
-import HeaderCake from 'calypso/components/header-cake';
-import Main from 'calypso/components/main';
-import ReadmeViewer from 'calypso/components/readme-viewer';
-import SearchCard from 'calypso/components/search-card';
-import { isEnabled } from '@automattic/calypso-config';
-
-/**
- * Docs examples
- */
+import page from 'page';
+import React from 'react';
 import AllSites from 'calypso/blocks/all-sites/docs/example';
+import AuthorCompactProfile from 'calypso/blocks/author-compact-profile/docs/example';
+import AuthorSelector from 'calypso/blocks/author-selector/docs/example';
 import CalendarButton from 'calypso/blocks/calendar-button/docs/example';
 import CalendarPopover from 'calypso/blocks/calendar-popover/docs/example';
-import AuthorSelector from 'calypso/blocks/author-selector/docs/example';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
 import CommentButtons from 'calypso/blocks/comment-button/docs/example';
-import FollowButton from 'calypso/blocks/follow-button/docs/example';
-import LikeButtons from 'calypso/blocks/like-button/docs/example';
-import PostSchedule from 'calypso/components/post-schedule/docs/example';
-import PostSelector from 'calypso/my-sites/post-selector/docs/example';
-import ProductPlanOverlapNotices from 'calypso/blocks/product-plan-overlap-notices/docs/example';
-import Site from 'calypso/blocks/site/docs/example';
-import SitePlaceholder from 'calypso/blocks/site/docs/placeholder-example';
-import SitesDropdown from 'calypso/components/sites-dropdown/docs/example';
-import SiteIcon from 'calypso/blocks/site-icon/docs/example';
-import Theme from 'calypso/components/theme/docs/example';
-import HappinessSupport from 'calypso/components/happiness-support/docs/example';
-import ThemesListExample from 'calypso/components/themes-list/docs/example';
-import PlanStorage from 'calypso/blocks/plan-storage/docs/example';
-import PlanCompareCard from 'calypso/my-sites/plan-compare-card/docs/example';
-import DomainTip from 'calypso/blocks/domain-tip/docs/example';
-import PostItem from 'calypso/blocks/post-item/docs/example';
-import ReaderAuthorLink from 'calypso/blocks/reader-author-link/docs/example';
-import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link/docs/example';
-import AuthorCompactProfile from 'calypso/blocks/author-compact-profile/docs/example';
-import RelatedPostCard from 'calypso/blocks/reader-related-card/docs/example';
-import PlanPrice from 'calypso/my-sites/plan-price/docs/example';
-import PostShare from 'calypso/blocks/post-share/docs/example';
-import PlanThankYouCard from 'calypso/blocks/plan-thank-you-card/docs/example';
-import DismissibleCard from 'calypso/blocks/dismissible-card/docs/example';
-import PostEditButton from 'calypso/blocks/post-edit-button/docs/example';
 import PostComment from 'calypso/blocks/comments/docs/post-comment-example';
-import ReaderAvatar from 'calypso/blocks/reader-avatar/docs/example';
-import ImageEditor from 'calypso/blocks/image-editor/docs/example';
-import VideoEditor from 'calypso/blocks/video-editor/docs/example';
-import ReaderPostCard from 'calypso/blocks/reader-post-card/docs/example';
-import ReaderCombinedCard from 'calypso/blocks/reader-combined-card/docs/example';
-import ReaderRecommendedSites from 'calypso/blocks/reader-recommended-sites/docs/example';
-import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu/docs/example';
-import DailyPostButton from 'calypso/blocks/daily-post-button/docs/example';
-import ReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/docs/example';
-import PostLikes from 'calypso/blocks/post-likes/docs/example';
-import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video/docs/example';
-import NpsSurvey from 'calypso/blocks/nps-survey/docs/example';
-import ReaderExportButton from 'calypso/blocks/reader-export-button/docs/example';
-import ReaderImportButton from 'calypso/blocks/reader-import-button/docs/example';
-import SharingPreviewPane from 'calypso/blocks/sharing-preview-pane/docs/example';
-import ReaderShare from 'calypso/blocks/reader-share/docs/example';
-import Login from 'calypso/blocks/login/docs/example';
-import ConversationCommentList from 'calypso/blocks/conversations/docs/example';
 import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar/docs/example';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button/docs/example';
-import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
-import UserMentions from 'calypso/blocks/user-mentions/docs/example';
+import ConversationCommentList from 'calypso/blocks/conversations/docs/example';
+import DailyPostButton from 'calypso/blocks/daily-post-button/docs/example';
+import DismissibleCard from 'calypso/blocks/dismissible-card/docs/example';
+import DomainTip from 'calypso/blocks/domain-tip/docs/example';
+import FollowButton from 'calypso/blocks/follow-button/docs/example';
+import ImageEditor from 'calypso/blocks/image-editor/docs/example';
+import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt/docs/example';
+import LikeButtons from 'calypso/blocks/like-button/docs/example';
+import Login from 'calypso/blocks/login/docs/example';
+import NpsSurvey from 'calypso/blocks/nps-survey/docs/example';
+import PlanStorage from 'calypso/blocks/plan-storage/docs/example';
+import PlanThankYouCard from 'calypso/blocks/plan-thank-you-card/docs/example';
+import PostEditButton from 'calypso/blocks/post-edit-button/docs/example';
+import PostItem from 'calypso/blocks/post-item/docs/example';
+import PostLikes from 'calypso/blocks/post-likes/docs/example';
+import PostShare from 'calypso/blocks/post-share/docs/example';
+import ProductPlanOverlapNotices from 'calypso/blocks/product-plan-overlap-notices/docs/example';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link/docs/example';
+import ReaderAvatar from 'calypso/blocks/reader-avatar/docs/example';
+import ReaderCombinedCard from 'calypso/blocks/reader-combined-card/docs/example';
+import ReaderExportButton from 'calypso/blocks/reader-export-button/docs/example';
+import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video/docs/example';
+import ReaderImportButton from 'calypso/blocks/reader-import-button/docs/example';
+import ReaderPostCard from 'calypso/blocks/reader-post-card/docs/example';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu/docs/example';
+import ReaderRecommendedSites from 'calypso/blocks/reader-recommended-sites/docs/example';
+import RelatedPostCard from 'calypso/blocks/reader-related-card/docs/example';
+import ReaderShare from 'calypso/blocks/reader-share/docs/example';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link/docs/example';
+import ReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/docs/example';
+import SharingPreviewPane from 'calypso/blocks/sharing-preview-pane/docs/example';
+import SiteIcon from 'calypso/blocks/site-icon/docs/example';
+import Site from 'calypso/blocks/site/docs/example';
+import SitePlaceholder from 'calypso/blocks/site/docs/placeholder-example';
 import SupportArticleDialog from 'calypso/blocks/support-article-dialog/docs/example';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning/docs/example';
 import UpsellNudge from 'calypso/blocks/upsell-nudge/docs/example';
-import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt/docs/example';
+import UserMentions from 'calypso/blocks/user-mentions/docs/example';
+import VideoEditor from 'calypso/blocks/video-editor/docs/example';
+import DocumentHead from 'calypso/components/data/document-head';
+import HappinessSupport from 'calypso/components/happiness-support/docs/example';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PostSchedule from 'calypso/components/post-schedule/docs/example';
+import ReadmeViewer from 'calypso/components/readme-viewer';
+import SearchCard from 'calypso/components/search-card';
+import SitesDropdown from 'calypso/components/sites-dropdown/docs/example';
+import Theme from 'calypso/components/theme/docs/example';
+import ThemesListExample from 'calypso/components/themes-list/docs/example';
+import Collection from 'calypso/devdocs/design/search-collection';
+import { slugToCamelCase } from 'calypso/devdocs/docs-example/util';
+import PlanCompareCard from 'calypso/my-sites/plan-compare-card/docs/example';
+import PlanPrice from 'calypso/my-sites/plan-price/docs/example';
+import PostSelector from 'calypso/my-sites/post-selector/docs/example';
 
 export default class AppComponents extends React.Component {
 	static displayName = 'AppComponents';

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 export { default as ActionCard } from 'calypso/components/action-card/docs/example';
 export { default as Animate } from 'calypso/components/animate/docs/example';
 export { default as BackButton } from 'calypso/components/back-button/docs/example';

--- a/client/devdocs/design/component-playground.jsx
+++ b/client/devdocs/design/component-playground.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import Gridicon from 'calypso/components/gridicon';
 import DocsExampleWrapper from 'calypso/devdocs/docs-example/wrapper';
 
 class ComponentPlayground extends Component {

--- a/client/devdocs/design/illustrations.jsx
+++ b/client/devdocs/design/illustrations.jsx
@@ -1,25 +1,23 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import DocumentHead from 'calypso/components/data/document-head';
-import Main from 'calypso/components/main';
-
-/**
- * Illustrations
- */
+import customerHomeIllustrationBusiness from 'calypso/assets/images/customer-home/illustration--business.svg';
+import customerHomeIllustrationChecklistComplete from 'calypso/assets/images/customer-home/illustration--checklist-complete.svg';
+import customerHomeIllustrationFireworks from 'calypso/assets/images/customer-home/illustration--fireworks-v2.svg';
+import customerHomeIllustrationImportComplete from 'calypso/assets/images/customer-home/illustration--import-complete.svg';
+import customerHomeIllustrationRocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
+import customerHomeIllustrationSecondaryEarn from 'calypso/assets/images/customer-home/illustration--secondary-earn.svg';
+import customerHomeIllustrationSecondaryFreePhoto from 'calypso/assets/images/customer-home/illustration--secondary-free-photo-library.svg';
+import customerHomeIllustrationSecondaryGutenberg from 'calypso/assets/images/customer-home/illustration--secondary-gutenberg.svg';
+import customerHomeIllustrationTaskConnect from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
+import customerHomeIllustrationTaskEarn from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
+import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
+import customerHomeIllustrationWebinars from 'calypso/assets/images/customer-home/illustration-webinars.svg';
 import adwordsGoogle from 'calypso/assets/images/illustrations/adwords-google.svg';
 import apps from 'calypso/assets/images/illustrations/apps.svg';
 import blockEditorFade from 'calypso/assets/images/illustrations/block-editor-fade.svg';
 import builderReferral from 'calypso/assets/images/illustrations/builder-referral.svg';
 import checkEmail from 'calypso/assets/images/illustrations/check-email.svg';
-import customDomain from 'calypso/assets/images/illustrations/custom-domain.svg';
 import customDomainBlogger from 'calypso/assets/images/illustrations/custom-domain-blogger.svg';
+import customDomain from 'calypso/assets/images/illustrations/custom-domain.svg';
 import dashboard from 'calypso/assets/images/illustrations/dashboard.svg';
 import dotcomSupport from 'calypso/assets/images/illustrations/dotcom-support.svg';
 import dotcomWordAds from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
@@ -27,6 +25,11 @@ import fireworks from 'calypso/assets/images/illustrations/fireworks.svg';
 import getAppsBanner from 'calypso/assets/images/illustrations/get-apps-banner.svg';
 import googleAnalytics from 'calypso/assets/images/illustrations/google-analytics.svg';
 import googleMyBusinessFeature from 'calypso/assets/images/illustrations/google-my-business-feature.svg';
+import helpDomains from 'calypso/assets/images/illustrations/help-domains.svg';
+import helpGetStarted from 'calypso/assets/images/illustrations/help-getstarted.svg';
+import helpPlugins from 'calypso/assets/images/illustrations/help-plugins.svg';
+import helpPrivacy from 'calypso/assets/images/illustrations/help-privacy.svg';
+import helpWebsite from 'calypso/assets/images/illustrations/help-website.svg';
 import jetpackBackup from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import jetpackConcierge from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 import jetpackScan from 'calypso/assets/images/illustrations/jetpack-scan.svg';
@@ -44,23 +47,8 @@ import themes from 'calypso/assets/images/illustrations/themes.svg';
 import updates from 'calypso/assets/images/illustrations/updates.svg';
 import videoHosting from 'calypso/assets/images/illustrations/video-hosting.svg';
 import whoops from 'calypso/assets/images/illustrations/whoops.svg';
-import helpDomains from 'calypso/assets/images/illustrations/help-domains.svg';
-import helpGetStarted from 'calypso/assets/images/illustrations/help-getstarted.svg';
-import helpPlugins from 'calypso/assets/images/illustrations/help-plugins.svg';
-import helpWebsite from 'calypso/assets/images/illustrations/help-website.svg';
-import helpPrivacy from 'calypso/assets/images/illustrations/help-privacy.svg';
-import customerHomeIllustrationBusiness from 'calypso/assets/images/customer-home/illustration--business.svg';
-import customerHomeIllustrationChecklistComplete from 'calypso/assets/images/customer-home/illustration--checklist-complete.svg';
-import customerHomeIllustrationFireworks from 'calypso/assets/images/customer-home/illustration--fireworks-v2.svg';
-import customerHomeIllustrationImportComplete from 'calypso/assets/images/customer-home/illustration--import-complete.svg';
-import customerHomeIllustrationRocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
-import customerHomeIllustrationSecondaryEarn from 'calypso/assets/images/customer-home/illustration--secondary-earn.svg';
-import customerHomeIllustrationSecondaryFreePhoto from 'calypso/assets/images/customer-home/illustration--secondary-free-photo-library.svg';
-import customerHomeIllustrationSecondaryGutenberg from 'calypso/assets/images/customer-home/illustration--secondary-gutenberg.svg';
-import customerHomeIllustrationTaskConnect from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
-import customerHomeIllustrationTaskEarn from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
-import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/customer-home/illustration--task-find-domain.svg';
-import customerHomeIllustrationWebinars from 'calypso/assets/images/customer-home/illustration-webinars.svg';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
 
 export default class Illustrations extends React.PureComponent {
 	render() {

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -1,25 +1,17 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
-import classnames from 'classnames';
-import { slugToCamelCase } from 'calypso/devdocs/docs-example/util';
-import { trim } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import DocumentHead from 'calypso/components/data/document-head';
-import HeaderCake from 'calypso/components/header-cake';
-import Main from 'calypso/components/main';
-import ReadmeViewer from 'calypso/components/readme-viewer';
-import SearchCard from 'calypso/components/search-card';
-
-/**
- * Docs examples
- */
+import Buttons from '@automattic/components/src/button/docs/example';
+import Cards from '@automattic/components/src/card/docs/example';
+import ProductIcon from '@automattic/components/src/product-icon/docs/example';
+import ProgressBar from '@automattic/components/src/progress-bar/docs/example';
+import Ribbon from '@automattic/components/src/ribbon/docs/example';
+import ScreenReaderTextExample from '@automattic/components/src/screen-reader-text/docs/example';
+import Suggestions from '@automattic/components/src/suggestions/docs/example';
+import classnames from 'classnames';
+import { trim } from 'lodash';
+import page from 'page';
+import React from 'react';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
+import JetpackReviewPromptExample from 'calypso/blocks/jetpack-review-prompt/docs/example';
 import ActionCard from 'calypso/components/action-card/docs/example';
 import ActionPanel from 'calypso/components/action-panel/docs/example';
 import Animate from 'calypso/components/animate/docs/example';
@@ -28,17 +20,12 @@ import Badge from 'calypso/components/badge/docs/example';
 import Banner from 'calypso/components/banner/docs/example';
 import BulkSelect from 'calypso/components/bulk-select/docs/example';
 import ButtonGroups from 'calypso/components/button-group/docs/example';
-import Buttons from '@automattic/components/src/button/docs/example';
 import CardHeading from 'calypso/components/card-heading/docs/example';
-import Cards from '@automattic/components/src/card/docs/example';
 import Chart from 'calypso/components/chart/docs/example';
 import Checklist from 'calypso/components/checklist/docs/example';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input/docs/example';
-import ClipboardButtons from 'calypso/components/forms/clipboard-button/docs/example';
-import Collection from 'calypso/devdocs/design/search-collection';
-import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
 import Count from 'calypso/components/count/docs/example';
-import CountedTextareas from 'calypso/components/forms/counted-textarea/docs/example';
+import DocumentHead from 'calypso/components/data/document-head';
 import DatePicker from 'calypso/components/date-picker/docs/example';
 import DateRange from 'calypso/components/date-range/docs/example';
 import DiffViewerExample from 'calypso/components/diff-viewer/docs/example';
@@ -56,15 +43,19 @@ import FoldableCard from 'calypso/components/foldable-card/docs/example';
 import FoldableFAQ from 'calypso/components/foldable-faq/docs/example';
 import FormattedDate from 'calypso/components/formatted-date/docs/example';
 import FormattedHeader from 'calypso/components/formatted-header/docs/example';
+import ClipboardButtons from 'calypso/components/forms/clipboard-button/docs/example';
+import CountedTextareas from 'calypso/components/forms/counted-textarea/docs/example';
 import FormFields from 'calypso/components/forms/docs/example';
+import Ranges from 'calypso/components/forms/range/docs/example';
 import Gauge from 'calypso/components/gauge/docs/example';
 import GlobalNotices from 'calypso/components/global-notices/docs/example';
-import Gravatar from 'calypso/components/gravatar/docs/example';
 import GravatarCaterpillar from 'calypso/components/gravatar-caterpillar/docs/example';
+import Gravatar from 'calypso/components/gravatar/docs/example';
 import Gridicon from 'calypso/components/gridicon/docs/example';
 import GSuiteExamples from 'calypso/components/gsuite/docs/example';
 import HappinessEngineersTray from 'calypso/components/happiness-engineers-tray/docs/example';
 import HeaderButton from 'calypso/components/header-button/docs/example';
+import HeaderCake from 'calypso/components/header-cake';
 import Headers from 'calypso/components/header-cake/docs/example';
 import ImagePreloader from 'calypso/components/image-preloader/docs/example';
 import InfoPopover from 'calypso/components/info-popover/docs/example';
@@ -74,10 +65,10 @@ import JetpackColophonExample from 'calypso/components/jetpack-colophon/docs/exa
 import JetpackHeaderExample from 'calypso/components/jetpack-header/docs/example';
 import JetpackLogoExample from 'calypso/components/jetpack-logo/docs/example';
 import LanguagePicker from 'calypso/components/language-picker/docs/example';
-import JetpackReviewPromptExample from 'calypso/blocks/jetpack-review-prompt/docs/example';
 import LayoutExample from 'calypso/components/layout/docs/example';
 import LineChart from 'calypso/components/line-chart/docs/example';
 import ListEnd from 'calypso/components/list-end/docs/example';
+import Main from 'calypso/components/main';
 import MarkedLinesExample from 'calypso/components/marked-lines/docs/example';
 import MultipleChoiceQuestionExample from 'calypso/components/multiple-choice-question/docs/example';
 import Notices from 'calypso/components/notice/docs/example';
@@ -88,14 +79,11 @@ import PodcastIndicator from 'calypso/components/podcast-indicator/docs/example'
 import Popovers from 'calypso/components/popover/docs/example';
 import ProductCard from 'calypso/components/product-card/docs/example';
 import ProductExpiration from 'calypso/components/product-expiration/docs/example';
-import ProductIcon from '@automattic/components/src/product-icon/docs/example';
-import ProgressBar from '@automattic/components/src/progress-bar/docs/example';
 import PromoSection from 'calypso/components/promo-section/docs/example';
 import PromoCard from 'calypso/components/promo-section/promo-card/docs/example';
-import Ranges from 'calypso/components/forms/range/docs/example';
 import Rating from 'calypso/components/rating/docs/example';
-import Ribbon from '@automattic/components/src/ribbon/docs/example';
-import ScreenReaderTextExample from '@automattic/components/src/screen-reader-text/docs/example';
+import ReadmeViewer from 'calypso/components/readme-viewer';
+import SearchCard from 'calypso/components/search-card';
 import SearchDemo from 'calypso/components/search/docs/example';
 import SectionHeader from 'calypso/components/section-header/docs/example';
 import SectionNav from 'calypso/components/section-nav/docs/example';
@@ -103,19 +91,18 @@ import SegmentedControl from 'calypso/components/segmented-control/docs/example'
 import SelectDropdown from 'calypso/components/select-dropdown/docs/example';
 import ShareButton from 'calypso/components/share-button/docs/example';
 import SocialLogos from 'calypso/components/social-logo/docs/example';
-import Spinner from 'calypso/components/spinner/docs/example';
 import SpinnerButton from 'calypso/components/spinner-button/docs/example';
 import SpinnerLine from 'calypso/components/spinner-line/docs/example';
+import Spinner from 'calypso/components/spinner/docs/example';
 import SplitButton from 'calypso/components/split-button/docs/example';
 import StepProgress from 'calypso/components/step-progress/docs/example';
-import Suggestions from '@automattic/components/src/suggestions/docs/example';
 import SuggestionSearchExample from 'calypso/components/suggestion-search/docs/example';
 import SupportInfoExample from 'calypso/components/support-info/docs/example';
-import TextareaAutosize from 'calypso/components/textarea-autosize/docs/example';
 import TextDiff from 'calypso/components/text-diff/docs/example';
+import TextareaAutosize from 'calypso/components/textarea-autosize/docs/example';
 import TileGrid from 'calypso/components/tile-grid/docs/example';
-import Timeline from 'calypso/components/timeline/docs/example';
 import TimeSince from 'calypso/components/time-since/docs/example';
+import Timeline from 'calypso/components/timeline/docs/example';
 import Timezone from 'calypso/components/timezone/docs/example';
 import TokenFields from 'calypso/components/token-field/docs/example';
 import Tooltip from 'calypso/components/tooltip/docs/example';
@@ -123,9 +110,11 @@ import UserItem from 'calypso/components/user/docs/example';
 import Version from 'calypso/components/version/docs/example';
 import VerticalMenu from 'calypso/components/vertical-menu/docs/example';
 import VerticalNav from 'calypso/components/vertical-nav/docs/example';
-import Wizard from 'calypso/components/wizard/docs/example';
 import WizardProgressBar from 'calypso/components/wizard-progress-bar/docs/example';
+import Wizard from 'calypso/components/wizard/docs/example';
 import WpcomColophon from 'calypso/components/wpcom-colophon/docs/example';
+import Collection from 'calypso/devdocs/design/search-collection';
+import { slugToCamelCase } from 'calypso/devdocs/docs-example/util';
 
 export default class DesignAssets extends React.Component {
 	static displayName = 'DesignAssets';

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 export {
 	Button,
 	Card,

--- a/client/devdocs/design/playground-utils.js
+++ b/client/devdocs/design/playground-utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { findKey } from 'lodash';
 import format from 'react-element-to-jsx-string';
-
-/**
- * Internal dependencies
- */
 import * as scope from './playground-scope';
 
 // Figure out a React element's display name, with the help of the `playground-scope` map.

--- a/client/devdocs/design/playground.jsx
+++ b/client/devdocs/design/playground.jsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
 import classnames from 'classnames';
-import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import { keys } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import * as componentExamples from 'calypso/devdocs/design/component-examples';
-import * as playgroundScope from 'calypso/devdocs/design/playground-scope';
+import page from 'page';
+import React from 'react';
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import * as componentExamples from 'calypso/devdocs/design/component-examples';
+import * as playgroundScope from 'calypso/devdocs/design/playground-scope';
 import { getExampleCodeFromComponent } from './playground-utils';
-
-/**
- * Style Dependencies
- */
 import './playground.scss';
 import './syntax.scss';
 

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { map, chunk } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import ComponentPlayground from 'calypso/devdocs/design/component-playground';
+import React from 'react';
 import LazyRender from 'react-lazily-render';
-import DocsExampleWrapper from 'calypso/devdocs/docs-example/wrapper';
-import { camelCaseToSlug, getComponentName } from 'calypso/devdocs/docs-example/util';
 import ReadmeViewer from 'calypso/components/readme-viewer';
+import ComponentPlayground from 'calypso/devdocs/design/component-playground';
 import Placeholder from 'calypso/devdocs/devdocs-async-load/placeholder';
+import { camelCaseToSlug, getComponentName } from 'calypso/devdocs/docs-example/util';
+import DocsExampleWrapper from 'calypso/devdocs/docs-example/wrapper';
 import { getExampleCodeFromComponent } from './playground-utils';
 
 const shouldShowInstance = ( example, filter, component ) => {

--- a/client/devdocs/design/test/component-playground.js
+++ b/client/devdocs/design/test/component-playground.js
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 import { LiveProvider } from 'react-live';
-
-/**
- * Internal dependencies
- */
 import ComponentPlayground from '../component-playground';
 
 jest.mock( 'calypso/devdocs/design/playground-scope', () => 'PlaygroundScope' );

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 

--- a/client/devdocs/design/wordpress-components-gallery/angle-picker-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/angle-picker-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { AnglePickerControl } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const AnglePickerControlExample = () => {
 	const [ angle, setAngle ] = useState();

--- a/client/devdocs/design/wordpress-components-gallery/animate.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/animate.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Animate, Notice } from '@wordpress/components';
+import React from 'react';
 
 const AnimateExample = () => (
 	<Animate type="loading">

--- a/client/devdocs/design/wordpress-components-gallery/base-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/base-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { BaseControl, TextareaControl } from '@wordpress/components';
+import React from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};

--- a/client/devdocs/design/wordpress-components-gallery/button-group.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/button-group.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Button, ButtonGroup } from '@wordpress/components';
+import React from 'react';
 
 const ButtonGroupExample = () => {
 	const style = { margin: '0 4px' };

--- a/client/devdocs/design/wordpress-components-gallery/button.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/button.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
-import { more } from '@wordpress/icons';
 import { Button as InnerButton, Flex, FlexItem } from '@wordpress/components';
+import { more } from '@wordpress/icons';
+import React from 'react';
 
 const Button = ( props: InnerButton.Props ) => (
 	<FlexItem>

--- a/client/devdocs/design/wordpress-components-gallery/card.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/card.tsx
@@ -1,11 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import {
 	Button,
 	Card,
@@ -16,6 +8,7 @@ import {
 	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
+import React from 'react';
 
 const CardExample = () => (
 	<Card isElevated>

--- a/client/devdocs/design/wordpress-components-gallery/checkbox-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/checkbox-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { CheckboxControl } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const CheckboxControlExample = () => {
 	const [ isChecked, setChecked ] = useState( false );

--- a/client/devdocs/design/wordpress-components-gallery/clipboard-button.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/clipboard-button.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { ClipboardButton } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const ClipboardButtonExample = () => {
 	const [ isCopied, setCopied ] = useState( false );

--- a/client/devdocs/design/wordpress-components-gallery/color-palette.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/color-palette.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { ColorPalette } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const ColorPaletteExample = () => {
 	const colors: ColorPalette.Color[] = [

--- a/client/devdocs/design/wordpress-components-gallery/custom-select-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/custom-select-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { CustomSelectControl } from '@wordpress/components';
+import React from 'react';
 
 const defaultOptions = [
 	{

--- a/client/devdocs/design/wordpress-components-gallery/date-time-picker.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/date-time-picker.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { DateTimePicker } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const DateTimePickerExample = () => {
 	const [ dateTime, setDateTime ] = useState( '' );

--- a/client/devdocs/design/wordpress-components-gallery/disabled.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/disabled.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Disabled, SelectControl, TextControl, TextareaControl } from '@wordpress/components';
+import React from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};

--- a/client/devdocs/design/wordpress-components-gallery/draggable.jsx
+++ b/client/devdocs/design/wordpress-components-gallery/draggable.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Draggable } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const Box = ( props ) => {
 	return (

--- a/client/devdocs/design/wordpress-components-gallery/dropdown-menu.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/dropdown-menu.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
-import { Fragment } from '@wordpress/element';
 import { DropdownMenu, MenuGroup, MenuItem, MenuItemsChoice } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 import { more, arrowUp, arrowDown, trash } from '@wordpress/icons';
+import React, { useState } from 'react';
 
 const DropdownMenuExample = () => {
 	const [ mode, setMode ] = useState( 'visual' );

--- a/client/devdocs/design/wordpress-components-gallery/external-link.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/external-link.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { ExternalLink } from '@wordpress/components';
+import React from 'react';
 
 const ExternalLinkExample = () => (
 	<ExternalLink href="https://wordpress.org">WordPress.org</ExternalLink>

--- a/client/devdocs/design/wordpress-components-gallery/focal-point-picker.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/focal-point-picker.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { FocalPointPicker } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const FocalPointPickerExample = () => {
 	const url = 'https://interactive-examples.mdn.mozilla.net/media/examples/flower.webm';

--- a/client/devdocs/design/wordpress-components-gallery/font-size-picker.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/font-size-picker.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { FontSizePicker } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const FontSizePickerExample = () => {
 	const [ fontSize, setFontSize ] = useState< number | undefined >( 16 );

--- a/client/devdocs/design/wordpress-components-gallery/form-file-upload.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/form-file-upload.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { FormFileUpload } from '@wordpress/components';
+import React from 'react';
 
 const FormFileUploadExample = () => (
 	<FormFileUpload

--- a/client/devdocs/design/wordpress-components-gallery/form-toggle.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/form-toggle.tsx
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { FormToggle } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
+import React, { useState } from 'react';
 import FormLabel from 'calypso/components/forms/form-label';
 
 const FormToggleExample = () => {

--- a/client/devdocs/design/wordpress-components-gallery/form-token-field.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/form-token-field.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { FormTokenField } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
+import React from 'react';
 
 const FormTokenFieldExample = withState( {
 	tokens: [],

--- a/client/devdocs/design/wordpress-components-gallery/guide.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/guide.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-import { times } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import { Button, Guide } from '@wordpress/components';
+import { times } from 'lodash';
+import React, { useState } from 'react';
 
 const GuideExample = () => {
 	const numberOfPages = 5;

--- a/client/devdocs/design/wordpress-components-gallery/index.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/index.tsx
@@ -1,16 +1,7 @@
-/**
- * External dependencies
- */
-import React, { ReactNode } from 'react';
-
-/**
- * WordPress dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, CardHeader, CardBody, Flex, FlexItem } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
+import React, { ReactNode } from 'react';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
 import AnglePickerControlExample from './angle-picker-control';
 import AnimateExample from './animate';
 import BaseControlExample from './base-control';
@@ -49,8 +40,6 @@ import ToolbarExample from './toolbar';
 import TooltipExample from './tooltip';
 import TreeSelectExample from './tree-select';
 import VisuallyHiddenExample from './visually-hidden';
-import { isEnabled } from '@automattic/calypso-config';
-import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
 
 import './style.scss';
 

--- a/client/devdocs/design/wordpress-components-gallery/panel.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/panel.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { ReactNode } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
+import React, { ReactNode } from 'react';
 
 function ScrollableContainer( { children }: { children: ReactNode } ) {
 	return (

--- a/client/devdocs/design/wordpress-components-gallery/placeholder.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/placeholder.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Placeholder, Notice } from '@wordpress/components';
 import { more } from '@wordpress/icons';
+import React from 'react';
 
 const PlaceholderExample = () => (
 	<Placeholder

--- a/client/devdocs/design/wordpress-components-gallery/query-controls.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/query-controls.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { QueryControls } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
+import React from 'react';
 
 const QueryControlsExample = withState( {
 	orderBy: 'title',

--- a/client/devdocs/design/wordpress-components-gallery/radio-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/radio-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { RadioControl } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const options = [
 	{ label: 'Public', value: 'public' },

--- a/client/devdocs/design/wordpress-components-gallery/resizable-box.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/resizable-box.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Flex, FlexItem, ResizableBox } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const ResizableBoxExample = () => {
 	const [ attributes, setAttributes ] = useState( {

--- a/client/devdocs/design/wordpress-components-gallery/slot-fill.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/slot-fill.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Fill, Slot, SlotFillProvider } from '@wordpress/components';
+import React from 'react';
 
 const SlotFillExample = () => (
 	<SlotFillProvider>

--- a/client/devdocs/design/wordpress-components-gallery/snackbar.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/snackbar.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Snackbar } from '@wordpress/components';
+import React from 'react';
 
 const SnackbarExample = () => {
 	const content = 'Use Snackbars with an action link to an external page.';

--- a/client/devdocs/design/wordpress-components-gallery/spinner.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/spinner.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Spinner } from '@wordpress/components';
+import React from 'react';
 
 const SpinnerExample = () => <Spinner />;
 

--- a/client/devdocs/design/wordpress-components-gallery/tab-panel.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/tab-panel.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { TabPanel } from '@wordpress/components';
+import React from 'react';
 
 const TabPanelExample = () => (
 	<TabPanel

--- a/client/devdocs/design/wordpress-components-gallery/text-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/text-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { TextControl } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const TextControlExample = () => {
 	const [ value, setValue ] = useState( '' );

--- a/client/devdocs/design/wordpress-components-gallery/textarea-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/textarea-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { TextareaControl } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const TextareaControlExample = () => {
 	const [ value, setValue ] = useState( '' );

--- a/client/devdocs/design/wordpress-components-gallery/tip.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/tip.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Tip } from '@wordpress/components';
+import React from 'react';
 
 const TipExample = () => <Tip>An example Tip</Tip>;
 

--- a/client/devdocs/design/wordpress-components-gallery/toggle-control.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/toggle-control.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { ToggleControl } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const ToggleControlExample = () => {
 	const [ hasFixedBackground, setHasFixedBackground ] = useState( true );

--- a/client/devdocs/design/wordpress-components-gallery/toolbar.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/toolbar.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
+import { Toolbar, ToolbarButton, ToolbarGroup, SVG, Path } from '@wordpress/components';
 import {
 	alignCenter,
 	alignLeft,
@@ -18,7 +11,7 @@ import {
 	more,
 	paragraph,
 } from '@wordpress/icons';
-import { Toolbar, ToolbarButton, ToolbarGroup, SVG, Path } from '@wordpress/components';
+import React from 'react';
 
 function InlineImageIcon() {
 	return (

--- a/client/devdocs/design/wordpress-components-gallery/tooltip.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/tooltip.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { Tooltip } from '@wordpress/components';
+import React from 'react';
 
 const TooltipExample = () => (
 	<Tooltip text="More information" position="top center">

--- a/client/devdocs/design/wordpress-components-gallery/tree-select.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/tree-select.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { TreeSelect } from '@wordpress/components';
+import React, { useState } from 'react';
 
 const TreeSelectExample = () => {
 	const [ selection, setSelection ] = useState( '' );

--- a/client/devdocs/design/wordpress-components-gallery/visually-hidden.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/visually-hidden.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * WordPress dependencies
- */
 import { VisuallyHidden } from '@wordpress/components';
+import React from 'react';
 
 const VisuallyHiddenExample = () => (
 	<>

--- a/client/devdocs/devdocs-async-load/index.jsx
+++ b/client/devdocs/devdocs-async-load/index.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import Placeholder from './placeholder';
 

--- a/client/devdocs/devdocs-async-load/placeholder.jsx
+++ b/client/devdocs/devdocs-async-load/placeholder.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
 import { range } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
+import PropTypes from 'prop-types';
+import React from 'react';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import Main from 'calypso/components/main';
 
 export default class DevdocsAsyncLoadPlaceholder extends React.PureComponent {
 	static propTypes = {

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import DocService from './service';
-import Error from './error';
 import DocumentHead from 'calypso/components/data/document-head';
 import highlight from 'calypso/lib/highlight';
+import Error from './error';
+import DocService from './service';
 
 export default class extends React.Component {
 	static displayName = 'SingleDocument';

--- a/client/devdocs/docs-example/error.jsx
+++ b/client/devdocs/docs-example/error.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 const DocsExampleError = () => (

--- a/client/devdocs/docs-example/index.jsx
+++ b/client/devdocs/docs-example/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 
 const DocsExampleToggle = ( { onClick, text } ) => <Button onClick={ onClick }>{ text }</Button>;
 

--- a/client/devdocs/docs-example/test/index.jsx
+++ b/client/devdocs/docs-example/test/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import DocsExample, { DocsExampleToggle } from '../index';
-import { Button } from '@automattic/components';
 
 const noop = () => {};
 

--- a/client/devdocs/docs-example/util.js
+++ b/client/devdocs/docs-example/util.js
@@ -3,9 +3,6 @@
  *
  */
 
-/**
- * External dependencies
- */
 import debug from 'debug';
 
 /**

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import DocsExampleError from 'calypso/devdocs/docs-example/error';
 
 const renderTitle = ( unique, name, url, onTitleClick ) =>

--- a/client/devdocs/docs-selectors/index.jsx
+++ b/client/devdocs/docs-selectors/index.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
-import DocsSelectorsSingle from './single';
-import DocsSelectorsSearch from './search';
 import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
 import ReadmeViewer from 'calypso/components/readme-viewer';
+import DocsSelectorsSearch from './search';
+import DocsSelectorsSingle from './single';
 
 export default class DocsSelectors extends PureComponent {
 	static propTypes = {

--- a/client/devdocs/docs-selectors/param-type.jsx
+++ b/client/devdocs/docs-selectors/param-type.jsx
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get } from 'lodash';
 
 /**
  * Matches an expression type

--- a/client/devdocs/docs-selectors/result.jsx
+++ b/client/devdocs/docs-selectors/result.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { filter, findLast } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { filter, findLast } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
 import DocsSelectorsParamType from './param-type';
 
 export default function DocsSelectorsResult( { url, name, description, tags, expanded } ) {

--- a/client/devdocs/docs-selectors/search.jsx
+++ b/client/devdocs/docs-selectors/search.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import page from 'page';
 import { map } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
 import { stringify } from 'qs';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import SearchCard from 'calypso/components/search-card';
 import { addQueryArgs } from 'calypso/lib/url';

--- a/client/devdocs/docs-selectors/single.jsx
+++ b/client/devdocs/docs-selectors/single.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import page from 'page';
 import { find } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
 import { stringify } from 'qs';
-
-/**
- * Internal dependencies
- */
-import { addQueryArgs } from 'calypso/lib/url';
+import React, { Component } from 'react';
 import HeaderCake from 'calypso/components/header-cake';
+import { addQueryArgs } from 'calypso/lib/url';
 import DocsSelectorsResult from './result';
 
 export default class DocsSelectorsSingle extends Component {

--- a/client/devdocs/error.jsx
+++ b/client/devdocs/error.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 export default class extends React.PureComponent {

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import page from 'page';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import controller from './controller';
+import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import controller from './controller';
 
 export default function () {
 	if ( config.isEnabled( 'devdocs' ) ) {

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -1,23 +1,11 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
 import debug from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import DocService from './service';
 import DocumentHead from 'calypso/components/data/document-head';
-import { Card } from '@automattic/components';
 import Main from 'calypso/components/main';
 import SearchCard from 'calypso/components/search-card';
-
-/**
- * Style dependencies
- */
+import DocService from './service';
 import './style.scss';
 
 /**

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { stringify } from 'qs';
 
 async function fetchDocsEndpoint( endpoint, params, callback ) {

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarHeading from 'calypso/layout/sidebar/heading';
-import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarItem from 'calypso/layout/sidebar/item';
+import SidebarMenu from 'calypso/layout/sidebar/menu';
 
 export default class DevdocsSidebar extends React.PureComponent {
 	static displayName = 'DevdocsSidebar';

--- a/client/devdocs/test/doc.jsx
+++ b/client/devdocs/test/doc.jsx
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import SingleDocClass from '../doc';
 
 jest.mock( 'calypso/devdocs/service', () => ( {

--- a/client/devdocs/welcome.jsx
+++ b/client/devdocs/welcome.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import React from 'react';
 
 export default class extends React.PureComponent {
 	static displayName = 'DevWelcome';

--- a/client/devdocs/wizard-component/index.jsx
+++ b/client/devdocs/wizard-component/index.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import Wizard from 'calypso/components/wizard/docs/example';
 import ReadmeViewer from 'calypso/components/readme-viewer';
+import Wizard from 'calypso/components/wizard/docs/example';
 
 class WizardComponent extends Component {
 	backToComponents = () => page( '/devdocs/design/' );


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/devdocs` to use `import/order`

#### Testing instructions

N/A

Note: there are preexisting eslint failures in some files.

