### PR TITLE
Avoid loading Fullstory on log-in page

### DIFF
--- a/client/lib/analytics/fullstory.js
+++ b/client/lib/analytics/fullstory.js
@@ -42,6 +42,10 @@ export function recordFullStoryEvent( name, _props ) {
 }
 
 function maybeAddFullStoryScript() {
+	if ( document?.location?.pathname.includes( 'log-in' ) ) {
+		return;
+	}
+
 	if (
 		fullStoryScriptLoaded ||
 		! config.isEnabled( 'fullstory' ) ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Loading the Fullstory script on the WPcom log-in page is triggering `Content-Security-Policy` alerts. This PR prevents the Fullstory script from loading on the log-in page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR and start Calypso locally.
* Open Chrome with the dev tools open to the Network tab showing Fetch/XHR requests and filtered to show `fullstory`
* Navigate to `http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F`
* Confirm that `fs.js` no longer loads on the log-in page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
