### PR TITLE
Jetpack site-less Checkout: include the temporary site's blog id in the payload

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -42,6 +42,7 @@ interface Props {
 	productSlug: string | 'no_product';
 	receiptId?: number;
 	source?: string;
+	jetpackTemporarySiteId?: number;
 }
 
 const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
@@ -49,6 +50,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 	productSlug,
 	receiptId = 0,
 	source = 'onboarding-calypso-ui',
+	jetpackTemporarySiteId = 0,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -109,9 +111,16 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 					receipt_id: receiptId,
 				} )
 			);
-			dispatch( requestUpdateJetpackCheckoutSupportTicket( siteUrl, receiptId, source ) );
+			dispatch(
+				requestUpdateJetpackCheckoutSupportTicket(
+					siteUrl,
+					receiptId,
+					source,
+					jetpackTemporarySiteId
+				)
+			);
 		},
-		[ siteInput, dispatch, translate, productSlug, receiptId, source ]
+		[ siteInput, dispatch, translate, productSlug, receiptId, source, jetpackTemporarySiteId ]
 	);
 
 	const onScheduleClick = useCallback( () => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -95,6 +95,15 @@ export default function useCreatePaymentCompleteCallback( {
 		( { paymentMethodId, transactionLastResponse }: PaymentCompleteCallbackArguments ): void => {
 			debug( 'payment completed successfully' );
 			const transactionResult = normalizeTransactionResponse( transactionLastResponse );
+
+			// In the case of a Jetpack product site-less purchase, we need to include the blog ID of the
+			// created site in the Thank You page URL.
+			let jetpackTemporarySiteId;
+			if ( isJetpackCheckout && ! siteSlug && responseCart.create_new_blog ) {
+				jetpackTemporarySiteId =
+					transactionResult.purchases && Object.keys( transactionResult.purchases ).pop();
+			}
+
 			const getThankYouPageUrlArguments = {
 				siteSlug: siteSlug || undefined,
 				adminUrl,
@@ -110,6 +119,7 @@ export default function useCreatePaymentCompleteCallback( {
 				hideNudge: isComingFromUpsell,
 				isInEditor,
 				isJetpackCheckout,
+				jetpackTemporarySiteId,
 			};
 			debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
 			const url = getThankYouPageUrl( getThankYouPageUrlArguments );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -10,7 +10,7 @@ const debug = debugFactory( 'calypso:composite-checkout:get-thank-you-page-url' 
 /**
  * Internal dependencies
  */
-import { isExternal, resemblesUrl, urlToSlug } from 'calypso/lib/url';
+import { addQueryArgs, isExternal, resemblesUrl, urlToSlug } from 'calypso/lib/url';
 import config from '@automattic/calypso-config';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
@@ -58,6 +58,7 @@ export default function getThankYouPageUrl( {
 	hideNudge,
 	isInEditor,
 	isJetpackCheckout = false,
+	jetpackTemporarySiteId,
 }: {
 	siteSlug: string | undefined;
 	adminUrl: string | undefined;
@@ -75,6 +76,7 @@ export default function getThankYouPageUrl( {
 	hideNudge?: boolean;
 	isInEditor?: boolean;
 	isJetpackCheckout?: boolean;
+	jetpackTemporarySiteId?: string;
 } ): string {
 	debug( 'starting getThankYouPageUrl' );
 
@@ -146,10 +148,13 @@ export default function getThankYouPageUrl( {
 		}`;
 
 		const isValidReceiptId = ! isNaN( parseInt( pendingOrReceiptId ) );
-
-		return isValidReceiptId
-			? `${ thankYouUrlSiteLess }?receiptId=${ pendingOrReceiptId }`
-			: thankYouUrlSiteLess;
+		return addQueryArgs(
+			{
+				receiptId: isValidReceiptId ? pendingOrReceiptId : undefined,
+				jetpackTemporarySiteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
+			},
+			thankYouUrlSiteLess
+		);
 	}
 
 	const fallbackUrl = getFallbackDestination( {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -1003,5 +1003,26 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 			expect( url ).toBe( '/checkout/jetpack/thank-you/no-site/jetpack_backup_daily' );
 		} );
+
+		it( 'redirects with jetpackTemporarySiteId query param when available', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: 'jetpack_backup_daily',
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: undefined,
+				cart,
+				isJetpackCheckout: true,
+				receiptId: 80023,
+				jetpackTemporarySiteId: 123456789,
+			} );
+			expect( url ).toBe(
+				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=80023&jetpackTemporarySiteId=123456789'
+			);
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -292,7 +292,7 @@ export function jetpackCheckoutThankYou( context, next ) {
 	const isSitelessCheckoutFlow =
 		context.path.includes( '/checkout/jetpack/thank-you/no-site' ) || forSitelessScheduling;
 
-	const { receiptId, source } = context.query;
+	const { receiptId, source, jetpackTemporarySiteId } = context.query;
 
 	context.primary = isSitelessCheckoutFlow ? (
 		<JetpackCheckoutSitelessThankYou
@@ -300,6 +300,7 @@ export function jetpackCheckoutThankYou( context, next ) {
 			receiptId={ receiptId }
 			forScheduling={ forSitelessScheduling }
 			source={ source }
+			jetpackTemporarySiteId={ jetpackTemporarySiteId }
 		/>
 	) : (
 		<JetpackCheckoutThankYou

--- a/client/state/data-layer/wpcom/jetpack-checkout/support-ticket/index.js
+++ b/client/state/data-layer/wpcom/jetpack-checkout/support-ticket/index.js
@@ -12,13 +12,17 @@ import {
 } from 'calypso/state/action-types';
 
 const updateSupportTicket = ( action ) => {
-	const { siteUrl, receiptId, source } = action;
+	const { siteUrl, receiptId, source, jetpackTemporarySiteId } = action;
 	return http(
 		{
 			method: 'POST',
 			path: '/jetpack-checkout/support-ticket',
 			apiNamespace: 'wpcom/v2',
-			body: { site_url: siteUrl, receipt_id: receiptId },
+			body: {
+				site_url: siteUrl,
+				receipt_id: receiptId,
+				...( jetpackTemporarySiteId ? { temporary_blog_id: jetpackTemporarySiteId } : {} ),
+			},
 			query: { source },
 		},
 		action

--- a/client/state/jetpack-checkout/actions.ts
+++ b/client/state/jetpack-checkout/actions.ts
@@ -10,18 +10,21 @@ interface UpdateJetpackCheckoutSupportTicketActionType {
 	type: typeof JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_REQUEST;
 	siteUrl: string;
 	receiptId: number;
-	source?: string;
+	source: string;
+	jetpackTemporarySiteId?: number;
 }
 
 export function requestUpdateJetpackCheckoutSupportTicket(
 	siteUrl: string,
 	receiptId: number,
-	source: string
+	source: string,
+	jetpackTemporarySiteId: number | undefined
 ): UpdateJetpackCheckoutSupportTicketActionType {
 	return {
 		type: JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_REQUEST,
 		siteUrl,
 		receiptId,
 		source,
+		jetpackTemporarySiteId,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* To update a ZD ticket with a user's site URL, we use the receipt id which is included in the request's payload sent to `/jetpack-checkout/support-ticket`. The problem is that the response of the `/transactions` endpoint doesn't always come back with a valid receipt id after a purchase has been completed. For that reason, we are including the blog id of the temporary site, which also can be used to find a ZD ticket.

#### Testing instructions

* Download this PR.
* Start Calypso with `yarn start`. 
* Complete a site-less checkout.
* On the post-purchase Thank You UI, verify that there is a query parameter called `jetpackTemporarySiteId` set to a numeric value.
* Open the Network tab.
* Submit a URL.
* On the Network tab, verify that the request's payload included a parameter called `temporary_blog_id` which was set to the same value you saw in the URL.
* Reload the page and go back to the post-purchase Thank You page.
* Remove from the URL the `jetpackTemporarySiteId` query parameter.
* Submit a URL.
* On the Network tab, verify that the request's payload included a parameter called `temporary_blog_id` which was set to `0`.

**(optional) Integration test**
* Patch your sandbox with D65063-code.
* Sandbox `public-api.wordpress.com`.
* Complete a site-less checkout.
* On the post-purchase Thank You UI, verify that there is a query parameter called `jetpackTemporarySiteId` set to a numeric value.
* Remove the `receiptId` query parameter (we will attempt an update via the temporary site's blog id).
* Reload the page (make sure there is no `receiptId` query parameter in the URL).
* Submit a URL.
* Make sure the ticket was updated.

Related to 1200479326344990-as-1200705457718835