### PR TITLE
Support custom domains by removing .substack.com validation

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -185,9 +185,6 @@ function getConfig( { siteTitle = '' } = {} ) {
 			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
 				args: { exampleUrl: 'https://newsletter.substack.com/' },
 			} ),
-			validate: ( urlInput ) => {
-				return /^(https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
-			},
 		},
 		weight: 0,
 	};

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -186,7 +186,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				args: { exampleUrl: 'https://newsletter.substack.com/' },
 			} ),
 			validate: ( urlInput ) => {
-				return /^(http|https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
+				return /^(https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
 			},
 		},
 		weight: 0,

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -186,7 +186,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				args: { exampleUrl: 'https://newsletter.substack.com/' },
 			} ),
 			validate: ( urlInput ) => {
-				return /^https:\/\/[\w-]+\.substack\.com\/?$/.test( urlInput.trim() );
+				return /^(http|https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
 			},
 		},
 		weight: 0,

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -173,7 +173,9 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	validateUrl = ( urlInput ) => {
-		return ! urlInput || urlInput === '' || this.props.optionalUrl.validate( urlInput );
+		const validationFn = this.props.optionalUrl.validate;
+
+		return ! urlInput || urlInput === '' || ( validationFn ? validationFn( urlInput ) : true );
 	};
 
 	setUrl = ( event ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, Substack sites on custom domains are not supported because of our `.substack.com` URL validation. This PR removes that validation to just make it a generic URL validation.

#### Testing instructions

1. You need to have async jobs enabled on your Sandbox to test this. [See this](PCYsg-3Ri-p2).
2. Go to Tools > Import.
3. Choose Substack, and enter a custom domain configured Substack URL.
4. Make sure everything goes off fine. 

<img width="751" alt="CleanShot 2021-08-04 at 10 36 57@2x" src="https://user-images.githubusercontent.com/533/128125147-283d8747-1cad-41f3-88c5-31a1f75043f7.png">


#### Sample File
[custom-domain.zip](https://github.com/Automattic/wp-calypso/files/6928729/custom-domain.zip)
`https://www.singleplayer.blog/`
