### PR TITLE
Fix/update the Tracks 'checkout_flow' prop to accomodate siteless checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -204,7 +204,6 @@ export default function WPCheckout( {
 		reduxDispatch(
 			recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
 				email: emailAddress,
-				checkout_flow: isJetpackCheckout ? 'site_only_checkout' : 'wpcom_registrationless',
 			} )
 		);
 
@@ -218,9 +217,6 @@ export default function WPCheckout( {
 								reduxDispatch(
 									recordTracksEvent( 'calypso_checkout_composite_login_click', {
 										email: emailAddress,
-										checkout_flow: isJetpackCheckout
-											? 'site_only_checkout'
-											: 'wpcom_registrationless',
 									} )
 								)
 							}

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -196,7 +196,7 @@ export default function WPCheckout( {
 		// checkout -> login -> checkout.
 		const currentURLQueryParameters = Object.fromEntries( new URL( href ).searchParams.entries() );
 		const redirectTo = isJetpackCheckout
-			? addQueryArgs( { ...currentURLQueryParameters, flow: 'logged-out-checkout' }, pathname )
+			? addQueryArgs( { ...currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
 			: '/checkout/no-site?cart=no-user';
 
 		const loginUrl = login( { redirectTo, emailAddress } );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -33,7 +33,7 @@ export default function useCheckoutFlowTrackKey( {
 		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}
-		return isJetpackNotAtomic ? 'jetpack-checkout' : 'wpcom-checkout';
+		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
 	}, [
 		hasJetpackSiteSlug,
 		isJetpackCheckout,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -13,27 +13,27 @@ interface Props {
 
 export default function useCheckoutFlowTrackKey( {
 	hasJetpackSiteSlug,
-	isJetpackCheckout,
+	isJetpackCheckout, // this flag is used for both "siteless checkout" and "site-only(userless) checkout"
 	isJetpackNotAtomic,
 	isLoggedOutCart,
 	isUserComingFromLoginForm,
 }: Props ): string {
 	return useMemo( () => {
 		const isSitelessJetpackCheckout = isJetpackCheckout && ! hasJetpackSiteSlug;
-		if ( isSitelessJetpackCheckout ) {
-			return 'jetpack_siteless_checkout';
-		}
 
-		if ( isLoggedOutCart ) {
-			if ( isJetpackCheckout ) {
-				return isUserComingFromLoginForm
-					? 'jetpack_site_only_coming_from_login'
-					: 'jetpack_site_only';
+		if ( isJetpackCheckout ) {
+			if ( isUserComingFromLoginForm ) {
+				// this allows us to track the flow: Checkout --> Login --> Checkout
+				return isSitelessJetpackCheckout
+					? 'jetpack_siteless_checkout_coming_from_login'
+					: 'jetpack_site_only_checkout_coming_from_login';
 			}
+			return isSitelessJetpackCheckout ? 'jetpack_siteless_checkout' : 'jetpack_site_only_checkout';
+		}
+		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}
-
-		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
+		return isJetpackNotAtomic ? 'jetpack-checkout' : 'wpcom-checkout';
 	}, [
 		hasJetpackSiteSlug,
 		isJetpackCheckout,

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -50,6 +50,7 @@ export function checkoutSiteless( context, next ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const { productSlug: product } = context.params;
+	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
 
 	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
@@ -68,6 +69,7 @@ export function checkoutSiteless( context, next ) {
 			isLoggedOutCart={ isLoggedOut }
 			isNoSiteCart={ true }
 			isJetpackCheckout={ true }
+			isUserComingFromLoginForm={ isUserComingFromLoginForm }
 		/>
 	);
 
@@ -87,7 +89,7 @@ export function checkout( context, next ) {
 		( isLoggedOut || ! hasSite || isDomainOnlyFlow );
 	const jetpackPurchaseToken = context.query.purchasetoken;
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
-	const isUserComingFromLoginForm = context.query?.flow === 'logged-out-checkout';
+	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
 	const isUserComingFromPlansPage = [ 'jetpack-plans', 'jetpack-connect-plans' ].includes(
 		context.query?.source
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Tracks `checkout_flow` property used by the `calypso_checkout_page_view` event.
The `checkout_flow` prop tells us the checkout flow the user is taking:
The possible values are:
- `wpcom-checkout`: For non-atomic WordPress.com purchases.
- `jetpack-checkout`: For standard Jetpack purchases.
- `jetpack_site_only_checkout`: For Jetpack site-only(userless) checkout.
- `jetpack_siteless_checkout`: For Simple Jetpack.com (siteless) checkout.
- `wpcom_registrationless`: For WordPress.com registrationless checkout.

And 2 special cases that tell us when the user enters into siteless or userless checkout, but then on the checkout form they enter their existing wordpress.com account email address, so they are redirected to login, and upon successful login, they are redirected back to checkout again (but now logged in).  The flow looks like this: Checkout --> Login --> Checkout.

These 2 special cases tell us the user is has reached Checkout for the second time, after successfully logging in.
The 2 special `checkout_flow` props are:

- `jetpack_siteless_checkout_coming_from_login`: For the siteless checkout flow, user has reached the checkout page a second time after successfully logging in.
- `jetpack_site_only_checkout_coming_from_login`: For the site-only(userless) checkout flow, user has reached the checkout page a second time after successfully logging in.

Related to 1200479326344990-as-1200693956107477

#### Testing instructions

1. Download and run this PR in Calypso blue env (`yarn start`)
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test site-only(userless) checkout** (`jetpack_site_only_checkout`):
1. In an incognito window, spin up a new JN site.
1. Click "Set up Jetpack" button
1. Make sure to select, "Continue without signing in".
1. On the /pricing page, select Backup Daily (or any Jetpack product, not Free)
1. On the Checkout page, in the URL, replace `https://wordpress.com` with `http://localhost:3000` and reload the page.
1. Open the console, and enter `localStorage.debug = 'calypso:analytics*';`
1. Reload the page again and verify the `calypso_checkout_page_view` event has prop `checkout_flow: "jetpack_site_only_checkout"`
1. On the checkout form, Billling Information, "Email:" field, enter an email associated with a WordPress.com account.
1. Enter Postal code and Country, then click "Continue".
1. Verify you get a validation error with message, "That email address is already in use. If you have an existing account, please log in."
1. Verify you you get a `calypso_checkout_wpcom_email_exists` event.
1. Click the "Please log in" link.
1. Verify you get a `calypso_checkout_composite_login_click` event.
1. Complete the login process.
1. After successful login, when redirected back to Checkout, verify you get `calypso_checkout_page_view` event with prop, `checkout_flow: "jetpack_site_only_checkout_coming_from_login"`.

**Test Simple(siteless) checkout:** (`jetpack_siteless_checkout`):
1. While still logged-in, go to, `http://calypso.localhost:3000/checkout/jetpack/jetpack_scan`.
1. Verify you get the `calypso_checkout_page_view` event and it has prop `checkout_flow: "site_only_checkout"`
1. Log out of wordpress.com.
1. Go to, `http://calypso.localhost:3000/checkout/jetpack/jetpack_scan` again and verify you get event `calypso_checkout_page_view` and it has prop `checkout_flow: "jetpack_siteless_checkout"`.
1. On the checkout form, Billling Information, "Email:" field, enter an email associated with a WordPress.com account.
1. Enter Postal code and Country, then click "Continue".
1. Verify you get a validation error with message, "That email address is already in use. If you have an existing account, please log in."
1. Verify you you get a `calypso_checkout_wpcom_email_exists` event.
1. Click the "Please log in" link.
1. Verify you get a `calypso_checkout_composite_login_click` event.
1. Complete the login process.
1. After successful login, when redirected back to Checkout, verify you get `calypso_checkout_page_view` event with prop, `checkout_flow: "jetpack_siteless_checkout_coming_from_login"`.

**Test standard jetpack checkout:** (`jetpack_checkout`)
1. While logged in to wordpress.com, select a self-hosted Jetpack site.
1. Go to: `http://calypso.localhost:3000/plans/:site` (Replace `:site` with the site slug you selected in the previous step.)
1. Select any Jetpack product.
1. On the Checkout page, verify you get event `calypso_checkout_page_view` and it has prop `checkout_flow: "jetpack_checkout"`.

**Test wordpress.com (non-atomic) checkout:** (`wpcom_checkout`)
1. Go to http://calypso.localhost:3000/pricing
1, Select a plan (ie- Personal)
1. Type and select some domain name, (any domain name, we'll not be purchasing)
1. Once on the Checkout page, verify you get event `calypso_checkout_page_view` and it has prop `checkout_flow: "wpcom_checkout"`.

AFAIK, wpcom registrationless checkout is not currently active so no need to test this flow.



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->