### PR TITLE
Checkout: Enable Jetpack siteless and userless checkout in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,6 +70,8 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/happychat": true,
 		"jetpack/only-realtime-products": false,
+		"jetpack/siteless-checkout": true,
+		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/54931, Jetpack checkout was enabled for production and it was already enabled for development and horizon, but it was never enabled for wpcalypso, which means that you cannot use it in calypso.live for testing PRs. This PR enables it in that environment.

#### Testing instructions

- Using the auto-generated calypso.live link in this PR, visit http://calypso.localhost:3000/checkout/jetpack/jetpack_scan (you must be logged in to WordPress.com but no site is required).
- Make sure you see checkout and not the site picker.