### PR TITLE
Domain suggestions page layout redesign

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -532,10 +532,20 @@ class RegisterDomainStep extends React.Component {
 		};
 
 		if ( isSignupStep ) {
-			return <Search { ...componentProps }>{ this.renderSearchFilters() }</Search>;
+			return (
+				<>
+					<Search { ...componentProps }></Search>
+					{ this.renderSearchFilters() }
+				</>
+			);
 		}
 
-		return <SearchWithTyper { ...componentProps }>{ this.renderSearchFilters() }</SearchWithTyper>;
+		return (
+			<>
+				<SearchWithTyper { ...componentProps }></SearchWithTyper>
+				{ this.renderSearchFilters() }
+			</>
+		);
 	}
 
 	rejectTrademarkClaim = () => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -431,12 +431,16 @@ class RegisterDomainStep extends React.Component {
 			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData )
 			: {};
 
+		const containerDivClassName = classNames( 'register-domain-step', {
+			'register-domain-step__signup': this.props.isSignupStep,
+		} );
+
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
 			'register-domain-step__search-domain-step': this.props.isSignupStep,
 		} );
 
 		return (
-			<div className="register-domain-step">
+			<div className={ containerDivClassName }>
 				<StickyPanel className={ searchBoxClassName }>
 					<CompactCard className="register-domain-step__search-card">
 						{ this.renderSearchBar() }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -1,6 +1,55 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.register-domain-step:not( .register-domain-step__signup ) {
+	display: block;
+	position: relative;
+	margin: 0 auto 10px;
+	padding: 24px;
+	box-sizing: border-box;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+
+	.card {
+		background: none;
+		box-shadow: none;
+		border-bottom: 1px solid var( --color-border-subtle );
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.domain-search-results__domain-available-notice,
+	.search-component {
+		border-bottom: none;
+	}
+
+	.domain-search-results__domain-available-notice {
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	.search-component {
+		border: 1px solid var( --color-border-subtle );
+		border-radius: 4px; /* stylelint-disable-line */
+	}
+
+	.search-component.is-open {
+		border: 1px solid #a7aaad;
+		border-radius: 4px; /* stylelint-disable-line */
+		height: 48px;
+	}
+
+	.search-component.is-open.has-focus {
+		border-color: #646970;
+		background: var( --color-surface );
+		box-shadow: none;
+
+		.search-component__input {
+			background: var( --color-surface );
+		}
+	}
+}
+
 .register-domain-step__search {
 	padding-bottom: 12px;
 
@@ -25,6 +74,7 @@
 		padding: 0;
 		display: flex;
 		align-items: center;
+		border-bottom: none;
 	}
 
 	.search {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -188,6 +188,13 @@ body.is-section-domains {
 	}
 }
 
+body.is-section-signup:not( .is-white-signup ) {
+	.register-domain-step__search-card {
+		background: none;
+		box-shadow: none;
+	}
+}
+
 body.is-section-signup.is-white-signup {
 	.domain-search-results__domain-availability .card {
 		box-shadow: none;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -14,6 +14,10 @@
 		padding: 24px;
 	}
 
+	.search-filters__dropdown-filters {
+		height: 50px;
+	}
+
 	.card {
 		background: none;
 		box-shadow: none;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -5,10 +5,14 @@
 	display: block;
 	position: relative;
 	margin: 0 auto 10px;
-	padding: 24px;
+	padding: 16px;
 	box-sizing: border-box;
 	background: var( --color-surface );
 	box-shadow: 0 0 0 1px var( --color-border-subtle );
+
+	@include break-mobile {
+		padding: 24px;
+	}
 
 	.card {
 		background: none;
@@ -21,6 +25,14 @@
 	.domain-search-results__domain-available-notice,
 	.search-component {
 		border-bottom: none;
+	}
+
+	.register-domain-step__next-page {
+		border-bottom: none;
+		padding-bottom: 0;
+		.register-domain-step__next-page-button {
+			padding-bottom: 0;
+		}
 	}
 
 	.domain-search-results__domain-available-notice {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -44,6 +44,10 @@
 		padding-bottom: 0;
 		.register-domain-step__next-page-button {
 			padding-bottom: 0;
+			padding-top: 0;
+			@include break-mobile {
+				padding-top: 8px;
+			}
 		}
 	}
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -16,6 +16,14 @@
 
 	.search-filters__dropdown-filters {
 		height: 50px;
+		@include break-mobile {
+			min-width: 120px;
+		}
+	}
+
+	.button.domain-suggestion__action {
+		min-width: 120px;
+		padding: 0;
 	}
 
 	.card {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -5,12 +5,10 @@
 	align-items: center;
 	height: 51px; // same as .search
 	z-index: z-index( 'root', '.search' );
-	/*!rtl:ignore*/
-	border-left: 1px solid var( --color-neutral-10 );
+	margin-left: 16px;
 
 	.button {
 		align-items: center;
-		border-radius: 0 3px 3px 0; /* stylelint-disable-line */
 		display: flex;
 		font-weight: normal;
 		height: 100%;
@@ -24,11 +22,15 @@
 			min-width: 120px;
 		}
 
+		background-color: var( --studio-white );
+
+		border: 1px solid var( --color-neutral-20 );
+		border-radius: 4px; /* stylelint-disable-line */
+
 		&.is-borderless {
 			&:hover,
 			&:focus {
-				border-color: transparent;
-				box-shadow: 0 0 0 3px var( --color-accent-light ), -1px 0 0 3px var( --color-accent-light );
+				border-color: var( --color-neutral );
 			}
 		}
 

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -187,6 +187,13 @@
 	}
 }
 
+body.is-section-signup:not( .is-white-signup ) {
+	.search-filters__dropdown-filters > button:hover,
+	.search-filters__dropdown-filters > button:active {
+		background-color: #fdfdfd;
+	}
+}
+
 body.is-section-signup.is-white-signup {
 	$accent-blue: #117ac9;
 

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -56,10 +56,6 @@
 		}
 	}
 
-	&.search-filters__dropdown-filters--is-open {
-		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
-	}
-
 	&.search-filters__dropdown-filters--has-filter-values {
 		.material-icon {
 			fill: var( --color-accent );

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -33,20 +33,20 @@ $input-z-index: 20;
 		box-sizing: border-box;
 		padding: 0;
 		-webkit-appearance: none;
-	
+
 		&::-webkit-search-cancel-button {
 			-webkit-appearance: none;
 		}
-	
+
 		&:disabled {
 			background: var( --color-surface );
 		}
-	
+
 		&:focus {
 			box-shadow: none;
 			border: none;
 			outline: none;
-	
+
 			&:hover {
 				border: none;
 				box-shadow: none;
@@ -127,14 +127,14 @@ $input-z-index: 20;
 		height: 100%;
 		top: 0;
 		right: 0;
-	
+
 		.search-component__input-fade {
 			position: relative;
 			flex: 0 0 auto;
 			display: flex;
 			align-items: center;
 		}
-	
+
 		.search-component__input {
 			flex: 1 1 auto;
 			display: flex;
@@ -179,25 +179,25 @@ $input-z-index: 20;
 	&.is-open {
 		background-color: $white;
 		width: 100%;
-	
+
 		.search-component__open-icon {
 			color: var( --color-neutral-60 );
 		}
-	
+
 		.search-component__close-icon {
 			display: inline-block;
 		}
-	
+
 		.search-component__input,
 		.search-component__close-icon {
 			opacity: 1;
 		}
-	
+
 		input.search-component__input[type='search'] {
 			font-size: inherit;
 			display: block;
 		}
-	
+
 		.search-component__input-fade {
 			display: flex;
 			align-items: center;
@@ -208,13 +208,10 @@ $input-z-index: 20;
 			font-size: $font-body;
 
 			&::before {
-				@include long-content-fade(
-					$size: 32px,
-					$z-index: $input-z-index + 2
-				);
+				@include long-content-fade( $size: 32px, $z-index: $input-z-index + 2 );
 				border-radius: inherit;
 			}
-	
+
 			&.ltr {
 				/*!rtl:ignore*/
 				&::before {
@@ -226,7 +223,7 @@ $input-z-index: 20;
 					border-radius: inherit;
 				}
 			}
-	
+
 			padding-left: 8px;
 		}
 	}


### PR DESCRIPTION
Implement the new domain suggestions layout screen design

#### Changes proposed in this Pull Request

* Update teh domain suggestions page layout

The updated screens looks like this (add a domain, NUX and domain-only flows):

Before:
<img width="1008" alt="Screenshot 2021-08-12 at 8 19 01" src="https://user-images.githubusercontent.com/1355045/129142264-f5c136d0-ad09-47ae-8c96-db0d9ed68d11.png">
<img width="962" alt="Screenshot 2021-08-12 at 8 19 20" src="https://user-images.githubusercontent.com/1355045/129142268-4136a88b-fc03-492c-b012-b0369e454576.png">
<img width="1074" alt="Screenshot 2021-08-12 at 8 19 37" src="https://user-images.githubusercontent.com/1355045/129142270-b6d8732f-3131-4b26-a904-368adc4bad37.png">

After:
<img width="1010" alt="Screenshot 2021-08-12 at 8 14 27" src="https://user-images.githubusercontent.com/1355045/129142284-ecde3719-ba68-4c36-af37-6032ec3a5422.png">
<img width="975" alt="Screenshot 2021-08-12 at 8 15 14" src="https://user-images.githubusercontent.com/1355045/129142293-099ec413-5509-45a2-b049-9a4061517995.png">
<img width="1084" alt="Screenshot 2021-08-16 at 22 07 42" src="https://user-images.githubusercontent.com/1355045/129616739-f821d60e-aa56-4fab-bf19-320771aeb128.png">

#### Testing instructions

* Open this branch and verify that the domain suggestions screen layout is the new layout (search field and the filter buttons are separated and basically everything is inside one big Card)
