### PR TITLE
Fix: change search purchase link to landing page for Calypso and Jetpack Cloud

### DIFF
--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -22,7 +22,9 @@ export default function JetpackSearchUpsell(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_search_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
-	const upgradeUrl = 'https://jetpack.com/upgrade/search/?site=' + siteSlug;
+	const upgradeUrl =
+		'https://jetpack.com/upgrade/search/?utm_campaign=my-sites-jetpack-search&utm_source=calypso&site=' +
+		siteSlug;
 
 	return (
 		<Main className="jetpack-search">

--- a/client/my-sites/jetpack-search/upsell.tsx
+++ b/client/my-sites/jetpack-search/upsell.tsx
@@ -22,10 +22,7 @@ export default function JetpackSearchUpsell(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_search_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
-	const upgradeUrl =
-		'/checkout/' +
-		siteSlug +
-		'/jetpack_search_monthly?utm_campaign=my-sites-jetpack-search&utm_source=calypso';
+	const upgradeUrl = 'https://jetpack.com/upgrade/search/?site=' + siteSlug;
 
 	return (
 		<Main className="jetpack-search">


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixed the issue the purchase link doesn't work for Jetpack Cloud by changing the link to `https://jetpack.com/upgrade/search/?site={siteSlug}`. Please note the change would also affect Calypso as they share the same components.

#### Testing instructions
1. 
- Run Jetpack Cloud locally with `CALYPSO_ENV=jetpack-cloud-development yarn start` and map `jetpack.cloud.localhost` to `127.0.0.1` in your “hosts” file.
- Visit http://jetpack.cloud.localhost:3000/ and choose the 'Search' item in the sidebar.
- Switch to a site without Jetpack Search subscription
- Ensure the purchase link works and could successfully add search subscription to the site
2. 
- Run Calypso locally `yarn start` 
- Switch to a site without Jetpack Search subscription
- Visit http://calypso.localhost:3000/ and choose the 'Jetpack -> Search' item in the sidebar.
- Ensure the purchase link works and could successfully add search subscription to the site

Related to #54998
