### PR TITLE
chore: migrate `client/extensions` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -187,6 +187,7 @@ module.exports = {
 				'client/data/**/*',
 				'client/devdocs/**/*',
 				'client/document/**/*',
+				'client/extensions/**/*',
 				'client/gutenberg/**/*',
 				'client/incoming-redirect/**/*',
 				'client/jetpack-cloud/**/*',

--- a/client/extensions/README.md
+++ b/client/extensions/README.md
@@ -33,17 +33,10 @@ The rest of the attributes handle different configuration settings: `group` is u
 `index.js` will be assumed to be the entry point to your extension. That file should export a function that sets up routing for your plugin extension:
 
 ```js
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { helloWorld } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
-import { helloWorld } from './controller';
 
 export default () => {
 	page( '/hello-world', siteSelection, navigation, helloWorld, makeLayout, clientRender );

--- a/client/extensions/hello-dolly/hello-dolly-page.js
+++ b/client/extensions/hello-dolly/hello-dolly-page.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import Main from 'calypso/components/main';
 import { Button, Card } from '@automattic/components';
-import SectionHeader from 'calypso/components/section-header';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FAQ from 'calypso/components/faq';
 import FAQItem from 'calypso/components/faq/faq-item';
-import getLyric from './state/selectors';
+import Main from 'calypso/components/main';
+import SectionHeader from 'calypso/components/section-header';
 import { nextLyric } from './state/actions';
+import getLyric from './state/selectors';
 
 class HelloDollyPage extends Component {
 	static propTypes = {

--- a/client/extensions/hello-dolly/index.js
+++ b/client/extensions/hello-dolly/index.js
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
 import page from 'page';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import reducer from './state/reducer';
-import HelloDollyPage from './hello-dolly-page';
-import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection } from 'calypso/my-sites/controller';
+import HelloDollyPage from './hello-dolly-page';
+import reducer from './state/reducer';
 
 const render = ( context, next ) => {
 	context.primary = <HelloDollyPage />;

--- a/client/extensions/hello-dolly/state/actions.js
+++ b/client/extensions/hello-dolly/state/actions.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { HELLO_DOLLY_NEXT_LYRIC } from './action-types';
 
 export function nextLyric() {

--- a/client/extensions/hello-dolly/state/reducer.js
+++ b/client/extensions/hello-dolly/state/reducer.js
@@ -1,10 +1,6 @@
-/**
- * Internal dependencies
- */
-
-import lyrics from './lyrics';
-import { HELLO_DOLLY_NEXT_LYRIC } from './action-types';
 import { ROUTE_SET, SECTION_SET, SITE_SETTINGS_SAVE } from 'calypso/state/action-types';
+import { HELLO_DOLLY_NEXT_LYRIC } from './action-types';
+import lyrics from './lyrics';
 
 export default function lyricIndex( state = 0, action ) {
 	switch ( action.type ) {

--- a/client/extensions/hello-dolly/state/selectors.js
+++ b/client/extensions/hello-dolly/state/selectors.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
 import lyrics from './lyrics';
 
 export const getCurrentLyric = ( lines ) => ( reduxState ) => {

--- a/client/extensions/hello-dolly/state/test/reducer.js
+++ b/client/extensions/hello-dolly/state/test/reducer.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import reducer from '../reducer';
 import { ROUTE_SET, SECTION_SET, SITE_SETTINGS_SAVE } from 'calypso/state/action-types';
+import reducer from '../reducer';
 
 describe( 'reducer', () => {
 	test( 'should initialize to the first index', () => {

--- a/client/extensions/hello-dolly/state/test/selectors.js
+++ b/client/extensions/hello-dolly/state/test/selectors.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { getCurrentLyric } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/extensions/index.js
+++ b/client/extensions/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 const fs = require( 'fs' ); // eslint-disable-line import/no-nodejs-modules
 const path = require( 'path' );
 

--- a/client/extensions/sensei/index.js
+++ b/client/extensions/sensei/index.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
 import page from 'page';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import Main from 'calypso/components/main';
-import { Card } from '@automattic/components';
 import SectionHeader from 'calypso/components/section-header';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection } from 'calypso/my-sites/controller';
 
 const render = ( context, next ) => {
 	context.primary = (

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import ActionHeader from 'woocommerce/components/action-header';
 import Main from 'calypso/components/main';
 import StoreMoveNoticeView from './store-move-notice-view';

--- a/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-move-notice-view.js
@@ -1,24 +1,11 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { Card, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-
-import { Card, Button } from '@automattic/components';
-import { getSelectedSiteWithFallback } from 'calypso/state/sites/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-/**
- * Image dependencies
- */
-
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import megaphoneImage from 'calypso/assets/images/woocommerce/megaphone.svg';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteWithFallback } from 'calypso/state/sites/selectors';
 
 class StoreMoveNoticeView extends Component {
 	trackTryWooCommerceClick = () => {

--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import WooCommerceColophon from 'woocommerce/components/woocommerce-colophon';
 
 function App( props ) {
 	const translate = useTranslate();

--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { translate } from 'i18n-calypso';
 
 const sparkWidgetList1 = [

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
-import { includes } from 'lodash';
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import { includes } from 'lodash';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
+import page from 'page';
+import React from 'react';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import AsyncLoad from 'calypso/components/async-load';
 import StatsPagePlaceholder from 'calypso/my-sites/stats/stats-page-placeholder';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { getQueryDate, getQueries } from './utils';
-import { recordTrack } from 'woocommerce/lib/analytics';
-import config from '@automattic/calypso-config';
 
 function isValidParameters( context ) {
 	const validParameters = {

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -1,28 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import moment from 'moment';
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
-import StatsNavigation from 'calypso/blocks/stats-navigation';
-import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import Chart from './store-stats-orders-chart';
-import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
-import DatePicker from 'calypso/my-sites/stats/stats-date-picker';
-import FormattedHeader from 'calypso/components/formatted-header';
-import Module from './store-stats-module';
-import List from './store-stats-list';
-import WidgetList from './store-stats-widget-list';
-import SectionHeader from 'calypso/components/section-header';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import titlecase from 'to-title-case';
 import {
 	sparkWidgets,
 	topProducts,
@@ -30,12 +12,23 @@ import {
 	topCoupons,
 	noDataMsg,
 } from 'woocommerce/app/store-stats/constants';
-import { getEndPeriod, getQueries, getWidgetPath } from './utils';
+import StatsNavigation from 'calypso/blocks/stats-navigation';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import config from '@automattic/calypso-config';
-import StoreStatsReferrerWidget from './store-stats-referrer-widget';
+import FormattedHeader from 'calypso/components/formatted-header';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
+import Main from 'calypso/components/main';
+import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import titlecase from 'to-title-case';
+import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
+import DatePicker from 'calypso/my-sites/stats/stats-date-picker';
+import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import List from './store-stats-list';
+import Module from './store-stats-module';
+import Chart from './store-stats-orders-chart';
+import StoreStatsReferrerWidget from './store-stats-referrer-widget';
+import WidgetList from './store-stats-widget-list';
+import { getEndPeriod, getQueries, getWidgetPath } from './utils';
 
 class StoreStats extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -1,25 +1,17 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getQueries } from './utils';
-import JetpackColophon from 'calypso/components/jetpack-colophon';
-import List from './store-stats-list';
-import Main from 'calypso/components/main';
-import Module from './store-stats-module';
-import { topProducts, topCategories, topCoupons } from 'woocommerce/app/store-stats/constants';
-import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
+import { topProducts, topCategories, topCoupons } from 'woocommerce/app/store-stats/constants';
+import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import List from './store-stats-list';
+import Module from './store-stats-module';
+import { getQueries } from './utils';
 
 const listType = {
 	products: topProducts,

--- a/client/extensions/woocommerce/app/store-stats/referrers/chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/chart/index.js
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { referrerChartTabs as tabs } from 'woocommerce/app/store-stats/constants';
 import StoreStatsChart from 'woocommerce/app/store-stats/store-stats-chart';
+import { formatValue } from 'woocommerce/app/store-stats/utils';
 import Tabs from 'calypso/my-sites/stats/stats-tabs';
 import Tab from 'calypso/my-sites/stats/stats-tabs/tab';
-import { formatValue } from 'woocommerce/app/store-stats/utils';
-import { referrerChartTabs as tabs } from 'woocommerce/app/store-stats/constants';
 import getStoreReferrersByReferrer from 'calypso/state/selectors/get-store-referrers-by-referrer';
 
 class Chart extends Component {

--- a/client/extensions/woocommerce/app/store-stats/referrers/helpers.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/helpers.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { sortBy } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -1,33 +1,25 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getEndPeriod, getWidgetPath } from 'woocommerce/app/store-stats/utils';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import titlecase from 'to-title-case';
+import { UNITS, noDataMsg } from 'woocommerce/app/store-stats/constants';
+import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
+import Module from 'woocommerce/app/store-stats/store-stats-module';
 import StoreStatsPeriodNav from 'woocommerce/app/store-stats/store-stats-period-nav';
+import StoreStatsReferrerConvWidget from 'woocommerce/app/store-stats/store-stats-referrer-conv-widget';
+import StoreStatsReferrerWidget from 'woocommerce/app/store-stats/store-stats-referrer-widget';
+import { getEndPeriod, getWidgetPath } from 'woocommerce/app/store-stats/utils';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
-import Module from 'woocommerce/app/store-stats/store-stats-module';
 import SearchCard from 'calypso/components/search-card';
-import StoreStatsReferrerWidget from 'woocommerce/app/store-stats/store-stats-referrer-widget';
-import StoreStatsReferrerConvWidget from 'woocommerce/app/store-stats/store-stats-referrer-conv-widget';
-import { sortBySales } from 'woocommerce/app/store-stats/referrers/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import titlecase from 'to-title-case';
 import getStoreReferrersByDate from 'calypso/state/selectors/get-store-referrers-by-date';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Chart from './chart';
-import { UNITS, noDataMsg } from 'woocommerce/app/store-stats/constants';
 
 const STAT_TYPE = 'statsStoreReferrers';
 const LIMIT = 10;

--- a/client/extensions/woocommerce/app/store-stats/referrers/test/helpers.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/test/helpers.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { sortBySales } from '../helpers';
 
 describe( 'sortBySales', () => {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import page from 'page';
-import { findIndex, find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { findIndex, find } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { UNITS } from 'woocommerce/app/store-stats/constants';
+import { getWidgetPath, formatValue } from 'woocommerce/app/store-stats/utils';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import ElementChart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { recordTrack } from 'woocommerce/lib/analytics';
-import { getWidgetPath, formatValue } from 'woocommerce/app/store-stats/utils';
-import { UNITS } from 'woocommerce/app/store-stats/constants';
 
 class StoreStatsChart extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import Table from 'woocommerce/components/table';
-import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
+import TableRow from 'woocommerce/components/table/table-row';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { formatValue } from '../utils';
 
 const StoreStatsList = ( { data, values } ) => {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { isEqual } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import ErrorPanel from 'calypso/my-sites/stats/stats-error';
+import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
 } from 'calypso/state/stats/lists/selectors';
-import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
-import ErrorPanel from 'calypso/my-sites/stats/stats-error';
 
 class StoreStatsModule extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/index.js
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { UNITS, chartTabs as tabs } from 'woocommerce/app/store-stats/constants';
 import StoreStatsChart from 'woocommerce/app/store-stats/store-stats-chart';
+import { formatValue } from 'woocommerce/app/store-stats/utils';
 import Delta from 'woocommerce/components/delta';
-import { getPeriodFormat } from 'calypso/state/stats/lists/utils';
-import { getDelta } from '../utils';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Tabs from 'calypso/my-sites/stats/stats-tabs';
+import Tab from 'calypso/my-sites/stats/stats-tabs/tab';
 import {
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
-import Tabs from 'calypso/my-sites/stats/stats-tabs';
-import Tab from 'calypso/my-sites/stats/stats-tabs/tab';
-import { UNITS, chartTabs as tabs } from 'woocommerce/app/store-stats/constants';
-import { formatValue } from 'woocommerce/app/store-stats/utils';
+import { getPeriodFormat } from 'calypso/state/stats/lists/utils';
+import { getDelta } from '../utils';
 
 class StoreStatsOrdersChart extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import PropTypes from 'prop-types';
 import qs from 'qs';
-
-/**
- * Internal dependencies
- */
+import React, { Fragment } from 'react';
+import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
+import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
-import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DatePicker from 'calypso/my-sites/stats/stats-date-picker';
-import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
+import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
 
 const goBack = ( unit, slug, queryParams ) => {
 	const { startDate } = queryParams;

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-conv-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-conv-widget/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import TableRow from 'woocommerce/components/table/table-row';
-import TableItem from 'woocommerce/components/table/table-item';
+import React, { Fragment } from 'react';
 import { formatValue } from 'woocommerce/app/store-stats/utils';
+import TableItem from 'woocommerce/components/table/table-item';
+import TableRow from 'woocommerce/components/table/table-row';
 import StoreStatsReferrerWidgetBase from '../store-stats-referrer-widget-base';
 
 const StoreStatsReferrerConvWidget = ( props ) => {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget-base/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget-base/index.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { Card } from '@automattic/components';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
-import { Card } from '@automattic/components';
-import ErrorPanel from 'calypso/my-sites/stats/stats-error';
-import { getWidgetPath } from 'woocommerce/app/store-stats/utils';
-import Pagination from 'calypso/components/pagination';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Pagination from 'calypso/components/pagination';
+import ErrorPanel from 'calypso/my-sites/stats/stats-error';
 import getStoreReferrersByDate from 'calypso/state/selectors/get-store-referrers-by-date';
 
 class StoreStatsReferrerWidgetBase extends Component {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import StoreStatsReferrerWidgetBase from '../store-stats-referrer-widget-base';
-import TableRow from 'woocommerce/components/table/table-row';
-import TableItem from 'woocommerce/components/table/table-item';
+import React, { Fragment } from 'react';
 import { formatValue } from 'woocommerce/app/store-stats/utils';
+import TableItem from 'woocommerce/components/table/table-item';
+import TableRow from 'woocommerce/components/table/table-row';
+import StoreStatsReferrerWidgetBase from '../store-stats-referrer-widget-base';
 
 const StoreStatsReferrerWidget = ( props ) => {
 	const { translate } = props;

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { connect } from 'react-redux';
-import { findIndex } from 'lodash';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import Delta from 'woocommerce/components/delta';
-import { formatValue, getDelta } from '../utils';
-import { getPeriodFormat } from 'calypso/state/stats/lists/utils';
-import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+import { findIndex } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { UNITS } from 'woocommerce/app/store-stats/constants';
 import Sparkline from 'woocommerce/components/d3/sparkline';
+import Delta from 'woocommerce/components/delta';
 import Table from 'woocommerce/components/table';
 import TableItem from 'woocommerce/components/table/table-item';
 import TableRow from 'woocommerce/components/table/table-row';
-import { UNITS } from 'woocommerce/app/store-stats/constants';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+import { getPeriodFormat } from 'calypso/state/stats/lists/utils';
+import { formatValue, getDelta } from '../utils';
 
 class StoreStatsWidgetList extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/store-stats/test/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/test/utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { assert, expect } from 'chai';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import { UNITS } from '../constants';
 import {
 	calculateDelta,

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import { find, includes, forEach, findIndex, round } from 'lodash';
+import formatCurrency from '@automattic/format-currency';
 import classnames from 'classnames';
 import { translate, numberFormat } from 'i18n-calypso';
-import qs from 'qs';
-import formatCurrency from '@automattic/format-currency';
+import { find, includes, forEach, findIndex, round } from 'lodash';
 import moment from 'moment'; // No localization needed in this file.
-
-/**
- * Internal dependencies
- */
+import qs from 'qs';
 import { UNITS } from './constants';
 
 /**

--- a/client/extensions/woocommerce/components/action-header/actions.js
+++ b/client/extensions/woocommerce/components/action-header/actions.js
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import ReactDom from 'react-dom';
-import PropTypes from 'prop-types';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { debounce } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import afterLayoutFlush from 'calypso/lib/after-layout-flush';
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import ReactDom from 'react-dom';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import SplitButton from 'calypso/components/split-button';
+import afterLayoutFlush from 'calypso/lib/after-layout-flush';
 
 class ActionButtons extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import SiteIcon from 'calypso/blocks/site-icon';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
-import ActionButtons from './actions';
-import { Button } from '@automattic/components';
 import { getSelectedSiteWithFallback } from 'calypso/state/sites/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import SiteIcon from 'calypso/blocks/site-icon';
+import ActionButtons from './actions';
 
 class ActionHeader extends React.Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/d3/base/index.js
+++ b/client/extensions/woocommerce/components/d3/base/index.js
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { select as d3Select } from 'd3-selection';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class D3Base extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/d3/base/test/index.js
+++ b/client/extensions/woocommerce/components/d3/base/test/index.js
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import D3Base from '../index';
 
 const noop = () => {};

--- a/client/extensions/woocommerce/components/d3/sparkline/index.js
+++ b/client/extensions/woocommerce/components/d3/sparkline/index.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { extent as d3Extent } from 'd3-array';
 import { scaleLinear as d3ScaleLinear } from 'd3-scale';
 import { line as d3Line } from 'd3-shape';
-import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 import D3Base from 'woocommerce/components/d3/base';
-
-/**
- * Internal dependencies
- */
 
 const Sparkline = ( {
 	aspectRatio,

--- a/client/extensions/woocommerce/components/d3/sparkline/test/index.jsx
+++ b/client/extensions/woocommerce/components/d3/sparkline/test/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import Sparkline from '../index';
 
 describe( 'Sparkline', () => {

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Gridicon from 'calypso/components/gridicon';
 
 export default class Delta extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/components/table/docs/example.js
+++ b/client/extensions/woocommerce/components/table/docs/example.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import React, { Component } from 'react';
 import Table from 'woocommerce/components/table';
-import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
-import Gridicon from 'calypso/components/gridicon';
+import TableRow from 'woocommerce/components/table/table-row';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import Gridicon from 'calypso/components/gridicon';
 
 class Example extends Component {
 	state = {

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const Table = ( {
 	className,

--- a/client/extensions/woocommerce/components/table/table-item/index.js
+++ b/client/extensions/woocommerce/components/table/table-item/index.js
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function getScope( isHeader, isRowHeader ) {
 	if ( isHeader ) {

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
 
 const TableRow = ( { className, isHeader, href, children, ...props } ) => {

--- a/client/extensions/woocommerce/components/text-control/index.js
+++ b/client/extensions/woocommerce/components/text-control/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import classNames from 'classnames';
+import React, { Component } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
-
-/**
- * Internal dependencies
- */
 import FormLabel from 'calypso/components/forms/form-label';
 
 /*

--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import ExternalLink from 'calypso/components/external-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
 import WooCommerceLogo from '../woocommerce-logo';
 
 class WooCommerceColophon extends React.Component {

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 
 import './style.scss';
 

--- a/client/extensions/woocommerce/components/woocommerce-logo/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-logo/index.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 const WooCommerceLogo = ( { height = 32, width = 120 } ) => {
 	return (

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -1,29 +1,17 @@
-/**
- * External dependencies
- */
-
+import { translate } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import EmptyContent from 'calypso/components/empty-content';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import App from './app';
 import Dashboard from './app/dashboard';
-import EmptyContent from 'calypso/components/empty-content';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import StatsController from './app/store-stats/controller';
-import StoreSidebar from './store-sidebar';
 import { bumpStat } from './lib/analytics';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getSiteOption } from 'calypso/state/sites/selectors';
-import isSiteStore from 'calypso/state/selectors/is-site-store';
-
-/**
- * Style dependencies
- */
+import StoreSidebar from './store-sidebar';
 import './style.scss';
 
 const getStorePages = () => {

--- a/client/extensions/woocommerce/lib/analytics/index.js
+++ b/client/extensions/woocommerce/lib/analytics/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import * as tracks from 'calypso/lib/analytics/tracks';
 import * as tracksUtils from './tracks-utils';
 const debug = debugFactory( 'woocommerce:analytics' );

--- a/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-
-/**
- * Internal dependencies
- */
 import { recordTrack } from '../tracks-utils';
 
 const noop = () => {};

--- a/client/extensions/woocommerce/lib/analytics/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/tracks-utils.js
@@ -1,12 +1,5 @@
-/**
- * Internal dependencies
- */
-import { bumpStat } from 'calypso/state/analytics/actions';
-
-/**
- * External dependencies
- */
 import { startsWith } from 'lodash';
+import { bumpStat } from 'calypso/state/analytics/actions';
 
 export const recordTrack = ( tracks, debug ) => ( eventName, eventProperties ) => {
 	if ( ! startsWith( eventName, 'calypso_woocommerce_' ) ) {

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -1,21 +1,13 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { getSelectedSiteWithFallback } from 'calypso/state/sites/selectors';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import { getSelectedSiteWithFallback } from 'calypso/state/sites/selectors';
 import StoreGroundControl from './store-ground-control';
 
 class StoreSidebar extends Component {

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
-import Gridicon from 'calypso/components/gridicon';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import Site from 'calypso/blocks/site';
+import Gridicon from 'calypso/components/gridicon';
 import { getSiteHomeUrl } from 'calypso/state/sites/selectors';
 
 const StoreGroundControl = ( { site, siteHomeUrl, translate } ) => {

--- a/client/extensions/wp-super-cache/app/constants.js
+++ b/client/extensions/wp-super-cache/app/constants.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { translate } from 'i18n-calypso';
 
 export const WPSC_MIN_VERSION = '1.5.4';

--- a/client/extensions/wp-super-cache/app/controller.js
+++ b/client/extensions/wp-super-cache/app/controller.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import React from 'react';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import WPSuperCache from './main';
 

--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -1,34 +1,26 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import titlecase from 'to-title-case';
 import ExtensionRedirect from 'calypso/blocks/extension-redirect';
+import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AdvancedTab from '../components/advanced';
 import CdnTab from '../components/cdn';
 import ContentsTab from '../components/contents';
+import QueryStatus from '../components/data/query-status';
 import DebugTab from '../components/debug';
 import EasyTab from '../components/easy';
-import Main from 'calypso/components/main';
 import Navigation from '../components/navigation';
-import Notice from 'calypso/components/notice';
 import PluginsTab from '../components/plugins';
 import PreloadTab from '../components/preload';
-import QueryStatus from '../components/data/query-status';
-import { Tabs, WPSC_MIN_VERSION } from './constants';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getStatus } from '../state/status/selectors';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import titlecase from 'to-title-case';
+import { Tabs, WPSC_MIN_VERSION } from './constants';
 
 class WPSuperCache extends Component {
 	static propTypes = {

--- a/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { get, pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { get, pick } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import FormLabel from 'calypso/components/forms/form-label';
 import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 

--- a/client/extensions/wp-super-cache/components/advanced/advanced.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/advanced.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { pick } from 'lodash';
+import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';

--- a/client/extensions/wp-super-cache/components/advanced/cache-location.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/cache-location.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { pick } from 'lodash';
+import React from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';

--- a/client/extensions/wp-super-cache/components/advanced/caching.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/caching.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { pick } from 'lodash';
+import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/extensions/wp-super-cache/components/advanced/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/directly-cached-files.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import { pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { pick } from 'lodash';
+import React, { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';

--- a/client/extensions/wp-super-cache/components/advanced/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/expiry-time.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
 import { pick } from 'lodash';
 import moment from 'moment';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import React from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';

--- a/client/extensions/wp-super-cache/components/advanced/fix-config.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/fix-config.jsx
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
-import { restoreSettings } from '../../state/settings/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { restoreSettings } from '../../state/settings/actions';
 import { isRestoringSettings } from '../../state/settings/selectors';
 
 class FixConfig extends Component {

--- a/client/extensions/wp-super-cache/components/advanced/index.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/index.jsx
@@ -1,14 +1,10 @@
-/**
- * External dependencies
- */
-
+import { flowRight, pick } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { flowRight, pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getStatus } from '../../state/status/selectors';
+import QueryStatus from '../data/query-status';
+import WrapSettingsForm from '../wrap-settings-form';
 import AcceptedFilenames from './accepted-filenames';
 import Advanced from './advanced';
 import CacheLocation from './cache-location';
@@ -18,11 +14,7 @@ import ExpiryTime from './expiry-time';
 import FixConfig from './fix-config';
 import LockDown from './lock-down';
 import Miscellaneous from './miscellaneous';
-import QueryStatus from '../data/query-status';
 import RejectedUserAgents from './rejected-user-agents';
-import WrapSettingsForm from '../wrap-settings-form';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getStatus } from '../../state/status/selectors';
 
 const AdvancedTab = ( {
 	fields: { is_cache_enabled, is_super_cache_enabled },

--- a/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
-import SectionHeader from 'calypso/components/section-header';
-import Gridicon from 'calypso/components/gridicon';
+import { ToggleControl } from '@wordpress/components';
+import { pick } from 'lodash';
+import React from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import WrapSettingsForm from '../wrap-settings-form';
+import Gridicon from 'calypso/components/gridicon';
 import Notice from 'calypso/components/notice';
+import SectionHeader from 'calypso/components/section-header';
+import WrapSettingsForm from '../wrap-settings-form';
 
 const LockDown = ( {
 	fields: { cache_lock_down },

--- a/client/extensions/wp-super-cache/components/advanced/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/miscellaneous.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { pick } from 'lodash';
+import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import SectionHeader from 'calypso/components/section-header';
 import Notice from 'calypso/components/notice';
+import SectionHeader from 'calypso/components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
 const Miscellaneous = ( {

--- a/client/extensions/wp-super-cache/components/advanced/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/rejected-user-agents.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { pick } from 'lodash';
+import React from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';

--- a/client/extensions/wp-super-cache/components/cdn/index.jsx
+++ b/client/extensions/wp-super-cache/components/cdn/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { get, pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { get, pick } from 'lodash';
+import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/extensions/wp-super-cache/components/contents/cache-stats.jsx
+++ b/client/extensions/wp-super-cache/components/contents/cache-stats.jsx
@@ -1,21 +1,13 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FoldableCard from 'calypso/components/foldable-card';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { deleteFile } from '../../state/stats/actions';
 import { isDeletingFile } from '../../state/stats/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function getAge( lower, upper ) {
 	if ( lower && upper ) {

--- a/client/extensions/wp-super-cache/components/contents/index.jsx
+++ b/client/extensions/wp-super-cache/components/contents/index.jsx
@@ -1,24 +1,16 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { flowRight, get, isEmpty, pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
-import CacheStats from './cache-stats';
-import QueryStats from '../data/query-stats';
+import { flowRight, get, isEmpty, pick } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
-import WrapSettingsForm from '../wrap-settings-form';
+import { getSiteTitle, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { generateStats } from '../../state/stats/actions';
-import { getSiteTitle, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { getStats, isGeneratingStats } from '../../state/stats/selectors';
+import QueryStats from '../data/query-stats';
+import WrapSettingsForm from '../wrap-settings-form';
+import CacheStats from './cache-stats';
 
 class ContentsTab extends Component {
 	static propTypes = {

--- a/client/extensions/wp-super-cache/components/data/query-plugins/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-plugins/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isRequestingPlugins } from '../../../state/plugins/selectors';
 import { requestPlugins } from '../../../state/plugins/actions';
+import { isRequestingPlugins } from '../../../state/plugins/selectors';
 
 class QueryPlugins extends Component {
 	UNSAFE_componentWillMount() {

--- a/client/extensions/wp-super-cache/components/data/query-settings/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-settings/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isRequestingSettings } from '../../../state/settings/selectors';
 import { requestSettings } from '../../../state/settings/actions';
+import { isRequestingSettings } from '../../../state/settings/selectors';
 
 class QuerySettings extends Component {
 	UNSAFE_componentWillMount() {

--- a/client/extensions/wp-super-cache/components/data/query-stats/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-stats/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isGeneratingStats } from '../../../state/stats/selectors';
 import { generateStats } from '../../../state/stats/actions';
+import { isGeneratingStats } from '../../../state/stats/selectors';
 
 class QueryStats extends Component {
 	UNSAFE_componentWillMount() {

--- a/client/extensions/wp-super-cache/components/data/query-status/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-status/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isRequestingStatus } from '../../../state/status/selectors';
 import { requestStatus } from '../../../state/status/actions';
+import { isRequestingStatus } from '../../../state/status/selectors';
 
 class QueryStatus extends Component {
 	UNSAFE_componentWillMount() {

--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
 import { pick } from 'lodash';
 import moment from 'moment';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';

--- a/client/extensions/wp-super-cache/components/easy/index.jsx
+++ b/client/extensions/wp-super-cache/components/easy/index.jsx
@@ -1,28 +1,21 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { flowRight, get, isEmpty, pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { isHttps } from 'calypso/lib/url';
 import { Button, Card } from '@automattic/components';
-import Notice from 'calypso/components/notice';
+import { ToggleControl } from '@wordpress/components';
+import { flowRight, get, isEmpty, pick } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import Gridicon from 'calypso/components/gridicon';
-import QueryStatus from '../data/query-status';
+import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
-import WrapSettingsForm from '../wrap-settings-form';
-import { testCache } from '../../state/cache/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isHttps } from 'calypso/lib/url';
 import { getSiteTitle } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { testCache } from '../../state/cache/actions';
 import { getCacheTestResults, isTestingCache } from '../../state/cache/selectors';
 import { getStatus } from '../../state/status/selectors';
+import QueryStatus from '../data/query-status';
+import WrapSettingsForm from '../wrap-settings-form';
 
 class EasyTab extends Component {
 	static propTypes = {

--- a/client/extensions/wp-super-cache/components/navigation/index.jsx
+++ b/client/extensions/wp-super-cache/components/navigation/index.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import HeaderCake from 'calypso/components/header-cake';
 import SectionNav from 'calypso/components/section-nav';
-import SectionNavTabs from 'calypso/components/section-nav/tabs';
 import SectionNavTabItem from 'calypso/components/section-nav/item';
+import SectionNavTabs from 'calypso/components/section-nav/tabs';
 import { addSiteFragment } from 'calypso/lib/route';
 import versionCompare from 'calypso/lib/version-compare';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { Tabs } from '../../app/constants';
 
 const Navigation = ( { activeTab, pluginVersion, siteSlug, translate } ) => (

--- a/client/extensions/wp-super-cache/components/plugins/index.jsx
+++ b/client/extensions/wp-super-cache/components/plugins/index.jsx
@@ -1,24 +1,17 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { flowRight, map, mapValues, pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { flowRight, map, mapValues, pick } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
-import SectionHeader from 'calypso/components/section-header';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import WrapSettingsForm from '../wrap-settings-form';
-import QueryPlugins from '../data/query-plugins';
+import SectionHeader from 'calypso/components/section-header';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { togglePlugin } from '../../state/plugins/actions';
 import { isRequestingPlugins, isTogglingPlugin, getPlugins } from '../../state/plugins/selectors';
+import QueryPlugins from '../data/query-plugins';
+import WrapSettingsForm from '../wrap-settings-form';
 
 class PluginsTab extends Component {
 	static propTypes = {

--- a/client/extensions/wp-super-cache/components/preload/index.jsx
+++ b/client/extensions/wp-super-cache/components/preload/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { flowRight, get, pick } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, pick } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
@@ -17,13 +10,13 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
-import QueryStatus from '../data/query-status';
 import SectionHeader from 'calypso/components/section-header';
-import WrapSettingsForm from '../wrap-settings-form';
-import { cancelPreloadCache, preloadCache } from '../../state/cache/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { cancelPreloadCache, preloadCache } from '../../state/cache/actions';
 import { isPreloadingCache } from '../../state/cache/selectors';
 import { getStatus } from '../../state/status/selectors';
+import QueryStatus from '../data/query-status';
+import WrapSettingsForm from '../wrap-settings-form';
 
 /**
  * Render cache preload interval number input

--- a/client/extensions/wp-super-cache/components/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/components/wrap-settings-form.jsx
@@ -1,29 +1,21 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import { flowRight, isEqual, omit, pick } from 'lodash';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import { flowRight, isEqual, omit, pick } from 'lodash';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { protectForm } from 'calypso/lib/protect-form';
 import trackForm from 'calypso/lib/track-form';
-import QuerySettings from './data/query-settings';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { deleteCache } from '../state/cache/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { saveSettings } from '../state/settings/actions';
 import { isCacheDeleteSuccessful, isDeletingCache } from '../state/cache/selectors';
+import { saveSettings } from '../state/settings/actions';
 import {
 	getSettings,
 	isRequestingSettings,
 	isSavingSettings,
 	isSettingsSaveSuccessful,
 } from '../state/settings/selectors';
+import QuerySettings from './data/query-settings';
 
 const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 	class WrappedSettingsForm extends Component {

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -1,22 +1,10 @@
-/**
- * External dependencies
- */
-
-import page from 'page';
 import { compact, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
-import { settings } from './app/controller';
-import { Tabs } from './app/constants';
+import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
+import { Tabs } from './app/constants';
+import { settings } from './app/controller';
 import reducer from './state/reducer';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default async function ( _, addReducer ) {

--- a/client/extensions/wp-super-cache/state/cache/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/actions.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
-
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSiteTitle } from 'calypso/state/sites/selectors';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,
@@ -19,8 +13,6 @@ import {
 	WP_SUPER_CACHE_TEST_CACHE_FAILURE,
 	WP_SUPER_CACHE_TEST_CACHE_SUCCESS,
 } from '../action-types';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSiteTitle } from 'calypso/state/sites/selectors';
 
 /*
  * Tests the cache for a site.

--- a/client/extensions/wp-super-cache/state/cache/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/reducer.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { combineReducers } from 'calypso/state/utils';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,

--- a/client/extensions/wp-super-cache/state/cache/selectors.js
+++ b/client/extensions/wp-super-cache/state/cache/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 function getCacheState( state ) {

--- a/client/extensions/wp-super-cache/state/cache/test/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/test/actions.js
@@ -1,11 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import useNock from 'calypso/test-helpers/use-nock';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,
@@ -18,8 +13,6 @@ import {
 	WP_SUPER_CACHE_TEST_CACHE_SUCCESS,
 } from '../../action-types';
 import { cancelPreloadCache, deleteCache, preloadCache, testCache } from '../actions';
-import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'actions', () => {
 	let spy;

--- a/client/extensions/wp-super-cache/state/cache/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/test/reducer.js
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,
@@ -19,7 +13,6 @@ import {
 	WP_SUPER_CACHE_TEST_CACHE_SUCCESS,
 } from '../../action-types';
 import reducer from '../reducer';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;

--- a/client/extensions/wp-super-cache/state/cache/test/selectors.js
+++ b/client/extensions/wp-super-cache/state/cache/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	isCacheDeleteSuccessful,
 	isDeletingCache,

--- a/client/extensions/wp-super-cache/state/plugins/actions.js
+++ b/client/extensions/wp-super-cache/state/plugins/actions.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
 	WP_SUPER_CACHE_REQUEST_PLUGINS,
@@ -17,7 +10,6 @@ import {
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_FAILURE,
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS,
 } from '../action-types';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 
 /**
  * Returns an action object to be used in signalling that WPSC plugins have been received.

--- a/client/extensions/wp-super-cache/state/plugins/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/reducer.js
@@ -1,9 +1,4 @@
-/**
- * Internal dependencies
- */
-
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
 	WP_SUPER_CACHE_REQUEST_PLUGINS,
@@ -13,6 +8,7 @@ import {
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_FAILURE,
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS,
 } from '../action-types';
+import { itemsSchema } from './schema';
 
 /**
  * Returns the updated plugins requesting state after an action has been dispatched.

--- a/client/extensions/wp-super-cache/state/plugins/selectors.js
+++ b/client/extensions/wp-super-cache/state/plugins/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 function getPluginsState( state ) {

--- a/client/extensions/wp-super-cache/state/plugins/test/actions.js
+++ b/client/extensions/wp-super-cache/state/plugins/test/actions.js
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
+import useNock from 'calypso/test-helpers/use-nock';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
 	WP_SUPER_CACHE_REQUEST_PLUGINS,
@@ -17,8 +12,6 @@ import {
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS,
 } from '../../action-types';
 import { receivePlugins, requestPlugins, togglePlugin } from '../actions';
-import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'actions', () => {
 	let spy;

--- a/client/extensions/wp-super-cache/state/plugins/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/test/reducer.js
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { serialize, deserialize } from 'calypso/state/utils';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
 	WP_SUPER_CACHE_REQUEST_PLUGINS,
@@ -17,8 +12,6 @@ import {
 	WP_SUPER_CACHE_TOGGLE_PLUGIN_SUCCESS,
 } from '../../action-types';
 import { items, requesting, toggling } from '../reducer';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
-import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;

--- a/client/extensions/wp-super-cache/state/plugins/test/selectors.js
+++ b/client/extensions/wp-super-cache/state/plugins/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getPlugins, isRequestingPlugins, isTogglingPlugin } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/extensions/wp-super-cache/state/reducer.js
+++ b/client/extensions/wp-super-cache/state/reducer.js
@@ -1,13 +1,10 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
-import cache from './cache/reducer';
 import { combineReducers } from 'calypso/state/utils';
+import cache from './cache/reducer';
 import plugins from './plugins/reducer';
-import status from './status/reducer';
 import settings from './settings/reducer';
 import stats from './stats/reducer';
+import status from './status/reducer';
 
 export default withStorageKey(
 	'wp-super-cache',

--- a/client/extensions/wp-super-cache/state/settings/actions.js
+++ b/client/extensions/wp-super-cache/state/settings/actions.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
-
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSiteTitle } from 'calypso/state/sites/selectors';
 import {
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
 	WP_SUPER_CACHE_REQUEST_SETTINGS,
@@ -20,10 +14,8 @@ import {
 	WP_SUPER_CACHE_SAVE_SETTINGS_FAILURE,
 	WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
 } from '../action-types';
-import { normalizeSettings, sanitizeSettings } from './utils';
 import { requestStatus } from '../status/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSiteTitle } from 'calypso/state/sites/selectors';
+import { normalizeSettings, sanitizeSettings } from './utils';
 
 /**
  * Returns an action object to be used in signalling that settings have been received.

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,8 +1,4 @@
-/**
- * Internal dependencies
- */
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
@@ -16,6 +12,7 @@ import {
 	WP_SUPER_CACHE_SAVE_SETTINGS_FAILURE,
 	WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
 } from '../action-types';
+import { itemsSchema } from './schema';
 
 /**
  * Returns the updated requesting state after an action has been dispatched.

--- a/client/extensions/wp-super-cache/state/settings/selectors.js
+++ b/client/extensions/wp-super-cache/state/settings/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 function getSettingsState( state ) {

--- a/client/extensions/wp-super-cache/state/settings/test/actions.js
+++ b/client/extensions/wp-super-cache/state/settings/test/actions.js
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
+import useNock from 'calypso/test-helpers/use-nock';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
 	WP_SUPER_CACHE_REQUEST_SETTINGS,
@@ -20,8 +15,6 @@ import {
 	WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
 } from '../../action-types';
 import { receiveSettings, requestSettings, restoreSettings, saveSettings } from '../actions';
-import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'actions', () => {
 	let spy;

--- a/client/extensions/wp-super-cache/state/settings/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/test/reducer.js
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { serialize, deserialize } from 'calypso/state/utils';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
@@ -21,8 +16,6 @@ import {
 	WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
 } from '../../action-types';
 import reducer, { items, restoring } from '../reducer';
-import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;

--- a/client/extensions/wp-super-cache/state/settings/test/selectors.js
+++ b/client/extensions/wp-super-cache/state/settings/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	isRequestingSettings,
 	isRestoringSettings,

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { mapValues } from 'lodash';
 
 /**

--- a/client/extensions/wp-super-cache/state/stats/actions.js
+++ b/client/extensions/wp-super-cache/state/stats/actions.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
-
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import wp from 'calypso/lib/wp';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSiteTitle } from 'calypso/state/sites/selectors';
 import {
 	WP_SUPER_CACHE_DELETE_FILE,
 	WP_SUPER_CACHE_DELETE_FILE_FAILURE,
@@ -16,8 +10,6 @@ import {
 	WP_SUPER_CACHE_GENERATE_STATS_FAILURE,
 	WP_SUPER_CACHE_GENERATE_STATS_SUCCESS,
 } from '../action-types';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSiteTitle } from 'calypso/state/sites/selectors';
 
 /*
  * Retrieves stats for a site.

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { statsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
 	WP_SUPER_CACHE_DELETE_FILE,
@@ -17,6 +9,7 @@ import {
 	WP_SUPER_CACHE_GENERATE_STATS_FAILURE,
 	WP_SUPER_CACHE_GENERATE_STATS_SUCCESS,
 } from '../action-types';
+import { statsSchema } from './schema';
 
 /**
  * Returns the updated generating state after an action has been dispatched.

--- a/client/extensions/wp-super-cache/state/stats/selectors.js
+++ b/client/extensions/wp-super-cache/state/stats/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 function getStatsState( state ) {

--- a/client/extensions/wp-super-cache/state/stats/test/actions.js
+++ b/client/extensions/wp-super-cache/state/stats/test/actions.js
@@ -1,11 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import useNock from 'calypso/test-helpers/use-nock';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_DELETE_FILE,
 	WP_SUPER_CACHE_DELETE_FILE_FAILURE,
@@ -15,8 +10,6 @@ import {
 	WP_SUPER_CACHE_GENERATE_STATS_SUCCESS,
 } from '../../action-types';
 import { deleteFile, generateStats } from '../actions';
-import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'actions', () => {
 	let spy;

--- a/client/extensions/wp-super-cache/state/stats/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/test/reducer.js
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { serialize, deserialize } from 'calypso/state/utils';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
 	WP_SUPER_CACHE_DELETE_FILE,
@@ -17,8 +12,6 @@ import {
 	WP_SUPER_CACHE_GENERATE_STATS_SUCCESS,
 } from '../../action-types';
 import reducer, { generating } from '../reducer';
-import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;

--- a/client/extensions/wp-super-cache/state/stats/test/selectors.js
+++ b/client/extensions/wp-super-cache/state/stats/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getStats, isDeletingFile, isGeneratingStats } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/extensions/wp-super-cache/state/status/actions.js
+++ b/client/extensions/wp-super-cache/state/status/actions.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import wp from 'calypso/lib/wp';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,

--- a/client/extensions/wp-super-cache/state/status/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/reducer.js
@@ -1,13 +1,10 @@
-/**
- * Internal dependencies
- */
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,
 	WP_SUPER_CACHE_REQUEST_STATUS,
 	WP_SUPER_CACHE_REQUEST_STATUS_FAILURE,
 } from '../action-types';
+import { itemsSchema } from './schema';
 
 /**
  * Returns the updated requesting state after an action has been dispatched.

--- a/client/extensions/wp-super-cache/state/status/selectors.js
+++ b/client/extensions/wp-super-cache/state/status/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 /**

--- a/client/extensions/wp-super-cache/state/status/test/actions.js
+++ b/client/extensions/wp-super-cache/state/status/test/actions.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import useNock from 'calypso/test-helpers/use-nock';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,
 	WP_SUPER_CACHE_REQUEST_STATUS,
 	WP_SUPER_CACHE_REQUEST_STATUS_FAILURE,
 } from '../../action-types';
 import { receiveStatus, requestStatus } from '../actions';
-import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'actions', () => {
 	let spy;

--- a/client/extensions/wp-super-cache/state/status/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/test/reducer.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { serialize, deserialize } from 'calypso/state/utils';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,
 	WP_SUPER_CACHE_REQUEST_STATUS,
 	WP_SUPER_CACHE_REQUEST_STATUS_FAILURE,
 } from '../../action-types';
 import reducer from '../reducer';
-import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;

--- a/client/extensions/wp-super-cache/state/status/test/selectors.js
+++ b/client/extensions/wp-super-cache/state/status/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { isRequestingStatus, getStatus } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import Settings from '../components/settings';
 
 export const renderTab = ( component ) => ( context, next ) => {

--- a/client/extensions/zoninator/app/util.js
+++ b/client/extensions/zoninator/app/util.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { find, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getSections } from 'calypso/sections-helper';
 
 const getSettingsPath = () => {

--- a/client/extensions/zoninator/components/data/query-feed/index.jsx
+++ b/client/extensions/zoninator/components/data/query-feed/index.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { requestFeed } from '../../../state/feeds/actions';
 
 class QueryFeed extends PureComponent {

--- a/client/extensions/zoninator/components/data/query-zones/index.jsx
+++ b/client/extensions/zoninator/components/data/query-zones/index.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
 import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { isRequestingZones } from '../../../state/zones/selectors';
 import { requestZones } from '../../../state/zones/actions';
+import { isRequestingZones } from '../../../state/zones/selectors';
 
 class QueryZones extends Component {
 	UNSAFE_componentWillMount() {

--- a/client/extensions/zoninator/components/data/zone-lock/index.jsx
+++ b/client/extensions/zoninator/components/data/zone-lock/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import getRequest from 'calypso/state/selectors/get-request';
 import { requestLock, resetLock } from '../../../state/locks/actions';
 import { created, expires, maxLockPeriod } from '../../../state/locks/selectors';

--- a/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
 import SectionHeader from 'calypso/components/section-header';
 import PostsList from './posts-list';

--- a/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
+import { setUrlScheme } from 'calypso/lib/url';
 import { getEditorPath } from 'calypso/state/editor/selectors';
 import { getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import { isSitePreviewable } from 'calypso/state/sites/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { setPreviewUrl } from 'calypso/state/ui/preview/actions';
-import { setUrlScheme } from 'calypso/lib/url';
 
 class PostCard extends Component {
 	static propTypes = {

--- a/client/extensions/zoninator/components/forms/zone-content-form/post-placeholder.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/post-placeholder.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import SectionHeader from 'calypso/components/section-header';
 
 const PostPlaceholder = () => <SectionHeader className="zone-content-form__placeholder" />;

--- a/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
@@ -1,21 +1,13 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { map, times } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SortableList from 'calypso/components/forms/sortable-list';
-import PostCard from './post-card';
-import PostPlaceholder from './post-placeholder';
 import RecentPostsDropdown from '../../recent-posts-dropdown';
 import SearchAutocomplete from './../../search-autocomplete';
+import PostCard from './post-card';
+import PostPlaceholder from './post-placeholder';
 
 class PostsList extends Component {
 	static propTypes = {

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { mapValues, trim } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 import SectionHeader from 'calypso/components/section-header';
-import { CompactCard } from '@automattic/components';
 
 class ZoneDetailsForm extends Component {
 	static propTypes = {

--- a/client/extensions/zoninator/components/recent-posts-dropdown/index.jsx
+++ b/client/extensions/zoninator/components/recent-posts-dropdown/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, flowRight, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { getPostsForQuery } from 'calypso/state/posts/selectors';

--- a/client/extensions/zoninator/components/search-autocomplete/index.jsx
+++ b/client/extensions/zoninator/components/search-autocomplete/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Search from 'calypso/components/search';
 import PostSuggestions from './post-suggestions';
 

--- a/client/extensions/zoninator/components/search-autocomplete/post-suggestions.jsx
+++ b/client/extensions/zoninator/components/search-autocomplete/post-suggestions.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Suggestions } from '@automattic/components';
 import { find, map } from 'lodash';
-
-/**
- * Internal depencencies
- */
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';
 import { getPostsForQuery } from 'calypso/state/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { Suggestions } from '@automattic/components';
 
 class PostSuggestions extends Component {
 	static propTypes = {

--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { connect } from 'react-redux';
 import ExtensionRedirect from 'calypso/blocks/extension-redirect';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -1,23 +1,15 @@
-/**
- * External dependencies
- */
-
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import HeaderCake from 'calypso/components/header-cake';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { settingsPath } from '../../../app/util';
+import { addZone } from '../../../state/zones/actions';
 import { isSavingZone } from '../../../state/zones/selectors';
 import ZoneDetailsForm from '../../forms/zone-details-form';
-import { addZone } from '../../../state/zones/actions';
-import { settingsPath } from '../../../app/util';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 class ZoneCreator extends PureComponent {
 	static propTypes = {

--- a/client/extensions/zoninator/components/settings/zone/delete-zone-dialog.jsx
+++ b/client/extensions/zoninator/components/settings/zone/delete-zone-dialog.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button, Dialog } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const DeleteZoneDialog = ( { onCancel, onConfirm, translate, zoneName } ) => {
 	const buttons = [

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -1,33 +1,25 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import HeaderCake from 'calypso/components/header-cake';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import DeleteZoneDialog from './delete-zone-dialog';
-import QueryFeed from '../../data/query-feed';
-import ZoneContentForm from '../../forms/zone-content-form';
-import ZoneDetailsForm from '../../forms/zone-details-form';
-import ZoneLock from '../../data/zone-lock';
-import ZoneLockWarningNotice from './zone-lock-warning-notice';
-import ZoneNotFound from './zone-not-found';
+import { settingsPath } from '../../../app/util';
 import { saveFeed } from '../../../state/feeds/actions';
-import { deleteZone, saveZone } from '../../../state/zones/actions';
 import { getFeed, isRequestingFeed, isSavingFeed } from '../../../state/feeds/selectors';
 import { blocked, expires } from '../../../state/locks/selectors';
+import { deleteZone, saveZone } from '../../../state/zones/actions';
 import { getZone, isRequestingZones, isSavingZone } from '../../../state/zones/selectors';
-import { settingsPath } from '../../../app/util';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryFeed from '../../data/query-feed';
+import ZoneLock from '../../data/zone-lock';
+import ZoneContentForm from '../../forms/zone-content-form';
+import ZoneDetailsForm from '../../forms/zone-details-form';
+import DeleteZoneDialog from './delete-zone-dialog';
+import ZoneLockWarningNotice from './zone-lock-warning-notice';
+import ZoneNotFound from './zone-not-found';
 
 class Zone extends Component {
 	static propTypes = {

--- a/client/extensions/zoninator/components/settings/zone/zone-lock-warning-notice.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-lock-warning-notice.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { requestFeed } from '../../../state/feeds/actions';
 import { requestLock, resetLock } from '../../../state/locks/actions';
-import { requestZones } from '../../../state/zones/actions';
 import { blocked } from '../../../state/locks/selectors';
+import { requestZones } from '../../../state/zones/actions';
 
 class ZoneLockWarningNotice extends PureComponent {
 	static propTypes = {

--- a/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import EmptyContent from 'calypso/components/empty-content';
 import { settingsPath } from '../../../app/util';
 

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -1,25 +1,17 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight, times } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import HeaderCake from 'calypso/components/header-cake';
 import SectionHeader from 'calypso/components/section-header';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { settingsPath } from '../../../app/util';
+import { getZones, isRequestingZones } from '../../../state/zones/selectors';
 import ZoneItem from './zone-item';
 import ZonePlaceholder from './zone-placeholder';
-import { getZones, isRequestingZones } from '../../../state/zones/selectors';
-import { settingsPath } from '../../../app/util';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 const placeholderCount = 5;
 

--- a/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { settingsPath } from '../../../app/util';
 

--- a/client/extensions/zoninator/components/settings/zones-dashboard/zone-placeholder.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/zone-placeholder.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import React from 'react';
 
 const ZonePlaceholder = () => (
 	<CompactCard>

--- a/client/extensions/zoninator/index.js
+++ b/client/extensions/zoninator/index.js
@@ -1,24 +1,12 @@
-/**
- * External dependencies
- */
-
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
 import { renderTab } from './app/controller';
-import ZoneCreator from './components/settings/zone-creator';
 import Zone from './components/settings/zone';
+import ZoneCreator from './components/settings/zone-creator';
 import ZonesDashboard from './components/settings/zones-dashboard';
 import installActionHandlers from './state/data-layer';
-import { makeLayout, render as clientRender } from 'calypso/controller';
 import reducer from './state/reducer';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default async function ( _, addReducer ) {

--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import { ZONINATOR_REQUEST_FEED, ZONINATOR_SAVE_FEED } from 'zoninator/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { fromApi, toApi } from './util';
 import { updateFeed, updateFeedError } from '../../feeds/actions';
 import { resetLock } from '../../locks/actions';
 import { getZone } from '../../zones/selectors';
-import { ZONINATOR_REQUEST_FEED, ZONINATOR_SAVE_FEED } from 'zoninator/state/action-types';
+import { fromApi, toApi } from './util';
 
 const requestFeedNotice = 'zoninator-request-feed';
 const saveFeedNotice = 'zoninator-save-feed';

--- a/client/extensions/zoninator/state/data-layer/feeds/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/test/index.js
@@ -1,12 +1,9 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
 import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import { updateFeed } from 'zoninator/state/feeds/actions';
+import { resetLock } from 'zoninator/state/locks/actions';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import {
 	announceSuccess,
 	announceFailure,
@@ -16,10 +13,6 @@ import {
 	updateZoneFeed,
 } from '../';
 import { fromApi, toApi } from '../util';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { updateFeed } from 'zoninator/state/feeds/actions';
-import { resetLock } from 'zoninator/state/locks/actions';
 
 const dummyAction = {
 	type: 'DUMMY_ACTION',

--- a/client/extensions/zoninator/state/data-layer/index.js
+++ b/client/extensions/zoninator/state/data-layer/index.js
@@ -1,13 +1,9 @@
-/**
- * Internal dependencies
- */
-
+import debugFactory from 'debug';
 import { mergeHandlers } from 'calypso/state/action-watchers/utils';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import feeds from './feeds';
 import locks from './locks';
 import zones from './zones';
-import debugFactory from 'debug';
 
 const debug = debugFactory( 'zoninator:errors' );
 

--- a/client/extensions/zoninator/state/data-layer/locks/index.js
+++ b/client/extensions/zoninator/state/data-layer/locks/index.js
@@ -1,11 +1,8 @@
-/**
- * Internal dependencies
- */
+import { ZONINATOR_REQUEST_LOCK } from 'zoninator/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { fromApi } from './utils';
 import { requestLockError, updateLock } from '../../locks/actions';
-import { ZONINATOR_REQUEST_LOCK } from 'zoninator/state/action-types';
+import { fromApi } from './utils';
 
 export const fetch = ( action ) =>
 	http(

--- a/client/extensions/zoninator/state/data-layer/locks/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/locks/test/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { fetch, onSuccess, onError } from '../';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { requestLock, requestLockError, updateLock } from 'zoninator/state/locks/actions';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { fetch, onSuccess, onError } from '../';
 
 describe( 'handlers', () => {
 	describe( '#fetch()', () => {

--- a/client/extensions/zoninator/state/data-layer/locks/test/utils.js
+++ b/client/extensions/zoninator/state/data-layer/locks/test/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { fromApi } from '../utils';
 
 describe( 'utils', () => {

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -1,12 +1,11 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import {
+	ZONINATOR_ADD_ZONE,
+	ZONINATOR_DELETE_ZONE,
+	ZONINATOR_REQUEST_ZONES,
+	ZONINATOR_SAVE_ZONE,
+} from 'zoninator/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
@@ -19,12 +18,6 @@ import {
 	updateZones,
 } from '../../zones/actions';
 import { zoneFromApi, zonesListFromApi } from './utils';
-import {
-	ZONINATOR_ADD_ZONE,
-	ZONINATOR_DELETE_ZONE,
-	ZONINATOR_REQUEST_ZONES,
-	ZONINATOR_SAVE_ZONE,
-} from 'zoninator/state/action-types';
 
 const settingsPath = '/extensions/zoninator';
 

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { zoneFromApi, zonesListFromApi } from '../utils';
 
 test( 'should convert zones list response to a zones list object', () => {

--- a/client/extensions/zoninator/state/data-layer/zones/utils.js
+++ b/client/extensions/zoninator/state/data-layer/zones/utils.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { keyBy, map, unescape } from 'lodash';
 
 const convertZone = ( zone ) => ( {

--- a/client/extensions/zoninator/state/feeds/actions.js
+++ b/client/extensions/zoninator/state/feeds/actions.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import {
 	ZONINATOR_REQUEST_FEED,
 	ZONINATOR_REQUEST_FEED_ERROR,

--- a/client/extensions/zoninator/state/feeds/reducer.js
+++ b/client/extensions/zoninator/state/feeds/reducer.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import {
 	ZONINATOR_REQUEST_FEED,

--- a/client/extensions/zoninator/state/feeds/selectors.js
+++ b/client/extensions/zoninator/state/feeds/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 const getFeedsState = ( state ) => get( state, 'extensions.zoninator.feeds', {} );

--- a/client/extensions/zoninator/state/feeds/test/actions.js
+++ b/client/extensions/zoninator/state/feeds/test/actions.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	ZONINATOR_REQUEST_FEED,
 	ZONINATOR_REQUEST_FEED_ERROR,

--- a/client/extensions/zoninator/state/feeds/test/reducer.js
+++ b/client/extensions/zoninator/state/feeds/test/reducer.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	ZONINATOR_REQUEST_FEED,
 	ZONINATOR_REQUEST_FEED_ERROR,

--- a/client/extensions/zoninator/state/feeds/test/selectors.js
+++ b/client/extensions/zoninator/state/feeds/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getFeed, isRequestingFeed, isSavingFeed } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/extensions/zoninator/state/locks/actions.js
+++ b/client/extensions/zoninator/state/locks/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	ZONINATOR_REQUEST_LOCK,
 	ZONINATOR_REQUEST_LOCK_ERROR,

--- a/client/extensions/zoninator/state/locks/reducer.js
+++ b/client/extensions/zoninator/state/locks/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import {
 	ZONINATOR_REQUEST_LOCK_ERROR,

--- a/client/extensions/zoninator/state/locks/selectors.js
+++ b/client/extensions/zoninator/state/locks/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get } from 'lodash';
 
 const getLocksState = ( state ) => get( state, 'extensions.zoninator.locks', {} );

--- a/client/extensions/zoninator/state/locks/test/actions.js
+++ b/client/extensions/zoninator/state/locks/test/actions.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	ZONINATOR_REQUEST_LOCK,
 	ZONINATOR_REQUEST_LOCK_ERROR,

--- a/client/extensions/zoninator/state/locks/test/reducer.js
+++ b/client/extensions/zoninator/state/locks/test/reducer.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	ZONINATOR_REQUEST_LOCK_ERROR,
 	ZONINATOR_RESET_LOCK,

--- a/client/extensions/zoninator/state/locks/test/selectors.js
+++ b/client/extensions/zoninator/state/locks/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { blocked, created, expires, maxLockPeriod } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/extensions/zoninator/state/reducer.js
+++ b/client/extensions/zoninator/state/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
 import { combineReducers } from 'calypso/state/utils';
 import feeds from './feeds/reducer';

--- a/client/extensions/zoninator/state/zones/actions.js
+++ b/client/extensions/zoninator/state/zones/actions.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import {
 	ZONINATOR_ADD_ZONE,
 	ZONINATOR_DELETE_ZONE,

--- a/client/extensions/zoninator/state/zones/reducer.js
+++ b/client/extensions/zoninator/state/zones/reducer.js
@@ -1,8 +1,4 @@
-/**
- * Internal dependencies
- */
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
-import { itemsSchema } from './schema';
 import {
 	ZONINATOR_ADD_ZONE,
 	ZONINATOR_REQUEST_ERROR,
@@ -12,6 +8,7 @@ import {
 	ZONINATOR_UPDATE_ZONE_ERROR,
 	ZONINATOR_UPDATE_ZONES,
 } from '../action-types';
+import { itemsSchema } from './schema';
 
 export const requesting = ( state = {}, action ) => {
 	switch ( action.type ) {

--- a/client/extensions/zoninator/state/zones/selectors.js
+++ b/client/extensions/zoninator/state/zones/selectors.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get, values } from 'lodash';
 
 const getZonesState = ( state ) => state.extensions.zoninator.zones;

--- a/client/extensions/zoninator/state/zones/test/actions.js
+++ b/client/extensions/zoninator/state/zones/test/actions.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	ZONINATOR_ADD_ZONE,
 	ZONINATOR_DELETE_ZONE,

--- a/client/extensions/zoninator/state/zones/test/reducer.js
+++ b/client/extensions/zoninator/state/zones/test/reducer.js
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { serialize, deserialize } from 'calypso/state/utils';
 import {
 	ZONINATOR_ADD_ZONE,
 	ZONINATOR_REQUEST_ERROR,
@@ -17,7 +11,6 @@ import {
 	ZONINATOR_UPDATE_ZONES,
 } from '../../action-types';
 import reducer, { requesting, items, saving } from '../reducer';
-import { serialize, deserialize } from 'calypso/state/utils';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;

--- a/client/extensions/zoninator/state/zones/test/selectors.js
+++ b/client/extensions/zoninator/state/zones/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getZone, getZones, isRequestingZones, isSavingZone } from '../selectors';
 
 describe( 'selectors', () => {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/extensions` to use `import/order`

#### Testing instructions

N/A

Note: there are quite a few eslint failures but one of them should be related to the `import/order` rule
