### PR TITLE
chore: migrate `client/signup` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -203,6 +203,7 @@ module.exports = {
 				'client/sections-preloaders.js',
 				'client/sections.js',
 				'client/server/**/*',
+				'client/signup/**/*',
 				'client/support/**/*',
 				'client/test-helpers/**/*',
 				'client/types.ts',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
 import { isEnabled } from '@automattic/calypso-config';
+import { translate } from 'i18n-calypso';
 
 const noop = () => {};
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { get, includes, reject } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import stepConfig from './steps';
-import { generateFlows } from 'calypso/signup/config/flows-pure';
 import { addQueryArgs } from 'calypso/lib/url';
+import { generateFlows } from 'calypso/signup/config/flows-pure';
+import stepConfig from './steps';
 
 function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 	let checkoutURL = `/checkout/${ dependencies.siteSlug }`;

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,11 +1,3 @@
-/**
- * External dependencies
- */
-import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 import {
 	PLAN_PERSONAL,
@@ -22,6 +14,7 @@ import {
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 } from '@automattic/calypso-products';
+import i18n from 'i18n-calypso';
 
 const noop = () => {};
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { current as currentPage } from 'page';
-
-/**
- * Internal dependencies
- */
 import {
 	addPlanToCart,
 	createAccount,

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { intersection, isEmpty, keys } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import flows from '../flows';
 import steps from '../steps';
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,19 +1,32 @@
-/**
- * External dependencies
- */
-import debugModule from 'debug';
-import React from 'react';
-import page from 'page';
-import { isEmpty } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import config from '@automattic/calypso-config';
-import { sectionify } from 'calypso/lib/route';
+import debugModule from 'debug';
+import { isEmpty } from 'lodash';
+import page from 'page';
+import React from 'react';
+import store from 'store';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import SignupComponent from './main';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
+import { login } from 'calypso/lib/paths';
+import { sectionify } from 'calypso/lib/route';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
+import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { setSiteType } from 'calypso/state/signup/steps/site-type/actions';
+import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
+import { setSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
+import {
+	getSiteVerticalId,
+	getSiteVerticalIsUserInput,
+} from 'calypso/state/signup/steps/site-vertical/selectors';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSiteId } from 'calypso/state/sites/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { getStepComponent } from './config/step-components';
+import SignupComponent from './main';
 import {
 	getStepUrl,
 	canResumeFlow,
@@ -24,26 +37,6 @@ import {
 	getFlowPageTitle,
 	shouldForceLogin,
 } from './utils';
-import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import store from 'store';
-import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
-import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
-import {
-	getSiteVerticalId,
-	getSiteVerticalIsUserInput,
-} from 'calypso/state/signup/steps/site-vertical/selectors';
-import { setSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
-import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { setSiteType } from 'calypso/state/signup/steps/site-type/actions';
-import { login } from 'calypso/lib/paths';
-import { getDotBlogVerticalId } from './config/dotblog-verticals';
-import { getSiteId } from 'calypso/state/sites/selectors';
-import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
-import { requestSite } from 'calypso/state/sites/actions';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 
 const debug = debugModule( 'calypso:signup' );
 

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-
-/**
- * Style dependencies
- */
+import { localize } from 'i18n-calypso';
+import React from 'react';
 import './style.scss';
 
 const FlowProgressIndicator = ( { flowLength, positionInFlow, translate, flowName } ) => {

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getLanguage, getLanguageRouteParam } from 'calypso/lib/i18n-utils';
 
 export default function ( router ) {

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import controller from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getLanguageRouteParam } from 'calypso/lib/i18n-utils';
+import controller from './controller';
 
 export default function () {
 	const lang = getLanguageRouteParam();

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -1,28 +1,17 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, getLocaleSlug } from 'i18n-calypso';
-import { get } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import { getStepUrl, isFirstStepInFlow } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { getFilteredSteps } from '../utils';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class NavigationLink extends Component {

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { NavigationLink } from '../';
 import Gridicon from 'calypso/components/gridicon';
+import { NavigationLink } from '../';
+const signupUtils = require( 'calypso/signup/utils' );
 
 jest.mock( 'calypso/signup/utils', () => ( {
 	getStepUrl: jest.fn(),
@@ -18,7 +12,6 @@ jest.mock( 'calypso/signup/utils', () => ( {
 } ) );
 
 const noop = () => {};
-const signupUtils = require( 'calypso/signup/utils' );
 const { getStepUrl, getFilteredSteps, getPreviousStepName, isFirstStepInFlow } = signupUtils;
 
 describe( 'NavigationLink', () => {

--- a/client/signup/p2-processing-screen/index.jsx
+++ b/client/signup/p2-processing-screen/index.jsx
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-
-/**
- * Style dependencies
- */
+import React from 'react';
 import './style.scss';
 
 function P2SignupProcessingScreen() {

--- a/client/signup/p2-step-wrapper/index.jsx
+++ b/client/signup/p2-step-wrapper/index.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import StepWrapper from 'calypso/signup/step-wrapper';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function P2StepWrapper( { flowName, stepName, headerText, positionInFlow, children } ) {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Style dependencies
- */
+import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import './style.scss';
 
 export class SignupProcessingScreen extends Component {

--- a/client/signup/recaptcha/index.jsx
+++ b/client/signup/recaptcha/index.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
-import React, { memo, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { defaultRegistry } from '@automattic/composite-checkout';
-
-/**
- * Internal dependencies
- */
-import { initGoogleRecaptcha } from 'calypso/lib/analytics/recaptcha';
 import config from '@automattic/calypso-config';
-
-/**
- * Style dependencies
- */
+import { defaultRegistry } from '@automattic/composite-checkout';
+import PropTypes from 'prop-types';
+import React, { memo, useEffect } from 'react';
+import { initGoogleRecaptcha } from 'calypso/lib/analytics/recaptcha';
 import './style.scss';
 
 function Recaptcha( { badgePosition } ) {

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
 import { useInterval } from 'calypso/lib/interval/use-interval';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 // Total time to perform "loading"

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -1,21 +1,7 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-
-/**
- * Style dependencies
- */
-
 import './style.scss';
 
 export default class SignupHeader extends Component {

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -1,19 +1,19 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { debounce, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { debounce, isEmpty } from 'lodash';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import QueryVerticals from 'calypso/components/data/query-verticals';
+import Gridicon from 'calypso/components/gridicon';
 import SignupSitePreview from 'calypso/components/signup-site-preview';
 import { getPreviewParamClass } from 'calypso/components/signup-site-preview/utils';
+import { getLocaleSlug, getLanguage } from 'calypso/lib/i18n-utils';
+import { getThemeCssUri, DEFAULT_FONT_URI as defaultFontUri } from 'calypso/lib/signup/site-theme';
+import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSiteStyle } from 'calypso/state/signup/steps/site-style/selectors';
+import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import {
 	getSiteVerticalName,
@@ -22,17 +22,6 @@ import {
 	getSiteVerticalPreviewStyles,
 	getSiteVerticalSlug,
 } from 'calypso/state/signup/steps/site-vertical/selectors';
-import { getSiteStyle } from 'calypso/state/signup/steps/site-style/selectors';
-import { getThemeCssUri, DEFAULT_FONT_URI as defaultFontUri } from 'calypso/lib/signup/site-theme';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getLocaleSlug, getLanguage } from 'calypso/lib/i18n-utils';
-import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-import QueryVerticals from 'calypso/components/data/query-verticals';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function SiteMockupHelpTip( { siteType } ) {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import FormattedHeader from 'calypso/components/formatted-header';
 import NavigationLink from 'calypso/signup/navigation-link';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class StepWrapper extends Component {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -1,54 +1,41 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
+import { Card, Button, ScreenReaderText } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import InfoPopover from 'calypso/components/info-popover';
+import SegmentedControl from 'calypso/components/segmented-control';
+import SiteVerticalsSuggestionSearch from 'calypso/components/site-verticals-suggestion-search';
 import formState from 'calypso/lib/form-state';
-import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
-import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
-import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
-import { setSiteGoals } from 'calypso/state/signup/steps/site-goals/actions';
-import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
-import { setUserExperience } from 'calypso/state/signup/steps/user-experience/actions';
-import { getUserExperience } from 'calypso/state/signup/steps/user-experience/selectors';
-import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getThemeForSiteGoals, getDesignTypeForSiteGoals } from 'calypso/signup/utils';
-import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
-import { getSurveyVertical } from 'calypso/state/signup/steps/survey/selectors';
+import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { isValidLandingPageVertical } from 'calypso/lib/signup/verticals';
 import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { getThemeForSiteGoals, getDesignTypeForSiteGoals } from 'calypso/signup/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
+import { setSiteGoals } from 'calypso/state/signup/steps/site-goals/actions';
+import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
+import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
+import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
+import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
+import { setSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
 import {
 	getSiteVerticalId,
 	getSiteVerticalParentId,
 } from 'calypso/state/signup/steps/site-vertical/selectors';
-import { setSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
-import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-//Form components
-import { Card, Button, ScreenReaderText } from '@automattic/components';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import InfoPopover from 'calypso/components/info-popover';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormLegend from 'calypso/components/forms/form-legend';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import SegmentedControl from 'calypso/components/segmented-control';
-import SiteVerticalsSuggestionSearch from 'calypso/components/site-verticals-suggestion-search';
-
-/**
- * Style dependencies
- */
+import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
+import { getSurveyVertical } from 'calypso/state/signup/steps/survey/selectors';
+import { setUserExperience } from 'calypso/state/signup/steps/user-experience/actions';
+import { getUserExperience } from 'calypso/state/signup/steps/user-experience/selectors';
 import './style.scss';
 
 const noop = () => {};

--- a/client/signup/steps/clone-cloning/index.jsx
+++ b/client/signup/steps/clone-cloning/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import { connect } from 'react-redux';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card, Button } from '@automattic/components';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CloneCloningStep extends Component {

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -1,26 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card } from '@automattic/components';
-import SectionHeader from 'calypso/components/section-header';
 import RewindCredentialsForm from 'calypso/components/rewind-credentials-form';
-import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import SectionHeader from 'calypso/components/section-header';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import getJetpackCredentialsUpdateStatus from 'calypso/state/selectors/get-jetpack-credentials-update-status';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CloneCredentialsStep extends Component {

--- a/client/signup/steps/clone-destination/index.jsx
+++ b/client/signup/steps/clone-destination/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card, Button } from '@automattic/components';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CloneDestinationStep extends Component {

--- a/client/signup/steps/clone-jetpack/index.jsx
+++ b/client/signup/steps/clone-jetpack/index.jsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import TileGrid from 'calypso/components/tile-grid';
 import Tile from 'calypso/components/tile-grid/tile';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CloneJetpackStep extends Component {

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -1,32 +1,21 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { Card } from '@automattic/components';
-import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
-import Pagination from 'calypso/components/pagination';
-import QuerySites from 'calypso/components/data/query-sites';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
-import StepWrapper from 'calypso/signup/step-wrapper';
-import Tile from 'calypso/components/tile-grid/tile';
-import TileGrid from 'calypso/components/tile-grid';
-import { requestActivityLogs } from 'calypso/state/data-getters';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import QuerySites from 'calypso/components/data/query-sites';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Pagination from 'calypso/components/pagination';
+import TileGrid from 'calypso/components/tile-grid';
+import Tile from 'calypso/components/tile-grid/tile';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { requestActivityLogs } from 'calypso/state/data-getters';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 const PAGE_SIZE = 20;

--- a/client/signup/steps/clone-ready/index.jsx
+++ b/client/signup/steps/clone-ready/index.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card, Button } from '@automattic/components';
-import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { rewindClone } from 'calypso/state/activity-log/actions';
+import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CloneReadyStep extends Component {

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card, Button } from '@automattic/components';
-import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
+import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 class CloneStartStep extends Component {

--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card, Button } from '@automattic/components';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CredsCompleteStep extends Component {

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -1,26 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { Card, Button } from '@automattic/components';
-import { autoConfigCredentials } from 'calypso/state/jetpack/credentials/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { autoConfigCredentials } from 'calypso/state/jetpack/credentials/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 class CredsConfirmStep extends Component {

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
 import { Card, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QuerySites from 'calypso/components/data/query-sites';
-import { autoConfigCredentials } from 'calypso/state/jetpack/credentials/actions';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { autoConfigCredentials } from 'calypso/state/jetpack/credentials/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CredsPermissionStep extends Component {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
+import DesignPicker from '@automattic/design-picker';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import DesignPicker from '@automattic/design-picker';
-
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class DesignPickerStep extends Component {

--- a/client/signup/steps/domains/test/utils.js
+++ b/client/signup/steps/domains/test/utils.js
@@ -1,13 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
 
-/**
- * Internal dependencies
- */
 import {
 	getExternalBackUrl,
 	backUrlExternalSourceStepsOverrides,

--- a/client/signup/steps/domains/utils.js
+++ b/client/signup/steps/domains/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import validUrl from 'valid-url';
-
-/**
- * Internal dependencies
- */
 
 // Only override the back button from an external URL source on the below step(s) which is typically where we'd send them to as the 'entry'.
 // We don't want to send them "back" to the source URL if they click back on "domains-launch/mapping" for example. Just send them back to the previous step.

--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -1,26 +1,15 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import { defer } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
-import EmailStepSideBar from 'calypso/components/emails/email-step-side-bar';
 import EmailSignupTitanCard from 'calypso/components/emails/email-signup-titan-card';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import StepWrapper from 'calypso/signup/step-wrapper';
+import EmailStepSideBar from 'calypso/components/emails/email-step-side-bar';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
-
-/**
- * Style dependencies
- */
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import './style.scss';
 
 class EmailsStep extends React.Component {

--- a/client/signup/steps/import-preview/index.jsx
+++ b/client/signup/steps/import-preview/index.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
+import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
-import { isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import importerConfig from 'calypso/lib/importer/importer-config';
-import { Button, Card } from '@automattic/components';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import StepWrapper from '../../step-wrapper';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ImportPreview extends Component {

--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -1,37 +1,26 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { get, includes, isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button, Card, ScreenReaderText } from '@automattic/components';
-import StepWrapper from 'calypso/signup/step-wrapper';
+import { localize } from 'i18n-calypso';
+import { get, includes, isEmpty } from 'lodash';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Notice from 'calypso/components/notice';
+import { getFileImporters } from 'calypso/lib/importer/importer-config';
+import { validateImportUrl } from 'calypso/lib/importer/url-validation';
+import { suggestDomainFromImportUrl } from 'calypso/lib/importer/utils';
+import wpcom from 'calypso/lib/wp';
+import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	setImportOriginSiteDetails,
 	setNuxUrlInputValue,
 } from 'calypso/state/importer-nux/actions';
-import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
 import { getNuxUrlInputValue } from 'calypso/state/importer-nux/temp-selectors';
-import { validateImportUrl } from 'calypso/lib/importer/url-validation';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import Notice from 'calypso/components/notice';
-import wpcom from 'calypso/lib/wp';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
-import { suggestDomainFromImportUrl } from 'calypso/lib/importer/utils';
-import { getFileImporters } from 'calypso/lib/importer/importer-config';
-import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
-
-/**
- * Style dependencies
- */
+import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
 import './style.scss';
 
 class ImportURLOnboardingStepComponent extends Component {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -1,36 +1,25 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button, ScreenReaderText } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { get, includes } from 'lodash';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import ExampleDomainBrowser from 'calypso/components/domains/example-domain-browser';
 import ExternalLink from 'calypso/components/external-link';
-import StepWrapper from 'calypso/signup/step-wrapper';
 import FormButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Notice from 'calypso/components/notice';
+import { validateImportUrl } from 'calypso/lib/importer/url-validation';
+import { suggestDomainFromImportUrl } from 'calypso/lib/importer/utils';
+import wpcom from 'calypso/lib/wp';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	setImportOriginSiteDetails,
 	setNuxUrlInputValue,
 } from 'calypso/state/importer-nux/actions';
 import { getNuxUrlInputValue } from 'calypso/state/importer-nux/temp-selectors';
-import { validateImportUrl } from 'calypso/lib/importer/url-validation';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import Notice from 'calypso/components/notice';
-import wpcom from 'calypso/lib/wp';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
-import { suggestDomainFromImportUrl } from 'calypso/lib/importer/utils';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const IMPORT_HELP_LINK = 'https://wordpress.com/support/import/';

--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 
 class LaunchSiteComponent extends Component {

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
-import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
 import { Button } from '@automattic/components';
-import { login } from 'calypso/lib/paths';
-import { getStepUrl } from 'calypso/signup/utils';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-
-/**
- * Style dependencies
- */
+import { login } from 'calypso/lib/paths';
+import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
+import { getStepUrl } from 'calypso/signup/utils';
 import './style.scss';
 
 function getRedirectToAfterLoginUrl( { flowName } ) {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -1,30 +1,19 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
+import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map, deburr, get } from 'lodash';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
+import React from 'react';
+import { connect } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import { login } from 'calypso/lib/paths';
-import ValidationFieldset from 'calypso/signup/validation-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormButton from 'calypso/components/forms/form-button';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import wpcom from 'calypso/lib/wp';
 import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { logToLogstash } from 'calypso/state/logstash/actions';
-
-/**
- * Style dependencies
- */
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import './style.scss';
 
 const debug = debugFactory( 'calypso:steps:p2-site' );

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
-import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
-import { Button } from '@automattic/components';
+import Notice from 'calypso/components/notice';
 import {
 	createPasswordlessUser,
 	verifyPasswordlessUser,
 } from 'calypso/lib/signup/step-actions/passwordless';
-import Notice from 'calypso/components/notice';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 
 export class PasswordlessStep extends Component {

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -1,26 +1,4 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import React, { Component } from 'react';
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { getSiteId } from 'calypso/state/sites/selectors';
-import StepWrapper from 'calypso/signup/step-wrapper';
-import QueryPlans from 'calypso/components/data/query-plans';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { isEnabled } from '@automattic/calypso-config';
-import PlanFeatures from 'calypso/my-sites/plan-features';
-import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
-import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
 import {
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
@@ -30,10 +8,20 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
-
-/**
- * Style dependencies
- */
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import QueryPlans from 'calypso/components/data/query-plans';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import PlanFeatures from 'calypso/my-sites/plan-features';
+import { DESIGN_TYPE_STORE } from 'calypso/signup/constants';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 export class PlansAtomicStoreStep extends Component {

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -6,16 +6,6 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: ( s ) => s,
 } ) );
 
-/**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { PlansAtomicStoreStep } from '../index';
 import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE,
@@ -36,6 +26,9 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { PlansAtomicStoreStep } from '../index';
 
 const noop = () => {};
 const props = {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,40 +1,28 @@
-/**
- * External dependencies
- */
-
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { intersection } from 'lodash';
+import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
+import { getUrlParts } from '@automattic/calypso-url';
+import { Button } from '@automattic/components';
+import { isDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { intersection } from 'lodash';
+import PropTypes from 'prop-types';
 import { parse as parseQs } from 'qs';
-import { Button } from '@automattic/components';
-
-/**
- * Internal dependencies
- */
-import { getTld, isSubdomain } from 'calypso/lib/domains';
-import { getSiteBySlug } from 'calypso/state/sites/selectors';
-import StepWrapper from 'calypso/signup/step-wrapper';
-import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
-import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
+import PulsingDot from 'calypso/components/pulsing-dot';
+import { getTld, isSubdomain } from 'calypso/lib/domains';
+import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
-import { getUrlParts } from '@automattic/calypso-url';
 import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
-
-/**
- * Style dependencies
- */
+import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
-import PulsingDot from 'calypso/components/pulsing-dot';
-import { isDesktop } from '@automattic/viewport';
 
 export class PlansStep extends Component {
 	componentDidMount() {

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -1,16 +1,6 @@
 jest.mock( 'calypso/signup/step-wrapper', () => 'step-wrapper' );
 jest.mock( 'calypso/my-sites/plan-features', () => 'plan-features' );
 
-/**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { PlansStep, isDotBlogDomainRegistration } from '../index';
 import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE,
@@ -31,6 +21,9 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { PlansStep, isDotBlogDomainRegistration } from '../index';
 
 const noop = () => {};
 const props = {

--- a/client/signup/steps/reader-landing/content.jsx
+++ b/client/signup/steps/reader-landing/content.jsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
-import React, { Fragment, PureComponent } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card, Button } from '@automattic/components';
-
-/**
- * Image dependencies
- */
+import { localize } from 'i18n-calypso';
+import React, { Fragment, PureComponent } from 'react';
 import conversationsImage from 'calypso/assets/images/reader/reader-conversations.png';
 import discoverImage from 'calypso/assets/images/reader/reader-discover.png';
 import mobileImage from 'calypso/assets/images/reader/reader-mobile.png';

--- a/client/signup/steps/reader-landing/index.jsx
+++ b/client/signup/steps/reader-landing/index.jsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import StepWrapper from 'calypso/signup/step-wrapper';
-import ReaderLandingStepContent from './content';
-import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import ReaderLandingStepContent from './content';
 import './style.scss';
 
 class ReaderLandingStep extends Component {

--- a/client/signup/steps/rebrand-cities-welcome/index.jsx
+++ b/client/signup/steps/rebrand-cities-welcome/index.jsx
@@ -1,23 +1,11 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { generateUniqueRebrandCitiesSiteUrl } from 'calypso/lib/rebrand-cities';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
-import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
+import { generateUniqueRebrandCitiesSiteUrl } from 'calypso/lib/rebrand-cities';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
+import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
 import './style.scss';
 
 class RebrandCitiesWelcomeStep extends Component {

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import RewindCredentialsForm from 'calypso/components/rewind-credentials-form';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class RewindFormCreds extends Component {

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import ActivityLogRewindToggle from 'calypso/my-sites/activity/activity-log/activity-log-rewind-toggle';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class RewindMigrate extends Component {

--- a/client/signup/steps/rewind-were-backing/index.jsx
+++ b/client/signup/steps/rewind-were-backing/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
 import { Card, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class RewindWereBacking extends Component {

--- a/client/signup/steps/site-or-domain/choice.jsx
+++ b/client/signup/steps/site-or-domain/choice.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import React, { Component } from 'react';
 
 export default class SiteOrDomainChoice extends Component {
 	handleClickChoice = ( event ) => {

--- a/client/signup/steps/site-or-domain/domain-image.jsx
+++ b/client/signup/steps/site-or-domain/domain-image.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const DomainImage = () => (

--- a/client/signup/steps/site-or-domain/existing-site-image.jsx
+++ b/client/signup/steps/site-or-domain/existing-site-image.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const ExistingSite = () => (

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -1,29 +1,18 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
+import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug } from 'calypso/lib/domains';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SiteOrDomainChoice from './choice';
 import DomainImage from './domain-image';
-import NewSiteImage from './new-site-image';
 import ExistingSiteImage from './existing-site-image';
-
-/**
- * Style dependencies
- */
+import NewSiteImage from './new-site-image';
 import './style.scss';
 
 class SiteOrDomain extends Component {

--- a/client/signup/steps/site-or-domain/new-site-image.jsx
+++ b/client/signup/steps/site-or-domain/new-site-image.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const NewSiteImage = () => (

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -1,20 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
-import SitePickerSubmit from './site-picker-submit';
+import React, { Component } from 'react';
 import SiteSelector from 'calypso/components/site-selector';
 import StepWrapper from 'calypso/signup/step-wrapper';
-
-/**
- * Style dependencies
- */
+import SitePickerSubmit from './site-picker-submit';
 import './style.scss';
 
 class SitePicker extends Component {

--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { isFreePlan } from '@automattic/calypso-products';
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isFreePlan } from '@automattic/calypso-products';
-import { getSite } from 'calypso/state/sites/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSite } from 'calypso/state/sites/selectors';
 
 export const siteHasPaidPlan = ( selectedSite ) =>
 	selectedSite && selectedSite.plan && ! isFreePlan( selectedSite.plan.product_slug );

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -2,16 +2,6 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 
-/**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { siteHasPaidPlan, SitePickerSubmit } from '../site-picker-submit';
 import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE,
@@ -33,6 +23,9 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { siteHasPaidPlan, SitePickerSubmit } from '../site-picker-submit';
 
 const noop = () => {};
 const props = {

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -1,33 +1,21 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import { getSiteStyleOptions } from 'calypso/lib/signup/site-styles';
+import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { setSiteStyle } from 'calypso/state/signup/steps/site-style/actions';
 import { getSiteStyle } from 'calypso/state/signup/steps/site-style/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { getSiteStyleOptions } from 'calypso/lib/signup/site-styles';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class SiteStyleStep extends Component {

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { SiteStyleStep } from '../';
 
 const noop = () => {};

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -1,28 +1,17 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { Button } from '@automattic/components';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { setSiteTitle } from 'calypso/state/signup/steps/site-title/actions';
 import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class SiteTitleStep extends Component {

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -1,18 +1,14 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SiteVerticalsSuggestionSearch from 'calypso/components/site-verticals-suggestion-search';
+import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { setSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
 import {
 	getSiteVerticalName,
@@ -22,14 +18,7 @@ import {
 	getSiteVerticalParentId,
 	getSiteVerticalSuggestedTheme,
 } from 'calypso/state/signup/steps/site-vertical/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getVerticals } from 'calypso/state/signup/verticals/selectors';
-import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class SiteTopicForm extends Component {

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import SiteTopicForm from './form';
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-import { getSiteVerticalIsUserInput } from 'calypso/state/signup/steps/site-vertical/selectors';
-import { submitSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
+import { submitSiteVertical } from 'calypso/state/signup/steps/site-vertical/actions';
+import { getSiteVerticalIsUserInput } from 'calypso/state/signup/steps/site-vertical/selectors';
+import SiteTopicForm from './form';
 
 class SiteTopicStep extends Component {
 	static propTypes = {

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Badge from 'calypso/components/badge';
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import Badge from 'calypso/components/badge';
 import { getAllSiteTypes } from 'calypso/lib/signup/site-type';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class SiteTypeForm extends Component {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
-import SiteTypeForm from './form';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { submitSiteType } from 'calypso/state/signup/steps/site-type/actions';
-import { saveSignupStep } from 'calypso/state/signup/progress/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
+import { saveSignupStep } from 'calypso/state/signup/progress/actions';
+import { submitSiteType } from 'calypso/state/signup/steps/site-type/actions';
+import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
+import SiteTypeForm from './form';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -1,31 +1,20 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
+import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map } from 'lodash';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
+import React from 'react';
+import { connect } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import LoggedOutForm from 'calypso/components/logged-out-form';
+import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import { login } from 'calypso/lib/paths';
-import ValidationFieldset from 'calypso/signup/validation-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormButton from 'calypso/components/forms/form-button';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import wpcom from 'calypso/lib/wp';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import LoggedOutForm from 'calypso/components/logged-out-form';
-import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
+import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const debug = debugFactory( 'calypso:steps:site' );

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -1,31 +1,20 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { find, get } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import page from 'page';
-import { find, get } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import verticals from './verticals';
-import { Button } from '@automattic/components';
-import { getStepUrl } from 'calypso/signup/utils';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
-import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
+import Gridicon from 'calypso/components/gridicon';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { getStepUrl } from 'calypso/signup/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-/**
- * Style dependencies
- */
+import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
+import verticals from './verticals';
 import './style.scss';
 
 class SurveyStep extends React.Component {

--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import { shuffle } from 'lodash';
 import { translate } from 'i18n-calypso';
+import { shuffle } from 'lodash';
 
 const verticals = [
 	{ value: 'a8c.14.7', label: () => translate( 'Wedding' ) },

--- a/client/signup/steps/test-step/index.jsx
+++ b/client/signup/steps/test-step/index.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import StepWrapper from 'calypso/signup/step-wrapper';
 import SubmitStepButton from 'calypso/signup/submit-step-button';
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,29 +1,18 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import SignupThemesList from './signup-themes-list';
-import StepWrapper from 'calypso/signup/step-wrapper';
-import { Button } from '@automattic/components';
 import { themes } from 'calypso/lib/signup/themes-data';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getSurveyVertical } from 'calypso/state/signup/steps/survey/selectors';
-import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-
-/**
- * Style dependencies
- */
+import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
+import { getSurveyVertical } from 'calypso/state/signup/steps/survey/selectors';
+import SignupThemesList from './signup-themes-list';
 import './style.scss';
 
 class ThemeSelectionStep extends Component {

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import getThemes from 'calypso/lib/signup/themes';
 import ThemesList from 'calypso/components/themes-list';
-
-/**
- * Style dependencies
- */
+import getThemes from 'calypso/lib/signup/themes';
 import './style.scss';
 
 const noop = () => {};

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,50 +1,39 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
+import i18n, { localize } from 'i18n-calypso';
+import { isEmpty, omit, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
-import { isEmpty, omit, get } from 'lodash';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import SignupForm from 'calypso/blocks/signup-form';
+import AsyncLoad from 'calypso/components/async-load';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/components/woocommerce-connect-cart-header';
+import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
+import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
 	isWooOAuth2Client,
 	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import StepWrapper from 'calypso/signup/step-wrapper';
+import { login } from 'calypso/lib/paths';
+import { WPCC } from 'calypso/lib/url/support';
 import flows from 'calypso/signup/config/flows';
-import SignupForm from 'calypso/blocks/signup-form';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getFlowSteps,
 	getNextStepName,
 	getPreviousStepName,
 	getStepUrl,
 } from 'calypso/signup/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { WPCC } from 'calypso/lib/url/support';
-import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
-import config from '@automattic/calypso-config';
-import AsyncLoad from 'calypso/components/async-load';
-import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/components/woocommerce-connect-cart-header';
-import { getSocialServiceFromClientId } from 'calypso/lib/login';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import { login } from 'calypso/lib/paths';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class UserStep extends Component {

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -2,18 +2,11 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
 import { UserStep as User } from '../';
 
 const noop = () => {};

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import cookie from 'cookie';
-
-/**
- * Internal dependencies
- */
 
 export const persistSignupDestination = ( url ) => {
 	const DAY_IN_SECONDS = 3600 * 24;

--- a/client/signup/submit-step-button/index.jsx
+++ b/client/signup/submit-step-button/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 
 export class SubmitStepButton extends Component {

--- a/client/signup/submit-step-button/test/index.jsx
+++ b/client/signup/submit-step-button/test/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import { SubmitStepButton } from '..';
 
 describe( 'SubmitStepButton', () => {

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -2,17 +2,10 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
-import mockedFlows from './fixtures/flows';
 import flows from 'calypso/signup/config/flows';
+import mockedFlows from './fixtures/flows';
 
 describe( 'Signup Flows Configuration', () => {
 	describe( 'getFlow', () => {

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -1,13 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
 
-/**
- * Internal dependencies
- */
+import flows from 'calypso/signup/config/flows';
 import {
 	canResumeFlow,
 	getCompletedSteps,
@@ -17,7 +12,6 @@ import {
 	getFlowName,
 	getFilteredSteps,
 } from '../utils';
-import flows from 'calypso/signup/config/flows';
 
 jest.mock( 'calypso/signup/config/flows-pure', () => ( {
 	generateFlows: () => require( './fixtures/flows' ).default,

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import steps from 'calypso/signup/config/steps-pure';
+import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import flows from 'calypso/signup/config/flows';
+import steps from 'calypso/signup/config/steps-pure';
 
 const { defaultFlowName } = flows;
 

--- a/client/signup/validation-fieldset/index.jsx
+++ b/client/signup/validation-fieldset/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import classNames from 'classnames';
-import { values } from 'lodash';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:validate-fieldset' );
-
-/**
- * Internal dependencies
- */
+import { values } from 'lodash';
+import React, { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
-
-/**
- * Style dependencies
- */
 import './style.scss';
+const debug = debugFactory( 'calypso:validate-fieldset' );
 
 export default class ValidationFieldset extends Component {
 	renderValidationNotice() {

--- a/client/signup/validation-fieldset/test/index.jsx
+++ b/client/signup/validation-fieldset/test/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ValidationFieldset from '..';
 
 describe( 'ValidationFieldset', () => {

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:signup:wpcom-login' );
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
+import React, { Component } from 'react';
+
+const debug = debugFactory( 'calypso:signup:wpcom-login' );
 
 export default class WpcomLoginForm extends Component {
 	form = null;

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import WpcomLoginForm from '..';
-import config from '@automattic/calypso-config';
 jest.mock( '@automattic/calypso-config', () => jest.fn().mockReturnValueOnce( 'wordpress.com' ) );
 
 describe( 'WpcomLoginForm', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/signup` to use `import/order`

#### Testing instructions

N/A

