### PR TITLE
Remove usages of _.partial

### DIFF
--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -1,7 +1,7 @@
 import path from 'path';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isEqual, partial } from 'lodash';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -283,10 +283,10 @@ export default connect(
 			isImageLoaded: isImageEditorImageLoaded( state ),
 		};
 	},
-	( dispatch, ownProp ) => {
+	( dispatch, ownProps ) => {
 		const defaultAspectRatio = getDefaultAspectRatio(
-			ownProp.defaultAspectRatio,
-			ownProp.allowedAspectRatios
+			ownProps.defaultAspectRatio,
+			ownProps.allowedAspectRatios
 		);
 
 		const resetActionsAdditionalData = {
@@ -297,8 +297,8 @@ export default connect(
 			{
 				setImageEditorFileInfo,
 				setImageEditorDefaultAspectRatio,
-				resetImageEditorState: partial( resetImageEditorState, resetActionsAdditionalData ),
-				resetAllImageEditorState: partial( resetAllImageEditorState, resetActionsAdditionalData ),
+				resetImageEditorState: () => resetImageEditorState( resetActionsAdditionalData ),
+				resetAllImageEditorState: () => resetAllImageEditorState( resetActionsAdditionalData ),
 			},
 			dispatch
 		);

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -1,4 +1,3 @@
-import { get, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
@@ -7,10 +6,11 @@ import Emojify from 'calypso/components/emojify';
 import FeaturedAsset from './featured-asset';
 
 const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {
-	let onVideoThumbnailClick = null;
-	if ( get( post, 'canonical_media.mediaType' ) === 'video' ) {
-		onVideoThumbnailClick = partial( expandCard, { postKey, post, site } );
-	}
+	const onVideoThumbnailClick =
+		post.canonical_media?.mediaType === 'video'
+			? () => expandCard( { postKey, post, site } )
+			: null;
+
 	return (
 		<div className="reader-post-card__post">
 			<FeaturedAsset

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { map, partial, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -30,14 +30,6 @@ export class RecommendedSites extends React.PureComponent {
 		this.props.dismissSite( siteId );
 	};
 
-	handleSiteClick = ( siteId, uiIndex ) => {
-		recordTrackWithRailcar( 'calypso_reader_recommended_site_clicked', this.props.railcar, {
-			ui_position: uiIndex,
-			siteId,
-		} );
-		recordAction( 'calypso_reader_recommended_site_clicked' );
-	};
-
 	render() {
 		const { followSource } = this.props;
 		const placeholders = [ {}, {} ];
@@ -59,7 +51,7 @@ export class RecommendedSites extends React.PureComponent {
 					{ this.props.translate( 'Recommended sites' ) }
 				</h2>
 				<ul className="reader-recommended-sites__list">
-					{ map( sites, ( site, index ) => {
+					{ sites.map( ( site, index ) => {
 						const siteId = site.siteId || site.blogId;
 						return (
 							<li
@@ -71,7 +63,7 @@ export class RecommendedSites extends React.PureComponent {
 										<Button
 											borderless
 											title={ this.props.translate( 'Dismiss this recommendation' ) }
-											onClick={ partial( this.handleSiteDismiss, siteId, index ) }
+											onClick={ () => this.handleSiteDismiss( siteId, index ) }
 										>
 											<Gridicon icon="cross" size={ 18 } />
 										</Button>

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -1,7 +1,7 @@
 import { CompactCard as Card } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, partial } from 'lodash';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
@@ -106,8 +106,8 @@ export function RelatedPostCard( {
 		'has-thumbnail': !! post.canonical_media,
 		'has-excerpt': post.excerpt && post.excerpt.length > 1,
 	} );
-	const postClickTracker = partial( onPostClick, post );
-	const siteClickTracker = partial( onSiteClick, post );
+	const postClickTracker = () => onPostClick( post );
+	const siteClickTracker = () => onSiteClick( post );
 
 	const canonicalMedia = post.canonical_media;
 	let featuredAsset;

--- a/client/components/vertical-menu/index.jsx
+++ b/client/components/vertical-menu/index.jsx
@@ -1,4 +1,3 @@
-import { partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 
@@ -18,17 +17,12 @@ export class VerticalMenu extends PureComponent {
 		onClick: noop,
 	};
 
-	constructor( props ) {
-		super( props );
+	state = {
+		selectedIndex: this.props.initialItemIndex,
+	};
 
-		this.state = {
-			selectedIndex: props.initialItemIndex,
-		};
-	}
-
-	select = ( selectedIndex, ...args ) => {
-		const { onClick } = this.props;
-		this.setState( { selectedIndex }, partial( onClick, ...args ) );
+	select = ( selectedIndex ) => ( ...args ) => {
+		this.setState( { selectedIndex }, () => this.props.onClick( ...args ) );
 	};
 
 	render() {
@@ -40,7 +34,7 @@ export class VerticalMenu extends PureComponent {
 				{ React.Children.map( children, ( Item, index ) =>
 					React.cloneElement( Item, {
 						isSelected: index === selectedIndex,
-						onClick: partial( this.select, index ),
+						onClick: this.select( index ),
 					} )
 				) }
 			</div>

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -132,7 +131,7 @@ class PreviewToolbar extends Component {
 							<SelectDropdown.Item
 								key={ device }
 								selected={ device === currentDevice }
-								onClick={ partial( setDeviceViewport, device ) }
+								onClick={ () => setDeviceViewport( device ) }
 								icon={ <Gridicon size={ 18 } icon={ this.devices[ device ].icon } /> }
 								e2eTitle={ device }
 							>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -5,7 +5,7 @@ import url from 'url';
 import config from '@automattic/calypso-config';
 import { getQueryArg } from '@wordpress/url';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { map, partial, pickBy, flowRight } from 'lodash';
+import { map, pickBy, flowRight } from 'lodash';
 import page from 'page';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -889,13 +889,8 @@ const mapStateToProps = (
 		siteUrl: getSiteUrl( state, siteId ),
 		customizerUrl: getCustomizerUrl( state, siteId ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		getTemplateEditorUrl: partial(
-			getEditorUrl,
-			state,
-			siteId,
-			partial.placeholder,
-			'wp_template_part'
-		),
+		getTemplateEditorUrl: ( templateId ) =>
+			getEditorUrl( state, siteId, templateId, 'wp_template_part' ),
 		unmappedSiteUrl: getSiteOption( state, siteId, 'unmapped_url' ),
 		siteCreationFlow: getSiteOption( state, siteId, 'site_creation_flow' ),
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -19,31 +18,26 @@ class MasterbarItemNotifications extends Component {
 		tooltip: TranslatableString,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
+		hasUnseenNotifications: PropTypes.bool,
 	};
 
 	notificationLink = createRef();
+
 	state = {
 		animationState: 0,
+		newNote: this.props.hasUnseenNotifications,
 	};
 
-	UNSAFE_componentWillMount() {
-		this.setState( {
-			newNote: this.props.hasUnseenNotifications,
-		} );
-	}
-
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { isNotificationsOpen: isOpen, recordOpening } = nextProps;
-
-		if ( ! this.props.isNotificationsOpen && isOpen ) {
-			recordOpening( {
+		if ( ! this.props.isNotificationsOpen && nextProps.isNotificationsOpen ) {
+			nextProps.recordTracksEvent( 'calypso_notification_open', {
 				unread_notifications: store.get( 'wpnotes_unseen_count' ),
 			} );
 			this.setNotesIndicator( 0 );
 		}
 
 		// focus on main window if we just closed the notes panel
-		if ( this.props.isNotificationsOpen && ! isOpen ) {
+		if ( this.props.isNotificationsOpen && ! nextProps.isNotificationsOpen ) {
 			this.notificationLink.current.blur();
 			window.focus();
 		}
@@ -145,7 +139,7 @@ const mapStateToProps = ( state ) => {
 };
 const mapDispatchToProps = {
 	toggleNotificationsPanel,
-	recordOpening: partial( recordTracksEvent, 'calypso_notification_open' ),
+	recordTracksEvent,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( MasterbarItemNotifications );

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { partial, isPlainObject } from 'lodash';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { isPlainObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,46 +16,41 @@ import BooleanPreference from './boolean-preference';
 import StringPreference from './string-preference';
 import NumberPreference from './number-preference';
 
-class Preference extends Component {
-	render() {
-		const { name, value, translate, unsetPreference } = this.props;
+export default function Preference( { name, value } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 
-		let preferenceHandler = (
-			<ul>
-				<li key={ name }>{ value.toString() } </li>
-			</ul>
-		);
+	let preferenceHandler = (
+		<ul>
+			<li key={ name }>{ value.toString() } </li>
+		</ul>
+	);
 
-		if ( Array.isArray( value ) ) {
-			preferenceHandler = <ArrayPreference name={ name } value={ value } />;
-		} else if ( isPlainObject( value ) ) {
-			preferenceHandler = <ObjectPreference name={ name } value={ value } />;
-		} else if ( 'string' === typeof value ) {
-			preferenceHandler = <StringPreference name={ name } value={ value } />;
-		} else if ( 'boolean' === typeof value ) {
-			preferenceHandler = <BooleanPreference name={ name } value={ value } />;
-		} else if ( 'number' === typeof value ) {
-			preferenceHandler = <NumberPreference name={ name } value={ value } />;
-		}
-
-		return (
-			<div>
-				<div className="preferences-helper__preference-header">
-					<button
-						className="preferences-helper__unset"
-						onClick={ partial( unsetPreference, name, null ) }
-						title={ translate( 'Unset Preference' ) }
-					>
-						{ 'X' }
-					</button>
-					<span>{ name }</span>
-				</div>
-				{ preferenceHandler }
-			</div>
-		);
+	if ( Array.isArray( value ) ) {
+		preferenceHandler = <ArrayPreference name={ name } value={ value } />;
+	} else if ( isPlainObject( value ) ) {
+		preferenceHandler = <ObjectPreference name={ name } value={ value } />;
+	} else if ( 'string' === typeof value ) {
+		preferenceHandler = <StringPreference name={ name } value={ value } />;
+	} else if ( 'boolean' === typeof value ) {
+		preferenceHandler = <BooleanPreference name={ name } value={ value } />;
+	} else if ( 'number' === typeof value ) {
+		preferenceHandler = <NumberPreference name={ name } value={ value } />;
 	}
-}
 
-export default connect( null, {
-	unsetPreference: savePreference,
-} )( localize( Preference ) );
+	return (
+		<div>
+			<div className="preferences-helper__preference-header">
+				<button
+					className="preferences-helper__unset"
+					onClick={ () => dispatch( savePreference( name, null ) ) }
+					title={ translate( 'Unset Preference' ) }
+				>
+					{ 'X' }
+				</button>
+				<span>{ name }</span>
+			</div>
+			{ preferenceHandler }
+		</div>
+	);
+}

--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { flowRight, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -82,8 +81,6 @@ class SharingButtonsAppearance extends Component {
 
 	getPreviewElement() {
 		if ( this.props.initialized ) {
-			const changeLabel = partial( this.props.onChange, 'sharing_label' );
-
 			return (
 				<ButtonsPreview
 					isPrivateSite={ this.props.isPrivate }
@@ -92,7 +89,7 @@ class SharingButtonsAppearance extends Component {
 					buttons={ this.props.buttons }
 					showLike={ this.isLikeButtonEnabled() }
 					showReblog={ ! this.props.isJetpack && this.isReblogButtonEnabled() }
-					onLabelChange={ changeLabel }
+					onLabelChange={ ( value ) => this.props.onChange( 'sharing_label', value ) }
 					onButtonsChange={ this.props.onButtonsChange }
 				/>
 			);
@@ -158,7 +155,6 @@ class SharingButtonsAppearance extends Component {
 	render() {
 		// Disable classname namespace because `sharing-buttons` makes the most sense here
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		const changeButtonStyle = partial( this.props.onChange, 'sharing_button_style' );
 		return (
 			<div className="sharing-buttons__panel sharing-buttons-appearance">
 				<p className="sharing-buttons-appearance__description">
@@ -171,7 +167,7 @@ class SharingButtonsAppearance extends Component {
 
 				<div className="sharing-buttons__fieldset-group">
 					<ButtonsStyle
-						onChange={ changeButtonStyle }
+						onChange={ ( value ) => this.props.onChange( 'sharing_button_style', value ) }
 						value={ this.props.values.sharing_button_style }
 						disabled={ ! this.props.initialized }
 					/>
@@ -208,4 +204,4 @@ const connectComponent = connect(
 	{ recordGoogleEvent, recordTracksEvent }
 );
 
-export default flowRight( connectComponent, localize )( SharingButtonsAppearance );
+export default connectComponent( localize( SharingButtonsAppearance ) );

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { filter, flowRight, get, partial, some, values, xor } from 'lodash';
+import { filter, flowRight, get, some, values, xor } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -218,7 +218,9 @@ class SharingButtonsOptions extends Component {
 	getSharingShowOptionsElement = () => {
 		const { initialized, settings, translate } = this.props;
 
-		const changeSharingPostTypes = partial( this.handleMultiCheckboxChange, 'sharing_show' );
+		const changeSharingPostTypes = ( event ) =>
+			this.handleMultiCheckboxChange( 'sharing_show', event );
+
 		return (
 			<FormFieldset className="sharing-buttons__fieldset">
 				<legend className="sharing-buttons__fieldset-heading">

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { debounce, partial } from 'lodash';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -135,6 +135,6 @@ class MediaLibraryScale extends Component {
 }
 
 export default connect( null, {
-	setMediaScalePreference: partial( setPreference, 'mediaScale' ),
-	saveMediaScalePreference: partial( savePreference, 'mediaScale' ),
+	setMediaScalePreference: ( value ) => setPreference( 'mediaScale', value ),
+	saveMediaScalePreference: ( value ) => savePreference( 'mediaScale', value ),
 } )( localize( MediaLibraryScale ) );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -3,7 +3,7 @@ import { CompactCard } from '@automattic/components';
 import { saveAs } from 'browser-filesaver';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, partial } from 'lodash';
+import { get } from 'lodash';
 import pageRouter from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -43,7 +43,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { statsLinkForPage } from '../helpers';
 import PageCardInfo from '../page-card-info';
 
-const recordEvent = partial( recordGoogleEvent, 'Pages' );
+const recordEvent = ( event ) => recordGoogleEvent( 'Pages', event );
 const noop = () => {};
 
 function sleep( ms ) {
@@ -780,11 +780,11 @@ const mapDispatch = {
 	setPreviewUrl,
 	setLayoutFocus,
 	recordEvent,
-	recordMoreOptions: partial( recordEvent, 'Clicked More Options Menu' ),
-	recordPageTitle: partial( recordEvent, 'Clicked Page Title' ),
-	recordEditPage: partial( recordEvent, 'Clicked Edit Page' ),
-	recordViewPage: partial( recordEvent, 'Clicked View Page' ),
-	recordStatsPage: partial( recordEvent, 'Clicked Stats Page' ),
+	recordMoreOptions: () => recordEvent( 'Clicked More Options Menu' ),
+	recordPageTitle: () => recordEvent( 'Clicked Page Title' ),
+	recordEditPage: () => recordEvent( 'Clicked Edit Page' ),
+	recordViewPage: () => recordEvent( 'Clicked View Page' ),
+	recordStatsPage: () => recordEvent( 'Clicked Stats Page' ),
 	updateSiteFrontPage,
 };
 

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { isEmpty, partial } from 'lodash';
+import { isEmpty } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -168,7 +168,7 @@ export default connect(
 		};
 	},
 	{
-		trackEvent: partial( recordGoogleEvent, 'Site Settings' ),
+		trackEvent: ( event ) => recordGoogleEvent( 'Site Settings', event ),
 		updateSiteMonitorSettings,
 	}
 )( localize( SiteSettingsFormJetpackMonitor ) );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get, isEqual, mapValues, omit, pickBy, partial } from 'lodash';
+import { get, isEqual, mapValues, omit, pickBy } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import pageTitleImage from 'calypso/assets/images/illustrations/seo-page-title.svg';
@@ -503,12 +503,12 @@ const mapDispatchToProps = {
 	refreshSiteData: requestSite,
 	requestSiteSettings,
 	saveSiteSettings,
-	trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
-	trackTitleFormatsUpdated: partial( recordTracksEvent, 'calypso_seo_tools_title_formats_updated' ),
-	trackFrontPageMetaUpdated: partial(
-		recordTracksEvent,
-		'calypso_seo_tools_front_page_meta_updated'
-	),
+	trackFormSubmitted: ( properties ) =>
+		recordTracksEvent( 'calypso_seo_settings_form_submit', properties ),
+	trackTitleFormatsUpdated: ( properties ) =>
+		recordTracksEvent( 'calypso_seo_tools_title_formats_updated', properties ),
+	trackFrontPageMetaUpdated: ( properties ) =>
+		recordTracksEvent( 'calypso_seo_tools_front_page_meta_updated', properties ),
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( protectForm( localize( SeoForm ) ) );

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { get, omit, partial } from 'lodash';
+import { get, omit } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -236,7 +236,7 @@ class SiteVerification extends Component {
 		};
 
 		this.props.saveSiteSettings( siteId, updatedOptions );
-		this.props.trackFormSubmitted( { path } );
+		this.props.trackFormSubmitted( path );
 
 		dirtyFields.forEach( ( service ) => {
 			trackSiteVerificationUpdated( service, path );
@@ -389,6 +389,7 @@ export default connect(
 				service,
 				path,
 			} ),
-		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
+		trackFormSubmitted: ( path ) =>
+			recordTracksEvent( 'calypso_seo_settings_form_submit', { path } ),
 	}
 )( protectForm( localize( SiteVerification ) ) );

--- a/client/post-editor/editor-media-modal/index.jsx
+++ b/client/post-editor/editor-media-modal/index.jsx
@@ -1,4 +1,4 @@
-import { partial, map, get } from 'lodash';
+import { map, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -26,7 +26,7 @@ class EditorMediaModal extends Component {
 		let media;
 		let stat;
 
-		const getItemMarkup = partial( markup.get, site );
+		const getItemMarkup = ( item ) => markup.get( site, item );
 
 		switch ( type ) {
 			case 'gallery':

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -106,7 +105,7 @@ export const EditorMediaModalDetail = localize( EditorMediaModalDetailBase );
 // (This is also the reason why we're `localize()`ing the named export.)
 // TODO: Fix this mess, rely on Redux state everywhere.
 export default connect( null, {
-	onReturnToList: partial( setEditorMediaModalView, ModalViews.LIST ),
-	onEditImageItem: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
-	onEditVideoItem: partial( setEditorMediaModalView, ModalViews.VIDEO_EDITOR ),
+	onReturnToList: () => setEditorMediaModalView( ModalViews.LIST ),
+	onEditImageItem: () => setEditorMediaModalView( ModalViews.IMAGE_EDITOR ),
+	onEditVideoItem: () => setEditorMediaModalView( ModalViews.VIDEO_EDITOR ),
 } )( EditorMediaModalDetail );

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { omitBy, some, isEqual, partial } from 'lodash';
+import { omitBy, some, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -154,6 +154,6 @@ class EditorMediaModalGallery extends React.Component {
 }
 
 export default connect( null, {
-	onReturnToList: partial( setEditorMediaModalView, ModalViews.LIST ),
+	onReturnToList: () => setEditorMediaModalView( ModalViews.LIST ),
 	getMediaItem,
 } )( localize( EditorMediaModalGallery ) );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { flow, get, isEmpty, partial, some, values } from 'lodash';
+import { flow, get, isEmpty, some, values } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -413,7 +413,7 @@ export class EditorMediaModal extends Component {
 				label: this.props.translate( 'Continue' ),
 				isPrimary: true,
 				disabled: isDisabled || ! this.props.site,
-				onClick: partial( this.props.setView, ModalViews.GALLERY ),
+				onClick: () => this.props.setView( ModalViews.GALLERY ),
 			} );
 		} else {
 			buttons.push( {
@@ -560,7 +560,7 @@ export default connect(
 		onViewDetails: flow(
 			withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
 			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
-			partial( setEditorMediaModalView, ModalViews.DETAIL )
+			() => setEditorMediaModalView( ModalViews.DETAIL )
 		),
 		recordEditorEvent,
 		recordEditorStat,

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { partial, pick } from 'lodash';
+import { pick } from 'lodash';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -147,15 +147,13 @@ export function recordTracksRailcar( action, eventName, railcar, overrides = {} 
 	);
 }
 
-export const recordTracksRailcarRender = partial(
-	recordTracksRailcar,
-	'calypso_traintracks_render'
-);
+export function recordTracksRailcarRender( eventName, railcar, overrides ) {
+	return recordTracksRailcar( 'calypso_traintracks_render', eventName, railcar, overrides );
+}
 
-export const recordTracksRailcarInteract = partial(
-	recordTracksRailcar,
-	'calypso_traintracks_interact'
-);
+export function recordTracksRailcarInteract( eventName, railcar, overrides ) {
+	return recordTracksRailcar( 'calypso_traintracks_interact', eventName, railcar, overrides );
+}
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {}, options ) {
 	recordTrack( eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { map, partial } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -20,21 +20,21 @@ function dismissPostAnalytics( uiIndex, storeId, post ) {
 	recordAction( 'in_stream_rec_dismiss' );
 }
 
-function handleSiteClick( uiIndex, post ) {
+const handleSiteClick = ( uiIndex ) => ( post ) => {
 	recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
 		recommendation_source: 'in-stream',
 		ui_position: uiIndex,
 	} );
 	recordAction( 'in_stream_rec_site_click' );
-}
+};
 
-function handlePostClick( uiIndex, post ) {
+const handlePostClick = ( uiIndex ) => ( post ) => {
 	recordTrackForPost( 'calypso_reader_recommended_post_clicked', post, {
 		recommendation_source: 'in-stream',
 		ui_position: uiIndex,
 	} );
 	recordAction( 'in_stream_rec_post_click' );
-}
+};
 
 export class RecommendedPosts extends React.PureComponent {
 	static propTypes = {
@@ -81,8 +81,8 @@ export class RecommendedPosts extends React.PureComponent {
 								</div>
 								<RelatedPostCard
 									post={ post }
-									onPostClick={ partial( handlePostClick, uiIndex ) }
-									onSiteClick={ partial( handleSiteClick, uiIndex ) }
+									onPostClick={ handlePostClick( uiIndex ) }
+									onSiteClick={ handleSiteClick( uiIndex ) }
 									followSource={ this.props.followSource }
 								/>
 							</li>

--- a/client/test-helpers/use-nock/index.js
+++ b/client/test-helpers/use-nock/index.js
@@ -1,5 +1,4 @@
 import debug from 'debug';
-import { partial } from 'lodash';
 import nock from 'nock';
 
 export { nock };
@@ -12,7 +11,7 @@ const log = debug( 'calypso:test:use-nock' );
  */
 export const useNock = ( setupCallback ) => {
 	if ( setupCallback ) {
-		beforeAll( partial( setupCallback, nock ) );
+		beforeAll( () => setupCallback( nock ) );
 	}
 	afterAll( () => {
 		log( 'Cleaning up nock' );


### PR DESCRIPTION
Removes usages of the `partial` function, mostly in favor of arrow function callback.

**How to review:**
Verify that we are passing all relevant arguments to the inner function and that we don't lose any.