### PR TITLE
Domains: Show "Get Domain Card" even if paid user does not have free domain credits anymore

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -47,8 +47,8 @@ function EmptyDomainsListCard( {
 	let contentType = 'no_plan';
 
 	if ( siteHasPaidPlan && ! hasDomainCredit ) {
-		title = translate( 'Get your domain' );
-		line = translate( 'Search for a domain or transfer one for your site.' );
+		title = translate( 'Add your domain' );
+		line = translate( 'You have no domains added to this site.' );
 		action = translate( 'Search for a domain' );
 		actionURL = domainAddNew( selectedSite.slug );
 		secondaryAction = translate( 'I have a domain' );

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -38,10 +38,6 @@ function EmptyDomainsListCard( {
 	const siteHasPaidPlan =
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
 
-	if ( siteHasPaidPlan && ! hasDomainCredit ) {
-		return null;
-	}
-
 	let title = translate( 'Get your domain' );
 	let line = translate( 'Get a free one-year domain registration or transfer with any paid plan.' );
 	let action = translate( 'Upgrade to a plan' );
@@ -49,6 +45,16 @@ function EmptyDomainsListCard( {
 	let secondaryAction = translate( 'Just search for a domain' );
 	let secondaryActionURL = domainAddNew( selectedSite.slug );
 	let contentType = 'no_plan';
+
+	if ( siteHasPaidPlan && ! hasDomainCredit ) {
+		title = translate( 'Get your domain' );
+		line = translate( 'Search for a domain or transfer one for your site.' );
+		action = translate( 'Search for a domain' );
+		actionURL = domainAddNew( selectedSite.slug );
+		secondaryAction = translate( 'I have a domain' );
+		secondaryActionURL = domainUseYourDomain( selectedSite.slug );
+		contentType = 'paid_plan_with_no_free_domain_credits';
+	}
 
 	if ( siteHasPaidPlan && hasDomainCredit ) {
 		title = translate( 'Claim your free domain' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the context of the domain pages redesign (pcYYhz-e4-p2), we redesigned the layout of the initial site domains management page (`Upgrades > Domains`) in #54615 - now it shows a large card with buttons for the user to either upgrade to a plan or search for a domain, depending if their account is free or has a plan. However, we missed the scenario when a paid user might have used their free domain credits and does not have any domain in their site; in that case, no card was shown and the page was quite empty (see `p1628072768015900-slack-C02FMH4G8` for a bug report). How it looked like:

<img width="1064" alt="Screen Shot 2021-08-05 at 15 01 49" src="https://user-images.githubusercontent.com/5324818/128398990-f8e0c495-6c73-4fb5-a111-0493d177890f.png">

This PR adds a card for the scenario when a paid user does not have free domain credits anymore and no domains in their site. This is how it will look like:

<img width="1059" alt="Screen Shot 2021-08-05 at 14 59 56" src="https://user-images.githubusercontent.com/5324818/128399002-5551bfd9-1f22-4434-8ca5-4df6b95c544b.png">

#### Testing instructions

Use the live Calypso link and select a site with a paid plan but with no free domain credits available and no domains in it. Access the `Upgrades > Domains` page and ensure the "Add your domain" card is shown.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
