### PR TITLE
Add better availability message when no site is selected

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -172,6 +172,18 @@ class DomainSearchResults extends React.Component {
 						}
 				  );
 
+			if ( ! selectedSite ) {
+				domainUnavailableMessage = translate(
+					'{{strong}}%(domain)s{{/strong}} is already registered. Please try another search.',
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			}
+
 			if ( TLD_NOT_SUPPORTED_TEMPORARILY === lastDomainStatus ) {
 				domainUnavailableMessage = translate(
 					'{{strong}}.%(tld)s{{/strong}} domains are temporarily not offered on WordPress.com. ' +


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the user is on a path that has no selected site, we should not show an offer to "use your domain" since there is no selected site to map or transfer the domain to.

#### Testing instructions

On `http://calypso.localhost:3000/start/domain/domain-only` enter a domain that is transferrable and or mappable. Make sure that you get the new message without the offer to map/transfer it.

Before:

<img width="1050" alt="Screen Shot 2021-08-04 at 10 31 12 AM" src="https://user-images.githubusercontent.com/1379730/128199691-e64dc0a2-da77-4910-bd2b-13860bb722ef.png">

After:

<img width="1050" alt="Screen Shot 2021-08-04 at 10 33 24 AM" src="https://user-images.githubusercontent.com/1379730/128199891-6be2e083-7cf9-4f22-8022-a2fd5f44c2aa.png">


Related to #55150
