### PR TITLE
Refactor `client/me` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,6 +198,7 @@ module.exports = {
 				'client/layout/**/*',
 				'client/login/**/*',
 				'client/mailing-lists/**/*',
+				'client/me/**/*',
 				'client/my-sites/**/*',
 				'client/notifications/**/*',
 				'client/post-editor/**/*',

--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import Spinner from 'calypso/components/spinner';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isAccountClosed from 'calypso/state/selectors/is-account-closed';
 
-/**
- * Style dependencies
- */
 import './closed.scss';
 
 class AccountSettingsClosedComponent extends Component {

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -1,27 +1,17 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button } from '@automattic/components';
-import Gridicon from 'calypso/components/gridicon';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import React from 'react';
+import { connect } from 'react-redux';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { closeAccount } from 'calypso/state/account/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 
-/**
- * Style dependencies
- */
 import './confirm-dialog.scss';
 
 const noop = () => {};

--- a/client/me/account-close/controller.js
+++ b/client/me/account-close/controller.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import AccountSettingsCloseComponent from 'calypso/me/account-close/main';
 import AccountSettingsClosedComponent from 'calypso/me/account-close/closed';
+import AccountSettingsCloseComponent from 'calypso/me/account-close/main';
 
 export function accountClose( context, next ) {
 	context.primary = React.createElement( AccountSettingsCloseComponent );

--- a/client/me/account-close/index.js
+++ b/client/me/account-close/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { accountClose, accountClosed } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
-import { isEnabled } from '@automattic/calypso-config';
+import { accountClose, accountClosed } from './controller';
 
 export default function () {
 	if ( isEnabled( 'me/account-close' ) ) {

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,43 +1,33 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import page from 'page';
-import Gridicon from 'calypso/components/gridicon';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import HeaderCake from 'calypso/components/header-cake';
+import page from 'page';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelFigureHeader from 'calypso/components/action-panel/figure-header';
 import ActionPanelFigureList from 'calypso/components/action-panel/figure-list';
 import ActionPanelFigureListItem from 'calypso/components/action-panel/figure-list-item';
-import ActionPanelLink from 'calypso/components/action-panel/link';
 import ActionPanelFooter from 'calypso/components/action-panel/footer';
-import { Button } from '@automattic/components';
+import ActionPanelLink from 'calypso/components/action-panel/link';
 import AccountCloseConfirmDialog from './confirm-dialog';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
-import getAccountClosureSites from 'calypso/state/selectors/get-account-closure-sites';
 import userHasAnyAtomicSites from 'calypso/state/selectors/user-has-any-atomic-sites';
 import isAccountClosed from 'calypso/state/selectors/is-account-closed';
 import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import getUserPurchasedPremiumThemes from 'calypso/state/selectors/get-user-purchased-premium-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
+import Gridicon from 'calypso/components/gridicon';
+import HeaderCake from 'calypso/components/header-cake';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getAccountClosureSites from 'calypso/state/selectors/get-account-closure-sites';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class AccountSettingsClose extends Component {

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -1,37 +1,26 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, isEmpty } from 'lodash';
 import React from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { protectForm } from 'calypso/lib/protect-form';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import { errorNotice } from 'calypso/state/notices/actions';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { generatePassword } from 'calypso/lib/generate-password';
+import { protectForm } from 'calypso/lib/protect-form';
+import wp from 'calypso/lib/wp';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { saveUserSettings } from 'calypso/state/user-settings/actions';
 import {
 	hasUserSettingsRequestFailed,
 	isPendingPasswordChange,
 } from 'calypso/state/user-settings/selectors';
-import { generatePassword } from 'calypso/lib/generate-password';
-import wp from 'calypso/lib/wp';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class AccountPassword extends React.Component {

--- a/client/me/account/close-link.jsx
+++ b/client/me/account/close-link.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-
 import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 
-/**
- * Style dependencies
- */
 import './close-link.scss';
 
 const noop = () => {};

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import page from 'page';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
+import page from 'page';
+import React from 'react';
 import AccountComponent, { noticeId as meSettingsNoticeId } from 'calypso/me/account/main';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 
 export function account( context, next ) {

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { account } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
+import { account } from './controller';
 
 export default function () {
 	page( '/me/account', sidebar, account, makeLayout, clientRender );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1,78 +1,71 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import TransitionGroup from 'react-transition-group/TransitionGroup';
-import CSSTransition from 'react-transition-group/CSSTransition';
-import { localize } from 'i18n-calypso';
+import config from '@automattic/calypso-config';
+import { Card, Button } from '@automattic/components';
+import languages from '@automattic/languages';
 import debugFactory from 'debug';
 import emailValidator from 'email-validator';
+import { localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, get, has, map, size } from 'lodash';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import CSSTransition from 'react-transition-group/CSSTransition';
+import TransitionGroup from 'react-transition-group/TransitionGroup';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormTextValidation from 'calypso/components/forms/form-input-validation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import LanguagePicker from 'calypso/components/language-picker';
+import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { protectForm } from 'calypso/lib/protect-form';
-import config from '@automattic/calypso-config';
-import languages from '@automattic/languages';
 import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
-import { Card, Button } from '@automattic/components';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormTextValidation from 'calypso/components/forms/form-input-validation';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormButton from 'calypso/components/forms/form-button';
-import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { recordGoogleEvent, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
 import ReauthRequired from 'calypso/me/reauth-required';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Main from 'calypso/components/main';
 import SitesDropdown from 'calypso/components/sites-dropdown';
-import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
-import { successNotice, errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { getLanguage, isLocaleVariant, canBeTranslated } from 'calypso/lib/i18n-utils';
-import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
-import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
-import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
-import AccountSettingsCloseLink from './close-link';
-import { requestGeoLocation } from 'calypso/state/data-getters';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getCurrentUserDate,
 	getCurrentUserDisplayName,
 	getCurrentUserName,
 	getCurrentUserVisibleSiteCount,
 } from 'calypso/state/current-user/selectors';
-import FormattedHeader from 'calypso/components/formatted-header';
-import wpcom from 'calypso/lib/wp';
-import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
+import { requestGeoLocation } from 'calypso/state/data-getters';
+import { successNotice, errorNotice, removeNotice } from 'calypso/state/notices/actions';
+import { getLanguage, isLocaleVariant, canBeTranslated } from 'calypso/lib/i18n-utils';
+import { savePreference } from 'calypso/state/preferences/actions';
+import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
+import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
+import isRequestingAllDomains from 'calypso/state/selectors/is-requesting-all-domains';
+import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
 import {
 	cancelPendingEmailChange,
 	clearUnsavedUserSettings,
 	removeUnsavedUserSetting,
 	setUserSetting,
 } from 'calypso/state/user-settings/actions';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
-import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
+import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
+import AccountSettingsCloseLink from './close-link';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import FormattedHeader from 'calypso/components/formatted-header';
+import wpcom from 'calypso/lib/wp';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { clearStore } from 'calypso/lib/user/store';
-import { savePreference } from 'calypso/state/preferences/actions';
-import isRequestingAllDomains from 'calypso/state/selectors/is-requesting-all-domains';
 import { getFlatDomainsList } from 'calypso/state/sites/domains/selectors';
 import QueryAllDomains from 'calypso/components/data/query-all-domains';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
@@ -82,9 +75,6 @@ const noticeOptions = {
 	id: noticeId,
 };
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const colorSchemeKey = 'colorScheme';

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -1,23 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import Gridicon from 'calypso/components/gridicon';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { deleteApplicationPassword } from 'calypso/state/application-passwords/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ApplicationPasswordsItem extends React.Component {

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,36 +1,26 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import classNames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AppPasswordItem from 'calypso/me/application-password-item';
 import { Button, Card } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import QueryApplicationPasswords from 'calypso/components/data/query-application-passwords';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import QueryApplicationPasswords from 'calypso/components/data/query-application-passwords';
+import Gridicon from 'calypso/components/gridicon';
 import SectionHeader from 'calypso/components/section-header';
+import AppPasswordItem from 'calypso/me/application-password-item';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import {
 	clearNewApplicationPassword,
 	createApplicationPassword,
 } from 'calypso/state/application-passwords/actions';
 import getApplicationPasswords from 'calypso/state/selectors/get-application-passwords';
 import getNewApplicationPassword from 'calypso/state/selectors/get-new-application-password';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 class ApplicationPasswords extends Component {
 	static initialState = Object.freeze( {

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -1,30 +1,23 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
-import { CompactCard } from '@automattic/components';
-import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
-import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
-import getConciergeAppointmentTimespan from 'calypso/state/selectors/get-concierge-appointment-timespan';
-import { getCurrentUserId, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { bookConciergeAppointment, requestConciergeInitial } from 'calypso/state/concierge/actions';
-import AvailableTimePicker from '../shared/available-time-picker';
+import { getCurrentUserId, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import getConciergeAppointmentTimespan from 'calypso/state/selectors/get-concierge-appointment-timespan';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
 import {
 	CONCIERGE_STATUS_BOOKED,
 	CONCIERGE_STATUS_BOOKING,
 	CONCIERGE_STATUS_BOOKING_ERROR,
 } from '../constants';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
-import FormattedHeader from 'calypso/components/formatted-header';
+import AvailableTimePicker from '../shared/available-time-picker';
 
 class CalendarStep extends Component {
 	static propTypes = {

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
-import { Button } from '@automattic/components';
-import Confirmation from '../shared/confirmation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import Confirmation from '../shared/confirmation';
 
 class ConfirmationStep extends Component {
 	componentDidMount() {

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -1,38 +1,31 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import config from '@automattic/calypso-config';
-import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import Notice from 'calypso/components/notice';
 import { CompactCard } from '@automattic/components';
-import FormButton from 'calypso/components/forms/form-button';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import IsRebrandCitiesSite from './is-rebrand-cities-site';
 import Timezone from 'calypso/components/timezone';
 import Site from 'calypso/blocks/site';
 import { localize } from 'i18n-calypso';
-import { updateConciergeSignupForm } from 'calypso/state/concierge/actions';
-import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { includes } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getLanguage } from 'calypso/lib/i18n-utils';
 import getCountries from 'calypso/state/selectors/get-countries';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import Notice from 'calypso/components/notice';
+import { updateConciergeSignupForm } from 'calypso/state/concierge/actions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
 class InfoStep extends Component {
 	static propTypes = {

--- a/client/me/concierge/book/is-rebrand-cities-site.js
+++ b/client/me/concierge/book/is-rebrand-cities-site.js
@@ -14,15 +14,8 @@
  * API call and used to customize the invitation and inform the HE that this is a Rebrand Cities session.
  */
 
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 
 const REBRAND_CITIES_ACCOUNT_USERNAME = 'rebrandcities';

--- a/client/me/concierge/book/skeleton.js
+++ b/client/me/concierge/book/skeleton.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
-import PrimaryHeader from '../shared/primary-header';
+import React, { Component } from 'react';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import PrimaryHeader from '../shared/primary-header';
 
 class Skeleton extends Component {
 	render() {

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -1,30 +1,23 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import HeaderCake from 'calypso/components/header-cake';
-import QuerySites from 'calypso/components/data/query-sites';
-import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryConciergeAppointmentDetails from 'calypso/components/data/query-concierge-appointment-details';
-import { Button } from '@automattic/components';
+import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
+import QuerySites from 'calypso/components/data/query-sites';
+import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import { localize } from 'i18n-calypso';
-import Confirmation from '../shared/confirmation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { cancelConciergeAppointment } from 'calypso/state/concierge/actions';
-import { CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING } from '../constants';
-import { getSite } from 'calypso/state/sites/selectors';
 import getConciergeAppointmentDetails from 'calypso/state/selectors/get-concierge-appointment-details';
 import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
 import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSite } from 'calypso/state/sites/selectors';
+import { CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING } from '../constants';
+import Confirmation from '../shared/confirmation';
 import { renderDisallowed } from '../shared/utils';
 
 class ConciergeCancel extends Component {

--- a/client/me/concierge/cancel/skeleton.js
+++ b/client/me/concierge/cancel/skeleton.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
 
 class Skeleton extends Component {
 	render() {

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -1,27 +1,17 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import i18n from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import ConciergeMain from './main';
-import ConciergeCancel from './cancel';
+import React from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import BookCalendarStep from './book/calendar-step';
 import BookConfirmationStep from './book/confirmation-step';
 import BookInfoStep from './book/info-step';
 import BookSkeleton from './book/skeleton';
+import ConciergeCancel from './cancel';
+import ConciergeMain from './main';
 import RescheduleCalendarStep from './reschedule/calendar-step';
 import RescheduleConfirmationStep from './reschedule/confirmation-step';
 import RescheduleSkeleton from './reschedule/skeleton';
-import i18n from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const book = ( context, next ) => {

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import controller from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
+import controller from './controller';
 
 const redirectToBooking = ( context ) => {
 	page.redirect( `/me/quickstart/${ context.params.siteSlug }/book` );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -9,32 +9,25 @@
  * gather the data they need.
  */
 
-/**
- * External dependencies
- */
+import { isEmpty } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import QuerySites from 'calypso/components/data/query-sites';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySites from 'calypso/components/data/query-sites';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
 import getConciergeAvailableTimes from 'calypso/state/selectors/get-concierge-available-times';
-import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
 import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { getSite } from 'calypso/state/sites/selectors';
+import AppointmentInfo from './shared/appointment-info';
 import NoAvailableTimes from './shared/no-available-times';
 import Upsell from './shared/upsell';
-import AppointmentInfo from './shared/appointment-info';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import ReauthRequired from 'calypso/me/reauth-required';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -1,33 +1,26 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { without } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { without } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
-import Timezone from 'calypso/components/timezone';
+import QueryConciergeAppointmentDetails from 'calypso/components/data/query-concierge-appointment-details';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import QueryConciergeAppointmentDetails from 'calypso/components/data/query-concierge-appointment-details';
-import getConciergeAppointmentDetails from 'calypso/state/selectors/get-concierge-appointment-details';
-import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
-import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
-import getConciergeAppointmentTimespan from 'calypso/state/selectors/get-concierge-appointment-timespan';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import Timezone from 'calypso/components/timezone';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	rescheduleConciergeAppointment,
 	updateConciergeAppointmentDetails,
 } from 'calypso/state/concierge/actions';
-import AvailableTimePicker from '../shared/available-time-picker';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import getConciergeAppointmentDetails from 'calypso/state/selectors/get-concierge-appointment-details';
+import getConciergeAppointmentTimespan from 'calypso/state/selectors/get-concierge-appointment-timespan';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
 import { CONCIERGE_STATUS_BOOKING, CONCIERGE_STATUS_BOOKED } from '../constants';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import AvailableTimePicker from '../shared/available-time-picker';
 import { renderDisallowed } from '../shared/utils';
 
 class CalendarStep extends Component {

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
-import { Button } from '@automattic/components';
-import Confirmation from '../shared/confirmation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import Confirmation from '../shared/confirmation';
 
 class ConfirmationStep extends Component {
 	componentDidMount() {

--- a/client/me/concierge/reschedule/skeleton.js
+++ b/client/me/concierge/reschedule/skeleton.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
 
 class Skeleton extends Component {
 	render() {

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -1,24 +1,18 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import 'moment-timezone';
 
-/**
- * Internal dependencies
- */
-import Confirmation from './confirmation';
 import { CompactCard } from '@automattic/components';
 import Site from 'calypso/blocks/site';
 import FormattedHeader from 'calypso/components/formatted-header';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormButton from 'calypso/components/forms/form-button';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Confirmation from './confirmation';
 
 class AppointmentInfo extends Component {
 	static propTypes = {

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -5,9 +5,6 @@
  * calendar view.
  */
 
-/**
- * External dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -16,19 +13,16 @@ import { localize } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import day from 'calypso/assets/images/quick-start/day.svg';
+import night from 'calypso/assets/images/quick-start/night.svg';
 import FoldableCard from 'calypso/components/foldable-card';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import SelectOptGroups from 'calypso/components/forms/select-opt-groups';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getLanguage } from 'calypso/lib/i18n-utils';
-import SelectOptGroups from 'calypso/components/forms/select-opt-groups';
-import day from 'calypso/assets/images/quick-start/day.svg';
-import night from 'calypso/assets/images/quick-start/night.svg';
 
 const defaultLanguage = getLanguage( config( 'i18n_default_locale_slug' ) ).name;
 

--- a/client/me/concierge/shared/available-time-picker.js
+++ b/client/me/concierge/shared/available-time-picker.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import moment from 'moment-timezone';
-
-/**
- * Internal dependencies
- */
-import AvailableTimeCard from './available-time-card';
 import { isDefaultLocale } from 'calypso/lib/i18n-utils';
+import AvailableTimeCard from './available-time-card';
 
 const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
 import { CompactCard as Card } from '@automattic/components';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 

--- a/client/me/concierge/shared/confirmation.js
+++ b/client/me/concierge/shared/confirmation.js
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-import FormattedHeader from 'calypso/components/formatted-header';
-
-/**
- * Image dependencies
- */
 import supportIllustration from 'calypso/assets/images/illustrations/happiness-support.svg';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 class Confirmation extends Component {
 	static propTypes = {

--- a/client/me/concierge/shared/gm-closure-notice.js
+++ b/client/me/concierge/shared/gm-closure-notice.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
 import { CompactCard as Card } from '@automattic/components';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-import PrimaryHeader from './primary-header';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PrimaryHeader from './primary-header';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
-import ClosureNotice from '../shared/closure-notice';
-import FormattedHeader from 'calypso/components/formatted-header';
-import ExternalLink from 'calypso/components/external-link';
 import { localize } from 'i18n-calypso';
+import React, { Component, Fragment } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { CONCIERGE_SUPPORT } from 'calypso/lib/url/support';
+import ClosureNotice from '../shared/closure-notice';
 
 class PrimaryHeader extends Component {
 	render() {

--- a/client/me/concierge/shared/upsell.js
+++ b/client/me/concierge/shared/upsell.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { Button, CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, CompactCard } from '@automattic/components';
-import PrimaryHeader from './primary-header';
 import Site from 'calypso/blocks/site';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PrimaryHeader from './primary-header';
 
 class Upsell extends Component {
 	static propTypes = {

--- a/client/me/concierge/shared/utils.js
+++ b/client/me/concierge/shared/utils.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import HeaderCake from 'calypso/components/header-cake';
 import { CompactCard } from '@automattic/components';
+import React from 'react';
+import HeaderCake from 'calypso/components/header-cake';
 
 export const renderDisallowed = ( translate, siteSlug ) => {
 	return (

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -1,15 +1,8 @@
 jest.mock( '../shared/upsell', () => 'Upsell' );
 jest.mock( '../shared/no-available-times', () => 'NoAvailableTimes' );
 
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { ConciergeMain } from '../main';
 
 const props = {

--- a/client/me/connected-application-icon/index.jsx
+++ b/client/me/connected-application-icon/index.jsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default class extends React.Component {

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -1,25 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
-import ConnectedApplicationIcon from 'calypso/me/connected-application-icon';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
 import FoldableCard from 'calypso/components/foldable-card';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
-import { deleteConnectedApplication } from 'calypso/state/connected-applications/actions';
+import ConnectedApplicationIcon from 'calypso/me/connected-application-icon';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { deleteConnectedApplication } from 'calypso/state/connected-applications/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ConnectedApplicationItem extends React.Component {

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -1,33 +1,23 @@
-/**
- * External dependencies
- */
-import React, { Fragment, PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { times } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import ConnectedAppItem from 'calypso/me/connected-application-item';
+import { localize } from 'i18n-calypso';
+import { times } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Fragment, PureComponent } from 'react';
+import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
 import EmptyContent from 'calypso/components/empty-content';
-import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ConnectedAppItem from 'calypso/me/connected-application-item';
 import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import FormattedHeader from 'calypso/components/formatted-header';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ConnectedApplications extends PureComponent {

--- a/client/me/constants.js
+++ b/client/me/constants.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
 
 export default {

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
-import SidebarComponent from 'calypso/me/sidebar';
+import page from 'page';
+import React from 'react';
 import AppsComponent from 'calypso/me/get-apps';
+import SidebarComponent from 'calypso/me/sidebar';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function sidebar( context, next ) {
 	context.secondary = React.createElement( SidebarComponent, {

--- a/client/me/form-base/with-form-base.jsx
+++ b/client/me/form-base/with-form-base.jsx
@@ -1,24 +1,17 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
-import hasUnsavedUserSettings from 'calypso/state/selectors/has-unsaved-user-settings';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import hasUnsavedUserSettings from 'calypso/state/selectors/has-unsaved-user-settings';
 import {
 	clearUnsavedUserSettings,
 	setUserSetting,
 	saveUserSettings,
 } from 'calypso/state/user-settings/actions';
 import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 const withFormBase = ( WrappedComponent ) => {
 	class EnhancedComponent extends React.Component {

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import GetAppsBlock from 'calypso/blocks/get-apps';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import GetAppsBlock from 'calypso/blocks/get-apps';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 
 export const GetApps = () => {
 	return (

--- a/client/me/happychat/index.jsx
+++ b/client/me/happychat/index.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { sidebar } from 'calypso/me/controller';
-import Happychat from './main';
-import { setDocumentHeadTitle } from 'calypso/state/document-head/actions';
+import { translate } from 'i18n-calypso';
+import page from 'page';
+import React from 'react';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { sidebar } from 'calypso/me/controller';
+import { setDocumentHeadTitle } from 'calypso/state/document-head/actions';
+import Happychat from './main';
 
 const renderChat = ( context, next ) => {
 	context.store.dispatch( setDocumentHeadTitle( translate( 'Chat', { textOnly: true } ) ) );

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -1,35 +1,25 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { isOutsideCalypso } from 'calypso/lib/url';
-// actions
-import { sendMessage, sendNotTyping, sendTyping } from 'calypso/state/happychat/connection/actions';
-import { blur, focus, setCurrentMessage } from 'calypso/state/happychat/ui/actions';
-// selectors
-import canUserSendMessages from 'calypso/state/happychat/selectors/can-user-send-messages';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import getCurrentMessage from 'calypso/state/happychat/selectors/get-happychat-current-message';
-import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
-import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
-import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happychat-timeline';
-import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-happychat-server-reachable';
-// UI components
-import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Composer from 'calypso/components/happychat/composer';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
 import Notices from 'calypso/components/happychat/notices';
 import Timeline from 'calypso/components/happychat/timeline';
+import { isOutsideCalypso } from 'calypso/lib/url';
+// actions
+// selectors
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { sendMessage, sendNotTyping, sendTyping } from 'calypso/state/happychat/connection/actions';
+import canUserSendMessages from 'calypso/state/happychat/selectors/can-user-send-messages';
+import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
+import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
+import getCurrentMessage from 'calypso/state/happychat/selectors/get-happychat-current-message';
+import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happychat-timeline';
+import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-happychat-server-reachable';
+import { blur, focus, setCurrentMessage } from 'calypso/state/happychat/ui/actions';
+// UI components
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/client/me/help/active-tickets-notice/index.jsx
+++ b/client/me/help/active-tickets-notice/index.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ActiveTicketsNotice extends React.Component {

--- a/client/me/help/contact-form-notice/chat-covid-limited-availability.jsx
+++ b/client/me/help/contact-form-notice/chat-covid-limited-availability.jsx
@@ -5,17 +5,10 @@
  * <ChatReducedAvailabilityNotice /> component instead.
  */
 
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
 import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 
 const ChatCovidLimitedAvailabilityNotice = ( { showAt, hideAt, compact } ) => {

--- a/client/me/help/contact-form-notice/chat-generic-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-generic-closure.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { translate } from 'i18n-calypso';
+import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
-import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/help/contact-form-notice/chat-holiday-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-holiday-closure.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { translate } from 'i18n-calypso';
+import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
-import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/help/contact-form-notice/chat-reduced-availability.jsx
+++ b/client/me/help/contact-form-notice/chat-reduced-availability.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { translate } from 'i18n-calypso';
+import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
-import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/help/contact-form-notice/index.jsx
+++ b/client/me/help/contact-form-notice/index.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
-/**
- * Internal dependencies
- */
 import FoldableCard from 'calypso/components/foldable-card';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const ContactFormNotice = ( { showAt, hideAt, heading, message, compact } ) => {

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,21 +1,13 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { login } from 'calypso/lib/paths';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import config from '@automattic/calypso-config';
-import HelpComponent from './main';
-import CoursesComponent from './help-courses';
-import ContactComponent from './help-contact';
+import i18n from 'i18n-calypso';
+import React from 'react';
+import { login } from 'calypso/lib/paths';
 import { CONTACT, SUPPORT_ROOT } from 'calypso/lib/url/support';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
+import ContactComponent from './help-contact';
+import CoursesComponent from './help-courses';
+import HelpComponent from './main';
 
 export function loggedOut( context, next ) {
 	if ( isUserLoggedIn( context.store.getState() ) ) {

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 import 'moment-timezone'; // monkey patches the existing moment.js
 import { some } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	isEcommercePlan,
 	isBusinessPlan,
@@ -20,13 +12,10 @@ import {
 import FoldableCard from 'calypso/components/foldable-card';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const DATE_FORMAT_SHORT = 'MMMM D';

--- a/client/me/help/help-contact-confirmation/index.jsx
+++ b/client/me/help/help-contact-confirmation/index.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Internal dependencies
- */
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default class extends React.PureComponent {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -1,32 +1,25 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { localize } from 'i18n-calypso';
+import { debounce, isEqual, find, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { debounce, isEqual, find, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { preventWidows } from 'calypso/lib/formatting';
-import config from '@automattic/calypso-config';
+import InlineHelpCompactResults from 'calypso/blocks/inline-help/inline-help-compact-results';
+import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
-import SegmentedControl from 'calypso/components/segmented-control';
-import SelectDropdown from 'calypso/components/select-dropdown';
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormButton from 'calypso/components/forms/form-button';
-import SitesDropdown from 'calypso/components/sites-dropdown';
-import InlineHelpCompactResults from 'calypso/blocks/inline-help/inline-help-compact-results';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import Gridicon from 'calypso/components/gridicon';
 import Notice from 'calypso/components/notice';
+import SegmentedControl from 'calypso/components/segmented-control';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { preventWidows } from 'calypso/lib/formatting';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import SitesDropdown from 'calypso/components/sites-dropdown';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { selectSiteId } from 'calypso/state/help/actions';
-import { getHelpSelectedSite, getHelpSelectedSiteId } from 'calypso/state/help/selectors';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { resemblesUrl } from 'calypso/lib/url';
 import wpcomLib from 'calypso/lib/wp';
 import HelpResults from 'calypso/me/help/help-results';
 import {
@@ -38,16 +31,13 @@ import {
 	getCurrentUserLocale,
 	getCurrentUserSiteCount,
 } from 'calypso/state/current-user/selectors';
-import { requestSite } from 'calypso/state/sites/actions';
-import isShowingQandAInlineHelpContactForm from 'calypso/state/selectors/is-showing-q-and-a-inline-help-contact-form';
+import { selectSiteId } from 'calypso/state/help/actions';
+import { getHelpSelectedSite, getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import { showQandAOnInlineHelpContactForm } from 'calypso/state/inline-help/actions';
-import { resemblesUrl } from 'calypso/lib/url';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
+import isShowingQandAInlineHelpContactForm from 'calypso/state/selectors/is-showing-q-and-a-inline-help-contact-form';
+import { requestSite } from 'calypso/state/sites/actions';
 import { generateSubjectFromMessage } from './utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/client/me/help/help-contact-form/test/utils.js
+++ b/client/me/help/help-contact-form/test/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { generateSubjectFromMessage } from '../utils';
 
 describe( 'utils', () => {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -1,45 +1,27 @@
-/**
- * External dependencies
- */
-
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import page from 'page';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import Main from 'calypso/components/main';
+import { getPlanTermLabel } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
-import Notice from 'calypso/components/notice';
-import HelpContactForm from 'calypso/me/help/help-contact-form';
-import ActiveTicketsNotice from 'calypso/me/help/active-tickets-notice';
-import HelpContactConfirmation from 'calypso/me/help/help-contact-confirmation';
-import HeaderCake from 'calypso/components/header-cake';
-import wpcomLib from 'calypso/lib/wp';
-import ChatHolidayClosureNotice from 'calypso/me/help/contact-form-notice/chat-holiday-closure';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
-import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
-import hasHappychatLocalizedSupport from 'calypso/state/happychat/selectors/has-happychat-localized-support';
-import {
-	isTicketSupportConfigurationReady,
-	getTicketSupportRequestError,
-} from 'calypso/state/help/ticket/selectors';
-import HappychatConnection from 'calypso/components/happychat/connection-connected';
-import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import QueryLanguageNames from 'calypso/components/data/query-language-names';
 import QuerySupportHistory from 'calypso/components/data/query-support-history';
-import { withoutHttp } from 'calypso/lib/url';
-import HelpUnverifiedWarning from '../help-unverified-warning';
-import {
-	sendMessage as sendHappychatMessage,
-	sendUserInfo,
-} from 'calypso/state/happychat/connection/actions';
-import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
+import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcomLib from 'calypso/lib/wp';
+import ActiveTicketsNotice from 'calypso/me/help/active-tickets-notice';
+import HelpContactForm from 'calypso/me/help/help-contact-form';
+import HelpContactConfirmation from 'calypso/me/help/help-contact-confirmation';
+import ChatHolidayClosureNotice from 'calypso/me/help/contact-form-notice/chat-holiday-closure';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import {
 	getCurrentUser,
 	getCurrentUserLocale,
@@ -47,22 +29,34 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import {
+	sendMessage as sendHappychatMessage,
+	sendUserInfo,
+} from 'calypso/state/happychat/connection/actions';
+import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
+import hasHappychatLocalizedSupport from 'calypso/state/happychat/selectors/has-happychat-localized-support';
+import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
+import {
+	isTicketSupportConfigurationReady,
+	getTicketSupportRequestError,
+} from 'calypso/state/help/ticket/selectors';
+import { withoutHttp } from 'calypso/lib/url';
+import { errorNotice } from 'calypso/state/notices/actions';
+import getActiveSupportTickets from 'calypso/state/selectors/get-active-support-tickets';
+import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import HelpUnverifiedWarning from '../help-unverified-warning';
+import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
+import {
 	askQuestion as askDirectlyQuestion,
 	initialize as initializeDirectly,
 } from 'calypso/state/help/directly/actions';
-import { isRequestingSites } from 'calypso/state/sites/selectors';
-import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
 import getSupportLevel from 'calypso/state/selectors/get-support-level';
 import hasUserAskedADirectlyQuestion from 'calypso/state/selectors/has-user-asked-a-directly-question';
 import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
 import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uninitialized';
-import getActiveSupportTickets from 'calypso/state/selectors/get-active-support-tickets';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import { isDefaultLocale, localizeUrl } from 'calypso/lib/i18n-utils';
-import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import QueryLanguageNames from 'calypso/components/data/query-language-names';
 import getInlineHelpSupportVariation, {
 	SUPPORT_CHAT_OVERFLOW,
 	SUPPORT_DIRECTLY,
@@ -71,12 +65,7 @@ import getInlineHelpSupportVariation, {
 	SUPPORT_TICKET,
 	SUPPORT_UPWORK_TICKET,
 } from 'calypso/state/selectors/get-inline-help-support-variation';
-import { errorNotice } from 'calypso/state/notices/actions';
-import { getPlanTermLabel } from '@automattic/calypso-products';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const debug = debugFactory( 'calypso:help-contact' );
@@ -307,18 +296,22 @@ class HelpContact extends React.Component {
 					? this.translateForForums( 'Yes' )
 					: this.translateForForums( 'Unknown' );
 
-				blogHelpMessage += '\n' + this.translateForForums( 'WP.com: Unknown \nJetpack: %s', {
-					args: [ jetpackMessage ],
-				} );
+				blogHelpMessage +=
+					'\n' +
+					this.translateForForums( 'WP.com: Unknown \nJetpack: %s', {
+						args: [ jetpackMessage ],
+					} );
 			}
 
 			const correctAccountMessage = userDeclaredUrl
 				? this.translateForForums( 'Unknown' )
 				: this.translateForForums( 'Yes' );
 
-			blogHelpMessage += '\n' + this.translateForForums( 'Correct account: %s', {
-				args: [ correctAccountMessage ],
-			} );
+			blogHelpMessage +=
+				'\n' +
+				this.translateForForums( 'Correct account: %s', {
+					args: [ correctAccountMessage ],
+				} );
 		}
 
 		const forumMessage = message + '\n\n' + blogHelpMessage;

--- a/client/me/help/help-courses/constants.js
+++ b/client/me/help/help-courses/constants.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
 
 export const helpCourses = [

--- a/client/me/help/help-courses/course-list.jsx
+++ b/client/me/help/help-courses/course-list.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Course from './course';
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+import Course from './course';
 
 class CourseList extends Component {
 	render() {

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import { Card, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import Gridicon from 'calypso/components/gridicon';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 export default localize( ( props ) => {

--- a/client/me/help/help-courses/course-video.jsx
+++ b/client/me/help/help-courses/course-video.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { localize } from 'i18n-calypso';
+import React from 'react';
 
 export default localize( ( props ) => {
 	const { youtubeId } = props;

--- a/client/me/help/help-courses/course-videos.jsx
+++ b/client/me/help/help-courses/course-videos.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
-import CourseVideo from './course-video';
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import CourseVideo from './course-video';
 
 export default localize( ( props ) => {
 	const { videos, translate } = props;

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -1,21 +1,13 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
-import CourseScheduleItem from './course-schedule-item';
-import HelpTeaserButton from '../help-teaser-button';
-import CourseVideo from './course-video';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import HelpTeaserButton from '../help-teaser-button';
+import CourseScheduleItem from './course-schedule-item';
+import CourseVideo from './course-video';
 
 class Course extends Component {
 	componentDidMount() {

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -1,33 +1,23 @@
-/**
- * External dependencies
- */
+import { planHasFeature, FEATURE_BUSINESS_ONBOARDING } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import CourseList, { CourseListPlaceholder } from './course-list';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getHelpCourses } from 'calypso/state/help/courses/selectors';
-import { helpCourses } from './constants';
-import { planHasFeature, FEATURE_BUSINESS_ONBOARDING } from '@automattic/calypso-products';
 import { receiveHelpCourses } from 'calypso/state/help/courses/actions';
+import { getHelpCourses } from 'calypso/state/help/courses/selectors';
 import {
 	getUserPurchases,
 	isFetchingUserPurchases,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { helpCourses } from './constants';
+import CourseList, { CourseListPlaceholder } from './course-list';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Courses extends Component {

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -1,12 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { mapStateToProps } from '../index';
 import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE,
@@ -28,7 +19,9 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+import React from 'react';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { mapStateToProps } from '../index';
 
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/components/main', () => 'Main' );

--- a/client/me/help/help-happiness-engineers/index.jsx
+++ b/client/me/help/help-happiness-engineers/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import HappinessEngineersTray from 'calypso/components/happiness-engineers-tray';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function HelpHappinessEngineers( { translate } ) {

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import React from 'react';
 import HelpResult from './item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default class extends React.PureComponent {

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -1,17 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-/**
- * External dependencies
- */
-
+import { CompactCard } from '@automattic/components';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
 import { decodeEntities } from 'calypso/lib/formatting';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 export default class extends React.PureComponent {

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEmpty } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
-import getHelpLinks from 'calypso/state/selectors/get-help-links';
-import HelpResults from 'calypso/me/help/help-results';
-import NoResults from 'calypso/my-sites/no-results';
 import QueryHelpLinks from 'calypso/components/data/query-help-links';
 import SearchCard from 'calypso/components/search-card';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import HelpResults from 'calypso/me/help/help-results';
+import NoResults from 'calypso/my-sites/no-results';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getHelpLinks from 'calypso/state/selectors/get-help-links';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class HelpSearch extends React.PureComponent {

--- a/client/me/help/help-search/test/index.js
+++ b/client/me/help/help-search/test/index.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { HelpSearch } from '../';
 
 const defaultProps = {

--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-
-/**
- * Style dependencies
- */
 import './help-teaser-button.scss';
 
 export default localize( ( { title, description, href, onClick, target } ) => {

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -1,21 +1,11 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import wpcom from 'calypso/lib/wp';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const RESEND_IDLE = 0;

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -1,11 +1,8 @@
-/**
- * Internal dependencies
- */
-import * as helpController from './controller';
 import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
+import * as helpController from './controller';
 
 export default function () {
 	if ( config.isEnabled( 'help' ) ) {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -1,49 +1,39 @@
-/**
- * External dependencies
- */
+import { planHasFeature, FEATURE_BUSINESS_ONBOARDING } from '@automattic/calypso-products';
+import { Button, CompactCard, Card } from '@automattic/components';
 import debugModule from 'debug';
-import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { some } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { Button, CompactCard, Card } from '@automattic/components';
+import React from 'react';
+import { connect } from 'react-redux';
+import helpPurchases from 'calypso/assets/images/customer-home/illustration--secondary-earn.svg';
+import helpSupportSession from 'calypso/assets/images/customer-home/illustration-webinars.svg';
+import helpDomains from 'calypso/assets/images/illustrations/help-domains.svg';
+import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import Gridicon from 'calypso/components/gridicon';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { getCurrentUserId, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id.js';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
 import HelpUnverifiedWarning from './help-unverified-warning';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { getCurrentUserId, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
-import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
-import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id.js';
 import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getUserPurchases, isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
-import { planHasFeature, FEATURE_BUSINESS_ONBOARDING } from '@automattic/calypso-products';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**
  * Images
  */
-import helpSupportSession from 'calypso/assets/images/customer-home/illustration-webinars.svg';
-import helpDomains from 'calypso/assets/images/illustrations/help-domains.svg';
 import helpGetStarted from 'calypso/assets/images/illustrations/help-getstarted.svg';
 import helpPlugins from 'calypso/assets/images/illustrations/help-plugins.svg';
 import helpWebsite from 'calypso/assets/images/illustrations/help-website.svg';
 import helpPrivacy from 'calypso/assets/images/illustrations/help-privacy.svg';
-import helpPurchases from 'calypso/assets/images/customer-home/illustration--secondary-earn.svg';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -1,11 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE,
@@ -27,8 +19,9 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
-import { mapStateToProps } from '../main';
+import React from 'react';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { mapStateToProps } from '../main';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( '../help-unverified-warning', () => 'HelpUnverifiedWarning' );

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import * as controller from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import * as controller from './controller';
 
 export default function () {
 	page( '/me', controller.sidebar, controller.profile, makeLayout, clientRender );

--- a/client/me/memberships/controller.js
+++ b/client/me/memberships/controller.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 import Subscription from './subscription';
 

--- a/client/me/memberships/header.tsx
+++ b/client/me/memberships/header.tsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function MembershipSiteHeader( {

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -1,37 +1,23 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import PurchasesNavigation from 'calyspo/me/purchases/purchases-navigation';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PurchasesNavigation from 'calyspo/me/purchases/purchases-navigation';
-import Main from 'calypso/components/main';
+import noMembershipsImage from 'calypso/assets/images/illustrations/no-memberships.svg';
 import DocumentHead from 'calypso/components/data/document-head';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
-import SectionHeader from 'calypso/components/section-header';
-import { CompactCard } from '@automattic/components';
 import EmptyContent from 'calypso/components/empty-content';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import SectionHeader from 'calypso/components/section-header';
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
 import titles from 'calypso/me/purchases/titles';
 import FormattedHeader from 'calypso/components/formatted-header';
 
-/**
- * Style dependencies
- */
 import './style.scss';
-
-/**
- * Image dependencies
- */
-import noMembershipsImage from 'calypso/assets/images/illustrations/no-memberships.svg';
 
 const getMembershipEndDate = ( translate, endDate, moment ) => {
 	if ( ! endDate ) {

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -1,36 +1,26 @@
-/**
- * External dependencies
- */
+import { Card, CompactCard } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
-import { Card, CompactCard } from '@automattic/components';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import Main from 'calypso/components/main';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
-import HeaderCake from 'calypso/components/header-cake';
-import { purchasesRoot } from '../purchases/paths';
-import MembershipSiteHeader from './header';
+import FormattedHeader from 'calypso/components/formatted-header';
 import Gridicon from 'calypso/components/gridicon';
-import { requestSubscriptionStop } from 'calypso/state/memberships/subscriptions/actions';
-import Notice from 'calypso/components/notice';
+import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import titles from 'calypso/me/purchases/titles';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { requestSubscriptionStop } from 'calypso/state/memberships/subscriptions/actions';
 import {
 	getSubscription,
 	getStoppingStatus,
 } from 'calypso/state/memberships/subscriptions/selectors';
-import titles from 'calypso/me/purchases/titles';
-import FormattedHeader from 'calypso/components/formatted-header';
+import { purchasesRoot } from '../purchases/paths';
+import MembershipSiteHeader from './header';
 
-/**
- * Style dependencies
- */
 import './subscription.scss';
 
 class Subscription extends React.Component {

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { getSite } from 'calypso/state/sites/selectors';
-import { Card } from '@automattic/components';
-import Header from './header';
 import SettingsForm from 'calypso/me/notification-settings/settings-form';
+import { getSite } from 'calypso/state/sites/selectors';
+import Header from './header';
 
 class BlogSettings extends Component {
 	static propTypes = {

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,20 +1,14 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { countBy, map, omit, values, flatten } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
-/**
- * Internal dependencies
- */
+import SiteInfo from 'calypso/blocks/site';
 import Gridicon from 'calypso/components/gridicon';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
-import SiteInfo from 'calypso/blocks/site';
 
 class BlogSettingsHeader extends PureComponent {
 	static propTypes = {

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -1,24 +1,14 @@
-/**
- * External dependencies
- */
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
+import InfiniteList from 'calypso/components/infinite-list';
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import Blog from './blog';
-import InfiniteList from 'calypso/components/infinite-list';
 import Placeholder from './placeholder';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const createPlaceholder = () => <Placeholder />;

--- a/client/me/notification-settings/blogs-settings/placeholder.jsx
+++ b/client/me/notification-settings/blogs-settings/placeholder.jsx
@@ -1,16 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-/**
- * External dependencies
- */
-
+import { CompactCard } from '@automattic/components';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
 
 export default class extends React.Component {
 	static displayName = 'NotificationsBlogSettingsPlaceholder';

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -1,33 +1,23 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
-import ReauthRequired from 'calypso/me/reauth-required';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import Navigation from '../navigation';
-import { Card } from '@automattic/components';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-import SettingsForm from 'calypso/me/notification-settings/settings-form';
 import QueryUserDevices from 'calypso/components/data/query-user-devices';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import SettingsForm from 'calypso/me/notification-settings/settings-form';
+import ReauthRequired from 'calypso/me/reauth-required';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { fetchSettings, toggle, saveSettings } from 'calypso/state/notification-settings/actions';
 import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
-import FormattedHeader from 'calypso/components/formatted-header';
+import Navigation from '../navigation';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class NotificationCommentsSettings extends Component {

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
-import NotificationsComponent from 'calypso/me/notification-settings/main';
+import React from 'react';
 import CommentSettingsComponent from 'calypso/me/notification-settings/comment-settings';
-import WPcomSettingsComponent from 'calypso/me/notification-settings/wpcom-settings';
+import NotificationsComponent from 'calypso/me/notification-settings/main';
 import NotificationSubscriptions from 'calypso/me/notification-settings/reader-subscriptions';
+import WPcomSettingsComponent from 'calypso/me/notification-settings/wpcom-settings';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function notifications( context, next ) {
 	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { notifications, comments, updates, subscriptions } from './controller';
-import { sidebar } from 'calypso/me/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
+import { notifications, comments, updates, subscriptions } from './controller';
 
 export default function () {
 	page( '/me/notifications', sidebar, notifications, makeLayout, clientRender );

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -1,29 +1,22 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
-import ReauthRequired from 'calypso/me/reauth-required';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import Navigation from './navigation';
-import BlogsSettings from './blogs-settings';
-import PushNotificationSettings from './push-notification-settings';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QueryUserDevices from 'calypso/components/data/query-user-devices';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { fetchSettings, toggle, saveSettings } from 'calypso/state/notification-settings/actions';
 import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
-import FormattedHeader from 'calypso/components/formatted-header';
+import BlogsSettings from './blogs-settings';
+import Navigation from './navigation';
+import PushNotificationSettings from './push-notification-settings';
 
 class NotificationSettings extends Component {
 	componentDidMount() {

--- a/client/me/notification-settings/navigation.jsx
+++ b/client/me/notification-settings/navigation.jsx
@@ -1,17 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import SectionNav from 'calypso/components/section-nav';
-import NavTabs from 'calypso/components/section-nav/tabs';
 import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 
 class NotificationSettingsNavigation extends React.Component {
 	static displayName = 'NotificationSettingsNavigation';

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -1,30 +1,19 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import React from 'react';
+import { Card, Button, Dialog, ScreenReaderText } from '@automattic/components';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { Card, Button, Dialog, ScreenReaderText } from '@automattic/components';
 import Notice from 'calypso/components/notice';
+import { toggleEnabled, toggleUnblockInstructions } from 'calypso/state/push-notifications/actions';
 import {
 	getStatus,
 	isApiReady,
 	isShowingUnblockInstructions,
 	isEnabled,
 } from 'calypso/state/push-notifications/selectors';
-import { toggleEnabled, toggleUnblockInstructions } from 'calypso/state/push-notifications/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class PushNotificationSettings extends React.Component {

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,24 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import { protectForm } from 'calypso/lib/protect-form';
-import { Card } from '@automattic/components';
-import Navigation from 'calypso/me/notification-settings/navigation';
+import React from 'react';
+import { connect } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormButton from 'calypso/components/forms/form-button';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -27,8 +18,10 @@ import Main from 'calypso/components/main';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import FormattedHeader from 'calypso/components/formatted-header';
+import { protectForm } from 'calypso/lib/protect-form';
 import withFormBase from 'calypso/me/form-base/with-form-base';
+import Navigation from 'calypso/me/notification-settings/navigation';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 
 class NotificationSubscriptions extends React.Component {
 	handleClickEvent( action ) {

--- a/client/me/notification-settings/settings-form/actions.jsx
+++ b/client/me/notification-settings/settings-form/actions.jsx
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import FormButton from 'calypso/components/forms/form-button';
 
-/**
- * Style dependencies
- */
 import './actions.scss';
 
 class NotificationSettingsFormActions extends React.PureComponent {

--- a/client/me/notification-settings/settings-form/device-selector.jsx
+++ b/client/me/notification-settings/settings-form/device-selector.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import { size, map } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { size, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import FormSelect from 'calypso/components/forms/form-select';
 import getUserDevices from 'calypso/state/selectors/get-user-devices';
 import StreamHeader from './stream-header';
-import FormSelect from 'calypso/components/forms/form-select';
 
 class NotificationSettingsFormDeviceSelector extends PureComponent {
 	static propTypes = {

--- a/client/me/notification-settings/settings-form/index.jsx
+++ b/client/me/notification-settings/settings-form/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-import Settings from './settings';
 import Actions from './actions';
+import Settings from './settings';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class NotificationSettingsForm extends Component {

--- a/client/me/notification-settings/settings-form/labels-list.jsx
+++ b/client/me/notification-settings/settings-form/labels-list.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { getLabelForSetting } from './locales';
 
 export default class extends React.Component {

--- a/client/me/notification-settings/settings-form/labels.jsx
+++ b/client/me/notification-settings/settings-form/labels.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import StreamHeader from './stream-header';
 import LabelsList from './labels-list';
+import StreamHeader from './stream-header';
 
 class NotificationSettingsFormLabels extends React.Component {
 	static displayName = 'NotificationSettingsFormLabels';

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
 
 export const streamLabels = {

--- a/client/me/notification-settings/settings-form/settings.jsx
+++ b/client/me/notification-settings/settings-form/settings.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-
+import { find, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { find, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import getUserDevices from 'calypso/state/selectors/get-user-devices';
 import Labels from './labels';
 import Stream from './stream';
 import StreamSelector from './stream-selector';
-import getUserDevices from 'calypso/state/selectors/get-user-devices';
 
 /**
  * Module variables

--- a/client/me/notification-settings/settings-form/stream-header.jsx
+++ b/client/me/notification-settings/settings-form/stream-header.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import { getLabelForStream } from './locales';
 
 export default class extends React.PureComponent {

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { NOTIFICATIONS_EXCEPTIONS } from './constants';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { NOTIFICATIONS_EXCEPTIONS } from './constants';
 
 export default class extends React.PureComponent {
 	static displayName = 'NotificationSettingsFormStreamOptions';

--- a/client/me/notification-settings/settings-form/stream-selector.jsx
+++ b/client/me/notification-settings/settings-form/stream-selector.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import FormSelect from 'calypso/components/forms/form-select';
-import { getLabelForStream } from './locales';
 import getUserDevices from 'calypso/state/selectors/get-user-devices';
+import { getLabelForStream } from './locales';
 
 class NotificationSettingsFormStreamSelector extends PureComponent {
 	static propTypes = {

--- a/client/me/notification-settings/settings-form/stream.jsx
+++ b/client/me/notification-settings/settings-form/stream.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { find, size } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { find, size } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import StreamHeader from './stream-header';
 import DeviceSelector from './device-selector';
+import StreamHeader from './stream-header';
 import StreamOptions from './stream-options';
 
 class NotificationSettingsFormStream extends PureComponent {

--- a/client/me/notification-settings/wpcom-settings/email-category.jsx
+++ b/client/me/notification-settings/wpcom-settings/email-category.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLegend from 'calypso/components/forms/form-legend';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
 import { toggleWPcomEmailSetting } from 'calypso/state/notification-settings/actions';
 
 class EmailCategory extends React.Component {

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import Main from 'calypso/components/main';
-import ReauthRequired from 'calypso/me/reauth-required';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import Navigation from '../navigation';
-import { Card } from '@automattic/components';
+import React from 'react';
+import { connect } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-import ActionButtons from '../settings-form/actions';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import {
 	fetchSettings,
 	toggleWPcomEmailSetting,
@@ -26,14 +19,11 @@ import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
-import EmailCategory from './email-category';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
-import FormattedHeader from 'calypso/components/formatted-header';
+import Navigation from '../navigation';
+import ActionButtons from '../settings-form/actions';
+import EmailCategory from './email-category';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/client/me/pending-payments/controller.js
+++ b/client/me/pending-payments/controller.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 import PendingPaymentsComponent from './index';
 

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -1,36 +1,26 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { CompactCard } from '@automattic/components';
+import Banner from 'calypso/components/banner';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import PendingListItem from './pending-list-item';
+import { getStatsPathForTab } from 'calypso/lib/route';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
-import PurchasesSite from '../purchases/purchases-site';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getHttpData, requestHttpData } from 'calypso/state/data-layer/http-data';
+import { convertToCamelCase } from 'calypso/state/data-layer/utils';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
-import Banner from 'calypso/components/banner';
-import { convertToCamelCase } from 'calypso/state/data-layer/utils';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getStatsPathForTab } from 'calypso/lib/route';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PurchasesSite from '../purchases/purchases-site';
+import PendingListItem from './pending-list-item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export const requestId = ( userId ) => `pending-payments:${ userId }`;

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { get } from 'lodash';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import { Card, Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { paymentMethodName } from 'calypso/lib/cart-values';
+import { purchaseType as getPurchaseType, getName } from 'calypso/lib/purchases';
 import { getSite, getSiteTitle, getSiteDomain } from 'calypso/state/sites/selectors';
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
-import { purchaseType as getPurchaseType, getName } from 'calypso/lib/purchases';
-import { paymentMethodName } from 'calypso/lib/cart-values';
 
 export function PendingListItem( {
 	paymentType,

--- a/client/me/pending-payments/test/index.js
+++ b/client/me/pending-payments/test/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { PendingPayments, requestId } from '../index';
 
 jest.mock( 'calypso/state/data-layer/http-data', () => ( {

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
 import { shallow } from 'enzyme';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
-import { PendingListItem } from '../pending-list-item';
-import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import React from 'react';
 import * as localizedMoment from 'calypso/components/localized-moment';
+import { PendingListItem } from '../pending-list-item';
 
 jest.mock( 'calypso/components/localized-moment' );
 localizedMoment.useLocalizedMoment.mockReturnValue( moment );

--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PrivacyComponent from 'calypso/me/privacy/main';
 
 export function privacy( context, next ) {

--- a/client/me/privacy/dpa.jsx
+++ b/client/me/privacy/dpa.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
 import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import SectionHeader from 'calypso/components/section-header';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import wp from 'calypso/lib/wp';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 const NOTICE_ID = 'request-dpa-notice';
 

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
 import page from 'page';
-
-/**
- * Internal dependencies
- */
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { privacy } from './controller';
 import { sidebar } from 'calypso/me/controller';
+import { privacy } from './controller';
 
 export default function () {
 	page( '/me/privacy', sidebar, privacy, makeLayout, clientRender );

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -1,34 +1,27 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { withLocalizeUrl } from '@automattic/i18n-utils';
+import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { withLocalizeUrl } from '@automattic/i18n-utils';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import ExternalLink from 'calypso/components/external-link';
+import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import Main from 'calypso/components/main';
+import SectionHeader from 'calypso/components/section-header';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
-import SectionHeader from 'calypso/components/section-header';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import FormattedHeader from 'calypso/components/formatted-header';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { setUserSetting, saveUserSettings } from 'calypso/state/user-settings/actions';
 import hasUnsavedUserSettings from 'calypso/state/selectors/has-unsaved-user-settings';
+import { setUserSetting, saveUserSettings } from 'calypso/state/user-settings/actions';
 import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import DPA from './dpa';
 
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import Animate from 'calypso/components/animate';
 import Gravatar from 'calypso/components/gravatar';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 // use imgSize = 400 for caching

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -1,23 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { withoutHttp } from 'calypso/lib/url';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ProfileLink extends React.Component {

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { addUserProfileLinks } from 'calypso/state/profile-links/actions';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { addUserProfileLinks } from 'calypso/state/profile-links/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ProfileLinksAddOther extends React.Component {

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, map, pickBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
-import ProfileLinksAddWordPressSite from './site';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { addUserProfileLinks } from 'calypso/state/profile-links/actions';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import getPublicSites from 'calypso/state/selectors/get-public-sites';
 import getSites from 'calypso/state/selectors/get-sites';
 import isSiteInProfileLinks from 'calypso/state/selectors/is-site-in-profile-links';
-import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import ProfileLinksAddWordPressSite from './site';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ProfileLinksAddWordPress extends Component {

--- a/client/me/profile-links-add-wordpress/site.jsx
+++ b/client/me/profile-links-add-wordpress/site.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import Site from 'calypso/blocks/site';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class ProfileLinksAddWordPressSite extends Component {

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'calypso/components/gridicon';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import ProfileLink from 'calypso/me/profile-link';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import QueryProfileLinks from 'calypso/components/data/query-profile-links';
-import AddProfileLinksButtons from 'calypso/me/profile-links/add-buttons';
-import SectionHeader from 'calypso/components/section-header';
-import { Card } from '@automattic/components';
 import Notice from 'calypso/components/notice';
-import ProfileLinksAddWordPress from 'calypso/me/profile-links-add-wordpress';
+import SectionHeader from 'calypso/components/section-header';
+import ProfileLink from 'calypso/me/profile-link';
 import ProfileLinksAddOther from 'calypso/me/profile-links-add-other';
+import ProfileLinksAddWordPress from 'calypso/me/profile-links-add-wordpress';
+import AddProfileLinksButtons from 'calypso/me/profile-links/add-buttons';
 import {
 	deleteUserProfileLink,
 	resetUserProfileLinkErrors,
@@ -24,9 +17,6 @@ import {
 import getProfileLinks from 'calypso/state/selectors/get-profile-links';
 import getProfileLinksErrorType from 'calypso/state/selectors/get-profile-links-error-type';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ProfileLinks extends React.Component {

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,37 +1,27 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import { flowRight as compose } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { flowRight as compose } from 'lodash';
-import { localize } from 'i18n-calypso';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
-import withFormBase from 'calypso/me/form-base/with-form-base';
+import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import SectionHeader from 'calypso/components/section-header';
+import { protectForm } from 'calypso/lib/protect-form';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import withFormBase from 'calypso/me/form-base/with-form-base';
 import ProfileLinks from 'calypso/me/profile-links';
 import ReauthRequired from 'calypso/me/reauth-required';
-import SectionHeader from 'calypso/components/section-header';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import { protectForm } from 'calypso/lib/protect-form';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import FormattedHeader from 'calypso/components/formatted-header';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Profile extends React.Component {

--- a/client/me/purchases/add-new-payment-method/index.jsx
+++ b/client/me/purchases/add-new-payment-method/index.jsx
@@ -1,31 +1,24 @@
-/**
- * External dependencies
- */
-import { useSelector, useDispatch } from 'react-redux';
-import page from 'page';
-import React, { useMemo, useEffect } from 'react';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { errorNotice } from 'calypso/state/notices/actions';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import page from 'page';
+import React, { useMemo, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
-import Main from 'calypso/components/main';
-import titles from 'calypso/me/purchases/titles';
-import { paymentMethods } from 'calypso/me/purchases/paths';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-method-selector';
+import { paymentMethods } from 'calypso/me/purchases/paths';
+import titles from 'calypso/me/purchases/titles';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods';
-import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 function AddNewPaymentMethod() {
 	const goToPaymentMethods = () => page( paymentMethods );

--- a/client/me/purchases/billing-history/billing-history-filters.jsx
+++ b/client/me/purchases/billing-history/billing-history-filters.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import closest from 'component-closest';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, isEqual } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import SelectDropdown from 'calypso/components/select-dropdown';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { setApp, setDate } from 'calypso/state/billing-transactions/ui/actions';
 import getBillingTransactionAppFilterValues from 'calypso/state/selectors/get-billing-transaction-app-filter-values';

--- a/client/me/purchases/billing-history/billing-history-list.jsx
+++ b/client/me/purchases/billing-history/billing-history-list.jsx
@@ -1,33 +1,26 @@
-/**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
+import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import React from 'react';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import titleCase from 'to-title-case';
-import { capitalPDangit } from 'calypso/lib/formatting';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
+import { capitalPDangit } from 'calypso/lib/formatting';
 import BillingHistoryFilters from 'calypso/me/purchases/billing-history/billing-history-filters';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'calypso/state/billing-transactions/actions';
+import { setPage } from 'calypso/state/billing-transactions/ui/actions';
+import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
+import getFilteredBillingTransactions from 'calypso/state/selectors/get-filtered-billing-transactions';
+import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
 	renderTransactionAmount,
 	renderTransactionQuantitySummary,
 } from './utils';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { setPage } from 'calypso/state/billing-transactions/ui/actions';
-import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
-import getFilteredBillingTransactions from 'calypso/state/selectors/get-filtered-billing-transactions';
-import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'calypso/state/billing-transactions/actions';
 
 class BillingHistoryList extends React.Component {
 	static displayName = 'BillingHistoryList';

--- a/client/me/purchases/billing-history/controller.js
+++ b/client/me/purchases/billing-history/controller.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 import BillingHistoryComponent from 'calypso/me/purchases/billing-history/main';
 import Receipt from './receipt';

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,29 +1,19 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize, useTranslate } from 'i18n-calypso';
-import { CompactCard, Card } from '@automattic/components';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import { vatDetails as vatDetailsPath, billingHistoryReceipt } from 'calypso/me/purchases/paths';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
-import Main from 'calypso/components/main';
+import { CompactCard, Card } from '@automattic/components';
+import { localize, useTranslate } from 'i18n-calypso';
+import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
-import titles from 'calypso/me/purchases/titles';
 import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingHistoryList from 'calypso/me/purchases/billing-history/billing-history-list';
+import { vatDetails as vatDetailsPath, billingHistoryReceipt } from 'calypso/me/purchases/paths';
+import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
+import titles from 'calypso/me/purchases/titles';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export function BillingHistoryContent( {

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -1,43 +1,36 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
-import { connect, useDispatch } from 'react-redux';
-import { localize, useTranslate } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import { Button, Card } from '@automattic/components';
-import FormLabel from 'calypso/components/forms/form-label';
-import TextareaAutosize from 'calypso/components/textarea-autosize';
+import { localize, useTranslate } from 'i18n-calypso';
+import page from 'page';
+import React from 'react';
+import { connect, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import HeaderCake from 'calypso/components/header-cake';
-import Main from 'calypso/components/main';
-import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormLabel from 'calypso/components/forms/form-label';
+import HeaderCake from 'calypso/components/header-cake';
+import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
+import Main from 'calypso/components/main';
+import TextareaAutosize from 'calypso/components/textarea-autosize';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
+import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
+import titles from 'calypso/me/purchases/titles';
+import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { sendBillingReceiptEmail } from 'calypso/state/billing-transactions/actions';
+import {
+	clearBillingTransactionError,
+	requestBillingTransaction,
+} from 'calypso/state/billing-transactions/individual-transactions/actions';
+import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
+import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
 	renderTransactionAmount,
 	renderTransactionQuantitySummary,
 } from './utils';
-import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
-import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
-import {
-	clearBillingTransactionError,
-	requestBillingTransaction,
-} from 'calypso/state/billing-transactions/individual-transactions/actions';
-import { sendBillingReceiptEmail } from 'calypso/state/billing-transactions/actions';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
-import titles from 'calypso/me/purchases/titles';
-import FormattedHeader from 'calypso/components/formatted-header';
-import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 
 class BillingReceipt extends React.Component {
 	componentDidMount() {

--- a/client/me/purchases/billing-history/test/tax.js
+++ b/client/me/purchases/billing-history/test/tax.js
@@ -1,14 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
-import { mount } from 'enzyme';
 
-/**
- * Internal dependencies
- */
+import { mount } from 'enzyme';
 import { renderTransactionAmount, transactionIncludesTax } from '../utils';
 
 const translate = ( x ) => x;

--- a/client/me/purchases/billing-history/test/utils.js
+++ b/client/me/purchases/billing-history/test/utils.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import { groupDomainProducts } from '../utils';
 
 const ident = ( x ) => x;

--- a/client/me/purchases/billing-history/utils.jsx
+++ b/client/me/purchases/billing-history/utils.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { getPlanTermLabel, isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
+import formatCurrency from '@automattic/format-currency';
 import { find, map, partition, reduce, some } from 'lodash';
 import React, { Fragment } from 'react';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
-import { getPlanTermLabel, isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
 
 export const groupDomainProducts = ( originalItems, translate ) => {
 	const transactionItems = Object.keys( originalItems ).map( ( key ) => {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { isDomainRegistration } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { getCurrencyDefaults } from '@automattic/format-currency';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import { getCurrencyDefaults } from '@automattic/format-currency';
-
-/**
- * Internal Dependencies
- */
-import { Button } from '@automattic/components';
-import { cancelAndRefundPurchase, cancelPurchase } from 'calypso/lib/purchases/actions';
-import { clearPurchases } from 'calypso/state/purchases/actions';
+import { connect } from 'react-redux';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import {
@@ -23,12 +15,13 @@ import {
 	isOneTimePurchase,
 	isSubscription,
 } from 'calypso/lib/purchases';
-import { isDomainRegistration } from '@automattic/calypso-products';
+import { cancelAndRefundPurchase, cancelPurchase } from 'calypso/lib/purchases/actions';
 import { confirmCancelDomain, purchasesRoot } from 'calypso/me/purchases/paths';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { clearPurchases } from 'calypso/state/purchases/actions';
+import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
 
 class CancelPurchaseButton extends Component {
 	static propTypes = {

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -1,14 +1,3 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal Dependencies
- */
-import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
-import { getName, getSubscriptionEndDate, isRefundable } from 'calypso/lib/purchases';
 import {
 	isDomainMapping,
 	isGSuiteOrGoogleWorkspace,
@@ -17,6 +6,9 @@ import {
 	isPlan,
 	isTheme,
 } from '@automattic/calypso-products';
+import React from 'react';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { getName, getSubscriptionEndDate, isRefundable } from 'calypso/lib/purchases';
 import { isJetpackTemporarySitePurchase } from '../utils';
 
 export function cancellationEffectHeadline( purchase, translate ) {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -1,19 +1,19 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { isDataLoading } from 'calypso/me/purchases/utils';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+	getIncludedDomainPurchase,
+} from 'calypso/state/purchases/selectors';
+import HeaderCake from 'calypso/components/header-cake';
+import { isDomainRegistration, isDomainTransfer } from '@automattic/calypso-products';
+import { Card, CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
-
-/**
- * Internal Dependencies
- */
-import { Card, CompactCard } from '@automattic/components';
-import CancelPurchaseButton from './button';
-import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
-import CancelPurchaseRefundInformation from './refund-information';
+import { connect } from 'react-redux';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getName,
 	purchaseType,
@@ -23,27 +23,17 @@ import {
 	isRefundable,
 	isSubscription,
 } from 'calypso/lib/purchases';
-import { isDataLoading } from 'calypso/me/purchases/utils';
-import {
-	getByPurchaseId,
-	hasLoadedUserPurchasesFromServer,
-	getIncludedDomainPurchase,
-} from 'calypso/state/purchases/selectors';
-import HeaderCake from 'calypso/components/header-cake';
-import { isDomainRegistration, isDomainTransfer } from '@automattic/calypso-products';
-import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
 import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import ProductLink from 'calypso/me/purchases/product-link';
+import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
+import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import CancelPurchaseButton from './button';
+import CancelPurchaseRefundInformation from './refund-information';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class CancelPurchase extends React.Component {

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
+import { Button, Card, CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card, CompactCard } from '@automattic/components';
 import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
 import titles from 'calypso/me/purchases/titles';
 

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -1,15 +1,11 @@
-/**
- * External dependencies
- */
-
-import { connect } from 'react-redux';
+import { isDomainRegistration, isDomainMapping } from '@automattic/calypso-products';
+import i18n from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import { connect } from 'react-redux';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
 import {
 	getName,
 	isRefundable,
@@ -17,12 +13,8 @@ import {
 	isOneTimePurchase,
 	maybeWithinRefundPeriod,
 } from 'calypso/lib/purchases';
-import { isDomainRegistration, isDomainMapping } from '@automattic/calypso-products';
-import { getIncludedDomainPurchase } from 'calypso/state/purchases/selectors';
 import { CALYPSO_CONTACT, UPDATE_NAMESERVERS } from 'calypso/lib/url/support';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormRadio from 'calypso/components/forms/form-radio';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { getIncludedDomainPurchase } from 'calypso/state/purchases/selectors';
 
 const CancelPurchaseRefundInformation = ( {
 	purchase,

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { cancellationEffectDetail, cancellationEffectHeadline } from '../cancellation-effect';
 import productsValues from '@automattic/calypso-products';
+import { expect } from 'chai';
 import { isRefundable, getSubscriptionEndDate } from 'calypso/lib/purchases';
+import { cancellationEffectDetail, cancellationEffectHeadline } from '../cancellation-effect';
 
 jest.mock( '@automattic/calypso-products', () => ( {} ) );
 jest.mock( 'calypso/lib/purchases', () => ( {

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class LoadingPlaceholder extends React.Component {

--- a/client/me/purchases/components/payment-method-loader/index.jsx
+++ b/client/me/purchases/components/payment-method-loader/index.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React from 'react';
 import CreditCardFormFieldsLoadingPlaceholder from 'calypso/components/credit-card-form-fields/loading-placeholder';
 import FormButton from 'calypso/components/forms/form-button';
-import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
+import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function PaymentMethodLoader( { title } ) {

--- a/client/me/purchases/components/payment-method-sidebar/index.jsx
+++ b/client/me/purchases/components/payment-method-sidebar/index.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import PropTypes from 'prop-types';
+import React from 'react';
 import CardHeading from 'calypso/components/card-heading';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function PaymentMethodSidebar( { purchase } ) {

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
-import PropTypes from 'prop-types';
-
-/**
- * Internal Dependencies
- */
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 import ActionCard from 'calypso/components/action-card';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 import {
 	CONCIERGE_HAS_UPCOMING_APPOINTMENT,
 	CONCIERGE_HAS_AVAILABLE_INCLUDED_SESSION,
@@ -20,9 +13,6 @@ import {
 	CONCIERGE_SUGGEST_PURCHASE_CONCIERGE,
 } from 'calypso/me/concierge/constants';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ConciergeBanner extends Component {

--- a/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
+++ b/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import React from 'react';
 import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from 'calypso/lib/url/support';
 
 export default [

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -1,26 +1,22 @@
-/**
- * External dependencies
- */
-import page from 'page';
+import { isDomainRegistration } from '@automattic/calypso-products';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import { map, find } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, find } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import cancellationReasons from './cancellation-reasons';
-import { cancelAndRefundPurchase } from 'calypso/lib/purchases/actions';
-import { Card } from '@automattic/components';
-import { clearPurchases } from 'calypso/state/purchases/actions';
-import ConfirmCancelDomainLoadingPlaceholder from './loading-placeholder';
 import { connect } from 'react-redux';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getName as getDomainName } from 'calypso/lib/purchases';
+import { cancelAndRefundPurchase } from 'calypso/lib/purchases/actions';
+import cancellationReasons from './cancellation-reasons';
+import { clearPurchases } from 'calypso/state/purchases/actions';
+import ConfirmCancelDomainLoadingPlaceholder from './loading-placeholder';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import HeaderCake from 'calypso/components/header-cake';
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
@@ -28,13 +24,10 @@ import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import { getName as getDomainName } from 'calypso/lib/purchases';
 import { isDataLoading } from '../utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { isDomainRegistration } from '@automattic/calypso-products';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { cancelPurchase, purchasesRoot } from 'calypso/me/purchases/paths';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { receiveDeletedSite } from 'calypso/state/sites/actions';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
@@ -44,9 +37,6 @@ import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 import FormSelect from 'calypso/components/forms/form-select';
 

--- a/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import { Button, Card, CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card, CompactCard } from '@automattic/components';
-import { cancelPurchase } from 'calypso/me/purchases/paths';
 import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
+import { cancelPurchase } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
 
 const ConfirmCancelDomainLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,35 +1,28 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal Dependencies
- */
-import AddNewPaymentMethod from 'calypso/me/purchases/add-new-payment-method';
-import ChangePaymentMethod from 'calypso/me/purchases/manage-purchase/change-payment-method';
-import CancelPurchase from './cancel-purchase';
-import ConfirmCancelDomain from './confirm-cancel-domain';
-import Main from 'calypso/components/main';
-import ManagePurchase from './manage-purchase';
-import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
-import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
-import PurchasesList from './purchases-list';
+import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import titles from './titles';
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import HeaderCake from 'calypso/components/header-cake';
-import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import AddNewPaymentMethod from 'calypso/me/purchases/add-new-payment-method';
+import ChangePaymentMethod from 'calypso/me/purchases/manage-purchase/change-payment-method';
 import {
 	managePurchase as managePurchaseUrl,
 	purchasesRoot,
 	vatDetails as vatDetailsPath,
 	billingHistory,
 } from 'calypso/me/purchases/paths';
-import FormattedHeader from 'calypso/components/formatted-header';
+import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import CancelPurchase from './cancel-purchase';
+import ConfirmCancelDomain from './confirm-cancel-domain';
+import ManagePurchase from './manage-purchase';
+import PurchasesList from './purchases-list';
+import titles from './titles';
 import VatInfoPage from './vat-info';
 
 const PurchasesWrapper = ( { title = null, children } ) => {

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
 import page from 'page';
-
-/**
- * Internal Dependencies
- */
-import * as paymentMethodsController from 'calypso/me/purchases/payment-methods/controller';
-import * as billingController from 'calypso/me/purchases/billing-history/controller';
-import * as pendingController from 'calypso/me/pending-payments/controller';
-import * as membershipsController from 'calypso/me/memberships/controller';
-import * as controller from './controller';
-import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
+import * as membershipsController from 'calypso/me/memberships/controller';
+import * as pendingController from 'calypso/me/pending-payments/controller';
+import * as billingController from 'calypso/me/purchases/billing-history/controller';
+import * as paymentMethodsController from 'calypso/me/purchases/payment-methods/controller';
 import { siteSelection } from 'calypso/my-sites/controller';
+import * as controller from './controller';
+import * as paths from './paths';
 
 export default ( router ) => {
 	router(

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Dialog } from '@automattic/components';
-import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	isDomainRegistration,
 	isGSuiteOrGoogleWorkspace,
 	isPlan,
 	isTitanMail,
 } from '@automattic/calypso-products';
+import { Button, Dialog } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite } from 'calypso/state/sites/selectors';
 import './style.scss';

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-payment-method-dialog/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
+import { Dialog } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class AutoRenewPaymentMethodDialog extends Component {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -1,29 +1,22 @@
-/**
- * External dependencies
- */
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { isExpiring } from 'calypso/lib/purchases';
 import { disableAutoRenew, enableAutoRenew } from 'calypso/lib/purchases/actions';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
-import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { createNotice } from 'calypso/state/notices/actions';
-import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
-import AutoRenewPaymentMethodDialog from './auto-renew-payment-method-dialog';
+import { fetchUserPurchases } from 'calypso/state/purchases/actions';
+import { isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
+import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isExpired, isOneTimePurchase, isRechargeable } from '../../../../lib/purchases';
 import { getChangePaymentMethodPath } from '../../utils';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
+import AutoRenewPaymentMethodDialog from './auto-renew-payment-method-dialog';
 
 class AutoRenewToggle extends Component {
 	static propTypes = {

--- a/client/me/purchases/manage-purchase/change-payment-method/index.jsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.jsx
@@ -1,40 +1,33 @@
-/**
- * External dependencies
- */
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import HeaderCake from 'calypso/components/header-cake';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import HeaderCake from 'calypso/components/header-cake';
+import Layout from 'calypso/components/layout';
+import Column from 'calypso/components/layout/column';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
+import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { clearPurchases } from 'calypso/state/purchases/actions';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import { getCurrentUserId, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
 import {
 	getStoredCardById,
 	hasLoadedStoredCardsFromServer,
 } from 'calypso/state/stored-cards/selectors';
-import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import Layout from 'calypso/components/layout';
-import Column from 'calypso/components/layout/column';
-import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
-import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PaymentMethodSelector from '../payment-method-selector';
 import getPaymentMethodIdFromPayment from '../payment-method-selector/get-payment-method-id-from-payment';
 import useCreateAssignablePaymentMethods from './use-create-assignable-payment-methods';

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -1,24 +1,17 @@
-/**
- * External dependencies
- */
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import { useStripe } from '@automattic/calypso-stripe';
 import { useTranslate } from 'i18n-calypso';
-import type { PaymentMethod } from '@automattic/composite-checkout';
-
-/**
- * Internal Dependencies
- */
-import { getStoredCards } from 'calypso/state/stored-cards/selectors';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import {
 	useCreateCreditCard,
 	useCreateExistingCards,
 	useCreatePayPal,
 } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods';
-import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import doesValueExist from 'calypso/my-sites/checkout/composite-checkout/lib/does-value-exist';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
+import { getStoredCards } from 'calypso/state/stored-cards/selectors';
 import useFetchAvailablePaymentMethods from './use-fetch-available-payment-methods';
+import type { PaymentMethod } from '@automattic/composite-checkout';
 
 export default function useCreateAssignablePaymentMethods(
 	currentPaymentMethodId: string

--- a/client/me/purchases/manage-purchase/change-payment-method/use-fetch-available-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-fetch-available-payment-methods.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useReducer, useEffect, useRef } from 'react';
-
-/**
- * Internal Dependencies
- */
 import wp from 'calypso/lib/wp';
 
 const wpcom = wp.undocumented();

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -1,64 +1,4 @@
-/**
- * External dependencies
- */
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-
-/**
- * Internal Dependencies
- */
-import AsyncLoad from 'calypso/components/async-load';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { Button, Card, CompactCard, ProductIcon } from '@automattic/components';
 import config from '@automattic/calypso-config';
-import {
-	cardProcessorSupportsUpdates,
-	getDomainRegistrationAgreementUrl,
-	getDisplayName,
-	getPartnerName,
-	getRenewalPrice,
-	handleRenewMultiplePurchasesClick,
-	handleRenewNowClick,
-	hasAmountAvailableToRefund,
-	hasPaymentMethod,
-	isPaidWithCredits,
-	isCancelable,
-	isExpired,
-	isOneTimePurchase,
-	isPaidWithCreditCard,
-	isPartnerPurchase,
-	isRenewable,
-	isRenewing,
-	isSubscription,
-	isCloseToExpiration,
-	purchaseType,
-	getName,
-	shouldRenderMonthlyRenewalOption,
-} from 'calypso/lib/purchases';
-import {
-	canEditPaymentDetails,
-	getAddNewPaymentMethodPath,
-	getChangePaymentMethodPath,
-	isJetpackTemporarySitePurchase,
-} from '../utils';
-import {
-	getByPurchaseId,
-	hasLoadedUserPurchasesFromServer,
-	hasLoadedSitePurchasesFromServer,
-	getRenewableSitePurchases,
-} from 'calypso/state/purchases/selectors';
-import { getCanonicalTheme } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
-import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
-import Gridicon from 'calypso/components/gridicon';
-import HeaderCake from 'calypso/components/header-cake';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import {
 	isPersonal,
 	isPremium,
@@ -85,17 +25,71 @@ import {
 	isP2Plus,
 	getMonthlyPlanByYearly,
 } from '@automattic/calypso-products';
-import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import PlanPrice from 'calypso/my-sites/plan-price';
-import ProductLink from 'calypso/me/purchases/product-link';
-import PurchaseMeta from './purchase-meta';
-import PurchaseNotice from './notices';
-import PurchasePlanDetails from './plan-details';
-import PurchaseSiteHeader from '../purchases-site/header';
+import { Button, Card, CompactCard, ProductIcon } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import AsyncLoad from 'calypso/components/async-load';
+import Badge from 'calypso/components/badge';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import Gridicon from 'calypso/components/gridicon';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import {
+	cardProcessorSupportsUpdates,
+	getDomainRegistrationAgreementUrl,
+	getDisplayName,
+	getPartnerName,
+	getRenewalPrice,
+	handleRenewMultiplePurchasesClick,
+	handleRenewNowClick,
+	hasAmountAvailableToRefund,
+	hasPaymentMethod,
+	isPaidWithCredits,
+	isCancelable,
+	isExpired,
+	isOneTimePurchase,
+	isPaidWithCreditCard,
+	isPartnerPurchase,
+	isRenewable,
+	isRenewing,
+	isSubscription,
+	isCloseToExpiration,
+	purchaseType,
+	getName,
+	shouldRenderMonthlyRenewalOption,
+} from 'calypso/lib/purchases';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+	hasLoadedSitePurchasesFromServer,
+	getRenewableSitePurchases,
+} from 'calypso/state/purchases/selectors';
+import {
+	canEditPaymentDetails,
+	getAddNewPaymentMethodPath,
+	getChangePaymentMethodPath,
+	isJetpackTemporarySitePurchase,
+} from '../utils';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import HeaderCake from 'calypso/components/header-cake';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import ProductLink from 'calypso/me/purchases/product-link';
+import PurchaseNotice from './notices';
+import PurchasePlanDetails from './plan-details';
+import PurchaseMeta from './purchase-meta';
+import PurchaseSiteHeader from '../purchases-site/header';
 import RemovePurchase from '../remove-purchase';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
@@ -112,13 +106,9 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
-import Badge from 'calypso/components/badge';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { addQueryArgs } from 'calypso/lib/url';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ManagePurchase extends Component {

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -1,18 +1,20 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import {
+	isDomainTransfer,
+	isConciergeSession,
+	isPlan,
+	isDomainRegistration,
+	isMonthly,
+} from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import { isEmpty, merge, minBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { isEmpty, merge, minBy } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import config from '@automattic/calypso-config';
-import { getAddNewPaymentMethodPath } from '../utils';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
@@ -33,23 +35,11 @@ import {
 	isPaidWithCredits,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 } from 'calypso/lib/purchases';
-import {
-	isDomainTransfer,
-	isConciergeSession,
-	isPlan,
-	isDomainRegistration,
-	isMonthly,
-} from '@automattic/calypso-products';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getAddNewPaymentMethodPath } from '../utils';
 
-/**
- * Style dependencies
- */
 import './notices.scss';
 
 const eventProperties = ( warning ) => ( { warning, position: 'individual-purchase' } );

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import React from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import PaymentLogo from 'calypso/components/payment-logo';
 import {
 	isExpiring,
 	isRechargeable,
@@ -17,8 +12,6 @@ import {
 	paymentLogoType,
 	hasPaymentMethod,
 } from 'calypso/lib/purchases';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import PaymentLogo from 'calypso/components/payment-logo';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 export default function PaymentInfoBlock( { purchase }: { purchase: Purchase } ): JSX.Element {

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -1,25 +1,18 @@
-/**
- * External dependencies
- */
 import { createStripeSetupIntent } from '@automattic/calypso-stripe';
-import type { Stripe, StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
 import {
 	makeRedirectResponse,
 	makeSuccessResponse,
 	makeErrorResponse,
 } from '@automattic/composite-checkout';
-import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import wp from 'calypso/lib/wp';
-import { updateCreditCard, saveCreditCard } from './stored-payment-method-api';
-import type { Purchase } from 'calypso/lib/purchases/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { updateCreditCard, saveCreditCard } from './stored-payment-method-api';
+import type { Stripe, StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+import type { Purchase } from 'calypso/lib/purchases/types';
 
 const wpcom = wp.undocumented();
 const wpcomAssignPaymentMethod = (

--- a/client/me/purchases/manage-purchase/payment-method-selector/get-payment-method-id-from-payment.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/get-payment-method-id-from-payment.ts
@@ -1,6 +1,3 @@
-/**
- * Internal Dependencies
- */
 import type { PurchasePayment } from 'calypso/lib/purchases/types';
 
 // Return an ID as used in the payment method list in PaymentMethodSelector

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,43 +1,36 @@
-/**
- * External dependencies
- */
-import React, { useCallback, useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
 import { useStripe } from '@automattic/calypso-stripe';
+import { Card } from '@automattic/components';
 import {
 	CheckoutProvider,
 	CheckoutPaymentMethods,
 	CheckoutSubmitButton,
 } from '@automattic/composite-checkout';
-import type { PaymentMethod } from '@automattic/composite-checkout';
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import type { TranslateResult } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import React, { useCallback, useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import Notice from 'calypso/components/notice';
-import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
-import { creditCardHasAlreadyExpired } from 'calypso/lib/purchases';
-import { getStoredPaymentAgreements } from 'calypso/state/stored-cards/selectors';
-import Gridicon from 'calypso/components/gridicon';
-import {
-	useHandleRedirectChangeError,
-	useHandleRedirectChangeComplete,
-} from './url-event-handlers';
-import {
-	assignPayPalProcessor,
-	assignNewCardProcessor,
-	assignExistingCardProcessor,
-} from './assignment-processor-functions';
 import getPaymentMethodIdFromPayment from './get-payment-method-id-from-payment';
 import TosText from './tos-text';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
+import Gridicon from 'calypso/components/gridicon';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import { creditCardHasAlreadyExpired } from 'calypso/lib/purchases';
+import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
+import { getStoredPaymentAgreements } from 'calypso/state/stored-cards/selectors';
+import {
+	assignPayPalProcessor,
+	assignNewCardProcessor,
+	assignExistingCardProcessor,
+} from './assignment-processor-functions';
+import {
+	useHandleRedirectChangeError,
+	useHandleRedirectChangeComplete,
+} from './url-event-handlers';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import type { StripeConfiguration } from '@automattic/calypso-stripe';
-
-/**
- * Internal dependencies
- */
-import wpcomFactory from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcomFactory from 'calypso/lib/wp';
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 const wpcom = wpcomFactory.undocumented();

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import React from 'react';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import {
 	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,

--- a/client/me/purchases/manage-purchase/payment-method-selector/url-event-handlers.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/url-event-handlers.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { useEffect, useRef } from 'react';
 
 export function useHandleRedirectChangeError( errorCallback: () => void ): void {

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import { isMonthly, getYearlyPlanByMonthly } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import { Button } from '@automattic/components';
-
-/**
- * Internal Dependencies
- */
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { isMonthly, getYearlyPlanByMonthly } from '@automattic/calypso-products';
 import {
 	isExpired,
 	isExpiring,

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -1,34 +1,24 @@
-/**
- * External dependencies
- */
+import { isJetpackPlan, isFreeJetpackPlan } from '@automattic/calypso-products';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { Card } from '@automattic/components';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
+import QueryPluginKeys from 'calypso/components/data/query-plugin-keys';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import QueryPluginKeys from 'calypso/components/data/query-plugin-keys';
 import SectionHeader from 'calypso/components/section-header';
-import PlanBillingPeriod from './billing-period';
-import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import { getName, isExpired, isPartnerPurchase } from 'calypso/lib/purchases';
+import { getPluginsForSite } from 'calypso/state/plugins/premium/selectors';
 import {
 	getByPurchaseId,
 	hasLoadedSitePurchasesFromServer,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
-import { getName, isExpired, isPartnerPurchase } from 'calypso/lib/purchases';
-import { isJetpackPlan, isFreeJetpackPlan } from '@automattic/calypso-products';
-import { getPluginsForSite } from 'calypso/state/plugins/premium/selectors';
+import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import PlanBillingPeriod from './billing-period';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class PurchasePlanDetails extends Component {

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
-import React from 'react';
-import moment from 'moment';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { PlanBillingPeriod } from '../billing-period';
+import moment from 'moment';
 import page from 'page';
+import React from 'react';
+import { PlanBillingPeriod } from '../billing-period';
 
 const props = {
 	purchase: {

--- a/client/me/purchases/manage-purchase/plan-details/test/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/index.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
-import React from 'react';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { PurchasePlanDetails } from '../index';
+import React from 'react';
 import PlanBillingPeriod from '../billing-period';
+import { PurchasePlanDetails } from '../index';
 
 const props = {
 	purchaseId: 123,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -1,16 +1,24 @@
-/**
- * External dependencies
- */
+import {
+	getPlan,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+	JETPACK_LEGACY_PLANS,
+	isDomainRegistration,
+	isDomainTransfer,
+	isConciergeSession,
+	isJetpackPlan,
+	isJetpackProduct,
+	getProductFromSlug,
+} from '@automattic/calypso-products';
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-import { times } from 'lodash';
-
-/**
- * Internal Dependencies
- */
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import UserItem from 'calypso/components/user';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	getName,
 	isExpired,
@@ -26,31 +34,16 @@ import {
 	isWithinIntroductoryOfferPeriod,
 	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
+import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
+import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
-import AutoRenewToggle from './auto-renew-toggle';
-import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
-import UserItem from 'calypso/components/user';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { canEditPaymentDetails, isJetpackTemporarySitePurchase } from '../utils';
-import {
-	getPlan,
-	TERM_BIENNIALLY,
-	TERM_MONTHLY,
-	JETPACK_LEGACY_PLANS,
-	isDomainRegistration,
-	isDomainTransfer,
-	isConciergeSession,
-	isJetpackPlan,
-	isJetpackProduct,
-	getProductFromSlug,
-} from '@automattic/calypso-products';
-import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
+import AutoRenewToggle from './auto-renew-toggle';
 import PaymentInfoBlock from './payment-info-block';
-import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
 
 export default function PurchaseMeta( {
 	purchaseId = false,

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -1,17 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * External dependencies
- */
+
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
 import { createReduxStore } from 'calypso/state';
 import PurchaseNotice from '../notices';
 

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -5,16 +5,9 @@
 /* eslint-disable jest/no-conditional-expect */
 /* eslint-disable jest/valid-title */
 
-/**
- * External dependencies
- */
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-
-/**
- * Internal dependencies
- */
 import PaymentInfoBlock from '../payment-info-block';
 
 describe( 'PaymentInfoBlock', () => {

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -1,21 +1,11 @@
-/**
- * External dependencies
- */
-import React, { useEffect, useState } from 'react';
-import { useTranslate } from 'i18n-calypso';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import React, { useEffect, useState } from 'react';
+import SiteIcon from 'calypso/blocks/site-icon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { MembershipSubscription } from 'calypso/lib/purchases/types';
-import SiteIcon from 'calypso/blocks/site-icon';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/style.scss';
 
 const MembershipTerms = ( { subscription }: { subscription: MembershipSubscription } ) => {

--- a/client/me/purchases/membership-site/index.tsx
+++ b/client/me/purchases/membership-site/index.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import MembershipItem from '../membership-item';
 import { MembershipSubscriptionsSite, MembershipSubscription } from 'calypso/lib/purchases/types';
+import MembershipItem from '../membership-item';
 
 export default function MembershipSite( {
 	site,

--- a/client/me/purchases/non-primary-domain-dialog/index.jsx
+++ b/client/me/purchases/non-primary-domain-dialog/index.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
+import { Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class NonPrimaryDomainDialog extends Component {

--- a/client/me/purchases/payment-methods/controller.js
+++ b/client/me/purchases/payment-methods/controller.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 import PaymentMethodsComponent from 'calypso/me/purchases/payment-methods/main';
 

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -1,25 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize, useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { getAddNewPaymentMethodPath } from 'calypso/me/purchases/utils';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import React from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
-import Main from 'calypso/components/main';
-import DocumentHead from 'calypso/components/data/document-head';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import titles from 'calypso/me/purchases/titles';
-import FormattedHeader from 'calypso/components/formatted-header';
+import { getAddNewPaymentMethodPath } from 'calypso/me/purchases/utils';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function PaymentMethods(): JSX.Element {

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent } from 'react';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button, Dialog } from '@automattic/components';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import React, { FunctionComponent } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -1,27 +1,19 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { ReduxDispatch } from 'calypso/state/redux-store';
-import { deleteStoredCard } from 'calypso/state/stored-cards/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { isDeletingStoredCard } from 'calypso/state/stored-cards/selectors';
-import { Button } from '@automattic/components';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	isPaymentAgreement,
 	getPaymentMethodSummary,
 	PaymentMethod,
 } from 'calypso/lib/checkout/payment-methods';
-import PaymentMethodDetails from './payment-method-details';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { ReduxDispatch } from 'calypso/state/redux-store';
+import { deleteStoredCard } from 'calypso/state/stored-cards/actions';
+import { isDeletingStoredCard } from 'calypso/state/stored-cards/selectors';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PaymentMethodDetails from './payment-method-details';
 
 interface Props {
 	card: PaymentMethod;

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -1,23 +1,13 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent } from 'react';
-import { useTranslate } from 'i18n-calypso';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import { useTranslate } from 'i18n-calypso';
+import React, { FunctionComponent } from 'react';
+import Gridicon from 'calypso/components/gridicon';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getPaymentMethodImageURL,
 	getPaymentMethodSummary,
 } from 'calypso/lib/checkout/payment-methods';
-import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {

--- a/client/me/purchases/payment-methods/payment-method-list.jsx
+++ b/client/me/purchases/payment-methods/payment-method-list.jsx
@@ -1,17 +1,12 @@
-/**
- * External dependencies
- */
-
-import { connect } from 'react-redux';
+import { Button, CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { Button, CompactCard } from '@automattic/components';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import QueryStoredCards from 'calypso/components/data/query-stored-cards';
+import SectionHeader from 'calypso/components/section-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import PaymentMethodDelete from 'calypso/me/purchases/payment-methods/payment-method-delete';
 import {
@@ -20,13 +15,7 @@ import {
 	hasLoadedStoredCardsFromServer,
 	isFetchingStoredCards,
 } from 'calypso/state/stored-cards/selectors';
-import QueryStoredCards from 'calypso/components/data/query-stored-cards';
-import SectionHeader from 'calypso/components/section-header';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 class PaymentMethodList extends Component {

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
-import React, { FunctionComponent, ComponentProps } from 'react';
-
-/**
- * Internal dependencies
- */
-import PaymentMethodDetails from './payment-method-details';
 import { CompactCard } from '@automattic/components';
+import React, { FunctionComponent, ComponentProps } from 'react';
+import PaymentMethodDetails from './payment-method-details';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -1,18 +1,3 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import React from 'react';
-import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
-import { emailManagement } from 'calypso/my-sites/email/paths';
-import { getThemeDetailsUrl } from 'calypso/state/themes/selectors';
 import {
 	isDomainProduct,
 	isGSuiteOrGoogleWorkspace,
@@ -21,6 +6,13 @@ import {
 	isTheme,
 	isTitanMail,
 } from '@automattic/calypso-products';
+import i18n from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { emailManagement } from 'calypso/my-sites/email/paths';
+import { getThemeDetailsUrl } from 'calypso/state/themes/selectors';
 
 const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	let url;

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -1,16 +1,16 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { isDomainTransfer, isConciergeSession } from '@automattic/calypso-products';
+import { CompactCard } from '@automattic/components';
+import classNames from 'classnames';
 import i18nCalypso, { localize } from 'i18n-calypso';
 import page from 'page';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
+import SiteIcon from 'calypso/blocks/site-icon';
+import Gridicon from 'calypso/components/gridicon';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import {
 	getDisplayName,
 	isExpired,
@@ -27,19 +27,9 @@ import {
 	isWithinIntroductoryOfferPeriod,
 	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
-import { isDomainTransfer, isConciergeSession } from '@automattic/calypso-products';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import SiteIcon from 'calypso/blocks/site-icon';
-import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
-import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
-import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import Gridicon from 'calypso/components/gridicon';
+import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/style.scss';
 
 const eventProperties = ( warning ) => ( { warning, position: 'purchase-list' } );

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
+import i18n from 'i18n-calypso';
 import moment from 'moment';
 import React from 'react';
-import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import { createStore } from 'redux';
 import PurchaseItem from '../';
-import i18n from 'i18n-calypso';
 
 describe( 'PurchaseItem', () => {
 	describe( 'a purchase that expired < 24 hours ago', () => {

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -1,25 +1,8 @@
-/**
- * External dependencies
- */
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { CompactCard } from '@automattic/components';
-import ConciergeBanner from '../concierge-banner';
-import EmptyContent from 'calypso/components/empty-content';
-import isBusinessPlanUser from 'calypso/state/selectors/is-business-plan-user';
-import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
-import PurchasesSite from '../purchases-site';
-import MembershipSite from '../membership-site';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
@@ -34,6 +17,13 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
 import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id.js';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import EmptyContent from 'calypso/components/empty-content';
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import {
 	CONCIERGE_HAS_UPCOMING_APPOINTMENT,
 	CONCIERGE_HAS_AVAILABLE_INCLUDED_SESSION,
@@ -42,10 +32,13 @@ import {
 	CONCIERGE_WPCOM_BUSINESS_ID,
 	CONCIERGE_WPCOM_SESSION_PRODUCT_ID,
 } from 'calypso/me/concierge/constants';
-import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
-import FormattedHeader from 'calypso/components/formatted-header';
-import InlineSupportLink from 'calypso/components/inline-support-link';
+import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import titles from 'calypso/me/purchases/titles';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import isBusinessPlanUser from 'calypso/state/selectors/is-business-plan-user';
+import ConciergeBanner from '../concierge-banner';
+import MembershipSite from '../membership-site';
+import PurchasesSite from '../purchases-site';
 import PurchasesListHeader from './purchases-list-header';
 
 class PurchasesList extends Component {

--- a/client/me/purchases/purchases-list/purchases-list-header.jsx
+++ b/client/me/purchases/purchases-list/purchases-list-header.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
 import { CompactCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 
-/**
- * Style dependencies
- */
 import 'calypso/me/purchases/style.scss';
 
 const PurchasesListHeader = ( { showSite = false } ) => {

--- a/client/me/purchases/purchases-navigation/index.jsx
+++ b/client/me/purchases/purchases-navigation/index.jsx
@@ -1,15 +1,10 @@
-/**
- * External dependencies
- */
-
+import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import Search from 'calypso/components/search';
+import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import {
@@ -19,9 +14,6 @@ import {
 	purchasesRoot,
 } from 'calypso/me/purchases/paths.js';
 import titles from 'calypso/me/purchases/titles';
-import SectionNav from 'calypso/components/section-nav';
-import { isEnabled } from '@automattic/calypso-config';
-import Search from 'calypso/components/search';
 import { setQuery } from 'calypso/state/billing-transactions/ui/actions';
 
 export default function PurchasesNavigation( { section } ) {

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -1,24 +1,14 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { CompactCard } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
-import { getSite } from 'calypso/state/sites/selectors';
-import QuerySites from 'calypso/components/data/query-sites';
+import { connect } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import QuerySites from 'calypso/components/data/query-sites';
+import Gridicon from 'calypso/components/gridicon';
+import { getSite } from 'calypso/state/sites/selectors';
 import { isJetpackTemporarySitePurchase } from '../utils';
 
-/**
- * Style dependencies
- */
 import './header.scss';
 
 class PurchaseSiteHeader extends Component {

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -1,31 +1,20 @@
-/**
- * External dependencies
- */
-
-import { connect } from 'react-redux';
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
-import AsyncLoad from 'calypso/components/async-load';
-import { getSite } from 'calypso/state/sites/selectors';
 import {
 	isJetpackPlan,
 	isJetpackProduct,
 	JETPACK_PLANS,
 	JETPACK_PRODUCTS_LIST,
 } from '@automattic/calypso-products';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import QuerySites from 'calypso/components/data/query-sites';
-import PurchaseItem from '../purchase-item';
+import { getSite } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
+import PurchaseItem from '../purchase-item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const PurchasesSite = ( {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -1,25 +1,4 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import page from 'page';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import Gridicon from 'calypso/components/gridicon';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Dialog, Button, CompactCard } from '@automattic/components';
 import config from '@automattic/calypso-config';
-import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
-import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
-import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
-import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
-import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'calypso/lib/purchases';
-import { isDataLoading } from '../utils';
 import {
 	isDomainMapping,
 	isDomainRegistration,
@@ -31,25 +10,36 @@ import {
 	isJetpackSearch,
 	isTitanMail,
 } from '@automattic/calypso-products';
-import { purchasesRoot } from '../paths';
+import { Dialog, Button, CompactCard } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import Gridicon from 'calypso/components/gridicon';
+import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
+import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
+import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'calypso/lib/purchases';
+import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { isDataLoading } from '../utils';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import { removePurchase } from 'calypso/state/purchases/actions';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { receiveDeletedSite } from 'calypso/state/sites/actions';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { purchasesRoot } from '../paths';
 import RemoveDomainDialog from './remove-domain-dialog';
-import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
-import VerticalNavItem from 'calypso/components/vertical-nav/item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class RemovePurchase extends Component {

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -1,31 +1,24 @@
-/**
- * External dependencies
- */
+import { Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { getSelectedDomain } from 'calypso/lib/domains';
+import { getName } from 'calypso/lib/purchases';
+import { getTitanProductName, hasTitanMailWithUs } from 'calypso/lib/titan';
+import wpcom from 'calypso/lib/wp';
 import {
 	domainManagementTransferOut,
 	domainManagementNameServers,
 } from 'calypso/my-sites/domains/paths';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import { getName } from 'calypso/lib/purchases';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getSelectedDomain } from 'calypso/lib/domains';
-import { getTitanProductName, hasTitanMailWithUs } from 'calypso/lib/titan';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import wpcom from 'calypso/lib/wp';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import i18n from 'i18n-calypso';
 
 const titles = {

--- a/client/me/purchases/track-purchase-page-view/index.js
+++ b/client/me/purchases/track-purchase-page-view/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 
 export class TrackPurchasePageView extends Component {
 	static propTypes = {

--- a/client/me/purchases/track-purchase-page-view/test/index.js
+++ b/client/me/purchases/track-purchase-page-view/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { shallow } from 'enzyme';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
+import { shallow } from 'enzyme';
+import React from 'react';
 import { TrackPurchasePageView } from '..';
 
 const baseProps = deepFreeze( {

--- a/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
@@ -2,19 +2,13 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import Modal from 'react-modal';
-import moment from 'moment';
 import { render, fireEvent, screen } from '@testing-library/react';
-import { unmountComponentAtNode } from 'react-dom';
+import moment from 'moment';
 import React from 'react';
+import { unmountComponentAtNode } from 'react-dom';
+import Modal from 'react-modal';
 import '@testing-library/jest-dom/extend-expect';
 
-/**
- * Internal dependencies
- */
 import UpcomingRenewalsDialog from '../upcoming-renewals-dialog';
 
 describe( '<UpcomingRenewalsDialog>', () => {

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -1,6 +1,7 @@
-/**
- * External dependencies
- */
+import { Button, Dialog } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { capitalize } from 'lodash';
 import React, {
 	FunctionComponent,
 	Fragment,
@@ -9,13 +10,9 @@ import React, {
 	useCallback,
 	useMemo,
 } from 'react';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
-import formatCurrency from '@automattic/format-currency';
-import { capitalize } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getName,
 	getRenewalPrice,
@@ -23,20 +20,9 @@ import {
 	isExpired,
 	isRenewing,
 } from 'calypso/lib/purchases';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import { Button, Dialog } from '@automattic/components';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { managePurchase } from '../paths';
-
-/**
- * Type dependencies
- */
 import type { Purchase } from 'calypso/lib/purchases/types';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface Site {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import { addPaymentMethod, changePaymentMethod, addNewPaymentMethod } from './paths';
+import { isDomainTransfer } from '@automattic/calypso-products';
 import {
 	isExpired,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
 } from 'calypso/lib/purchases';
-import { isDomainTransfer } from '@automattic/calypso-products';
+import { addPaymentMethod, changePaymentMethod, addNewPaymentMethod } from './paths';
 
 function isDataLoading( props ) {
 	return ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,27 +1,20 @@
-/**
- * External dependencies
- */
-import React, { useState, useEffect } from 'react';
-import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
 import { CompactCard, Button, Card } from '@automattic/components';
-
-/**
- * Internal dependencies
- */
-import Layout from 'calypso/components/layout';
-import Column from 'calypso/components/layout/column';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
-import useVatDetails from './use-vat-details';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import type { VatDetails, UpdateError } from './use-vat-details';
-import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import Layout from 'calypso/components/layout';
+import Column from 'calypso/components/layout/column';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
+import useVatDetails from './use-vat-details';
+import type { VatDetails, UpdateError } from './use-vat-details';
 
 import './style.scss';
 

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { useCallback, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export interface VatDetails {

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -1,18 +1,12 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { supported } from '@github/webauthn-json';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import PropTypes from 'prop-types';
-import { supported } from '@github/webauthn-json';
+import React from 'react';
+import { connect } from 'react-redux';
 
 const debug = debugFactory( 'calypso:me:reauth-required' );
 
-/**
- * Internal Dependencies
- */
 import { Card, Dialog } from '@automattic/components';
 import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -20,16 +14,13 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import Notice from 'calypso/components/notice';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import SecurityKeyForm from './security-key-form';
 import TwoFactorActions from './two-factor-actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 // autofocus is used for tracking purposes, not an a11y issue

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
+import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import { localize } from 'i18n-calypso';
 import Spinner from 'calypso/components/spinner';
 
-/**
- * Style dependencies
- */
 import './security-key-form.scss';
 
 class SecurityKeyForm extends Component {

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './two-factor-actions.scss';
 
 class TwoFactorActions extends Component {

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -1,34 +1,23 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
+import { Button } from '@automattic/components';
+import { saveAs } from 'browser-filesaver';
+import Clipboard from 'clipboard';
 import { localize } from 'i18n-calypso';
+import { flowRight as compose } from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-import Clipboard from 'clipboard';
-import Gridicon from 'calypso/components/gridicon';
-import { saveAs } from 'browser-filesaver';
-import { flowRight as compose } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import ButtonGroup from 'calypso/components/button-group';
 import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
-import Notice from 'calypso/components/notice';
-import ButtonGroup from 'calypso/components/button-group';
-import { Button } from '@automattic/components';
-import Tooltip from 'calypso/components/tooltip';
+import Gridicon from 'calypso/components/gridicon';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import Notice from 'calypso/components/notice';
+import Tooltip from 'calypso/components/tooltip';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faBackupCodesList extends React.Component {

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -8,20 +5,14 @@ import React from 'react';
 
 const debug = debugFactory( 'calypso:me:security:2fa-backup-codes-prompt' );
 
-/**
- * Internal dependencies
- */
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
 import Notice from 'calypso/components/notice';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faBackupCodesPrompt extends React.Component {

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -1,25 +1,15 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-list';
 import Security2faBackupCodesPrompt from 'calypso/me/security-2fa-backup-codes-prompt';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faBackupCodes extends React.Component {

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -8,10 +5,6 @@ import React from 'react';
 
 const debug = debugFactory( 'calypso:me:security:2fa-code-prompt' );
 
-/**
- * Internal dependencies
- */
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -19,11 +12,9 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
 import Notice from 'calypso/components/notice';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faCodePrompt extends React.Component {

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FormButton from 'calypso/components/forms/form-button';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import Security2faStatus from 'calypso/me/security-2fa-status';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import Security2faCodePrompt from 'calypso/me/security-2fa-code-prompt';
+import Security2faStatus from 'calypso/me/security-2fa-status';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faDisable extends Component {

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -10,21 +7,15 @@ import React from 'react';
 
 const debug = debugFactory( 'calypso:me:security:2fa-enable' );
 
-/**
- * Internal dependencies
- */
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import FormButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
 import Notice from 'calypso/components/notice';
-import Security2faProgress from 'calypso/me/security-2fa-progress';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import Security2faProgress from 'calypso/me/security-2fa-progress';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faEnable extends React.Component {

--- a/client/me/security-2fa-initial-setup/index.jsx
+++ b/client/me/security-2fa-initial-setup/index.jsx
@@ -1,15 +1,9 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import React from 'react';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 const debug = debugFactory( 'calypso:me:security:2fa-initial-setup' );
 
-/**
- * Internal dependencies
- */
 import FormButton from 'calypso/components/forms/form-button';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 

--- a/client/me/security-2fa-key/add.jsx
+++ b/client/me/security-2fa-key/add.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-import { errorNotice, warningNotice, successNotice } from 'calypso/state/notices/actions';
 import { registerSecurityKey } from 'calypso/lib/webauthn';
+import { errorNotice, warningNotice, successNotice } from 'calypso/state/notices/actions';
 import Security2faKeyAddName from './name';
 import WaitForKey from './wait-for-key';
 

--- a/client/me/security-2fa-key/delete-item-button.jsx
+++ b/client/me/security-2fa-key/delete-item-button.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
+import { Button, Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { Button, Dialog } from '@automattic/components';
-import { successNotice } from '../../state/notices/actions';
-import { recordGoogleEvent } from '../../state/analytics/actions';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
+import { recordGoogleEvent } from '../../state/analytics/actions';
+import { successNotice } from '../../state/notices/actions';
 
 class Security2faKeyDeleteButton extends Component {
 	static propTypes = {

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import Gridicon from 'calypso/components/gridicon';
+import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import Gridicon from 'calypso/components/gridicon';
+import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
-import Security2faKeyAdd from './add';
-import Security2faKeyList from './list';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 import wpcom from 'calypso/lib/wp';
-import Notice from 'calypso/components/notice';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import Security2faKeyAdd from './add';
+import Security2faKeyList from './list';
 
 class Security2faKey extends React.Component {
 	state = {

--- a/client/me/security-2fa-key/item.jsx
+++ b/client/me/security-2fa-key/item.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
+import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
+import React from 'react';
+import { connect } from 'react-redux';
 import { recordGoogleEvent } from '../../state/analytics/actions';
 import Security2faDeleteButton from './delete-item-button';
 

--- a/client/me/security-2fa-key/list.jsx
+++ b/client/me/security-2fa-key/list.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { connect } from 'react-redux';
 import { recordGoogleEvent } from '../../state/analytics/actions';
 import Security2faKeyItem from './item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function Security2faKeyList( props ) {

--- a/client/me/security-2fa-key/name.jsx
+++ b/client/me/security-2fa-key/name.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/me/security-2fa-key/wait-for-key.jsx
+++ b/client/me/security-2fa-key/wait-for-key.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import Spinner from 'calypso/components/spinner';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import Spinner from 'calypso/components/spinner';
 
 export default function WaitForKey() {
 	const translate = useTranslate();

--- a/client/me/security-2fa-progress/index.jsx
+++ b/client/me/security-2fa-progress/index.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 const debug = debugFactory( 'calypso:me:security:2fa-progress' );
 import ProgressItem from './progress-item';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security2faProgress extends React.Component {

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import FormLabel from 'calypso/components/forms/form-label';
 import Gridicon from 'calypso/components/gridicon';
 

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-list';
 import Security2faProgress from 'calypso/me/security-2fa-progress';
-import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class Security2faSetupBackupCodes extends React.Component {

--- a/client/me/security-2fa-setup/index.jsx
+++ b/client/me/security-2fa-setup/index.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import Security2faEnable from 'calypso/me/security-2fa-enable';
+import Security2faInitialSetup from 'calypso/me/security-2fa-initial-setup';
 import Security2faSetupBackupCodes from 'calypso/me/security-2fa-setup-backup-codes';
 import Security2faSMSSettings from 'calypso/me/security-2fa-sms-settings';
-import Security2faInitialSetup from 'calypso/me/security-2fa-initial-setup';
 import { successNotice } from 'calypso/state/notices/actions';
 
 class Security2faSetup extends Component {

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -1,31 +1,21 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import { flowRight as compose } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import Notice from 'calypso/components/notice';
-import Security2faProgress from 'calypso/me/security-2fa-progress';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { protectForm } from 'calypso/lib/protect-form';
+import Security2faProgress from 'calypso/me/security-2fa-progress';
 import getCountries from 'calypso/state/selectors/get-countries';
-import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { setUserSetting, saveUserSettings } from 'calypso/state/user-settings/actions';
 import { saveTwoStepSMSSettings } from 'calypso/state/user-settings/thunks';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
 

--- a/client/me/security-2fa-status/index.jsx
+++ b/client/me/security-2fa-status/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const debug = debugFactory( 'calypso:me:security:2fa-status' );

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import FormButton from 'calypso/components/forms/form-button';
 import Gridicon from 'calypso/components/gridicon';
 

--- a/client/me/security-account-recovery/edit-email.jsx
+++ b/client/me/security-account-recovery/edit-email.jsx
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import ReactDom from 'react-dom';
-import React from 'react';
 import emailValidator from 'email-validator';
-
-/**
- * Internal dependencies
- */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDom from 'react-dom';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import Buttons from './buttons';
 
 class SecurityAccountRecoveryRecoveryEmailEdit extends React.Component {

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import { isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormPhoneInput from 'calypso/components/forms/form-phone-input';
-import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import Buttons from './buttons';
-import getCountries from 'calypso/state/selectors/get-countries';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import getCountries from 'calypso/state/selectors/get-countries';
+import Buttons from './buttons';
 
 class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 	static displayName = 'SecurityAccountRecoveryRecoveryPhoneEdit';

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -1,28 +1,18 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { CompactCard } from '@automattic/components';
-import config from '@automattic/calypso-config';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
-import ReauthRequired from 'calypso/me/reauth-required';
-import RecoveryEmail from './recovery-email';
-import RecoveryEmailValidationNotice from './recovery-email-validation-notice';
-import RecoveryPhone from './recovery-phone';
-import RecoveryPhoneValidationNotice from './recovery-phone-validation-notice';
-import SecuritySectionNav from 'calypso/me/security-section-nav';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SecuritySectionNav from 'calypso/me/security-section-nav';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import {
 	updateAccountRecoveryEmail,
 	updateAccountRecoveryPhone,
@@ -46,12 +36,11 @@ import {
 	shouldPromptAccountRecoveryPhoneValidationNotice,
 } from 'calypso/state/account-recovery/settings/selectors';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import FormattedHeader from 'calypso/components/formatted-header';
+import RecoveryEmail from './recovery-email';
+import RecoveryEmailValidationNotice from './recovery-email-validation-notice';
+import RecoveryPhone from './recovery-phone';
+import RecoveryPhoneValidationNotice from './recovery-phone-validation-notice';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const SecurityAccountRecovery = ( props ) => (

--- a/client/me/security-account-recovery/manage-contact.jsx
+++ b/client/me/security-account-recovery/manage-contact.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FormButton from 'calypso/components/forms/form-button';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 

--- a/client/me/security-account-recovery/recovery-email-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-email-validation-notice.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 

--- a/client/me/security-account-recovery/recovery-email.jsx
+++ b/client/me/security-account-recovery/recovery-email.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import ManageContact from './manage-contact';
-import EditEmail from './edit-email';
+import React, { Component } from 'react';
 import accept from 'calypso/lib/accept';
+import EditEmail from './edit-email';
+import ManageContact from './manage-contact';
 
 class RecoveryEmail extends Component {
 	render() {

--- a/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormLabel from 'calypso/components/forms/form-label';

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import ManageContact from './manage-contact';
-import EditPhone from './edit-phone';
+import React, { Component } from 'react';
 import accept from 'calypso/lib/accept';
+import EditPhone from './edit-phone';
+import ManageContact from './manage-contact';
 
 class RecoveryPhone extends Component {
 	render() {

--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import {
 	getCurrentUserEmail,
 	isCurrentUserEmailVerified,

--- a/client/me/security-checkup/account-recovery-email.jsx
+++ b/client/me/security-checkup/account-recovery-email.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import {
 	getAccountRecoveryEmail,
 	isAccountRecoveryEmailActionInProgress,
 	isAccountRecoveryEmailValidated,
 } from 'calypso/state/account-recovery/settings/selectors';
 import { getOKIcon, getWarningIcon } from './icons.js';
-import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountRecoveryEmail extends React.Component {

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import {
 	getAccountRecoveryPhone,
 	isAccountRecoveryPhoneActionInProgress,
 	isAccountRecoveryPhoneValidated,
 } from 'calypso/state/account-recovery/settings/selectors';
 import { getOKIcon, getWarningIcon } from './icons.js';
-import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountRecoveryPhone extends React.Component {

--- a/client/me/security-checkup/connected-applications.jsx
+++ b/client/me/security-checkup/connected-applications.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
+import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupConnectedApplications extends React.Component {

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,20 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import ReauthRequired from 'calypso/me/reauth-required';
 import SectionHeader from 'calypso/components/section-header';
+import VerticalNav from 'calypso/components/vertical-nav';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import SecurityCheckupAccountEmail from './account-email';
 import SecurityCheckupAccountRecoveryEmail from './account-recovery-email';
 import SecurityCheckupAccountRecoveryPhone from './account-recovery-phone';
@@ -23,12 +18,7 @@ import SecurityCheckupPassword from './password';
 import SecurityCheckupSocialLogins from './social-logins';
 import SecurityCheckupTwoFactorAuthentication from './two-factor-authentication';
 import SecurityCheckupTwoFactorBackupCodes from './two-factor-backup-codes';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import VerticalNav from 'calypso/components/vertical-nav';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class SecurityCheckupComponent extends React.Component {

--- a/client/me/security-checkup/navigation-item.jsx
+++ b/client/me/security-checkup/navigation-item.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 

--- a/client/me/security-checkup/password.jsx
+++ b/client/me/security-checkup/password.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import { getOKIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 

--- a/client/me/security-checkup/social-logins.jsx
+++ b/client/me/security-checkup/social-logins.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import SecurityCheckupNavigationItem from './navigation-item';
 

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { getOKIcon, getWarningIcon } from './icons.js';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import hasUserSettings from 'calypso/state/selectors/has-user-settings';
 import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
 import isTwoStepSmsEnabled from 'calypso/state/selectors/is-two-step-sms-enabled';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { getOKIcon, getWarningIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupTwoFactorAuthentication extends React.Component {

--- a/client/me/security-checkup/two-factor-backup-codes.jsx
+++ b/client/me/security-checkup/two-factor-backup-codes.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { getOKIcon, getWarningIcon } from './icons.js';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import hasUserSettings from 'calypso/state/selectors/has-user-settings';
 import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { getOKIcon, getWarningIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupTwoFactorBackupCodes extends React.Component {

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
+import i18n from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import SectionNav from 'calypso/components/section-nav';
 
 export default class SecuritySectionNav extends React.Component {
 	static propTypes = {

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import page from 'page';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PasswordComponent from 'calypso/me/security/main';
-import SocialLoginComponent from 'calypso/me/social-login';
+import page from 'page';
+import React from 'react';
+import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import ConnectedAppsComponent from 'calypso/me/connected-applications';
 import AccountRecoveryComponent from 'calypso/me/security-account-recovery';
 import SecurityCheckupComponent from 'calypso/me/security-checkup';
-import { getSocialServiceFromClientId } from 'calypso/lib/login';
+import PasswordComponent from 'calypso/me/security/main';
+import SocialLoginComponent from 'calypso/me/social-login';
 import { successNotice } from 'calypso/state/notices/actions';
 
 export function password( context, next ) {

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
 import {

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -1,33 +1,22 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import { Card } from '@automattic/components';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AccountPassword from 'calypso/me/account-password';
-import { Card } from '@automattic/components';
-import config from '@automattic/calypso-config';
 import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import AccountPassword from 'calypso/me/account-password';
 import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import FormattedHeader from 'calypso/components/formatted-header';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 
 const debug = debugFactory( 'calypso:me:security:password' );
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Security extends React.Component {

--- a/client/me/sidebar-navigation/index.jsx
+++ b/client/me/sidebar-navigation/index.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import Gravatar from 'calypso/components/gravatar';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function MeSidebarNavigation( { currentUser } ) {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -1,33 +1,23 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import config from '@automattic/calypso-config';
-import ProfileGravatar from 'calypso/me/profile-gravatar';
-import { purchasesRoot } from 'calypso/me/purchases/paths';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
+import { clearStore, disablePersistence } from 'calypso/lib/user/store';
+import ProfileGravatar from 'calypso/me/profile-gravatar';
+import { purchasesRoot } from 'calypso/me/purchases/paths';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar-unified/utils';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { logoutUser } from 'calypso/state/logout/actions';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { itemLinkMatches } from 'calypso/my-sites/sidebar-unified/utils';
-import { clearStore, disablePersistence } from 'calypso/lib/user/store';
-import { redirectToLogout } from 'calypso/state/current-user/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 import 'calypso/my-sites/sidebar-unified/style.scss'; // nav-unification overrides. Should be removed once launched.
 

--- a/client/me/site-blocks/controller.js
+++ b/client/me/site-blocks/controller.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import SiteBlockListComponent from 'calypso/me/site-blocks/main';
 
 export function siteBlockList( context, next ) {

--- a/client/me/site-blocks/index.js
+++ b/client/me/site-blocks/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { siteBlockList } from './controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
+import { siteBlockList } from './controller';
 
 export default function () {
 	page( '/me/site-blocks', sidebar, siteBlockList, makeLayout, clientRender );

--- a/client/me/site-blocks/list-item-placeholder.jsx
+++ b/client/me/site-blocks/list-item-placeholder.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React, { PureComponent } from 'react';
 
 class SiteBlockListItemPlaceholder extends PureComponent {

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import ExternalLink from 'calypso/components/external-link';
 import { Button } from '@automattic/components';
-import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import ExternalLink from 'calypso/components/external-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 
 class SiteBlockListItem extends Component {
 	unblockSite = () => {

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -1,20 +1,17 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { times } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { times } from 'lodash';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QuerySiteBlocks from 'calypso/components/data/query-site-blocks';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InfiniteList from 'calypso/components/infinite-list';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { requestSiteBlocks } from 'calypso/state/reader/site-blocks/actions';
 import {
 	getBlockedSites,
 	isFetchingSiteBlocks,
@@ -22,15 +19,8 @@ import {
 	getSiteBlocksLastPage,
 } from 'calypso/state/reader/site-blocks/selectors';
 import SiteBlockListItem from './list-item';
-import InfiniteList from 'calypso/components/infinite-list';
-import { requestSiteBlocks } from 'calypso/state/reader/site-blocks/actions';
 import SiteBlockListItemPlaceholder from './list-item-placeholder';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import FormattedHeader from 'calypso/components/formatted-header';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class SiteBlockList extends Component {

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { isRequesting } from 'calypso/state/login/selectors';
-import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/actions';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
-import GoogleLoginButton from 'calypso/components/social-buttons/google';
 import AppleLoginButton from 'calypso/components/social-buttons/apple';
+import GoogleLoginButton from 'calypso/components/social-buttons/google';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
+import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/actions';
+import { isRequesting } from 'calypso/state/login/selectors';
 
 class SocialLoginActionButton extends Component {
 	static propTypes = {

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -1,34 +1,24 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import config from '@automattic/calypso-config';
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AppleIcon from 'calypso/components/social-icons/apple';
-import { CompactCard } from '@automattic/components';
-import config from '@automattic/calypso-config';
+import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import { getRequestError } from 'calypso/state/login/selectors';
-import GoogleIcon from 'calypso/components/social-icons/google';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import Notice from 'calypso/components/notice';
+import AppleIcon from 'calypso/components/social-icons/apple';
+import GoogleIcon from 'calypso/components/social-icons/google';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { getRequestError } from 'calypso/state/login/selectors';
 import SocialLoginService from './service';
-import FormattedHeader from 'calypso/components/formatted-header';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class SocialLogin extends Component {

--- a/client/me/social-login/service.jsx
+++ b/client/me/social-login/service.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import React from 'react';
-import { find, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { CompactCard } from '@automattic/components';
+import { find, get } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import SocialLoginActionButton from './action-button';
 

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -1,40 +1,29 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AppPasswords from 'calypso/me/application-passwords';
-import { Card } from '@automattic/components';
-import config from '@automattic/calypso-config';
 import DocumentHead from 'calypso/components/data/document-head';
-import { fetchUserSettings } from 'calypso/state/user-settings/actions';
-import FormattedHeader from 'calypso/components/formatted-header';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import HeaderCake from 'calypso/components/header-cake';
-import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
-import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
-import Main from 'calypso/components/main';
-import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import AppPasswords from 'calypso/me/application-passwords';
+import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
+import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import ReauthRequired from 'calypso/me/reauth-required';
 import Security2faBackupCodes from 'calypso/me/security-2fa-backup-codes';
 import Security2faDisable from 'calypso/me/security-2fa-disable';
 import Security2faKey from 'calypso/me/security-2fa-key';
 import Security2faSetup from 'calypso/me/security-2fa-setup';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class TwoStep extends Component {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/me` to use `import/order`

#### Testing instructions

N/A

Note: there are quite a few eslint failures but none of them should be related to the `import/order` rule
