### PR TITLE
Legacy FSE: Update editor classes for template block styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -26,29 +26,31 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 } )( ( { templateClasses } ) => {
 	useEffect( () => {
 		// templateClasses will be an array with an undefined element when loading.
-		if ( templateClasses.some( ( templateClass ) => undefined !== templateClass ) ) {
-			const blockListInception = setInterval( () => {
-				const blockListParent = document.querySelector(
-					'.editor-styles-wrapper > .block-editor-block-list__layout'
-				);
-
-				if ( ! blockListParent ) {
-					return;
-				}
-
-				clearInterval( blockListInception );
-
-				if ( ! blockListParent.className.includes( 'a8c-template-editor fse-template-part' ) ) {
-					blockListParent.className = classNames(
-						blockListParent.className,
-						'a8c-template-editor fse-template-part',
-						...templateClasses
-					);
-				}
-			}, 100 );
-
-			return () => clearInterval( blockListInception );
+		if ( ! templateClasses.some( ( templateClass ) => undefined !== templateClass ) ) {
+			return;
 		}
+
+		const blockListInception = setInterval( () => {
+			const blockListParent = document.querySelector(
+				'.editor-styles-wrapper > .block-editor-block-list__layout'
+			);
+
+			if ( ! blockListParent ) {
+				return;
+			}
+
+			clearInterval( blockListInception );
+
+			if ( ! blockListParent.className.includes( 'a8c-template-editor fse-template-part' ) ) {
+				blockListParent.className = classNames(
+					blockListParent.className,
+					'a8c-template-editor fse-template-part',
+					...templateClasses
+				);
+			}
+		}, 100 );
+
+		return () => clearInterval( blockListInception );
 	}, [ ...templateClasses ] ); // eslint-disable-line react-hooks/exhaustive-deps
 	return null;
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -26,7 +26,7 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 } )( ( { templateClasses } ) => {
 	useEffect( () => {
 		// templateClasses will be an array with an undefined element when loading.
-		if ( ! templateClasses.some( ( templateClass ) => undefined !== templateClass ) ) {
+		if ( ! templateClasses.some( ( templateClass ) => templateClass ) ) {
 			return;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -25,24 +25,30 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 	return { templateClasses };
 } )( ( { templateClasses } ) => {
 	useEffect( () => {
-		const blockListInception = setInterval( () => {
-			const blockListParent = document.querySelector(
-				'.editor-styles-wrapper > .block-editor-block-list__layout'
-			);
+		// templateClasses will be an array with an undefined element when loading.
+		if ( templateClasses.some( ( templateClass ) => undefined !== templateClass ) ) {
+			const blockListInception = setInterval( () => {
+				const blockListParent = document.querySelector(
+					'.editor-styles-wrapper > .block-editor-block-list__layout'
+				);
 
-			if ( ! blockListParent ) {
-				return;
-			}
-			clearInterval( blockListInception );
+				if ( ! blockListParent ) {
+					return;
+				}
 
-			blockListParent.className = classNames(
-				blockListParent.className,
-				'a8c-template-editor fse-template-part',
-				...templateClasses
-			);
-		} );
+				clearInterval( blockListInception );
 
-		return () => clearInterval( blockListInception );
+				if ( ! blockListParent.className.includes( 'a8c-template-editor fse-template-part' ) ) {
+					blockListParent.className = classNames(
+						blockListParent.className,
+						'a8c-template-editor fse-template-part',
+						...templateClasses
+					);
+				}
+			}, 100 );
+
+			return () => clearInterval( blockListInception );
+		}
 	}, [ ...templateClasses ] ); // eslint-disable-line react-hooks/exhaustive-deps
 	return null;
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -24,7 +24,9 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 	return { templateClasses };
 } )( ( { templateClasses } ) => {
 	const blockListInception = setInterval( () => {
-		const blockListParent = document.querySelector( '.block-editor-writing-flow' );
+		const blockListParent = document.querySelector(
+			'.editor-styles-wrapper > .block-editor-block-list__layout'
+		);
 
 		if ( ! blockListParent ) {
 			return;
@@ -32,7 +34,7 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 		clearInterval( blockListInception );
 
 		blockListParent.className = classNames(
-			'block-editor-writing-flow',
+			blockListParent.className,
 			'a8c-template-editor fse-template-part',
 			...templateClasses
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -41,7 +41,9 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 				...templateClasses
 			);
 		} );
-	}, [ ...templateClasses ] );
+
+		return () => clearInterval( blockListInception );
+	}, [ ...templateClasses ] ); // eslint-disable-line react-hooks/exhaustive-deps
 	return null;
 } );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -34,7 +34,6 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 		clearInterval( blockListInception );
 
 		blockListParent.className = classNames(
-			blockListParent.className,
 			'a8c-template-editor fse-template-part',
 			...templateClasses
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -4,6 +4,7 @@ import { withSelect } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import classNames from 'classnames';
 import { get, map } from 'lodash';
+import { useEffect } from 'react';
 
 const EditorTemplateClasses = withSelect( ( select ) => {
 	const { getEntityRecord } = select( 'core' );
@@ -23,22 +24,24 @@ const EditorTemplateClasses = withSelect( ( select ) => {
 	} );
 	return { templateClasses };
 } )( ( { templateClasses } ) => {
-	const blockListInception = setInterval( () => {
-		const blockListParent = document.querySelector(
-			'.editor-styles-wrapper > .block-editor-block-list__layout'
-		);
+	useEffect( () => {
+		const blockListInception = setInterval( () => {
+			const blockListParent = document.querySelector(
+				'.editor-styles-wrapper > .block-editor-block-list__layout'
+			);
 
-		if ( ! blockListParent ) {
-			return;
-		}
-		clearInterval( blockListInception );
+			if ( ! blockListParent ) {
+				return;
+			}
+			clearInterval( blockListInception );
 
-		blockListParent.className = classNames(
-			'a8c-template-editor fse-template-part',
-			...templateClasses
-		);
-	} );
-
+			blockListParent.className = classNames(
+				blockListParent.className,
+				'a8c-template-editor fse-template-part',
+				...templateClasses
+			);
+		} );
+	}, [ ...templateClasses ] );
 	return null;
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the legacy FSE editor template classes plugin to make sure it applies to a div inside `editor-styles-wrapper`.

#### Testing instructions

* On a site with legacy FSE enabled, open a page in the editor and edit the header template
* Ensure the menu styles are applied

| **Before** | **After** |
| - | - |
| <img width="798" alt="Screen Shot 2021-08-02 at 21 06 03" src="https://user-images.githubusercontent.com/1699996/127946315-d8482510-3840-4edf-860d-b9908b4b6c8c.png"> | <img width="871" alt="Screen Shot 2021-08-02 at 21 02 17" src="https://user-images.githubusercontent.com/1699996/127946291-e0e6e47f-2d83-4f27-9ebe-7be84fb7d9a7.png"> |


