### PR TITLE
Titan: Update all flows to use Set Up Mailbox page for setting up unused mailboxes

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import i18nCalypso, { getLocaleSlug, translate } from 'i18n-calypso';
 import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
@@ -212,7 +212,11 @@ export const getTask = (
 				description: translate(
 					'Complete your Professional Email setup to start sending and receiving emails from your custom domain today.'
 				),
-				actionText: translate( 'Set up mailbox' ),
+				/* Make sure we show a translated string while we wait for the new string to be translated. */
+				actionText:
+					'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
+						? translate( 'Set up mailbox' )
+						: translate( 'Complete setup' ),
 				isSkippable: false,
 				actionUrl: emailManagementTitanSetupMailbox( siteSlug, task.domain ),
 			};

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -212,7 +212,7 @@ export const getTask = (
 				description: translate(
 					'Complete your Professional Email setup to start sending and receiving emails from your custom domain today.'
 				),
-				actionText: translate( 'Complete setup' ),
+				actionText: translate( 'Set up mailbox' ),
 				isSkippable: false,
 				actionUrl: emailManagementTitanSetupMailbox( siteSlug, task.domain ),
 			};

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -13,9 +13,9 @@ import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-com
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import TitanAddMailboxes from 'calypso/my-sites/email/titan-add-mailboxes';
 import TitanControlPanelRedirect from 'calypso/my-sites/email/email-management/titan-control-panel-redirect';
-import TitanSetupMailbox from 'calypso/my-sites/email/titan-setup-mailbox';
 import TitanManageMailboxes from 'calypso/my-sites/email/email-management/titan-manage-mailboxes';
 import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan-management-iframe';
+import TitanSetupMailbox from 'calypso/my-sites/email/titan-setup-mailbox';
 import TitanSetupThankYou from 'calypso/my-sites/email/titan-setup-thank-you';
 
 export default {

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@automattic/components';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import i18nCalypso, { getLocaleSlug, localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -38,7 +38,9 @@ class EmailPlanWarnings extends React.Component {
 
 		return (
 			<Button compact primary href={ setupMailboxUrl }>
-				{ translate( 'Set Up Mailbox' ) }
+				{ 'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
+					? translate( 'Set up mailbox' )
+					: translate( 'Activate mailbox' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -40,7 +40,7 @@ class EmailPlanWarnings extends React.Component {
 			<Button compact primary href={ setupMailboxUrl }>
 				{ 'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
 					? translate( 'Set up mailbox' )
-					: translate( 'Activate mailbox' ) }
+					: translate( 'Activate Mailbox' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -3,7 +3,6 @@
  */
 import { Button } from '@automattic/components';
 import { connect } from 'react-redux';
-import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -11,10 +10,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import {
-	emailManagementManageTitanAccount,
-	emailManagementTitanControlPanelRedirect,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetupMailbox } from 'calypso/my-sites/email/paths';
 import { getConfiguredTitanMailboxCount, getMaxTitanMailboxCount } from 'calypso/lib/titan';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getGoogleAdminUrl } from 'calypso/lib/gsuite';
@@ -25,7 +21,6 @@ import {
 	hasGoogleAccountTOSWarning,
 	isTitanMailAccount,
 } from 'calypso/lib/emails';
-import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 
 class EmailPlanWarnings extends React.Component {
 	static propTypes = {
@@ -36,26 +31,17 @@ class EmailPlanWarnings extends React.Component {
 	renderCTAForTitanUnusedMailboxes() {
 		const { currentRoute, domain, selectedSiteSlug, translate } = this.props;
 
-		const showExternalControlPanelLink = ! isEnabled( 'titan/iframe-control-panel' );
-		const controlPanelUrl = showExternalControlPanelLink
-			? emailManagementTitanControlPanelRedirect( selectedSiteSlug, domain.name, currentRoute, {
-					context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
-			  } )
-			: emailManagementManageTitanAccount( selectedSiteSlug, domain.name, currentRoute, {
-					context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
-			  } );
+		const setupMailboxUrl = emailManagementTitanSetupMailbox(
+			selectedSiteSlug,
+			domain.name,
+			currentRoute
+		);
 
 		return (
-			<Button
-				compact
-				primary
-				href={ controlPanelUrl }
-				target={ showExternalControlPanelLink ? '_blank' : null }
-			>
+			<Button compact primary href={ setupMailboxUrl }>
 				{ translate( 'Activate Mailbox', 'Activate Mailboxes', {
 					count: getMaxTitanMailboxCount( domain ) - getConfiguredTitanMailboxCount( domain ),
 				} ) }
-				{ showExternalControlPanelLink && <Gridicon icon="external" /> }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -11,7 +11,6 @@ import React from 'react';
  * Internal dependencies
  */
 import { emailManagementTitanSetupMailbox } from 'calypso/my-sites/email/paths';
-import { getConfiguredTitanMailboxCount, getMaxTitanMailboxCount } from 'calypso/lib/titan';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getGoogleAdminUrl } from 'calypso/lib/gsuite';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -39,9 +38,7 @@ class EmailPlanWarnings extends React.Component {
 
 		return (
 			<Button compact primary href={ setupMailboxUrl }>
-				{ translate( 'Activate Mailbox', 'Activate Mailboxes', {
-					count: getMaxTitanMailboxCount( domain ) - getConfiguredTitanMailboxCount( domain ),
-				} ) }
+				{ translate( 'Set Up Mailbox' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -150,13 +150,13 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
-			paths.emailManagementTitanSetupThankYouPage(
+			paths.emailManagementTitanSetupThankYou(
 				':site',
 				':domain',
 				null,
 				paths.emailManagementAllSitesPrefix
 			),
-			paths.emailManagementTitanSetupThankYouPage( ':site', ':domain' ),
+			paths.emailManagementTitanSetupThankYou( ':site', ':domain' ),
 		],
 		handlers: [
 			...commonHandlers,

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -82,6 +82,21 @@ export function emailManagementTitanSetupMailbox( siteName, domainName, relative
 	return emailManagementEdit( siteName, domainName, 'titan/setup-mailbox', relativeTo );
 }
 
+export function emailManagementTitanSetupThankYou(
+	siteName,
+	domainName,
+	emailAddress = null,
+	relativeTo = null
+) {
+	return emailManagementEdit(
+		siteName,
+		domainName,
+		'titan/setup-mailbox/thank-you',
+		relativeTo,
+		emailAddress ? { email: emailAddress } : {}
+	);
+}
+
 export function emailManagementTitanControlPanelRedirect(
 	siteName,
 	domainName,
@@ -94,21 +109,6 @@ export function emailManagementTitanControlPanelRedirect(
 		'titan/control-panel',
 		relativeTo,
 		urlParameters
-	);
-}
-
-export function emailManagementTitanSetupThankYouPage(
-	siteName,
-	domainName,
-	emailAddress = null,
-	relativeTo = null
-) {
-	return emailManagementEdit(
-		siteName,
-		domainName,
-		'titan/setup-mailbox/thank-you',
-		relativeTo,
-		emailAddress ? { email: emailAddress } : {}
 	);
 }
 

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -5,7 +5,6 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
-import { isEnabled } from '@automattic/calypso-config';
 import { withShoppingCart } from '@automattic/shopping-cart';
 
 /**
@@ -24,9 +23,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
 	emailManagement,
-	emailManagementManageTitanAccount,
 	emailManagementNewTitanAccount,
-	emailManagementTitanControlPanelRedirect,
+	emailManagementTitanSetupMailbox,
 } from 'calypso/my-sites/email/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {
@@ -49,10 +47,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
-import {
-	TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
-	TITAN_MAIL_MONTHLY_SLUG,
-} from 'calypso/lib/titan/constants';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import SectionHeader from 'calypso/components/section-header';
 import TitanMailboxPricingNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
@@ -195,22 +190,12 @@ class TitanAddMailboxes extends React.Component {
 
 		this.recordClickEvent( 'calypso_email_management_titan_add_mailboxes_create_mailbox_click' );
 
-		const domainName = isSelectedDomainNameValid ? selectedDomainName : null;
-
-		if ( isEnabled( 'titan/iframe-control-panel' ) ) {
-			page(
-				emailManagementManageTitanAccount( selectedSite.slug, domainName, currentRoute, {
-					context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
-				} )
-			);
-
-			return;
-		}
-
-		window.open(
-			emailManagementTitanControlPanelRedirect( selectedSite.slug, domainName, currentRoute, {
-				context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
-			} )
+		page(
+			emailManagementTitanSetupMailbox(
+				selectedSite.slug,
+				isSelectedDomainNameValid ? selectedDomainName : null,
+				currentRoute
+			)
 		);
 	};
 
@@ -272,7 +257,6 @@ class TitanAddMailboxes extends React.Component {
 		}
 
 		const analyticsPath = emailManagementNewTitanAccount( ':site', ':domain', currentRoute );
-		const finishSetupLinkIsExternal = ! isEnabled( 'titan/iframe-control-panel' );
 
 		return (
 			<>
@@ -294,11 +278,11 @@ class TitanAddMailboxes extends React.Component {
 					{ selectedDomain && (
 						<TitanUnusedMailboxesNotice
 							domain={ selectedDomain }
-							linkIsExternal={ finishSetupLinkIsExternal }
 							maxTitanMailboxCount={ maxTitanMailboxCount }
 							onFinishSetupClick={ this.handleUnusedMailboxFinishSetupClick }
 						/>
 					) }
+
 					{ selectedDomain && titanMonthlyProduct && (
 						<TitanMailboxPricingNotice
 							domain={ selectedDomain }

--- a/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
@@ -33,19 +33,21 @@ const TitanUnusedMailboxesNotice = ( { domain, maxTitanMailboxCount, onFinishSet
 		comment: 'This refers to the number of mailboxes purchased that have not been set up yet',
 	};
 
-	const text = i18nCalypso.hasTranslation(
-		'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?'
-	)
-		? translate(
-				'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
-				'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
-				translateOptions
-		  )
-		: translate(
-				'You have %(numberOfMailboxes)d unused mailbox. Do you want to configure it now instead?',
-				'You have %(numberOfMailboxes)d unused mailboxes. Do you want to configure them now instead?',
-				translateOptions
-		  );
+	const text =
+		'en' === getLocaleSlug() ||
+		i18nCalypso.hasTranslation(
+			'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?'
+		)
+			? translate(
+					'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
+					'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
+					translateOptions
+			  )
+			: translate(
+					'You have %(numberOfMailboxes)d unused mailbox. Do you want to configure it now instead?',
+					'You have %(numberOfMailboxes)d unused mailboxes. Do you want to configure them now instead?',
+					translateOptions
+			  );
 
 	const ctaText =
 		'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )

--- a/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useTranslate } from 'i18n-calypso';
+import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,21 +25,36 @@ const TitanUnusedMailboxesNotice = ( { domain, maxTitanMailboxCount, onFinishSet
 		return null;
 	}
 
-	const text = translate(
-		'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
-		'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
-		{
-			count: numberOfUnusedMailboxes,
-			args: {
-				numberOfMailboxes: numberOfUnusedMailboxes,
-			},
-			comment: 'This refers to the number of mailboxes purchased that have not been set up yet',
-		}
-	);
+	const translateOptions = {
+		count: numberOfUnusedMailboxes,
+		args: {
+			numberOfMailboxes: numberOfUnusedMailboxes,
+		},
+		comment: 'This refers to the number of mailboxes purchased that have not been set up yet',
+	};
+
+	const text = i18nCalypso.hasTranslation(
+		'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?'
+	)
+		? translate(
+				'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
+				'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
+				translateOptions
+		  )
+		: translate(
+				'You have %(numberOfMailboxes)d unused mailbox. Do you want to configure it now instead?',
+				'You have %(numberOfMailboxes)d unused mailboxes. Do you want to configure them now instead?',
+				translateOptions
+		  );
+
+	const ctaText =
+		'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
+			? translate( 'Set up mailbox' )
+			: translate( 'Finish Setup' );
 
 	return (
 		<Notice icon="notice" showDismiss={ false } status="is-warning" text={ text }>
-			<NoticeAction onClick={ onFinishSetupClick }>{ translate( 'Finish Setup' ) }</NoticeAction>
+			<NoticeAction onClick={ onFinishSetupClick }>{ ctaText }</NoticeAction>
 		</Notice>
 	);
 };

--- a/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
@@ -12,12 +12,7 @@ import { getConfiguredTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 
-const TitanUnusedMailboxesNotice = ( {
-	domain,
-	linkIsExternal = false,
-	maxTitanMailboxCount,
-	onFinishSetupClick,
-} ) => {
+const TitanUnusedMailboxesNotice = ( { domain, maxTitanMailboxCount, onFinishSetupClick } ) => {
 	const translate = useTranslate();
 
 	if ( ! hasTitanMailWithUs( domain ) ) {
@@ -31,8 +26,8 @@ const TitanUnusedMailboxesNotice = ( {
 	}
 
 	const text = translate(
-		'You have %(numberOfMailboxes)d unused mailbox. Do you want to configure it now instead?',
-		'You have %(numberOfMailboxes)d unused mailboxes. Do you want to configure them now instead?',
+		'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
+		'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
 		{
 			count: numberOfUnusedMailboxes,
 			args: {
@@ -44,16 +39,13 @@ const TitanUnusedMailboxesNotice = ( {
 
 	return (
 		<Notice icon="notice" showDismiss={ false } status="is-warning" text={ text }>
-			<NoticeAction external={ linkIsExternal } onClick={ onFinishSetupClick }>
-				{ translate( 'Finish Setup' ) }
-			</NoticeAction>
+			<NoticeAction onClick={ onFinishSetupClick }>{ translate( 'Finish Setup' ) }</NoticeAction>
 		</Notice>
 	);
 };
 
 TitanUnusedMailboxesNotice.propTypes = {
 	domain: PropTypes.object.isRequired,
-	linkIsExternal: PropTypes.bool.isRequired,
 	maxTitanMailboxCount: PropTypes.number.isRequired,
 	onFinishSetupClick: PropTypes.func.isRequired,
 };

--- a/client/my-sites/email/titan-setup-mailbox/index.js
+++ b/client/my-sites/email/titan-setup-mailbox/index.js
@@ -82,7 +82,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 					{ getTitanProductName() + ': ' + selectedDomainName }
 				</HeaderCake>
 
-				<SectionHeader label={ title } />
+				<SectionHeader label={ title } className="titan-setup-mailbox__section-header" />
 
 				<TitanSetupMailboxForm
 					areSiteDomainsLoaded={ areSiteDomainsLoaded }

--- a/client/my-sites/email/titan-setup-mailbox/index.js
+++ b/client/my-sites/email/titan-setup-mailbox/index.js
@@ -5,7 +5,7 @@ import page from 'page';
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
+import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -62,6 +62,11 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 		return null;
 	}
 
+	const title =
+		'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
+			? translate( 'Set up mailbox' )
+			: translate( 'Set up your Professional Email' );
+
 	return (
 		<>
 			<PageViewTracker path={ analyticsPath } title="Email Management > Set Up Titan Mailbox" />
@@ -69,7 +74,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 			<Main wideLayout={ true }>
-				<DocumentHead title={ translate( 'Set Up Mailbox' ) } />
+				<DocumentHead title={ title } />
 
 				<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 
@@ -77,7 +82,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 					{ getTitanProductName() + ': ' + selectedDomainName }
 				</HeaderCake>
 
-				<SectionHeader label={ translate( 'Set Up Mailbox' ) } />
+				<SectionHeader label={ title } />
 
 				<TitanSetupMailboxForm
 					areSiteDomainsLoaded={ areSiteDomainsLoaded }

--- a/client/my-sites/email/titan-setup-mailbox/index.js
+++ b/client/my-sites/email/titan-setup-mailbox/index.js
@@ -64,10 +64,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 
 	return (
 		<>
-			<PageViewTracker
-				path={ analyticsPath }
-				title="Email Management > Set Up Titan Mailbox"
-			/>
+			<PageViewTracker path={ analyticsPath } title="Email Management > Set Up Titan Mailbox" />
 
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
@@ -80,7 +77,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 					{ getTitanProductName() + ': ' + selectedDomainName }
 				</HeaderCake>
 
-				<SectionHeader label={ translate( 'Set Up Mailbox') } />
+				<SectionHeader label={ translate( 'Set Up Mailbox' ) } />
 
 				<TitanSetupMailboxForm
 					areSiteDomainsLoaded={ areSiteDomainsLoaded }

--- a/client/my-sites/email/titan-setup-mailbox/index.js
+++ b/client/my-sites/email/titan-setup-mailbox/index.js
@@ -18,11 +18,13 @@ import {
 } from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { hasTitanMailWithUs } from 'calypso/lib/titan';
+import { hasTitanMailWithUs, getTitanProductName } from 'calypso/lib/titan';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import SectionHeader from 'calypso/components/section-header';
 import TitanSetupMailboxForm from 'calypso/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -31,6 +33,8 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 
 	const currentRoute = useSelector( getCurrentRoute );
+
+	const previousRoute = useSelector( getPreviousRoute );
 
 	const siteId = selectedSite?.ID ?? null;
 
@@ -46,9 +50,9 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 
 	const siteSlug = selectedSite?.slug ?? null;
 
-	const goToCustomerHome = useCallback( () => {
-		page.redirect( `/home/${ siteSlug }` );
-	}, [ siteSlug ] );
+	const handleBack = useCallback( () => {
+		page( previousRoute );
+	}, [ previousRoute ] );
 
 	const translate = useTranslate();
 
@@ -62,19 +66,21 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 		<>
 			<PageViewTracker
 				path={ analyticsPath }
-				title="Email Management > Set up your Professional Email"
+				title="Email Management > Set Up Titan Mailbox"
 			/>
 
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 			<Main wideLayout={ true }>
-				<DocumentHead title={ translate( 'Set up your Professional Email' ) } />
+				<DocumentHead title={ translate( 'Set Up Mailbox' ) } />
 
 				<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 
-				<HeaderCake onClick={ goToCustomerHome }>
-					{ translate( 'Set up your Professional Email' ) }
+				<HeaderCake onClick={ handleBack }>
+					{ getTitanProductName() + ': ' + selectedDomainName }
 				</HeaderCake>
+
+				<SectionHeader label={ translate( 'Set Up Mailbox') } />
 
 				<TitanSetupMailboxForm
 					areSiteDomainsLoaded={ areSiteDomainsLoaded }

--- a/client/my-sites/email/titan-setup-mailbox/style.scss
+++ b/client/my-sites/email/titan-setup-mailbox/style.scss
@@ -1,3 +1,4 @@
-.titan-setup-mailbox-form__button {
+.titan-setup-mailbox-form__button,
+.titan-setup-mailbox__section-header {
 	text-transform: capitalize;
 }

--- a/client/my-sites/email/titan-setup-mailbox/style.scss
+++ b/client/my-sites/email/titan-setup-mailbox/style.scss
@@ -1,0 +1,3 @@
+.titan-setup-mailbox-form__button {
+	text-transform: capitalize;
+}

--- a/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
+++ b/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
@@ -26,6 +26,11 @@ import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/tita
 import { useCreateTitanMailboxMutation } from 'calypso/data/emails/use-create-titan-mailbox-mutation';
 import { useGetTitanMailboxAvailability } from 'calypso/data/emails/use-get-titan-mailbox-availability';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const getMailboxDomainName = ( mailbox ) => mailbox?.domain?.value;
 const getMailboxUserName = ( mailbox ) => mailbox?.mailbox?.value;
 
@@ -178,12 +183,12 @@ const TitanSetupMailboxForm = ( { areSiteDomainsLoaded, selectedDomainName } ) =
 				validatedMailboxUuids={ validatedMailboxUuids }
 			>
 				<Button
-					className="titan-setup-mailbox__action-continue"
+					className="titan-setup-mailbox-form__button"
 					primary
 					busy={ isBusy }
 					onClick={ handleSetup }
 				>
-					{ translate( 'Complete Setup' ) }
+					{ translate( 'Complete setup' ) }
 				</Button>
 			</TitanNewMailboxList>
 		</Card>

--- a/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
+++ b/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
@@ -183,7 +183,7 @@ const TitanSetupMailboxForm = ( { areSiteDomainsLoaded, selectedDomainName } ) =
 					busy={ isBusy }
 					onClick={ handleSetup }
 				>
-					{ translate( 'Set Up' ) }
+					{ translate( 'Complete Setup' ) }
 				</Button>
 			</TitanNewMailboxList>
 		</Card>

--- a/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
+++ b/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
@@ -18,7 +18,7 @@ import {
 	decorateMailboxWithAvailabilityError,
 	validateMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
-import { emailManagementTitanSetupThankYouPage } from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetupThankYou } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -54,7 +54,7 @@ const useHandleSetupAction = (
 
 	const goToThankYouPage = ( emailAddress ) => {
 		page(
-			emailManagementTitanSetupThankYouPage(
+			emailManagementTitanSetupThankYou(
 				selectedSite?.slug ?? null,
 				selectedDomainName,
 				emailAddress


### PR DESCRIPTION
This pull request updates the `Email Plan` and `Add New Mailboxes` pages to direct users to the new `Set Up Mailbox` page in order to configure unused mailboxes (previously users would be redirected to the Titan Control Panel to perform that task). This means the `Set Up Mailbox` page is now accessible from the following pages:

* `Customer Home`
* `Email Plan`
* `Add New Mailboxes`

This pull request also makes a number of refinements to make the user experience more consistent across those flows, taking into account the fact that we can only set up one mailbox at a time:

###### `Customer Home`

Before | After
------ | -----
<img width="622" alt="CUSTOMER HOME B" src="https://user-images.githubusercontent.com/594356/128040129-97aaea25-ea7e-4b1b-8486-9a1f7e51bbf1.png"> | <img width="623" alt="CUSTOMER HOME A" src="https://user-images.githubusercontent.com/594356/128040156-d06896a4-3d4b-4c53-9b05-140ba124926f.png">

###### `Email Plan`

Before | After
------ | -----
<img width="623" alt="EMAIL PLAN B" src="https://user-images.githubusercontent.com/594356/128041201-5bf50fb9-4b58-484a-8355-383f69bda0e4.png"> | <img width="624" alt="EMAIL PLAN A" src="https://user-images.githubusercontent.com/3376401/128488014-fb39e655-79a8-490b-92cd-a03e7477a540.png">


###### `Add New Mailboxes`

Before | After
------ | -----
<img width="623" alt="ADD NEW MAILBOXES B" src="https://user-images.githubusercontent.com/594356/128041250-0317b945-4c82-49cf-8eb6-87b43a30a79b.png"> | <img width="622" alt="ADD NEW MAILBOXES A" src="https://user-images.githubusercontent.com/3376401/128488221-adba98d7-424e-4758-840a-539b08cd3f08.png">

###### `Set Up Mailbox`

Before | After
------ | -----
<img width="623" alt="SET UP MAILBOX B" src="https://user-images.githubusercontent.com/594356/128040692-e89a7c44-3b61-426b-aa04-359c958f4ef3.png"> | <img width="623" alt="SET UP MAILBOX A" src="https://user-images.githubusercontent.com/594356/128040775-4127c77b-c1e4-4388-bd9f-3447312dc1df.png">

The header for the `Set Up Mailbox` page was updated to match the one for `Add New Mailboxes`, and the various CTAs have been updated to `Set up mailbox`. Note that the new text is conditional on the text being translated -- we'll show the existing text for non-`en` locales until we get the relevant strings translated. Finally, this pull request renames a helper function and reorders some code.

#### Testing instructions

> If you don't have a Professional Email subscription with unused mailboxes:
> 1. Pick an existing subscription (or create a new one)
> 2. Access the Titan Control Panel
> 3. Delete a mailbox from there (click on the kebab menu and selecting `Delete Account`)

1. Load this branch locally or via the live branch (linked from [this comment](https://github.com/Automattic/wp-calypso/pull/55104#issuecomment-891138838))
2. Log into a WordPress.com account with a Professional Email mailbox purchased during signup (but not activated yet) -- ensure this account is using the `en`/English locale.
3. Check the flow starting from the [`Customer Home` page](http://calypso.localhost:3000/email)
4. Navigate to the `Email Plan` page
5. Check the flow starting from the `Set up mailbox` button in the unused mailbox notice
6. Check the flow starting from the `Add new mailboxes` link
7. Assert that you are no longer presented with the Titan Control Panel

Next, update your account to use another locale (I found `en-gb`/English (UK) to be easy to test).
Repeat the steps above and verify that you see the Before text in all cases.

Related to #54934