### PR TITLE
InlineHelp: use `wpcom.req.get` directly instead of `Undocumented.getHelpLinks`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1909,17 +1909,6 @@ Undocumented.prototype.uploadExportFile = function ( siteId, params ) {
 	} );
 };
 
-/**
- * GET help links
- *
- * @param {string} searchQuery User input for help search
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getHelpLinks = function ( searchQuery, fn ) {
-	debug( 'help-search/ searchQuery' );
-	return this.wpcom.req.get( '/help/search', { query: searchQuery, include_post_id: 1 }, fn );
-};
-
 Undocumented.prototype.getQandA = function ( query, site, fn ) {
 	debug( 'help-contact-qanda/ searchQuery {query}' );
 


### PR DESCRIPTION
Note: this might only be an intermediate step as we're exploring on how to extract the InlineHelp widget from Calypso

#### Changes proposed in this Pull Request

* Remove `Undocumented.getHelpLinks`
* InlineHelp: make use of `wpcom.req.get` directly
* (on a side use `async await` instead of `.then` chaining)

#### Testing instructions

* Open the InlineHelp widget on a page where it's available (FAB `?` button on the bottom right)
* Make use of the search functionality and ensure it's working as before
