### PR TITLE
Cart: Round Price to Appropriate Decimal Point

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { get } from 'lodash';
-import { getCurrencyDefaults, getCurrencyObject } from '@automattic/format-currency';
+import { getCurrencyObject } from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
 import { withShoppingCart } from '@automattic/shopping-cart';
 
@@ -61,10 +61,7 @@ export class CartItem extends React.Component {
 			return this.getDomainPlanPrice( cartItem );
 		}
 
-		const unformattedCost = cartItem.cost * cartItem.volume;
-		const cost = unformattedCost.toFixed( getCurrencyDefaults( cartItem.currency ).precision );
-
-		if ( 0 === cost ) {
+		if ( 0 === cartItem.cost ) {
 			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;
 		}
 
@@ -72,6 +69,7 @@ export class CartItem extends React.Component {
 			const {
 				cost_before_coupon: costPerProductBeforeCoupon,
 				is_sale_coupon_applied: isSaleCouponApplied,
+				item_subtotal_display: cost,
 			} = cartItem;
 			const costBeforeCoupon = costPerProductBeforeCoupon * cartItem.volume;
 
@@ -82,9 +80,7 @@ export class CartItem extends React.Component {
 					<div className="cart__gsuite-discount">
 						<span className="cart__gsuite-discount-regular-price">{ costBeforeCoupon }</span>
 
-						<span className="cart__gsuite-discount-discounted-price">
-							{ cost } { cartItem.currency }
-						</span>
+						<span className="cart__gsuite-discount-discounted-price">{ cost }</span>
 
 						<span className="cart__gsuite-discount-text">
 							{ isCouponApplied
@@ -96,12 +92,7 @@ export class CartItem extends React.Component {
 			}
 		}
 
-		return translate( '%(cost)s %(currency)s', {
-			args: {
-				cost: cost,
-				currency: cartItem.currency,
-			},
-		} );
+		return cartItem.item_subtotal_display;
 	}
 
 	monthlyPrice() {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -61,7 +61,7 @@ export class CartItem extends React.Component {
 			return this.getDomainPlanPrice( cartItem );
 		}
 
-		if ( 0 === cartItem.cost ) {
+		if ( 0 === cartItem.cost * cartItem.volume ) {
 			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;
 		}
 

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { get } from 'lodash';
-import { getCurrencyObject } from '@automattic/format-currency';
+import { getCurrencyDefaults, getCurrencyObject } from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
 import { withShoppingCart } from '@automattic/shopping-cart';
 
@@ -61,7 +61,8 @@ export class CartItem extends React.Component {
 			return this.getDomainPlanPrice( cartItem );
 		}
 
-		const cost = cartItem.cost * cartItem.volume;
+		const unformattedCost = cartItem.cost * cartItem.volume;
+		const cost = unformattedCost.toFixed( getCurrencyDefaults( cartItem.currency ).precision );
 
 		if ( 0 === cost ) {
 			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rounds the price to an appropriate decimal point in the Cart popover

#### Testing instructions

Add the discounted `.blog` domain to your cart, and verify that the price displays appropriately. If you change your currency to one which rounds to a different number of decimal points (Bahraini Dinar rounds to three), that should be reflected here too.

**Before:**
<img width="388" alt="Screenshot 2021-08-03 at 11 40 11" src="https://user-images.githubusercontent.com/43215253/128002442-fb0d8b8d-3f29-4f1c-af37-dc0c390a8a92.png">

**After:**
<img width="375" alt="Screenshot 2021-08-03 at 11 39 52" src="https://user-images.githubusercontent.com/43215253/128002395-048c44d5-1345-4d7c-8a30-3801b71862bf.png">

cc @sirbrillig

Fixes #55119