### PR TITLE
Fix deprecated selector and DRY the `openBlockInserterAndSearch` method

### DIFF
--- a/test/e2e/lib/components/abstract-editor-component.js
+++ b/test/e2e/lib/components/abstract-editor-component.js
@@ -33,6 +33,20 @@ export default class AbstractEditorComponent extends AsyncBaseContainer {
 		await driverHelper.clickWhenClickable( this.driver, patternItemLocator );
 	}
 
+	async openBlockInserterAndSearch( searchTerm ) {
+		await this.runInCanvas( async () => {
+			await driverHelper.scrollIntoView(
+				this.driver,
+				By.css( '.block-editor-writing-flow' ),
+				'start'
+			);
+		} );
+
+		await this.openBlockInserter();
+		const inserterSearchInputLocator = By.css( 'input.components-search-control__input' );
+		await driverHelper.setWhenSettable( this.driver, inserterSearchInputLocator, searchTerm );
+	}
+
 	/**
 	 * Set the running context for operating on the DOM, i.e switch to the right
 	 * iframe. By default, it's defined here as a noop, but can be overriden in

--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -69,20 +69,6 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, inserterMenuLocator );
 	}
 
-	async openBlockInserterAndSearch( searchTerm ) {
-		await this.runInCanvas( async () => {
-			await driverHelper.scrollIntoView(
-				this.driver,
-				By.css( '.block-editor-writing-flow' ),
-				'start'
-			);
-		} );
-
-		await this.openBlockInserter();
-		const inserterSearchInputLocator = By.css( 'input.block-editor-inserter__search-input' );
-		await driverHelper.setWhenSettable( this.driver, inserterSearchInputLocator, searchTerm );
-	}
-
 	async insertPattern( category, name ) {
 		await this.openBlockInserter();
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -239,20 +239,6 @@ export default class GutenbergEditorComponent extends AbstractEditorComponent {
 		await driverHelper.waitUntilElementLocatedAndVisible( this.driver, inserterMenuLocator );
 	}
 
-	async openBlockInserterAndSearch( searchTerm ) {
-		await driverHelper.scrollIntoView(
-			this.driver,
-			By.css( '.block-editor-writing-flow' ),
-			'start'
-		);
-
-		await this.openBlockInserter();
-
-		const inserterSearchInputLocator = By.css( `input.components-search-control__input` );
-
-		await driverHelper.setWhenSettable( this.driver, inserterSearchInputLocator, searchTerm );
-	}
-
 	async insertPattern( category, name ) {
 		await this.openBlockInserter();
 


### PR DESCRIPTION
Fixes for issues found as part of the testing process for the upcoming [Gutenberg v11.2.0 release on WPCOM](https://github.com/Automattic/wp-calypso/issues/54859). These have nothing to do with v11.2.0[RC1] though, and were already failing on production.

#### Changes proposed in this Pull Request

* Fix a deprecated CSS selector in the `openBlockInserterAndSearch` method;
* Move it to the common ancestor class.

#### Testing instructions

* Tests should pass.
