### PR TITLE
Change description of Substack URL to Recommended

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -183,7 +183,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				'Recommended: A Substack Newsletter URL to import comments and author information.'
 			),
 			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
-				args: { exampleUrl: 'https://newsletter.substack.com/' },
+				args: { exampleUrl: 'https://example-newsletter.substack.com/' },
 			} ),
 			validate: ( urlInput ) => {
 				return /^https:\/\/[\w-]+\.substack\.com\/?$/.test( urlInput.trim() );

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -180,7 +180,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 		optionalUrl: {
 			title: translate( 'Substack Newsletter URL' ),
 			description: translate(
-				'An optional Substack Newsletter URL to import comments and author information.'
+				'Recommended: A Substack Newsletter URL to import comments and author information.'
 			),
 			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
 				args: { exampleUrl: 'https://newsletter.substack.com/' },


### PR DESCRIPTION
These changes will help:
1. make sure that the URL is considered in addition to the file, and not as a substitute for it.
2. the user understand that URLs are recommended as that's the only way to import authors and comments.

From pcmemI-72-p2#comment-337, as this was causing confusion amongst initial testers.


#### Testing instructions

This is just a text change, see Tools > Import > Substack

<img width="704" alt="CleanShot 2021-08-03 at 14 33 50@2x" src="https://user-images.githubusercontent.com/533/127988952-433ae540-f12e-4d9d-80cf-938360b94f55.png">
