### PR TITLE
Signup: remove the soon-to-be-deactivated tt1-blocks theme

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -15,20 +15,6 @@
 			"features": []
 		},
 		{
-			"title": "Twenty Twenty One",
-			"slug": "tt1-blocks",
-			"template": "tt1-blocks",
-			"theme": "tt1-blocks",
-			"fonts": {
-				"headings": "Playfair Display",
-				"base": "Fira Sans"
-			},
-			"categories": [ "featured" ],
-			"is_premium": false,
-			"is_fse": true,
-			"features": []
-		},
-		{
 			"title": "Cassel",
 			"slug": "cassel",
 			"template": "cassel",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* remove the `tt1-blocks` theme from signup

#### Testing instructions

1. Visit `/new?flags=gutenboarding/site-editor`
2. Verify that "Twenty Twenty One" is not in the "Choose a Design" step

Note that after this is complete, we will deactivate this theme on WP.com