### PR TITLE
Playwright: implement Site Selector.

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -62,11 +62,16 @@ export function getAccountCredential( accountType: string ): string[] {
  * Returns the site URL for a specified account from the secrets file.
  *
  * @param {string} accountType Type of the account for which the site URL is to be obtained.
+ * @param {{key: string}: boolean} param1 Keyed object parameter.
+ * @param {boolean} param1.protocol Whether to include the protocol in the returned URL. Defaults to true.
  * @returns {string} Site URL for the given username.
  * @throws {Error} If the accountType does not have a site URL defined, or accountType does not have an entry in the file.
  * @throws {ReferenceError} If URL is not defined for the accountType.
  */
-export function getAccountSiteURL( accountType: string ): string {
+export function getAccountSiteURL(
+	accountType: string,
+	{ protocol = true }: { protocol?: boolean } = {}
+): string {
 	const testAccounts: { [ key: string ]: string } = config.get( 'testAccounts' );
 	if ( ! Object.keys( testAccounts ).includes( accountType ) ) {
 		throw new Error( `Secrets file did not contain URL for requested user ${ accountType }.` );
@@ -77,7 +82,11 @@ export function getAccountSiteURL( accountType: string ): string {
 		throw new ReferenceError( `Secrets entry for ${ accountType } has no site URL defined.` );
 	}
 
-	return new URL( `https://${ url }` ).toString();
+	if ( protocol ) {
+		return new URL( `https://${ url }` ).toString();
+	}
+
+	return url.toString();
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -4,3 +4,4 @@ export * from './sidebar-component';
 export * from './support-component';
 export * from './preview-component';
 export * from './notifications-component';
+export * from './site-select-component';

--- a/packages/calypso-e2e/src/lib/components/site-select-component.ts
+++ b/packages/calypso-e2e/src/lib/components/site-select-component.ts
@@ -26,32 +26,36 @@ export class SiteSelectComponent {
 	 *
 	 * @returns {Promise<boolean>} Whether the site selector is shown.
 	 */
-	async siteSelectorShown(): Promise< boolean > {
+	async isSiteSelectorVisible(): Promise< boolean > {
 		await this.page.waitForLoadState( 'load' );
 		return await this.page.isVisible( ':has-text("Select a site")' );
 	}
 
 	/**
+	 * Navigate to the site selector endpoint.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async showSiteSelector(): Promise< void > {
+		// Wait for any preceding page load to finish first.
+		await this.page.waitForLoadState( 'load' );
+		// Obtain and navigate to the raw /home endpoint, which de-selects the
+		// currently selected site.
+		const homeURL = getCalypsoURL( 'home' );
+		await this.page.goto( homeURL );
+		await this.page.waitForLoadState( 'load' );
+	}
+
+	/**
 	 * Given a site URL, search for and select the matching site.
 	 *
-	 * This method will forcibly navigate the page to the /home endpoint with no site forming
-	 * part of the URL. The raw /home endpoint will present to the user a list of sites belonging
-	 * to the said user.
-	 *
-	 * This method will then enter the desired site URL to the input field, wait for the matching
+	 * This method will enter the desired site URL to the input field, wait for the matching
 	 * result to load, then click on the entry.
 	 *
 	 * @param {string} url URL of the desired site. Must not include the protocol (https).
 	 * @returns {Promise<void>} No return value.
 	 */
 	async selectSite( url: string ): Promise< void > {
-		// Wait for any preceding page load to finish first.
-		await this.page.waitForLoadState( 'load' );
-		const homeURL = getCalypsoURL( 'home' );
-		await this.page.goto( homeURL );
-		// Navigate to the raw /home endpoint to trigger site selection.
-		await this.page.waitForLoadState( 'load' );
-
 		await this.page.fill( selectors.searchInput, url );
 		// For some accounts with many sites, the search process takes a looooong time.
 		await this.page.waitForSelector( '.is-loading', { state: 'hidden', timeout: 60 * 1000 } );

--- a/packages/calypso-e2e/src/lib/components/site-select-component.ts
+++ b/packages/calypso-e2e/src/lib/components/site-select-component.ts
@@ -22,6 +22,16 @@ export class SiteSelectComponent {
 	}
 
 	/**
+	 * Check if the Site Selector page is shown.
+	 *
+	 * @returns {Promise<boolean>} Whether the site selector is shown.
+	 */
+	async siteSelectorShown(): Promise< boolean > {
+		await this.page.waitForLoadState( 'load' );
+		return await this.page.isVisible( ':has-text("Select a site")' );
+	}
+
+	/**
 	 * Given a site URL, search for and select the matching site.
 	 *
 	 * This method will forcibly navigate the page to the /home endpoint with no site forming

--- a/packages/calypso-e2e/src/lib/components/site-select-component.ts
+++ b/packages/calypso-e2e/src/lib/components/site-select-component.ts
@@ -1,0 +1,57 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+const selectors = {
+	searchInput: '[aria-label="Search"]',
+	siteList: '.site-selector__sites',
+};
+
+/**
+ * Represents the Site Select component.
+ */
+export class SiteSelectComponent {
+	private page: Page;
+
+	/**
+	 * Creates an instance of the Site Select component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Given a site URL, search for and select the matching site.
+	 *
+	 * This method will forcibly navigate the page to the /home endpoint with no site forming
+	 * part of the URL. The raw /home endpoint will present to the user a list of sites belonging
+	 * to the said user.
+	 *
+	 * This method will then enter the desired site URL to the input field, wait for the matching
+	 * result to load, then click on the entry.
+	 *
+	 * @param {string} url URL of the desired site. Must not include the protocol (https).
+	 * @returns {Promise<void>} No return value.
+	 */
+	async selectSite( url: string ): Promise< void > {
+		// Wait for any preceding page load to finish first.
+		await this.page.waitForLoadState( 'load' );
+		const homeURL = getCalypsoURL( 'home' );
+		await this.page.goto( homeURL );
+		// Navigate to the raw /home endpoint to trigger site selection.
+		await this.page.waitForLoadState( 'load' );
+
+		await this.page.fill( selectors.searchInput, url );
+		// For some accounts with many sites, the search process takes a looooong time.
+		await this.page.waitForSelector( '.is-loading', { state: 'hidden', timeout: 60 * 1000 } );
+
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.click( `${ selectors.siteList } :text("${ url }")`, { timeout: 60 * 1000 } ),
+		] );
+
+		// Assert the resulting URL is in the form of <protocol><calypsoBaseURL>/home/<url>.
+		await this.page.waitForURL( `**/home/${ url }` );
+	}
+}

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -19,6 +19,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 	// This test will use partial matching names to cycle between available themes.
 	const themeName = 'Twenty Twen';
 	const user = 'defaultUser';
+	const siteURL = DataHelper.getAccountSiteURL( user, { protocol: false } );
 
 	setupHooks( ( args ) => {
 		page = args.page;
@@ -34,13 +35,11 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
 	} );
 
-	it( 'Select test site', async function () {
+	it( `Choose test site ${ siteURL } if Site Selector is shown`, async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
 
 		if ( await siteSelectComponent.isSiteSelectorVisible() ) {
-			await siteSelectComponent.selectSite(
-				DataHelper.getAccountSiteURL( user, { protocol: false } )
-			);
+			await siteSelectComponent.selectSite( siteURL );
 		}
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -31,7 +31,6 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 
 	it( 'Select test site', async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
-		await page.pause();
 		await siteSelectComponent.selectSite(
 			DataHelper.getAccountSiteURL( user, { protocol: false } )
 		);

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -6,6 +6,7 @@ import {
 	PreviewComponent,
 	ThemesPage,
 	ThemesDetailPage,
+	SiteSelectComponent,
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
@@ -26,6 +27,14 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 	it( 'Log In', async function () {
 		const loginFlow = new LoginFlow( page, user );
 		await loginFlow.logIn();
+	} );
+
+	it( 'Select test site', async function () {
+		const siteSelectComponent = new SiteSelectComponent( page );
+		await page.pause();
+		await siteSelectComponent.selectSite(
+			DataHelper.getAccountSiteURL( user, { protocol: false } )
+		);
 	} );
 
 	it( 'Navigate to Appearance > Themes', async function () {

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -29,16 +29,19 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 		await loginFlow.logIn();
 	} );
 
-	it( 'Select test site', async function () {
-		const siteSelectComponent = new SiteSelectComponent( page );
-		await siteSelectComponent.selectSite(
-			DataHelper.getAccountSiteURL( user, { protocol: false } )
-		);
-	} );
-
 	it( 'Navigate to Appearance > Themes', async function () {
 		sidebarComponent = new SidebarComponent( page );
 		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
+	} );
+
+	it( 'Select test site', async function () {
+		const siteSelectComponent = new SiteSelectComponent( page );
+
+		if ( await SiteSelectComponent.siteSelectorShown() ) {
+			await siteSelectComponent.selectSite(
+				DataHelper.getAccountSiteURL( user, { protocol: false } )
+			);
+		}
 	} );
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -37,7 +37,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 	it( 'Select test site', async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
 
-		if ( await SiteSelectComponent.siteSelectorShown() ) {
+		if ( await siteSelectComponent.siteSelectorShown() ) {
 			await siteSelectComponent.selectSite(
 				DataHelper.getAccountSiteURL( user, { protocol: false } )
 			);

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -37,7 +37,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 	it( 'Select test site', async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
 
-		if ( await siteSelectComponent.siteSelectorShown() ) {
+		if ( await siteSelectComponent.isSiteSelectorVisible() ) {
 			await siteSelectComponent.selectSite(
 				DataHelper.getAccountSiteURL( user, { protocol: false } )
 			);

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -34,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 	it( 'Select test site', async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
 
-		if ( await SiteSelectComponent.siteSelectorShown() ) {
+		if ( await siteSelectComponent.siteSelectorShown() ) {
 			await siteSelectComponent.selectSite(
 				DataHelper.getAccountSiteURL( user, { protocol: false } )
 			);

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -28,7 +28,6 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 
 	it( 'Select test site', async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
-		await page.pause();
 		await siteSelectComponent.selectSite(
 			DataHelper.getAccountSiteURL( user, { protocol: false } )
 		);

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -12,10 +12,11 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 	let sidebarComponent;
 	let themesPage;
 	let previewComponent;
+	let page;
 	// This test will use this specific theme as it will never be active.
 	const themeName = 'Twenty Seventeen';
 	const user = 'defaultUser';
-	let page;
+	const siteURL = DataHelper.getAccountSiteURL( user, { protocol: false } );
 
 	setupHooks( ( args ) => {
 		page = args.page;
@@ -31,13 +32,11 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
 	} );
 
-	it( 'Select test site', async function () {
+	it( `Choose test site ${ siteURL } if Site Selector is shown`, async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
 
 		if ( await siteSelectComponent.isSiteSelectorVisible() ) {
-			await siteSelectComponent.selectSite(
-				DataHelper.getAccountSiteURL( user, { protocol: false } )
-			);
+			await siteSelectComponent.selectSite( siteURL );
 		}
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -26,16 +26,19 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 		await loginFlow.logIn();
 	} );
 
-	it( 'Select test site', async function () {
-		const siteSelectComponent = new SiteSelectComponent( page );
-		await siteSelectComponent.selectSite(
-			DataHelper.getAccountSiteURL( user, { protocol: false } )
-		);
-	} );
-
 	it( 'Navigate to Themes', async function () {
 		sidebarComponent = new SidebarComponent( page );
 		await sidebarComponent.gotoMenu( { item: 'Appearance', subitem: 'Themes' } );
+	} );
+
+	it( 'Select test site', async function () {
+		const siteSelectComponent = new SiteSelectComponent( page );
+
+		if ( await SiteSelectComponent.siteSelectorShown() ) {
+			await siteSelectComponent.selectSite(
+				DataHelper.getAccountSiteURL( user, { protocol: false } )
+			);
+		}
 	} );
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -5,6 +5,7 @@ import {
 	ThemesPage,
 	PreviewComponent,
 	setupHooks,
+	SiteSelectComponent,
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
@@ -13,6 +14,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 	let previewComponent;
 	// This test will use this specific theme as it will never be active.
 	const themeName = 'Twenty Seventeen';
+	const user = 'defaultUser';
 	let page;
 
 	setupHooks( ( args ) => {
@@ -20,8 +22,16 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 	} );
 
 	it( 'Log In', async function () {
-		const loginFlow = new LoginFlow( page );
+		const loginFlow = new LoginFlow( page, user );
 		await loginFlow.logIn();
+	} );
+
+	it( 'Select test site', async function () {
+		const siteSelectComponent = new SiteSelectComponent( page );
+		await page.pause();
+		await siteSelectComponent.selectSite(
+			DataHelper.getAccountSiteURL( user, { protocol: false } )
+		);
 	} );
 
 	it( 'Navigate to Themes', async function () {

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -34,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 	it( 'Select test site', async function () {
 		const siteSelectComponent = new SiteSelectComponent( page );
 
-		if ( await siteSelectComponent.siteSelectorShown() ) {
+		if ( await siteSelectComponent.isSiteSelectorVisible() ) {
 			await siteSelectComponent.selectSite(
 				DataHelper.getAccountSiteURL( user, { protocol: false } )
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to implement an additional step in the Theme specs to select the target site.

Key changes:
- new component `SiteSelectComponent` to interact with the site selector.
- ability to retrieve from config a user's test site without the protocol prefix.
- Themes spec modified to check if site selection is necessary.

Background details:

Occasionally in CI, there are instances where the test accounts used run into a situation where a site is _not_ selected by default. This can be reproduced manually by logging into WordPress.com then removing the portion of the URL after `wordpress.com/home/`.

In this situation, most of calypo's functionality is not impacted. However, for certain tasks that need to modify the state of a site - eg. Themes - the user is prompted to select the target site before calypso will load the task page. 

This situation is encountered occasionally on CI and I suspect it is due to other tests running at the same time that modifies the state of the test account. Until full isolation is implemented, inserting this optional step where needed will ensure reliability of our test suite.

#### Testing instructions

- [ ] Theme specs pass as expected on both mobile and desktop

