### PR TITLE
Empty Content Component: Truncate Button Text

### DIFF
--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -39,6 +39,10 @@
 
 .empty-content__action {
 	margin: 0 0 10px 10px;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .empty-content.is-compact {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses ellipses to truncate the Empty Content action

#### Testing instructions

It's probably easiest to test with a long site name in the example given in https://github.com/Automattic/wp-calypso/issues/54778 by visiting `/settings/security/slug` on a site with a long site name.

**Before:**
<img width="389" alt="Screenshot 2021-08-05 at 11 04 59" src="https://user-images.githubusercontent.com/43215253/128333259-5d1f8bca-5be7-4551-b35c-672426ecd996.png">

**After:**
<img width="415" alt="Screenshot 2021-08-05 at 11 04 47" src="https://user-images.githubusercontent.com/43215253/128333254-2f77366e-1ba8-404e-81ec-6bdccd93a399.png">

For what it's worth, other cases should also be unaffected.

<img width="1385" alt="Screenshot 2021-08-05 at 11 11 09" src="https://user-images.githubusercontent.com/43215253/128333270-d536b7b4-5e29-464f-9db1-af13c59fa0f9.png">

Fixes #54778