### PR TITLE
Fix failing Site Editor /Global Styles tracking tests.

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -176,14 +176,19 @@ const testGlobalStylesColorAndTypography = async ( driver, blocksLevel = false )
 	}
 
 	// Update link color option.
-	await changeGlobalStylesColor( driver, 3, 2 );
+	await changeGlobalStylesColor( driver, 3, 1 );
 	// The last sleep before accessing the event stack must be longer to ensure there is
 	// enough time for the function to retrieve entities and compare.
 	await driver.sleep( 500 );
 
 	let updateEvents = await getGlobalStylesUpdateEvents( driver );
 
-	assert.strictEqual( updateEvents.length, 3 );
+	// Due to variation in test speed combined with the debouncing of events the step to update the
+	// fontSize input can trigger anywhere between 1 and 3 events.  Thus we expect to see between 3
+	// and 5 events total.
+	assert( updateEvents.length >= 3, 'There should be at least 3 update events' );
+	assert( updateEvents.length <= 5, 'There should be no more than 5 update events' );
+
 	assert(
 		updateEvents.some( ( event ) => {
 			const { block_type, section, field, field_value, element_type, palette_slug } = event[ 1 ];
@@ -194,7 +199,7 @@ const testGlobalStylesColorAndTypography = async ( driver, blocksLevel = false )
 				element_type === undefined &&
 				palette_slug === undefined &&
 				typeof field_value === 'string' &&
-				field_value[ 0 ] === '#'
+				( field_value[ 0 ] === '#' || field_value.startsWith( 'var' ) )
 			);
 		} )
 	);
@@ -221,7 +226,7 @@ const testGlobalStylesColorAndTypography = async ( driver, blocksLevel = false )
 				element_type === 'link' &&
 				palette_slug === undefined &&
 				typeof field_value === 'string' &&
-				field_value[ 0 ] === '#'
+				( field_value[ 0 ] === '#' || field_value.startsWith( 'var' ) )
 			);
 		} )
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For various reasons the global styles tracking tests have started failing:

1.  The theme for the test site's default link color changed to the value we were selecting in the tests, preventing it from triggering an update event.
2. The color values from the presets are now setting to the variable where previously they were setting the hex tag.
3. The speed of the test can influence how many updates come from updating the fontSize input.  If we update the value quickly, there is only 1 update.  If the value is updated slowly, there can be up to 3 (one for clearing the input, one for inputing the first number, and one for inputing the final number).

Here we have made updates to accommodate these changes and variables.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify the tests pass by running the site editor tracking tests locally from `test/e2e/` directory `./node_modules/.bin/mocha specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
