### PR TITLE
chore: migrate `client/layout` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -190,6 +190,7 @@ module.exports = {
 				'client/incoming-redirect/**/*',
 				'client/jetpack-connect/**/*',
 				'client/landing/**/*',
+				'client/layout/**/*',
 				'client/login/**/*',
 				'client/mailing-lists/**/*',
 				'client/my-sites/customer-home/**/*',

--- a/client/layout/body-section-css-class.js
+++ b/client/layout/body-section-css-class.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 /*

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -1,42 +1,30 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
+import config from '@automattic/calypso-config';
+import { Button, Dialog } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
-import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { addQueryArgs } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import translator, { trackTranslatorStatus } from 'calypso/lib/translator-jumpstart';
 import localStorageHelper from 'store';
-import { Button, Dialog } from '@automattic/components';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 import { bumpStat } from 'calypso/lib/analytics/mc';
-import { TranslationScanner } from 'calypso/lib/i18n-utils/translation-scanner';
 import {
 	getLanguageEmpathyModeActive,
 	toggleLanguageEmpathyMode,
 } from 'calypso/lib/i18n-utils/empathy-mode';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
-import { setLocale } from 'calypso/state/ui/language/actions';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import FormLabel from 'calypso/components/forms/form-label';
+import { TranslationScanner } from 'calypso/lib/i18n-utils/translation-scanner';
+import translator, { trackTranslatorStatus } from 'calypso/lib/translator-jumpstart';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-
-/**
- * Style dependencies
- */
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { setLocale } from 'calypso/state/ui/language/actions';
 import './style.scss';
 
 class TranslatorLauncher extends React.Component {

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { bumpStat } from 'calypso/lib/analytics/mc';
 import EmptyContent from 'calypso/components/empty-content';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { setSection } from 'calypso/state/ui/section/actions';
 
 /**

--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -1,7 +1,4 @@
-/**
- * Internal dependencies
- */
-
+import combineTours from './config-elements/combine-tours';
 import { ChecklistSiteTitleTour } from './tours/checklist-site-title-tour';
 import { JetpackChecklistTour } from './tours/jetpack-checklist-tour';
 import { JetpackLazyImagesTour } from './tours/jetpack-lazy-images-tour';
@@ -15,7 +12,6 @@ import { MainTour } from './tours/main-tour';
 import { marketingConnectionsTour } from './tours/marketing-connections-tour';
 import { MediaBasicsTour } from './tours/media-basics-tour';
 import { TutorialSitePreviewTour } from './tours/tutorial-site-preview-tour';
-import combineTours from './config-elements/combine-tours';
 
 export default combineTours( {
 	checklistSiteTitle: ChecklistSiteTitleTour,

--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-import { useTranslate } from 'i18n-calypso';
 
 // Returns React component with a localized label and optional icon
 function button( label, icon ) {

--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -1,30 +1,19 @@
-/**
- * External dependencies
- */
+import { RootChild } from '@automattic/components';
+import { defer } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { defer } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import AllTours from './all-tours';
 import QueryPreferences from 'calypso/components/data/query-preferences';
-import { RootChild } from '@automattic/components';
-import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
-import { getLastAction } from 'calypso/state/ui/action-log/selectors';
-import { getSectionName, isSectionLoading } from 'calypso/state/ui/selectors';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	nextGuidedTourStep,
 	quitGuidedTour,
 	resetGuidedToursHistory,
 } from 'calypso/state/guided-tours/actions';
-
-/**
- * Style dependencies
- */
+import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import { getLastAction } from 'calypso/state/ui/action-log/selectors';
+import { getSectionName, isSectionLoading } from 'calypso/state/ui/selectors';
+import AllTours from './all-tours';
 import './style.scss';
 
 class GuidedToursComponent extends Component {

--- a/client/layout/guided-tours/config-elements/button-row.js
+++ b/client/layout/guided-tours/config-elements/button-row.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const ButtonRow = ( { children } ) => {

--- a/client/layout/guided-tours/config-elements/combine-tours.js
+++ b/client/layout/guided-tours/config-elements/combine-tours.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 export default function combineTours( tours ) {

--- a/client/layout/guided-tours/config-elements/conditional-block.js
+++ b/client/layout/guided-tours/config-elements/conditional-block.js
@@ -1,13 +1,5 @@
-/**
- *
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { contextTypes } from '../context-types';
 
 export default class ConditionalBlock extends React.PureComponent {

--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { targetForSlug } from '../positioning';
 import { contextTypes } from '../context-types';
+import { targetForSlug } from '../positioning';
 
 export default class Continue extends Component {
 	static displayName = 'Continue';

--- a/client/layout/guided-tours/config-elements/index.js
+++ b/client/layout/guided-tours/config-elements/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 export { default as ButtonRow } from './button-row';
 export { default as combineTours } from './combine-tours';
 export { default as ConditionalBlock } from './conditional-block';

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { translate } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { contextTypes } from '../context-types';
 
 export default class LinkQuit extends Component {

--- a/client/layout/guided-tours/config-elements/link.js
+++ b/client/layout/guided-tours/config-elements/link.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import ExternalLink from 'calypso/components/external-link';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 

--- a/client/layout/guided-tours/config-elements/make-tour.js
+++ b/client/layout/guided-tours/config-elements/make-tour.js
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
-import PropTypes from 'prop-types';
-import { isEmpty, omit } from 'lodash';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import { tourBranching } from '../tour-branching';
+import { isEmpty, omit } from 'lodash';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { contextTypes } from '../context-types';
+import { tourBranching } from '../tour-branching';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 

--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { contextTypes } from '../context-types';
 
 export default class Next extends Component {

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
-import { targetForSlug } from '../positioning';
+import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { contextTypes } from '../context-types';
+import { targetForSlug } from '../positioning';
 
 export default class Quit extends Component {
 	static displayName = 'Quit';

--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { contextTypes } from '../context-types';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { Button } from '@automattic/components';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { contextTypes } from '../context-types';
 
 class SiteLink extends Component {
 	static propTypes = {

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -1,18 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component, CSSProperties, FunctionComponent } from 'react';
+import { Card } from '@automattic/components';
 import classNames from 'classnames';
-import { defer } from 'lodash';
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
+import { defer } from 'lodash';
+import React, { Component, CSSProperties, FunctionComponent } from 'react';
 import pathToSection from 'calypso/lib/path-to-section';
 import { ROUTE_SET } from 'calypso/state/action-types';
+import { TimestampMS } from 'calypso/types';
+import { contextTypes } from '../context-types';
 import {
 	posToCss,
 	getStepPosition,
@@ -20,9 +15,7 @@ import {
 	query,
 	targetForSlug,
 } from '../positioning';
-import { contextTypes } from '../context-types';
 import { ArrowPosition, DialogPosition, Coordinate } from '../types';
-import { TimestampMS } from 'calypso/types';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 

--- a/client/layout/guided-tours/config-elements/tour.js
+++ b/client/layout/guided-tours/config-elements/tour.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
-import PropTypes from 'prop-types';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { contextTypes } from '../context-types';
 
 export default class Tour extends Component {

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -1,10 +1,3 @@
-/**
- * Internal dependencies
- */
-import main from 'calypso/layout/guided-tours/tours/main-tour/meta';
-import tutorialSitePreview from 'calypso/layout/guided-tours/tours/tutorial-site-preview-tour/meta';
-import marketingConnectionsTour from 'calypso/layout/guided-tours/tours/marketing-connections-tour/meta';
-import mediaBasicsTour from 'calypso/layout/guided-tours/tours/media-basics-tour/meta';
 import checklistSiteTitle from 'calypso/layout/guided-tours/tours/checklist-site-title-tour/meta';
 import jetpackChecklist from 'calypso/layout/guided-tours/tours/jetpack-checklist-tour/meta';
 import jetpackLazyImages from 'calypso/layout/guided-tours/tours/jetpack-lazy-images-tour/meta';
@@ -14,6 +7,10 @@ import jetpackSearch from 'calypso/layout/guided-tours/tours/jetpack-search-tour
 import jetpackSignIn from 'calypso/layout/guided-tours/tours/jetpack-sign-in-tour/meta';
 import jetpackSiteAccelerator from 'calypso/layout/guided-tours/tours/jetpack-site-accelerator-tour/meta';
 import jetpackVideoHosting from 'calypso/layout/guided-tours/tours/jetpack-video-hosting-tour/meta';
+import main from 'calypso/layout/guided-tours/tours/main-tour/meta';
+import marketingConnectionsTour from 'calypso/layout/guided-tours/tours/marketing-connections-tour/meta';
+import mediaBasicsTour from 'calypso/layout/guided-tours/tours/media-basics-tour/meta';
+import tutorialSitePreview from 'calypso/layout/guided-tours/tours/tutorial-site-preview-tour/meta';
 
 export default {
 	checklistSiteTitle,

--- a/client/layout/guided-tours/context-types.js
+++ b/client/layout/guided-tours/context-types.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 
 // Shape of context provided by the `makeTour` context provider.

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -58,9 +58,6 @@ First we'll need to create a directory tour, under `tours`. In there, we create 
 `meta.js` contains the metadata for a tour. Here's an empty boilerplate:
 
 ```javascript
-/**
- * Internal dependencies
- */
 import { and } from 'calypso/layout/guided-tours/utils';
 
 export default {};
@@ -69,14 +66,7 @@ export default {};
 For `index.js`, this is the essential boilerplate, which comprises the imports and the `makeTour` wrapping:
 
 ```javascript
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import meta from './meta';
 import {
 	makeTour,

--- a/client/layout/guided-tours/docs/examples/selectors/has-selected-site-premium-or-business-plan.js
+++ b/client/layout/guided-tours/docs/examples/selectors/has-selected-site-premium-or-business-plan.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -1,15 +1,6 @@
-/**
- * External dependencies
- *
- */
 import { isDesktop } from '@automattic/viewport';
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import { and } from 'calypso/layout/guided-tours/utils';
 import {
 	makeTour,
 	Continue,
@@ -20,8 +11,9 @@ import {
 	Quit,
 	Link,
 } from 'calypso/layout/guided-tours/config-elements';
-import { hasSelectedSitePremiumOrBusinessPlan } from '../selectors/has-selected-site-premium-or-business-plan';
+import { and } from 'calypso/layout/guided-tours/utils';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { hasSelectedSitePremiumOrBusinessPlan } from '../selectors/has-selected-site-premium-or-business-plan';
 
 export const SimplePaymentsEndOfYearGuide = makeTour(
 	<Tour

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import AsyncLoad from 'calypso/components/async-load';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
 

--- a/client/layout/guided-tours/positioning.ts
+++ b/client/layout/guided-tours/positioning.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { isMobile } from '@automattic/viewport';
 import { find, startsWith } from 'lodash';
 import { CSSProperties } from 'react';
-
-/**
- * Internal dependencies
- */
 import scrollTo from 'calypso/lib/scroll-to';
 import { Coordinate, DialogPosition, ArrowPosition } from './types';
 

--- a/client/layout/guided-tours/test/tour-branching.js
+++ b/client/layout/guided-tours/test/tour-branching.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { tourBranching } from '../tour-branching';
 
 describe( 'Guided Tours Branching', () => {

--- a/client/layout/guided-tours/test/utils.js
+++ b/client/layout/guided-tours/test/utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { and } from 'calypso/layout/guided-tours/utils';
 
 describe( 'Guided Tours utilities: and()', () => {

--- a/client/layout/guided-tours/tour-branching.js
+++ b/client/layout/guided-tours/tour-branching.js
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import { Children } from 'react';
 import { flatMap } from 'lodash';
+import { Children } from 'react';
 
 /*
  * Transforms a React `Children` object into an array. The children of a `Step` are

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
 import React, { Fragment } from 'react';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import meta from './meta';
+import { SiteTitleButton } from 'calypso/layout/guided-tours/button-labels';
 import {
 	ButtonRow,
 	Continue,
@@ -18,7 +10,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
-import { SiteTitleButton } from 'calypso/layout/guided-tours/button-labels';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const ChecklistSiteTitleTour = makeTour(

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/meta.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/meta.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { noop } from 'calypso/layout/guided-tours/utils';
 
 export default {

--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import meta from './meta';
 import {
 	ButtonRow,
 	makeTour,
@@ -15,6 +7,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 export const JetpackChecklistTour = makeTour(
 	<Tour { ...meta }>

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
 import {
 	ButtonRow,
 	Continue,
@@ -17,6 +9,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackLazyImagesTour = makeTour(

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
 import {
 	ButtonRow,
 	Continue,
@@ -17,6 +9,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackMonitoringTour = makeTour(

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -1,15 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import {
 	ButtonRow,
 	Continue,
@@ -19,6 +9,9 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import meta from './meta';
 
 const JETPACK_TOGGLE_SELECTOR = '.plugin-item-jetpack .components-form-toggle';
 

--- a/client/layout/guided-tours/tours/jetpack-search-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
 import {
 	ButtonRow,
 	Continue,
@@ -17,6 +9,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackSearchTour = makeTour(

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
 import {
 	ButtonRow,
 	Continue,
@@ -17,6 +9,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackSignInTour = makeTour(

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
 import {
 	ButtonRow,
 	Continue,
@@ -17,6 +9,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackSiteAcceleratorTour = makeTour(

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
-import meta from './meta';
 import {
 	ButtonRow,
 	Continue,
@@ -17,6 +9,7 @@ import {
 	Step,
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
+import meta from './meta';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackVideoHostingTour = makeTour(

--- a/client/layout/guided-tours/tours/main-tour/index.js
+++ b/client/layout/guided-tours/tours/main-tour/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
-import meta from './meta';
+import { ViewSiteButton } from 'calypso/layout/guided-tours/button-labels';
 import {
 	makeTour,
 	Tour,
@@ -17,13 +10,13 @@ import {
 	Continue,
 	Link,
 } from 'calypso/layout/guided-tours/config-elements';
+import { getScrollableSidebar } from 'calypso/layout/guided-tours/positioning';
+import scrollTo from 'calypso/lib/scroll-to';
 import {
 	isSelectedSitePreviewable,
 	isSelectedSiteCustomizable,
 } from 'calypso/state/guided-tours/contexts';
-import { getScrollableSidebar } from 'calypso/layout/guided-tours/positioning';
-import scrollTo from 'calypso/lib/scroll-to';
-import { ViewSiteButton } from 'calypso/layout/guided-tours/button-labels';
+import meta from './meta';
 
 const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSidebar() } );
 

--- a/client/layout/guided-tours/tours/main-tour/meta.js
+++ b/client/layout/guided-tours/tours/main-tour/meta.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { and } from 'calypso/layout/guided-tours/utils';
 import { isNewUser, isEnabled } from 'calypso/state/guided-tours/contexts';
 

--- a/client/layout/guided-tours/tours/marketing-connections-tour/index.js
+++ b/client/layout/guided-tours/tours/marketing-connections-tour/index.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import meta from './meta';
 import {
 	ButtonRow,
 	makeTour,
@@ -16,6 +8,7 @@ import {
 	Tour,
 } from 'calypso/layout/guided-tours/config-elements';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import meta from './meta';
 
 const CONNECT_BUTTON_SELECTOR = '.sharing-service.not-connected .button.is-compact';
 

--- a/client/layout/guided-tours/tours/media-basics-tour/index.js
+++ b/client/layout/guided-tours/tours/media-basics-tour/index.js
@@ -1,12 +1,10 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
-import meta from './meta';
+import {
+	AddNewButton,
+	EditButton,
+	EditImageButton,
+	DoneButton,
+} from 'calypso/layout/guided-tours/button-labels';
 import {
 	makeTour,
 	Tour,
@@ -17,12 +15,7 @@ import {
 	Continue,
 } from 'calypso/layout/guided-tours/config-elements';
 import { doesSelectedSiteHaveMediaFiles } from 'calypso/state/guided-tours/contexts';
-import {
-	AddNewButton,
-	EditButton,
-	EditImageButton,
-	DoneButton,
-} from 'calypso/layout/guided-tours/button-labels';
+import meta from './meta';
 
 export const MediaBasicsTour = makeTour(
 	<Tour { ...meta }>

--- a/client/layout/guided-tours/tours/media-basics-tour/meta.js
+++ b/client/layout/guided-tours/tours/media-basics-tour/meta.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { isDesktop } from '@automattic/viewport';
-
-/**
- * Internal dependencies
- */
 import { and } from 'calypso/layout/guided-tours/utils';
 import { isNewUser } from 'calypso/state/guided-tours/contexts';
 

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour/index.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
-import meta from './meta';
+import { ViewSiteButton } from 'calypso/layout/guided-tours/button-labels';
 import {
 	makeTour,
 	Tour,
@@ -16,7 +8,7 @@ import {
 	Quit,
 	Continue,
 } from 'calypso/layout/guided-tours/config-elements';
-import { ViewSiteButton } from 'calypso/layout/guided-tours/button-labels';
+import meta from './meta';
 
 export const TutorialSitePreviewTour = makeTour(
 	<Tour { ...meta }>

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour/meta.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour/meta.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { and } from 'calypso/layout/guided-tours/utils';
 import {
 	isNewUser,

--- a/client/layout/html-is-iframe-classname.tsx
+++ b/client/layout/html-is-iframe-classname.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import isIframeForHtmlElement from 'calypso/state/selectors/is-iframe-for-html-element';
 
 const HtmlIsIframeClassname = () => {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -1,65 +1,54 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { startsWith, flowRight as compose, some } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import AsyncLoad from 'calypso/components/async-load';
-import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
-import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
-import EmptyMasterbar from 'calypso/layout/masterbar/empty';
-import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
 import config from '@automattic/calypso-config';
-import OfflineStatus from 'calypso/layout/offline-status';
+import { isWithinBreakpoint } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
+import classnames from 'classnames';
+import { startsWith, flowRight as compose, some } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import SitePreview from 'calypso/blocks/site-preview';
+import AsyncLoad from 'calypso/components/async-load';
+import DocumentHead from 'calypso/components/data/document-head';
 import QueryPreferences from 'calypso/components/data/query-preferences';
-import QuerySites from 'calypso/components/data/query-sites';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSelectedEditor from 'calypso/components/data/query-site-selected-editor';
+import QuerySites from 'calypso/components/data/query-sites';
+import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
+import { withCurrentRoute } from 'calypso/components/route';
+import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
+import EmptyMasterbar from 'calypso/layout/masterbar/empty';
+import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
+import OfflineStatus from 'calypso/layout/offline-status';
+import { isE2ETest } from 'calypso/lib/e2e';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import KeyboardShortcutsMenu from 'calypso/lib/keyboard-shortcuts/menu';
+import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
+import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { getMessagePathForJITM } from 'calypso/lib/route';
+import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isOffline } from 'calypso/state/application/selectors';
+import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
+import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isSupportSession } from 'calypso/state/support/selectors';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
 	getSelectedSiteId,
 	masterbarIsVisible,
 	getSelectedSite,
 	getSidebarIsCollapsed,
 } from 'calypso/state/ui/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import UserVerificationChecker from 'calypso/lib/user/verification-checker';
-import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
-import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { isSupportSession } from 'calypso/state/support/selectors';
-import SitePreview from 'calypso/blocks/site-preview';
-import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import DocumentHead from 'calypso/components/data/document-head';
-import { getPreference } from 'calypso/state/preferences/selectors';
-import KeyboardShortcutsMenu from 'calypso/lib/keyboard-shortcuts/menu';
 import SupportUser from 'calypso/support/support-user';
-import isCommunityTranslatorEnabled from 'calypso/state/selectors/is-community-translator-enabled';
-import { isE2ETest } from 'calypso/lib/e2e';
-import { getMessagePathForJITM } from 'calypso/lib/route';
 import BodySectionCssClass from './body-section-css-class';
-import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
-import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import LayoutLoader from './loader';
-import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-import { withCurrentRoute } from 'calypso/components/route';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { getShouldShowAppBanner, handleScroll } from './utils';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
-import { useBreakpoint } from '@automattic/viewport-react';
-import { isWithinBreakpoint } from '@automattic/viewport';
-import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-
-/**
- * Style dependencies
- */
 // goofy import for environment badge, which is SSR'd
 import 'calypso/components/environment-badge/style.scss';
 import './style.scss';

--- a/client/layout/loader.jsx
+++ b/client/layout/loader.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import PulsingDot from 'calypso/components/pulsing-dot';
 import { isSectionLoading } from 'calypso/state/ui/selectors';
-
-/**
- * Style dependencies
- */
 import './loader.scss';
 
 export default function LayoutLoader() {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,19 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-import { get, startsWith, flowRight as compose } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import AsyncLoad from 'calypso/components/async-load';
 import config from '@automattic/calypso-config';
+import classNames from 'classnames';
+import { get, startsWith, flowRight as compose } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import GdprBanner from 'calypso/blocks/gdpr-banner';
+import AsyncLoad from 'calypso/components/async-load';
+import { withCurrentRoute } from 'calypso/components/route';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import {
 	getCurrentOAuth2Client,
@@ -23,14 +20,6 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-import GdprBanner from 'calypso/blocks/gdpr-banner';
-import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-import { withCurrentRoute } from 'calypso/components/route';
-import { isWpMobileApp } from 'calypso/lib/mobile-app';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const LayoutLoggedOut = ( {

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import Masterbar from './masterbar';
-import Item from './item';
-import WordPressWordmark from 'calypso/components/wordpress-wordmark';
+import React, { FunctionComponent, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import WordPressWordmark from 'calypso/components/wordpress-wordmark';
+import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
+import Item from './item';
+import Masterbar from './masterbar';
 
 interface Props {
 	title: string;

--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-
-/**
- * Style dependencies
- */
 import './crowdsignal.scss';
 
 class CrowdsignalOauthMasterbar extends Component {

--- a/client/layout/masterbar/drafts-popover.jsx
+++ b/client/layout/masterbar/drafts-popover.jsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { createSelector } from '@automattic/state-utils';
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { createSelector } from '@automattic/state-utils';
-import { newPost } from 'calypso/lib/paths';
-import Popover from 'calypso/components/popover';
 import Count from 'calypso/components/count';
+import QueryPosts from 'calypso/components/data/query-posts';
+import Popover from 'calypso/components/popover';
+import { newPost } from 'calypso/lib/paths';
+import Draft from 'calypso/my-sites/draft';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
 	getPostsForQueryIgnoringPage,
 	isRequestingPostsForQuery,
 } from 'calypso/state/posts/selectors';
-import Draft from 'calypso/my-sites/draft';
-import QueryPosts from 'calypso/components/data/query-posts';
-import { Button } from '@automattic/components';
 import { getSite } from 'calypso/state/sites/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 class MasterbarDraftsPopover extends Component {
 	render() {

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import AsyncLoad from 'calypso/components/async-load';
-import QueryPostCounts from 'calypso/components/data/query-post-counts';
-import { Button } from '@automattic/components';
 import Count from 'calypso/components/count';
+import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getMyPostCount } from 'calypso/state/posts/counts/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const MasterbarDraftsPopover = ( props ) => (
 	<AsyncLoad { ...props } require="calypso/layout/masterbar/drafts-popover" placeholder={ null } />

--- a/client/layout/masterbar/empty.jsx
+++ b/client/layout/masterbar/empty.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 const EmptyMasterbar = () => <header id="header" className="masterbar" />;

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import classNames from 'classnames';
 import Gridicon from 'calypso/components/gridicon';
 import TranslatableString from 'calypso/components/translatable/proptype';
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1,46 +1,39 @@
-/**
- * External dependencies
- */
-import { parse } from 'qs';
-import { connect } from 'react-redux';
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { parse } from 'qs';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import Masterbar from './masterbar';
-import Item from './item';
-import Notifications from './notifications';
-import Gravatar from 'calypso/components/gravatar';
-import config from '@automattic/calypso-config';
-import { preload } from 'calypso/sections-helper';
-import { getCurrentUserSiteCount, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { isSupportSession } from 'calypso/state/support/selectors';
+import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
-import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
-import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
-import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
-import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
+import Gravatar from 'calypso/components/gravatar';
 import { getStatsPathForTab } from 'calypso/lib/route';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
-import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
-import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
+import { preload } from 'calypso/sections-helper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserSiteCount, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { requestHttpData } from 'calypso/state/data-layer/http-data';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { hasUnseen } from 'calypso/state/reader-ui/seen-posts/selectors';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path.js';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
+import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
+import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
+import { isSupportSession } from 'calypso/state/support/selectors';
+import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PopUpSearch from '../popup-search';
+import Item from './item';
+import Masterbar from './masterbar';
+import Notifications from './notifications';
 
 class MasterbarLoggedIn extends React.Component {
 	state = {

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,27 +1,20 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { getLocaleSlug, localize } from 'i18n-calypso';
+import { get, includes, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { getLocaleSlug, localize } from 'i18n-calypso';
-import { get, includes, startsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import Masterbar from './masterbar';
-import Item from './item';
+import AsyncLoad from 'calypso/components/async-load';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
+import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
+import { isDefaultLocale, addLocaleToPath } from 'calypso/lib/i18n-utils';
+import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { login } from 'calypso/lib/paths';
-import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
-import { isDefaultLocale, addLocaleToPath } from 'calypso/lib/i18n-utils';
-import AsyncLoad from 'calypso/components/async-load';
+import Item from './item';
+import Masterbar from './masterbar';
 
 class MasterbarLoggedOut extends React.Component {
 	static propTypes = {

--- a/client/layout/masterbar/masterbar.jsx
+++ b/client/layout/masterbar/masterbar.jsx
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const Masterbar = ( { children, className } ) => (

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -1,24 +1,16 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, createRef } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { partial } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import MasterbarItem from './item';
-import AsyncLoad from 'calypso/components/async-load';
 import store from 'store';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
-import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import AsyncLoad from 'calypso/components/async-load';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
+import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
+import MasterbarItem from './item';
 
 class MasterbarItemNotifications extends Component {
 	static propTypes = {

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -1,26 +1,14 @@
-/**
- * External dependencies
- */
-
-import Gridicon from 'calypso/components/gridicon';
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import Gridicon from 'calypso/components/gridicon';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import {
 	isCrowdsignalOAuth2Client,
 	isWooOAuth2Client,
 	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import CrowdsignalOauthMasterbar from './crowdsignal';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-
-/**
- * Style dependencies
- */
 import './oauth-client.scss';
 
 const DefaultOauthClientMasterbar = ( { oauth2Client } ) => (

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -1,28 +1,21 @@
-/**
- * External dependencies
- */
 import { isMobile } from '@automattic/viewport';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import AsyncLoad from 'calypso/components/async-load';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import MasterbarItem from './item';
-import { preloadEditor } from 'calypso/sections-preloaders';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getCurrentUserVisibleSiteCount } from 'calypso/state/current-user/selectors';
-import MasterbarDrafts from './drafts';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { navigate } from 'calypso/lib/navigate';
+import { reduxGetState } from 'calypso/lib/redux-bridge';
+import { preloadEditor } from 'calypso/sections-preloaders';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserVisibleSiteCount } from 'calypso/state/current-user/selectors';
 import { getEditorUrl } from 'calypso/state/selectors/get-editor-url';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSectionGroup from 'calypso/state/ui/selectors/get-section-group';
-import { reduxGetState } from 'calypso/lib/redux-bridge';
-import { navigate } from 'calypso/lib/navigate';
+import MasterbarDrafts from './drafts';
+import MasterbarItem from './item';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import languages from '@automattic/languages';
 import React, { Fragment, useReducer } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import MasterbarItem from './item';
 import LanguagePickerModal from 'calypso/components/language-picker/modal';
-import languages from '@automattic/languages';
-import { setLocale } from 'calypso/state/ui/language/actions';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import {
 	getLanguageEmpathyModeActive,
 	toggleLanguageEmpathyMode,
 } from 'calypso/lib/i18n-utils/empathy-mode';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import { setLocale } from 'calypso/state/ui/language/actions';
+import MasterbarItem from './item';
 
 function QuickLanguageSwitcher( props ) {
 	const [ isShowingModal, toggleLanguagesModal ] = useReducer( ( toggled ) => ! toggled, false );

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -1,26 +1,22 @@
-/**
- * External dependencies
- */
+import { isBusinessPlan } from '@automattic/calypso-products';
+import { Dialog } from '@automattic/components';
+import { get } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
-import QuerySites from 'calypso/components/data/query-sites';
 import NpsSurvey from 'calypso/blocks/nps-survey';
-import {
-	setNpsSurveyDialogShowing,
-	setupNpsSurveyDevTrigger,
-} from 'calypso/state/nps-survey/notice/actions';
-import { isNpsSurveyDialogShowing } from 'calypso/state/nps-survey/notice/selectors';
+import QuerySites from 'calypso/components/data/query-sites';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	submitNpsSurveyWithNoScore,
 	setupNpsSurveyEligibility,
 	markNpsSurveyShownThisSession,
 } from 'calypso/state/nps-survey/actions';
+import {
+	setNpsSurveyDialogShowing,
+	setupNpsSurveyDevTrigger,
+} from 'calypso/state/nps-survey/notice/actions';
+import { isNpsSurveyDialogShowing } from 'calypso/state/nps-survey/notice/selectors';
 import {
 	getNpsSurveyScore,
 	hasAnsweredNpsSurvey,
@@ -28,15 +24,8 @@ import {
 	isSectionAndSessionEligibleForNpsSurvey,
 	wasNpsSurveyShownThisSession,
 } from 'calypso/state/nps-survey/selectors';
-import { isSupportSession } from 'calypso/state/support/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
-import { isBusinessPlan } from '@automattic/calypso-products';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { bumpStat } from 'calypso/lib/analytics/mc';
-
-/**
- * Style dependencies
- */
+import { isSupportSession } from 'calypso/state/support/selectors';
 import './style.scss';
 
 const SURVEY_NAME = 'calypso-global-notice-radio-buttons-v1';

--- a/client/layout/offline-status/index.jsx
+++ b/client/layout/offline-status/index.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const OfflineStatus = () => (

--- a/client/layout/popup-search/index.js
+++ b/client/layout/popup-search/index.js
@@ -1,29 +1,19 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/interactive-supports-focus */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-/**
- * External dependencies
- */
-import React from 'react';
+
 import { localize, useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import HelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getInlineHelpAdminSectionSearchResultsForQuery from 'calypso/state/inline-help/selectors/get-inline-help-admin-section-search-results-query';
-import hasInlineHelpAPIResults from 'calypso/state/selectors/has-inline-help-api-results';
-import { selectResult } from 'calypso/state/inline-help/actions';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import QueryInlineHelpSearch from 'calypso/components/data/query-inline-help-search';
-
-/**
- * Style dependencies
- */
-import './style.scss';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { selectResult } from 'calypso/state/inline-help/actions';
+import getInlineHelpAdminSectionSearchResultsForQuery from 'calypso/state/inline-help/selectors/get-inline-help-admin-section-search-results-query';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
+import hasInlineHelpAPIResults from 'calypso/state/selectors/has-inline-help-api-results';
+import './style.scss';
 
 export function PopUpSearch( props ) {
 	const translate = useTranslate();

--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { isExternal } from 'calypso/lib/url';
 import { preload } from 'calypso/sections-helper';
 

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -8,9 +8,6 @@
  *   source other than grid icons or material icons.
  **/
 
-/**
- * External dependencies
- */
 import React from 'react';
 
 const SidebarCustomIcon = ( { icon, ...rest } ) => {

--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import Gridicon from 'calypso/components/gridicon';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import Count from 'calypso/components/count';
+import Gridicon from 'calypso/components/gridicon';
 import MaterialIcon from 'calypso/components/material-icon';
-import SidebarHeading from 'calypso/layout/sidebar/heading';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import SidebarHeading from 'calypso/layout/sidebar/heading';
 import { decodeEntities } from 'calypso/lib/formatting';
 
 const noop = () => {};

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useMemo, useState, useRef, useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { get } from 'lodash';
 import { v4 as uuid } from 'uuid';
-
-/**
- * Internal dependencies
- */
 import TranslatableString from 'calypso/components/translatable/proptype';
-import ExpandableSidebarHeading from './expandable-heading';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
-import { hasTouch } from 'calypso/lib/touch-detect';
 import HoverIntent from 'calypso/lib/hover-intent';
+import { hasTouch } from 'calypso/lib/touch-detect';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import ExpandableSidebarHeading from './expandable-heading';
 
 const isTouch = hasTouch();
 

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const SidebarFooter = ( { children } ) => {

--- a/client/layout/sidebar/heading.jsx
+++ b/client/layout/sidebar/heading.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const SidebarHeading = ( { children, onClick, ...props } ) => {

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import SidebarRegion from './region';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const Sidebar = ( { children, onClick, className, ...props } ) => {

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { isExternal } from 'calypso/lib/url';
-import MaterialIcon from 'calypso/components/material-icon';
-import Count from 'calypso/components/count';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 import Badge from 'calypso/components/badge';
-import { preload } from 'calypso/sections-helper';
+import Count from 'calypso/components/count';
+import Gridicon from 'calypso/components/gridicon';
+import MaterialIcon from 'calypso/components/material-icon';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
+import { isExternal } from 'calypso/lib/url';
+import { preload } from 'calypso/sections-helper';
 
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );

--- a/client/layout/sidebar/menu.jsx
+++ b/client/layout/sidebar/menu.jsx
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 
 const SidebarMenu = React.forwardRef( ( { children, className, ...props }, ref ) => (
 	<ul ref={ ref } className={ classNames( 'sidebar__menu', className ) } { ...props }>

--- a/client/layout/sidebar/region.jsx
+++ b/client/layout/sidebar/region.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import SkipNavigation from './skip-navigation';
 
 const SidebarRegion = ( { children, className } ) => (

--- a/client/layout/sidebar/separator.jsx
+++ b/client/layout/sidebar/separator.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const SidebarSeparator = () => <li className="sidebar__separator" />;

--- a/client/layout/sidebar/skip-navigation.jsx
+++ b/client/layout/sidebar/skip-navigation.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class SkipNavigation extends React.Component {
 	static propTypes = {

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-import { Provider } from 'react-redux';
 import { renderToString } from 'react-dom/server';
-
-/**
- * Internal dependencies
- */
+import { Provider } from 'react-redux';
 import LayoutLoggedOut from '../logged-out';
 
 jest.mock( 'calypso/lib/signup/step-actions', () => ( {} ) );


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/layout` to use `import/order`

#### Testing instructions

N/A

Note: there are preexisting eslint failures in some files