### PR TITLE
desktop: exempt net error 27 from "failed to load" handler

### DIFF
--- a/desktop/app/window-handlers/failed-to-load/index.js
+++ b/desktop/app/window-handlers/failed-to-load/index.js
@@ -11,7 +11,7 @@ const FAILED_FILE = 'file://' + assets.getPath( FAIL_TO_LOAD_FILE );
 const NETWORK_FAILED_FILE = 'file://' + assets.getPath( 'network-failed.html' );
 
 // Error codes we might get in the course of using the app and should not result in an error page
-// Full list of error codes here: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+// Full list of error codes here: https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
 const ERRORS_TO_IGNORE = [
 	-3, // ABORTED
 	-27, // BLOCKED_BY_RESPONSE

--- a/desktop/app/window-handlers/failed-to-load/index.js
+++ b/desktop/app/window-handlers/failed-to-load/index.js
@@ -14,6 +14,7 @@ const NETWORK_FAILED_FILE = 'file://' + assets.getPath( 'network-failed.html' );
 // Full list of error codes here: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
 const ERRORS_TO_IGNORE = [
 	-3, // ABORTED
+	-27, // BLOCKED_BY_RESPONSE
 	-30, // ERR_BLOCKED_BY_CSP
 	-102, // CONNECTION_REFUSED
 	-109, // ADDRESS_UNREACHABLE


### PR DESCRIPTION
### Description

This PR adds net error code 27 to the list of "failed to load" exemptions. 

### To Test

Navigate to [this P2 post](p7DVsv-clW-p2) in the Desktop app and verify that the page loads without issue. This particular bug was caused by a failing youtube account network request embedded within the page:

```
https://accounts.youtube.com/accounts/CheckConnection?pmpo=https%3A%2F%2Faccounts.google.com&v=xxxxx&timestamp=xxxxxxx
```

The borked request would end up failing the entire page load.