### PR TITLE
Emails: Fix empty margin when resizing browser to a mobile settings

### DIFF
--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -54,10 +54,6 @@
 
 body.is-section-signup.is-white-signup {
 	.domain-search-results {
-		@include break-medium {
-			margin-left: 20px;
-		}
-
 		@include break-xlarge {
 			margin-left: 0;
 		}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -225,13 +225,9 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 
 body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	margin: 0;
-
-	@include break-mobile {
+	
+	@include breakpoint-deprecated( '<960px' ) {
 		margin: 0 20px;
-	}
-
-	@include break-large {
-		margin: 0;
 	}
 }
 

--- a/client/components/emails/email-signup-titan-card/style.scss
+++ b/client/components/emails/email-signup-titan-card/style.scss
@@ -5,12 +5,9 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		align-items: center;
 		flex-direction: row;
-	}
-
-	@include breakpoint-deprecated( '>660px' ) {
 		padding: 15px 20px;
 	}
 }
@@ -58,7 +55,7 @@
 	padding: 0.25em 3em;
 	transition: all 0.1s linear;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 1 0 auto;
 		margin-left: 1em;
 		margin-top: 0;
@@ -89,12 +86,19 @@ body.is-section-signup.is-white-signup {
 		@include break-mobile {
 			border: 1px solid #e2e4e7;
 			border-radius: 4px; /* stylelint-disable-line */
-			flex-direction: row;
 			margin: 0 20px;
+		}
+
+		@include break-small {
+			flex-direction: row;
 		}
 
 		@include break-large {
 			margin: 0;
+		}
+
+		@include breakpoint-deprecated( '<660px' ) {
+			flex-direction: column;
 		}
 
 		.email-product-price {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -140,7 +140,7 @@ body.is-section-signup.is-white-signup {
 			margin: 20px 20px 0;
 
 			@include break-large {
-				margin: 0 0 0 20px;
+				margin: 0;
 			}
 
 			@include break-wide {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -714,11 +714,10 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup__step.is-emails {
 		@include break-large {
 			margin: 0 0 0 20px;
-			padding-left: 20px;
 		}
 
 		@include break-wide {
-			margin: initial;
+			padding-left: 20px;
 		}
 		.is-wide-layout {
 			max-width: 1280px;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -712,6 +712,14 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 	.signup__step.is-domains,
 	.signup__step.is-emails {
+		@include break-large {
+			margin: 0 0 0 20px;
+			padding-left: 20px;
+		}
+
+		@include break-wide {
+			margin: initial;
+		}
 		.is-wide-layout {
 			max-width: 1280px;
 		}


### PR DESCRIPTION
Fix empty margin when resizing browser to mobile settings on domains and emails step

#### Changes proposed in this Pull Request
Add mobile breaks to add a small margin (20px) and remove an extra margin that the input text form had for domains lookup.



#### Testing instructions

1. Check that when resizing the browser at 1280px width, there is a margin on the left side of the emails step.

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/128041707-49627d58-4b02-4734-ad9d-1c77f6276e10.png) | ![image](https://user-images.githubusercontent.com/5689927/128041774-6d012a90-817c-4eae-81ac-aed9cad5fd4a.png)

2. Check that when resizing the browser at 1080px width, there is a margin on the left side on the domains step.

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/128042004-50230e12-01a0-4389-bdd6-1e0efd08d322.png) | ![image](https://user-images.githubusercontent.com/5689927/128042212-ed951ffc-f29c-4fc8-9833-f484688ff96f.png)

Related to {1200182182542585-as-1200703026939303}
