### PR TITLE
Add conflicting themes list, which prefer to fetch info from jetpack

### DIFF
--- a/client/components/data/query-canonical-theme/index.jsx
+++ b/client/components/data/query-canonical-theme/index.jsx
@@ -11,14 +11,22 @@ import { connect } from 'react-redux';
  */
 import QueryTheme from 'calypso/components/data/query-theme';
 import { isWpcomTheme, isWporgTheme } from 'calypso/state/themes/selectors';
+import { knownConflictingThemes } from 'calypso/state/themes/selectors/get-canonical-theme';
 
-const QueryCanonicalTheme = ( { siteId, themeId, isWpcom, isWporg } ) => (
-	<Fragment>
-		<QueryTheme themeId={ themeId } siteId="wpcom" />
-		{ ! isWpcom && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-		{ ! isWpcom && ! isWporg && siteId && <QueryTheme themeId={ themeId } siteId={ siteId } /> }
-	</Fragment>
-);
+const QueryCanonicalTheme = ( { siteId, themeId, isWpcom, isWporg } ) => {
+	// Conflicting themes are themes we always search Jetpack+Atomic sites for information about.
+	// Usually, it's only searched if we can't find info on both Wpcom and Wporg.
+	const isConflictingTheme = knownConflictingThemes.has( themeId );
+	return (
+		<Fragment>
+			<QueryTheme themeId={ themeId } siteId="wpcom" />
+			{ ! isWpcom && <QueryTheme themeId={ themeId } siteId="wporg" /> }
+			{ ( ( ! isWpcom && ! isWporg ) || isConflictingTheme ) && siteId && (
+				<QueryTheme themeId={ themeId } siteId={ siteId } />
+			) }
+		</Fragment>
+	);
+};
 
 QueryCanonicalTheme.propTypes = {
 	siteId: PropTypes.number,

--- a/client/state/themes/selectors/get-canonical-theme.js
+++ b/client/state/themes/selectors/get-canonical-theme.js
@@ -11,6 +11,33 @@ import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import 'calypso/state/themes/init';
 
 /**
+ * knownConflictingThemes: A list of themeIds which we prefer to fetch from the
+ * jetpack/atomic site over the wpcom/wporg galleries.
+ *
+ * In most cases, we want to prefer the theme information found on wpcom or
+ * wporg over the information found on a user's jetpack or atomic site, because
+ * the info on wpcom or wporg has a longer description, more screenshots, and
+ * more fields.
+ *
+ * However, some themes have a conflicting themeId. For example, let's say I
+ * buy the bistro theme off woocommerce.com and install it on my jetpack or
+ * atomic site. When I search for information about 'bistro' in the WPCOM ->
+ * WPORG -> JP/Atomic order, I will first find information in
+ * https://wp-themes.com/bistro/, which is a completely different theme than
+ * the one offered on woocommerce.
+ *
+ * One solution would be to always prefer what's found on a user's
+ * jetpack/atomic site over the centralized galleries. However, that results in
+ * a notably degraded experience when looking at the theme info for popular
+ * bundled themes like twentytwentyone.
+ *
+ * So it seems somewhat hacky, but keeping a list of themes where we prefer the
+ * jetpack/atomic versions is a straightforward way to solve the bistro conflict while
+ * keeping the rich theme information for twentytwentyone.
+ */
+export const knownConflictingThemes = new Set( [ 'bistro' ] );
+
+/**
  * Returns a theme object from what is considered the 'canonical' source, i.e.
  * the one with richest information. Checks WP.com (which has a long description
  * and multiple screenshots, and a preview URL) first, then WP.org (which has a
@@ -22,6 +49,11 @@ import 'calypso/state/themes/init';
  * @returns {?object}         Theme object
  */
 export function getCanonicalTheme( state, siteId, themeId ) {
-	const source = find( [ 'wpcom', 'wporg', siteId ], ( s ) => getTheme( state, s, themeId ) );
+	let searchOrder = [ 'wpcom', 'wporg', siteId ];
+	if ( knownConflictingThemes.has( themeId ) ) {
+		searchOrder = [ siteId, 'wpcom', 'wporg' ];
+	}
+
+	const source = find( searchOrder, ( s ) => getTheme( state, s, themeId ) );
 	return getTheme( state, source, themeId );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Usually, we fetch information about themes from sources in this order: wpcom -> wporg -> jetpack/atomic site. If information is found any step along the way, we stop looking.
* This PR adds a list of "conflicting themes", which are themes that are searched for in this order: jetpack/atomic -> wpcom -> wporg.
* The root issue is that when the themeid=`bistro` is [purchased off woocommerce.com,](https://woocommerce.com/products/bistro/) then searched for in the default order, information is found [about a different theme with the same themeid='bistro'](https://wp-themes.com/bistro/).
  * https://github.com/Automattic/wp-calypso/issues/54411
* If I change the default search order to "jetpack/atomic theme information always wins if it is present", the experience for default, bundled themes like twentytwentyone on jetpack/atomic is much degraded. The information on wpcom is much richer; the information for twentytwentyone on disk doesn't even include some fields which cause rendering to look strange.
![2021-08-04_10-32](https://user-images.githubusercontent.com/937354/128211439-a50e8731-4246-49b3-ad3f-2f8a5a561429.png)
* The only solution left in my mind is to normally use the default search order (wpcom -> wporg -> jetpack/atomic), but to keep a manual list of 'conflicted themes' which follow the order (jetpack/atomic -> wpcom -> wporg). This allows the correct theme information for purchased bistro to be found, while maintaining a rich experience for twentytwentyone on jetpack/atomic sites.
  *  This seems overly manual and somewhat hackish, however, I an unable to find another way that fixes the bistro problem without negatively affecting the theme info experience on other themes. Open to any other suggestions.

#### Testing instructions

* On a jetpack/atomic site, install the Bistro theme. This is [a purchased theme on woocommerce.com](https://woocommerce.com/products/bistro/). For a8c, use this information to obtain the theme for testing:  p1628025185007900/1628018031.005000-slack-C0Q664T29
* Switch to bistro.
* Without this PR, visit the theme showcase. Check the "Current Theme" card at the top, and click the info button on the theme. You should see a picture of a pizza, and the theme description text will mention being a child theme for Syndey. This is the incorrect bistro and not the one bought from woocommerce.com.
* With this PR, visit the theme showcase. Check the "Current Theme" card at the top, and click the info button on the theme. You should see a picture of veggies, and the theme description text will mention storefront. This is the correct bistro and the one bought from woocommerce.com.
* The Theme-info tab should offer the same experience before and after the PR for themes like twentytwentyone on jetpack and atomic sites.

---

<img width="1233" alt="bistro-pizza" src="https://user-images.githubusercontent.com/937354/128212815-e78c3dd3-222b-4fb5-8fd3-f3580b795367.png">

^ Incorrect Bistro from wp-themes

---

<img width="991" alt="bistro-veggies" src="https://user-images.githubusercontent.com/937354/128212846-6f365b8c-b407-431e-80f9-a870b7165f97.png">
^ Correct Bistro from woocommerce


Related to https://github.com/Automattic/wp-calypso/issues/54411