### PR TITLE
Refactor `client/blocks` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
 				'apps/o2-blocks/**/*',
 				'apps/wpcom-block-editor/**/*',
 				'client/auth/**/*',
+				'client/blocks/**/*',
 				'client/boot/**/*',
 				'client/controller/**/*',
 				'client/data/**/*',

--- a/client/blocks/all-sites/all-sites-icon.jsx
+++ b/client/blocks/all-sites/all-sites-icon.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import SiteIcon from 'calypso/blocks/site-icon';
 
-/**
- * Style dependencies
- */
 import './all-sites-icon.scss';
 
 const MAX_ICONS = 10;

--- a/client/blocks/all-sites/docs/example.jsx
+++ b/client/blocks/all-sites/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import AllSites from 'calypso/blocks/all-sites';
 import { Card } from '@automattic/components';
+import React from 'react';
+import AllSites from 'calypso/blocks/all-sites';
 
 const AllSitesExample = () => (
 	<Card style={ { padding: 0 } }>

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -1,25 +1,14 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import AllSitesIcon from './all-sites-icon';
-import config from '@automattic/calypso-config';
 import Count from 'calypso/components/count';
-import getSites from 'calypso/state/selectors/get-sites';
 import { getCurrentUserVisibleSiteCount } from 'calypso/state/current-user/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
+import AllSitesIcon from './all-sites-icon';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -1,22 +1,14 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { get, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
-import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
-import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import versionCompare from 'calypso/lib/version-compare';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -24,7 +16,11 @@ import {
 	withAnalytics,
 } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
+import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	ALLOWED_SECTIONS,
 	EDITOR,
@@ -38,13 +34,7 @@ import {
 	isDismissed,
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 } from './utils';
-import versionCompare from 'calypso/lib/version-compare';
-import { isWpMobileApp } from 'calypso/lib/mobile-app';
-import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const IOS_REGEX = /iPad|iPod|iPhone/i;

--- a/client/blocks/app-banner/test/app-banner.jsx
+++ b/client/blocks/app-banner/test/app-banner.jsx
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { getiOSDeepLink, buildDeepLinkFragment } from 'calypso/blocks/app-banner';
 import { EDITOR, NOTES, READER, STATS, getCurrentSection } from 'calypso/blocks/app-banner/utils';
 

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { get, includes, reduce } from 'lodash';
 
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -1,37 +1,18 @@
-/**
- * External dependencies
- */
-
+import { Dialog } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import { sample } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { sample } from 'lodash';
 import store from 'store';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { Dialog } from '@automattic/components';
-import { fetchUserSettings } from 'calypso/state/user-settings/actions';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import { sendEmailLogin } from 'calypso/state/auth/actions';
-
-/**
- * Image dependencies
- */
 import wordpressLogoImage from 'calypso/assets/images/illustrations/logo-jpc.svg';
+import Gridicon from 'calypso/components/gridicon';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import React from 'react';

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
 import { Card } from '@automattic/components';
+import React from 'react';
+import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
 
 export default class AuthorCompactProfileExample extends React.Component {
 	static displayName = 'AuthorCompactProfileExample';

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import React from 'react';
+import classnames from 'classnames';
 import { numberFormat, localize } from 'i18n-calypso';
 import { has } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getStreamUrl } from 'calypso/reader/route';
-import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import AuthorCompactProfilePlaceholder from './placeholder';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class AuthorCompactProfile extends React.Component {

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const AuthorCompactProfilePlaceholder = () => {

--- a/client/blocks/author-selector/README.md
+++ b/client/blocks/author-selector/README.md
@@ -5,7 +5,7 @@ This component allows an administrator with sufficient privileges to edit the au
 ```js
 <AuthorSelector post={ post }>
 	<span>by William Shakespeare</span>
-</AuthorSelector>;
+</AuthorSelector>
 ```
 
 The component will retrieve site users and render the child span as a clickable element to expand the `author-selector` UX. If selecting other authors is not appropriate (i.e., only one available author, Users not loaded, or insufficient permission), it will simply display the span.

--- a/client/blocks/author-selector/docs/example.jsx
+++ b/client/blocks/author-selector/docs/example.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import AuthorSelector from '../';
-import { Card } from '@automattic/components';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import AuthorSelector from '../';
 
 function AuthorSelectorExample( { primarySiteId, displayName } ) {
 	return (

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import SwitcherShell from './switcher-shell';
+import React from 'react';
 import useUsersQuery from 'calypso/data/users/use-users-query';
+import SwitcherShell from './switcher-shell';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const AuthorSelector = ( {

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import debugModule from 'debug';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React, { Component, createRef } from 'react';
 import ReactDom from 'react-dom';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
 import AsyncLoad from 'calypso/components/async-load';
 import Gridicon from 'calypso/components/gridicon';
+import InfiniteList from 'calypso/components/infinite-list';
 import Popover from 'calypso/components/popover';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import UserItem from 'calypso/components/user';
-import InfiniteList from 'calypso/components/infinite-list';
 import { hasTouch } from 'calypso/lib/touch-detect';
 
 /**

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -1,24 +1,14 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal Dependencies
- */
 import { connect } from 'react-redux';
-import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import QueryBlogStickers from 'calypso/components/data/query-blog-stickers';
-import getBlogStickers from 'calypso/state/selectors/get-blog-stickers';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
 import BlogStickersList from 'calypso/blocks/blog-stickers/list';
+import QueryBlogStickers from 'calypso/components/data/query-blog-stickers';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import InfoPopover from 'calypso/components/info-popover';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import getBlogStickers from 'calypso/state/selectors/get-blog-stickers';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const BlogStickers = ( { blogId, teams, stickers } ) => {

--- a/client/blocks/blog-stickers/list.jsx
+++ b/client/blocks/blog-stickers/list.jsx
@@ -1,10 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { map } from 'lodash';
+import React from 'react';
 
 const BlogStickersList = ( { stickers, translate } ) => {
 	return (

--- a/client/blocks/calendar-button/docs/example.jsx
+++ b/client/blocks/calendar-button/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import CalendarButton from 'calypso/blocks/calendar-button';
 
 const CalendarButtonExample = () => {

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import Gridicon from 'calypso/components/gridicon';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import Gridicon from 'calypso/components/gridicon';
 
 const noop = () => {};
 

--- a/client/blocks/calendar-popover/docs/example.jsx
+++ b/client/blocks/calendar-popover/docs/example.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import moment from 'moment';
+import React, { PureComponent } from 'react';
 import CalendarPopover from 'calypso/blocks/calendar-popover';
 
 const tomorrow = ( date ) => date.date( date.date() + 1 );

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-
+import { pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
-import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import Popover from 'calypso/components/popover';
 import PostSchedule from 'calypso/components/post-schedule';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -1,28 +1,21 @@
-/**
- * External dependencies
- */
 import { compact } from 'lodash';
-
-/**
- * Image dependencies
- */
+import aquaticImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-aquatic.svg';
+import blueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-blue.svg';
+import classicBlueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-blue.svg';
 import classicBrightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-bright.svg';
 import classicDarkImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-dark.svg';
-import classicBlueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-blue.svg';
-import blueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-blue.svg';
-import powderSnowImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-powder-snow.svg';
-import lightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-light.svg';
-import modernImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-modern.svg';
-import nightfallImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-nightfall.svg';
-import sakuraImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sakura.svg';
-import oceanImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-ocean.svg';
-import aquaticImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-aquatic.svg';
-import sunriseImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sunrise.svg';
-import sunsetImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sunset.svg';
-import midnightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-midnight.svg';
 import coffeeImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-coffee.svg';
 import contrastImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-contrast.svg';
 import ectoplasmImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-ectoplasm.svg';
+import lightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-light.svg';
+import midnightImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-midnight.svg';
+import modernImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-modern.svg';
+import nightfallImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-nightfall.svg';
+import oceanImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-ocean.svg';
+import powderSnowImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-powder-snow.svg';
+import sakuraImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sakura.svg';
+import sunriseImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sunrise.svg';
+import sunsetImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-sunset.svg';
 
 /**
  * !! Note !!

--- a/client/blocks/color-scheme-picker/docs/example.jsx
+++ b/client/blocks/color-scheme-picker/docs/example.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import React, { PureComponent } from 'react';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 
 class ColorSchemePickerExample extends PureComponent {

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -1,24 +1,14 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
+import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import { savePreference, setPreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getColorSchemesData from './constants';
-import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ColorSchemePicker extends PureComponent {

--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import CommentButton from 'calypso/blocks/comment-button';
 import { Card } from '@automattic/components';
+import React from 'react';
+import CommentButton from 'calypso/blocks/comment-button';
 
 export default class CommentButtonExample extends React.Component {
 	static displayName = 'CommentButtonExample';

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-
+import { useTranslate } from 'i18n-calypso';
+import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-import { omitBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import Gridicon from 'calypso/components/gridicon';
 import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/comments/autoresizing-form-textarea.jsx
+++ b/client/blocks/comments/autoresizing-form-textarea.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React, { forwardRef } from 'react';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import React, { forwardRef } from 'react';
+import withUserMentions from 'calypso/blocks/user-mentions/index';
 import AutoDirection from 'calypso/components/auto-direction';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import withUserMentions from 'calypso/blocks/user-mentions/index';
 import withPasteToLink from 'calypso/lib/paste-to-link';
 
 import './autoresizing-form-textarea.scss';

--- a/client/blocks/comments/block-editor/autocompleters/index.js
+++ b/client/blocks/comments/block-editor/autocompleters/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import makeUserCompleter from './user';
 import makeXPostCompleter from './xpost';
 

--- a/client/blocks/comments/block-editor/autocompleters/user.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/user.jsx
@@ -1,7 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
+
 import React from 'react';
 
 export default ( suggestions ) => ( {

--- a/client/blocks/comments/block-editor/autocompleters/xpost.jsx
+++ b/client/blocks/comments/block-editor/autocompleters/xpost.jsx
@@ -1,12 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/**
- * External dependencies
- */
-import React from 'react';
 
-/**
- * Internal dependencies
- */
+import React from 'react';
 import wpcom from 'calypso/lib/wp';
 
 export default () => ( {

--- a/client/blocks/comments/block-editor/index.jsx
+++ b/client/blocks/comments/block-editor/index.jsx
@@ -1,17 +1,6 @@
-/**
- * External dependencies
- */
-import React, { useEffect } from 'react';
-import IsolatedBlockEditor from 'isolated-block-editor';
-
-/**
- * WordPress dependencies
- */
 import { addFilter } from '@wordpress/hooks';
-
-/**
- * Internal dependencies
- */
+import IsolatedBlockEditor from 'isolated-block-editor';
+import React, { useEffect } from 'react';
 import connectUserMentions from 'calypso/blocks/user-mentions/connect';
 import getAddAutocompleters from './autocompleters';
 

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -1,30 +1,16 @@
-/**
- * External dependencies
- */
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-import classnames from 'classnames';
-
-/**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { changeCommentStatus } from 'calypso/state/comments/actions';
-import CommentLikeButtonContainer from './comment-likes';
-import CommentApproveAction from './comment-approve-action';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import Gridicon from 'calypso/components/gridicon';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import PopoverMenuSeparator from 'calypso/components/popover/menu-separator';
+import { changeCommentStatus } from 'calypso/state/comments/actions';
+import CommentApproveAction from './comment-approve-action';
+import CommentLikeButtonContainer from './comment-likes';
 
-/**
- * Style dependencies
- */
 import './comment-actions.scss';
 
 const noop = () => {};

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import classnames from 'classnames';
 
-/**
- * Internal dependencies
- */
-import { Button } from '@wordpress/components';
-
-/**
- * Style dependencies
- */
 import './comment-approve-action.scss';
 
 const noop = () => {};

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
-
-/**
- * Style dependencies
- */
 import './comment-count.scss';
 
 const CommentCount = ( { count, translate } ) => {

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { isEnabled } from '@automattic/calypso-config';
+import AsyncLoad from 'calypso/components/async-load';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import Notice from 'calypso/components/notice';
-import { editComment } from 'calypso/state/comments/actions';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { editComment } from 'calypso/state/comments/actions';
 import AutoresizingFormTextarea from './autoresizing-form-textarea';
-import AsyncLoad from 'calypso/components/async-load';
 
-/**
- * Style dependencies
- */
 import './comment-edit-form.scss';
 
 const noop = () => {};

--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { translate } from 'i18n-calypso';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, pick } from 'lodash';
 import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import LikeButton from 'calypso/blocks/like-button/button';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { likeComment, unlikeComment } from 'calypso/state/comments/actions';

--- a/client/blocks/comments/docs/post-comment-example.jsx
+++ b/client/blocks/comments/docs/post-comment-example.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PostComment from 'calypso/blocks/comments/post-comment';
 import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
-import { Card } from '@automattic/components';
 
 const mockComment = {
 	author: {

--- a/client/blocks/comments/form-root.jsx
+++ b/client/blocks/comments/form-root.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { some } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import PostCommentForm from './form';
 
 const noop = () => {};

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -1,31 +1,21 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import { isEnabled } from '@automattic/calypso-config';
-import AutoresizingFormTextarea from './autoresizing-form-textarea';
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { isCommentableDiscoverPost } from 'calypso/blocks/comments/helper';
 import AsyncLoad from 'calypso/components/async-load';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import Gravatar from 'calypso/components/gravatar';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
-import { isCommentableDiscoverPost } from 'calypso/blocks/comments/helper';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
+import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import AutoresizingFormTextarea from './autoresizing-form-textarea';
 
-/**
- * Style dependencies
- */
 import './form.scss';
 
 const noop = () => {};

--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -1,9 +1,6 @@
 /*
  */
 
-/**
- * Internal dependencies
- */
 import * as DiscoverHelper from 'calypso/reader/discover/helper';
 
 export function shouldShowComments( post ) {

--- a/client/blocks/comments/index.jsx
+++ b/client/blocks/comments/index.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PostCommentsList from './post-comment-list';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
 import { requestPostComments } from 'calypso/state/comments/actions';
+import PostCommentsList from './post-comment-list';
 
 class PostComments extends React.Component {
 	static propTypes = {

--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import AutoDirection from 'calypso/components/auto-direction';
 import Emojify from 'calypso/components/emojify';
 
-/**
- * Style dependencies
- */
 import './post-comment-content.scss';
 
 class PostCommentContent extends React.Component {

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -1,44 +1,34 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { get, size, delay } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-import { get, size, delay } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import {
-	commentsFetchingStatus,
-	getActiveReplyCommentId,
-	getCommentById,
-	getPostCommentsTree,
-} from 'calypso/state/comments/selectors';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
+import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import Gridicon from 'calypso/components/gridicon';
+import SegmentedControl from 'calypso/components/segmented-control';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import {
 	requestPostComments,
 	requestComment,
 	setActiveReply,
 } from 'calypso/state/comments/actions';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from 'calypso/state/comments/constants';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import PostComment from './post-comment';
-import PostCommentFormRoot from './form-root';
-import CommentCount from './comment-count';
-import SegmentedControl from 'calypso/components/segmented-control';
-import Gridicon from 'calypso/components/gridicon';
-import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import {
+	commentsFetchingStatus,
+	getActiveReplyCommentId,
+	getCommentById,
+	getPostCommentsTree,
+} from 'calypso/state/comments/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import CommentCount from './comment-count';
+import PostCommentFormRoot from './form-root';
+import PostComment from './post-comment';
 
-/**
- * Style dependencies
- */
 import './post-comment-list.scss';
 
 /**

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PostCommentForm from './form';
 
-/**
- * Style dependencies
- */
 import './post-comment.scss'; // intentional, shares styles
 import './post-comment-with-error.scss';
 

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -1,40 +1,30 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { get, some, flatMap } from 'lodash';
-import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import TimeSince from 'calypso/components/time-since';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { get, some, flatMap } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
+import Emojify from 'calypso/components/emojify';
 import Gravatar from 'calypso/components/gravatar';
-import { recordAction, recordGaEvent, recordPermalinkClick } from 'calypso/reader/stats';
-import { getStreamUrl } from 'calypso/reader/route';
-import PostCommentContent from './post-comment-content';
-import PostCommentForm from './form';
-import CommentEditForm from './comment-edit-form';
-import { PLACEHOLDER_STATE, POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
+import Gridicon from 'calypso/components/gridicon';
+import TimeSince from 'calypso/components/time-since';
 import { decodeEntities } from 'calypso/lib/formatting';
+import withDimensions from 'calypso/lib/with-dimensions';
+import { getStreamUrl } from 'calypso/reader/route';
+import { recordAction, recordGaEvent, recordPermalinkClick } from 'calypso/reader/stats';
+import { expandComments } from 'calypso/state/comments/actions';
+import { PLACEHOLDER_STATE, POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import CommentActions from './comment-actions';
+import CommentEditForm from './comment-edit-form';
+import PostCommentForm from './form';
+import PostCommentContent from './post-comment-content';
 import PostCommentWithError from './post-comment-with-error';
 import PostTrackback from './post-trackback';
-import CommentActions from './comment-actions';
-import Emojify from 'calypso/components/emojify';
-import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
-import withDimensions from 'calypso/lib/with-dimensions';
-import { expandComments } from 'calypso/state/comments/actions';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './post-comment.scss';
 
 const noop = () => {};

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import TimeSince from 'calypso/components/time-since';
 
-/**
- * Style dependencies
- */
 import './post-comment.scss'; // yes, this is intentional. they share styles.
 
 function unescape( str ) {

--- a/client/blocks/comments/utils.jsx
+++ b/client/blocks/comments/utils.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 /**

--- a/client/blocks/conversation-caterpillar/docs/example.jsx
+++ b/client/blocks/conversation-caterpillar/docs/example.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { Card } from '@automattic/components';
 import { size } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { ConversationCaterpillar } from 'calypso/blocks/conversation-caterpillar';
 import { comments, commentsTree } from 'calypso/blocks/conversation-caterpillar/docs/fixtures';
-import { Card } from '@automattic/components';
 
 const ConversationCaterpillarExample = () => {
 	return (

--- a/client/blocks/conversation-caterpillar/docs/fixtures.js
+++ b/client/blocks/conversation-caterpillar/docs/fixtures.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { keyBy, map } from 'lodash';
 
 export const comments = [

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { map, get, last, uniqBy, size, filter, compact } from 'lodash';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import { getPostCommentsTree, getDateSortedPostComments } from 'calypso/state/comments/selectors';
-import { expandComments } from 'calypso/state/comments/actions';
-import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
+import { map, get, last, uniqBy, size, filter, compact } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import { isAncestor } from 'calypso/blocks/comments/utils';
 import GravatarCaterpillar from 'calypso/components/gravatar-caterpillar';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { expandComments } from 'calypso/state/comments/actions';
+import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
+import { getPostCommentsTree, getDateSortedPostComments } from 'calypso/state/comments/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const MAX_GRAVATARS_TO_DISPLAY = 10;

--- a/client/blocks/conversation-follow-button/button.jsx
+++ b/client/blocks/conversation-follow-button/button.jsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
 const noop = () => {};

--- a/client/blocks/conversation-follow-button/docs/example.jsx
+++ b/client/blocks/conversation-follow-button/docs/example.jsx
@@ -1,16 +1,9 @@
 /*
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import ConversationFollowButton from 'calypso/blocks/conversation-follow-button/button';
 import { CompactCard as Card } from '@automattic/components';
+import React from 'react';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button/button';
 
 export default class ConversationFollowButtonExample extends React.PureComponent {
 	static displayName = 'ConversationFollowButton';

--- a/client/blocks/conversation-follow-button/helper.js
+++ b/client/blocks/conversation-follow-button/helper.js
@@ -1,11 +1,8 @@
 /*
  */
 
-/**
- * Internal dependencies
- */
-import { isDiscoverPost } from 'calypso/reader/discover/helper';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
+import { isDiscoverPost } from 'calypso/reader/discover/helper';
 
 export function shouldShowConversationFollowButton( post ) {
 	return (

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -4,19 +4,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import ConversationFollowButton from './button';
-import { isFollowingReaderConversation } from 'calypso/state/reader/conversations/selectors';
-import { followConversation, muteConversation } from 'calypso/state/reader/conversations/actions';
 import { getTracksPropertiesForPost } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { followConversation, muteConversation } from 'calypso/state/reader/conversations/actions';
+import { isFollowingReaderConversation } from 'calypso/state/reader/conversations/selectors';
+import ConversationFollowButton from './button';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { map, compact } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { commentsTree } from 'calypso/blocks/conversations/docs/fixtures';
 import { ConversationCommentList } from 'calypso/blocks/conversations/list';
 import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
-import { commentsTree } from 'calypso/blocks/conversations/docs/fixtures';
 
 const noop = () => {};
 

--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 import EmptyContent from 'calypso/components/empty-content';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 /**
  * Asset dependencies
  */
-import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 
 class ConversationsEmptyContent extends React.Component {
 	shouldComponentUpdate() {

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,15 +1,16 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { map, zipObject, size, filter, get, compact, partition } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import PostCommentFormRoot from 'calypso/blocks/comments/form-root';
 import PostComment from 'calypso/blocks/comments/post-comment';
+import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import {
+	requestPostComments,
+	requestComment,
+	setActiveReply,
+} from 'calypso/state/comments/actions';
 import { POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
 import {
 	commentsFetchingStatus,
@@ -20,21 +21,10 @@ import {
 	getHiddenCommentsForPost,
 	getPostCommentsTree,
 } from 'calypso/state/comments/selectors';
-import ConversationCaterpillar from 'calypso/blocks/conversation-caterpillar';
-import { recordAction, recordGaEvent } from 'calypso/reader/stats';
-import PostCommentFormRoot from 'calypso/blocks/comments/form-root';
-import {
-	requestPostComments,
-	requestComment,
-	setActiveReply,
-} from 'calypso/state/comments/actions';
 import { getErrorKey } from 'calypso/state/comments/utils';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './list.scss';
 
 /**

--- a/client/blocks/daily-post-button/docs/example.jsx
+++ b/client/blocks/daily-post-button/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import DailyPostButton from 'calypso/blocks/daily-post-button';
 const DailyPostButtonExample = () => {
 	return (

--- a/client/blocks/daily-post-button/helper.js
+++ b/client/blocks/daily-post-button/helper.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import config from '@automattic/calypso-config';
 
 const types = {

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -1,32 +1,22 @@
-/**
- * External Dependencies
- */
-import React from 'react';
+import { Button } from '@automattic/components';
 import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { get, defer } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
-import { get, defer } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import AsyncLoad from 'calypso/components/async-load';
-import { translate } from 'i18n-calypso';
-import { preloadEditor } from 'calypso/sections-preloaders';
-import { Button } from '@automattic/components';
-import { markPostSeen } from 'calypso/state/reader/posts/actions';
+import Gridicon from 'calypso/components/gridicon';
 import { recordGaEvent, recordAction, recordTrackForPost } from 'calypso/reader/stats';
-import { getDailyPostType } from './helper';
+import { preloadEditor } from 'calypso/sections-preloaders';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { markPostSeen } from 'calypso/state/reader/posts/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getDailyPostType } from './helper';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function getPingbackAttributes( post ) {

--- a/client/blocks/daily-post-button/test/helper.js
+++ b/client/blocks/daily-post-button/test/helper.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import * as helper from '../helper';
 import * as posts from './fixtures';
 

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -2,18 +2,11 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import pageSpy from 'page';
 import { parse } from 'qs';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { DailyPostButton } from '../index';
 import { sites, dailyPromptPost } from './fixtures';
 

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -1,36 +1,25 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
-import Gridicon from 'calypso/components/gridicon';
-import { connect } from 'react-redux';
+import { getPlanClass } from '@automattic/calypso-products';
+import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
-import HappychatButton from 'calypso/components/happychat/button';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import Gridicon from 'calypso/components/gridicon';
+import HappychatButton from 'calypso/components/happychat/button';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { disconnect } from 'calypso/state/jetpack/connection/actions';
-import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import {
 	successNotice,
 	errorNotice,
 	infoNotice,
 	removeNotice,
 } from 'calypso/state/notices/actions';
-import { getPlanClass } from '@automattic/calypso-products';
-import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/dismissible-card/docs/example.jsx
+++ b/client/blocks/dismissible-card/docs/example.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import DismissibleCard from '../';
 import { savePreference } from 'calypso/state/preferences/actions';
+import DismissibleCard from '../';
 
 function DismissibleCardExample() {
 	const dispatch = useDispatch();

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -1,23 +1,12 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
 import QueryPreferences from 'calypso/components/data/query-preferences';
+import Gridicon from 'calypso/components/gridicon';
 import { savePreference, setPreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const PREFERENCE_PREFIX = 'dismissible-card-';

--- a/client/blocks/domain-tip/docs/example.jsx
+++ b/client/blocks/domain-tip/docs/example.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import DomainTip from '../index';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import DomainTip from '../index';
 
 const DomainTipExample = ( { siteId } ) => (
 	<DomainTip siteId={ siteId } event="domain_app_example" />

--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { FEATURE_CUSTOM_DOMAIN, isFreePlanProduct } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
-
-/**
- * Internal dependencies
- */
-import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
-import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
-import { getDomainsSuggestions } from 'calypso/state/domains/suggestions/selectors';
-import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
-import QueryDomainsSuggestions from 'calypso/components/data/query-domains-suggestions';
-import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
+import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import { FEATURE_CUSTOM_DOMAIN, isFreePlanProduct } from '@automattic/calypso-products';
+import QueryDomainsSuggestions from 'calypso/components/data/query-domains-suggestions';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
+import { getDomainsSuggestions } from 'calypso/state/domains/suggestions/selectors';
+import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
+import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 
 function getQueryObject( site, siteSlug, vendor ) {
 	if ( ! site || ! siteSlug ) {

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -1,32 +1,22 @@
-/**
- * External dependencies
- */
+import { getPlan, PLAN_PERSONAL, FEATURE_NO_ADS } from '@automattic/calypso-products';
+import formatCurrency from '@automattic/format-currency';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
-import { getPlan, PLAN_PERSONAL, FEATURE_NO_ADS } from '@automattic/calypso-products';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import isEligibleForDomainToPaidPlanUpsell from 'calypso/state/selectors/is-eligible-for-domain-to-paid-plan-upsell';
 import {
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 	getPlanRawDiscount,
 	getPlansBySiteId,
 } from 'calypso/state/sites/plans/selectors';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import isEligibleForDomainToPaidPlanUpsell from 'calypso/state/selectors/is-eligible-for-domain-to-paid-plan-upsell';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class DomainToPlanNudge extends Component {

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -1,44 +1,34 @@
-/**
- * External dependencies
- */
+import path from 'path';
+import { Dialog } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import path from 'path';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { ALLOWED_FILE_EXTENSIONS } from './constants';
-import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
-import { Dialog } from '@automattic/components';
-import FilePicker from 'calypso/components/file-picker';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import Gravatar from 'calypso/components/gravatar';
-import { isCurrentUserUploadingGravatar } from 'calypso/state/current-user/gravatar-status/selectors';
-import { resetAllImageEditorState } from 'calypso/state/editor/image-editor/actions';
-import Spinner from 'calypso/components/spinner';
-import {
-	receiveGravatarImageFailed,
-	uploadGravatar,
-} from 'calypso/state/current-user/gravatar-status/actions';
 import ImageEditor from 'calypso/blocks/image-editor';
-import InfoPopover from 'calypso/components/info-popover';
-import ExternalLink from 'calypso/components/external-link';
-import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
 import DropZone from 'calypso/components/drop-zone';
+import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
+import ExternalLink from 'calypso/components/external-link';
+import FilePicker from 'calypso/components/file-picker';
+import Gravatar from 'calypso/components/gravatar';
+import Gridicon from 'calypso/components/gridicon';
+import InfoPopover from 'calypso/components/info-popover';
+import Spinner from 'calypso/components/spinner';
 import {
 	recordTracksEvent,
 	recordGoogleEvent,
 	composeAnalytics,
 } from 'calypso/state/analytics/actions';
+import {
+	receiveGravatarImageFailed,
+	uploadGravatar,
+} from 'calypso/state/current-user/gravatar-status/actions';
+import { isCurrentUserUploadingGravatar } from 'calypso/state/current-user/gravatar-status/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { resetAllImageEditorState } from 'calypso/state/editor/image-editor/actions';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
+import { ALLOWED_FILE_EXTENSIONS } from './constants';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class EditGravatar extends Component {

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -2,24 +2,17 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { EditGravatar } from 'calypso/blocks/edit-gravatar';
+import ImageEditor from 'calypso/blocks/image-editor';
+import DropZone from 'calypso/components/drop-zone';
+import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
 import FilePicker from 'calypso/components/file-picker';
 import Gravatar from 'calypso/components/gravatar';
-import ImageEditor from 'calypso/blocks/image-editor';
-import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
-import DropZone from 'calypso/components/drop-zone';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
+import { useSandbox } from 'calypso/test-helpers/use-sinon';
 
 jest.mock( 'event', () => require( 'component-event' ), { virtual: true } );
 jest.mock( 'calypso/lib/oauth-token', () => ( {

--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
+import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { Modal } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Icon, wordpress } from '@wordpress/icons';
-import { Modal } from '@wordpress/components';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { useTranslate } from 'i18n-calypso';
-import type { RequestCart } from '@automattic/shopping-cart';
-
-/**
- * Internal dependencies
- */
-import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/payment-method-helpers';
-import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import wp from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import CompositeCheckout from 'calypso/my-sites/checkout/composite-checkout/composite-checkout';
+import { fetchStripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/payment-method-helpers';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { RequestCart } from '@automattic/shopping-cart';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function fetchStripeConfigurationWpcom( args: Record< string, unknown > ) {

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import CardHeading from 'calypso/components/card-heading';
 import Gridicon from 'calypso/components/gridicon';
 import Notice from 'calypso/components/notice';

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -1,43 +1,33 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { connect } from 'react-redux';
-import { localize, LocalizeProps } from 'i18n-calypso';
-import { includes } from 'lodash';
-import classNames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import {
 	FEATURE_UPLOAD_PLUGINS,
 	FEATURE_PERFORMANCE,
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_SFTP,
 } from '@automattic/calypso-products';
+import { Button, CompactCard } from '@automattic/components';
+import classNames from 'classnames';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import { includes } from 'lodash';
+import page from 'page';
+import React from 'react';
+import { connect } from 'react-redux';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import Gridicon from 'calypso/components/gridicon';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { Button, CompactCard } from '@automattic/components';
-import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
-import HoldList, { hasBlockingHold } from './hold-list';
-import WarningList from './warning-list';
-import { launchSite } from 'calypso/state/sites/launch/actions';
-import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
-import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import getRequest from 'calypso/state/selectors/get-request';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
+import { launchSite } from 'calypso/state/sites/launch/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import HoldList, { hasBlockingHold } from './hold-list';
 import { isAtomicSiteWithoutBusinessPlan } from './utils';
+import WarningList from './warning-list';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -2,19 +2,14 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
+import { fireEvent, render } from '@testing-library/react';
 import page from 'page';
 import React, { ReactChild } from 'react';
-import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { fireEvent, render } from '@testing-library/react';
+import { createStore } from 'redux';
+
 import '@testing-library/jest-dom/extend-expect';
 
-/**
- * Internal dependencies
- */
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
 } ) );

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import ExternalLink from 'calypso/components/external-link';
+import React from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
+import ExternalLink from 'calypso/components/external-link';
+import Gridicon from 'calypso/components/gridicon';
 
 interface ExternalProps {
 	context: string | null;

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -1,20 +1,12 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import versionCompare from 'calypso/lib/version-compare';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import versionCompare from 'calypso/lib/version-compare';
+import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 class ExtensionRedirect extends Component {
 	static propTypes = {

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/follow-button/docs/example.jsx
+++ b/client/blocks/follow-button/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import FollowButton from 'calypso/blocks/follow-button/button';
 import { CompactCard as Card } from '@automattic/components';
+import React from 'react';
+import FollowButton from 'calypso/blocks/follow-button/button';
 
 export default class FollowButtonExample extends React.PureComponent {
 	static displayName = 'FollowButtonExample';

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
+import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { omitBy } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import FollowButton from './button';
-import { isFollowing } from 'calypso/state/reader/follows/selectors';
 import { follow, unfollow } from 'calypso/state/reader/follows/actions';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
+import FollowButton from './button';
 
 const noop = () => {};
 

--- a/client/blocks/follow-button/test/button.js
+++ b/client/blocks/follow-button/test/button.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { render } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import FollowButton from '../button';
 
 describe( 'FollowButton', () => {

--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Count from 'calypso/components/count';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 class FollowersCount extends Component {
 	render() {

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
 import cookie from 'cookie';
 import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { isCurrentUserMaybeInGdprZone } from 'calypso/lib/analytics/utils';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Internal dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { startsWith } from 'lodash';
-import { translate } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import TranslatableString from 'calypso/components/translatable/proptype';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import TranslatableString from 'calypso/components/translatable/proptype';
 
-/**
- * Style dependencies
- */
 import './apps-badge.scss';
 
 // the locale slugs for each stores' image paths follow different rules

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { Card, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Card, Button } from '@automattic/components';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const WINDOWS_LINK = 'https://apps.wordpress.com/d/windows?ref=getapps';

--- a/client/blocks/get-apps/illustration.jsx
+++ b/client/blocks/get-apps/illustration.jsx
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import getAppsImage from 'calypso/assets/images/illustrations/get-apps-banner.svg';
 
 const GetAppsIllustration = ( { translate } ) => (

--- a/client/blocks/get-apps/index.jsx
+++ b/client/blocks/get-apps/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import GetAppsIllustration from './illustration.jsx';
-import DesktopDownloadCard from './desktop-download-card.jsx';
-import MobileDownloadCard from './mobile-download-card.jsx';
 import config from '@automattic/calypso-config';
+import React from 'react';
+import DesktopDownloadCard from './desktop-download-card.jsx';
+import GetAppsIllustration from './illustration.jsx';
+import MobileDownloadCard from './mobile-download-card.jsx';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export const GetApps = () => {

--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -1,36 +1,28 @@
-/**
- * External dependencies
- */
-
+import { Card, Button } from '@automattic/components';
+import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import AppsBadge from './apps-badge';
-import ReauthRequired from 'calypso/me/reauth-required';
-import { Card, Button } from '@automattic/components';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormPhoneInput from 'calypso/components/forms/form-phone-input';
-import getCountries from 'calypso/state/selectors/get-countries';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { fetchUserSettings } from 'calypso/state/user-settings/actions';
+import phoneValidation from 'calypso/lib/phone-validation';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import userAgent from 'calypso/lib/user-agent';
+import ReauthRequired from 'calypso/me/reauth-required';
 import { accountRecoverySettingsFetch } from 'calypso/state/account-recovery/settings/actions';
 import {
 	getAccountRecoveryPhone,
 	isAccountRecoverySettingsReady,
 } from 'calypso/state/account-recovery/settings/selectors';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import hasUserSettings from 'calypso/state/selectors/has-user-settings';
-import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import phoneValidation from 'calypso/lib/phone-validation';
-import userAgent from 'calypso/lib/user-agent';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import getCountries from 'calypso/state/selectors/get-countries';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import hasUserSettings from 'calypso/state/selectors/has-user-settings';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
+import AppsBadge from './apps-badge';
 
 function sendSMS( phone ) {
 	function onSuccess( dispatch ) {

--- a/client/blocks/get-apps/test/apps-badge.js
+++ b/client/blocks/get-apps/test/apps-badge.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { AppsBadge } from '../apps-badge';
 
 jest.mock( 'calypso/lib/i18n-utils', () => ( {

--- a/client/blocks/global-notice/index.js
+++ b/client/blocks/global-notice/index.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { infoNotice, removeNotice } from 'calypso/state/notices/actions';
 
 export class GlobalNotice extends Component {

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import { get } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import ImageEditor from '../';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
+import ImageEditor from '../';
 
 class ImageEditorExample extends Component {
 	constructor() {

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import {
 	getImageEditorFileInfo,
 	imageEditorHasChanges,

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -1,32 +1,25 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
-import ImageEditorCrop from './image-editor-crop';
 import { mediaURLToProxyConfig, canvasToBlob } from 'calypso/lib/media/utils';
+import wpcom from 'calypso/lib/wp';
+import {
+	setImageEditorCropBounds,
+	setImageEditorImageHasLoaded,
+} from 'calypso/state/editor/image-editor/actions';
 import {
 	getImageEditorTransform,
 	getImageEditorFileInfo,
 	getImageEditorCrop,
 	isImageEditorImageLoaded,
 } from 'calypso/state/editor/image-editor/selectors';
-import {
-	setImageEditorCropBounds,
-	setImageEditorImageHasLoaded,
-} from 'calypso/state/editor/image-editor/actions';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
+import ImageEditorCrop from './image-editor-crop';
 
 const noop = () => {};
 

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -1,16 +1,15 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import Draggable from 'calypso/components/draggable';
+import {
+	imageEditorCrop,
+	imageEditorComputedCrop,
+} from 'calypso/state/editor/image-editor/actions';
+import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
+import { defaultCrop } from 'calypso/state/editor/image-editor/reducer';
 import {
 	getImageEditorCropBounds,
 	getImageEditorAspectRatio,
@@ -18,12 +17,6 @@ import {
 	getImageEditorCrop,
 	imageEditorHasChanges,
 } from 'calypso/state/editor/image-editor/selectors';
-import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
-import {
-	imageEditorCrop,
-	imageEditorComputedCrop,
-} from 'calypso/state/editor/image-editor/actions';
-import { defaultCrop } from 'calypso/state/editor/image-editor/reducer';
 import getImageEditorOriginalAspectRatio from 'calypso/state/selectors/get-image-editor-original-aspect-ratio';
 
 const noop = () => {};

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -1,26 +1,19 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { values as objectValues } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { values as objectValues } from 'lodash';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'calypso/components/gridicon';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import PopoverMenu from 'calypso/components/popover/menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
-import { AspectRatios, MinimumImageDimensions } from 'calypso/state/editor/image-editor/constants';
-import { getImageEditorAspectRatio } from 'calypso/state/editor/image-editor/selectors';
 import {
 	imageEditorRotateCounterclockwise,
 	imageEditorFlip,
 	setImageEditorAspectRatio,
 } from 'calypso/state/editor/image-editor/actions';
+import { AspectRatios, MinimumImageDimensions } from 'calypso/state/editor/image-editor/constants';
+import { getImageEditorAspectRatio } from 'calypso/state/editor/image-editor/selectors';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
 
 const noop = () => {};

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -1,23 +1,14 @@
-/**
- * External dependencies
- */
+import path from 'path';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { isEqual, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { isEqual, partial } from 'lodash';
-import path from 'path';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import CloseOnEscape from 'calypso/components/close-on-escape';
+import QuerySites from 'calypso/components/data/query-sites';
 import Notice from 'calypso/components/notice';
-import ImageEditorCanvas from './image-editor-canvas';
-import ImageEditorToolbar from './image-editor-toolbar';
-import ImageEditorButtons from './image-editor-buttons';
 import { getMimeType, url } from 'calypso/lib/media/utils';
 import {
 	resetImageEditorState,
@@ -25,19 +16,18 @@ import {
 	setImageEditorFileInfo,
 	setImageEditorDefaultAspectRatio,
 } from 'calypso/state/editor/image-editor/actions';
+import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
 import {
 	getImageEditorFileInfo,
 	isImageEditorImageLoaded,
 } from 'calypso/state/editor/image-editor/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
-import QuerySites from 'calypso/components/data/query-sites';
-import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ImageEditorButtons from './image-editor-buttons';
+import ImageEditorCanvas from './image-editor-canvas';
+import ImageEditorToolbar from './image-editor-toolbar';
 import { getDefaultAspectRatio } from './utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/image-editor/test/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/test/image-editor-canvas.jsx
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { ImageEditorCanvas } from '../image-editor-canvas';
 
 jest.mock( 'calypso/blocks/image-editor/image-editor-crop', () => {

--- a/client/blocks/image-editor/test/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/test/image-editor-toolbar.jsx
@@ -2,18 +2,11 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { ImageEditorToolbar } from '../image-editor-toolbar';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import { ImageEditorToolbar } from '../image-editor-toolbar';
 
 describe( 'ImageEditorToolbar', () => {
 	let defaultProps;

--- a/client/blocks/image-editor/test/utils.js
+++ b/client/blocks/image-editor/test/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
 import { getDefaultAspectRatio } from '../utils';
 

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -3,10 +3,6 @@
  *
  */
 import { includes, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { AspectRatios, AspectRatiosValues } from 'calypso/state/editor/image-editor/constants';
 
 /**

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import { intersection, words, memoize } from 'lodash';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { getCustomizerUrl } from 'calypso/state/sites/selectors';
-import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
-import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
+import { intersection, words, memoize } from 'lodash';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
+import { getCustomizerUrl } from 'calypso/state/sites/selectors';
+import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
 
 /**
  * Returns admin section items with site-based urls.

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { compact, get } from 'lodash';
 import i18n, { translate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { RESULT_TOUR, RESULT_VIDEO } from './constants';
+import { compact, get } from 'lodash';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 
 /**
  * Module variables

--- a/client/blocks/inline-help/dialog.jsx
+++ b/client/blocks/inline-help/dialog.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import { Button, Dialog } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button, Dialog } from '@automattic/components';
+import React from 'react';
 import ResizableIframe from 'calypso/components/resizable-iframe';
 
-/**
- * Style dependencies
- */
 import './dialog.scss';
 
 function InlineHelpDialog( { dialogType, videoLink, onClose, translate } ) {

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -1,30 +1,20 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { Button, RootChild } from '@automattic/components';
+import { isWithinBreakpoint } from '@automattic/viewport';
+import classNames from 'classnames';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-import debugFactory from 'debug';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
-import config from '@automattic/calypso-config';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getGlobalKeyboardShortcuts from 'calypso/lib/keyboard-shortcuts/global';
-import { Button, RootChild } from '@automattic/components';
-import { isWithinBreakpoint } from '@automattic/viewport';
-import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import AsyncLoad from 'calypso/components/async-load';
+import Gridicon from 'calypso/components/gridicon';
+import getGlobalKeyboardShortcuts from 'calypso/lib/keyboard-shortcuts/global';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { showInlineHelpPopover, hideInlineHelpPopover } from 'calypso/state/inline-help/actions';
 import isInlineHelpPopoverVisible from 'calypso/state/inline-help/selectors/is-inline-help-popover-visible';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/client/blocks/inline-help/inline-help-compact-result.jsx
+++ b/client/blocks/inline-help/inline-help-compact-result.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 
 class InlineHelpCompactResult extends Component {

--- a/client/blocks/inline-help/inline-help-compact-results.jsx
+++ b/client/blocks/inline-help/inline-help-compact-results.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import InlineHelpCompactResult from 'calypso/blocks/inline-help/inline-help-compact-result';
 
 class InlineHelpCompactResults extends Component {

--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import HelpContact from 'calypso/me/help/help-contact';
 import InlineHelpForumView from 'calypso/blocks/inline-help/inline-help-forum-view';
 import PlaceholderLines from 'calypso/blocks/inline-help/placeholder-lines';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import HelpContact from 'calypso/me/help/help-contact';
+import { getHelpSelectedSite } from 'calypso/state/help/selectors';
 import getInlineHelpSupportVariation, {
 	SUPPORT_FORUM,
 } from 'calypso/state/selectors/get-inline-help-support-variation';
-import { getHelpSelectedSite } from 'calypso/state/help/selectors';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 
 const InlineHelpContactView = ( {
 	/* eslint-disable no-shadow */

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
 import { Button } from '@automattic/components';
-import { preventWidows } from 'calypso/lib/formatting';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { preventWidows } from 'calypso/lib/formatting';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 const trackForumOpen = () =>

--- a/client/blocks/inline-help/inline-help-query-support-types.jsx
+++ b/client/blocks/inline-help/inline-help-query-support-types.jsx
@@ -1,28 +1,21 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import config from '@automattic/calypso-config';
-import HappychatConnection from 'calypso/components/happychat/connection-connected';
-import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
 import QueryLanguageNames from 'calypso/components/data/query-language-names';
 import QuerySupportHistory from 'calypso/components/data/query-support-history';
+import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
 import { initialize as initializeDirectly } from 'calypso/state/help/directly/actions';
-import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
-import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
 import {
 	isTicketSupportConfigurationReady,
 	getTicketSupportRequestError,
 } from 'calypso/state/help/ticket/selectors';
-import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uninitialized';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
 
 class QueryInlineHelpSupportTypes extends Component {
 	componentDidMount() {

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -1,17 +1,16 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+import { get, omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, getLocaleSlug } from 'i18n-calypso';
-import classNames from 'classnames';
-import { get, omitBy } from 'lodash';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
+import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
+import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 import {
 	RESULT_ARTICLE,
 	RESULT_DESCRIPTION,
@@ -21,12 +20,6 @@ import {
 	RESULT_TYPE,
 	RESULT_VIDEO,
 } from './constants';
-import { Button } from '@automattic/components';
-import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
-import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 
 class InlineHelpRichResult extends Component {
 	static propTypes = {

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-
-/**
- * Internal Dependencies
- */
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SearchCard from 'calypso/components/search-card';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setInlineHelpSearchQuery } from 'calypso/state/inline-help/actions';
 import getInlineHelpCurrentlySelectedLink from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-link';
 import isRequestingInlineHelpSearchResultsForQuery from 'calypso/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
-import { setInlineHelpSearchQuery } from 'calypso/state/inline-help/actions';
 
 /**
  * Module variables

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -1,39 +1,32 @@
-/**
- * External dependencies
- */
-import React, { Fragment, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { debounce, isEmpty } from 'lodash';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-import page from 'page';
 import { speak } from '@wordpress/a11y';
-
-/**
- * Internal Dependencies
- */
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { debounce, isEmpty } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Fragment, useEffect } from 'react';
+import { connect } from 'react-redux';
 import QueryInlineHelpSearch from 'calypso/components/data/query-inline-help-search';
-import PlaceholderLines from './placeholder-lines';
-import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { getSectionName } from 'calypso/state/ui/selectors';
-import getSearchResultsByQuery from 'calypso/state/inline-help/selectors/get-inline-help-search-results-for-query';
-import getSelectedResultIndex from 'calypso/state/inline-help/selectors/get-selected-result-index';
-import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
-import isRequestingInlineHelpSearchResultsForQuery from 'calypso/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
-import hasInlineHelpAPIResults from 'calypso/state/selectors/has-inline-help-api-results';
-import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import Gridicon from 'calypso/components/gridicon';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { selectResult } from 'calypso/state/inline-help/actions';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import Gridicon from 'calypso/components/gridicon';
+import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
+import getSearchResultsByQuery from 'calypso/state/inline-help/selectors/get-inline-help-search-results-for-query';
+import getSelectedResultIndex from 'calypso/state/inline-help/selectors/get-selected-result-index';
+import isRequestingInlineHelpSearchResultsForQuery from 'calypso/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import hasInlineHelpAPIResults from 'calypso/state/selectors/has-inline-help-api-results';
+import { getSectionName } from 'calypso/state/ui/selectors';
 import {
 	SUPPORT_TYPE_ADMIN_SECTION,
 	SUPPORT_TYPE_API_HELP,
 	SUPPORT_TYPE_CONTEXTUAL_HELP,
 } from './constants';
+import PlaceholderLines from './placeholder-lines';
 
 const noop = () => {};
 

--- a/client/blocks/inline-help/placeholder-lines.jsx
+++ b/client/blocks/inline-help/placeholder-lines.jsx
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { times } from 'lodash';
+import React from 'react';
 
 export default ( { lines = 4 } ) => (
 	<div className="inline-help__results-placeholder">

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -1,31 +1,24 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import { flowRight as compose } from 'lodash';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
+import { Button } from '@automattic/components';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal Dependencies
- */
-import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
-import { selectResult, resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
-import { Button } from '@automattic/components';
-import Popover from 'calypso/components/popover';
-import InlineHelpSearchResults from './inline-help-search-results';
-import InlineHelpSearchCard from './inline-help-search-card';
-import InlineHelpRichResult from './inline-help-rich-result';
-import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
-import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { flowRight as compose } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 import InlineHelpContactView from 'calypso/blocks/inline-help/inline-help-contact-view';
+import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
+import Gridicon from 'calypso/components/gridicon';
+import Popover from 'calypso/components/popover';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { selectResult, resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
+import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
+import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
+import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
+import InlineHelpRichResult from './inline-help-rich-result';
+import InlineHelpSearchCard from './inline-help-search-card';
+import InlineHelpSearchResults from './inline-help-search-results';
 
 const noop = () => {};
 

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { filterListBySearchTerm } from 'calypso/blocks/inline-help/admin-sections';
 
 describe( 'filterListBySearchTerm()', () => {

--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -1,25 +1,15 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { settingsPath } from 'calypso/lib/jetpack/paths';
-import Banner from 'calypso/components/banner';
-import getRewindState from 'calypso/state/selectors/get-rewind-state';
-import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import jetpackDisconnected from 'calypso/assets/images/jetpack/disconnected.svg';
+import Banner from 'calypso/components/banner';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class JetpackBackupCredsBanner extends Component {

--- a/client/blocks/jetpack-connect-site-only/index.js
+++ b/client/blocks/jetpack-connect-site-only/index.js
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
+import React, { Component } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/route';
 import { urlToSlug } from 'calypso/lib/url';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class JetpackConnectSiteOnly extends Component {

--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React, { FC, useCallback, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import ExternalLink from 'calypso/components/external-link';
 import Notice from 'calypso/components/notice';
 import { preventWidows } from 'calypso/lib/formatting';

--- a/client/blocks/jetpack-review-prompt/docs/example.tsx
+++ b/client/blocks/jetpack-review-prompt/docs/example.tsx
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
+import { Button, Card } from '@automattic/components';
 import React, { FunctionComponent, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
-import { getIsDismissed, getValidFromDate } from 'calypso/state/jetpack-review-prompt/selectors';
-import { PREFERENCE_NAME } from 'calypso/state/jetpack-review-prompt/constants';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
-import CardHeading from 'calypso/components/card-heading';
 import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
+import CardHeading from 'calypso/components/card-heading';
 import SegmentedControl from 'calypso/components/segmented-control';
+import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
+import { PREFERENCE_NAME } from 'calypso/state/jetpack-review-prompt/constants';
+import { getIsDismissed, getValidFromDate } from 'calypso/state/jetpack-review-prompt/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
 
 const JetpackReviewPromptExample: FunctionComponent = () => {
 	const dispatch = useDispatch();

--- a/client/blocks/jetpack-review-prompt/index.tsx
+++ b/client/blocks/jetpack-review-prompt/index.tsx
@@ -1,26 +1,16 @@
-/**
- * External dependencies
- */
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useSelector, useDispatch } from 'react-redux';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useCallback, useEffect } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import { useSelector, useDispatch } from 'react-redux';
+import QueryPreferences from 'calypso/components/data/query-preferences';
+import Gridicon from 'calypso/components/gridicon';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { dismiss } from 'calypso/state/jetpack-review-prompt/actions';
 import { getIsDismissed, getValidFromDate } from 'calypso/state/jetpack-review-prompt/selectors';
 import { hasReceivedRemotePreferences as getHasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
-import { preventWidows } from 'calypso/lib/formatting';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import Gridicon from 'calypso/components/gridicon';
-import QueryPreferences from 'calypso/components/data/query-preferences';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 interface Props {

--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -1,27 +1,17 @@
-/**
- * External Dependencies
- */
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { connect, useDispatch } from 'react-redux';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getTopJITM } from 'calypso/state/jitm/selectors';
-import { dismissJITM, setupDevTool } from 'calypso/state/jitm/actions';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryJITM from 'calypso/components/data/query-jitm';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { dismissJITM, setupDevTool } from 'calypso/state/jitm/actions';
+import { getTopJITM } from 'calypso/state/jitm/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import 'calypso/state/data-layer/wpcom/marketing';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const debug = debugFactory( 'calypso:jitm' );

--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -1,12 +1,5 @@
-/**
- * External Dependencies
- */
-import React from 'react';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 export default function DefaultTemplate( {

--- a/client/blocks/jitm/templates/notice.jsx
+++ b/client/blocks/jitm/templates/notice.jsx
@@ -1,11 +1,4 @@
-/**
- * External Dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 export default function NoticeTemplate( { id, CTA, tracks, ...props } ) {

--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
 
-/**
- * Style dependencies
- */
 import './sidebar-banner.scss';
 
 export default function SidebarBannerTemplate( {

--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -1,27 +1,20 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import requestExternalAccess from '@automattic/request-external-access';
+import { localize } from 'i18n-calypso';
+import { find, last, some } from 'lodash';
+import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { find, last, some } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import {
 	deleteStoredKeyringConnection,
 	requestKeyringConnections,
 } from 'calypso/state/sharing/keyring/actions';
-import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
-import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
-import requestExternalAccess from '@automattic/request-external-access';
 import {
 	getKeyringConnectionsByName,
 	isKeyringConnectionsFetching,
 } from 'calypso/state/sharing/keyring/selectors';
+import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
 
 const noop = () => {};
 

--- a/client/blocks/legal-updates-banner/index.js
+++ b/client/blocks/legal-updates-banner/index.js
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
-import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import ExternalLink from 'calypso/components/external-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { acceptTos, requestLegalData } from 'calypso/state/legal/actions';
 import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
-import ExternalLink from 'calypso/components/external-link';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const LegalUpdateBanner = ( props ) => {

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -1,21 +1,10 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import classNames from 'classnames';
-import { omitBy } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import LikeIcons from './icons';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class LikeButton extends PureComponent {

--- a/client/blocks/like-button/docs/example.jsx
+++ b/client/blocks/like-button/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import LikeButton from 'calypso/blocks/like-button/button';
 import { CompactCard as Card } from '@automattic/components';
+import React from 'react';
+import LikeButton from 'calypso/blocks/like-button/button';
 
 class SimpleLikeButtonContainer extends React.PureComponent {
 	state = {

--- a/client/blocks/like-button/icons.jsx
+++ b/client/blocks/like-button/icons.jsx
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Style dependencies
- */
 import './icons.scss';
 
 const LikeIcons = ( { size } ) => (

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
+import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { omit } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
 import { like, unlike } from 'calypso/state/posts/likes/actions';
-import LikeButton from './button';
 import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-count';
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
-import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import LikeButton from './button';
 
 const noop = () => {};
 

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -1,23 +1,13 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { get } from 'lodash';
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import { useTranslate } from 'i18n-calypso';
-import { Button } from '@automattic/components';
-
-/**
- * Internal dependencies
- */
+import Gravatar from 'calypso/components/gravatar';
 import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
-import Gravatar from 'calypso/components/gravatar';
 
-/**
- * Style dependencies
- */
 import './continue-as-user.scss';
 
 // Validate redirect URL using the REST endpoint.

--- a/client/blocks/login/divider.jsx
+++ b/client/blocks/login/divider.jsx
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
-/**
- * Style dependencies
- */
 import './divider.scss';
 
 export default function Divider( { children } ) {

--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import LoginBlock from 'calypso/blocks/login';
 
 const LoginExample = () => (

--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -1,23 +1,15 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
+import Notice from 'calypso/components/notice';
 import {
 	getRequestError,
 	getTwoFactorAuthRequestError,
 	getCreateSocialAccountError,
 	getRequestSocialAccountError,
 } from 'calypso/state/login/selectors';
-import Notice from 'calypso/components/notice';
 
 class ErrorNotice extends Component {
 	static propTypes = {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1,20 +1,29 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { capitalize, get } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { capitalize, get } from 'lodash';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import VisitSite from 'calypso/blocks/visit-site';
+import AsyncLoad from 'calypso/components/async-load';
 import Gridicon from 'calypso/components/gridicon';
-import config from '@automattic/calypso-config';
+import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
+import Notice from 'calypso/components/notice';
+import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/components/woocommerce-connect-cart-header';
+import { getIsAnchorFmSignup } from 'calypso/landing/gutenboarding/utils';
+import {
+	isCrowdsignalOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isWooOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
+import { login } from 'calypso/lib/paths';
+import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { wasManualRenewalImmediateLoginAttempted } from 'calypso/state/immediate-login/selectors';
+import { rebootAfterLogin } from 'calypso/state/login/actions';
 import {
 	getAuthAccountType,
 	getRedirectToOriginal,
@@ -26,33 +35,14 @@ import {
 	getSocialAccountIsLinking,
 	getSocialAccountLinkService,
 } from 'calypso/state/login/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { wasManualRenewalImmediateLoginAttempted } from 'calypso/state/immediate-login/selectors';
+import { isPasswordlessAccount } from 'calypso/state/login/utils';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
-import { rebootAfterLogin } from 'calypso/state/login/actions';
-import { isPasswordlessAccount } from 'calypso/state/login/utils';
-import {
-	isCrowdsignalOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isWooOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
-import { login } from 'calypso/lib/paths';
-import Notice from 'calypso/components/notice';
-import AsyncLoad from 'calypso/components/async-load';
-import VisitSite from 'calypso/blocks/visit-site';
-import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/components/woocommerce-connect-cart-header';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-import { isWebAuthnSupported } from 'calypso/lib/webauthn';
-import JetpackPlusWpComLogo from 'calypso/components/jetpack-plus-wpcom-logo';
-import { getIsAnchorFmSignup } from 'calypso/landing/gutenboarding/utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class Login extends Component {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1,35 +1,30 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
-import ReactDom from 'react-dom';
-import { capitalize, defer, includes, get } from 'lodash';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import Divider from './divider';
-import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import { Button, Card } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { capitalize, defer, includes, get } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
+import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
 import FormsButton from 'calypso/components/forms/form-button';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import Gridicon from 'calypso/components/gridicon';
 import Notice from 'calypso/components/notice';
-import SocialLoginForm from './social';
 import TextControl from 'calypso/extensions/woocommerce/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-import { Button, Card } from '@automattic/components';
-import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { preventWidows } from 'calypso/lib/formatting';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { getSignupUrl } from 'calypso/lib/login';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { addQueryArgs } from 'calypso/lib/url';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
 	formUpdate,
@@ -46,15 +41,13 @@ import {
 	getSocialAccountLinkService,
 	isFormDisabled as isFormDisabledSelector,
 } from 'calypso/state/login/selectors';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { getSignupUrl } from 'calypso/lib/login';
 import { isRegularAccount } from 'calypso/state/login/utils';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { preventWidows } from 'calypso/lib/formatting';
-import { addQueryArgs } from 'calypso/lib/url';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import { sendEmailLogin } from 'calypso/state/auth/actions';
-import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import Divider from './divider';
+import SocialLoginForm from './social';
 
 export class LoginForm extends Component {
 	static propTypes = {

--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -1,31 +1,20 @@
-/**
- * External dependencies
- */
-
+import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { capitalize } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { capitalize } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button, Card } from '@automattic/components';
+import AppleIcon from 'calypso/components/social-icons/apple';
+import GoogleIcon from 'calypso/components/social-icons/google';
+import SocialLogo from 'calypso/components/social-logo';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
+import { connectSocialUser } from 'calypso/state/login/actions';
 import {
 	getSocialAccountLinkAuthInfo,
 	getSocialAccountLinkService,
 	getRedirectToSanitized,
 } from 'calypso/state/login/selectors';
-import { connectSocialUser } from 'calypso/state/login/actions';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import SocialLogo from 'calypso/components/social-logo';
-import GoogleIcon from 'calypso/components/social-icons/google';
-import AppleIcon from 'calypso/components/social-icons/apple';
 
-/**
- * Style dependencies
- */
 import './social-connect-prompt.scss';
 
 class SocialConnectPrompt extends Component {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -1,19 +1,16 @@
-/**
- * External dependencies
- */
-
+import config from '@automattic/calypso-config';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { InfoNotice } from 'calypso/blocks/global-notice';
 import AppleLoginButton from 'calypso/components/social-buttons/apple';
 import GoogleLoginButton from 'calypso/components/social-buttons/google';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import { Card } from '@automattic/components';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { login } from 'calypso/lib/paths';
+import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	loginSocialUser,
 	createSocialUser,
@@ -25,15 +22,7 @@ import {
 	getRedirectToOriginal,
 	isSocialAccountCreating,
 } from 'calypso/state/login/selectors';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
-import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
-import { InfoNotice } from 'calypso/blocks/global-notice';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { login } from 'calypso/lib/paths';
 
-/**
- * Style dependencies
- */
 import './social.scss';
 
 class SocialLoginForm extends Component {

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import FormsButton from 'calypso/components/forms/form-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';

--- a/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-
-/**
- * Internal dependencies
- */
+import { connect } from 'react-redux';
 import { startPollAppPushAuth, stopPollAppPushAuth } from 'calypso/state/login/actions';
 import { getTwoFactorPushPollSuccess } from 'calypso/state/login/selectors';
 

--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.jsx
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import colorStudio from '@automattic/color-studio';
+import React from 'react';
 
-/**
- * Style dependencies
- */
 import './push-notification-illustration.scss';
 
 /**

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -1,24 +1,14 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
+import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
-import { localize } from 'i18n-calypso';
+import Spinner from 'calypso/components/spinner';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { formUpdate, loginUserWithSecurityKey } from 'calypso/state/login/actions';
 import TwoFactorActions from './two-factor-actions';
-import Spinner from 'calypso/components/spinner';
 
-/**
- * Style dependencies
- */
 import './verification-code-form.scss';
 
 class SecurityKeyForm extends Component {

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -1,25 +1,13 @@
-/**
- * External dependencies
- */
-
+import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-
-import { Button, Card } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { isTwoFactorAuthTypeSupported } from 'calypso/state/login/selectors';
+import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { sendSmsCode } from 'calypso/state/login/actions';
-import { isWebAuthnSupported } from 'calypso/lib/webauthn';
+import { isTwoFactorAuthTypeSupported } from 'calypso/state/login/selectors';
 
-/**
- * Style dependencies
- */
 import './two-factor-actions.scss';
 
 class TwoFactorActions extends Component {

--- a/client/blocks/login/two-factor-authentication/two-factor-content.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-content.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PushNotificationApprovalPoller from './push-notification-approval-poller';
-import VerificationCodeForm from './verification-code-form';
 import SecurityKeyForm from './security-key-form';
+import VerificationCodeForm from './verification-code-form';
 import WaitingTwoFactorNotificationApproval from './waiting-notification-approval';
 
 export default function TwoFactorContent( {

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -1,34 +1,23 @@
-/**
- * External dependencies
- */
-
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
+import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
-import { localize } from 'i18n-calypso';
-import { getTwoFactorAuthRequestError } from 'calypso/state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	formUpdate,
 	loginUserWithTwoFactorVerificationCode,
 	sendSmsCode,
 } from 'calypso/state/login/actions';
+import { getTwoFactorAuthRequestError } from 'calypso/state/login/selectors';
 import TwoFactorActions from './two-factor-actions';
 
-/**
- * Style dependencies
- */
 import './verification-code-form.scss';
 
 class VerificationCodeForm extends Component {

--- a/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
+++ b/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
@@ -1,20 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Fragment } from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
+import Divider from '../divider';
 import PushNotificationIllustration from './push-notification-illustration';
 import TwoFactorActions from './two-factor-actions';
-import Divider from '../divider';
 
-/**
- * Style dependencies
- */
 import './waiting-notification-approval.scss';
 
 export default function WaitingTwoFactorNotificationApproval( { switchTwoFactorAuthType } ) {

--- a/client/blocks/nav-unification-quick-switch-modal/index.jsx
+++ b/client/blocks/nav-unification-quick-switch-modal/index.jsx
@@ -1,28 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { Guide } from '@wordpress/components';
 import { Title } from '@automattic/onboarding';
-import { useSelector, useDispatch } from 'react-redux';
+import { Guide } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import featureImage from 'calypso/assets/images/nav-unification-announcement/quick-switch-feature-no-text.png';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isNewUserId from 'calypso/state/selectors/is-new-user-id';
 
-/**
- * Image dependencies
- */
-import featureImage from 'calypso/assets/images/nav-unification-announcement/quick-switch-feature-no-text.png';
-
-/**
- * Style dependencies
- */
 import './style.scss';
 
 // User registered on 28 July 2021

--- a/client/blocks/nps-survey/README.md
+++ b/client/blocks/nps-survey/README.md
@@ -5,7 +5,7 @@ This block is used to display a Net Promoter Score (NPS) survey to the user.
 ## Usage
 
 ```javascript
-<NpsSurvey name="some_screen_v1" onClose={ this.handleSurveyClose } />;
+<NpsSurvey name="some_screen_v1" onClose={ this.handleSurveyClose } />
 ```
 
 ## Props

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -1,17 +1,14 @@
-/**
- * External dependencies
- */
-
+import { translate } from 'i18n-calypso';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
-import { NpsSurvey } from '../';
+import { successNotice } from 'calypso/state/notices/actions';
+import {
+	submitNpsSurvey,
+	submitNpsSurveyWithNoScore,
+	sendNpsSurveyFeedback,
+} from 'calypso/state/nps-survey/actions';
 import {
 	isNpsSurveySubmitted,
 	isNpsSurveySubmitFailure,
@@ -21,12 +18,7 @@ import {
 	getNpsSurveyScore,
 	getNpsSurveyFeedback,
 } from 'calypso/state/nps-survey/selectors';
-import {
-	submitNpsSurvey,
-	submitNpsSurveyWithNoScore,
-	sendNpsSurveyFeedback,
-} from 'calypso/state/nps-survey/actions';
-import { successNotice } from 'calypso/state/notices/actions';
+import { NpsSurvey } from '../';
 
 const noop = () => {};
 

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -1,38 +1,28 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { PureComponent, Fragment } from 'react';
-import Gridicon from 'calypso/components/gridicon';
-import { connect } from 'react-redux';
+import { Button, Card, ScreenReaderText } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { trim } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Button, Card, ScreenReaderText } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { PureComponent, Fragment } from 'react';
+import { connect } from 'react-redux';
 import FormTextArea from 'calypso/components/forms/form-textarea';
+import Gridicon from 'calypso/components/gridicon';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import {
 	submitNpsSurvey,
 	submitNpsSurveyWithNoScore,
 	sendNpsSurveyFeedback,
 } from 'calypso/state/nps-survey/actions';
-import { successNotice } from 'calypso/state/notices/actions';
-import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import {
 	hasAnsweredNpsSurvey,
 	isAvailableForConciergeSession,
 } from 'calypso/state/nps-survey/selectors';
-import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import { bumpStat } from 'calypso/lib/analytics/mc';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import RecommendationSelect from './recommendation-select';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import FormRadio from 'calypso/components/forms/form-radio';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
 
 class RecommendationOption extends Component {
 	constructor( props ) {

--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
+import { range } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { range } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import RecommendationOption from './recommendation-option';
 
 class RecommendationSelect extends PureComponent {

--- a/client/blocks/nps-survey/test/index.jsx
+++ b/client/blocks/nps-survey/test/index.jsx
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { shallow, mount } from 'enzyme';
-import React from 'react';
 import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { NpsSurvey } from '../';
 
 jest.mock( 'react-redux', () => ( {

--- a/client/blocks/plan-storage/README.md
+++ b/client/blocks/plan-storage/README.md
@@ -6,7 +6,7 @@ will query media storage limits for you.
 ## Usage
 
 ```javascript
-<PlanStorage siteId={ this.props.siteId } />;
+<PlanStorage siteId={ this.props.siteId } />
 ```
 
 ## Props

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
+import { planHasFeature, FEATURE_UNLIMITED_STORAGE } from '@automattic/calypso-products';
+import { ProgressBar } from '@automattic/components';
 import classNames from 'classnames';
 import filesize from 'filesize';
-
-/**
- * Internal dependencies
- */
-import { ProgressBar } from '@automattic/components';
-import { planHasFeature, FEATURE_UNLIMITED_STORAGE } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 const ALERT_PERCENT = 80;
 const WARN_PERCENT = 60;

--- a/client/blocks/plan-storage/docs/example.jsx
+++ b/client/blocks/plan-storage/docs/example.jsx
@@ -1,16 +1,3 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import PlanStorage from '../index';
-import PlanStorageBar from '../bar';
 import {
 	PLAN_ECOMMERCE,
 	PLAN_BUSINESS,
@@ -18,8 +5,13 @@ import {
 	PLAN_PERSONAL,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
+import { get } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import PlanStorageBar from '../bar';
+import PlanStorage from '../index';
 
 const PlanStorageExample = ( { siteId, siteSlug } ) => {
 	const mediaStorage = {

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -1,32 +1,22 @@
-/**
- * External dependencies
- */
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import QueryMediaStorage from 'calypso/components/data/query-media-storage';
-import { getMediaStorage } from 'calypso/state/sites/media-storage/selectors';
-import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import {
 	FEATURE_UNLIMITED_STORAGE,
 	planHasFeature,
 	isBusinessPlan,
 	isEcommercePlan,
 } from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import QueryMediaStorage from 'calypso/components/data/query-media-storage';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { getMediaStorage } from 'calypso/state/sites/media-storage/selectors';
+import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import PlanStorageBar from './bar';
 import Tooltip from './tooltip';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class PlanStorage extends Component {

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -1,11 +1,5 @@
 const translate = ( x ) => x;
 
-/**
- * External dependencies
- */
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
-import React from 'react';
 import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
@@ -17,10 +11,9 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
-
-/**
- * Internal dependencies
- */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
 import { PlanStorageBar } from '../bar';
 
 describe( 'PlanStorageBar basic tests', () => {

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -1,9 +1,3 @@
-/**
- * External dependencies
- */
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
-import React from 'react';
 import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
@@ -15,10 +9,9 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
-
-/**
- * Internal dependencies
- */
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
 import { PlanStorage } from '../index';
 
 describe( 'PlanStorage basic tests', () => {

--- a/client/blocks/plan-storage/tooltip.jsx
+++ b/client/blocks/plan-storage/tooltip.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import {
 	useTooltipState,

--- a/client/blocks/plan-thank-you-card/docs/example.jsx
+++ b/client/blocks/plan-thank-you-card/docs/example.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import PlanThankYouCard from '../';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import PlanThankYouCard from '../';
 
 function PlanThankYouCardExample( { primarySiteId } ) {
 	return <PlanThankYouCard siteId={ primarySiteId } />;

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -1,27 +1,17 @@
-/**
- * External dependencies
- */
+import { getPlan, getPlanClass } from '@automattic/calypso-products';
+import { ProductIcon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import classnames from 'classnames';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
-import { ProductIcon } from '@automattic/components';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySites from 'calypso/components/data/query-sites';
+import ThankYouCard from 'calypso/components/thank-you-card';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import QuerySites from 'calypso/components/data/query-sites';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import { getPlan, getPlanClass } from '@automattic/calypso-products';
-import ThankYouCard from 'calypso/components/thank-you-card';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class PlanThankYouCard extends Component {

--- a/client/blocks/post-edit-button/docs/example.jsx
+++ b/client/blocks/post-edit-button/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import PostEditButton from 'calypso/blocks/post-edit-button';
 
 export default class PostEditButtonExample extends React.PureComponent {

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
 import { getEditURL } from 'calypso/state/posts/utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const PostEditButton = ( { post, site, iconSize, onClick, translate } ) => {

--- a/client/blocks/post-item/docs/example.jsx
+++ b/client/blocks/post-item/docs/example.jsx
@@ -1,19 +1,11 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySites from 'calypso/components/data/query-sites';
-import PostItem from '../';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSitePosts } from 'calypso/state/posts/selectors';
+import PostItem from '../';
 
 function PostItemExample( { primarySiteId, globalId } ) {
 	return (

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -1,40 +1,30 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import getEditorUrl from 'calypso/state/selectors/get-editor-url';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getNormalizedPost } from 'calypso/state/posts/selectors';
-import { isSingleUserSite } from 'calypso/state/sites/selectors';
-import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
-import { canCurrentUserEditPost } from 'calypso/state/posts/selectors/can-current-user-edit-post';
-import { isSharePanelOpen } from 'calypso/state/ui/post-type-list/selectors';
-import { hideActiveSharePanel } from 'calypso/state/ui/post-type-list/actions';
-import { bumpStat } from 'calypso/state/analytics/actions';
-import ExternalLink from 'calypso/components/external-link';
 import PostShare from 'calypso/blocks/post-share';
-import PostTypeListPostThumbnail from 'calypso/my-sites/post-type-list/post-thumbnail';
+import ExternalLink from 'calypso/components/external-link';
+import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 import PostActionCounts from 'calypso/my-sites/post-type-list/post-action-counts';
 import PostActionsEllipsisMenu from 'calypso/my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostActionsEllipsisMenuEdit from 'calypso/my-sites/post-type-list/post-actions-ellipsis-menu/edit';
 import PostActionsEllipsisMenuTrash from 'calypso/my-sites/post-type-list/post-actions-ellipsis-menu/trash';
-import PostTypeSiteInfo from 'calypso/my-sites/post-type-list/post-type-site-info';
+import PostTypeListPostThumbnail from 'calypso/my-sites/post-type-list/post-thumbnail';
 import PostTypePostAuthor from 'calypso/my-sites/post-type-list/post-type-post-author';
+import PostTypeSiteInfo from 'calypso/my-sites/post-type-list/post-type-site-info';
 import { preloadEditor } from 'calypso/sections-preloaders';
-import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
+import { bumpStat } from 'calypso/state/analytics/actions';
+import { getNormalizedPost } from 'calypso/state/posts/selectors';
+import { canCurrentUserEditPost } from 'calypso/state/posts/selectors/can-current-user-edit-post';
+import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
+import getEditorUrl from 'calypso/state/selectors/get-editor-url';
+import { isSingleUserSite } from 'calypso/state/sites/selectors';
+import { hideActiveSharePanel } from 'calypso/state/ui/post-type-list/actions';
+import { isSharePanelOpen } from 'calypso/state/ui/post-type-list/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class PostItem extends React.Component {

--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@automattic/components';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import FormLabel from 'calypso/components/forms/form-label';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
 import PostLikes from '../';
 import PostLikesPopover from '../popover';
-import { Button } from '@automattic/components';
 
 class PostLikesExample extends React.PureComponent {
 	popoverContext = React.createRef();

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -1,23 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classnames from 'classnames';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Gravatar from 'calypso/components/gravatar';
+import React from 'react';
+import { connect } from 'react-redux';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import Gravatar from 'calypso/components/gravatar';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
 import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class PostLikes extends React.PureComponent {

--- a/client/blocks/post-likes/popover.jsx
+++ b/client/blocks/post-likes/popover.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
+import { omit } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { omit } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import Popover from 'calypso/components/popover';
-import PostLikes from './index';
-import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
 import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
+import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
+import PostLikes from './index';
 
-/**
- * Style dependencies
- */
 import './popover.scss';
 
 function PostLikesPopover( props ) {

--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classNames from 'classnames';
 import { FormToggle, BaseControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import cssSafeUrl from 'calypso/lib/css-safe-url';
+import classNames from 'classnames';
+import React from 'react';
 import SocialLogo from 'calypso/components/social-logo';
+import cssSafeUrl from 'calypso/lib/css-safe-url';
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {
 	const {

--- a/client/blocks/post-share/connections-list.jsx
+++ b/client/blocks/post-share/connections-list.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import Connection from './connection';
 
 class ConnectionsList extends PureComponent {

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -1,23 +1,16 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { get } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import Notice from 'calypso/components/notice';
 import PostShare from 'calypso/blocks/post-share';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
-import { Card } from '@automattic/components';
+import Notice from 'calypso/components/notice';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { getSitePosts } from 'calypso/state/posts/selectors';
+import { getSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
 
 class PostShareExample extends Component {
 	state = {

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -1,36 +1,35 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
+import { FEATURE_REPUBLICIZE } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { get, includes, map, concat } from 'lodash';
+import { current as currentPage } from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { get, includes, map, concat } from 'lodash';
-import { localize } from 'i18n-calypso';
-import { isEnabled } from '@automattic/calypso-config';
-import Gridicon from 'calypso/components/gridicon';
-import { current as currentPage } from 'page';
-
-/**
- * Internal dependencies
- */
+import CalendarButton from 'calypso/blocks/calendar-button';
+import ButtonGroup from 'calypso/components/button-group';
 import QueryPostTypes from 'calypso/components/data/query-post-types';
 import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import { Button } from '@automattic/components';
-import ButtonGroup from 'calypso/components/button-group';
-import NoticeAction from 'calypso/components/notice/notice-action';
+import EventsTooltip from 'calypso/components/date-picker/events-tooltip';
+import Gridicon from 'calypso/components/gridicon';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import PublicizeMessage from 'calypso/components/publicize-message';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { sectionify } from 'calypso/lib/route';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getPostSharePublishedActions from 'calypso/state/selectors/get-post-share-published-actions';
 import getPostShareScheduledActions from 'calypso/state/selectors/get-post-share-scheduled-actions';
 import getScheduledPublicizeShareActionTime from 'calypso/state/selectors/get-scheduled-publicize-share-action-time';
 import isPublicizeEnabled from 'calypso/state/selectors/is-publicize-enabled';
 import isSchedulingPublicizeShareAction from 'calypso/state/selectors/is-scheduling-publicize-share-action';
 import isSchedulingPublicizeShareActionError from 'calypso/state/selectors/is-scheduling-publicize-share-action-error';
-import { getSiteSlug, getSitePlanSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-
 import {
 	fetchConnections as requestConnections,
 	sharePost,
@@ -44,27 +43,17 @@ import {
 	sharePostFailure,
 	sharePostSuccessMessage,
 } from 'calypso/state/sharing/publicize/selectors';
-import PublicizeMessage from 'calypso/components/publicize-message';
-import Notice from 'calypso/components/notice';
 import {
 	hasFeature,
 	isRequestingSitePlans as siteIsRequestingPlans,
 } from 'calypso/state/sites/plans/selectors';
-import { FEATURE_REPUBLICIZE } from '@automattic/calypso-products';
-import { UpgradeToPremiumNudge } from './nudges';
-import SharingPreviewModal from './sharing-preview-modal';
+import { getSiteSlug, getSitePlanSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import ConnectionsList from './connections-list';
 import NoConnectionsNotice from './no-connections-notice';
+import { UpgradeToPremiumNudge } from './nudges';
 import ActionsList from './publicize-actions-list';
-import CalendarButton from 'calypso/blocks/calendar-button';
-import EventsTooltip from 'calypso/components/date-picker/events-tooltip';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { sectionify } from 'calypso/lib/route';
+import SharingPreviewModal from './sharing-preview-modal';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const REGEXP_PUBLICIZE_SERVICE_SKIPPED = /^_wpas_skip_(\d+)$/;

--- a/client/blocks/post-share/no-connections-notice.jsx
+++ b/client/blocks/post-share/no-connections-notice.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
+import { findFirstSimilarPlanKey, TYPE_PREMIUM, TERM_ANNUALLY } from '@automattic/calypso-products';
+import formatCurrency from '@automattic/format-currency';
 import React from 'react';
 import { connect } from 'react-redux';
-import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import { findFirstSimilarPlanKey, TYPE_PREMIUM, TERM_ANNUALLY } from '@automattic/calypso-products';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSitePlan } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 } from 'calypso/state/sites/plans/selectors';
+import { getSitePlan } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const UpgradeToPremiumNudgePure = ( props ) => {
 	const { price, planSlug, translate, userCurrency, canUserUpgrade, isJetpack } = props;

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -1,33 +1,25 @@
-/**
- * External dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
+import { Dialog } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import getPostSharePublishedActions from 'calypso/state/selectors/get-post-share-published-actions';
-
-import getPostShareScheduledActions from 'calypso/state/selectors/get-post-share-scheduled-actions';
 import QuerySharePostActions from 'calypso/components/data/query-share-post-actions/index.jsx';
-import SocialLogo from 'calypso/components/social-logo';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
-import { SCHEDULED, PUBLISHED } from './constants';
-import SectionNav from 'calypso/components/section-nav';
-import NavTabs from 'calypso/components/section-nav/tabs';
-import NavItem from 'calypso/components/section-nav/item';
-import { isEnabled } from '@automattic/calypso-config';
-import { Dialog } from '@automattic/components';
-import { deletePostShareAction } from 'calypso/state/sharing/publicize/publicize-actions/actions';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import SharingPreviewModal from './sharing-preview-modal';
-import Notice from 'calypso/components/notice';
+import Gridicon from 'calypso/components/gridicon';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import SocialLogo from 'calypso/components/social-logo';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getPostSharePublishedActions from 'calypso/state/selectors/get-post-share-published-actions';
+import getPostShareScheduledActions from 'calypso/state/selectors/get-post-share-scheduled-actions';
+import { deletePostShareAction } from 'calypso/state/sharing/publicize/publicize-actions/actions';
+import { SCHEDULED, PUBLISHED } from './constants';
+import SharingPreviewModal from './sharing-preview-modal';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Dialog } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
 import SharingPreviewPane from 'calypso/blocks/sharing-preview-pane';
+import Gridicon from 'calypso/components/gridicon';
 
 const SharingPreviewModal = ( props ) => {
 	const { isVisible, onClose, ...previewProps } = props;

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -3,16 +3,6 @@ jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
 
-/**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import { UpgradeToPremiumNudgePure } from '../nudges';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS_MONTHLY,
@@ -34,6 +24,9 @@ import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
 } from '@automattic/calypso-products';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { UpgradeToPremiumNudgePure } from '../nudges';
 
 const props = {
 	translate: ( x ) => x,

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -1,24 +1,17 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { localize } from 'i18n-calypso';
+import { flowRight as compose, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { flowRight as compose, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import Banner from 'calypso/components/banner';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getHttpData, requestHttpData } from 'calypso/state/data-layer/http-data';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
 import getCurrentUserRegisterDate from 'calypso/state/selectors/get-current-user-register-date';
-import Banner from 'calypso/components/banner';
-import config from '@automattic/calypso-config';
 import PrivacyPolicyDialog from './privacy-policy-dialog';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 const AUTOMATTIC_ENTITY = 'automattic';
 const PRIVACY_POLICY_PREFERENCE = 'privacy_policy';

--- a/client/blocks/privacy-policy-banner/privacy-policy-dialog.jsx
+++ b/client/blocks/privacy-policy-banner/privacy-policy-dialog.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { Dialog, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 
-/**
- * Style dependencies
- */
 import './privacy-policy-dialog.scss';
 
 export default function PrivacyPolicyDialog( { title, content, onClose } ) {

--- a/client/blocks/product-plan-overlap-notices/README.md
+++ b/client/blocks/product-plan-overlap-notices/README.md
@@ -7,9 +7,9 @@ Those notices will appear when there is a feature overlap between the current pl
 ## Usage
 
 ```jsx
+import { JETPACK_PRODUCTS_LIST, JETPACK_PLANS } from '@automattic/calypso-products';
 import React from 'react';
 import ProductPlanOverlapNotices from 'calypso/blocks/product-plan-overlap-notices';
-import { JETPACK_PRODUCTS_LIST, JETPACK_PLANS } from '@automattic/calypso-products';
 
 export default class extends React.Component {
 	render() {

--- a/client/blocks/product-plan-overlap-notices/docs/example.jsx
+++ b/client/blocks/product-plan-overlap-notices/docs/example.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
-import SitesDropdown from 'calypso/components/sites-dropdown';
 import { JETPACK_PRODUCTS_LIST, JETPACK_PLANS } from '@automattic/calypso-products';
+import React, { Component } from 'react';
+import SitesDropdown from 'calypso/components/sites-dropdown';
 import ProductPlanOverlapNotices from '../';
 
 class ProductPlanOverlapNoticesExample extends Component {

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -1,29 +1,22 @@
-/**
- * External dependencies
- */
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import Notice from 'calypso/components/notice';
-import QueryProductsList from 'calypso/components/data/query-products-list';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import {
 	isJetpackProduct,
 	planHasFeature,
 	planHasSuperiorFeature,
 } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import Notice from 'calypso/components/notice';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import adsRemovedImage from 'calypso/assets/images/illustrations/removed-ads.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 const noop = () => {};
 

--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 function getEditCSSLink( selectedSite ) {
 	return '/customize/custom-css/' + selectedSite.slug;

--- a/client/blocks/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features-list/custom-domain.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import CustomDomainPurchaseDetail from 'calypso/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail';
 
 export default function CustomDomainPurchaseDetailItem( {

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 function getCustomizeLink( selectedSite ) {
 	return '/customize/' + selectedSite.slug;

--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import premiumThemesImage from 'calypso/assets/images/illustrations/themes.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features-list/google-analytics-stats.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import googleAnalyticsImage from 'calypso/assets/images/illustrations/google-analytics.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/google-my-business.js
+++ b/client/blocks/product-purchase-features-list/google-my-business.js
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import googleMyBusinessImage from 'calypso/assets/images/illustrations/google-my-business-feature.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/happiness-support-card.jsx
+++ b/client/blocks/product-purchase-features-list/happiness-support-card.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import HappinessSupport from 'calypso/components/happiness-support';
 
 export const HappinessSupportCard = ( {

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -1,13 +1,4 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlan,
 	GROUP_WPCOM,
@@ -27,34 +18,34 @@ import {
 	TERM_MONTHLY,
 	getPlans,
 } from '@automattic/calypso-products';
-import FindNewTheme from './find-new-theme';
-import UploadPlugins from './upload-plugins';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { isWordadsInstantActivationEligible } from 'calypso/lib/ads/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
+import { hasDomainCredit, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AdvertisingRemoved from './advertising-removed';
-import CustomizeTheme from './customize-theme';
-import CustomCSS from './custom-css';
-import VideoAudioPosts from './video-audio-posts';
-import MonetizeSite from './monetize-site';
 import BusinessOnboarding from './business-onboarding';
+import CustomCSS from './custom-css';
 import CustomDomain from './custom-domain';
+import CustomizeTheme from './customize-theme';
+import FindNewTheme from './find-new-theme';
 import GoogleAnalyticsStats from './google-analytics-stats';
 import GoogleMyBusiness from './google-my-business';
 import HappinessSupportCard from './happiness-support-card';
 import JetpackPublicize from './jetpack-publicize';
 import MobileApps from './mobile-apps';
+import MonetizeSite from './monetize-site';
 import SellOnlinePaypal from './sell-online-paypal';
 import SiteActivity from './site-activity';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { isEnabled } from '@automattic/calypso-config';
-import { isWordadsInstantActivationEligible } from 'calypso/lib/ads/utils';
-import { hasDomainCredit, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isSiteUsingFullSiteEditing from 'calypso/state/selectors/is-site-using-full-site-editing';
-import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
-/**
- * Style dependencies
- */
+import UploadPlugins from './upload-plugins';
+import VideoAudioPosts from './video-audio-posts';
+
 import './style.scss';
 
 const PLANS_LIST = getPlans();

--- a/client/blocks/product-purchase-features-list/jetpack-publicize.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-publicize.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import marketingImage from 'calypso/assets/images/illustrations/marketing.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/mobile-apps.jsx
+++ b/client/blocks/product-purchase-features-list/mobile-apps.jsx
@@ -1,20 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import appsImage from 'calypso/assets/images/illustrations/apps.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { addQueryArgs } from 'calypso/lib/route';
-
-/**
- * Image dependencies
- */
-import appsImage from 'calypso/assets/images/illustrations/apps.svg';
 
 const noop = () => {};
 

--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
 	const adSettingsUrl = selectedSite.jetpack

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -1,20 +1,8 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import paymentsImage from 'calypso/assets/images/illustrations/payments.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-
-/**
- * Image dependencies
- */
-import paymentsImage from 'calypso/assets/images/illustrations/payments.svg';
 
 export default localize( ( { isJetpack, translate } ) => {
 	const supportDocLink = localizeUrl(

--- a/client/blocks/product-purchase-features-list/site-activity.jsx
+++ b/client/blocks/product-purchase-features-list/site-activity.jsx
@@ -1,20 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import siteActivity from 'calypso/assets/images/illustrations/site-activity.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-
-/**
- * Image dependencies
- */
-import siteActivity from 'calypso/assets/images/illustrations/site-activity.svg';
 
 const SiteActivity = ( { siteSlug, translate } ) => (
 	<div className="product-purchase-features-list__item">

--- a/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
+++ b/client/blocks/product-purchase-features-list/test/product-purchase-features-list.jsx
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -23,10 +18,8 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
-
-/**
- * Internal dependencies
- */
+import { shallow } from 'enzyme';
+import React from 'react';
 import { ProductPurchaseFeaturesList } from '../index';
 
 jest.mock(

--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -1,10 +1,5 @@
 jest.mock( 'calypso/components/purchase-detail', () => 'PurchaseDetail' );
 
-/**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-import React from 'react';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -23,10 +18,8 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
-
-/**
- * Internal dependencies
- */
+import { shallow } from 'enzyme';
+import React from 'react';
 import { VideoAudioPosts } from '../video-audio-posts';
 
 describe( 'VideoAudioPosts basic tests', () => {

--- a/client/blocks/product-purchase-features-list/upload-plugins.jsx
+++ b/client/blocks/product-purchase-features-list/upload-plugins.jsx
@@ -1,19 +1,7 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-
-/**
- * Image dependencies
- */
+import React from 'react';
 import updatesImage from 'calypso/assets/images/illustrations/updates.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -1,24 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import PurchaseDetail from 'calypso/components/purchase-detail';
-import { newPost } from 'calypso/lib/paths';
 import {
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
 	isWpComPremiumPlan,
 } from '@automattic/calypso-products';
-
-/**
- * Image dependencies
- */
+import { localize } from 'i18n-calypso';
+import React from 'react';
 import videoImage from 'calypso/assets/images/illustrations/video-hosting.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { newPost } from 'calypso/lib/paths';
 
 function getDescription( plan, translate ) {
 	if ( isWpComBusinessPlan( plan ) ) {

--- a/client/blocks/reader-author-link/README.md
+++ b/client/blocks/reader-author-link/README.md
@@ -9,7 +9,7 @@ This component does not dictate the content of the link, only the href and click
 The `ReaderAuthorLink` component can be used in much the same way that you would use an `<ExternalLink>` component. The link wraps whatever is placed between the ReaderAuthorLink elements.
 
 ```html
-<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>Your link text here</ReaderAuthorLink>
+<ReaderAuthorLink author="{" author } siteUrl="{" siteUrl }>Your link text here</ReaderAuthorLink>
 ```
 
 ## Props

--- a/client/blocks/reader-author-link/docs/example.jsx
+++ b/client/blocks/reader-author-link/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import { Card } from '@automattic/components';
+import React from 'react';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 
 const ReaderAuthorLinkExample = () => {
 	const author = { URL: 'http://wpcalypso.wordpress.com', name: 'Barnaby Blogwit' };

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -1,21 +1,11 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
+import Emojify from 'calypso/components/emojify';
 import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import * as stats from 'calypso/reader/stats';
-import Emojify from 'calypso/components/emojify';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/reader-author-link/test/index.js
+++ b/client/blocks/reader-author-link/test/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderAuthorLink from '../index';
 
 jest.mock( 'calypso/reader/stats', () => ( {

--- a/client/blocks/reader-avatar/README.md
+++ b/client/blocks/reader-avatar/README.md
@@ -7,7 +7,7 @@ If both a feed/site icon and author Gravatar are available, they will be overlai
 ## Example
 
 ```html
-<ReaderAvatar author={ author } siteIcon={ siteIcon } isCompact={ true } />
+<ReaderAvatar author="{" author } siteIcon="{" siteIcon } isCompact="{" true } />
 ```
 
 ## Props

--- a/client/blocks/reader-avatar/docs/example.jsx
+++ b/client/blocks/reader-avatar/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const ReaderAvatarExample = () => {

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { startsWith, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { startsWith, get } from 'lodash';
-import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import Gravatar from 'calypso/components/gravatar';
 import SiteIcon from 'calypso/blocks/site-icon';
+import Gravatar from 'calypso/components/gravatar';
 import safeImageUrl from 'calypso/lib/safe-image-url';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { ReaderCombinedCard, combinedCardPostKeyToKeys } from 'calypso/blocks/reader-combined-card';
 import { posts, feed, site } from 'calypso/blocks/reader-post-card/docs/fixtures';
 

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -1,37 +1,27 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { get, size, filter, isEmpty, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, size, filter, isEmpty, includes } from 'lodash';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-import { getStreamUrl } from 'calypso/reader/route';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
-import ReaderCombinedCardPost from './post';
-import { keysAreEqual, keyForPost } from 'calypso/reader/post-key';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
-import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
-import { getSiteName } from 'calypso/reader/get-helpers';
-import FollowButton from 'calypso/reader/follow-button';
-import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
-import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import FollowButton from 'calypso/reader/follow-button';
+import { getSiteName } from 'calypso/reader/get-helpers';
+import { keysAreEqual, keyForPost } from 'calypso/reader/post-key';
+import { getStreamUrl } from 'calypso/reader/route';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { getPostsByKeys } from 'calypso/state/reader/posts/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import ReaderCombinedCardPost from './post';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ReaderCombinedCardComponent extends React.Component {

--- a/client/blocks/reader-combined-card/placeholders/post.jsx
+++ b/client/blocks/reader-combined-card/placeholders/post.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const ReaderCombinedCardPostPlaceholder = () => {

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -1,34 +1,27 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
-import { has } from 'lodash';
-import ReactDom from 'react-dom';
+import classnames from 'classnames';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import AutoDirection from 'calypso/components/auto-direction';
-import Emojify from 'calypso/components/emojify';
-import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
-import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
+import { has } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import ReactDom from 'react-dom';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
-import { recordPermalinkClick } from 'calypso/reader/stats';
-import TimeSince from 'calypso/components/time-since';
+import ReaderCombinedCardPostPlaceholder from 'calypso/blocks/reader-combined-card/placeholders/post';
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
-import ReaderCombinedCardPostPlaceholder from 'calypso/blocks/reader-combined-card/placeholders/post';
-import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
+import AutoDirection from 'calypso/components/auto-direction';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import Emojify from 'calypso/components/emojify';
+import TimeSince from 'calypso/components/time-since';
 import {
 	canBeMarkedAsSeen,
 	getDefaultSeenValue,
 	isEligibleForUnseen,
 } from 'calypso/reader/get-helpers';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import { recordPermalinkClick } from 'calypso/reader/stats';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External Dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal Dependencies
- */
 import AutoDirection from 'calypso/components/auto-direction';
 import Emojify from 'calypso/components/emojify';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const ReaderExcerpt = ( { post, isDiscover } ) => {

--- a/client/blocks/reader-export-button/docs/example.jsx
+++ b/client/blocks/reader-export-button/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderExportButtonBlock from 'calypso/blocks/reader-export-button';
 
 const ReaderExportButton = () => (

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -1,28 +1,18 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { saveAs } from 'browser-filesaver';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { saveAs } from 'browser-filesaver';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import { errorNotice } from 'calypso/state/notices/actions';
-import Gridicon from 'calypso/components/gridicon';
 import {
 	READER_EXPORT_TYPE_SUBSCRIPTIONS,
 	READER_EXPORT_TYPE_LIST,
 } from 'calypso/blocks/reader-export-button/constants';
+import Gridicon from 'calypso/components/gridicon';
 import wp from 'calypso/lib/wp';
+import { errorNotice } from 'calypso/state/notices/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ReaderExportButton extends React.Component {

--- a/client/blocks/reader-featured-image/README.md
+++ b/client/blocks/reader-featured-image/README.md
@@ -7,11 +7,11 @@ Displays a featured image for a Reader post card.
 The component outputs an `<a>` element with imageUrl as a background image. It wraps whatever is placed between the ReaderFeaturedImage elements (we use this to add a play button to video thumbnails, for example).
 
 ```html
-<ReaderFeaturedImage imageUrl={ imageUrl } href={ href } />
+<ReaderFeaturedImage imageUrl="{" imageUrl } href="{" href } />
 ```
 
 ```html
-<ReaderFeaturedImage imageUrl={ imageUrl } href={ href }>[button]</ReaderFeaturedImage>
+<ReaderFeaturedImage imageUrl="{" imageUrl } href="{" href }>[button]</ReaderFeaturedImage>
 ```
 
 ## Props

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import cssSafeUrl from 'calypso/lib/css-safe-url';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/reader-featured-video/README.md
+++ b/client/blocks/reader-featured-video/README.md
@@ -5,7 +5,7 @@ Displays a featured video for a Reader post card.
 ## Example
 
 ```html
-<ReaderFeaturedVideo thumbnailUrl={ thumbnail } videoEmbed={ post.canonical_media } />
+<ReaderFeaturedVideo thumbnailUrl="{" thumbnail } videoEmbed="{" post.canonical_media } />
 ```
 
 ## Props

--- a/client/blocks/reader-featured-video/docs/example.jsx
+++ b/client/blocks/reader-featured-video/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderFeaturedVideoBlock from 'calypso/blocks/reader-featured-video';
 
 const exampleVideo = {

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -1,30 +1,16 @@
-/**
- * External Dependencies
- */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
-import { throttle } from 'lodash';
 import ReactDom from 'react-dom';
-import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
-
-/**
- * Internal Dependencies
- */
-import EmbedHelper from 'calypso/reader/embed-helper';
-import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
-import { getThumbnailForIframe } from 'calypso/state/reader/thumbnails/selectors';
-import QueryReaderThumbnail from 'calypso/components/data/query-reader-thumbnails';
-
-/**
- * Image dependencies
- */
+import { connect } from 'react-redux';
 import playIconImage from 'calypso/assets/images/reader/play-icon.png';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import QueryReaderThumbnail from 'calypso/components/data/query-reader-thumbnails';
+import EmbedHelper from 'calypso/reader/embed-helper';
+import { getThumbnailForIframe } from 'calypso/state/reader/thumbnails/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -1,6 +1,3 @@
-/**
- * External Dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -1,43 +1,33 @@
-/**
- * External Dependencies
- */
+import { Card } from '@automattic/components';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
-import { Card } from '@automattic/components';
+import BlogStickers from 'calypso/blocks/blog-stickers';
+import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
+import SiteIcon from 'calypso/blocks/site-icon';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import Gridicon from 'calypso/components/gridicon';
 import ReaderFollowButton from 'calypso/reader/follow-button';
-import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
-import HeaderBack from 'calypso/reader/header-back';
 import {
 	getSiteDescription,
 	getSiteName,
 	getSiteUrl,
 	isEligibleForUnseen,
 } from 'calypso/reader/get-helpers';
-import SiteIcon from 'calypso/blocks/site-icon';
-import BlogStickers from 'calypso/blocks/blog-stickers';
-import ReaderFeedHeaderSiteBadge from './badge';
-import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
-import getUserSetting from 'calypso/state/selectors/get-user-setting';
-import { isFollowing } from 'calypso/state/reader/follows/selectors';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import Gridicon from 'calypso/components/gridicon';
-import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import HeaderBack from 'calypso/reader/header-back';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { isFollowing } from 'calypso/state/reader/follows/selectors';
+import { requestMarkAllAsSeen } from 'calypso/state/reader/seen-posts/actions';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import ReaderFeedHeaderSiteBadge from './badge';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class FeedHeader extends Component {

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
+import { take, values } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { take, values } from 'lodash';
 
 const TAGS_TO_SHOW = 5;
 

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import classNames from 'classnames';
+import { keys, trim } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { keys, trim } from 'lodash';
-import classNames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import AutoDirection from 'calypso/components/auto-direction';
 import ExternalLink from 'calypso/components/external-link';
-import { recordPermalinkClick } from 'calypso/reader/stats';
+import Gridicon from 'calypso/components/gridicon';
 import TimeSince from 'calypso/components/time-since';
-import ReaderFullPostHeaderTags from './header-tags';
 import { isDiscoverPost } from 'calypso/reader/discover/helper';
+import { recordPermalinkClick } from 'calypso/reader/stats';
+import ReaderFullPostHeaderTags from './header-tags';
 import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
 const ReaderFullPostHeader = ( { post, referralPost } ) => {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -1,93 +1,83 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { get, startsWith, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-import classNames from 'classnames';
-import { get, startsWith, pickBy } from 'lodash';
-import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
-import AutoDirection from 'calypso/components/auto-direction';
-import ReaderMain from 'calypso/reader/components/reader-main';
-import EmbedContainer from 'calypso/components/embed-container';
-import PostExcerpt from 'calypso/components/post-excerpt';
-import { markPostSeen } from 'calypso/state/reader/posts/actions';
-import ReaderFullPostHeader from './header';
 import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
-import LikeButton from 'calypso/reader/like-button';
-import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
-import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
+import CommentButton from 'calypso/blocks/comment-button';
+import Comments from 'calypso/blocks/comments';
+import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
+import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import DailyPostButton from 'calypso/blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/helper';
+import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
+import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import AutoDirection from 'calypso/components/auto-direction';
+import BackButton from 'calypso/components/back-button';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import EmbedContainer from 'calypso/components/embed-container';
+import Emojify from 'calypso/components/emojify';
+import ExternalLink from 'calypso/components/external-link';
+import Gridicon from 'calypso/components/gridicon';
+import PostExcerpt from 'calypso/components/post-excerpt';
+import {
+	RelatedPostsFromSameSite,
+	RelatedPostsFromOtherSites,
+} from 'calypso/components/related-posts';
+import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
+import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
+import scrollTo from 'calypso/lib/scroll-to';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
+import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
+import { READER_FULL_POST } from 'calypso/reader/follow-sources';
+import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
-import { shouldShowComments } from 'calypso/blocks/comments/helper';
-import CommentButton from 'calypso/blocks/comment-button';
+import PostExcerptLink from 'calypso/reader/post-excerpt-link';
+import { keyForPost } from 'calypso/reader/post-key';
+import { getStreamUrlFromPost } from 'calypso/reader/route';
 import {
 	recordAction,
 	recordGaEvent,
 	recordTrackForPost,
 	recordPermalinkClick,
 } from 'calypso/reader/stats';
-import Comments from 'calypso/blocks/comments';
-import scrollTo from 'calypso/lib/scroll-to';
-import PostExcerptLink from 'calypso/reader/post-excerpt-link';
-import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
-import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
-import ReaderPostActions from 'calypso/blocks/reader-post-actions';
-import {
-	RelatedPostsFromSameSite,
-	RelatedPostsFromOtherSites,
-} from 'calypso/components/related-posts';
-import { getStreamUrlFromPost } from 'calypso/reader/route';
-import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
-import FeaturedImage from 'calypso/blocks/reader-full-post/featured-image';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
-import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
-import QueryReaderPost from 'calypso/components/data/query-reader-post';
-import ExternalLink from 'calypso/components/external-link';
-import DocumentHead from 'calypso/components/data/document-head';
-import ReaderFullPostUnavailable from './unavailable';
-import BackButton from 'calypso/components/back-button';
-import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
-import ReaderFullPostContentPlaceholder from './placeholders/content';
-import { keyForPost } from 'calypso/reader/post-key';
 import { showSelectedPost } from 'calypso/reader/utils';
-import Emojify from 'calypso/components/emojify';
-import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
-import { READER_FULL_POST } from 'calypso/reader/follow-sources';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
-import QueryPostLikes from 'calypso/components/data/query-post-likes';
-import getCurrentStream from 'calypso/state/selectors/get-reader-current-stream';
-import {
-	setViewingFullPostKey,
-	unsetViewingFullPostKey,
-} from 'calypso/state/reader/viewing/actions';
-import { getNextItem, getPreviousItem } from 'calypso/state/reader/streams/selectors';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { markPostSeen } from 'calypso/state/reader/posts/actions';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import {
 	requestMarkAsSeen,
 	requestMarkAsUnseen,
 	requestMarkAsSeenBlog,
 	requestMarkAsUnseenBlog,
 } from 'calypso/state/reader/seen-posts/actions';
-import Gridicon from 'calypso/components/gridicon';
-import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import { getNextItem, getPreviousItem } from 'calypso/state/reader/streams/selectors';
+import {
+	setViewingFullPostKey,
+	unsetViewingFullPostKey,
+} from 'calypso/state/reader/viewing/actions';
+import getCurrentStream from 'calypso/state/selectors/get-reader-current-stream';
 import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
-import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import ReaderFullPostHeader from './header';
+import ReaderFullPostContentPlaceholder from './placeholders/content';
+import ReaderFullPostUnavailable from './unavailable';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class FullPostView extends React.Component {

--- a/client/blocks/reader-full-post/placeholders/content.jsx
+++ b/client/blocks/reader-full-post/placeholders/content.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const ReaderFullPostContentPlaceholder = () => {

--- a/client/blocks/reader-full-post/placeholders/header.jsx
+++ b/client/blocks/reader-full-post/placeholders/header.jsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
 
 const ReaderFullPostHeaderPlaceholder = () => {

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import FeaturedImage from '../featured-image';
 
 describe( 'FeaturedImage', () => {

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import ReaderMain from 'calypso/reader/components/reader-main';
-import DocumentHead from 'calypso/components/data/document-head';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
 import BackButton from 'calypso/components/back-button';
+import DocumentHead from 'calypso/components/data/document-head';
 import ExternalLink from 'calypso/components/external-link';
+import ReaderMain from 'calypso/reader/components/reader-main';
 
 const noop = () => {};
 

--- a/client/blocks/reader-import-button/docs/example.jsx
+++ b/client/blocks/reader-import-button/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderImportButtonBlock from 'calypso/blocks/reader-import-button';
 
 const ReaderImportButton = () => (

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -1,22 +1,12 @@
-/**
- * External dependencies
- */
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
 import FilePicker from 'calypso/components/file-picker';
+import Gridicon from 'calypso/components/gridicon';
+import wpcom from 'calypso/lib/wp';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/reader-list-item/connected.jsx
+++ b/client/blocks/reader-list-item/connected.jsx
@@ -1,17 +1,10 @@
-/**
- * External Dependencies
- */
+import { flowRight as compose } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import connectSite from 'calypso/lib/reader-connect-site';
-import ReaderListItem from '.';
 import { isFollowing as isFollowingSelector } from 'calypso/state/reader/follows/selectors';
+import ReaderListItem from '.';
 
 const noop = () => {};
 

--- a/client/blocks/reader-list-item/docs/example.jsx
+++ b/client/blocks/reader-list-item/docs/example.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { PureComponent } from 'react';
+import { Card } from '@automattic/components';
 import { map } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React, { PureComponent } from 'react';
 import ConnectedReaderListItem from 'calypso/blocks/reader-list-item/connected';
 import ReaderListItemPlaceholder from 'calypso/blocks/reader-list-item/placeholder';
-import { Card } from '@automattic/components';
 
 const sites = {
 	longreads: { siteId: 70135762 },

--- a/client/blocks/reader-list-item/index.jsx
+++ b/client/blocks/reader-list-item/index.jsx
@@ -1,19 +1,14 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classnames from 'classnames';
-import { flowRight as compose, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { flowRight as compose, isEmpty, get } from 'lodash';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import FollowButton from 'calypso/reader/follow-button';
-import { getStreamUrl } from 'calypso/reader/route';
+import ReaderListItemPlaceholder from 'calypso/blocks/reader-list-item/placeholder';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
+import ExternalLink from 'calypso/components/external-link';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import FollowButton from 'calypso/reader/follow-button';
 import {
 	getSiteName,
 	getSiteDescription,
@@ -21,16 +16,11 @@ import {
 	getFeedUrl,
 	getSiteUrl,
 } from 'calypso/reader/get-helpers';
-import ReaderListItemPlaceholder from 'calypso/blocks/reader-list-item/placeholder';
-import { recordRailcar } from 'calypso/reader/stats';
-import ExternalLink from 'calypso/components/external-link';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { getStreamUrl } from 'calypso/reader/route';
+import { recordRailcar } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function ReaderListItem( {

--- a/client/blocks/reader-list-item/placeholder.jsx
+++ b/client/blocks/reader-list-item/placeholder.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const ReaderListItemPlaceholder = () => {

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -1,29 +1,19 @@
-/**
- * External dependencies
- */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import CommentButton from 'calypso/blocks/comment-button';
-import LikeButton from 'calypso/reader/like-button';
-import ShareButton from 'calypso/blocks/reader-share';
+import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
-import { shouldShowComments } from 'calypso/blocks/comments/helper';
-import { shouldShowLikes } from 'calypso/reader/like-helper';
+import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowShare } from 'calypso/blocks/reader-share/helper';
-import { userCan } from 'calypso/state/posts/utils';
-import * as stats from 'calypso/reader/stats';
-import { localize } from 'i18n-calypso';
 import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
+import LikeButton from 'calypso/reader/like-button';
+import { shouldShowLikes } from 'calypso/reader/like-helper';
+import * as stats from 'calypso/reader/stats';
+import { userCan } from 'calypso/state/posts/utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const ReaderPostActions = ( props ) => {

--- a/client/blocks/reader-post-card/blocked.jsx
+++ b/client/blocks/reader-post-card/blocked.jsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
-import { Card } from '@automattic/components';
 import { recordTrack as recordReaderTrack } from 'calypso/reader/stats';
 import { bumpStat, recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
 
 class PostBlocked extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -1,28 +1,21 @@
-/**
- * External Dependencies
- */
+import { get, map, take, values } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, map, take, values } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import Gridicon from 'calypso/components/gridicon';
 import TimeSince from 'calypso/components/time-since';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import { getSiteName } from 'calypso/reader/get-helpers';
+import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
+import { getStreamUrl } from 'calypso/reader/route';
 import {
 	recordAction,
 	recordGaEvent,
 	recordTrackForPost,
 	recordPermalinkClick,
 } from 'calypso/reader/stats';
-import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
-import { getStreamUrl } from 'calypso/reader/route';
-import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
-import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
-import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 
 const TAGS_TO_SHOW = 3;
 

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,16 +1,9 @@
-/**
- * External Dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal Dependencies
- */
-import AutoDirection from 'calypso/components/auto-direction';
-import Emojify from 'calypso/components/emojify';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
+import AutoDirection from 'calypso/components/auto-direction';
+import Emojify from 'calypso/components/emojify';
 import FeaturedAsset from './featured-asset';
 
 const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -1,12 +1,5 @@
-/**
- * External Dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal Dependencies
- */
+import React from 'react';
 import ConversationPostList from 'calypso/blocks/conversations/list';
 import CompactPostCard from 'calypso/blocks/reader-post-card/compact';
 

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderPostCardBlock from 'calypso/blocks/reader-post-card';
 import { posts, site } from './fixtures';
 

--- a/client/blocks/reader-post-card/docs/fixtures.js
+++ b/client/blocks/reader-post-card/docs/fixtures.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import DisplayTypes from 'calypso/state/reader/posts/display-types';
 
 export const posts = [

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -1,14 +1,7 @@
-/**
- * External Dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal Dependencies
- */
-import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
 
 const FeaturedAsset = ( {
 	canonicalMedia,

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -1,19 +1,12 @@
-/**
- * External Dependencies
- */
+import { map, take, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, take, filter } from 'lodash';
-
-/**
- * Internal Dependencies
- */
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import AutoDirection from 'calypso/components/auto-direction';
 import Emojify from 'calypso/components/emojify';
-import resizeImageUrl from 'calypso/lib/resize-image-url';
 import cssSafeUrl from 'calypso/lib/css-safe-url';
 import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
-import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { imageIsBigEnoughForGallery } from 'calypso/state/reader/posts/normalization-rules';
 import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -1,50 +1,40 @@
-/**
- * External Dependencies
- */
+import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import closest from 'component-closest';
+import { truncate, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
-import { truncate, get } from 'lodash';
-import classnames from 'classnames';
 import ReactDom from 'react-dom';
-import closest from 'component-closest';
-
-/**
- * Internal Dependencies
- */
-import { Card } from '@automattic/components';
-import DisplayTypes from 'calypso/state/reader/posts/display-types';
-import * as stats from 'calypso/reader/stats';
-import ReaderPostActions from 'calypso/blocks/reader-post-actions';
-import PostByline from './byline';
-import GalleryPost from './gallery';
-import PhotoPost from './photo';
-import StandardPost from './standard';
-import ConversationPost from './conversation-post';
-import FollowButton from 'calypso/reader/follow-button';
+import { connect } from 'react-redux';
 import DailyPostButton from 'calypso/blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/helper';
+import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import DiscoverFollowButton from 'calypso/reader/discover/follow-button';
 import {
 	getDiscoverBlogName,
 	getSourceFollowUrl as getDiscoverFollowUrl,
 } from 'calypso/reader/discover/helper';
-import DiscoverFollowButton from 'calypso/reader/discover/follow-button';
-import { expandCard as expandCardAction } from 'calypso/state/reader-ui/card-expansions/actions';
-import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
-
-/**
- * Style dependencies
- */
-import './style.scss';
+import FollowButton from 'calypso/reader/follow-button';
 import {
 	canBeMarkedAsSeen,
 	getDefaultSeenValue,
 	isEligibleForUnseen,
 } from 'calypso/reader/get-helpers';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import * as stats from 'calypso/reader/stats';
+import { expandCard as expandCardAction } from 'calypso/state/reader-ui/card-expansions/actions';
+import DisplayTypes from 'calypso/state/reader/posts/display-types';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import isReaderCardExpanded from 'calypso/state/selectors/is-reader-card-expanded';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import PostByline from './byline';
+import ConversationPost from './conversation-post';
+import GalleryPost from './gallery';
+import PhotoPost from './photo';
+import StandardPost from './standard';
+
+import './style.scss';
 
 const noop = () => {};
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -1,14 +1,7 @@
-/**
- * External Dependencies
- */
+import classnames from 'classnames';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { debounce } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * Internal Dependencies
- */
 import AutoDirection from 'calypso/components/auto-direction';
 import Emojify from 'calypso/components/emojify';
 import cssSafeUrl from 'calypso/lib/css-safe-url';

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -1,16 +1,9 @@
-/**
- * External Dependencies
- */
+import { get, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, partial } from 'lodash';
-
-/**
- * Internal Dependencies
- */
+import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import AutoDirection from 'calypso/components/auto-direction';
 import Emojify from 'calypso/components/emojify';
-import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import FeaturedAsset from './featured-asset';
 
 const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -1,14 +1,7 @@
-/**
- * External Dependencies
- */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import { addBlogSticker, removeBlogSticker } from 'calypso/state/sites/blog-stickers/actions';
 

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
+import { map, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, includes } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import getBlogStickers from 'calypso/state/selectors/get-blog-stickers';
 import QueryBlogStickers from 'calypso/components/data/query-blog-stickers';
+import getBlogStickers from 'calypso/state/selectors/get-blog-stickers';
 import ReaderPostOptionsMenuBlogStickerMenuItem from './blog-sticker-menu-item';
 
 class ReaderPostOptionsMenuBlogStickers extends React.Component {

--- a/client/blocks/reader-post-options-menu/docs/example.jsx
+++ b/client/blocks/reader-post-options-menu/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 
 export default class ReaderPostOptionsMenuExample extends React.Component {

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -1,50 +1,40 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import React from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { size, map } from 'lodash';
 import page from 'page';
-import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
-import { blockSite } from 'calypso/state/reader/site-blocks/actions';
-import * as PostUtils from 'calypso/state/posts/utils';
-import FollowButton from 'calypso/reader/follow-button';
-import * as DiscoverHelper from 'calypso/reader/discover/helper';
-import * as stats from 'calypso/reader/stats';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import { getSite } from 'calypso/state/reader/sites/selectors';
+import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
+import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
-import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
-import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
-import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import * as DiscoverHelper from 'calypso/reader/discover/helper';
+import FollowButton from 'calypso/reader/follow-button';
 import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
+import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import * as stats from 'calypso/reader/stats';
+import * as PostUtils from 'calypso/state/posts/utils';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import {
 	requestMarkAsSeen,
 	requestMarkAsUnseen,
 	requestMarkAsSeenBlog,
 	requestMarkAsUnseenBlog,
 } from 'calypso/state/reader/seen-posts/actions';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import { blockSite } from 'calypso/state/reader/site-blocks/actions';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
+import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/reader-recommended-sites/docs/example.jsx
+++ b/client/blocks/reader-recommended-sites/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
-import ReaderRecommendedSites from '../';
 import { Card } from '@automattic/components';
+import React, { PureComponent } from 'react';
+import ReaderRecommendedSites from '../';
 
 const sites = {
 	longreads: { siteId: 70135762 },

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -1,28 +1,18 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { map, partial, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { map, partial, isEmpty } from 'lodash';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import ConnectedListItem from 'calypso/blocks/reader-list-item/connected';
+import Gridicon from 'calypso/components/gridicon';
 import {
 	recordAction,
 	recordTrackWithRailcar,
 	recordTracksRailcarRender,
 } from 'calypso/reader/stats';
-import { Button } from '@automattic/components';
 import { dismissSite } from 'calypso/state/reader/site-dismissals/actions';
-import ConnectedListItem from 'calypso/blocks/reader-list-item/connected';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class RecommendedSites extends React.PureComponent {

--- a/client/blocks/reader-related-card/docs/example.jsx
+++ b/client/blocks/reader-related-card/docs/example.jsx
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import { Card } from '@automattic/components';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import {
 	RelatedPostsFromSameSite,
 	RelatedPostsFromOtherSites,
 } from 'calypso/components/related-posts';
-import { Card } from '@automattic/components';
 
 const LONGREADS_SITE_ID = 70135762;
 const LONGREADS_POST_ID = 65877;

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -1,30 +1,20 @@
-/**
- * External Dependencies
- */
+import { CompactCard as Card } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { get, partial } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import classnames from 'classnames';
-import { get, partial } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
-import { getPostById } from 'calypso/state/reader/posts/selectors';
-import { getSite } from 'calypso/state/reader/sites/selectors';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
+import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
-import { CompactCard as Card } from '@automattic/components';
 import Gravatar from 'calypso/components/gravatar';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import FollowButton from 'calypso/reader/follow-button';
 import { getPostUrl, getStreamUrl } from 'calypso/reader/route';
-import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
-import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
-import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
-import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import { getPostById } from 'calypso/state/reader/posts/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const RELATED_IMAGE_WIDTH = 385; // usual width of featured images in related post card

--- a/client/blocks/reader-share/docs/example.jsx
+++ b/client/blocks/reader-share/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import ReaderShare from 'calypso/blocks/reader-share';
 import { posts } from 'calypso/blocks/reader-post-card/docs/fixtures';
+import ReaderShare from 'calypso/blocks/reader-share';
 
 const ReaderShareExample = () => (
 	<div style={ { width: '100px' } }>

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -1,31 +1,21 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { defer } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { defer } from 'lodash';
-import config from '@automattic/calypso-config';
-import classnames from 'classnames';
-import PropTypes from 'prop-types';
-import page from 'page';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import Gridicon from 'calypso/components/gridicon';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import SiteSelector from 'calypso/components/site-selector';
 import SocialLogo from 'calypso/components/social-logo';
+import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
 import * as stats from 'calypso/reader/stats';
 import { preloadEditor } from 'calypso/sections-preloaders';
-import SiteSelector from 'calypso/components/site-selector';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { Button } from '@automattic/components';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,20 +1,14 @@
-/**
- * External dependencies
- */
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import { find, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, get } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { localize } from 'i18n-calypso';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import Gridicon from 'calypso/components/gridicon';
-import ReaderPopover from 'calypso/reader/components/reader-popover';
 import SegmentedControl from 'calypso/components/segmented-control';
-import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
+import ReaderPopover from 'calypso/reader/components/reader-popover';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	subscribeToNewPostEmail,
 	updateNewPostEmailSubscription,
@@ -24,13 +18,9 @@ import {
 	subscribeToNewPostNotifications,
 	unsubscribeToNewPostNotifications,
 } from 'calypso/state/reader/follows/actions';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class ReaderSiteNotificationSettings extends Component {

--- a/client/blocks/reader-site-stream-link/README.md
+++ b/client/blocks/reader-site-stream-link/README.md
@@ -9,7 +9,7 @@ This component does not dictate the content of the link, only the href and click
 The `ReaderSiteStreamLink` component can be used in much the same way that you would use an `<a>` element. The link wraps whatever is placed between the ReaderSiteStreamLink elements.
 
 ```html
-<ReaderSiteStreamLink post={ post }>Your link text here</ReaderSiteStreamLink>
+<ReaderSiteStreamLink post="{" post }>Your link text here</ReaderSiteStreamLink>
 ```
 
 ## Props

--- a/client/blocks/reader-site-stream-link/docs/example.jsx
+++ b/client/blocks/reader-site-stream-link/docs/example.jsx
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-
-/**
- * Internal dependencies
- */
-import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import { Card } from '@automattic/components';
+import React from 'react';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 
 export default class ReaderSiteStreamLinkExample extends React.Component {
 	static displayName = 'ReaderSiteStreamLinkExample';

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import Emojify from 'calypso/components/emojify';
 import { getStreamUrl } from 'calypso/reader/route';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
-import Emojify from 'calypso/components/emojify';
 
 class ReaderSiteStreamLink extends React.Component {
 	static propTypes = {

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -1,17 +1,10 @@
-/**
- * External Dependencies
- */
+import { flowRight as compose } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal Dependencies
- */
 import connectSite from 'calypso/lib/reader-connect-site';
-import SubscriptionListItem from '.';
 import { isFollowing as isFollowingSelector } from 'calypso/state/reader/follows/selectors';
+import SubscriptionListItem from '.';
 
 const noop = () => {};
 

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
-import React, { PureComponent } from 'react';
+import { Card } from '@automattic/components';
 import { map } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React, { PureComponent } from 'react';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
-import { Card } from '@automattic/components';
 
 const sites = {
 	longreads: { siteId: 70135762 },

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -1,18 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import classnames from 'classnames';
-import { flowRight as compose, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import { flowRight as compose, isEmpty, get } from 'lodash';
+import React from 'react';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import FollowButton from 'calypso/reader/follow-button';
-import { getStreamUrl } from 'calypso/reader/route';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
+import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
+import ExternalLink from 'calypso/components/external-link';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import FollowButton from 'calypso/reader/follow-button';
 import {
 	getSiteName,
 	getSiteDescription,
@@ -20,15 +15,10 @@ import {
 	getFeedUrl,
 	getSiteUrl,
 } from 'calypso/reader/get-helpers';
-import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
-import { recordTrack, recordTrackWithRailcar } from 'calypso/reader/stats';
-import ExternalLink from 'calypso/components/external-link';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
+import { getStreamUrl } from 'calypso/reader/route';
+import { recordTrack, recordTrackWithRailcar } from 'calypso/reader/stats';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function ReaderSubscriptionListItem( {

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 
 const ReaderSubscriptionListItemPlaceholder = () => {

--- a/client/blocks/reader-visit-link/README.md
+++ b/client/blocks/reader-visit-link/README.md
@@ -7,7 +7,7 @@ A link to an external site from Reader.
 The component can be used in much the same way that you would use an `<a>` element. The link wraps whatever is placed between the ReaderVisitLink elements.
 
 ```html
-<ReaderVisitLink href={ post.URL }>Visit this</ReaderVisitLink>
+<ReaderVisitLink href="{" post.URL }>Visit this</ReaderVisitLink>
 ```
 
 ## Props

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ExternalLink from 'calypso/components/external-link';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/sharing-preview-pane/docs/example.jsx
+++ b/client/blocks/sharing-preview-pane/docs/example.jsx
@@ -1,22 +1,14 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
+import { Card } from '@automattic/components';
 import { get } from 'lodash';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import SharingPreviewPane from 'calypso/blocks/sharing-preview-pane';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
+import QuerySites from 'calypso/components/data/query-sites';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSitePosts } from 'calypso/state/posts/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
-import { Card } from '@automattic/components';
-import QuerySites from 'calypso/components/data/query-sites';
 
 const SharingPreviewPaneExample = ( { postId, site, siteId } ) => (
 	<div>

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -1,34 +1,23 @@
-/**
- * External dependencies
- */
-
+import { localize } from 'i18n-calypso';
+import { get, find, map } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { get, find, map } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { getPostImage, getExcerptForPost, getSummaryForPost } from './utils';
-import FacebookSharePreview from 'calypso/components/share/facebook-share-preview';
-import LinkedinSharePreview from 'calypso/components/share/linkedin-share-preview';
-import TwitterSharePreview from 'calypso/components/share/twitter-share-preview';
-import TumblrSharePreview from 'calypso/components/share/tumblr-share-preview';
-import VerticalMenu from 'calypso/components/vertical-menu';
-import { SocialItem } from 'calypso/components/vertical-menu/items';
-import { getSitePost } from 'calypso/state/posts/selectors';
-import { getSeoTitle, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSiteUserConnections } from 'calypso/state/sharing/publicize/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import FacebookSharePreview from 'calypso/components/share/facebook-share-preview';
+import LinkedinSharePreview from 'calypso/components/share/linkedin-share-preview';
+import TumblrSharePreview from 'calypso/components/share/tumblr-share-preview';
+import TwitterSharePreview from 'calypso/components/share/twitter-share-preview';
+import VerticalMenu from 'calypso/components/vertical-menu';
+import { SocialItem } from 'calypso/components/vertical-menu/items';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getSitePost } from 'calypso/state/posts/selectors';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
+import { getSiteUserConnections } from 'calypso/state/sharing/publicize/selectors';
+import { getSeoTitle, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getPostImage, getExcerptForPost, getSummaryForPost } from './utils';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const serviceNames = {

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { get, find, trim } from 'lodash';
 import striptags from 'striptags';
-
-/**
- * Internal dependencies
- */
-import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
 import { parseHtml } from 'calypso/lib/formatting';
+import { formatExcerpt } from 'calypso/lib/post-normalizer/rule-create-better-excerpt';
 
 const PREVIEW_IMAGE_WIDTH = 512;
 

--- a/client/blocks/shortcode/frame.js
+++ b/client/blocks/shortcode/frame.js
@@ -1,17 +1,9 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { isEqual, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { isEqual, omit } from 'lodash';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import generateEmbedFrameMarkup from 'calypso/lib/embed-frame-markup';
 import ResizableIframe from 'calypso/components/resizable-iframe';
+import generateEmbedFrameMarkup from 'calypso/lib/embed-frame-markup';
 
 export default class ShortcodeFrame extends React.Component {
 	static propTypes = {

--- a/client/blocks/shortcode/index.js
+++ b/client/blocks/shortcode/index.js
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
+import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
-
-/**
- * Local dependencies
- */
 import ShortcodeFrame from './frame';
 
 function useRenderedShortcode( siteId, shortcode ) {

--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -1,27 +1,17 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import Gridicon from 'calypso/components/gridicon';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import AutomatticLogo from 'calypso/components/automattic-logo';
-import { Button } from '@automattic/components';
 import FormButton from 'calypso/components/forms/form-button';
+import Gridicon from 'calypso/components/gridicon';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import SocialSignupForm from './social';
 
-/**
- * Style dependencies
- */
 import './crowdsignal.scss';
 
 class CrowdsignalSignupForm extends Component {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,8 +1,7 @@
-/**
- * External dependencies
- */
-import React, { Component, useEffect } from 'react';
-import { connect } from 'react-redux';
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import debugModule from 'debug';
+import { localize } from 'i18n-calypso';
 import {
 	camelCase,
 	find,
@@ -18,48 +17,39 @@ import {
 	omitBy,
 	snakeCase,
 } from 'lodash';
-import debugModule from 'debug';
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import wpcom from 'calypso/lib/wp';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { Button } from '@automattic/components';
+import React, { Component, useEffect } from 'react';
+import { connect } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormButton from 'calypso/components/forms/form-button';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import Notice from 'calypso/components/notice';
 import LoggedOutForm from 'calypso/components/logged-out-form';
-import { login, lostPassword } from 'calypso/lib/paths';
-import { addQueryArgs } from 'calypso/lib/url';
-import formState from 'calypso/lib/form-state';
-import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
-import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
-import CrowdsignalSignupForm from './crowdsignal';
-import SocialSignupForm from './social';
+import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
+import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import Notice from 'calypso/components/notice';
+import TextControl from 'calypso/extensions/woocommerce/components/text-control';
+import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import formState from 'calypso/lib/form-state';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { login, lostPassword } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
 import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import { createSocialUserFailed } from 'calypso/state/login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSectionName } from 'calypso/state/ui/selectors';
-import TextControl from 'calypso/extensions/woocommerce/components/text-control';
-import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import CrowdsignalSignupForm from './crowdsignal';
+import SocialSignupForm from './social';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 2000;

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,21 +1,14 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import AppleLoginButton from 'calypso/components/social-buttons/apple';
-import config from '@automattic/calypso-config';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import GoogleLoginButton from 'calypso/components/social-buttons/google';
-import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { preventWidows } from 'calypso/lib/formatting';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 class SocialSignupForm extends Component {
 	static propTypes = {

--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
 import { Dialog } from '@automattic/components';
-import FormLabel from 'calypso/components/forms/form-label';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import Gridicon from 'calypso/components/gridicon';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 
 const noop = () => {};

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,24 +1,16 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { debounce, get, isEmpty } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
-import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
-import ConfirmationDialog from './dialog';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import Gridicon from 'calypso/components/gridicon';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -30,12 +22,10 @@ import { getSiteAddressAvailabilityPending } from 'calypso/state/site-address-ch
 import { getSiteAddressValidationError } from 'calypso/state/site-address-change/selectors/get-site-address-validation-error';
 import { isRequestingSiteAddressChange } from 'calypso/state/site-address-change/selectors/is-requesting-site-address-change';
 import { isSiteAddressValidationAvailable } from 'calypso/state/site-address-change/selectors/is-site-address-validation-available';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ConfirmationDialog from './dialog';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const SUBDOMAIN_LENGTH_MINIMUM = 4;

--- a/client/blocks/site-icon/docs/example.jsx
+++ b/client/blocks/site-icon/docs/example.jsx
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import SiteIcon from '../';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import SiteIcon from '../';
 
 /**
  * Site ID of en.blog.wordpress.com, to be used as fallback for SiteIcon if

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -1,30 +1,19 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import classNames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import Image from 'calypso/components/image';
-import MediaImage from 'calypso/my-sites/media-library/media-image';
-import Spinner from 'calypso/components/spinner';
 import QuerySites from 'calypso/components/data/query-sites';
-import { getSite } from 'calypso/state/sites/selectors';
+import Gridicon from 'calypso/components/gridicon';
+import Image from 'calypso/components/image';
+import Spinner from 'calypso/components/spinner';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import MediaImage from 'calypso/my-sites/media-library/media-image';
 import getSiteIconId from 'calypso/state/selectors/get-site-icon-id';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
 import isTransientMedia from 'calypso/state/selectors/is-transient-media';
-import resizeImageUrl from 'calypso/lib/resize-image-url';
+import { getSite } from 'calypso/state/sites/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {

--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -1,25 +1,18 @@
-/**
- * External dependencies
- */
+import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import WebPreview from 'calypso/components/web-preview';
+import { addQueryArgs } from 'calypso/lib/route';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { closePreview } from 'calypso/state/ui/preview/actions';
 import {
 	getPreviewSite,
 	getPreviewSiteId,
 	getPreviewUrl,
 } from 'calypso/state/ui/preview/selectors';
-import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
-import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import { addQueryArgs } from 'calypso/lib/route';
-import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
-import WebPreview from 'calypso/components/web-preview';
 
 const debug = debugFactory( 'calypso:site-preview' );
 

--- a/client/blocks/site/docs/example.jsx
+++ b/client/blocks/site/docs/example.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Card } from '@automattic/components';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import Site from 'calypso/blocks/site';
-import { Card } from '@automattic/components';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 

--- a/client/blocks/site/docs/placeholder-example.jsx
+++ b/client/blocks/site/docs/placeholder-example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 
 export default class SitePlaceholderExample extends PureComponent {

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -1,29 +1,19 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { isEnabled } from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
+import Gridicon from 'calypso/components/gridicon';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
-import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
-import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import isAtomicAndEditingToolkitPluginDeactivated from 'calypso/state/selectors/is-atomic-and-editing-toolkit-plugin-deactivated';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
+import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/site/placeholder.jsx
+++ b/client/blocks/site/placeholder.jsx
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import debugFactory from 'debug';
+import React from 'react';
 const debug = debugFactory( 'calypso:my-sites:site' );
 
 export default class extends React.Component {

--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -1,29 +1,19 @@
-/**
- * External Dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import FollowersCount from 'calypso/blocks/followers-count';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import Intervals from './intervals';
-import FollowersCount from 'calypso/blocks/followers-count';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteOption } from 'calypso/state/sites/selectors';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { navItems, intervals as intervalConstants } from './constants';
-import config from '@automattic/calypso-config';
+import Intervals from './intervals';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class StatsNavigation extends Component {

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -1,20 +1,10 @@
-/**
- * External Dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { intervals } from './constants';
+import PropTypes from 'prop-types';
+import React from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
+import { intervals } from './constants';
 
-/**
- * Style dependencies
- */
 import './intervals.scss';
 
 const Intervals = ( props ) => {

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const DEFAULT_HEIGHT = 20;

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -1,43 +1,33 @@
-/**
- * External Dependencies
- */
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { memoize } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { memoize } from 'lodash';
-import { useTranslate } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal Dependencies
- */
-import { Button, Dialog } from '@automattic/components';
-import SupportArticleHeader from './header';
-import Placeholders from './placeholders';
-import EmbedContainer from 'calypso/components/embed-container';
-import Emojify from 'calypso/components/emojify';
+import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QuerySupportArticleAlternates from 'calypso/components/data/query-support-article-alternates';
+import EmbedContainer from 'calypso/components/embed-container';
+import Emojify from 'calypso/components/emojify';
+import Gridicon from 'calypso/components/gridicon';
 import { isDefaultLocale } from 'calypso/lib/i18n-utils';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
-import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
-import getInlineSupportArticlePostId from 'calypso/state/selectors/get-inline-support-article-post-id';
-import getInlineSupportArticleBlogId from 'calypso/state/selectors/get-inline-support-article-blog-id';
-import getInlineSupportArticleActionUrl from 'calypso/state/selectors/get-inline-support-article-action-url';
-import getInlineSupportArticleActionLabel from 'calypso/state/selectors/get-inline-support-article-action-label';
-import getInlineSupportArticleActionIsExternal from 'calypso/state/selectors/get-inline-support-article-action-is-external';
 import { closeSupportArticleDialog as closeDialog } from 'calypso/state/inline-support-article/actions';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getInlineSupportArticleActionIsExternal from 'calypso/state/selectors/get-inline-support-article-action-is-external';
+import getInlineSupportArticleActionLabel from 'calypso/state/selectors/get-inline-support-article-action-label';
+import getInlineSupportArticleActionUrl from 'calypso/state/selectors/get-inline-support-article-action-url';
+import getInlineSupportArticleBlogId from 'calypso/state/selectors/get-inline-support-article-blog-id';
+import getInlineSupportArticlePostId from 'calypso/state/selectors/get-inline-support-article-post-id';
 import {
 	getSupportArticleAlternatesForLocale,
 	isRequestingSupportArticleAlternates,
 	shouldRequestSupportArticleAlternates,
 } from 'calypso/state/support-articles-alternates/selectors';
+import SupportArticleHeader from './header';
+import Placeholders from './placeholders';
 
-/**
- * Style Dependencies
- */
 import './style.scss';
 import './content.scss';
 

--- a/client/blocks/support-article-dialog/docs/example.jsx
+++ b/client/blocks/support-article-dialog/docs/example.jsx
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import { Button } from '@automattic/components';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
-import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 
 const postId = 143180;
 const postUrl = localizeUrl(

--- a/client/blocks/support-article-dialog/header.jsx
+++ b/client/blocks/support-article-dialog/header.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import ExternalLink from 'calypso/components/external-link';
 
 const SupportArticleHeader = ( { post, isLoading } ) =>

--- a/client/blocks/support-article-dialog/index.jsx
+++ b/client/blocks/support-article-dialog/index.jsx
@@ -1,12 +1,5 @@
-/**
- * External Dependencies
- */
 import React from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import AsyncLoad from 'calypso/components/async-load';
 import isInlineSupportArticleVisible from 'calypso/state/selectors/is-inline-support-article-visible';
 

--- a/client/blocks/support-article-dialog/placeholders.jsx
+++ b/client/blocks/support-article-dialog/placeholders.jsx
@@ -1,6 +1,3 @@
-/**
- * External Dependencies
- */
 import React from 'react';
 
 const PlaceHolders = () => (

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@automattic/components';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import SearchCard from 'calypso/components/search-card';
-import { Button } from '@automattic/components';
-import TermsList from './list';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
-import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
 import TermFormDialog from 'calypso/blocks/term-form-dialog';
+import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
+import SearchCard from 'calypso/components/search-card';
 import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
+import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import TermsList from './list';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export class TaxonomyManager extends Component {

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,34 +1,26 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import page from 'page';
-import { connect } from 'react-redux';
+import { Dialog } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Count from 'calypso/components/count';
-import { Dialog } from '@automattic/components';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import Gridicon from 'calypso/components/gridicon';
+import PodcastIndicator from 'calypso/components/podcast-indicator';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import PopoverMenuSeparator from 'calypso/components/popover/menu-separator';
 import Tooltip from 'calypso/components/tooltip';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
+import getPodcastingCategoryId from 'calypso/state/selectors/get-podcasting-category-id';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
-import { decodeEntities } from 'calypso/lib/formatting';
 import { deleteTerm } from 'calypso/state/terms/actions';
-import { saveSiteSettings } from 'calypso/state/site-settings/actions';
-import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
-import PodcastIndicator from 'calypso/components/podcast-indicator';
-import getPodcastingCategoryId from 'calypso/state/selectors/get-podcasting-category-id';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class TaxonomyManagerListItem extends Component {
 	static propTypes = {

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -1,29 +1,21 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { CompactCard } from '@automattic/components';
+import { WindowScroller } from '@automattic/react-virtualized';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { includes, filter, map, reduce } from 'lodash';
-import { WindowScroller } from '@automattic/react-virtualized';
-
-/**
- * Internal dependencies
- */
-import VirtualList from 'calypso/components/virtual-list';
-import ListItem from './list-item';
-import { CompactCard } from '@automattic/components';
-import QueryTerms from 'calypso/components/data/query-terms';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import QueryTerms from 'calypso/components/data/query-terms';
+import VirtualList from 'calypso/components/virtual-list';
 import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsLastPageForQuery,
 	getTermsForQueryIgnoringPage,
 } from 'calypso/state/terms/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ListItem from './list-item';
 
 /**
  * Constants

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -1,34 +1,24 @@
-/**
- * External dependencies
- */
+import { Dialog } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import { get, find } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import { get, find } from 'lodash';
-import { ToggleControl } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
 import TermTreeSelectorTerms from 'calypso/blocks/term-tree-selector/terms';
-import FormInputValidation from 'calypso/components/forms/form-input-validation';
-import FormTextarea from 'calypso/components/forms/form-textarea';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
-import FormLegend from 'calypso/components/forms/form-legend';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
-import { getTerms } from 'calypso/state/terms/selectors';
-import { addTerm, updateTerm } from 'calypso/state/terms/actions';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
+import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
+import { addTerm, updateTerm } from 'calypso/state/terms/actions';
+import { getTerms } from 'calypso/state/terms/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/term-tree-selector/add-term.jsx
+++ b/client/blocks/term-tree-selector/add-term.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import TermFormDialog from 'calypso/blocks/term-form-dialog';
 import QueryTaxonomies from 'calypso/components/data/query-taxonomies';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import Gridicon from 'calypso/components/gridicon';
 import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
 import { getTerms } from 'calypso/state/terms/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './add-term.scss';
 
 const noop = () => {};

--- a/client/blocks/term-tree-selector/index.jsx
+++ b/client/blocks/term-tree-selector/index.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import TermTreeSelectorTerms from './terms';
 import TermSelectorAddTerm from './add-term';
+import TermTreeSelectorTerms from './terms';
 
 export default class TermTreeSelector extends React.Component {
 	static propTypes = {

--- a/client/blocks/term-tree-selector/no-results.jsx
+++ b/client/blocks/term-tree-selector/no-results.jsx
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class TermTreeSelectorNoResults extends React.PureComponent {

--- a/client/blocks/term-tree-selector/search.jsx
+++ b/client/blocks/term-tree-selector/search.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import Gridicon from 'calypso/components/gridicon';
 
-/**
- * Internal dependencies
- */
-import FormTextInput from 'calypso/components/forms/form-text-input';
-
-/**
- * Style dependencies
- */
 import './search.scss';
 
 function TermTreeSelectorSearch( { searchTerm, onSearch } ) {

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -1,11 +1,6 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import { AutoSizer, List } from '@automattic/react-virtualized';
-import { connect } from 'react-redux';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import {
 	debounce,
 	difference,
@@ -17,32 +12,27 @@ import {
 	range,
 	reduce,
 } from 'lodash';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
+import QueryTerms from 'calypso/components/data/query-terms';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import PodcastIndicator from 'calypso/components/podcast-indicator';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { decodeEntities } from 'calypso/lib/formatting';
 import getPodcastingCategoryId from 'calypso/state/selectors/get-podcasting-category-id';
 import {
 	getTermsForQueryIgnoringPage,
 	getTermsLastPageForQuery,
 	isRequestingTermsForQueryIgnoringPage,
 } from 'calypso/state/terms/selectors';
-import NoResults from './no-results';
-import PodcastIndicator from 'calypso/components/podcast-indicator';
-import QuerySiteSettings from 'calypso/components/data/query-site-settings';
-import QueryTerms from 'calypso/components/data/query-terms';
-import Search from './search';
-import { decodeEntities } from 'calypso/lib/formatting';
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import NoResults from './no-results';
+import Search from './search';
 
-/**
- * Style dependencies
- */
 import './terms.scss';
 
 /**

--- a/client/blocks/time-mismatch-warning/docs/example.tsx
+++ b/client/blocks/time-mismatch-warning/docs/example.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { TimeMismatchWarning } from 'calypso/blocks/time-mismatch-warning';
 
 const TimeMismatchWarningExample = () => {

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { useTranslate } from 'i18n-calypso';
 import React, { FC } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import Notice from 'calypso/components/notice';
-import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import { preventWidows } from 'calypso/lib/formatting';
-import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 
 interface ExternalProps {
 	status?: string;

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -1,18 +1,12 @@
 /* eslint-disable no-irregular-whitespace */
-/**
- * External dependencies
- */
-import React from 'react';
+
 import { shallow } from 'enzyme';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { TimeMismatchWarning } from '../index';
-import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import { TimeMismatchWarning } from '../index';
 
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -1,27 +1,16 @@
-/**
- * External dependencies
- */
-
+import classNames from 'classnames';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-import Gridicon from 'calypso/components/gridicon';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import FilePicker from 'calypso/components/file-picker';
 import DropZone from 'calypso/components/drop-zone';
+import FilePicker from 'calypso/components/file-picker';
+import Gridicon from 'calypso/components/gridicon';
+import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import debugFactory from 'debug';
-import { MAX_UPLOAD_ZIP_SIZE } from 'calypso/lib/automated-transfer/constants';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const debug = debugFactory( 'calypso:upload-drop-zone' );

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 const UpsellNudgeExample = () => (

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -1,13 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import classnames from 'classnames';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import {
 	planMatches,
 	isBloggerPlan,
@@ -20,19 +10,19 @@ import {
 	FEATURE_NO_ADS,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
+import classnames from 'classnames';
+import React from 'react';
+import { connect } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import { addQueryArgs } from 'calypso/lib/url';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export const UpsellNudge = ( {

--- a/client/blocks/upsell-nudge/test/index.jsx
+++ b/client/blocks/upsell-nudge/test/index.jsx
@@ -1,13 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { shallow } from 'enzyme';
-
-/**
- * Internal dependencies
- */
-import { UpsellNudge } from '../index';
 import {
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
@@ -22,6 +12,9 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { UpsellNudge } from '../index';
 
 const props = {
 	callToAction: null,

--- a/client/blocks/upwork-banner/actions.js
+++ b/client/blocks/upwork-banner/actions.js
@@ -1,8 +1,5 @@
-/**
- * Internal Dependencies
- */
-import { getPreference } from 'calypso/state/preferences/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 
 export const dismissBanner = ( location ) => ( dispatch, getState ) => {
 	const preference = getPreference( getState(), 'upwork-dismissible-banner' ) || {};

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -1,21 +1,11 @@
-/**
- * External dependencies
- */
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-
-/**
- * Internal dependencies
- */
+import { connect } from 'react-redux';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 class UpworkBanner extends PureComponent {

--- a/client/blocks/user-mentions/README.md
+++ b/client/blocks/user-mentions/README.md
@@ -7,8 +7,8 @@ It also provides the components `UserMentionsSuggestionList` and `UserMentionsSu
 ## How to use
 
 ```js
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import withUserMentions from 'calypso/blocks/user-mentions';
+import FormTextarea from 'calypso/components/forms/form-textarea';
 
 const ExampleInput = React.forwardRef( ( props, ref ) => (
 	<FormTextarea forwardedRef={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { escapeRegExp, findIndex, get, throttle, pick } from 'lodash';
 import React, { Fragment } from 'react';
 import getCaretCoordinates from 'textarea-caret';
-import { escapeRegExp, findIndex, get, throttle, pick } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import UserMentionSuggestionList from './suggestion-list';
 
 const keys = { tab: 9, enter: 13, esc: 27, spaceBar: 32, upArrow: 38, downArrow: 40 };

--- a/client/blocks/user-mentions/connect.jsx
+++ b/client/blocks/user-mentions/connect.jsx
@@ -1,11 +1,8 @@
-/**
- * External dependencies
- */
+import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryUsersSuggestions from 'calypso/components/data/query-users-suggestions';
 import { getUserSuggestions } from 'calypso/state/user-suggestions/selectors';
-import PropTypes from 'prop-types';
 
 /**
  * connectUserMentions is a higher-order component that connects the child component to user suggestions from the API.

--- a/client/blocks/user-mentions/docs/example-input.jsx
+++ b/client/blocks/user-mentions/docs/example-input.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
-import addUserMentions from '../add';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import addUserMentions from '../add';
 
 const UserMentionsExampleInput = React.forwardRef( ( props, ref ) => (
 	<FormTextarea forwardedRef={ ref } onKeyUp={ props.onKeyUp } onKeyDown={ props.onKeyDown } />

--- a/client/blocks/user-mentions/docs/example.jsx
+++ b/client/blocks/user-mentions/docs/example.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import UserMentionsExampleInput from './example-input';
 
 const exampleSuggestions = [

--- a/client/blocks/user-mentions/index.jsx
+++ b/client/blocks/user-mentions/index.jsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
-import connectUserMentions from './connect';
+import React from 'react';
 import addUserMentions from './add';
+import connectUserMentions from './connect';
 
 /**
  * withUserMentions is a higher-order component that adds connected user mention support to whatever input it wraps.

--- a/client/blocks/user-mentions/suggestion-list.jsx
+++ b/client/blocks/user-mentions/suggestion-list.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
+import UserMentionsSuggestion from 'calypso/blocks/user-mentions/suggestion';
 import PopoverMenu from 'calypso/components/popover/menu';
 import PopoverMenuItem from 'calypso/components/popover/menu-item';
-import UserMentionsSuggestion from 'calypso/blocks/user-mentions/suggestion';
 
-/**
- * Style dependencies
- */
 import './suggestion-list.scss';
 
 const UserMentionsSuggestionList = ( {

--- a/client/blocks/user-mentions/suggestion.jsx
+++ b/client/blocks/user-mentions/suggestion.jsx
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
 import PropTypes from 'prop-types';
 import React from 'react';
 
-/**
- * Style dependencies
- */
 import './suggestion.scss';
 
 const UserMentionsSuggestion = ( { avatarUrl, fullName, query, username } ) => {

--- a/client/blocks/video-editor/docs/example.jsx
+++ b/client/blocks/video-editor/docs/example.jsx
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import React, { Component } from 'react';
-
-/**
- * Internal dependencies
- */
 import VideoEditor from '../';
 
 class VideoEditorExample extends Component {

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -1,28 +1,18 @@
-/**
- * External dependencies
- */
+import { ProgressBar } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { ProgressBar } from '@automattic/components';
 import Notice from 'calypso/components/notice';
 import DetailPreviewVideo from 'calypso/post-editor/media-modal/detail/detail-preview-video';
-import VideoEditorControls from './video-editor-controls';
 import { updatePoster } from 'calypso/state/editor/video-editor/actions';
 import getPosterUploadProgress from 'calypso/state/selectors/get-poster-upload-progress';
 import getPosterUrl from 'calypso/state/selectors/get-poster-url';
 import shouldShowVideoEditorError from 'calypso/state/selectors/should-show-video-editor-error';
+import VideoEditorControls from './video-editor-controls';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const noop = () => {};

--- a/client/blocks/video-editor/video-editor-controls.jsx
+++ b/client/blocks/video-editor/video-editor-controls.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
+import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { Button } from '@automattic/components';
 import UploadButton from './video-editor-upload-button';
 
 const noop = () => {};

--- a/client/blocks/video-editor/video-editor-upload-button.js
+++ b/client/blocks/video-editor/video-editor-upload-button.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@automattic/components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import FilePicker from 'calypso/components/file-picker';
 
 const noop = () => {};

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
-import React, { useState, useEffect } from 'react';
 import { useTranslate } from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import React, { useState, useEffect } from 'react';
 import wpcom from 'calypso/lib/wp';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function useSite( siteSlug ) {


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/blocks` to use `import/order`

#### Testing instructions

N/A

Note: there are quite a few eslint failures but none of them should be related to the `import/order` rule
