### PR TITLE
Checkout: Add isMounted guards to some hooks

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -38,6 +38,13 @@ export default function useAddProductsFromUrl( {
 	addProductsToCart: AddProductsToCart;
 	replaceProductsInCart: ReplaceProductsInCart;
 } ): isPendingAddingProductsFromUrl {
+	const isMounted = useRef( true );
+	useEffect( () => {
+		isMounted.current = true;
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
 	const [ isLoading, setIsLoading ] = useState< boolean >( true );
 	const hasRequestedInitialProducts = useRef< boolean >( false );
 
@@ -55,7 +62,7 @@ export default function useAddProductsFromUrl( {
 			! isCartPendingUpdate
 		) {
 			debug( 'no products or coupons to add; skipping initial cart requests' );
-			setIsLoading( false );
+			isMounted.current && setIsLoading( false );
 			return;
 		}
 	}, [
@@ -100,7 +107,7 @@ export default function useAddProductsFromUrl( {
 		}
 		Promise.all( cartPromises ).then( () => {
 			debug( 'initial cart requests have completed' );
-			setIsLoading( false );
+			isMounted.current && setIsLoading( false );
 		} );
 		hasRequestedInitialProducts.current = true;
 	}, [

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 import page from 'page';
 import debugFactory from 'debug';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -58,6 +58,14 @@ export default function useRemoveFromCartAndRedirect(
 		}
 	}, [ createUserAndSiteBeforeTransaction, siteSlug, siteSlugLoggedOutCart, checkoutBackUrl ] );
 
+	const isMounted = useRef( true );
+	useEffect( () => {
+		isMounted.current = true;
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
+
 	const [ isRemovingProductFromCart, setIsRemovingFromCart ] = useState< boolean >( false );
 	const removeProductFromCartAndMaybeRedirect = useCallback(
 		( uuid: string ) => {
@@ -68,7 +76,7 @@ export default function useRemoveFromCartAndRedirect(
 					// Don't turn off isRemovingProductFromCart if we are redirecting so that the loading page remains active.
 					return cart;
 				}
-				setIsRemovingFromCart( false );
+				isMounted.current && setIsRemovingFromCart( false );
 				return cart;
 			} );
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds some `isMounted` guards to the checkout hooks `useAddProductsFromUrl` and `useRemoveFromCartAndRedirect` so they won't take actions that modify component state when the component has been unmounted. 

Specifically, when the hooks trigger an async action and then try to modify the state when that action completes, there's a chance that the hook's component will have been removed from the page by that time, causing a React memory leak warning.

#### Testing instructions

To test `useAddProductsFromUrl`, visit a URL like `/checkout/example.com/business` (checkout followed by the site url followed by a product alias) and verify that you end up in checkout with the selected product in the cart.

To test `useRemoveFromCartAndRedirect`, add two products to your cart (eg: a plan and a domain) and visit checkout, verifying that when you click to remove one of the products, no redirect happens, but when you remove the second product, you're redirected to the plans page.