### PR TITLE
My Home: Fix the behavior of toggling QuickLinks many times quickly is weird

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -51,10 +51,11 @@ export const QuickLinks = ( {
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
-	const [ debouncedUpdateHomeQuickLinksToggleStatus ] = useDebouncedCallback(
-		updateHomeQuickLinksToggleStatus,
-		1000
-	);
+	const [
+		debouncedUpdateHomeQuickLinksToggleStatus,
+		,
+		flushDebouncedUpdateHomeQuickLinksToggleStatus,
+	] = useDebouncedCallback( updateHomeQuickLinksToggleStatus, 1000 );
 
 	const quickLinks = (
 		<div className="quick-links__boxes">
@@ -186,9 +187,9 @@ export const QuickLinks = ( {
 
 	useEffect( () => {
 		return () => {
-			debouncedUpdateHomeQuickLinksToggleStatus.flush();
+			flushDebouncedUpdateHomeQuickLinksToggleStatus();
 		};
-	}, [ debouncedUpdateHomeQuickLinksToggleStatus ] );
+	}, [] );
 
 	return (
 		<FoldableCard

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,4 +1,5 @@
 import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { debounce } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
@@ -43,14 +44,17 @@ export const QuickLinks = ( {
 	trackAddEmailAction,
 	trackAddDomainAction,
 	isExpanded,
-	expand,
-	collapse,
+	updateHomeQuickLinksToggleStatus,
 	isUnifiedNavEnabled,
 	siteAdminUrl,
 	editHomePageUrl,
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
+	const debouncedUpdateHomeQuickLinksToggleStatus = debounce(
+		updateHomeQuickLinksToggleStatus,
+		1000
+	);
 
 	const quickLinks = (
 		<div className="quick-links__boxes">
@@ -186,8 +190,8 @@ export const QuickLinks = ( {
 			header={ translate( 'Quick links' ) }
 			clickableHeader
 			expanded={ isExpanded }
-			onOpen={ expand }
-			onClose={ collapse }
+			onOpen={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'expanded' ) }
+			onClose={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'collapsed' ) }
 		>
 			{ quickLinks }
 		</FoldableCard>
@@ -353,8 +357,8 @@ const mapDispatchToProps = {
 	trackAnchorPodcastAction,
 	trackAddEmailAction,
 	trackAddDomainAction,
-	expand: () => savePreference( 'homeQuickLinksToggleStatus', 'expanded' ),
-	collapse: () => savePreference( 'homeQuickLinksToggleStatus', 'collapsed' ),
+	updateHomeQuickLinksToggleStatus: ( status ) =>
+		savePreference( 'homeQuickLinksToggleStatus', status ),
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,7 +1,7 @@
 import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
-import { debounce } from 'lodash';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { useDebouncedCallback } from 'use-debounce';
 import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
 import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import FoldableCard from 'calypso/components/foldable-card';
@@ -51,7 +51,7 @@ export const QuickLinks = ( {
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
-	const debouncedUpdateHomeQuickLinksToggleStatus = debounce(
+	const [ debouncedUpdateHomeQuickLinksToggleStatus ] = useDebouncedCallback(
 		updateHomeQuickLinksToggleStatus,
 		1000
 	);
@@ -183,6 +183,12 @@ export const QuickLinks = ( {
 			/>
 		</div>
 	);
+
+	useEffect( () => {
+		return () => {
+			debouncedUpdateHomeQuickLinksToggleStatus.flush();
+		};
+	}, [ debouncedUpdateHomeQuickLinksToggleStatus ] );
 
 	return (
 		<FoldableCard

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { debounce } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'calypso/components/foldable-card';
@@ -30,12 +31,15 @@ export const QuickLinks = ( {
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
 	isExpanded,
-	expand,
-	collapse,
+	updateHomeQuickLinksToggleStatus,
 	editHomePageUrl,
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
+	const debouncedUpdateHomeQuickLinksToggleStatus = debounce(
+		updateHomeQuickLinksToggleStatus,
+		1000
+	);
 
 	const quickLinks = (
 		<div className="wp-for-teams-quick-links__boxes quick-links__boxes">
@@ -116,8 +120,8 @@ export const QuickLinks = ( {
 			header={ translate( 'Quick Links' ) }
 			clickableHeader
 			expanded={ isExpanded }
-			onOpen={ expand }
-			onClose={ collapse }
+			onOpen={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'expanded' ) }
+			onClose={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'collapsed' ) }
 		>
 			{ quickLinks }
 		</FoldableCard>
@@ -212,8 +216,8 @@ const mapDispatchToProps = {
 	trackManageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	expand: () => savePreference( 'homeQuickLinksToggleStatus', 'expanded' ),
-	collapse: () => savePreference( 'homeQuickLinksToggleStatus', 'collapsed' ),
+	updateHomeQuickLinksToggleStatus: ( status ) =>
+		savePreference( 'homeQuickLinksToggleStatus', status ),
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import { debounce } from 'lodash';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { useDebouncedCallback } from 'use-debounce';
 import FoldableCard from 'calypso/components/foldable-card';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -36,7 +36,7 @@ export const QuickLinks = ( {
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
-	const debouncedUpdateHomeQuickLinksToggleStatus = debounce(
+	const [ debouncedUpdateHomeQuickLinksToggleStatus ] = useDebouncedCallback(
 		updateHomeQuickLinksToggleStatus,
 		1000
 	);
@@ -114,6 +114,13 @@ export const QuickLinks = ( {
 			) }
 		</div>
 	);
+
+	useEffect( () => {
+		return () => {
+			debouncedUpdateHomeQuickLinksToggleStatus.flush();
+		};
+	}, [ debouncedUpdateHomeQuickLinksToggleStatus ] );
+
 	return (
 		<FoldableCard
 			className="wp-for-teams-quick-links quick-links"

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -36,10 +36,11 @@ export const QuickLinks = ( {
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
-	const [ debouncedUpdateHomeQuickLinksToggleStatus ] = useDebouncedCallback(
-		updateHomeQuickLinksToggleStatus,
-		1000
-	);
+	const [
+		debouncedUpdateHomeQuickLinksToggleStatus,
+		,
+		flushDebouncedUpdateHomeQuickLinksToggleStatus,
+	] = useDebouncedCallback( updateHomeQuickLinksToggleStatus, 1000 );
 
 	const quickLinks = (
 		<div className="wp-for-teams-quick-links__boxes quick-links__boxes">
@@ -117,9 +118,9 @@ export const QuickLinks = ( {
 
 	useEffect( () => {
 		return () => {
-			debouncedUpdateHomeQuickLinksToggleStatus.flush();
+			flushDebouncedUpdateHomeQuickLinksToggleStatus();
 		};
-	}, [ debouncedUpdateHomeQuickLinksToggleStatus ] );
+	}, [] );
 
 	return (
 		<FoldableCard

--- a/client/package.json
+++ b/client/package.json
@@ -216,6 +216,7 @@
 		"twemoji": "^12.1.4",
 		"ua-parser-js": "^0.7.22",
 		"url": "^0.11.0",
+		"use-debounce": "^3.1.0",
 		"use-subscription": "^1.3.0",
 		"util": "^0.12.3",
 		"utility-types": "^3.10.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, when we toggle the quick links, it would send the request to save preference. However, if we toggle quickly and the latest preference responses faster than the previous one, the toggle status will go back to the previous one and it is weird. 
* Use `debounce` to avoid save preference all the time. In the future, we should also need to cancel previous API request if possible. I try to use callback function for `wpcom.req` to get the xhr instance and call the `abort` but seems not to work 😞

Before

https://user-images.githubusercontent.com/13596067/127999528-1170fd84-3a06-47e9-8e5f-cecbff22634d.mov

After

https://user-images.githubusercontent.com/13596067/127999555-f400d17f-5425-4efa-a1a9-33a198fcafc3.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Home
* Toggle Quick links

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

N/A
