### PR TITLE
Themes: Fix Button Icon Alignment

### DIFF
--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -130,6 +130,7 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	}
 
 	.current-theme__button {
+		display: flex;
 		margin-right: 10px;
 		margin-bottom: 16px;
 		font-weight: normal;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -256,6 +256,7 @@
 }
 
 .button.themes-magic-search-card__advanced-toggle {
+	display: flex;
 	font-size: 0.75rem;
 	white-space: nowrap;
 	border: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the two reported cases of misalignment with the button and the icon in the Themes section - should be fairly straight-forward to review.

#### Testing instructions

Should just be a quick visual change on the Themes section.

**Before:**

<img width="1512" alt="Screenshot 2021-08-03 at 12 01 06" src="https://user-images.githubusercontent.com/43215253/128004965-2c668ca3-413f-4620-928b-12877f63f4a9.png">

**After:**

<img width="1515" alt="Screenshot 2021-08-03 at 12 00 25" src="https://user-images.githubusercontent.com/43215253/128004969-0071e996-276d-441c-b873-b1a73f711962.png">

cc @sixhours 

Fixes #55118
Fixes #55140 