### PR TITLE
Welcome Tour and Modal: Allow modal to be dismissed on mobile devices

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/style.scss
@@ -34,7 +34,12 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	}
 
 	.components-modal__header {
-		display: none;
+		position: absolute;
+		max-width: 90%;
+		left: 5%;
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			display: none;
+		}
 	}
 
 	.components-guide__container {
@@ -62,8 +67,13 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	.components-guide__page {
 		position: absolute;
 		width: 100%;
+		max-width: 90vw;
 		height: 100%;
 		justify-content: start;
+
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			max-width: 100%;
+		}
 	}
 
 	.components-guide__page-control {
@@ -100,12 +110,14 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	justify-content: flex-end;
 	background: white;
 	width: 100%;
-	height: 100%;
+	height: 90%;
+	max-width: 90vw;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		flex-direction: row;
 		justify-content: flex-start;
 		position: absolute;
+		max-width: 100%;
 		min-height: $wpcom-modal-content-min-height;
 		bottom: 0;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -64,6 +64,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 .welcome-tour-card {
 	width: 400px;
+	max-width: 92vw;
 
 	&.welcome-tour-card.is-elevated {
 		box-shadow: rgba( 0, 0, 0, 0.1 ) 0 0 0 1px, rgba( 0, 0, 0, 0.1 ) 0 2px 4px 0;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -156,11 +156,13 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	}
 }
 
-.wpcom-editor-welcome-tour-frame:hover .welcome-tour-card__overlay-controls .components-button {
+.wpcom-editor-welcome-tour-frame:hover .welcome-tour-card__overlay-controls .components-button,
+.welcome-tour-card__overlay-controls-visible .components-button {
 	opacity: 0.7;
 }
 
-.wpcom-editor-welcome-tour-frame .welcome-tour-card__overlay-controls .components-button:hover {
+.wpcom-editor-welcome-tour-frame .welcome-tour-card__overlay-controls .components-button:hover,
+.welcome-tour-card__overlay-controls-visible .components-button:hover {
 	opacity: 0.9;
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isMobile } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -127,9 +128,12 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 			slide_number: slideNumber,
 		} );
 	};
+	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls', {
+		'welcome-tour-card__overlay-controls-visible': isMobile(),
+	} );
 
 	return (
-		<div className="welcome-tour-card__overlay-controls">
+		<div className={ buttonClasses }>
 			<Flex>
 				<Button
 					label={ __( 'Minimize Tour', 'full-site-editing' ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -1,8 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isMobile } from '@automattic/viewport';
+import { subscribeIsMobile } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -121,6 +121,15 @@ function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIn
 }
 
 function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
+	const [ isMobile, setIsMobile ] = useState( false );
+
+	useEffectOnlyOnce( () => {
+		const unsubscribe = subscribeIsMobile( ( isNarrow ) => setIsMobile( isNarrow ) );
+		return function cleanup() {
+			unsubscribe();
+		};
+	} );
+
 	const handleOnMinimize = () => {
 		onMinimize( true );
 		recordTracksEvent( 'calypso_editor_wpcom_tour_minimize', {
@@ -129,7 +138,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 		} );
 	};
 	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls', {
-		'welcome-tour-card__overlay-controls-visible': isMobile(),
+		'welcome-tour-card__overlay-controls-visible': isMobile,
 	} );
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set max-width on tour modal window to avoid it overflowing screens smaller than 400px wide
* Always show dismiss icon on mobile devices since there's no ability to hover to show them
* Set max-width and height on welcome modal window to avoid overflow
* Don't hide the dismiss icon on small screens

**Before**

Tour:

<img width="390" alt="Screen Shot 2021-08-03 at 10 43 31 AM" src="https://user-images.githubusercontent.com/2124984/128035653-9220a1e7-9f0b-4599-a67c-6bd1999fbf27.png">

Welcome modal:

![IMG_0461](https://user-images.githubusercontent.com/2124984/128048787-d32e57c6-04c6-4d40-a117-6539bfdc778f.PNG)


**After**

Tour:

<img width="399" alt="Screen Shot 2021-08-03 at 10 40 53 AM" src="https://user-images.githubusercontent.com/2124984/128035399-4429c99a-5b78-48f1-b0bc-3422c499a7b0.png">

Welcome modal:

![IMG_0460](https://user-images.githubusercontent.com/2124984/128048771-75d9eefa-5ef3-4bd9-be1f-dafa8f766602.PNG)

#### Testing instructions

Test the welcome tour:
* Switch to this PR and `yarn dev --sync` to your sandbox from the `/apps/editing-toolkit` plugin
* Open a new post or page on your sandboxed site
* Click the three-dots menu in the upper right of the editor and click Welcome Tour
* Make sure the tour operates as expected on a large screen; hovering over the top part should show the dismiss and minimize icons
* Switch to a mobile browser and note the dismiss and minimize icons remain
* The tour should also not overflow the browser window

Test the welcome modal:

There's probably an easier way to do this that doesn't involve hacking local storage, but 🙃 

* While on the same PR, sandboxed, etc.
* Open your browser inspector, go to the Applications tab, click on Local Storage, and find the entry for your user ID:
<img width="1246" alt="Screen Shot 2021-08-03 at 12 14 25 PM" src="https://user-images.githubusercontent.com/2124984/128050127-0f5f8a69-0405-43f1-9e09-907a1444532f.png">
* One of the values in that entry should be `"welcomeGuideVariant":"tour"` -- change `tour` to `modal`
* Refresh the page; you should see the modal variant above rather than the tour variant

Fixes #54426