### PR TITLE
Update eslint-branch tool to support --fix flag and deleted files

### DIFF
--- a/bin/eslint-branch.js
+++ b/bin/eslint-branch.js
@@ -6,24 +6,33 @@
  * small bit of a big fail, you may get errors that weren't caused by you.
  */
 
-const path = require( 'path' );
 const child_process = require( 'child_process' );
-
-const eslintBin = path.join( '.', 'node_modules', '.bin', 'eslint' );
+const path = require( 'path' );
+const yargs = require( 'yargs' );
 
 const branchName = child_process.execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().trim();
-const rev = child_process
+
+const revision = child_process
 	.execSync( 'git merge-base ' + branchName + ' trunk' )
 	.toString()
 	.trim();
+
 const files = child_process
-	.execSync( 'git diff --name-only ' + rev + '..HEAD' )
+	.execSync( 'git diff --name-only --diff-filter=d ' + revision + ' HEAD' )
 	.toString()
 	.split( '\n' )
 	.map( ( name ) => name.trim() )
 	.filter( ( name ) => /\.[jt]sx?$/.test( name ) );
 
-const lintResult = child_process.spawnSync( eslintBin, [ '--cache', ...files ], {
+const flags = [ '--cache' ];
+
+if ( yargs.argv.fix ) {
+	flags.push( '--fix' );
+}
+
+const eslintBin = path.join( '.', 'node_modules', '.bin', 'eslint' );
+
+const lintResult = child_process.spawnSync( eslintBin, [ ...flags, ...files ], {
 	shell: true,
 	stdio: 'inherit',
 } );


### PR DESCRIPTION
This pull request updates the `eslint-branch` command-line tool to support the `--fix` flag. This tool would indeed invite the user to specify that flag whenever it found linting errors that could be fixed:

```shell
yarn run v1.22.10
$ node bin/eslint-branch.js

/var/sources/client/my-sites/email/titan-add-mailboxes/index.jsx
   57:9  error  Replace `⏎↹titanMailMonthly⏎` with `·titanMailMonthly·`  prettier/prettier
   63:8  error  'titleCase' is defined but never used                    no-unused-vars

✖ 2 problems (2 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

However specifying that flag as argument would have no effect, but this pull request addresses that issue:

```shell
yarn eslint-branch --fix
```

Finally, this pull request fixes a file matching pattern error that would be triggered when a file was deleted:

```shell
yarn run v1.22.10
$ node bin/eslint-branch.js

Oops! Something went wrong! :(

ESLint: 7.31.0

No files matching the pattern "client/my-sites/email/email-management/home/email-plan.jsx" were found.
Please check for typing mistakes in the pattern.
```

#### Testing instructions

1. Run `git checkout update/estlint-branch`
2. Make a change that would trigger a linting error, e.g. change the indentation of some code
3. Delete a random file
4. Commit those two changes to your local branch
5. Run `yarn eslint-branch`
6. Assert that ESLint ran successfully
7. Assert that it shows a linting error for your first change
8. Run `yarn eslint-branch --fix`
9. Assert that the error is now fixed (if it can be fixed)