### PR TITLE
fix: Drop cache-loader for Sass transformer

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -223,11 +223,6 @@ const webpackConfig = {
 					].filter( Boolean ),
 				},
 				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,
-				...( shouldUsePersistentCache
-					? {}
-					: {
-							cacheDirectory: path.resolve( cachePath, 'css-loader' ),
-					  } ),
 			} ),
 			{
 				include: path.join( __dirname, 'sections.js' ),

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## trunk
 
+- Droped `cache-loader`, as it is not compatible with Webpack 5.
+- Dropped `cacheDirectory` option in Sass loader
+
 ## 9.0.0
 
 - Added new, extensible TypeScript config for modern TS and JS packages in `./typescript/[tj]-package.json`

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -53,7 +53,6 @@
 		"babel-jest": "^27.0.6",
 		"babel-loader": "^8.2.2",
 		"browserslist": "^4.8.2",
-		"cache-loader": "^4.1.0",
 		"css-loader": "^5.2.4",
 		"css-minimizer-webpack-plugin": "^1.3.0",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- **** WARNING: No ES6 modules here. Not transpiled! ****
+ * WARNING: No ES6 modules here. Not transpiled! *
  */
 /* eslint-disable import/no-nodejs-modules */
 
@@ -30,7 +30,6 @@ const cachePath = path.resolve( '.cache' );
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  * @see {@link https://webpack.js.org/api/cli/}
- *
  * @param  {object}  env                                 environment options
  * @param  {object}  argv                                options map
  * @param  {object}  argv.entry                          Entry point(s)
@@ -116,7 +115,6 @@ function getWebpackConfig(
 					postCssOptions: {
 						...( fs.existsSync( postCssConfigPath ) ? { config: postCssConfigPath } : {} ),
 					},
-					cacheDirectory: path.resolve( cachePath, 'css-loader' ),
 				} ),
 				FileConfig.loader(),
 			],

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -9,24 +9,12 @@ const MiniCSSWithRTLPlugin = require( './mini-css-with-rtl' );
  * @param  {string[]}  _.includePaths                 Sass files lookup paths
  * @param  {string}    _.prelude                      String to prepend to each Sass file
  * @param  {object}    _.postCssOptions               PostCSS options
- * @param  {object}    _.cacheDirectory               Directory used to store the cache
- *
  * @returns {object}                                  webpack loader object
  */
-module.exports.loader = ( { includePaths, prelude, postCssOptions, cacheDirectory } ) => ( {
+module.exports.loader = ( { includePaths, prelude, postCssOptions } ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPlugin.loader,
-		...( cacheDirectory
-			? [
-					{
-						loader: require.resolve( 'cache-loader' ),
-						options: {
-							cacheDirectory: cacheDirectory,
-						},
-					},
-			  ]
-			: [] ),
 		{
 			loader: require.resolve( 'css-loader' ),
 			options: {
@@ -63,7 +51,6 @@ module.exports.loader = ( { includePaths, prelude, postCssOptions, cacheDirector
  * @param  {string}   _.chunkFilename  filename pattern to use for CSS files
  * @param  {string}   _.filename       filename pattern to use for CSS chunk files
  * @param  {boolean}  _.minify         whether to minify CSS
- *
  * @returns {object[]}                 styling relevant webpack plugin objects
  */
 module.exports.plugins = ( { chunkFilename, filename, minify } ) => [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Drops `cache-loader` in `calypso-build`, as it was deprecated in Webpack 5. It was only used in the sass transformer.

Closes #55181
