### PR TITLE
chore: migrate `client/reader` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,6 +198,7 @@ module.exports = {
 				'client/my-sites/customer-home/**/*',
 				'client/notifications/**/*',
 				'client/post-editor/**/*',
+				'client/reader/**/*',
 				'client/root.js',
 				'client/sections-filter.js',
 				'client/sections-helper.js',

--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import { connect, useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import Stream from 'calypso/reader/stream';
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect, useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
-import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import Stream from 'calypso/reader/stream';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { SECTION_A8C_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { SECTION_A8C_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 
 const A8CFollowing = ( props ) => {
 	const { translate, teams } = props;

--- a/client/reader/components/favicon/index.js
+++ b/client/reader/components/favicon/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React, { useState } from 'react';
 import Gridicon from 'calypso/components/gridicon';
 

--- a/client/reader/components/reader-blank-suggestions/index.js
+++ b/client/reader/components/reader-blank-suggestions/index.js
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function BlankSuggestions( props ) {

--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import {
 	CellMeasurer,
 	CellMeasurerCache,
@@ -10,17 +5,10 @@ import {
 	List,
 	WindowScroller,
 } from '@automattic/react-virtualized';
-
 import { debounce, get, pickBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { recordTracksRailcarRender } from 'calypso/reader/stats';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/reader/components/reader-infinite-stream/row-renderers.js
+++ b/client/reader/components/reader-infinite-stream/row-renderers.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import ConnectedSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 
 export const siteRowRenderer = ( {

--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
-
-/**
- * Style dependencies
- */
+import Main from 'calypso/components/main';
 import './style.scss';
 
 /*

--- a/client/reader/components/reader-popover/index.jsx
+++ b/client/reader/components/reader-popover/index.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classnames from 'classnames';
 import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import Popover from 'calypso/components/popover';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const ReaderPopover = ( props ) => {

--- a/client/reader/components/reader-popover/menu.jsx
+++ b/client/reader/components/reader-popover/menu.jsx
@@ -1,14 +1,7 @@
-/**
- * External Dependencies
- */
-import React from 'react';
 import { omit } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import ReaderPopover from 'calypso/reader/components/reader-popover';
+import React from 'react';
 import PopoverMenu from 'calypso/components/popover/menu';
+import ReaderPopover from 'calypso/reader/components/reader-popover';
 
 const ReaderPopoverMenu = ( props ) => {
 	const popoverProps = omit( props, 'popoverComponent' );

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -1,15 +1,8 @@
-/**
- * External Dependencies
- */
 import i18n from 'i18n-calypso';
 import moment from 'moment';
-
-/**
- * Internal Dependencies
- */
-import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { recordTrack } from 'calypso/reader/stats';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -1,14 +1,20 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import page from 'page';
+import React from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 import { sectionify } from 'calypso/lib/route';
+import FeedError from 'calypso/reader/feed-error';
+import StreamComponent from 'calypso/reader/following/main';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getPrettyFeedUrl, getPrettySiteUrl } from 'calypso/reader/route';
+import { recordTrack } from 'calypso/reader/stats';
+import { requestFeedDiscovery } from 'calypso/state/data-getters';
+import { waitForHttpData } from 'calypso/state/data-layer/http-data';
+import { getLastPath } from 'calypso/state/reader-ui/selectors';
+import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
+import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import { getSection } from 'calypso/state/ui/selectors';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
@@ -16,19 +22,6 @@ import {
 	setPageTitle,
 	getStartDate,
 } from './controller-helper';
-import FeedError from 'calypso/reader/feed-error';
-import StreamComponent from 'calypso/reader/following/main';
-import { getPrettyFeedUrl, getPrettySiteUrl } from 'calypso/reader/route';
-import { recordTrack } from 'calypso/reader/stats';
-import { requestFeedDiscovery } from 'calypso/state/data-getters';
-import { waitForHttpData } from 'calypso/state/data-layer/http-data';
-import AsyncLoad from 'calypso/components/async-load';
-import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
-import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
-import { getLastPath } from 'calypso/state/reader-ui/selectors';
-import { getSection } from 'calypso/state/ui/selectors';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
 
 const analyticsPageTitle = 'Reader';
 let lastRoute = null;

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { sectionify } from 'calypso/lib/route';
-import { recordTrack } from 'calypso/reader/stats';
 import AsyncLoad from 'calypso/components/async-load';
+import { sectionify } from 'calypso/lib/route';
 import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
+import { recordTrack } from 'calypso/reader/stats';
 
 export function conversations( context, next ) {
 	const basePath = sectionify( context.path );

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { conversations, conversationsA8c } from './controller';
-import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { conversations, conversationsA8c } from './controller';
 
 export default function () {
 	page( '/read/conversations', updateLastRoute, sidebar, conversations, makeLayout, clientRender );

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -1,28 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import Gridicon from 'calypso/components/gridicon';
+import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 import QueryPreferences from 'calypso/components/data/query-preferences';
+import Gridicon from 'calypso/components/gridicon';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Asset dependencies
- */
-import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
-
-/**
- * Style dependencies
- */
 import './intro.scss';
 
 const getPreferenceName = ( isInternal ) =>

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -1,20 +1,9 @@
-/**
- * External Dependencies
- */
-import React from 'react';
 import { get } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import Stream from 'calypso/reader/stream';
-import DocumentHead from 'calypso/components/data/document-head';
-import ConversationsIntro from './intro';
+import React from 'react';
 import ConversationsEmptyContent from 'calypso/blocks/conversations/empty';
-
-/**
- * Style dependencies
- */
+import DocumentHead from 'calypso/components/data/document-head';
+import Stream from 'calypso/reader/stream';
+import ConversationsIntro from './intro';
 import './stream.scss';
 
 export default function ( props ) {

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import React from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 import { sectionify } from 'calypso/lib/route';
-import { recordTrack } from 'calypso/reader/stats';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'calypso/reader/controller-helper';
-import AsyncLoad from 'calypso/components/async-load';
+import { recordTrack } from 'calypso/reader/stats';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FollowButton from 'calypso/reader/follow-button';
-import { recordFollowToggle } from './stats';
 import { DISCOVER_POST } from 'calypso/reader/follow-sources';
+import { recordFollowToggle } from './stats';
 
 class DiscoverFollowButton extends React.Component {
 	static propTypes = {

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { find, get } from 'lodash';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
 import { getUrlParts } from '@automattic/calypso-url';
+import { find, get } from 'lodash';
+import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
 
 function hasDiscoverSlug( post, searchSlug ) {
 	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { discover } from './controller';
-import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { discover } from './controller';
 
 export default function () {
 	page( '/discover', updateLastRoute, sidebar, discover, makeLayout, clientRender );

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get } from 'lodash';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import SiteIcon from 'calypso/blocks/site-icon';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import { getSiteUrl, getSourceFollowUrl, getSourceData } from 'calypso/reader/discover/helper';
 import FollowButton from 'calypso/reader/follow-button';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 import { getLinkProps } from './helper';
 import { recordFollowToggle, recordSiteClick } from './stats';
-import { getSiteUrl, getSourceFollowUrl, getSourceData } from 'calypso/reader/discover/helper';
-import SiteIcon from 'calypso/blocks/site-icon';
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
-
-/**
- * Style dependencies
- */
 import './site-attribution.scss';
 
 class DiscoverSiteAttribution extends React.Component {

--- a/client/reader/discover/stats.js
+++ b/client/reader/discover/stats.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { recordAction, recordGaEvent, recordTrack } from 'calypso/reader/stats';
 
 export function recordAuthorClick( author ) {

--- a/client/reader/discover/test/fixtures/index.js
+++ b/client/reader/discover/test/fixtures/index.js
@@ -1,7 +1,5 @@
 /* eslint-disable quote-props*/
-/**
- * External dependencies
- */
+
 import { cloneDeep } from 'lodash';
 
 export const discoverSiteId = 53424024;

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { assert } from 'chai';
 import { get, omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import * as helper from '../helper';
 import * as fixtures from './fixtures';
 jest.mock( '@automattic/calypso-config', () => {

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import percentageFactory from 'percentage-regex';
 
 const percentageRegex = percentageFactory( { exact: true } );

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ReaderMain from 'calypso/reader/components/reader-main';
-import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
 import EmptyContent from 'calypso/components/empty-content';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
+import ReaderMain from 'calypso/reader/components/reader-main';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import EmptyContent from './empty';
-import DocumentHead from 'calypso/components/data/document-head';
-import Stream from 'calypso/reader/stream';
-import FeedError from 'calypso/reader/feed-error';
 import ReaderFeedHeader from 'calypso/blocks/reader-feed-header';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import DocumentHead from 'calypso/components/data/document-head';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import FeedError from 'calypso/reader/feed-error';
 import { getSiteName } from 'calypso/reader/get-helpers';
-import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
 import SiteBlocked from 'calypso/reader/site-blocked';
+import Stream from 'calypso/reader/stream';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import EmptyContent from './empty';
 
 // If the blog_ID of a reader feed is 0, that means no site exists for it.
 const getReaderSiteId = ( feed ) => ( feed && feed.blog_ID === 0 ? null : feed && feed.blog_ID );

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import FollowButtonContainer from 'calypso/blocks/follow-button';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import {

--- a/client/reader/follow-helpers.tsx
+++ b/client/reader/follow-helpers.tsx
@@ -1,11 +1,4 @@
-/**
- * External Dependencies
- */
 import { escapeRegExp } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import {
 	getSiteName,
 	getSiteUrl,

--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { take, times } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { take, times } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
-import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'calypso/reader/follow-sources';
+import Gridicon from 'calypso/components/gridicon';
 import InfiniteStream from 'calypso/reader/components/reader-infinite-stream';
 import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'calypso/reader/follow-sources';
 import { requestFeedSearch } from 'calypso/state/reader/feed-searches/actions';
 
 class FollowingManageSearchFeedsResults extends React.Component {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,24 +1,27 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
-import { trim, debounce, random, take, reject, includes } from 'lodash';
+import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import { trim, debounce, random, take, reject, includes } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import RecommendedSites from 'calypso/blocks/reader-recommended-sites';
 import DocumentHead from 'calypso/components/data/document-head';
-import SearchInput from 'calypso/components/search';
+import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
+import QueryReaderRecommendedSites from 'calypso/components/data/query-reader-recommended-sites';
 import HeaderCake from 'calypso/components/header-cake';
+import SearchInput from 'calypso/components/search';
+import { resemblesUrl, withoutHttp, addSchemeIfMissing, addQueryArgs } from 'calypso/lib/url';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
-import { getDismissedSites } from 'calypso/state/reader/site-dismissals/selectors';
+import FollowButton from 'calypso/reader/follow-button';
+import {
+	READER_FOLLOWING_MANAGE_URL_INPUT,
+	READER_FOLLOWING_MANAGE_RECOMMENDATION,
+} from 'calypso/reader/follow-sources';
+import { recordAction } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SORT_BY_RELEVANCE } from 'calypso/state/reader/feed-searches/actions';
 import {
 	getReaderFeedsCountForQuery,
 	getReaderFeedsForQuery,
@@ -31,25 +34,11 @@ import {
 	getReaderRecommendedSites,
 	getReaderRecommendedSitesPagingOffset,
 } from 'calypso/state/reader/recommended-sites/selectors';
-import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
-import QueryReaderRecommendedSites from 'calypso/components/data/query-reader-recommended-sites';
-import RecommendedSites from 'calypso/blocks/reader-recommended-sites';
-import FollowingManageSubscriptions from './subscriptions';
-import FollowingManageSearchFeedsResults from './feed-search-results';
+import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
+import { getDismissedSites } from 'calypso/state/reader/site-dismissals/selectors';
 import FollowingManageEmptyContent from './empty';
-import FollowButton from 'calypso/reader/follow-button';
-import {
-	READER_FOLLOWING_MANAGE_URL_INPUT,
-	READER_FOLLOWING_MANAGE_RECOMMENDATION,
-} from 'calypso/reader/follow-sources';
-import { resemblesUrl, withoutHttp, addSchemeIfMissing, addQueryArgs } from 'calypso/lib/url';
-import { recordAction } from 'calypso/reader/stats';
-import { SORT_BY_RELEVANCE } from 'calypso/state/reader/feed-searches/actions';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import FollowingManageSearchFeedsResults from './feed-search-results';
+import FollowingManageSubscriptions from './subscriptions';
 import './style.scss';
 
 const PAGE_SIZE = 4;

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -1,13 +1,6 @@
-/**
- * External Dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
 import SearchCard from 'calypso/components/search-card';
 
 const noop = () => {};

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FormSelect from 'calypso/components/forms/form-select';
 
 const noop = () => {};

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -1,33 +1,26 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { sortBy, isEmpty } from 'lodash';
 import page from 'page';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import ReaderImportButton from 'calypso/blocks/reader-import-button';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import ReaderExportButton from 'calypso/blocks/reader-export-button';
-import InfiniteStream from 'calypso/reader/components/reader-infinite-stream';
-import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
+import ReaderImportButton from 'calypso/blocks/reader-import-button';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
-import FollowingManageSearchFollowed from './search-followed';
-import FollowingManageSortControls from './sort-controls';
-import { getReaderFollows, getReaderFollowsCount } from 'calypso/state/reader/follows/selectors';
-import UrlSearch from 'calypso/lib/url-search';
-import { filterFollowsByQuery } from 'calypso/reader/follow-helpers';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
-import { formatUrlForDisplay, getFeedTitle } from 'calypso/reader/lib/feed-display-helper';
 import { addQueryArgs } from 'calypso/lib/url';
+import UrlSearch from 'calypso/lib/url-search';
+import InfiniteStream from 'calypso/reader/components/reader-infinite-stream';
+import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import { filterFollowsByQuery } from 'calypso/reader/follow-helpers';
 import { READER_SUBSCRIPTIONS } from 'calypso/reader/follow-sources';
-import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
+import { formatUrlForDisplay, getFeedTitle } from 'calypso/reader/lib/feed-display-helper';
+import { getReaderFollows, getReaderFollowsCount } from 'calypso/state/reader/follows/selectors';
+import FollowingManageSearchFollowed from './search-followed';
+import FollowingManageSortControls from './sort-controls';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 import { sectionify } from 'calypso/lib/route';
 import { trackPageLoad, setPageTitle } from 'calypso/reader/controller-helper';
-import AsyncLoad from 'calypso/components/async-load';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { followingManage } from './controller';
-import { updateLastRoute, sidebar } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { updateLastRoute, sidebar } from 'calypso/reader/controller';
+import { followingManage } from './controller';
 
 export default function () {
 	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -1,26 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import readerBackground from 'calypso/assets/images/reader/reader-intro-background.svg';
+import readerImage from 'calypso/assets/images/reader/reader-intro-character.svg';
 import QueryPreferences from 'calypso/components/data/query-preferences';
+import Gridicon from 'calypso/components/gridicon';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
+import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
-import cssSafeUrl from 'calypso/lib/css-safe-url';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Asset dependencies
- */
-import readerImage from 'calypso/assets/images/reader/reader-intro-character.svg';
-import readerBackground from 'calypso/assets/images/reader/reader-intro-background.svg';
 
 class FollowingIntro extends React.Component {
 	componentDidMount() {

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,36 +1,25 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import { flatMap, trim } from 'lodash';
-import { connect, useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
-import Stream from 'calypso/reader/stream';
 import { CompactCard, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { flatMap, trim } from 'lodash';
+import page from 'page';
+import React from 'react';
+import { connect, useDispatch } from 'react-redux';
 import SearchInput from 'calypso/components/search';
-import { recordTrack } from 'calypso/reader/stats';
+import SectionHeader from 'calypso/components/section-header';
+import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
+import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import Suggestion from 'calypso/reader/search-stream/suggestion';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
-import FollowingIntro from './intro';
 import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
-import SectionHeader from 'calypso/components/section-header';
-import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { recordTrack } from 'calypso/reader/stats';
+import Stream from 'calypso/reader/stream';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
-import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { SECTION_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
-
-/**
- * Style dependencies
- */
+import FollowingIntro from './intro';
 import './style.scss';
 
 function handleSearch( query ) {

--- a/client/reader/following/vote-banner.jsx
+++ b/client/reader/following/vote-banner.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
+import { sample } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { sample } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import Banner from 'calypso/components/banner';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -1,15 +1,8 @@
-/**
- * External Dependencies
- */
-import React from 'react';
-import page from 'page';
 import { defer } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import { trackPageLoad } from 'calypso/reader/controller-helper';
+import page from 'page';
+import React from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import { trackPageLoad } from 'calypso/reader/controller-helper';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { blogPost, feedPost } from './controller';
-import { updateLastRoute, unmountSidebar } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { updateLastRoute, unmountSidebar } from 'calypso/reader/controller';
+import { blogPost, feedPost } from './controller';
 
 export default function () {
 	// Feed full post

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,16 +1,9 @@
-/**
- * External Dependencies
- */
+import config from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
 import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isSiteDescriptionBlocked } from 'calypso/reader/lib/site-description-blocklist';
-import { getUrlParts } from '@automattic/calypso-url';
-import config from '@automattic/calypso-config';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 
 /**

--- a/client/reader/header-back/index.jsx
+++ b/client/reader/header-back/index.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import HeaderCake from 'calypso/components/header-cake';
 
 function goBack() {

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { addMiddleware } from 'redux-dynamic-middlewares';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	blogListing,
 	feedDiscovery,
@@ -19,13 +15,7 @@ import {
 	sidebar,
 	updateLastRoute,
 } from './controller';
-import config from '@automattic/calypso-config';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import { addMiddleware } from 'redux-dynamic-middlewares';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function forceTeamA8C( context, next ) {

--- a/client/reader/lib/content-width/index.js
+++ b/client/reader/lib/content-width/index.js
@@ -1,10 +1,3 @@
-/**
- * External Dependencies
- */
-
-/**
- * Internal Dependencies
- */
 const PAGE_MARGIN_LARGE = 32 * 2;
 const PAGE_MARGIN_MEDIUM = 24 * 2;
 const PAGE_MARGIN_SMALL = 10 * 2;

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getSiteUrl as getSiteUrlFromRoute, getFeedUrl } from 'calypso/reader/route';
 
 const exported = {

--- a/client/reader/lib/site-description-blocklist/test/index.js
+++ b/client/reader/lib/site-description-blocklist/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isSiteDescriptionBlocked } from '../';
 
 describe( 'isSiteDescriptionBlocked', () => {

--- a/client/reader/lib/teams/index.js
+++ b/client/reader/lib/teams/index.js
@@ -1,6 +1,3 @@
-/**
- * External Dependencies
- */
 import { find } from 'lodash';
 
 export const isAutomatticTeamMember = ( teams ) => !! find( teams, [ 'slug', 'a8c' ] );

--- a/client/reader/lib/teams/test/index.js
+++ b/client/reader/lib/teams/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { isAutomatticTeamMember } from '../';
 
 describe( 'isAutomatticTeamMember', () => {

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import LikeButtonContainer from 'calypso/blocks/like-button';
 import PostLikesPopover from 'calypso/blocks/post-likes/popover';
-import { markPostSeen } from 'calypso/state/reader/posts/actions';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-count';
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
-
-/**
- * Style dependencies
- */
+import { markPostSeen } from 'calypso/state/reader/posts/actions';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import './style.scss';
 
 class ReaderLikeButton extends React.Component {

--- a/client/reader/like-helper.jsx
+++ b/client/reader/like-helper.jsx
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	isDiscoverPost,
 	isInternalDiscoverPost,

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { sectionify } from 'calypso/lib/route';
 import {
 	trackPageLoad,

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class TagEmptyContent extends React.Component {

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { likes } from './controller';
-import { updateLastRoute, sidebar } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { updateLastRoute, sidebar } from 'calypso/reader/controller';
+import { likes } from './controller';
 
 export default function () {
 	page( '/activities/likes', updateLastRoute, sidebar, likes, makeLayout, clientRender );

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import Stream from 'calypso/reader/stream';
 import EmptyContent from './empty';
-import DocumentHead from 'calypso/components/data/document-head';
 
 const title = translate( 'My Likes' );
 const documentTitle = translate( '%s ‹ Reader', {

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { fillGap } from 'calypso/state/reader/streams/actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import { fillGap } from 'calypso/state/reader/streams/actions';
 import './style.scss';
 
 class Gap extends React.Component {

--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -1,24 +1,18 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
+
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
-import Gridicon from 'calypso/components/gridicon';
-import { Item, Feed, FeedError, List } from './types';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import Gridicon from 'calypso/components/gridicon';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { addReaderListFeed, deleteReaderListFeed } from 'calypso/state/reader/lists/actions';
 import { getMatchingItem } from 'calypso/state/reader/lists/selectors';
 import ItemRemoveDialog from './item-remove-dialog';
+import { Item, Feed, FeedError, List } from './types';
 
 function isFeedError( feed: Feed | FeedError ): feed is FeedError {
 	return 'errors' in feed;

--- a/client/reader/list-manage/feed-url-adder.jsx
+++ b/client/reader/list-manage/feed-url-adder.jsx
@@ -1,13 +1,6 @@
-/**
- * External Dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import FollowButton from 'calypso/blocks/follow-button/button';
 import { addSchemeIfMissing, withoutHttp } from 'calypso/lib/url';
 import { addReaderListFeedByUrl, deleteReaderListFeed } from 'calypso/state/reader/lists/actions';

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -1,14 +1,20 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import ReaderExportButton from 'calypso/blocks/reader-export-button';
+import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/constants';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
+import QueryReaderListItems from 'calypso/components/data/query-reader-list-items';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { preventWidows } from 'calypso/lib/formatting';
+import Missing from 'calypso/reader/list-stream/missing';
+import { createReaderList, updateReaderList } from 'calypso/state/reader/lists/actions';
 import {
 	getListByOwnerAndSlug,
 	getListItems,
@@ -16,27 +22,10 @@ import {
 	isUpdatingList as isUpdatingListSelector,
 	isMissingByOwnerAndSlug,
 } from 'calypso/state/reader/lists/selectors';
-import FormattedHeader from 'calypso/components/formatted-header';
-import QueryReaderList from 'calypso/components/data/query-reader-list';
-import QueryReaderListItems from 'calypso/components/data/query-reader-list-items';
-import SectionNav from 'calypso/components/section-nav';
-import NavTabs from 'calypso/components/section-nav/tabs';
-import NavItem from 'calypso/components/section-nav/item';
-import Main from 'calypso/components/main';
-import { createReaderList, updateReaderList } from 'calypso/state/reader/lists/actions';
-import ReaderExportButton from 'calypso/blocks/reader-export-button';
-import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/constants';
-import Missing from 'calypso/reader/list-stream/missing';
 import ItemAdder from './item-adder';
 import ListDelete from './list-delete';
 import ListForm from './list-form';
 import ListItem from './list-item';
-import EmptyContent from 'calypso/components/empty-content';
-import { preventWidows } from 'calypso/lib/formatting';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function Details( { list } ) {

--- a/client/reader/list-manage/item-adder.jsx
+++ b/client/reader/list-manage/item-adder.jsx
@@ -1,22 +1,15 @@
-/**
- * External Dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
 import SyncReaderFollows from 'calypso/components/data/sync-reader-follows';
 import SearchInput from 'calypso/components/search';
 import { resemblesUrl } from 'calypso/lib/url';
 import { filterFollowsByQuery } from 'calypso/reader/follow-helpers';
+import { SORT_BY_RELEVANCE } from 'calypso/state/reader/feed-searches/actions';
 import { getReaderFeedsForQuery } from 'calypso/state/reader/feed-searches/selectors';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
-import { SORT_BY_RELEVANCE } from 'calypso/state/reader/feed-searches/actions';
 import FeedUrlAdder from './feed-url-adder';
 import ListItem from './list-item';
 

--- a/client/reader/list-manage/item-remove-dialog.jsx
+++ b/client/reader/list-manage/item-remove-dialog.jsx
@@ -1,13 +1,6 @@
-/**
- * External Dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
 
 export default function ItemRemoveDialog( props ) {

--- a/client/reader/list-manage/list-delete.jsx
+++ b/client/reader/list-manage/list-delete.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { Button, Card, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import { deleteReaderList } from 'calypso/state/reader/lists/actions';
 
 function ListDelete( { list } ) {

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import * as React from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
-import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import { useTranslate } from 'i18n-calypso';
+import * as React from 'react';
 import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';

--- a/client/reader/list-manage/list-item.tsx
+++ b/client/reader/list-manage/list-item.tsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { Item, List } from './types';
 import FeedItem from './feed-item';
 import SiteItem from './site-item';
 import TagItem from './tag-item';
+import { Item, List } from './types';
 
 export default function ListItem( props: {
 	hideIfInList?: boolean;

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -1,15 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
+
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Gridicon from 'calypso/components/gridicon';

--- a/client/reader/list-manage/tag-item.tsx
+++ b/client/reader/list-manage/tag-item.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Gridicon from 'calypso/components/gridicon';

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React from 'react';
+import { Card } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-import { isExternal } from 'calypso/lib/url';
+import PropTypes from 'prop-types';
+import React from 'react';
 import FollowButton from 'calypso/blocks/follow-button/button';
+import Gridicon from 'calypso/components/gridicon';
+import { isExternal } from 'calypso/lib/url';
 
 const ListStreamHeader = ( {
 	isPlaceholder,

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -1,32 +1,21 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import Stream from 'calypso/reader/stream';
-import EmptyContent from './empty';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import ListMissing from './missing';
-import ListStreamHeader from './header';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import Stream from 'calypso/reader/stream';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { followList, unfollowList } from 'calypso/state/reader/lists/actions';
 import {
 	getListByOwnerAndSlug,
 	isSubscribedByOwnerAndSlug,
 	isMissingByOwnerAndSlug,
 } from 'calypso/state/reader/lists/selectors';
-import QueryReaderList from 'calypso/components/data/query-reader-list';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import EmptyContent from './empty';
+import ListStreamHeader from './header';
+import ListMissing from './missing';
 import './style.scss';
 
 class ListStream extends React.Component {

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import ReaderMain from 'calypso/reader/components/reader-main';

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { recordTrack } from 'calypso/reader/stats';
+import AsyncLoad from 'calypso/components/async-load';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'calypso/reader/controller-helper';
-import AsyncLoad from 'calypso/components/async-load';
+import { recordTrack } from 'calypso/reader/stats';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import {
 	createList,
 	deleteList,
@@ -14,9 +10,6 @@ import {
 	exportList,
 	listListing,
 } from './controller';
-import { sidebar, updateLastRoute } from 'calypso/reader/controller';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import config from '@automattic/calypso-config';
 
 export default function () {
 	if ( config.isEnabled( 'reader/list-management' ) ) {

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import { connect, useDispatch } from 'react-redux';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import Stream from 'calypso/reader/stream';
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect, useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
-import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import Stream from 'calypso/reader/stream';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { SECTION_P2_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 import { P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import { getReaderOrganizationFeedsInfo } from 'calypso/state/reader/organizations/selectors';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import { SECTION_P2_FOLLOWING } from 'calypso/state/reader/seen-posts/constants';
 
 const P2Following = ( props ) => {
 	const { translate } = props;

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { recordPermalinkClick } from 'calypso/reader/stats';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class PostExcerptLink extends React.Component {

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Style dependencies
- */
+import React from 'react';
 import './style.scss';
 
 class ReadingTime extends React.PureComponent {

--- a/client/reader/route/index.js
+++ b/client/reader/route/index.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import config from '@automattic/calypso-config';
 
 const FEED_URL_BASE = '/read/feeds/';

--- a/client/reader/route/test/index.js
+++ b/client/reader/route/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import * as route from '../';
 import config from '@automattic/calypso-config';
+import { expect } from 'chai';
+import * as route from '../';
 
 describe( 'index', () => {
 	describe( 'getStreamUrlFromPost', () => {

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class SearchEmptyContent extends React.Component {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,45 +1,34 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { trim, flatMap } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { trim, flatMap } from 'lodash';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
-import SegmentedControl from 'calypso/components/segmented-control';
-import { CompactCard } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
 import SearchInput from 'calypso/components/search';
-import { recordAction } from 'calypso/reader/stats';
-import SiteResults from './site-results';
-import PostResults from './post-results';
-import ReaderMain from 'calypso/reader/components/reader-main';
+import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs, resemblesUrl, withoutHttp, addSchemeIfMissing } from 'calypso/lib/url';
-import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
+import withDimensions from 'calypso/lib/with-dimensions';
+import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import FollowButton from 'calypso/reader/follow-button';
+import { SEARCH_RESULTS_URL_INPUT } from 'calypso/reader/follow-sources';
+import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
+import { recordAction } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import {
 	SORT_BY_RELEVANCE,
 	SORT_BY_LAST_UPDATED,
 } from 'calypso/state/reader/feed-searches/actions';
-import withDimensions from 'calypso/lib/with-dimensions';
-import SuggestionProvider from './suggestion-provider';
-import Suggestion from './suggestion';
 import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
-import { SEARCH_RESULTS_URL_INPUT } from 'calypso/reader/follow-sources';
-import FollowButton from 'calypso/reader/follow-button';
-import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
-import { getSearchPlaceholderText } from 'calypso/reader/search/utils';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import PostResults from './post-results';
+import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
+import SiteResults from './site-results';
+import Suggestion from './suggestion';
+import SuggestionProvider from './suggestion-provider';
 import './style.scss';
 
 const WIDE_DISPLAY_CUTOFF = 660;

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -1,19 +1,12 @@
-/**
- * External Dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import Stream from 'calypso/reader/stream';
-import EmptyContent from './empty';
-import HeaderBack from 'calypso/reader/header-back';
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
 import { SEARCH_RESULTS } from 'calypso/reader/follow-sources';
+import HeaderBack from 'calypso/reader/header-back';
+import Stream from 'calypso/reader/stream';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
+import EmptyContent from './empty';
 
 const defaultTransform = ( item ) => item;
 

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -1,17 +1,10 @@
-/**
- * External Dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { values } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import NavTabs from 'calypso/components/section-nav/tabs';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 
 const noop = () => {};
 export const SEARCH_TYPES = { POSTS: 'posts', SITES: 'sites' };

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -1,28 +1,21 @@
-/**
- * External Dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import {
-	getReaderFeedsForQuery,
-	getReaderFeedsCountForQuery,
-} from 'calypso/state/reader/feed-searches/selectors';
 import QueryReaderFeedsSearch from 'calypso/components/data/query-reader-feeds-search';
+import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderInfiniteStream from 'calypso/reader/components/reader-infinite-stream';
+import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
+import { SEARCH_RESULTS_SITES } from 'calypso/reader/follow-sources';
 import {
 	requestFeedSearch,
 	SORT_BY_RELEVANCE,
 	SORT_BY_LAST_UPDATED,
 } from 'calypso/state/reader/feed-searches/actions';
-import { SEARCH_RESULTS_SITES } from 'calypso/reader/follow-sources';
-import { siteRowRenderer } from 'calypso/reader/components/reader-infinite-stream/row-renderers';
-import withDimensions from 'calypso/lib/with-dimensions';
+import {
+	getReaderFeedsForQuery,
+	getReaderFeedsCountForQuery,
+} from 'calypso/state/reader/feed-searches/selectors';
 
 class SiteResults extends React.Component {
 	static propTypes = {

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -1,13 +1,6 @@
-/**
- * External Dependencies
- */
-import { connect } from 'react-redux';
-import React, { Component } from 'react';
 import { map, sampleSize, times } from 'lodash';
-
-/**
- * Internal Dependencies
- */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { suggestions } from 'calypso/reader/search-stream/suggestions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { recordTracksRailcarInteract } from 'calypso/reader/stats';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { recordTracksRailcarInteract } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 export class Suggestion extends Component {

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import page from 'page';
 import { stringify } from 'qs';
-
-/**
- * Internal dependencies
- */
-import { recordTrack } from 'calypso/reader/stats';
+import React from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'calypso/reader/controller-helper';
-import AsyncLoad from 'calypso/components/async-load';
 import { SEARCH_TYPES } from 'calypso/reader/search-stream/search-stream-header';
+import { recordTrack } from 'calypso/reader/stats';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { search } from './controller';
-import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { search } from './controller';
 
 export default function () {
 	// Old recommendations page

--- a/client/reader/search/utils.js
+++ b/client/reader/search/utils.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
 
 export function getSearchPlaceholderText() {

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
 import { some, startsWith } from 'lodash';
 

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,53 +1,42 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 import { defer, startsWith } from 'lodash';
 import page from 'page';
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ReaderSidebarHelper from './helper';
-import ReaderSidebarLists from './reader-sidebar-lists';
-import ReaderSidebarTags from './reader-sidebar-tags';
-import ReaderSidebarOrganizations from './reader-sidebar-organizations';
-import ReaderSidebarNudges from './reader-sidebar-nudges';
 import QueryReaderLists from 'calypso/components/data/query-reader-lists';
+import QueryReaderOrganizations from 'calypso/components/data/query-reader-organizations';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
+import SidebarSeparator from 'calypso/layout/sidebar/separator';
 import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getTagStreamUrl } from 'calypso/reader/route';
+import ReaderSidebarFollowedSites from 'calypso/reader/sidebar/reader-sidebar-followed-sites';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import { getSubscribedLists } from 'calypso/state/reader/lists/selectors';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import {
 	toggleReaderSidebarLists,
 	toggleReaderSidebarTags,
 } from 'calypso/state/reader-ui/sidebar/actions';
 import { isListsOpen, isTagsOpen } from 'calypso/state/reader-ui/sidebar/selectors';
-import ReaderSidebarPromo from './promo';
-import QueryReaderOrganizations from 'calypso/components/data/query-reader-organizations';
-import { getReaderOrganizations } from 'calypso/state/reader/organizations/selectors';
-import ReaderSidebarFollowedSites from 'calypso/reader/sidebar/reader-sidebar-followed-sites';
-import SidebarSeparator from 'calypso/layout/sidebar/separator';
-import { isEnabled } from '@automattic/calypso-config';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
-import './style.scss';
+import { getSubscribedLists } from 'calypso/state/reader/lists/selectors';
+import { getReaderOrganizations } from 'calypso/state/reader/organizations/selectors';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import ReaderSidebarHelper from './helper';
+import ReaderSidebarPromo from './promo';
+import ReaderSidebarLists from './reader-sidebar-lists';
+import ReaderSidebarNudges from './reader-sidebar-nudges';
+import ReaderSidebarOrganizations from './reader-sidebar-organizations';
+import ReaderSidebarTags from './reader-sidebar-tags';
 import 'calypso/my-sites/sidebar-unified/style.scss'; // nav-unification overrides. Should be removed once launched.
+import './style.scss';
 
 const A8CConversationsIcon = () => (
 	<svg

--- a/client/reader/sidebar/promo.jsx
+++ b/client/reader/sidebar/promo.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import { isMobile } from '@automattic/viewport';
-import React, { Fragment } from 'react';
-import store from 'store';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AsyncLoad from 'calypso/components/async-load';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import config from '@automattic/calypso-config';
+import { isMobile } from '@automattic/viewport';
+import { localize } from 'i18n-calypso';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import store from 'store';
+import AsyncLoad from 'calypso/components/async-load';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
 export const ReaderSidebarPromo = ( { currentUserLocale, shouldRenderAppPromo } ) => {

--- a/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
@@ -1,29 +1,18 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import Count from 'calypso/components/count';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import ReaderSidebarFollowingItem from './item';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
 import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
-import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
-import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
-import SidebarItem from 'calypso/layout/sidebar/item';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import Count from 'calypso/components/count';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
+import ReaderSidebarFollowingItem from './item';
 import '../style.scss';
 
 export class ReaderSidebarFollowedSites extends Component {

--- a/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import Count from 'calypso/components/count';
-import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { useDispatch } from 'react-redux';
+import Count from 'calypso/components/count';
 import Favicon from 'calypso/reader/components/favicon';
-
-/**
- * Style dependencies
- */
+import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
 import '../style.scss';
 
 const ReaderSidebarFollowingItem = ( props ) => {

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderSidebarListsList from './list';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class ReaderSidebarLists extends Component {

--- a/client/reader/sidebar/reader-sidebar-lists/list-item-create-link.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item-create-link.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import ReaderSidebarHelper from '../helper';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
 
 const ReaderSidebarListsListItemCreateLink = ( props ) => {
 	const dispatch = useDispatch();

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
 
 export class ReaderSidebarListsListItem extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { isEnabled } from '@automattic/calypso-config';
 import ListItem from './list-item';
 import ListItemCreateLink from './list-item-create-link';
 

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 import React, { Fragment } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
-import getSites from 'calypso/state/selectors/get-sites';
+import { clickUpgradeNudge } from 'calypso/state/marketing/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
-import { clickUpgradeNudge } from 'calypso/state/marketing/actions';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import getSites from 'calypso/state/selectors/get-sites';
+import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-for-free-to-paid-upsell';
 
 const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 

--- a/client/reader/sidebar/reader-sidebar-organizations/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderSidebarOrganizationsList from './list';
 
 export class ReaderSidebarOrganizations extends Component {

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ReaderSidebarHelper from '../helper';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Count from 'calypso/components/count';
 import Favicon from 'calypso/reader/components/favicon';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
 
 /**
  * Styles

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -1,32 +1,21 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import ReaderSidebarOrganizationsListItem from './list-item';
-import getOrganizationSites from 'calypso/state/reader/follows/selectors/get-reader-follows-organization';
-import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
-import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
-import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
-import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
-import SidebarItem from 'calypso/layout/sidebar/item';
-import Count from 'calypso/components/count';
-
-/**
- * Styles
- */
-import '../style.scss';
-import SVGIcon from 'calypso/components/svg-icon';
 import AutomatticLogo from 'calypso/assets/images/icons/a8c-logo.svg';
 import P2Logo from 'calypso/assets/images/icons/p2-logo.svg';
+import Count from 'calypso/components/count';
+import SVGIcon from 'calypso/components/svg-icon';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
+import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
+import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
+import getOrganizationSites from 'calypso/state/reader/follows/selectors/get-reader-follows-organization';
+import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import ReaderSidebarOrganizationsListItem from './list-item';
+import '../style.scss';
 
 export class ReaderSidebarOrganizationsList extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
 import { localize } from 'i18n-calypso';
 import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
-import ReaderSidebarTagsList from './list';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { requestFollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarTagsList from './list';
 
 export class ReaderSidebarTags extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import ReaderSidebarHelper from '../helper';
 import '../style.scss';
 
 export class ReaderSidebarTagsListItem extends Component {

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderSidebarTagsListItem from './list-item';
 
 export class ReaderSidebarTagsList extends Component {

--- a/client/reader/sidebar/test/promo.jsx
+++ b/client/reader/sidebar/test/promo.jsx
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { ReaderSidebarPromo, shouldRenderAppPromo } from '../promo';
 
 describe( 'ReaderSidebarPromo', () => {

--- a/client/reader/site-blocked/index.jsx
+++ b/client/reader/site-blocked/index.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ReaderMain from 'calypso/reader/components/reader-main';
-import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
 import EmptyContent from 'calypso/components/empty-content';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
+import ReaderMain from 'calypso/reader/components/reader-main';
 import { recordTrack as recordReaderTrack } from 'calypso/reader/stats';
 import { bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { unblockSite } from 'calypso/state/reader/site-blocks/actions';

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
 import { recordAction as statRecordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
-import DocumentHead from 'calypso/components/data/document-head';
 import ReaderFeedHeader from 'calypso/blocks/reader-feed-header';
-import EmptyContent from './empty';
-import Stream from 'calypso/reader/stream';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import FeedError from 'calypso/reader/feed-error';
-import { getSite } from 'calypso/state/reader/sites/selectors';
+import SiteBlocked from 'calypso/reader/site-blocked';
+import Stream from 'calypso/reader/stream';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { isSiteBlocked } from 'calypso/state/reader/site-blocks/selectors';
-import SiteBlocked from 'calypso/reader/site-blocked';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
-import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import EmptyContent from './empty';
 
 class SiteStream extends React.Component {
 	static propTypes = {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import { partial, pick } from 'lodash';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { partial, pick } from 'lodash';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const debug = debugFactory( 'calypso:reader:stats' );
 

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
-import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
 import { EMPTY_SEARCH_RECOMMENDATIONS } from 'calypso/reader/follow-sources';
+import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
 
 export default function EmptySearchRecommendedPost( { post } ) {
 	function handlePostClick() {

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Asset dependencies
- */
 import welcomeImage from 'calypso/assets/images/reader/reader-welcome-illustration.svg';
+import EmptyContent from 'calypso/components/empty-content';
+import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class FollowingEmptyContent extends React.Component {
 	shouldComponentUpdate() {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,19 +1,31 @@
-/**
- * External dependencies
- */
-import ReactDom from 'react-dom';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { findLast, times } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
-import { findLast, times } from 'lodash';
+import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import InfiniteList from 'calypso/components/infinite-list';
+import ListEnd from 'calypso/components/list-end';
+import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
+import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
+import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
+import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { reduxGetState } from 'calypso/lib/redux-bridge';
+import scrollTo from 'calypso/lib/scroll-to';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import EmptyContent from './empty';
+import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { keysAreEqual, keyToString, keyForPost } from 'calypso/reader/post-key';
+import UpdateNotice from 'calypso/reader/update-notice';
+import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
+import XPostHelper from 'calypso/reader/xpost-helper';
+import { PER_FETCH, INITIAL_FETCH } from 'calypso/state/data-layer/wpcom/read/streams';
+import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
+import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
+import { viewStream } from 'calypso/state/reader-ui/actions';
+import { resetCardExpansions } from 'calypso/state/reader-ui/card-expansions/actions';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
 import {
 	requestPage,
 	selectItem,
@@ -26,33 +38,9 @@ import {
 	getTransformedStreamItems,
 	shouldRequestRecs,
 } from 'calypso/state/reader/streams/selectors';
-
-import { shouldShowLikes } from 'calypso/reader/like-helper';
-import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
-import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
-import ListEnd from 'calypso/components/list-end';
-import InfiniteList from 'calypso/components/infinite-list';
-import MobileBackToSidebar from 'calypso/components/mobile-back-to-sidebar';
-import PostPlaceholder from './post-placeholder';
-import UpdateNotice from 'calypso/reader/update-notice';
-import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
-import scrollTo from 'calypso/lib/scroll-to';
-import XPostHelper from 'calypso/reader/xpost-helper';
+import EmptyContent from './empty';
 import PostLifecycle from './post-lifecycle';
-import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
-import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
-import { keysAreEqual, keyToString, keyForPost } from 'calypso/reader/post-key';
-import { resetCardExpansions } from 'calypso/state/reader-ui/card-expansions/actions';
-import { reduxGetState } from 'calypso/lib/redux-bridge';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
-import { viewStream } from 'calypso/state/reader-ui/actions';
-import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
-import { PER_FETCH, INITIAL_FETCH } from 'calypso/state/data-layer/wpcom/read/streams';
-import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-
-/**
- * Style dependencies
- */
+import PostPlaceholder from './post-placeholder';
 import './style.scss';
 
 const GUESSED_POST_HEIGHT = 600;

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -1,28 +1,21 @@
-/**
- * External Dependencies
- */
+import { omit, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { omit, includes } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import PostPlaceholder from './post-placeholder';
-import PostUnavailable from './post-unavailable';
-import ListGap from 'calypso/reader/list-gap';
-import CrossPost from './x-post';
-import RecommendedPosts from './recommended-posts';
-import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
-import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
-import Post from './post';
-import { IN_STREAM_RECOMMENDATION } from 'calypso/reader/follow-sources';
 import CombinedCard from 'calypso/blocks/reader-combined-card';
-import EmptySearchRecommendedPost from './empty-search-recommended-post';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import compareProps from 'calypso/lib/compare-props';
+import { IN_STREAM_RECOMMENDATION } from 'calypso/reader/follow-sources';
+import ListGap from 'calypso/reader/list-gap';
+import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import EmptySearchRecommendedPost from './empty-search-recommended-post';
+import Post from './post';
+import PostPlaceholder from './post-placeholder';
+import PostUnavailable from './post-unavailable';
+import RecommendedPosts from './recommended-posts';
+import CrossPost from './x-post';
 
 class PostLifecycle extends React.Component {
 	static propTypes = {

--- a/client/reader/stream/post-placeholder.jsx
+++ b/client/reader/stream/post-placeholder.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import React from 'react';
 
 class PostPlaceholder extends React.PureComponent {
 	render() {

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 
 class PostUnavailable extends React.PureComponent {
 	componentDidMount() {

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -1,25 +1,18 @@
-/**
- * External dependencies
- */
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import ReaderPostCard from 'calypso/blocks/reader-post-card';
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import {
 	getSourceData as getDiscoverSourceData,
 	discoverBlogId,
 } from 'calypso/reader/discover/helper';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
-import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 
 class ReaderPostCardAdapter extends React.Component {
 	static displayName = 'ReaderPostCardAdapter';

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -1,23 +1,16 @@
-/**
- * External Dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { map, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { map, partial } from 'lodash';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
-import { recordAction, recordTrackForPost } from 'calypso/reader/stats';
-import { Button } from '@automattic/components';
-import { dismissPost } from 'calypso/state/reader/site-dismissals/actions';
-import { keyForPost } from 'calypso/reader/post-key';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import Gridicon from 'calypso/components/gridicon';
+import { keyForPost } from 'calypso/reader/post-key';
+import { recordAction, recordTrackForPost } from 'calypso/reader/stats';
 import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
+import { dismissPost } from 'calypso/state/reader/site-dismissals/actions';
 
 function dismissPostAnalytics( uiIndex, storeId, post ) {
 	recordTrackForPost( 'calypso_reader_recommended_post_dismissed', post, {

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect, assert } from 'chai';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import { sameDay, sameSite, combine, combineCards, injectRecommendations } from '../utils';
 
 describe( 'reader stream', () => {

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { flatMap, last } from 'lodash';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import { isDiscoverBlog, isDiscoverFeed } from 'calypso/reader/discover/helper';
 
 export function isDiscoverPostKey( postKey ) {

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -1,30 +1,23 @@
-/**
- * External Dependencies
- */
+import { getUrlParts } from '@automattic/calypso-url';
+import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import closest from 'component-closest';
+import { localize } from 'i18n-calypso';
+import { get, forEach, uniqBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
-import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
-import closest from 'component-closest';
-import { get, forEach, uniqBy } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import { Card } from '@automattic/components';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import Emojify from 'calypso/components/emojify';
-import { getUrlParts } from '@automattic/calypso-url';
 import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class CrossPost extends PureComponent {

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { trim } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { recordTrack } from 'calypso/reader/stats';
+import React from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
 	getStartDate,
 } from 'calypso/reader/controller-helper';
-import AsyncLoad from 'calypso/components/async-load';
 import { TAG_PAGE } from 'calypso/reader/follow-sources';
+import { recordTrack } from 'calypso/reader/stats';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { isDiscoverEnabled } from 'calypso/reader/discover/helper';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 class TagEmptyContent extends React.Component {

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { sample } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import QueryReaderTagImages from 'calypso/components/data/query-reader-tag-images';
-import { getTagImages } from 'calypso/state/reader/tags/images/selectors';
-import resizeImageUrl from 'calypso/lib/resize-image-url';
+import Gridicon from 'calypso/components/gridicon';
 import cssSafeUrl from 'calypso/lib/css-safe-url';
 import { decodeEntities } from 'calypso/lib/formatting';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import { getTagImages } from 'calypso/state/reader/tags/images/selectors';
 
 const TAG_HEADER_WIDTH = 800;
 const TAG_HEADER_HEIGHT = 140;

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import page from 'page';
 import { startsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { tagListing } from './controller';
-import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, updateLastRoute } from 'calypso/reader/controller';
+import { tagListing } from './controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
 	if ( context.hashstring && startsWith( context.pathname, '/tag/#' ) ) {

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -1,31 +1,20 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import Stream from 'calypso/reader/stream';
 import DocumentHead from 'calypso/components/data/document-head';
-import EmptyContent from './empty';
-import TagStreamHeader from './header';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import HeaderBack from 'calypso/reader/header-back';
-import { getReaderTags, getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
-import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import HeaderBack from 'calypso/reader/header-back';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import Stream from 'calypso/reader/stream';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-
-/**
- * Style dependencies
- */
+import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
+import { getReaderTags, getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import EmptyContent from './empty';
+import TagStreamHeader from './header';
 import './style.scss';
 
 class TagStream extends React.Component {

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getSiteUrl, getSiteName } from '../get-helpers';
 
 describe( '#getSiteUrl', () => {

--- a/client/reader/test/id-helpers.js
+++ b/client/reader/test/id-helpers.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { toValidId } from '../id-helpers';
 
 describe( 'toValidId', () => {

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
 import { showSelectedPost } from '../utils';
 
 jest.mock( 'page', () => ( {

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -1,25 +1,14 @@
-/**
- * External Dependencies
- */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { filter, get, flatMap } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { filter, get, flatMap } from 'lodash';
-import classnames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import DocumentHead from 'calypso/components/data/document-head';
-import { getDocumentHeadCappedUnreadCount } from 'calypso/state/document-head/selectors/get-document-head-capped-unread-count';
+import Gridicon from 'calypso/components/gridicon';
 import { getCommentById } from 'calypso/state/comments/selectors';
+import { getDocumentHeadCappedUnreadCount } from 'calypso/state/document-head/selectors/get-document-head-capped-unread-count';
 import { getStream } from 'calypso/state/reader/streams/selectors';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,13 +1,6 @@
-/**
- * External Dependencies
- */
 import page from 'page';
-
-/**
- * Internal Dependencies
- */
-import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { reduxGetState } from 'calypso/lib/redux-bridge';
+import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 
 export function isSpecialClick( event ) {

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { has } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import displayTypes from 'calypso/state/reader/posts/display-types';
 import { getUrlParts } from '@automattic/calypso-url';
+import { has } from 'lodash';
+import displayTypes from 'calypso/state/reader/posts/display-types';
 
 const { X_POST } = displayTypes;
 


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/reader` to use `import/order`

#### Testing instructions

N/A
