### PR TITLE
resize dotpager card when children change

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -89,7 +89,7 @@ export const DotPager = ( {
 		const targetHeight = pagesRef.current?.children[ currentPage ]?.offsetHeight;
 
 		setPagesStyle( targetHeight ? { height: targetHeight } : undefined );
-	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle ] );
+	}, [ hasDynamicHeight, currentPage, sizes.width, setPagesStyle, children ] );
 
 	return (
 		<div className={ className } { ...props }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue on My Home where the new card loaded after dismissing one can be cut off:

![Slack___dotcom-pod-my-home___A8C___42_new_items](https://user-images.githubusercontent.com/5952255/128093838-26057406-d0c4-4d1c-be32-27a8eb81247d.jpg)

#### Testing instructions

Dismiss cards from the My Home page until the new card is a different size and confirm that the pager component resizes appropriately.

Thanks for the report @donlair!