### PR TITLE
Add manageHref prop to mobile Manage Plan button

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -295,7 +295,9 @@ export class PlanFeatures extends Component {
 			isLandingPage,
 			isJetpack,
 			planProperties,
+			purchaseId,
 			selectedPlan,
+			selectedSiteSlug,
 			translate,
 			showPlanCreditsApplied,
 			isLaunchPage,
@@ -384,6 +386,11 @@ export class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						isLaunchPage={ isLaunchPage }
+						manageHref={
+							purchaseId
+								? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
+								: `/plans/my-plan/${ selectedSiteSlug }`
+						}
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will add the manageHref prop to the mobile button in the PlanFeaturesActions component found in the renderMobileView function.

Unlike the desktop view, this prop is missing from the mobile view which causes the Manage Purchase button to be disabled on mobile.

![image](https://user-images.githubusercontent.com/16580129/128246416-21d0b611-74a0-4fb9-80d0-2146da6f76e2.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a site with a plan
* Open https://wordpress.com/plans/
* Open dev tools and emulate a mobile device
* Observe Manage Plans button for your current plan, it should now be active and have the prop `manageHref` along with an working href attached to the button.
* href should open to the plan's subscription options page

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #55046
