### PR TITLE
Remove padding from inline-help button

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -50,6 +50,7 @@
 		top: 0;
 		height: 42px;
 		width: 42px;
+		padding: 0;
 
 		> use:first-child,
 		> g:first-child {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes https://github.com/Automattic/wp-calypso/issues/55016

#### Testing instructions

1. Visit the preview link + /start/domains?flags=signup/professional-email-step
2. Allow 3rd party cookies (click the eye on the right end of the URL bar)
3. Verify that https://github.com/Automattic/wp-calypso/issues/55016 is not reproducible. 
