### PR TITLE
Emails: Automatically redirect to email management if only one provider to manage

### DIFF
--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from "page";
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import titleCase from 'to-title-case';
@@ -18,7 +18,7 @@ import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
-import { emailManagement } from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetupMailbox } from 'calypso/my-sites/email/paths';
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
@@ -118,9 +118,11 @@ class EmailManagementHome extends React.Component {
 		if (
 			domainsWithEmail.length === 1 &&
 			domainsWithNoEmail.length === 0 &&
-			domainsWithEmail[ 0 ].domain === selectedSite.domain
+			domainsWithEmail[ 0 ].domain === selectedSite.domain &&
+			domainsWithEmail[ 0 ].titanMailSubscription?.maximumMailboxCount > 0 &&
+			domainsWithEmail[ 0 ].titanMailSubscription?.numberOfMailboxes === 0
 		) {
-			page( emailManagement( selectedSite.slug, selectedSite.domain ) );
+			page( emailManagementTitanSetupMailbox( selectedSite.slug, selectedSite.domain ) );
 		}
 
 		return this.renderContentWithHeader(

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from "page";
 import PropTypes from 'prop-types';
 import React from 'react';
 import titleCase from 'to-title-case';
@@ -17,6 +18,7 @@ import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import EmailListActive from 'calypso/my-sites/email/email-management/home/email-list-active';
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
+import { emailManagement } from 'calypso/my-sites/email/paths';
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
@@ -111,6 +113,14 @@ class EmailManagementHome extends React.Component {
 					skipHeaderElement={ true }
 				/>
 			);
+		}
+
+		if (
+			domainsWithEmail.length === 1 &&
+			domainsWithNoEmail.length === 0 &&
+			domainsWithEmail[ 0 ].domain === selectedSite.domain
+		) {
+			page( emailManagement( selectedSite.slug, selectedSite.domain ) );
 		}
 
 		return this.renderContentWithHeader(

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -27,7 +27,6 @@ import {
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getEmailForwards } from 'calypso/state/selectors/get-email-forwards';
 import {
 	getEmailPurchaseByDomain,
@@ -46,15 +45,14 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
-import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import HeaderCake from 'calypso/components/header-cake';
 import isRequestingEmailForwards from 'calypso/state/selectors/is-requesting-email-forwards';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
-import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
@@ -288,7 +286,6 @@ const EmailPlan = ( props ) => {
 		hasSubscription,
 		purchase,
 		isLoadingPurchase,
-		domains,
 	} = props;
 
 	// Ensure we check for email forwarding additions and removals
@@ -298,21 +295,6 @@ const EmailPlan = ( props ) => {
 		retry: false,
 	} );
 
-	function shouldHideHeaderCake() {
-		const domainHasEmail = ( itemDomain ) =>
-			hasTitanMailWithUs( itemDomain ) ||
-			hasGSuiteWithUs( itemDomain ) ||
-			hasEmailForwards( itemDomain );
-		const nonWpcomDomains = domains.filter( ( itemDomain ) => ! itemDomain.isWPCOMDomain );
-		const domainsWithEmail = nonWpcomDomains.filter( domainHasEmail );
-		const domainsWithNoEmail = nonWpcomDomains.filter(
-			( itemDomain ) => ! domainHasEmail( itemDomain )
-		);
-
-		const hideHeaderCake = domainsWithEmail.length === 1 && domainsWithNoEmail.length === 0;
-		return hideHeaderCake;
-	}
-
 	return (
 		<>
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
@@ -321,9 +303,7 @@ const EmailPlan = ( props ) => {
 
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
 
-			{ ! shouldHideHeaderCake() && (
-				<HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake>
-			) }
+			<HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake>
 
 			<EmailPlanHeader
 				domain={ domain }
@@ -383,6 +363,5 @@ export default connect( ( state, ownProps ) => {
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 		purchase: getEmailPurchaseByDomain( state, ownProps.domain ),
 		hasSubscription: hasEmailSubscription( ownProps.domain ),
-		domains: getDomainsBySiteId( state, ownProps.selectedSite.ID ),
 	};
 } )( localize( EmailPlan ) );

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -27,6 +27,7 @@ import {
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getEmailForwards } from 'calypso/state/selectors/get-email-forwards';
 import {
 	getEmailPurchaseByDomain,
@@ -45,14 +46,15 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
+import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import HeaderCake from 'calypso/components/header-cake';
 import isRequestingEmailForwards from 'calypso/state/selectors/is-requesting-email-forwards';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
+import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
 
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
@@ -286,6 +288,7 @@ const EmailPlan = ( props ) => {
 		hasSubscription,
 		purchase,
 		isLoadingPurchase,
+		domains,
 	} = props;
 
 	// Ensure we check for email forwarding additions and removals
@@ -295,6 +298,21 @@ const EmailPlan = ( props ) => {
 		retry: false,
 	} );
 
+	function shouldHideHeaderCake() {
+		const domainHasEmail = ( itemDomain ) =>
+			hasTitanMailWithUs( itemDomain ) ||
+			hasGSuiteWithUs( itemDomain ) ||
+			hasEmailForwards( itemDomain );
+		const nonWpcomDomains = domains.filter( ( itemDomain ) => ! itemDomain.isWPCOMDomain );
+		const domainsWithEmail = nonWpcomDomains.filter( domainHasEmail );
+		const domainsWithNoEmail = nonWpcomDomains.filter(
+			( itemDomain ) => ! domainHasEmail( itemDomain )
+		);
+
+		const hideHeaderCake = domainsWithEmail.length === 1 && domainsWithNoEmail.length === 0;
+		return hideHeaderCake;
+	}
+
 	return (
 		<>
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
@@ -303,7 +321,9 @@ const EmailPlan = ( props ) => {
 
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
 
-			<HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake>
+			{ ! shouldHideHeaderCake() && (
+				<HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake>
+			) }
 
 			<EmailPlanHeader
 				domain={ domain }
@@ -363,5 +383,6 @@ export default connect( ( state, ownProps ) => {
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 		purchase: getEmailPurchaseByDomain( state, ownProps.domain ),
 		hasSubscription: hasEmailSubscription( ownProps.domain ),
+		domains: getDomainsBySiteId( state, ownProps.selectedSite.ID ),
 	};
 } )( localize( EmailPlan ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Pull Request adds a bit of cleverness to the emails management home. It will redirect the user to the mailbox provisioning screen if the site has unused mailboxes

#### Testing instructions

**Scenario where more than one email provider in the selected domain there should not be any change at all**

1. Go to Upgrade -> Emails
2. Check that you can still see which email plan to manage

![image](https://user-images.githubusercontent.com/5689927/127876424-03adbe3d-24f5-437a-88f2-b36fb5a44539.png)

**Scenario when only one email plan is in the selected site/domain

1. Go to Upgrade -> Emails
2. Check that you don't see the email management screen presented in scenario 1
3. Check that you are seeing the mailbox provisioning screen for the only one email provider

![image](https://user-images.githubusercontent.com/5689927/127880491-202142aa-c734-4d56-a6df-84e3700e0061.png)


Related to {1200182182542585-as-1200588428897571}
