### PR TITLE
Break line for longer domain names in email signups

### DIFF
--- a/client/signup/steps/emails/index.jsx
+++ b/client/signup/steps/emails/index.jsx
@@ -126,7 +126,7 @@ class EmailsStep extends React.Component {
 			'Add a custom email address to start sending and receiving emails from {{strong}}%(domainName)s{{/strong}} today.',
 			{
 				args: { domainName },
-				components: { strong: <strong /> },
+				components: { strong: <strong className="emails__register-email-step--domain-name" /> },
 				comment: '%(domainName)s is a domain name chosen by the user',
 			}
 		);

--- a/client/signup/steps/emails/style.scss
+++ b/client/signup/steps/emails/style.scss
@@ -48,7 +48,7 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
-		.register-email-step .register-email-step .emails__email-side-content-container {
+		.register-email-step .emails__email-side-content-container {
 			display: flex;
 
 			@include break-small {

--- a/client/signup/steps/emails/style.scss
+++ b/client/signup/steps/emails/style.scss
@@ -14,6 +14,12 @@
 	}
 }
 
+.signup__step.is-emails {
+	.emails__register-email-step--domain-name {
+		word-break: break-all;
+	}
+}
+
 /**
  * Styles for design reskin
  * The `is-white-signup` class is attached to the body when the user is assigned the `reskinned` group of the `reskinSignupFlow` a/b test
@@ -42,7 +48,7 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
-		.register-email-step .emails__email-side-content-container {
+		.register-email-step .register-email-step .emails__email-side-content-container {
 			display: flex;
 
 			@include break-small {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/55017

#### Testing instructions

1. Visit https://container-tender-varahamihira.calypso.live/start/domains?flags=signup/professional-email-step
2. Allow 3rd party cookies (click the eye on the end of the URL bar)
3. Make sure https://github.com/Automattic/wp-calypso/issues/55017 isn't reproducible.
