### PR TITLE
chore: Refactor `client/lib` to use `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -196,6 +196,7 @@ module.exports = {
 				'client/jetpack-connect/**/*',
 				'client/landing/**/*',
 				'client/layout/**/*',
+				'client/lib/**/*',
 				'client/login/**/*',
 				'client/mailing-lists/**/*',
 				'client/my-sites/**/*',

--- a/client/lib/a11y/types.ts
+++ b/client/lib/a11y/types.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { ARIA_STATES, ARIA_PROPERTIES } from './constants';
 
 export type RawAriaState = typeof ARIA_STATES[ number ];

--- a/client/lib/a11y/use-aria-props.ts
+++ b/client/lib/a11y/use-aria-props.ts
@@ -1,11 +1,4 @@
-/**
- * Internal dependencies
- */
 import { ARIA_STATES, ARIA_PROPERTIES } from './constants';
-
-/**
- * Types
- */
 import type {
 	AriaProps,
 	AriaAttributes,

--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -1,19 +1,9 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { Dialog } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
-/**
- * Style dependencies
- */
 import './dialog.scss';
 
 class AcceptDialog extends Component {

--- a/client/lib/accept/index.js
+++ b/client/lib/accept/index.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import ReactDom from 'react-dom';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
+import ReactDom from 'react-dom';
 import AcceptDialog from './dialog';
 
 export default function ( message, callback, confirmButtonText, cancelButtonText, options ) {

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import accept from '../';
 
 describe( '#accept()', () => {

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-import { userCan } from 'calypso/lib/site/utils';
 import {
 	isBusiness,
 	isPremium,
@@ -10,6 +6,7 @@ import {
 	isSecurityRealTime,
 	isComplete,
 } from '@automattic/calypso-products';
+import { userCan } from 'calypso/lib/site/utils';
 
 export function hasWordAdsPlan( site ) {
 	return (

--- a/client/lib/after-layout-flush/index.ts
+++ b/client/lib/after-layout-flush/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { TimerHandle } from 'calypso/types';
 
 interface Cancelable {

--- a/client/lib/after-layout-flush/test/index.js
+++ b/client/lib/after-layout-flush/test/index.js
@@ -2,14 +2,7 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
 import afterLayoutFlush from '../';
 
 jest.useFakeTimers();

--- a/client/lib/analytics/ad-tracking/ad-track-registration.js
+++ b/client/lib/analytics/ad-tracking/ad-track-registration.js
@@ -1,8 +1,4 @@
-/**
- * Internal dependencies
- */
 import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
-
 import {
 	debug,
 	isFacebookEnabled,
@@ -12,8 +8,8 @@ import {
 	isPinterestEnabled,
 	TRACKING_IDS,
 } from './constants';
-import { loadTrackingScripts } from './load-tracking-scripts';
 import { recordParamsInFloodlightGtag } from './floodlight';
+import { loadTrackingScripts } from './load-tracking-scripts';
 
 // Ensure setup has run.
 import './setup';

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
+import { getCurrentUser } from '@automattic/calypso-analytics';
 import { v4 as uuid } from 'uuid';
-
-/**
- * Internal dependencies
- */
 import {
 	costToUSD,
 	isAdTrackingAllowed,
 	refreshCountryCodeCookieGdpr,
 } from 'calypso/lib/analytics/utils';
-
-import { getCurrentUser } from '@automattic/calypso-analytics';
 import {
 	debug,
 	isFacebookEnabled,
@@ -26,8 +18,8 @@ import {
 	TRACKING_IDS,
 	ICON_MEDIA_SIGNUP_PIXEL_URL,
 } from './constants';
-import { loadTrackingScripts } from './load-tracking-scripts';
 import { recordParamsInFloodlightGtag } from './floodlight';
+import { loadTrackingScripts } from './load-tracking-scripts';
 
 // Ensure setup has run.
 import './setup';

--- a/client/lib/analytics/ad-tracking/ad-track-signup-start.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-start.js
@@ -1,12 +1,8 @@
-/**
- * Internal dependencies
- */
-import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
-
 import { getCurrentUser } from '@automattic/calypso-analytics';
+import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { debug, isWpcomGoogleAdsGtagEnabled, isFloodlightEnabled, TRACKING_IDS } from './constants';
-import { loadTrackingScripts } from './load-tracking-scripts';
 import { recordParamsInFloodlightGtag } from './floodlight';
+import { loadTrackingScripts } from './load-tracking-scripts';
 
 // Ensure setup has run.
 import './setup';

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
 
 // Enable/disable ad-tracking
 // These should not be put in the json config as they must not differ across environments

--- a/client/lib/analytics/ad-tracking/criteo.js
+++ b/client/lib/analytics/ad-tracking/criteo.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-import { clone, cloneDeep } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { isAdTrackingAllowed } from 'calypso/lib/analytics/utils';
-
 import { getCurrentUser } from '@automattic/calypso-analytics';
+import { clone, cloneDeep } from 'lodash';
+import { isAdTrackingAllowed } from 'calypso/lib/analytics/utils';
 import { debug, isCriteoEnabled, TRACKING_IDS } from './constants';
 import { loadTrackingScripts } from './load-tracking-scripts';
 

--- a/client/lib/analytics/ad-tracking/floodlight.js
+++ b/client/lib/analytics/ad-tracking/floodlight.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
+import { getTracksAnonymousUserId, getCurrentUser } from '@automattic/calypso-analytics';
 import cookie from 'cookie';
 import { v4 as uuid } from 'uuid';
-
-/**
- * Internal dependencies
- */
 import { isAdTrackingAllowed } from 'calypso/lib/analytics/utils';
-
-import { getTracksAnonymousUserId, getCurrentUser } from '@automattic/calypso-analytics';
 import {
 	debug,
 	isFloodlightEnabled,

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -1,12 +1,9 @@
-/**
- * Internal dependencies
- */
 import { getCurrentUser, getDoNotTrack } from '@automattic/calypso-analytics';
-import { isGoogleAnalyticsEnabled, TRACKING_IDS } from './constants';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isPiiUrl, mayWeTrackCurrentUserGdpr } from 'calypso/lib/analytics/utils';
-import { setupGtag } from './setup-gtag';
 import config from '@automattic/calypso-config';
+import { isPiiUrl, mayWeTrackCurrentUserGdpr } from 'calypso/lib/analytics/utils';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { isGoogleAnalyticsEnabled, TRACKING_IDS } from './constants';
+import { setupGtag } from './setup-gtag';
 
 // Ensure setup has run.
 import './setup';

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-import { loadScript } from '@automattic/load-script';
-
-/**
- * Internal dependencies
- */
 import { getCurrentUser } from '@automattic/calypso-analytics';
-
+import { loadScript } from '@automattic/load-script';
 import {
 	debug,
 	isFacebookEnabled,

--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import {
 	debug,
@@ -12,9 +9,9 @@ import {
 	isPinterestEnabled,
 	TRACKING_IDS,
 } from './constants';
-import { loadTrackingScripts } from './load-tracking-scripts';
-import { recordParamsInFloodlightGtag } from './floodlight';
 import { recordInCriteo } from './criteo';
+import { recordParamsInFloodlightGtag } from './floodlight';
+import { loadTrackingScripts } from './load-tracking-scripts';
 
 // Ensure setup has run.
 import './setup';

--- a/client/lib/analytics/ad-tracking/record-alias-in-floodlight.js
+++ b/client/lib/analytics/ad-tracking/record-alias-in-floodlight.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isAdTrackingAllowed } from 'calypso/lib/analytics/utils';
 import { debug, isFloodlightEnabled } from './constants';
 import { recordParamsInFloodlightGtag } from './floodlight';

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -1,6 +1,4 @@
-/**
- * Internal dependencies
- */
+import { getCurrentUser } from '@automattic/calypso-analytics';
 import { isJetpackPlan, isJetpackProduct } from '@automattic/calypso-products';
 import {
 	costToUSD,
@@ -34,10 +32,9 @@ import {
 	GA_PRODUCT_BRAND_WPCOM,
 	GA_PRODUCT_BRAND_JETPACK,
 } from './constants';
-import { loadTrackingScripts } from './load-tracking-scripts';
-import { recordParamsInFloodlightGtag } from './floodlight';
 import { cartToCriteoItems, recordInCriteo } from './criteo';
-import { getCurrentUser } from '@automattic/calypso-analytics';
+import { recordParamsInFloodlightGtag } from './floodlight';
+import { loadTrackingScripts } from './load-tracking-scripts';
 
 // Ensure setup has run.
 import './setup';

--- a/client/lib/analytics/ad-tracking/record-view-checkout.js
+++ b/client/lib/analytics/ad-tracking/record-view-checkout.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isCriteoEnabled } from './constants';
 import { recordViewCheckoutInCriteo } from './criteo';
 

--- a/client/lib/analytics/ad-tracking/retarget-view-plans.js
+++ b/client/lib/analytics/ad-tracking/retarget-view-plans.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isAdTrackingAllowed } from 'calypso/lib/analytics/utils';
 import { isCriteoEnabled } from './constants';
 import { recordPlansViewInCriteo } from './criteo';

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -1,8 +1,4 @@
-/**
- * Internal dependencies
- */
 import { isAdTrackingAllowed, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
-
 import {
 	debug,
 	isFacebookEnabled,

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	isAdRollEnabled,
 	isBingEnabled,
@@ -20,7 +17,6 @@ import {
 	ADROLL_PURCHASE_PIXEL_URL_2,
 	TRACKING_IDS,
 } from './constants';
-
 import { setupGtag } from './setup-gtag';
 
 if ( typeof window !== 'undefined' ) {

--- a/client/lib/analytics/ad-tracking/track-anonymous-user-id.js
+++ b/client/lib/analytics/ad-tracking/track-anonymous-user-id.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import cookie from 'cookie';
 
 // Ensure setup has run.

--- a/client/lib/analytics/ad-tracking/track-custom-events.js
+++ b/client/lib/analytics/ad-tracking/track-custom-events.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { debug, TRACKING_IDS } from './constants';
 
 // Ensure setup has run.

--- a/client/lib/analytics/cart.js
+++ b/client/lib/analytics/cart.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { recordAddToCart } from 'calypso/lib/analytics/record-add-to-cart';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 function removeNestedProperties( cartItem ) {
 	return omit( cartItem, [ 'extra' ] );

--- a/client/lib/analytics/fullstory.js
+++ b/client/lib/analytics/fullstory.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import debug from 'debug';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import { mayWeTrackCurrentUserGdpr, isPiiUrl } from './utils';
 import { getCurrentUser, getDoNotTrack } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import debug from 'debug';
 import { isE2ETest } from 'calypso/lib/e2e';
 import { TRACKING_IDS } from './ad-tracking/constants';
+import { mayWeTrackCurrentUserGdpr, isPiiUrl } from './utils';
 
 const fullStoryDebug = debug( 'calypso:analytics:fullstory' );
 

--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import debug from 'debug';
-
-/**
- * Internal dependencies
- */
 import {
 	getGoogleAnalyticsDefaultConfig,
 	setupGoogleAnalyticsGtag,

--- a/client/lib/analytics/hotjar.js
+++ b/client/lib/analytics/hotjar.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import debug from 'debug';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
-import { mayWeTrackCurrentUserGdpr, isPiiUrl } from './utils';
 import { getDoNotTrack } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import debug from 'debug';
 import { isE2ETest } from 'calypso/lib/e2e';
+import { mayWeTrackCurrentUserGdpr, isPiiUrl } from './utils';
 
 const hotjarDebug = debug( 'calypso:analytics:hotjar' );
 

--- a/client/lib/analytics/identify-user.js
+++ b/client/lib/analytics/identify-user.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
-import { recordAliasInFloodlight } from 'calypso/lib/analytics/ad-tracking';
 import {
 	identifyUser as baseIdentifyUser,
 	getTracksAnonymousUserId,
 	getCurrentUser,
 } from '@automattic/calypso-analytics';
+import debugModule from 'debug';
+import { recordAliasInFloodlight } from 'calypso/lib/analytics/ad-tracking';
 
 /**
  * Module variables

--- a/client/lib/analytics/init.js
+++ b/client/lib/analytics/init.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
 import {
 	initializeAnalytics as initializeCalypsoAnalytics,
 	getTracksAnonymousUserId,
 	getCurrentUser,
 } from '@automattic/calypso-analytics';
+import debugModule from 'debug';
 
 /**
  * Module variables

--- a/client/lib/analytics/mc.js
+++ b/client/lib/analytics/mc.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import debug from 'debug';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import debug from 'debug';
 
 const mcDebug = debug( 'calypso:analytics:mc' );
 

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -1,25 +1,17 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { getSiteFragment } from 'calypso/lib/route';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { withEnhancers } from 'calypso/state/utils';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { withEnhancers } from 'calypso/state/utils';
 
 /**
  * Module variables

--- a/client/lib/analytics/page-view-tracker/test/index.jsx
+++ b/client/lib/analytics/page-view-tracker/test/index.jsx
@@ -2,19 +2,12 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import React from 'react';
 import { spy } from 'sinon';
-
-/**
- * Internal dependencies
- */
-import { PageViewTracker } from '../';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
+import { PageViewTracker } from '../';
 
 describe( 'PageViewTracker', () => {
 	let clock;

--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -1,17 +1,13 @@
 // pageView is a wrapper for pageview events across Tracks and GA.
 
-/**
- * Internal dependencies
- */
-import { saveCouponQueryArgument } from 'calypso/lib/analytics/utils';
-
+import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytics';
 import { retarget as retargetAdTrackers } from 'calypso/lib/analytics/ad-tracking';
-import { updateQueryParamsTracking } from 'calypso/lib/analytics/sem';
 import { retargetFullStory } from 'calypso/lib/analytics/fullstory';
+import { updateQueryParamsTracking } from 'calypso/lib/analytics/sem';
+import { saveCouponQueryArgument } from 'calypso/lib/analytics/utils';
 import { gaRecordPageView } from './ga';
 import { processQueue } from './queue';
 import { referRecordPageView } from './refer';
-import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytics';
 
 export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) {
 	// Add delay to avoid stale `_dl` in recorded calypso_page_view event details.

--- a/client/lib/analytics/queue.js
+++ b/client/lib/analytics/queue.js
@@ -1,8 +1,5 @@
 // This is a `localStorage` queue for delayed event triggers.
 
-/**
- * External dependencies
- */
 import debug from 'debug';
 
 /**

--- a/client/lib/analytics/recaptcha.js
+++ b/client/lib/analytics/recaptcha.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import { loadScript } from '@automattic/load-script';
+import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:analytics:recaptcha' );
 

--- a/client/lib/analytics/record-add-to-cart.js
+++ b/client/lib/analytics/record-add-to-cart.js
@@ -1,9 +1,5 @@
-/**
- * Internal dependencies
- */
-import { costToUSD } from 'calypso/lib/analytics/utils';
-
 import { recordAddToCart as trackAddToCart } from 'calypso/lib/analytics/ad-tracking';
+import { costToUSD } from 'calypso/lib/analytics/utils';
 import { gaRecordEvent } from './ga';
 
 export function recordAddToCart( { cartItem } ) {

--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
-import { costToUSD } from 'calypso/lib/analytics/utils';
 import { recordOrder } from 'calypso/lib/analytics/ad-tracking';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { costToUSD } from 'calypso/lib/analytics/utils';
 import { gaRecordEvent } from './ga';
 
 export function recordPurchase( { cart, orderId } ) {

--- a/client/lib/analytics/refer.js
+++ b/client/lib/analytics/refer.js
@@ -1,8 +1,5 @@
 // Refer platform tracking.
 
-/**
- * Internal dependencies
- */
 import { urlParseAmpCompatible } from 'calypso/lib/analytics/utils';
 import { trackAffiliateReferral } from './track-affiliate-referral';
 import { recordTracksEvent } from './tracks';

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { pushEventToTracksQueue } from '@automattic/calypso-analytics';
 import cookie from 'cookie';
 import debugFactory from 'debug';
-import { pushEventToTracksQueue } from '@automattic/calypso-analytics';
-
-/**
- * Internal dependencies.
- */
 import { urlParseAmpCompatible } from 'calypso/lib/analytics/utils';
 
 /**

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
-import debug from 'debug';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { identifyUser } from 'calypso/lib/analytics/identify-user';
-import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
-import { gaRecordEvent } from 'calypso/lib/analytics/ga';
-import { addToQueue } from 'calypso/lib/analytics/queue';
+import debug from 'debug';
 import {
 	adTrackSignupStart,
 	adTrackSignupComplete,
 	adTrackRegistration,
 } from 'calypso/lib/analytics/ad-tracking';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { identifyUser } from 'calypso/lib/analytics/identify-user';
+import { addToQueue } from 'calypso/lib/analytics/queue';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const signupDebug = debug( 'calypso:analytics:signup' );
 

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 function generateUrl( featureSlug: string, eventType: string, eventValue: string ) {

--- a/client/lib/analytics/statsd.js
+++ b/client/lib/analytics/statsd.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import debug from 'debug';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import debug from 'debug';
 import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
 import { getFeatureSlugFromPageUrl } from './feature-slug';
 

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import { shouldReportOmitBlogId } from 'calypso/lib/analytics/utils';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	const state = reduxStore.getState();

--- a/client/lib/analytics/test/google-analytics.js
+++ b/client/lib/analytics/test/google-analytics.js
@@ -1,9 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * Internal dependencies
- */
+
 import { makeGoogleAnalyticsTrackingFunction } from '../ga';
 
 jest.mock( '@automattic/calypso-config', () => {

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -2,27 +2,20 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import url from 'url';
+import { loadScript } from '@automattic/load-script';
 import cookie from 'cookie';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent, tracksEvents } from 'calypso/lib/analytics/tracks';
+import { recordAliasInFloodlight } from 'calypso/lib/analytics/ad-tracking';
 import { identifyUser } from 'calypso/lib/analytics/identify-user';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
-import { recordAliasInFloodlight } from 'calypso/lib/analytics/ad-tracking';
+import { recordTracksEvent, tracksEvents } from 'calypso/lib/analytics/tracks';
 
 jest.mock( '@automattic/calypso-config', () => require( './mocks/config' ) );
 jest.mock( 'calypso/lib/analytics/ad-tracking', () => ( {
 	retarget: () => {},
 	recordAliasInFloodlight: jest.fn(),
 } ) );
-import { loadScript } from '@automattic/load-script';
 
 jest.mock( '@automattic/load-script', () => ( {
 	loadScript: jest.fn( () => Promise.reject() ),

--- a/client/lib/analytics/test/mocks/lib/load-script/index.js
+++ b/client/lib/analytics/test/mocks/lib/load-script/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { defer } from 'lodash';
 
 function fakeLoader( url, callback ) {

--- a/client/lib/analytics/test/statsd-utils.js
+++ b/client/lib/analytics/test/statsd-utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import url from 'url';
-
-/**
- * Internal dependencies
- */
 import { statsdTimingUrl, statsdCountingUrl } from '../statsd-utils';
 
 describe( 'StatsD Analytics Utils', () => {

--- a/client/lib/analytics/test/utils.js
+++ b/client/lib/analytics/test/utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { shouldReportOmitBlogId, hashPii } from '../utils';
 
 describe( 'hashPii', () => {

--- a/client/lib/analytics/timing.js
+++ b/client/lib/analytics/timing.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
+import { getMostRecentUrlPath } from '@automattic/calypso-analytics';
 import { gaRecordTiming } from './ga';
 import { statsdRecordTiming } from './statsd';
-import { getMostRecentUrlPath } from '@automattic/calypso-analytics';
 
 export function recordTiming( eventType, duration, triggerName ) {
 	const urlPath = getMostRecentUrlPath() || 'unknown';

--- a/client/lib/analytics/track-affiliate-referral.js
+++ b/client/lib/analytics/track-affiliate-referral.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { pick } from 'lodash';
 import debug from 'debug';
-
-/**
- * Internal dependencies
- */
+import { pick } from 'lodash';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const referDebug = debug( 'calypso:analytics:refer' );

--- a/client/lib/analytics/track-component-view/README.md
+++ b/client/lib/analytics/track-component-view/README.md
@@ -14,7 +14,7 @@ Render the component passing one or both of:
 ```jsx
 <ContainerComponent>
 	<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-</ContainerComponent>;
+</ContainerComponent>
 ```
 
 It does not accept any children, nor does it render any elements to the page.

--- a/client/lib/analytics/track-component-view/index.jsx
+++ b/client/lib/analytics/track-component-view/index.jsx
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**

--- a/client/lib/analytics/tracks.js
+++ b/client/lib/analytics/tracks.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { EventEmitter } from 'events';
-
-/**
- * Internal dependencies
- */
 import {
 	recordTracksEvent as baseRecordTracksEvent,
 	analyticsEvents,

--- a/client/lib/analytics/utils/debug.js
+++ b/client/lib/analytics/utils/debug.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 
 /**

--- a/client/lib/analytics/utils/hash-pii.js
+++ b/client/lib/analytics/utils/hash-pii.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import sha256 from 'hash.js/lib/hash/sha/256';
 
 /**

--- a/client/lib/analytics/utils/is-ad-tracking-allowed.js
+++ b/client/lib/analytics/utils/is-ad-tracking-allowed.js
@@ -1,12 +1,9 @@
-/**
- * Internal dependencies
- */
+import { getDoNotTrack } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import debug from './debug';
-import isUrlExcludedForPerformance from './is-url-excluded-for-performance';
 import isPiiUrl from './is-pii-url';
+import isUrlExcludedForPerformance from './is-url-excluded-for-performance';
 import mayWeTrackCurrentUserGdpr from './may-we-track-current-user-gdpr';
-import { getDoNotTrack } from '@automattic/calypso-analytics';
 /**
  * Returns whether ad tracking is allowed.
  *

--- a/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.js
+++ b/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import cookie from 'cookie';
 import { includes } from 'lodash';
 

--- a/client/lib/analytics/utils/is-pii-url.js
+++ b/client/lib/analytics/utils/is-pii-url.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import debug from './debug';
 
 // If this list catches things that are not necessarily forbidden we're ok with

--- a/client/lib/analytics/utils/is-url-excluded-for-performance.js
+++ b/client/lib/analytics/utils/is-url-excluded-for-performance.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import debug from './debug';
 
 // For better load performance, these routes are excluded from loading ads.

--- a/client/lib/analytics/utils/may-we-track-current-user-gdpr.js
+++ b/client/lib/analytics/utils/may-we-track-current-user-gdpr.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import cookie from 'cookie';
-
-/**
- * Internal dependencies
- */
 import debug from './debug';
 import isCurrentUserMaybeInGdprZone from './is-current-user-maybe-in-gdpr-zone';
 

--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import cookie from 'cookie';
-
-/**
- * Internal dependencies
- */
 import debug from './debug';
 
 /**

--- a/client/lib/analytics/utils/save-coupon-query-argument.js
+++ b/client/lib/analytics/utils/save-coupon-query-argument.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import debug from './debug';
 import MARKETING_COUPONS_KEY from './marketing-coupons-key';
 import urlParseAmpCompatible from './url-parse-amp-compatible';

--- a/client/lib/analytics/utils/url-parse-amp-compatible.js
+++ b/client/lib/analytics/utils/url-parse-amp-compatible.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import debug from './debug';
 
 /**

--- a/client/lib/analytics/with-tracking-tool/README.md
+++ b/client/lib/analytics/with-tracking-tool/README.md
@@ -25,9 +25,9 @@ export default withTrackingTool( 'HotJar' )( MyComponent );
 When combined with other wrappers (like `localize()`):
 
 ```js
-import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
-import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
+import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 
 class MyComponent {
 	render() {

--- a/client/lib/analytics/with-tracking-tool/index.jsx
+++ b/client/lib/analytics/with-tracking-tool/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import { createHigherOrderComponent } from '@wordpress/compose';
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
 import { loadTrackingTool } from 'calypso/state/analytics/actions';
 
 export default ( trackingTool ) =>

--- a/client/lib/auth-helper/index.jsx
+++ b/client/lib/auth-helper/index.jsx
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import React from 'react';
 import ReactDom from 'react-dom';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import FormRadio from 'calypso/components/forms/form-radio';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 function AuthHelper() {

--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-
-import { get } from 'lodash';
-/**
- * Internal dependencies
- */
 import config, { isEnabled } from '@automattic/calypso-config';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import { get } from 'lodash';
 import { userCan } from 'calypso/lib/site/utils';
 
 /**

--- a/client/lib/automated-transfer/test/index.js
+++ b/client/lib/automated-transfer/test/index.js
@@ -9,10 +9,6 @@ jest.mock( 'calypso/lib/site/utils', () => ( {
 	userCan: jest.fn(),
 } ) );
 
-/**
- * External dependencies
- */
-import { assert } from 'chai';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -32,12 +28,8 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
-
-/**
- * Internal dependencies
- */
+import { assert } from 'chai';
 import { isATEnabled } from '../index';
-
 const config = require( '@automattic/calypso-config' );
 const utils = require( 'calypso/lib/site/utils' );
 

--- a/client/lib/browser-storage/bypass.ts
+++ b/client/lib/browser-storage/bypass.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
 import { StoredItems } from './types';
 
 const debug = debugModule( 'calypso:support-user' );

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -1,12 +1,7 @@
-/**
- * External dependencies
- */
-import { kebabCase } from 'lodash';
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { kebabCase } from 'lodash';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { once } from 'calypso/lib/memoize-last';
 import {
 	getStoredItem as bypassGet,
@@ -16,8 +11,6 @@ import {
 	activate as activateBypass,
 } from './bypass';
 import { StoredItems } from './types';
-import { bumpStat } from 'calypso/lib/analytics/mc';
-import config from '@automattic/calypso-config';
 
 const debug = debugFactory( 'calypso:browser-storage' );
 

--- a/client/lib/browser-storage/test/bypass.js
+++ b/client/lib/browser-storage/test/bypass.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import {
 	clearStorage,
 	setStoredItem,

--- a/client/lib/browser-storage/test/indexed-db.js
+++ b/client/lib/browser-storage/test/indexed-db.js
@@ -2,14 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import 'fake-indexeddb/auto'; // Polyfill indexedDB for this set of tests.
 
-/**
- * Internal dependencies
- */
 import {
 	supportsIDB,
 	clearStorage,

--- a/client/lib/browser-storage/test/local-storage.js
+++ b/client/lib/browser-storage/test/local-storage.js
@@ -4,9 +4,6 @@
 
 // No IndexedDB support, so the library will default to localStorage.
 
-/**
- * Internal dependencies
- */
 import {
 	supportsIDB,
 	clearStorage,

--- a/client/lib/build-url/test/index.js
+++ b/client/lib/build-url/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { buildRelativeSearchUrl } from '..';
 
 describe( 'buildRelativeSearchUrl', () => {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1,11 +1,3 @@
-/**
- * Internal dependencies
- */
-import {
-	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-	GSUITE_EXTRA_LICENSE_SLUG,
-} from 'calypso/lib/gsuite/constants';
-import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import {
 	formatProduct,
 	isCustomDesign,
@@ -44,6 +36,11 @@ import {
 } from '@automattic/calypso-products';
 import { getTld } from 'calypso/lib/domains';
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+	GSUITE_EXTRA_LICENSE_SLUG,
+} from 'calypso/lib/gsuite/constants';
+import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 
 /**
  * Retrieves all the items in the specified shopping cart.

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { hasRenewalItem } from './cart-items';
 import {
 	isCredits,
 	isDomainRedemption,
 	allowedProductAttributes,
 } from '@automattic/calypso-products';
+import { translate } from 'i18n-calypso';
+import { hasRenewalItem } from './cart-items';
 
 export function canRemoveFromCart( cart, cartItem ) {
 	if ( isCredits( cartItem ) ) {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -1,3 +1,4 @@
+import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
 import {
 	PLAN_FREE,
 	PLAN_BLOGGER,
@@ -16,10 +17,8 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_DAILY,
 } from '@automattic/calypso-products';
-import { GSUITE_BASIC_SLUG } from 'calypso/lib/gsuite/constants';
-
-const cartItems = require( '../cart-items' );
 const { getPlan, getTermDuration } = require( '@automattic/calypso-products' );
+const cartItems = require( '../cart-items' );
 const {
 	planItem,
 	isNextDomainFree,
@@ -31,10 +30,6 @@ const {
 	getRenewalItemFromProduct,
 	supportsPrivacyProtectionPurchase,
 } = cartItems;
-
-/**
- * External dependencies
- */
 
 describe( 'planItem()', () => {
 	test( 'should return null for free plan', () => {

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import assert from 'assert';
-
-/**
- * Internal Dependencies
- */
-import * as cartValues from '../index';
 import * as cartItems from '../cart-items';
+import * as cartValues from '../index';
 
 describe( 'index', () => {
 	const TEST_BLOG_ID = 1;

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-import TraceKit from 'tracekit';
 import debug from 'debug';
-
+import TraceKit from 'tracekit';
 import wpcom from 'calypso/lib/wp';
 
 /**

--- a/client/lib/catch-js-errors/log.js
+++ b/client/lib/catch-js-errors/log.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:catch-js-errors:log' );

--- a/client/lib/checklist/index.js
+++ b/client/lib/checklist/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { memoize, pick } from 'lodash';
 
 class WpcomTaskList {

--- a/client/lib/checkout/masking.js
+++ b/client/lib/checkout/masking.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getCreditCardType } from 'calypso/lib/checkout';
 
 /**

--- a/client/lib/checkout/payment-methods.ts
+++ b/client/lib/checkout/payment-methods.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-
-/**
- * Image assets
- */
 import creditCardAmexImage from 'calypso/assets/images/upgrades/cc-amex.svg';
 import creditCardDinersImage from 'calypso/assets/images/upgrades/cc-diners.svg';
 import creditCardDiscoverImage from 'calypso/assets/images/upgrades/cc-discover.svg';

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -2,13 +2,9 @@
  * External dependencies
  *
  */
+import { CPF, CNPJ } from 'cpf_cnpj';
 import i18n from 'i18n-calypso';
 import { pick } from 'lodash';
-import { CPF, CNPJ } from 'cpf_cnpj';
-
-/**
- * Internal dependencies
- */
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'calypso/lib/checkout/constants';
 import isPaymentMethodEnabled from 'calypso/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled';
 import { translateWpcomPaymentMethodToCheckoutPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';

--- a/client/lib/checkout/test/ebanx.js
+++ b/client/lib/checkout/test/ebanx.js
@@ -2,13 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
-
-/**
- * Internal dependencies
- */
 import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	isValidCPF,

--- a/client/lib/checkout/test/masking.js
+++ b/client/lib/checkout/test/masking.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { formatCreditCard, maskField, unmaskField } from '../masking';
 
 describe( 'Masking', () => {

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -2,14 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
+import * as processorSpecificMethods from '../processor-specific';
 import {
 	validatePaymentDetails,
 	getCreditCardType,
@@ -17,7 +11,6 @@ import {
 	getCreditCardFieldRules,
 	mergeValidationRules,
 } from '../validation';
-import * as processorSpecificMethods from '../processor-specific';
 
 jest.mock( '../processor-specific', () => {
 	const realProcessorSpecificMethods = jest.requireActual( '../processor-specific' );

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import creditcards from 'creditcards';
-import { capitalize, compact, isEmpty, mergeWith } from 'lodash';
-import i18n from 'i18n-calypso';
 import { isValidPostalCode } from '@automattic/wpcom-checkout';
-
-/**
- * Internal dependencies
- */
+import creditcards from 'creditcards';
+import i18n from 'i18n-calypso';
+import { capitalize, compact, isEmpty, mergeWith } from 'lodash';
 import {
 	isValidCPF,
 	isValidCNPJ,

--- a/client/lib/compare-props/index.js
+++ b/client/lib/compare-props/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { includes, isEqual } from 'lodash';
 
 export default ( options = {} ) => {

--- a/client/lib/compare-props/test/index.js
+++ b/client/lib/compare-props/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import compareProps from '..';
 
 describe( 'compare-props', () => {

--- a/client/lib/css-safe-url/index.js
+++ b/client/lib/css-safe-url/index.js
@@ -1,11 +1,3 @@
-/**
- * External dependencies
- */
-
-/**
- * Internal Dependencies
- */
-
 export default function cssSafeUrl( url ) {
 	return url && url.replace( /([()])/g, '\\$1' );
 }

--- a/client/lib/css-safe-url/test/index.js
+++ b/client/lib/css-safe-url/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import cssSafeUrl from '../';
 
 describe( 'css-safe-url', () => {

--- a/client/lib/data-poller/index.js
+++ b/client/lib/data-poller/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:poller' );
-
-/**
- * Internal dependencies
- */
 import Poller from './poller';
 
+const debug = debugFactory( 'calypso:poller' );
 const _pollers = {};
 
 function add( dataStore, fetcher, options ) {

--- a/client/lib/data-poller/poller.js
+++ b/client/lib/data-poller/poller.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:poller' );
 

--- a/client/lib/desktop-listeners/index.js
+++ b/client/lib/desktop-listeners/index.js
@@ -1,22 +1,15 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import { newPost } from 'calypso/lib/paths';
-import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { navigate } from 'calypso/lib/navigate';
 import * as oAuthToken from 'calypso/lib/oauth-token';
+import { newPost } from 'calypso/lib/paths';
 import { getStatsPathForTab } from 'calypso/lib/route';
-import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
-import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET } from 'calypso/state/desktop/window-events';
 import { setForceRefresh as forceNotificationsRefresh } from 'calypso/state/notifications-panel/actions';
-import { navigate } from 'calypso/lib/navigate';
-import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 
 /**
  * Module variables

--- a/client/lib/detect-history-navigation/README.md
+++ b/client/lib/detect-history-navigation/README.md
@@ -5,8 +5,8 @@ This module determines when a page has been rendered via the history event (back
 This can be used alongside the [page.js module](https://www.npmjs.com/package/page) by calling the `start()` method of this module _prior_ to the `start()` method of `page.js`.
 
 ```js
-import page from 'page';
 import detectHistoryNavigation from 'detect-history-navigation';
+import page from 'page';
 
 detectHistoryNavigation.start();
 page.start();

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -6,20 +6,10 @@
  * @see https:
  */
 
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import { loadScript } from '@automattic/load-script';
 import wpcom from 'calypso/lib/wp';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 const DIRECTLY_RTM_SCRIPT_URL = 'https://widgets.wp.com/directly/embed.js';

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import nock from 'nock';
 
 jest.mock( '@automattic/load-script', () => ( { loadScript: jest.fn() } ) );

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	GROUP_JETPACK,
 	GROUP_WPCOM,

--- a/client/lib/discounts/index.js
+++ b/client/lib/discounts/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import activeDiscounts from './active-discounts';
 
 function getDiscountByName( discountName, endsAt = null ) {

--- a/client/lib/domains/can-redirect.js
+++ b/client/lib/domains/can-redirect.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import inherits from 'inherits';
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 function ValidationError( code ) {

--- a/client/lib/domains/cart-utils.js
+++ b/client/lib/domains/cart-utils.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { isEmpty, find, values } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { hasDomainRegistration, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { isDomainRegistration } from '@automattic/calypso-products';
+import { isEmpty, find, values } from 'lodash';
+import { hasDomainRegistration, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 
 /**
  * Depending on the current step in checkout, the user's domain can be found in

--- a/client/lib/domains/check-auth-code.js
+++ b/client/lib/domains/check-auth-code.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function checkAuthCode( domainName, authCode, onComplete ) {

--- a/client/lib/domains/check-domain-availability.js
+++ b/client/lib/domains/check-domain-availability.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 import { domainAvailability } from './constants';
 

--- a/client/lib/domains/check-inbound-transfer-status.js
+++ b/client/lib/domains/check-inbound-transfer-status.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function checkInboundTransferStatus( domainName, onComplete ) {

--- a/client/lib/domains/email-forwarding/has-email-forwards.js
+++ b/client/lib/domains/email-forwarding/has-email-forwards.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getEmailForwardsCount } from 'calypso/lib/domains/email-forwarding/get-email-forwards-count';
 
 /**

--- a/client/lib/domains/email-forwarding/index.js
+++ b/client/lib/domains/email-forwarding/index.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { mapValues } from 'lodash';
 import emailValidator from 'email-validator';
+import { mapValues } from 'lodash';
 
 function validateAllFields( fieldValues ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {

--- a/client/lib/domains/get-available-tlds.js
+++ b/client/lib/domains/get-available-tlds.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function getAvailableTlds( query = {} ) {

--- a/client/lib/domains/get-domain-price.js
+++ b/client/lib/domains/get-domain-price.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import { getUnformattedDomainPrice } from './get-unformatted-domain-price';
 
 export function getDomainPrice( slug, productsList, currencyCode, stripZeros = false ) {

--- a/client/lib/domains/get-domain-product-slug.js
+++ b/client/lib/domains/get-domain-product-slug.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getTld } from './get-tld';
 
 export function getDomainProductSlug( domain ) {

--- a/client/lib/domains/get-domain-sale-price.js
+++ b/client/lib/domains/get-domain-sale-price.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import formatCurrency from '@automattic/format-currency';
-
-/**
- * Internal dependencies
- */
 import { getUnformattedDomainSalePrice } from './get-unformatted-domain-sale-price';
 
 export function getDomainSalePrice( slug, productsList, currencyCode, stripZeros = false ) {

--- a/client/lib/domains/get-domain-suggestion-search.js
+++ b/client/lib/domains/get-domain-suggestion-search.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getFixedDomainSearch } from './get-fixed-domain-search';
 
 /*

--- a/client/lib/domains/get-domain-transfer-sale-price.js
+++ b/client/lib/domains/get-domain-transfer-sale-price.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { get } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
+import { get } from 'lodash';
 
 export function getDomainTransferSalePrice( slug, productsList, currencyCode ) {
 	const saleCost = get( productsList, [ slug, 'sale_cost' ], null );

--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { type as domainTypes } from './constants';
 
 /**

--- a/client/lib/domains/get-primary-domain.js
+++ b/client/lib/domains/get-primary-domain.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function getPrimaryDomain( siteId, onComplete ) {

--- a/client/lib/domains/get-selection-domain.js
+++ b/client/lib/domains/get-selection-domain.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { type as domainTypes } from './constants';
 
 export function getSelectedDomain( { domains, selectedDomainName, isSiteRedirect = false } ) {

--- a/client/lib/domains/get-tld.js
+++ b/client/lib/domains/get-tld.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { parseDomainAgainstTldList } from './utils';
 import wpcomMultiLevelTlds from './tlds/wpcom-multi-level-tlds.json';
+import { parseDomainAgainstTldList } from './utils';
 
 /**
  * Parse the tld from a given domain name, semi-naively. The function

--- a/client/lib/domains/get-unformatted-domain-price.js
+++ b/client/lib/domains/get-unformatted-domain-price.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 export function getUnformattedDomainPrice( slug, productsList ) {

--- a/client/lib/domains/get-unformatted-domain-sale-price.js
+++ b/client/lib/domains/get-unformatted-domain-sale-price.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 export function getUnformattedDomainSalePrice( slug, productsList ) {

--- a/client/lib/domains/get-wpcom-domain.js
+++ b/client/lib/domains/get-wpcom-domain.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { type as domainTypes } from './constants';
 
 export function getWpcomDomain( domainObjects ) {

--- a/client/lib/domains/is-domain-in-grace-period.js
+++ b/client/lib/domains/is-domain-in-grace-period.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
 
 export function isDomainInGracePeriod( domain ) {

--- a/client/lib/domains/is-hsts-required.js
+++ b/client/lib/domains/is-hsts-required.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { find, get } from 'lodash';
 
 export function isHstsRequired( productSlug, productsList ) {

--- a/client/lib/domains/mapped-domains.js
+++ b/client/lib/domains/mapped-domains.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { type as domainTypes } from './constants';
 
 export function isMappedDomain( domain ) {

--- a/client/lib/domains/registered-domains.js
+++ b/client/lib/domains/registered-domains.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { type as domainTypes } from './constants';
 
 export function getRegisteredDomains( domains ) {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -1,22 +1,15 @@
 /* eslint-disable no-case-declarations */
 
-/**
- * External dependencies
- */
-import React from 'react';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import { getTld } from 'calypso/lib/domains';
+import { domainAvailability } from 'calypso/lib/domains/constants';
 import {
 	CALYPSO_CONTACT,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	MAP_EXISTING_DOMAIN,
 } from 'calypso/lib/url/support';
-import { domainAvailability } from 'calypso/lib/domains/constants';
 import {
 	domainManagementTransferToOtherSite,
 	domainManagementTransferIn,

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -2,11 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
-import { getAvailabilityNotice } from '../availability-messages';
 import { domainAvailability } from 'calypso/lib/domains/constants';
+import { getAvailabilityNotice } from '../availability-messages';
 
 jest.mock( 'i18n-calypso', () => ( {
 	translate: jest.fn( () => 'default' ),

--- a/client/lib/domains/request-gdpr-consent-management-link.js
+++ b/client/lib/domains/request-gdpr-consent-management-link.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function requestGdprConsentManagementLink( domainName, onComplete ) {

--- a/client/lib/domains/resend-icann-verification.js
+++ b/client/lib/domains/resend-icann-verification.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function resendIcannVerification( domainName, onComplete ) {

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
-import { transferStatus, type as domainTypes } from './constants';
+import React from 'react';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
 import { shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
 import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
+import { transferStatus, type as domainTypes } from './constants';
 
 export function resolveDomainStatus(
 	domain,

--- a/client/lib/domains/start-inbound-transfer.js
+++ b/client/lib/domains/start-inbound-transfer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function startInboundTransfer( siteId, domainName, authCode, onComplete ) {

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 import { getDomainSuggestionsVendor } from '@automattic/domain-picker';
 

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { forEach } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getFixedDomainSearch, getDomainSuggestionSearch } from 'calypso/lib/domains';
 
 describe( 'index', () => {

--- a/client/lib/domains/utils/get-domain-type.js
+++ b/client/lib/domains/utils/get-domain-type.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 
 export function getDomainType( domainFromApi ) {

--- a/client/lib/domains/utils/get-gdpr-consent-status.js
+++ b/client/lib/domains/utils/get-gdpr-consent-status.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { gdprConsentStatus } from 'calypso/lib/domains/constants';
 
 export function getGdprConsentStatus( domainFromApi ) {

--- a/client/lib/domains/utils/get-transfer-status.js
+++ b/client/lib/domains/utils/get-transfer-status.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { transferStatus } from 'calypso/lib/domains/constants';
 
 export function getTransferStatus( domainFromApi ) {

--- a/client/lib/domains/utils/is-expiring-soon.js
+++ b/client/lib/domains/utils/is-expiring-soon.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
 
 export function isExpiringSoon( domain, expiresWithinDays ) {

--- a/client/lib/domains/utils/is-recently-registered.js
+++ b/client/lib/domains/utils/is-recently-registered.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
 
 export function isRecentlyRegistered( registrationDate ) {

--- a/client/lib/domains/utils/test/parse-domain-against-tld-list.js
+++ b/client/lib/domains/utils/test/parse-domain-against-tld-list.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { parseDomainAgainstTldList } from '../';
 
 describe( 'parseDomainAgainstTldList', () => {

--- a/client/lib/domains/whois/test/utils.js
+++ b/client/lib/domains/whois/test/utils.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { findRegistrantWhois, findPrivacyServiceWhois } from '../utils';
 import { whoisType } from '../constants';
+import { findRegistrantWhois, findPrivacyServiceWhois } from '../utils';
 
 describe( 'utils', () => {
 	const whoisData = [

--- a/client/lib/domains/whois/utils.js
+++ b/client/lib/domains/whois/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { whoisType } from './constants';
 
 export function findRegistrantWhois( whoisContacts ) {

--- a/client/lib/emails/has-google-account-t-o-s-warning.js
+++ b/client/lib/emails/has-google-account-t-o-s-warning.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { accountHasWarningWithSlug } from './account-has-warning-with-slug';
 import { EMAIL_WARNING_SLUG_GOOGLE_ACCOUNT_TOS } from './email-provider-constants';
 

--- a/client/lib/emails/has-paid-email-with-us.js
+++ b/client/lib/emails/has-paid-email-with-us.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 

--- a/client/lib/emails/has-unused-mailbox-warning.js
+++ b/client/lib/emails/has-unused-mailbox-warning.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { accountHasWarningWithSlug } from './account-has-warning-with-slug';
 import { EMAIL_WARNING_SLUG_UNUSED_MAILBOXES } from './email-provider-constants';
 

--- a/client/lib/emails/has-unverified-email-forward.js
+++ b/client/lib/emails/has-unverified-email-forward.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS } from './email-provider-constants';
 
 /**

--- a/client/lib/emails/is-email-forward-account.js
+++ b/client/lib/emails/is-email-forward-account.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from './email-provider-constants';
 
 export function isEmailForwardAccount( emailAccount ) {

--- a/client/lib/emails/is-email-forward.js
+++ b/client/lib/emails/is-email-forward.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { EMAIL_TYPE_FORWARD } from './email-provider-constants';
 
 export function isEmailForward( emailUser ) {

--- a/client/lib/emails/is-email-user-admin.js
+++ b/client/lib/emails/is-email-user-admin.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { EMAIL_USER_ROLE_ADMIN } from './email-provider-constants';
 
 export function isEmailUserAdmin( emailUser ) {

--- a/client/lib/emails/is-google-email-account.js
+++ b/client/lib/emails/is-google-email-account.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE,
 	EMAIL_ACCOUNT_TYPE_GSUITE,

--- a/client/lib/emails/is-titan-mail-account.js
+++ b/client/lib/emails/is-titan-mail-account.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
 	EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL,

--- a/client/lib/embed-frame-markup/index.jsx
+++ b/client/lib/embed-frame-markup/index.jsx
@@ -1,12 +1,9 @@
 // Here be dragons...
 /* eslint-disable react/no-danger */
 
-/**
- * External dependencies
- */
+import { flatMap, map } from 'lodash';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { flatMap, map } from 'lodash';
 
 /**
  * Constants

--- a/client/lib/embed-frame-markup/test/index.jsx
+++ b/client/lib/embed-frame-markup/test/index.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import generateEmbedFrameMarkup from '../';
 
 describe( '#generateEmbedFrameMarkup()', () => {

--- a/client/lib/explat/index.ts
+++ b/client/lib/explat/index.ts
@@ -1,12 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { createExPlatClient } from '@automattic/explat-client';
 import createExPlatClientReactHelpers from '@automattic/explat-client-react-helpers';
-
-/**
- * Internal dependencies
- */
 import { getAnonId, initializeAnonId } from './internals/anon-id';
 import fetchExperimentAssignment from './internals/fetch-experiment-assignment';
 import { logError } from './internals/log-error';

--- a/client/lib/explat/internals/anon-id.ts
+++ b/client/lib/explat/internals/anon-id.ts
@@ -1,16 +1,9 @@
-/**
- * WordPress dependencies
- */
 import {
 	getCurrentUser,
 	recordTracksEvent,
 	getTracksAnonymousUserId,
 	getTracksLoadPromise,
 } from '@automattic/calypso-analytics';
-
-/**
- * Internal dependencies
- */
 import { logError } from './log-error';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check

--- a/client/lib/explat/internals/fetch-experiment-assignment.ts
+++ b/client/lib/explat/internals/fetch-experiment-assignment.ts
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check

--- a/client/lib/explat/internals/log-error.ts
+++ b/client/lib/explat/internals/log-error.ts
@@ -1,11 +1,4 @@
-/**
- * WordPress dependencies
- */
 import wpcom from 'calypso/lib/wp';
-
-/**
- * Internal dependencies
- */
 import { getLogger } from 'calypso/server/lib/logger';
 import { isDevelopmentMode } from './misc';
 

--- a/client/lib/explat/internals/test/anon-id.ts
+++ b/client/lib/explat/internals/test/anon-id.ts
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import '@automattic/calypso-polyfills';
 
 import * as AnonId from '../anon-id';

--- a/client/lib/explat/internals/test/log-error.ts
+++ b/client/lib/explat/internals/test/log-error.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 import * as Logger from 'calypso/server/lib/logger';
 import { logError } from '../log-error';

--- a/client/lib/explat/test/index.ts
+++ b/client/lib/explat/test/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import * as ExPlatClient from '../index';
 
 const mockLogError = jest.fn();

--- a/client/lib/features-helper/feature-list.js
+++ b/client/lib/features-helper/feature-list.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
+import React from 'react';
 
 const headerClass = 'features-helper__feature-header';
 const itemClass = 'features-helper__feature-item';

--- a/client/lib/features-helper/index.js
+++ b/client/lib/features-helper/index.js
@@ -1,17 +1,7 @@
-/**
- * External dependencies
- */
-import ReactDom from 'react-dom';
 import React from 'react';
-
-/**
- * Internal dependencies
- */
+import ReactDom from 'react-dom';
 import FeatureList from './feature-list';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 /**

--- a/client/lib/flags/test/index.js
+++ b/client/lib/flags/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { flagUrl } from '..';
 
 describe( 'flagUrl', () => {

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -1,6 +1,4 @@
-/**
- * External dependencies
- */
+import update from 'immutability-helper';
 import {
 	camelCase,
 	debounce,
@@ -13,7 +11,6 @@ import {
 	property,
 	some,
 } from 'lodash';
-import update from 'immutability-helper';
 import { v4 as uuid } from 'uuid';
 
 function Controller( options ) {

--- a/client/lib/form-state/test/index.js
+++ b/client/lib/form-state/test/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { mapValues, zipObject } from 'lodash';
 import assert from 'assert';
-
-/**
- * Internal dependencies
- */
+import { mapValues, zipObject } from 'lodash';
 import formState from '../';
 
 function checkNthState( n, callback ) {

--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import i18n, { numberFormat } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { THOUSANDS } from './thousands';
 
 /**

--- a/client/lib/format-number-compact/test/index.js
+++ b/client/lib/format-number-compact/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import formatNumberCompact, { formatNumberMetric } from 'calypso/lib/format-number-compact';
 
 describe( 'formatNumberCompact', () => {

--- a/client/lib/formatting/decode-entities.js
+++ b/client/lib/formatting/decode-entities.js
@@ -1,6 +1,3 @@
-/**
- * Internal Dependencies
- */
 import decode from './decode';
 
 export function decodeEntities( text ) {

--- a/client/lib/formatting/decode/test/browser.js
+++ b/client/lib/formatting/decode/test/browser.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import decodeEntities from '../browser';
 
 describe( 'decodeEntities', () => {

--- a/client/lib/formatting/decode/test/node.js
+++ b/client/lib/formatting/decode/test/node.js
@@ -1,9 +1,6 @@
 /**
  */
 
-/**
- * Internal dependencies
- */
 import decodeEntities from '../node';
 
 describe( 'decodeEntities', () => {

--- a/client/lib/formatting/prevent-widows.js
+++ b/client/lib/formatting/prevent-widows.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 /**

--- a/client/lib/formatting/removep.js
+++ b/client/lib/formatting/removep.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { hasGutenbergBlocks } from './has-gutenberg-blocks';
 
 export function removep( html ) {

--- a/client/lib/formatting/strip-html.js
+++ b/client/lib/formatting/strip-html.js
@@ -1,6 +1,3 @@
-/**
- * External Dependencies
- */
 import stripTags from 'striptags';
 
 /**

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { capitalPDangit, parseHtml, preventWidows } from '../index';
 
 describe( 'formatting', () => {

--- a/client/lib/formatting/unescape-and-format-spaces.js
+++ b/client/lib/formatting/unescape-and-format-spaces.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { decodeEntities } from './decode-entities';
 
 const nbsp = String.fromCharCode( 160 );

--- a/client/lib/formatting/wpautop.js
+++ b/client/lib/formatting/wpautop.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { hasGutenbergBlocks } from './has-gutenberg-blocks';
 
 /**

--- a/client/lib/geocoding/index.js
+++ b/client/lib/geocoding/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 

--- a/client/lib/geocoding/test/index.js
+++ b/client/lib/geocoding/test/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { geocode, reverseGeocode } from '../';
 
 jest.mock( '@automattic/load-script', () => require( './mocks/load-script' ).default );

--- a/client/lib/geocoding/test/mocks/load-script/index.js
+++ b/client/lib/geocoding/test/mocks/load-script/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { defer } from 'lodash';
 
 function fakeLoader( url, callback ) {

--- a/client/lib/get-asset-file-path/index.js
+++ b/client/lib/get-asset-file-path/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import path from 'path';
 
 export default function getAssetFilePath( target, filePath ) {

--- a/client/lib/gsuite/constants.js
+++ b/client/lib/gsuite/constants.js
@@ -1,14 +1,11 @@
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	GSUITE_BASIC_SLUG,
 	GSUITE_BUSINESS_SLUG,
 	GSUITE_EXTRA_LICENSE_SLUG,
 } from '@automattic/calypso-products';
+import PropTypes from 'prop-types';
+
 export {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	GSUITE_BASIC_SLUG,

--- a/client/lib/gsuite/get-annual-price.js
+++ b/client/lib/gsuite/get-annual-price.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 
 /**

--- a/client/lib/gsuite/get-eligible-gsuite-domain.js
+++ b/client/lib/gsuite/get-eligible-gsuite-domain.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get, sortBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { canDomainAddGSuite } from './can-domain-add-gsuite';
 import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
 

--- a/client/lib/gsuite/get-google-mail-service-family.js
+++ b/client/lib/gsuite/get-google-mail-service-family.js
@@ -1,6 +1,3 @@
-/**
- * Internal Dependencies
- */
 import {
 	GSUITE_PRODUCT_FAMILY,
 	GOOGLE_WORKSPACE_PRODUCT_FAMILY,

--- a/client/lib/gsuite/get-gsuite-mailbox-count.js
+++ b/client/lib/gsuite/get-gsuite-mailbox-count.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 export function getGSuiteMailboxCount( domain ) {

--- a/client/lib/gsuite/get-monthly-price.js
+++ b/client/lib/gsuite/get-monthly-price.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 
 /**

--- a/client/lib/gsuite/gsuite-product-type.js
+++ b/client/lib/gsuite/gsuite-product-type.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 	GOOGLE_WORKSPACE_PRODUCT_TYPE,

--- a/client/lib/gsuite/gsuite-supported-domain.js
+++ b/client/lib/gsuite/gsuite-supported-domain.js
@@ -1,10 +1,7 @@
-/**
- * Internal dependencies
- */
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'calypso/lib/domains';
 import { canDomainAddGSuite } from './can-domain-add-gsuite';
-import { hasGSuiteWithUs } from './has-gsuite-with-us';
 import { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
+import { hasGSuiteWithUs } from './has-gsuite-with-us';
 
 /**
  * Filters a list of domains by the domains that eligible for G Suite.

--- a/client/lib/gsuite/has-gsuite-with-another-provider.js
+++ b/client/lib/gsuite/has-gsuite-with-another-provider.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 /**

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 /**

--- a/client/lib/gsuite/has-pending-gsuite-users.js
+++ b/client/lib/gsuite/has-pending-gsuite-users.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 /**

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
 import emailValidator from 'email-validator';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { countBy, find, includes, groupBy, map, mapValues } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-
-/**
- * Internal dependencies
- */
 import { googleApps, googleAppsExtraLicenses } from 'calypso/lib/cart-values/cart-items';
 import {
 	getGSuiteMailboxCount,
@@ -17,6 +9,7 @@ import {
 	isGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
 } from 'calypso/lib/gsuite';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	canDomainAddGSuite,
 	getAnnualPrice,

--- a/client/lib/gsuite/utils/format-price.js
+++ b/client/lib/gsuite/utils/format-price.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import formatCurrency from '@automattic/format-currency';
 
 /**

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import IO from 'socket.io-client';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import IO from 'socket.io-client';
 import {
 	receiveAccept,
 	receiveConnect,

--- a/client/lib/happychat/test/index.js
+++ b/client/lib/happychat/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { EventEmitter } from 'events';
-
-/**
- * Internal dependencies
- */
 import {
 	receiveAccept,
 	receiveConnect,

--- a/client/lib/highlight/index.js
+++ b/client/lib/highlight/index.js
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import { compact } from 'lodash';
 import debugFactory from 'debug';
+import { compact } from 'lodash';
 const debug = debugFactory( 'calypso:highlight' );
 
 /**

--- a/client/lib/highlight/test/index.js
+++ b/client/lib/highlight/test/index.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
-import highlight from '../';
-
-/**
- * External dependencies
- */
 import { expect } from 'chai';
+import highlight from '../';
 
 describe( 'highlight', () => {
 	describe( 'unit test', () => {

--- a/client/lib/hover-intent/README.md
+++ b/client/lib/hover-intent/README.md
@@ -32,8 +32,8 @@ Default `interval: 700`
 ## Example
 
 ```javascript
-import HoverIntent from 'calypso/lib/hover-intent';
 import classnames from 'classnames';
+import HoverIntent from 'calypso/lib/hover-intent';
 
 class App extends Component {
 	constructor() {

--- a/client/lib/hover-intent/index.js
+++ b/client/lib/hover-intent/index.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 class HoverIntent extends Component {
 	constructor() {

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
 import moment from 'moment';
 

--- a/client/lib/human-date/test/index.js
+++ b/client/lib/human-date/test/index.js
@@ -2,11 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
-import humanDate from '..';
 import moment from 'moment';
+import humanDate from '..';
 
 describe( 'humanDate', () => {
 	it( 'should work without a provided format or locale', () => {

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
 
 export {

--- a/client/lib/i18n-utils/empathy-mode.js
+++ b/client/lib/i18n-utils/empathy-mode.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import i18n, { I18N, translate } from 'i18n-calypso';
 
 let defaultUntranslatedPlacehoder = translate( "I don't understand" );

--- a/client/lib/i18n-utils/glotpress.js
+++ b/client/lib/i18n-utils/glotpress.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import { GP_BASE_URL } from './constants';
 
 const debug = debugFactory( 'calypso:i18n-utils:glotpress' );

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 // we cannot use the following export

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import i18n from 'i18n-calypso';
-import debugFactory from 'debug';
-import { forEach, throttle } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { isDefaultLocale, getLanguage } from './utils';
 import { getUrlFromParts, getUrlParts } from '@automattic/calypso-url';
+import debugFactory from 'debug';
+import i18n from 'i18n-calypso';
+import { forEach, throttle } from 'lodash';
+import { isDefaultLocale, getLanguage } from './utils';
 
 const debug = debugFactory( 'calypso:i18n' );
 

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { startsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	getLanguageFilePathUrl,
 	getLanguageFileUrl,

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -1,10 +1,3 @@
-/**
- * External dependencies
- */
-
-/**
- * Internal dependencies
- */
 import {
 	addLocaleToPath,
 	getLanguage,

--- a/client/lib/i18n-utils/translation-scanner.js
+++ b/client/lib/i18n-utils/translation-scanner.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { debounce } from 'lodash';
-import { registerTranslateHook } from 'i18n-calypso';
 import cookie from 'cookie';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { registerTranslateHook } from 'i18n-calypso';
+import { debounce } from 'lodash';
 import { recordOriginals, encodeOriginalKey } from './glotpress';
 
 const debug = debugFactory( 'calypso:translation-scanner' );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import { find, map, pickBy, includes } from 'lodash';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
-import { localizeUrl as _localizeUrl } from '@automattic/i18n-utils';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import languages from '@automattic/languages';
 import { getUrlParts } from '@automattic/calypso-url';
+import { localizeUrl as _localizeUrl } from '@automattic/i18n-utils';
+import languages from '@automattic/languages';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
+import { find, map, pickBy, includes } from 'lodash';
 
 /**
  * a locale can consist of three component

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import React from 'react';
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { filter, orderBy, values } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
+import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 function getConfig( { siteTitle = '' } = {} ) {

--- a/client/lib/importer/test/utils.js
+++ b/client/lib/importer/test/utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { suggestDomainFromImportUrl } from '../utils';
 
 describe( 'suggestDomainFromImportUrl', () => {

--- a/client/lib/importer/url-validation.js
+++ b/client/lib/importer/url-validation.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import url from 'url';
 import { isURL } from '@wordpress/url';
 import { translate } from 'i18n-calypso';

--- a/client/lib/importer/utils.ts
+++ b/client/lib/importer/utils.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import url from 'url';
 import { trim } from 'lodash';
 

--- a/client/lib/interval/index.ts
+++ b/client/lib/interval/index.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { TimeoutMS } from 'calypso/types';
 
 export { Interval } from './interval';

--- a/client/lib/interval/interval.ts
+++ b/client/lib/interval/interval.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import { TimeoutMS } from 'calypso/types';
 import { useInterval } from './use-interval';
 

--- a/client/lib/interval/test/interval.tsx
+++ b/client/lib/interval/test/interval.tsx
@@ -2,16 +2,9 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
-
-/**
- * Internal dependencies
- */
 import { Interval, EVERY_SECOND, EVERY_MINUTE } from '../index';
 
 jest.useFakeTimers();

--- a/client/lib/interval/use-interval.ts
+++ b/client/lib/interval/use-interval.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useEffect, useRef } from 'react';
-
-/**
- * Internal dependencies
- */
 import type { TimeoutMS } from 'calypso/types';
 
 /**

--- a/client/lib/jetpack/actionable-rewind-id.ts
+++ b/client/lib/jetpack/actionable-rewind-id.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { useMemo } from 'react';
 
 type Activity = {

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
 
 export const INDEX_FORMAT = 'YYYYMMDD';

--- a/client/lib/jetpack/contact-support-url.js
+++ b/client/lib/jetpack/contact-support-url.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { JETPACK_CONTACT_SUPPORT } from 'calypso/lib/url/support';
 import { addQueryArgs } from 'calypso/lib/url';
+import { JETPACK_CONTACT_SUPPORT } from 'calypso/lib/url/support';
 
 /**
  * Creates a URL that refers to the Jetpack 'Contact Support' page,

--- a/client/lib/jetpack/get-calendly-url.ts
+++ b/client/lib/jetpack/get-calendly-url.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 const getCalendlyURL = (): string | null => {

--- a/client/lib/jetpack/hooks/use-date-with-offset.ts
+++ b/client/lib/jetpack/hooks/use-date-with-offset.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { Moment } from 'moment';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';

--- a/client/lib/jetpack/is-jetpack-cloud.ts
+++ b/client/lib/jetpack/is-jetpack-cloud.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 
 const jetpackCloudEnvironments = [

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { addQueryArgs } from 'calypso/lib/url';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { addQueryArgs } from 'calypso/lib/url';
 
 const backupBasePath = () => '/backup';
 export const backupPath = ( siteSlug?: string, query = {} ) => {

--- a/client/lib/jetpack/test/backup-utils.js
+++ b/client/lib/jetpack/test/backup-utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getBackupAttemptsForDate } from '../backup-utils';
 
 describe( 'getBackupAttemptsForDate', () => {

--- a/client/lib/jetpack/trigger-scan-run.ts
+++ b/client/lib/jetpack/trigger-scan-run.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	requestJetpackScanEnqueue,

--- a/client/lib/jetpack/types.ts
+++ b/client/lib/jetpack/types.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { ReactNode } from 'react';
 import type PageJS from 'page';
 import type Redux from 'redux';

--- a/client/lib/jetpack/use-target-url.ts
+++ b/client/lib/jetpack/use-target-url.ts
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import { useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import isJetpackCloudEligible from 'calypso/state/selectors/is-jetpack-cloud-eligible';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Constants

--- a/client/lib/jetpack/use-threats.ts
+++ b/client/lib/jetpack/use-threats.ts
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import { FixableThreat, Threat } from 'calypso/components/jetpack/threat-item/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fixAllThreats, fixThreat, ignoreThreat } from 'calypso/state/jetpack-scan/threats/actions';
-import { FixableThreat, Threat } from 'calypso/components/jetpack/threat-item/types';
 import getSiteScanUpdatingThreats from 'calypso/state/selectors/get-site-scan-updating-threats';
 
 export const useThreats = ( siteId: number ) => {

--- a/client/lib/jetpack/use-track-callback.ts
+++ b/client/lib/jetpack/use-track-callback.ts
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 

--- a/client/lib/jetpack/wpcom-upsell-controller.tsx
+++ b/client/lib/jetpack/wpcom-upsell-controller.tsx
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
-import type { Context } from './types';
+import React from 'react';
+import BusinessATSwitch from 'calypso/components/jetpack/business-at-switch';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import BusinessATSwitch from 'calypso/components/jetpack/business-at-switch';
+import type { Context } from './types';
 
 export default function upsellSwitch( UpsellComponent: typeof React.Component ): Function {
 	return ( context: Context, next: Function ) => {

--- a/client/lib/keyboard-shortcuts/global.js
+++ b/client/lib/keyboard-shortcuts/global.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { getStatsDefaultSitePage } from 'calypso/lib/route';
+import page from 'page';
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 import { reduxDispatch, reduxGetState } from 'calypso/lib/redux-bridge';
-import { getSectionGroup, getSelectedSite } from 'calypso/state/ui/selectors';
+import { getStatsDefaultSitePage } from 'calypso/lib/route';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getSectionGroup, getSelectedSite } from 'calypso/state/ui/selectors';
 
 let singleton;
 

--- a/client/lib/keyboard-shortcuts/index.js
+++ b/client/lib/keyboard-shortcuts/index.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
 import { flatMap } from 'lodash';
+import Emitter from 'calypso/lib/mixins/emitter';
+import KEY_BINDINGS from './key-bindings';
 
 // only require keymaster if this is a browser environment
 const keymaster = typeof window === 'undefined' ? undefined : require( 'keymaster' );
 const defaultFilter = keymaster ? keymaster.filter : undefined;
-
-/**
- * Internal dependencies
- */
-import Emitter from 'calypso/lib/mixins/emitter';
-import KEY_BINDINGS from './key-bindings';
 
 // Flatten the key-bindings object to create an array of key-bindings. `_.flatMap` converts
 // object in shape `{ c1: [ k1, k2 ], c2: [ k3, k4 ] }` to `[ k1, k2, k3, k4 ]`, i.e., flat-maps

--- a/client/lib/keyboard-shortcuts/menu.jsx
+++ b/client/lib/keyboard-shortcuts/menu.jsx
@@ -1,22 +1,11 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { Dialog } from '@automattic/components';
 import config from '@automattic/calypso-config';
+import { Dialog } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 import KEY_BINDINGS from 'calypso/lib/keyboard-shortcuts/key-bindings';
 
-/**
- * Style dependencies
- */
 import './menu.scss';
 
 class KeyboardShortcutsMenu extends React.Component {

--- a/client/lib/keyboard-shortcuts/test/index.js
+++ b/client/lib/keyboard-shortcuts/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import KeyboardShortcuts from 'calypso/lib/keyboard-shortcuts';
 
 describe( 'KeyboardShortcuts', () => {

--- a/client/lib/load-jquery-dependent-script-desktop-wrapper/index.js
+++ b/client/lib/load-jquery-dependent-script-desktop-wrapper/index.js
@@ -4,9 +4,6 @@
  * It needs to be loaded using require and npm package.
  */
 
-/**
- * External dependencies
- */
 import { loadjQueryDependentScript } from '@automattic/load-script';
 import debugFactory from 'debug';
 const debug = debugFactory( 'lib/load-jquery-dependent-script-desktop-wrapper' );

--- a/client/lib/local-storage-bypass/index.js
+++ b/client/lib/local-storage-bypass/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import debugModule from 'debug';
 
 const debug = debugModule( 'calypso:support-user' );

--- a/client/lib/local-storage-bypass/test/index.js
+++ b/client/lib/local-storage-bypass/test/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { spy } from 'sinon';
-
-/**
- * Internal dependencies
- */
 import { key, clear, setItem, getItem, removeItem, length } from '..';
 
 describe( 'localstorage-bypass', () => {

--- a/client/lib/local-storage-polyfill/index.js
+++ b/client/lib/local-storage-polyfill/index.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
 import localStorageBypass from '../local-storage-bypass';
 
 const debug = debugFactory( 'calypso:local-storage' );

--- a/client/lib/local-storage-polyfill/test/index.js
+++ b/client/lib/local-storage-polyfill/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import localStoragePolyfill from '..';
 
 describe( 'localStorage', () => {

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { get, includes, startsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
+import { get, includes, startsWith } from 'lodash';
 import {
 	isAkismetOAuth2Client,
 	isCrowdsignalOAuth2Client,

--- a/client/lib/logmein/index.ts
+++ b/client/lib/logmein/index.ts
@@ -4,17 +4,11 @@
  * This triggers a remote-login redirect flow that sets authentication cookies on the
  * mapped domain enabling the nav bar and other features.
  */
-/**
- * External Dependencies
- */
-import { Store } from 'redux';
 
-/**
- * Internal Dependencies
- */
-import getSitesItems from 'calypso/state/selectors/get-sites-items';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isEnabled } from '@automattic/calypso-config';
+import { Store } from 'redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
 
 // Used as placeholder / default domain to detect when we're looking at a relative url,
 // Note: also prevents exceptions from being raised

--- a/client/lib/logmein/test/index.js
+++ b/client/lib/logmein/test/index.js
@@ -3,14 +3,8 @@
  */
 import '@testing-library/jest-dom/extend-expect';
 
-/**
- * External Dependencies
- */
+import config from '@automattic/calypso-config';
 import { createStore } from 'redux';
-
-/**
- * Internal Dependencies
- */
 import {
 	logmeinUrl,
 	attachLogmein,
@@ -18,7 +12,6 @@ import {
 	logmeinOnRightClick,
 	setLogmeinReduxStore,
 } from '../';
-import config from '@automattic/calypso-config';
 
 jest.mock( '@automattic/calypso-config', () => {
 	const fn = () => '';

--- a/client/lib/make-json-schema-parser/index.js
+++ b/client/lib/make-json-schema-parser/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import schemaValidator from 'is-my-json-valid';
 import { get } from 'lodash';
 

--- a/client/lib/make-json-schema-parser/test/index.js
+++ b/client/lib/make-json-schema-parser/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import makeJsonSchemaParser from '..';
 
 describe( 'makeJsonSchemaParser', () => {

--- a/client/lib/media-serialization/create-element-from-string.js
+++ b/client/lib/media-serialization/create-element-from-string.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { domForHtml } from 'calypso/lib/post-normalizer/utils';
 
 /**

--- a/client/lib/media-serialization/detect-format.js
+++ b/client/lib/media-serialization/detect-format.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Formats, MediaTypes } from './constants';
 import { getMimePrefix } from 'calypso/lib/media/utils';
+import { Formats, MediaTypes } from './constants';
 
 /**
  * Module variables

--- a/client/lib/media-serialization/index.js
+++ b/client/lib/media-serialization/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import detectFormat from './detect-format';
 import Strategies from './strategies';
 

--- a/client/lib/media-serialization/strategies/api.js
+++ b/client/lib/media-serialization/strategies/api.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getMimePrefix } from 'calypso/lib/media/utils';
 import { MediaTypes } from '../constants';
 

--- a/client/lib/media-serialization/strategies/dom.js
+++ b/client/lib/media-serialization/strategies/dom.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { MediaTypes } from '../constants';
 
 /**

--- a/client/lib/media-serialization/strategies/index.js
+++ b/client/lib/media-serialization/strategies/index.js
@@ -1,11 +1,8 @@
-/**
- * Internal dependencies
- */
-import * as dom from './dom';
-import * as string from './string';
-import * as shortcode from './shortcode';
-import * as object from './object';
 import * as api from './api';
+import * as dom from './dom';
+import * as object from './object';
+import * as shortcode from './shortcode';
+import * as string from './string';
 import * as unknown from './unknown';
 
 export default { dom, string, shortcode, object, api, unknown };

--- a/client/lib/media-serialization/strategies/shortcode.js
+++ b/client/lib/media-serialization/strategies/shortcode.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { deserialize as _recurse } from '../';
 
 /**

--- a/client/lib/media-serialization/strategies/string.js
+++ b/client/lib/media-serialization/strategies/string.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { parse } from 'calypso/lib/shortcode';
 import { deserialize as _recurse } from '../';
 import createElementFromString from '../create-element-from-string';

--- a/client/lib/media-serialization/strategies/unknown.js
+++ b/client/lib/media-serialization/strategies/unknown.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { MediaTypes } from '../constants';
 
 /**

--- a/client/lib/media-serialization/test/index.js
+++ b/client/lib/media-serialization/test/index.js
@@ -2,14 +2,7 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { deserialize } from '../';
 import { MediaTypes } from '../constants';
 

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -2,17 +2,10 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import { map } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import * as MediaUtils from '../utils';
 import { ValidationErrors as MediaValidationErrors } from '../constants';
+import * as MediaUtils from '../utils';
 
 jest.mock( 'uuid', () => ( {
 	v4: () => 'someid',

--- a/client/lib/media/utils/create-transient-media-id.js
+++ b/client/lib/media/utils/create-transient-media-id.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { v4 as uuid } from 'uuid';
 
 /**

--- a/client/lib/media/utils/create-transient-media.js
+++ b/client/lib/media/utils/create-transient-media.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import path from 'path';
-
-/**
- * Internal dependencies
- */
+import { createTransientMediaId } from 'calypso/lib/media/utils';
 import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
-import { createTransientMediaId } from 'calypso/lib/media/utils';
 
 /**
  * Returns an object describing a transient media item which can be used in

--- a/client/lib/media/utils/filter-items-by-mime-prefix.js
+++ b/client/lib/media/utils/filter-items-by-mime-prefix.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getMimePrefix } from 'calypso/lib/media/utils/get-mime-prefix';
 
 /**

--- a/client/lib/media/utils/generate-gallery-shortcode.js
+++ b/client/lib/media/utils/generate-gallery-shortcode.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { includes, omitBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	GalleryColumnedTypes,
 	GalleryDefaultAttrs,

--- a/client/lib/media/utils/get-file-extension.js
+++ b/client/lib/media/utils/get-file-extension.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import path from 'path';
-import { isUri } from 'valid-url';
-
-/**
- * Internal dependencies
- */
 import { getUrlParts } from '@automattic/calypso-url';
+import { isUri } from 'valid-url';
 
 /**
  * Given a media string, File, or object, returns the file extension.

--- a/client/lib/media/utils/get-file-uploader.js
+++ b/client/lib/media/utils/get-file-uploader.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:media' );
-
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
+
+const debug = debugFactory( 'calypso:media' );
 
 export const getFileUploader = ( file, siteId, postId ) => {
 	// Determine upload mechanism by object type

--- a/client/lib/media/utils/get-mime-prefix.js
+++ b/client/lib/media/utils/get-mime-prefix.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
 
 /**

--- a/client/lib/media/utils/get-mime-type.js
+++ b/client/lib/media/utils/get-mime-type.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { MimeTypes } from 'calypso/lib/media/constants';
 import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
 

--- a/client/lib/media/utils/get-thumbnail-size-dimensions.js
+++ b/client/lib/media/utils/get-thumbnail-size-dimensions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { ThumbnailSizeDimensions } from 'calypso/lib/media/constants';
 
 /**

--- a/client/lib/media/utils/is-exceeding-site-max-upload-size.js
+++ b/client/lib/media/utils/is-exceeding-site-max-upload-size.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { includes, startsWith, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
 
 /**

--- a/client/lib/media/utils/is-supported-file-type-for-site.js
+++ b/client/lib/media/utils/is-supported-file-type-for-site.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { isSiteAllowedFileTypesToBeTrusted } from 'calypso/lib/media/utils/is-site-allowed-file-types-to-be-trusted';
 import { getAllowedFileTypesForSite } from 'calypso/lib/media/utils/get-allowed-file-types-for-site';
+import { isSiteAllowedFileTypesToBeTrusted } from 'calypso/lib/media/utils/is-site-allowed-file-types-to-be-trusted';
 
 /**
  * Returns true if the specified item is a valid file for the given site,

--- a/client/lib/media/utils/is-supported-file-type-in-premium.js
+++ b/client/lib/media/utils/is-supported-file-type-in-premium.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { VideoPressFileTypes } from 'calypso/lib/media/constants';
 import { isSiteAllowedFileTypesToBeTrusted } from 'calypso/lib/media/utils/is-site-allowed-file-types-to-be-trusted';
 

--- a/client/lib/media/utils/media-url-to-proxy-config.js
+++ b/client/lib/media/utils/media-url-to-proxy-config.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getUrlParts } from '@automattic/calypso-url';
 
 /**

--- a/client/lib/media/utils/test/create-transient-media-id.js
+++ b/client/lib/media/utils/test/create-transient-media-id.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { createTransientMediaId } from '../create-transient-media-id';
 
 describe( 'createTransientMediaId()', () => {

--- a/client/lib/media/utils/test/is-transient-media-id.js
+++ b/client/lib/media/utils/test/is-transient-media-id.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import isTransientMediaId from '../is-transient-media-id';
 
 describe( 'isTransientMediaId()', () => {

--- a/client/lib/media/utils/url.js
+++ b/client/lib/media/utils/url.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import photon from 'photon';
-
-/**
- * Internal dependencies
- */
 import resize from 'calypso/lib/resize-image-url';
 
 /**

--- a/client/lib/media/utils/validate-media-item.js
+++ b/client/lib/media/utils/validate-media-item.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { ValidationErrors as MediaValidationErrors } from 'calypso/lib/media/constants';
 import { isExceedingSiteMaxUploadSize } from 'calypso/lib/media/utils/is-exceeding-site-max-upload-size';
 import { isSupportedFileTypeForSite } from 'calypso/lib/media/utils/is-supported-file-type-for-site';

--- a/client/lib/memoize-last/test/index.js
+++ b/client/lib/memoize-last/test/index.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import memoizeLast, { once } from '../';
 
 describe( 'memoizeLast', () => {

--- a/client/lib/mixins/emitter/index.js
+++ b/client/lib/mixins/emitter/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { EventEmitter } from 'events';
 
 export default function ( prototype ) {

--- a/client/lib/mobile-app/test/index.js
+++ b/client/lib/mobile-app/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 
 describe( 'isWpMobileApp', () => {

--- a/client/lib/naive-client-side-rollout/index.ts
+++ b/client/lib/naive-client-side-rollout/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { getCurrentUser } from '@automattic/calypso-analytics';
 
 /**

--- a/client/lib/naive-client-side-rollout/test/index.ts
+++ b/client/lib/naive-client-side-rollout/test/index.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { getCurrentUser } from '@automattic/calypso-analytics';
-
-/**
- * Internal dependencies
- */
 import { badNaiveClientSideRollout } from '../index';
 
 jest.mock( '@automattic/calypso-analytics' );

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
 import { logmeinUrl } from 'calypso/lib/logmein';
 
 // Using page() for cross origin navigations would throw a `History.pushState` exception

--- a/client/lib/network-connection/index.js
+++ b/client/lib/network-connection/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import PollerPool from 'calypso/lib/data-poller';
 import Emitter from 'calypso/lib/mixins/emitter';
 import { connectionLost, connectionRestored } from 'calypso/state/application/actions';

--- a/client/lib/network-connection/test/index.js
+++ b/client/lib/network-connection/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
-import config from '@automattic/calypso-config';
 import NetworkConnectionApp from 'calypso/lib/network-connection';
 
 describe( 'index', () => {

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { compact, find } from 'lodash';
 
 /**

--- a/client/lib/oauth-token/index.js
+++ b/client/lib/oauth-token/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import cookie from 'cookie';
 import store from 'store';
 

--- a/client/lib/paste-to-link/index.jsx
+++ b/client/lib/paste-to-link/index.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { resemblesUrl } from 'calypso/lib/url';
 
 /**

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { filter, get, maxBy, startsWith } from 'lodash';
 import { getSections } from 'calypso/sections-helper';
 

--- a/client/lib/path-to-section/test/index.js
+++ b/client/lib/path-to-section/test/index.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { receiveSections } from 'calypso/sections-helper';
 import sections from 'calypso/sections';
+import { receiveSections } from 'calypso/sections-helper';
 import pathToSection from '..';
 
 describe( 'pathToSection', () => {

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 export { login } from './login';
 export { lostPassword } from './lost-password';
 

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { addQueryArgs } from 'calypso/lib/url';
 import { addLocaleToPath } from 'calypso/lib/i18n-utils';
+import { addQueryArgs } from 'calypso/lib/url';
 
 export function login( {
 	isJetpack = undefined,

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { login } from '..';
 
 describe( 'login', () => {

--- a/client/lib/paths/lost-password.ts
+++ b/client/lib/paths/lost-password.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 type LostPasswordOptions = {

--- a/client/lib/paths/test/index.js
+++ b/client/lib/paths/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { newPost } from '../index';
 
 /**

--- a/client/lib/payment-gateway-loader/index.js
+++ b/client/lib/payment-gateway-loader/index.js
@@ -1,15 +1,7 @@
-/**
- * External dependencies
- */
-
+import { loadScript } from '@automattic/load-script';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:payment-gateway' );
-
-/**
- * Internal dependencies
- */
-import { loadScript } from '@automattic/load-script';
 
 /**
  * PaymentGatewayLoader component

--- a/client/lib/performance-tracking/index.node.js
+++ b/client/lib/performance-tracking/index.node.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import EmptyComponent from 'calypso/components/empty-component';
 
 export const performanceTrackerStart = () => null;

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -1,15 +1,5 @@
-/**
- * External dependencies
- */
 import { start, stop } from '@automattic/browser-data-collector';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import {
 	getCurrentUserSiteCount,
 	getCurrentUserVisibleSiteCount,
@@ -17,6 +7,9 @@ import {
 	isCurrentUserBootstrapped,
 	getCurrentUserLocale,
 } from 'calypso/state/current-user/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { collectTranslationTimings, clearTranslationTimings } from './collectors/translations';
 /**
  * This reporter is added to _all_ performance tracking metrics.

--- a/client/lib/performance-tracking/performance-tracker-start.js
+++ b/client/lib/performance-tracking/performance-tracker-start.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { startPerformanceTracking } from './lib';
 
 export const performanceTrackerStart = ( pageName ) => {

--- a/client/lib/performance-tracking/performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/performance-tracker-stop.jsx
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { usePerformanceTrackerStop } from './use-performance-tracker-stop';
 
 const PerformanceTrackerStop = () => {

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -1,16 +1,5 @@
-/**
- * External dependencies
- */
 import { start, stop } from '@automattic/browser-data-collector';
-
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
-import { startPerformanceTracking, stopPerformanceTracking } from '../lib';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import {
 	getCurrentUserCountryCode,
 	getCurrentUserSiteCount,
@@ -18,7 +7,11 @@ import {
 	isCurrentUserBootstrapped,
 	getCurrentUserLocale,
 } from 'calypso/state/current-user/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { collectTranslationTimings, clearTranslationTimings } from '../collectors/translations';
+import { startPerformanceTracking, stopPerformanceTracking } from '../lib';
 
 jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn(),

--- a/client/lib/performance-tracking/test/performance-tracker-start.js
+++ b/client/lib/performance-tracking/test/performance-tracker-start.js
@@ -2,11 +2,8 @@ jest.mock( '../lib', () => ( {
 	startPerformanceTracking: jest.fn(),
 } ) );
 
-/**
- * Internal dependencies
- */
-import { performanceTrackerStart } from '../performance-tracker-start';
 import { startPerformanceTracking } from '../lib';
+import { performanceTrackerStart } from '../performance-tracker-start';
 
 describe( 'performance-tracker-start', () => {
 	afterEach( () => {

--- a/client/lib/performance-tracking/test/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/test/use-performance-tracker-stop.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import { useLayoutEffect } from 'react';
 import { useSelector, useStore } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import { getSectionName } from 'calypso/state/ui/selectors';
-import { usePerformanceTrackerStop } from '../use-performance-tracker-stop';
 import { stopPerformanceTracking } from '../lib';
+import { usePerformanceTrackerStop } from '../use-performance-tracker-stop';
 
 jest.mock( 'react', () => ( {
 	useLayoutEffect: jest.fn(),

--- a/client/lib/performance-tracking/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/use-performance-tracker-stop.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { useLayoutEffect } from 'react';
 import { useSelector, useStore } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { stopPerformanceTracking } from './lib';
 import { getSectionName } from 'calypso/state/ui/selectors';
+import { stopPerformanceTracking } from './lib';
 
 export function usePerformanceTrackerStop() {
 	const sectionName = useSelector( getSectionName );

--- a/client/lib/performance-tracking/with-performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/with-performance-tracker-stop.jsx
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
 import PerformanceTrackerStop from './performance-tracker-stop';
 
 export const withPerformanceTrackerStop = createHigherOrderComponent( ( Wrapped ) => {

--- a/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
+++ b/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { stopPerformanceTracking } from './lib';
 import { getSectionName } from 'calypso/state/ui/selectors';
+import { stopPerformanceTracking } from './lib';
 
 export const withStopPerformanceTrackingProp = ( () => {
 	return connect( null, {

--- a/client/lib/phone-validation/index.jsx
+++ b/client/lib/phone-validation/index.jsx
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import phone from 'phone';
 import i18n from 'i18n-calypso';
+import phone from 'phone';
 
 export default function ( phoneNumber ) {
 	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import assert from 'assert';
-
-/**
- * Internal dependencies
- */
 import phoneValidation from '..';
 
 describe( 'Phone Validation Library', () => {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1,12 +1,3 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import {
 	FEATURE_13GB_STORAGE,
 	FEATURE_200GB_STORAGE,
@@ -139,9 +130,11 @@ import {
 	FEATURE_WP_SUBDOMAIN_SIGNUP,
 	PREMIUM_DESIGN_FOR_STORES,
 } from '@automattic/calypso-products';
-import MaterialIcon from 'calypso/components/material-icon';
+import i18n from 'i18n-calypso';
+import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
+import MaterialIcon from 'calypso/components/material-icon';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 
 export const FEATURES_LIST = {

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { filter } from 'lodash';
 import validUrl from 'valid-url';
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { sanitizeSectionContent as clean } from '../sanitize-section-content';
 
 /**

--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -2,14 +2,7 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import * as PluginUtils from '../utils';
 
 describe( 'Plugins Utils', () => {

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { filter, map, pick, sortBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
 import { sanitizeSectionContent } from './sanitize-section-content';
 

--- a/client/lib/post-normalizer/rule-add-discover-properties.js
+++ b/client/lib/post-normalizer/rule-add-discover-properties.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { get, find } from 'lodash';
 
 const DISCOVER_BLOG_ID = 53424024;

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,17 +1,9 @@
 /* eslint-disable jsdoc/no-undefined-types */
 
-/**
- * External dependencies
- */
-
-import { map, compact, includes, some, filter } from 'lodash';
 import getEmbedMetadata from 'get-video-id';
-
-/**
- * Internal Dependencies
- */
-import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
+import { map, compact, includes, some, filter } from 'lodash';
 import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
+import { iframeIsAllowed, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
 
 /** Checks whether or not an image is a tracking pixel
  *

--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import { forEach } from 'lodash';
 import i18n from 'i18n-calypso';
-
-/**
- * Internal Dependencies
- */
+import { forEach } from 'lodash';
 import { domForHtml } from './utils';
 
 const pollLinkSelectors = [

--- a/client/lib/post-normalizer/rule-content-detect-surveys.js
+++ b/client/lib/post-normalizer/rule-content-detect-surveys.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { forEach } from 'lodash';
 import i18n from 'i18n-calypso';
+import { forEach } from 'lodash';
 
 export default function detectSurveys( post, dom ) {
 	if ( ! dom ) {

--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 
 function stripAutoPlays( searchParams ) {

--- a/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
+++ b/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { forEach, get } from 'lodash';
 
 /**

--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { some, forEach, startsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { iframeIsAllowed } from './utils';
 import { getUrlParts } from '@automattic/calypso-url';
+import { some, forEach, startsWith } from 'lodash';
+import { iframeIsAllowed } from './utils';
 
 /** Given an iframe, is it okay to have it run without a sandbox?
  *

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import { forEach, startsWith, some, includes, filter } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import safeImageURL from 'calypso/lib/safe-image-url';
-import { maxWidthPhotonishURL } from './utils';
-import { resolveRelativePath } from 'calypso/lib/url';
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
+import { forEach, startsWith, some, includes, filter } from 'lodash';
+import safeImageURL from 'calypso/lib/safe-image-url';
+import { resolveRelativePath } from 'calypso/lib/url';
+import { maxWidthPhotonishURL } from './utils';
 
 const TRANSPARENT_GIF =
 	'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';

--- a/client/lib/post-normalizer/rule-content-make-links-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-links-safe.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { forEach } from 'lodash';
 import { safeLinkRe } from './utils';
 

--- a/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
+++ b/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { forEach } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 
 const thingsToRemove = [
 	'.sharedaddy', // share daddy

--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { forEach } from 'lodash';
 
 function matches( element, selector ) {

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -1,13 +1,5 @@
-/**
- * External dependencies
- */
-
-import striptags from 'striptags';
 import { trim, forEach } from 'lodash';
-
-/**
- * Internal Dependencies
- */
+import striptags from 'striptags';
 import { domForHtml } from './utils';
 
 /**

--- a/client/lib/post-normalizer/rule-decode-entities.js
+++ b/client/lib/post-normalizer/rule-decode-entities.js
@@ -1,6 +1,3 @@
-/**
- * Internal Dependencies
- */
 import { decodeEntities as decode } from 'calypso/lib/formatting';
 import safeImageURL from 'calypso/lib/safe-image-url';
 

--- a/client/lib/post-normalizer/rule-keep-valid-images.js
+++ b/client/lib/post-normalizer/rule-keep-valid-images.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { filter } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import safeImageUrl from 'calypso/lib/safe-image-url';
 
 function isValidImage( width, height ) {

--- a/client/lib/post-normalizer/rule-make-links-safe.js
+++ b/client/lib/post-normalizer/rule-make-links-safe.js
@@ -1,9 +1,6 @@
 /**
  */
 
-/**
- * Internal dependencies
- */
 import { safeLinkRe } from './utils';
 
 export default function makeLinksSafe( post ) {

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { thumbIsLikelyImage, isCandidateForCanonicalImage } from './utils';
 
 export default function pickCanonicalImage( post ) {

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { find, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { isUrlLikelyAnImage } from './utils';
 import safeImageUrl from 'calypso/lib/safe-image-url';
+import { isUrlLikelyAnImage } from './utils';
 
 /** Returns true if an image is large enough to be a featured asset
  *

--- a/client/lib/post-normalizer/rule-pick-primary-tag.js
+++ b/client/lib/post-normalizer/rule-pick-primary-tag.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { maxBy, values } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 
 export default function pickPrimaryTag( post ) {
 	// if we hand max an invalid or empty array, it returns -Infinity

--- a/client/lib/post-normalizer/rule-prevent-widows.js
+++ b/client/lib/post-normalizer/rule-prevent-widows.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { forEach } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import { preventWidows as preventWidowFormatting } from 'calypso/lib/formatting';
 
 export default function preventWidows( post ) {

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { startsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { makeImageURLSafe } from './utils';
 
 export default function safeImagePropertiesForWidth( maxWidth ) {

--- a/client/lib/post-normalizer/rule-strip-html.js
+++ b/client/lib/post-normalizer/rule-strip-html.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { forEach } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { stripHTML } from 'calypso/lib/formatting';
 
 export default function stripHtml( post ) {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { filter, find, forEach, map, take } from 'lodash';
-
-/**
- * Internal Dependencies
- */
-import { deduceImageWidthAndHeight, thumbIsLikelyImage } from './utils';
 import debugFactory from 'debug';
+import { filter, find, forEach, map, take } from 'lodash';
+import { deduceImageWidthAndHeight, thumbIsLikelyImage } from './utils';
 
 const debug = debugFactory( 'calypso:post-normalizer:wait-for-images-to-load' );
 

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { reduce } from 'lodash';
-
-/**
- * Internal Dependencies
- */
 import { domForHtml } from './utils';
 
 export default function createDomTransformRunner( transforms ) {

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1,28 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-jest.mock( 'calypso/lib/safe-image-url', () => require( './mocks/lib/safe-image-url' ) );
-
-/**
- * External dependencies
- */
 import { flow, trim } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import safeImageUrlFake from 'calypso/lib/safe-image-url';
-import decodeEntities from '../rule-decode-entities';
-import stripHtml from '../rule-strip-html';
-import preventWidows from '../rule-prevent-widows';
-import pickCanonicalImage from '../rule-pick-canonical-image';
-import makeSiteIDSafeForAPI from '../rule-make-site-id-safe-for-api';
-import pickPrimaryTag from '../rule-pick-primary-tag';
-import safeImageProperties from '../rule-safe-image-properties';
-import makeLinksSafe from '../rule-make-links-safe';
-import keepValidImages from '../rule-keep-valid-images';
-import createBetterExcerpt from '../rule-create-better-excerpt';
-import withContentDOM from '../rule-with-content-dom';
 import detectMedia from '../rule-content-detect-media';
 import detectPolls from '../rule-content-detect-polls';
 import detectSurveys from '../rule-content-detect-surveys';
@@ -33,6 +13,19 @@ import makeImagesSafe from '../rule-content-make-images-safe';
 import makeContentLinksSafe from '../rule-content-make-links-safe';
 import removeElementsBySelector from '../rule-content-remove-elements-by-selector';
 import removeStyles from '../rule-content-remove-styles';
+import createBetterExcerpt from '../rule-create-better-excerpt';
+import decodeEntities from '../rule-decode-entities';
+import keepValidImages from '../rule-keep-valid-images';
+import makeLinksSafe from '../rule-make-links-safe';
+import makeSiteIDSafeForAPI from '../rule-make-site-id-safe-for-api';
+import pickCanonicalImage from '../rule-pick-canonical-image';
+import pickPrimaryTag from '../rule-pick-primary-tag';
+import preventWidows from '../rule-prevent-widows';
+import safeImageProperties from '../rule-safe-image-properties';
+import stripHtml from '../rule-strip-html';
+import withContentDOM from '../rule-with-content-dom';
+
+jest.mock( 'calypso/lib/safe-image-url', () => require( './mocks/lib/safe-image-url' ) );
 
 describe( 'index', () => {
 	test( 'should leave an empty object alone', () => {

--- a/client/lib/post-normalizer/test/mocks/lib/safe-image-url.js
+++ b/client/lib/post-normalizer/test/mocks/lib/safe-image-url.js
@@ -2,9 +2,7 @@
  * A stub that makes safe-image-url deterministic
  *
  */
-/**
- * Internal dependencies
- */
+
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 
 let returnValue;

--- a/client/lib/post-normalizer/test/utils.js
+++ b/client/lib/post-normalizer/test/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { isFeaturedImageInContent } from '../utils';
 
 describe( 'isFeaturedImageInContent', () => {

--- a/client/lib/post-normalizer/utils/iframe-is-allowed.js
+++ b/client/lib/post-normalizer/utils/iframe-is-allowed.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getUrlParts } from '@automattic/calypso-url';
+import { some } from 'lodash';
 
 /**
  * Determines if an iframe is from a source we trust. We allow these to be the featured media and also give

--- a/client/lib/post-normalizer/utils/image-size-from-attachments.js
+++ b/client/lib/post-normalizer/utils/image-size-from-attachments.js
@@ -1,6 +1,3 @@
-/**
- * External Dependencies
- */
 import { find } from 'lodash';
 
 export function imageSizeFromAttachments( post, imageUrl ) {

--- a/client/lib/post-normalizer/utils/is-featured-image-in-content.js
+++ b/client/lib/post-normalizer/utils/is-featured-image-in-content.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { getUrlParts } from '@automattic/calypso-url';
 import { findIndex } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { isPhotonHost } from 'calypso/lib/post-normalizer/utils/is-photon-host';
 import { thumbIsLikelyImage } from 'calypso/lib/post-normalizer/utils/thumb-is-likely-image';
-import { getUrlParts } from '@automattic/calypso-url';
 
 function getPathname( uri ) {
 	const { pathname, hostname } = getUrlParts( uri );

--- a/client/lib/post-normalizer/utils/is-url-likely-an-image.js
+++ b/client/lib/post-normalizer/utils/is-url-likely-an-image.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getUrlParts } from '@automattic/calypso-url';
+import { some } from 'lodash';
 
 /** Determine if url is likely pointed to an image
  *

--- a/client/lib/post-normalizer/utils/make-image-url-safe.js
+++ b/client/lib/post-normalizer/utils/make-image-url-safe.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
+import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 import { maxWidthPhotonishURL } from 'calypso/lib/post-normalizer/utils/max-width-photonish-url';
 import safeImageURL from 'calypso/lib/safe-image-url';
-import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 import { resolveRelativePath } from 'calypso/lib/url';
 
 export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {

--- a/client/lib/post-normalizer/utils/max-width-photonish-url.js
+++ b/client/lib/post-normalizer/utils/max-width-photonish-url.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { format, getUrlParts, getUrlFromParts, determineUrlType } from '@automattic/calypso-url';
 
 const IMAGE_SCALE_FACTOR =

--- a/client/lib/post-normalizer/utils/thumb-is-likely-image.js
+++ b/client/lib/post-normalizer/utils/thumb-is-likely-image.js
@@ -1,6 +1,3 @@
-/**
- * Internal Dependencies
- */
 import { isUrlLikelyAnImage } from 'calypso/lib/post-normalizer/utils/is-url-likely-an-image';
 
 /**

--- a/client/lib/preferences-helper/array-preference.js
+++ b/client/lib/preferences-helper/array-preference.js
@@ -1,10 +1,7 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 class ArrayPreference extends Component {
 	static propTypes = {

--- a/client/lib/preferences-helper/boolean-preference.tsx
+++ b/client/lib/preferences-helper/boolean-preference.tsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import { useDispatch } from 'react-redux';
 import React, {
 	FunctionComponent,
 	ChangeEventHandler,
@@ -9,10 +5,7 @@ import React, {
 	useEffect,
 	useState,
 } from 'react';
-
-/**
- * Internal dependencies
- */
+import { useDispatch } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 
 interface Props {

--- a/client/lib/preferences-helper/index.js
+++ b/client/lib/preferences-helper/index.js
@@ -1,18 +1,8 @@
-/**
- * External dependencies
- */
-import ReactDom from 'react-dom';
 import React from 'react';
+import ReactDom from 'react-dom';
 import { Provider } from 'react-redux';
-
-/**
- * Internal dependencies
- */
 import PreferenceList from './preference-list';
 
-/**
- * Style dependencies
- */
 import './style.scss';
 
 export default function injectPreferenceHelper( element, store ) {

--- a/client/lib/preferences-helper/number-preference.tsx
+++ b/client/lib/preferences-helper/number-preference.tsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import { useDispatch } from 'react-redux';
 import React, {
 	FunctionComponent,
 	ChangeEventHandler,
@@ -9,10 +5,7 @@ import React, {
 	useEffect,
 	useState,
 } from 'react';
-
-/**
- * Internal dependencies
- */
+import { useDispatch } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 
 interface Props {

--- a/client/lib/preferences-helper/object-preference.tsx
+++ b/client/lib/preferences-helper/object-preference.tsx
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import React, { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
+import BooleanPreference from './boolean-preference';
 import NumberPreference from './number-preference';
 import StringPreference from './string-preference';
-import BooleanPreference from './boolean-preference';
 
 interface Props {
 	name: string;

--- a/client/lib/preferences-helper/preference-list.js
+++ b/client/lib/preferences-helper/preference-list.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { Card } from '@automattic/components';
-import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
+import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
 import Preference from './preference';
 
 class PreferenceList extends Component {

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -1,20 +1,13 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { useDispatch } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { isPlainObject } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 import ArrayPreference from './array-preference';
-import ObjectPreference from './object-preference';
 import BooleanPreference from './boolean-preference';
-import StringPreference from './string-preference';
 import NumberPreference from './number-preference';
+import ObjectPreference from './object-preference';
+import StringPreference from './string-preference';
 
 export default function Preference( { name, value } ) {
 	const translate = useTranslate();

--- a/client/lib/preferences-helper/string-preference.tsx
+++ b/client/lib/preferences-helper/string-preference.tsx
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import { useDispatch } from 'react-redux';
 import React, {
 	FunctionComponent,
 	ChangeEventHandler,
@@ -9,10 +5,7 @@ import React, {
 	useEffect,
 	useState,
 } from 'react';
-
-/**
- * Internal dependencies
- */
+import { useDispatch } from 'react-redux';
 import { savePreference } from 'calypso/state/preferences/actions';
 
 interface Props {

--- a/client/lib/products-list/index.js
+++ b/client/lib/products-list/index.js
@@ -1,16 +1,8 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
+import Emitter from 'calypso/lib/mixins/emitter';
+import wpcom from 'calypso/lib/wp';
 
 const debug = debugFactory( 'calypso:ProductsList' );
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
-import Emitter from 'calypso/lib/mixins/emitter';
 
 /**
  * Initialize a new list of products.
@@ -108,7 +100,7 @@ ProductsList.prototype.fetch = function () {
  * Initializes data with a list of products.
  *
  * @param {object} productsList The list of products
- **/
+ */
 ProductsList.prototype.initialize = function ( productsList ) {
 	this.data = productsList;
 	this.initialized = true;

--- a/client/lib/protect-form/README.md
+++ b/client/lib/protect-form/README.md
@@ -24,7 +24,7 @@ export default protectForm( MyComponent );
 The `protectForm` HoC provides a `markChanged` prop you can call on the `onChange` event of your form like this:
 
 ```jsx
-<form onChange={ this.props.markChanged } onSubmit={ this.handleSubmit } />;
+<form onChange={ this.props.markChanged } onSubmit={ this.handleSubmit } />
 ```
 
 And then very important, you also need to to call the second prop `markSaved` when your form has been successfully submitted. Here is an example onSubmit callback handler.
@@ -51,7 +51,7 @@ component state instead of calling functions:
 <form onChange={ this.handleChange } onSubmit={ this.handleSubmit }>
 	<ProtectFormGuard isChanged={ this.state.isChanged } />
 	...
-</form>;
+</form>
 ```
 
 Here are example `onChange` and `onSubmit` handlers that change the state:

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -1,11 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import debugModule from 'debug';
-import page from 'page';
-import i18n from 'i18n-calypso';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import debugModule from 'debug';
+import i18n from 'i18n-calypso';
+import page from 'page';
+import React from 'react';
 
 /**
  * Module variables

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import wpcom from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
 
 const debug = debugFactory( 'calypso:purchases:actions' );
 

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { camelCase } from 'lodash';
 
 function createPurchaseObject( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -1,19 +1,3 @@
-/**
- * External dependencies
- */
-import { find } from 'lodash';
-import moment from 'moment';
-import page from 'page';
-import i18n from 'i18n-calypso';
-import debugFactory from 'debug';
-import { encodeProductForUrl } from '@automattic/wpcom-checkout';
-
-/**
- * Internal dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
-import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import {
 	getPlan,
 	isMonthly as isMonthlyPlan,
@@ -33,6 +17,15 @@ import {
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 } from '@automattic/calypso-products';
+import { encodeProductForUrl } from '@automattic/wpcom-checkout';
+import debugFactory from 'debug';
+import i18n from 'i18n-calypso';
+import { find } from 'lodash';
+import moment from 'moment';
+import page from 'page';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { errorNotice } from 'calypso/state/notices/actions';
 
 const debug = debugFactory( 'calypso:purchases' );

--- a/client/lib/purchases/is-google-workspace-extra-license.js
+++ b/client/lib/purchases/is-google-workspace-extra-license.js
@@ -1,6 +1,3 @@
-/**
- * Internal Dependencies
- */
 import { isGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
 
 /**

--- a/client/lib/purchases/test/assembler.js
+++ b/client/lib/purchases/test/assembler.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { createPurchasesArray } from '../assembler';
 
 describe( 'assembler', () => {

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
 import page from 'page';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-
-/**
- * Internal dependencies
- */
 import {
 	isRemovable,
 	isCancelable,
@@ -19,7 +12,6 @@ import {
 	handleRenewMultiplePurchasesClick,
 	shouldRenderMonthlyRenewalOption,
 } from '../index';
-
 import data from './data';
 const {
 	DOMAIN_PURCHASE,

--- a/client/lib/purchases/utils.ts
+++ b/client/lib/purchases/utils.ts
@@ -1,10 +1,3 @@
-/**
- * Internal dependencies
- */
-
-/**
- * Type dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import type { Purchase } from './types';
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { clone, difference, get, isEqual, map, omit, reduce, values } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import QueryKey from './key';
 
 /**

--- a/client/lib/query-manager/key.js
+++ b/client/lib/query-manager/key.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { sortBy, omitBy } from 'lodash';
 
 /**

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import moment from 'moment';
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import moment from 'moment';
 import PaginatedQueryManager from '../paginated';
-import MediaQueryKey from './key';
 import { DEFAULT_MEDIA_QUERY } from './constants';
+import MediaQueryKey from './key';
 
 /**
  * MediaQueryManager manages media which can be queried and change over time

--- a/client/lib/query-manager/media/key.js
+++ b/client/lib/query-manager/media/key.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import PaginatedQueryKey from '../paginated/key';
 import { DEFAULT_MEDIA_QUERY } from './constants';
 

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import MediaQueryManager from '../';
 
 /**

--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { cloneDeep, includes, omit, range } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import QueryManager from '../';
-import PaginatedQueryKey from './key';
 import { DEFAULT_PAGINATED_QUERY, PAGINATION_QUERY_KEYS } from './constants';
+import PaginatedQueryKey from './key';
 
 const pageCache = new WeakMap();
 

--- a/client/lib/query-manager/paginated/key.js
+++ b/client/lib/query-manager/paginated/key.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { omit } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import QueryKey from '../key';
 import { PAGINATION_QUERY_KEYS } from './constants';
 

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import PaginatedQueryManager from '../';
 
 /**

--- a/client/lib/query-manager/paginated/test/key.js
+++ b/client/lib/query-manager/paginated/test/key.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import PaginatedQueryKey from '../key';
 
 describe( 'PaginatedQueryKey', () => {

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import moment from 'moment';
 import { some, includes, get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import moment from 'moment';
 import PaginatedQueryManager from '../paginated';
-import PostQueryKey from './key';
 import { DEFAULT_POST_QUERY } from './constants';
+import PostQueryKey from './key';
 
 /**
  * PostQueryManager manages posts which can be queried and change over time

--- a/client/lib/query-manager/post/key.js
+++ b/client/lib/query-manager/post/key.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { omitBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import PaginatedQueryKey from '../paginated/key';
 import { DEFAULT_POST_QUERY } from './constants';
 

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import PostQueryManager from '../';
 
 /**

--- a/client/lib/query-manager/post/test/key.js
+++ b/client/lib/query-manager/post/test/key.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import PostQueryKey from '../key';
 
 describe( 'PostQueryKey', () => {

--- a/client/lib/query-manager/schema.js
+++ b/client/lib/query-manager/schema.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
 import { cloneDeepWith } from 'lodash';
 

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import PaginatedQueryManager from '../paginated';
-import TermQueryKey from './key';
 import { DEFAULT_TERM_QUERY } from './constants';
+import TermQueryKey from './key';
 
 /**
  * TermQueryManager manages terms which can be queried and change over time

--- a/client/lib/query-manager/term/key.js
+++ b/client/lib/query-manager/term/key.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { omitBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import PaginatedQueryKey from '../paginated/key';
 import { DEFAULT_TERM_QUERY } from './constants';
 

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import TermQueryManager from '../';
 
 /**

--- a/client/lib/query-manager/term/test/key.js
+++ b/client/lib/query-manager/term/test/key.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import TermQueryKey from '../key';
 
 describe( 'TermQueryKey', () => {

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import QueryManager, { DELETE_PATCH_KEY } from '../';
 
 describe( 'QueryManager', () => {

--- a/client/lib/query-manager/test/key.js
+++ b/client/lib/query-manager/test/key.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import QueryKey from '../key';
 
 describe( 'QueryKey', () => {

--- a/client/lib/query-manager/test/schema.js
+++ b/client/lib/query-manager/test/schema.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import queryManagerSchema, { withItemsSchema } from '../schema';
 
 describe( 'queryManagerSchema', () => {

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
 import PaginatedQueryManager from '../paginated';
-import ThemeQueryKey from './key';
 import { DEFAULT_THEME_QUERY } from './constants';
+import ThemeQueryKey from './key';
 
 /**
  * ThemeQueryManager manages themes which can be queried

--- a/client/lib/query-manager/theme/key.js
+++ b/client/lib/query-manager/theme/key.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { omitBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import PaginatedQueryKey from '../paginated/key';
 import { DEFAULT_THEME_QUERY } from './constants';
 

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import ThemeQueryManager from '../';
 
 describe( 'ThemeQueryManager', () => {

--- a/client/lib/query-manager/theme/test/key.js
+++ b/client/lib/query-manager/theme/test/key.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import ThemeQueryKey from '../key';
 
 describe( 'ThemeQueryKey', () => {

--- a/client/lib/react-pass-to-children/index.js
+++ b/client/lib/react-pass-to-children/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 
 export default function ( element, additionalProps ) {

--- a/client/lib/react-pass-to-children/test/index.js
+++ b/client/lib/react-pass-to-children/test/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import ShallowRenderer from 'react-test-renderer/shallow';
-import React from 'react';
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import passToChildren from '../';
 
 /**

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -1,18 +1,10 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
-
-/*
- * Internal Dependencies
- */
-import { getSite } from 'calypso/state/reader/sites/selectors';
-import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
+import { getSite } from 'calypso/state/reader/sites/selectors';
 
 /**
  * A HoC function that will take in reader identifiers siteId or feedId and

--- a/client/lib/rebrand-cities/index.js
+++ b/client/lib/rebrand-cities/index.js
@@ -1,9 +1,5 @@
-/**
- * External dependencies
- */
-
-import { v4 as uuid } from 'uuid';
 import config from '@automattic/calypso-config';
+import { v4 as uuid } from 'uuid';
 
 const allHyphens = new RegExp( '-', 'g' );
 

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
-
-import { mapValues } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import safeImageUrl from 'calypso/lib/safe-image-url';
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
+import { mapValues } from 'lodash';
+import safeImageUrl from 'calypso/lib/safe-image-url';
 
 /**
  * Pattern matching valid http(s) URLs

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 
 describe( 'resizeImageUrl()', () => {

--- a/client/lib/route/legacy-routes.ts
+++ b/client/lib/route/legacy-routes.ts
@@ -3,15 +3,8 @@
  * to reload the page.
  */
 
-/**
- * External dependencies
- */
-import { URL as URLString } from 'calypso/types';
-
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
+import { URL as URLString } from 'calypso/types';
 
 interface LegacyRoute {
 	match: RegExp;

--- a/client/lib/route/normalize.ts
+++ b/client/lib/route/normalize.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
 import untrailingslashit from './untrailingslashit';
 
 const appendQueryString = ( basepath: string, querystring: string ): string =>

--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { URL as URLString, SiteSlug, SiteId } from 'calypso/types';
-
-/**
- * Internal Dependencies
- */
 import { trailingslashit, untrailingslashit } from './index';
 
 /**

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -2,14 +2,7 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import * as route from '../';
 
 describe( 'route', function () {

--- a/client/lib/route/test/legacy-routes.js
+++ b/client/lib/route/test/legacy-routes.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
 import { isLegacyRoute } from '../legacy-routes';
-import config from '@automattic/calypso-config';
 
 let features = [];
 

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import photon from 'photon';
-
-/**
- * Internal dependencies
- */
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
+import photon from 'photon';
 
 /**
  * Pattern matching URLs to be left unmodified.

--- a/client/lib/safe-protocol-url/index.js
+++ b/client/lib/safe-protocol-url/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 
 export default function safeProtocolUrl( url ) {

--- a/client/lib/safe-protocol-url/test/index.js
+++ b/client/lib/safe-protocol-url/test/index.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { expect } from 'chai';
-
-/**
- * Internal Dependencies
- */
 import safeProtocolUrl from '../';
 
 describe( 'index', () => {

--- a/client/lib/scroll-into-viewport/test/index.js
+++ b/client/lib/scroll-into-viewport/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { recursivelyWalkAndSum } from '../index';
 
 describe( 'recursivelyWalkAndSum', () => {

--- a/client/lib/scroll-to/test/index.js
+++ b/client/lib/scroll-to/test/index.js
@@ -2,15 +2,8 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
 import scrollTo from '../';
 
 describe( 'scroll-to', () => {

--- a/client/lib/search-url/index.js
+++ b/client/lib/search-url/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import page from 'page';
-
-/**
- * Internal dependencies
- */
-import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import debugFactory from 'debug';
+import page from 'page';
+import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 
 const debug = debugFactory( 'calypso:search-url' );
 

--- a/client/lib/search-url/test/index.js
+++ b/client/lib/search-url/test/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import page from 'page';
-
-/**
- * Internal dependencies
- */
-import searchUrl from '..';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import searchUrl from '..';
 
 const SEARCH_KEYWORD = 'giraffe';
 

--- a/client/lib/seo/index.js
+++ b/client/lib/seo/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { includes } from 'lodash';
 
 const conflictingSeoPlugins = [

--- a/client/lib/shortcode/index.js
+++ b/client/lib/shortcode/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { isEqual, memoize } from 'lodash';
 
 /**

--- a/client/lib/shortcode/test/index.js
+++ b/client/lib/shortcode/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { normalizeAttributes, parse, parseAttributes, stringify } from '../index';
 
 describe( 'index', () => {

--- a/client/lib/siftscience/index.js
+++ b/client/lib/siftscience/index.js
@@ -1,18 +1,9 @@
-/**
- * External dependencies
- */
-
-import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:siftscience' );
-
-/**
- * Internal dependencies
- */
-import { loadScript } from '@automattic/load-script';
 import config from '@automattic/calypso-config';
+import { loadScript } from '@automattic/load-script';
+import debugFactory from 'debug';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
+const debug = debugFactory( 'calypso:siftscience' );
 const SIFTSCIENCE_URL = 'https://cdn.siftscience.com/s.js';
 let hasLoaded = false;
 

--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -47,8 +47,8 @@ If `errors` has a non-zero length, it will be attached to the step and the step'
 Actions which provide a `providedDependencies` object will have this information added to the dependency store.
 
 ```js
-import SignupDependencyStore from 'calypso/lib/signup/dependency-store';
 import SignupActions from 'calypso/lib/signup/actions';
+import SignupDependencyStore from 'calypso/lib/signup/dependency-store';
 
 SignupActions.completeSignupStep( { stepName: 'example' }, [], { userId: 1337 } );
 

--- a/client/lib/signup/asserts.js
+++ b/client/lib/signup/asserts.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get, keys, difference } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import steps from 'calypso/signup/config/steps-pure';
 
 export function assertValidDependencies( stepName, providedDependencies ) {

--- a/client/lib/signup/cart.ts
+++ b/client/lib/signup/cart.ts
@@ -1,20 +1,14 @@
-/**
- * External dependencies
- */
-import type { ResponseCart, RequestCart, RequestCartProduct } from '@automattic/shopping-cart';
 import {
 	getEmptyResponseCart,
 	convertResponseCartToRequestCart,
 	createRequestCartProduct,
 } from '@automattic/shopping-cart';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
-import productsListFactory from 'calypso/lib/products-list';
-const productsList = productsListFactory();
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
+import productsListFactory from 'calypso/lib/products-list';
+import wpcom from 'calypso/lib/wp';
+import type { ResponseCart, RequestCart, RequestCartProduct } from '@automattic/shopping-cart';
+
+const productsList = productsListFactory();
 
 function addProductsToCart( cart: ResponseCart, newCartItems: RequestCartProduct[] ): RequestCart {
 	const productsData = productsList.get();

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import {
 	defer,
 	difference,
@@ -17,30 +14,26 @@ import {
 } from 'lodash';
 import page from 'page';
 import { Store, Unsubscribe as ReduxUnsubscribe } from 'redux';
-
-/**
- * Internal dependencies
- */
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import flows from 'calypso/signup/config/flows';
 import untypedSteps from 'calypso/signup/config/steps';
-import wpcom from 'calypso/lib/wp';
 import { getStepUrl } from 'calypso/signup/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { ProgressState } from 'calypso/state/signup/progress/schema';
-import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
-import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import {
 	resetSignup,
 	updateDependencies,
 	removeSiteSlugDependency,
 } from 'calypso/state/signup/actions';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { getCurrentFlowName, getPreviousFlowName } from 'calypso/state/signup/flow/selectors';
 import {
 	completeSignupStep,
 	invalidateStep,
 	processStep,
 } from 'calypso/state/signup/progress/actions';
-import { getCurrentFlowName, getPreviousFlowName } from 'calypso/state/signup/flow/selectors';
+import { ProgressState } from 'calypso/state/signup/progress/schema';
+import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 
 interface Dependencies {
 	[ other: string ]: string[];

--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -1,9 +1,6 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import i18n from 'i18n-calypso';
 import { get } from 'lodash';
+import React from 'react';
 
 // For now the site style step will determine which 'style pack' to use on pub/radcliffe-2
 export const siteStyleOptions = {

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -4,10 +4,6 @@
 import i18n from 'i18n-calypso';
 import { find, get } from 'lodash';
 
-/**
- * Internal dependencies
- */
-
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{

--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
-import { getSiteId } from 'calypso/state/sites/selectors';
 import { requestSites } from 'calypso/state/sites/actions';
+import { getSiteId } from 'calypso/state/sites/selectors';
 
 async function fetchSitesUntilSiteAppears( siteSlug, reduxStore ) {
 	while ( ! getSiteId( reduxStore.getState(), siteSlug ) ) {

--- a/client/lib/signup/step-actions/passwordless.js
+++ b/client/lib/signup/step-actions/passwordless.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 /**

--- a/client/lib/signup/test/cart.js
+++ b/client/lib/signup/test/cart.js
@@ -1,13 +1,10 @@
-/**
- * Internal dependencies
- */
-import { createCart, addToCart } from '../cart';
-import wp from 'calypso/lib/wp';
 import {
 	getEmptyResponseCart,
 	convertResponseCartToRequestCart,
 	createRequestCartProduct,
 } from '@automattic/shopping-cart';
+import wp from 'calypso/lib/wp';
+import { createCart, addToCart } from '../cart';
 
 jest.mock( 'calypso/lib/wp' );
 

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -2,20 +2,13 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import { size } from 'lodash';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-
-/**
- * Internal dependencies
- */
-import { combineReducers } from 'calypso/state/utils';
-import signupReducer from 'calypso/state/signup/reducer';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import signupReducer from 'calypso/state/signup/reducer';
+import { combineReducers } from 'calypso/state/utils';
 import SignupFlowController from '../flow-controller';
 
 jest.mock( 'calypso/signup/config/flows', () => require( './mocks/signup/config/flows' ) );

--- a/client/lib/signup/test/mocks/signup/config/flows.js
+++ b/client/lib/signup/test/mocks/signup/config/flows.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import flows from './flows-pure';
 
 export default {

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { defer } from 'lodash';
 
 export default {

--- a/client/lib/signup/test/site-type.js
+++ b/client/lib/signup/test/site-type.js
@@ -1,10 +1,6 @@
 /**
  */
 
-/**
- * Internal dependencies
- */
-
 import { getSiteTypePropertyValue } from '../site-type';
 
 describe( 'getSiteTypePropertyValue()', () => {

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -1,9 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-/**
- * Internal dependencies
- */
+
+import flows from 'calypso/signup/config/flows';
+import { isDomainStepSkippable } from 'calypso/signup/config/steps';
+import { useNock } from 'calypso/test-helpers/use-nock';
 import {
 	createSiteWithCart,
 	isDomainFulfilled,
@@ -11,9 +12,6 @@ import {
 	isSiteTopicFulfilled,
 	isSiteTypeFulfilled,
 } from '../step-actions';
-import { useNock } from 'calypso/test-helpers/use-nock';
-import flows from 'calypso/signup/config/flows';
-import { isDomainStepSkippable } from 'calypso/signup/config/steps';
 
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
 jest.mock( 'calypso/signup/config/flows', () => require( './mocks/signup/config/flows' ) );

--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
 
 export const themes = [

--- a/client/lib/signup/themes.js
+++ b/client/lib/signup/themes.js
@@ -1,12 +1,4 @@
-/**
- * External dependencies
- */
-
 import { includes, sampleSize } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { themes } from 'calypso/lib/signup/themes-data';
 
 function getUnusedThemes( themeSet, themePool, quantity ) {

--- a/client/lib/signup/verticals.js
+++ b/client/lib/signup/verticals.js
@@ -3,10 +3,6 @@
  */
 
 /**
- * Internal dependencies
- */
-
-/**
  * Current list of verticals that have/will have landing pages.
  * A user who comes in via a landing page will not see the Site Topic dropdown.
  */

--- a/client/lib/site/test/utils.js
+++ b/client/lib/site/test/utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import chai from 'chai';
-
-/**
- * Internal dependencies
- */
 import { canUpdateFiles, isMainNetworkSite } from 'calypso/lib/site/utils';
 
 const assert = chai.assert;

--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import moment from 'moment-timezone';
 
 /**

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
+import { planHasFeature } from '@automattic/calypso-products';
 import i18n from 'i18n-calypso';
 import { get } from 'lodash';
 import { withoutHttp } from 'calypso/lib/url';
-
-/**
- * Internal dependencies
- */
-import { planHasFeature } from '@automattic/calypso-products';
 
 export function userCan( capability, site ) {
 	return site && site.capabilities && site.capabilities[ capability ];

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import { translatedEbanxError } from 'calypso/lib/checkout/processor-specific';
 import paymentGatewayLoader from 'calypso/lib/payment-gateway-loader';
 import wp from 'calypso/lib/wp';
-import { translatedEbanxError } from 'calypso/lib/checkout/processor-specific';
 
 const debug = debugFactory( 'calypso:store-transactions' );
 

--- a/client/lib/string/test/index.js
+++ b/client/lib/string/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { areEqualIgnoringWhitespaceAndCase } from '../';
 
 describe( 'lib/string/areEqualIgnoringWhitespaceAndCase', () => {

--- a/client/lib/titan/get-titan-product-name.js
+++ b/client/lib/titan/get-titan-product-name.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { translate } from 'i18n-calypso';
 
 export function getTitanProductName() {

--- a/client/lib/titan/has-titan-mail-with-us.js
+++ b/client/lib/titan/has-titan-mail-with-us.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
 export function hasTitanMailWithUs( domain ) {

--- a/client/lib/titan/new-mailbox.js
+++ b/client/lib/titan/new-mailbox.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import React from 'react';
 import emailValidator from 'email-validator';
-import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-
-/**
- * Internal dependencies
- */
 import { validatePasswordField } from 'calypso/lib/gsuite/new-users';
 import wp from 'calypso/lib/wp';
 

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React, { useRef, useEffect, useState } from 'react';
 import { throttle } from 'lodash';
+import React, { useRef, useEffect, useState } from 'react';
 
 type NullableDOMRect = ClientRect | DOMRect | null;
 type NullableElement = Element | null;

--- a/client/lib/track-element-size/test/index.js
+++ b/client/lib/track-element-size/test/index.js
@@ -2,14 +2,10 @@
  * @jest-environment jsdom
  */
 
-/**
- * External dependencies
- */
 import React, { useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { useFakeTimers } from 'sinon';
-
 import { useWindowResizeCallback, useWindowResizeRect, THROTTLE_RATE } from '..';
 
 const initialRect = { width: 10, height: 10 };

--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import React, { Component } from 'react';
 import debugFactory from 'debug';
+import React, { Component } from 'react';
 
 const debug = debugFactory( 'calypso:track-form' );
 

--- a/client/lib/track-scroll-page/index.js
+++ b/client/lib/track-scroll-page/index.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
-import { recordPageView } from 'calypso/lib/analytics/page-view';
-import { bumpStat } from 'calypso/lib/analytics/mc';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
 
 export default function ( path, title, category, page ) {
 	gaRecordEvent( category, 'Loaded Next Page', 'page', page );

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
+import languages from '@automattic/languages';
 import { isMobile } from '@automattic/viewport';
 import debugModule from 'debug';
-import React from 'react';
 import i18n from 'i18n-calypso';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import languages from '@automattic/languages';
-import { loadjQueryDependentScriptDesktopWrapper } from 'calypso/lib/load-jquery-dependent-script-desktop-wrapper';
+import React from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { canBeTranslated } from 'calypso/lib/i18n-utils';
+import { loadjQueryDependentScriptDesktopWrapper } from 'calypso/lib/load-jquery-dependent-script-desktop-wrapper';
 
 const debug = debugModule( 'calypso:community-translator' );
 

--- a/client/lib/trigram/index.js
+++ b/client/lib/trigram/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import LRU from 'lru';
 
 /**

--- a/client/lib/trigram/test/index.js
+++ b/client/lib/trigram/test/index.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { cosineSimilarity, trigrams, gramsToLookup, lookupToMagnitude } from '../';
 
 describe( 'trigram: cosineSimilarity()', () => {

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -1,24 +1,16 @@
-/**
- * External dependencies
- */
-import debugFactory from 'debug';
-import { get as webauthn_auth } from '@github/webauthn-json';
-
-const debug = debugFactory( 'calypso:two-step-authorization' );
-
-/**
- * Internal Dependencies
- */
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { bumpStat } from 'calypso/lib/analytics/mc';
 import config from '@automattic/calypso-config';
+import { get as webauthn_auth } from '@github/webauthn-json';
+import debugFactory from 'debug';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import emitter from 'calypso/lib/mixins/emitter';
-import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import wp from 'calypso/lib/wp';
 import { requestConnectedApplications } from 'calypso/state/connected-applications/actions';
 import { requestUserProfileLinks } from 'calypso/state/profile-links/actions';
-import wp from 'calypso/lib/wp';
+import { fetchUserSettings } from 'calypso/state/user-settings/actions';
 
+const debug = debugFactory( 'calypso:two-step-authorization' );
 const wpcom = wp.undocumented();
 
 /*

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
-import React from 'react';
-import debugFactory from 'debug';
-import page from 'page';
 import url from 'url';
+import debugFactory from 'debug';
 import { pick } from 'lodash';
+import page from 'page';
+import React from 'react';
 
-/**
- * Internal dependencies
- */
 const debug = debugFactory( 'calypso:url-search' );
 
 /**

--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { buildSearchUrl } from '../';
 
 describe( '#buildSearchUrl', () => {

--- a/client/lib/url/add-query-args.ts
+++ b/client/lib/url/add-query-args.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { pickBy } from 'lodash';
-import type { Primitive } from 'utility-types';
-
-/**
- * Internal dependencies
- */
-import type { URL as URLString } from 'calypso/types';
 import { format, determineUrlType, URL_TYPE } from '@automattic/calypso-url';
+import { pickBy } from 'lodash';
+import type { URL as URLString } from 'calypso/types';
+import type { Primitive } from 'utility-types';
 
 const BASE_URL = 'http://__domain__.invalid';
 

--- a/client/lib/url/decode-utils.ts
+++ b/client/lib/url/decode-utils.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { Falsy } from 'utility-types';
 
 interface Stringable {

--- a/client/lib/url/http-utils.ts
+++ b/client/lib/url/http-utils.ts
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { URL as TypedURL, SiteSlug } from 'calypso/types';
 import { Falsy } from 'utility-types';
+import { URL as TypedURL, SiteSlug } from 'calypso/types';
 
 const urlWithoutHttpRegex = /^https?:\/\//;
 

--- a/client/lib/url/is-external.ts
+++ b/client/lib/url/is-external.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
-import { URL as URLString } from 'calypso/types';
-
-/**
- * Internal dependencies
- */
 import { isLegacyRoute } from 'calypso/lib/route/legacy-routes';
+import { URL as URLString } from 'calypso/types';
 
 // Base URL used for URL parsing. The WHATWG URL API doesn't support relative
 // URLs, so we always need to provide a base of some sort.

--- a/client/lib/url/is-https.ts
+++ b/client/lib/url/is-https.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { URL as URLString } from 'calypso/types';
 
 export default function isHttps( url: URLString ): boolean {

--- a/client/lib/url/is-outside-calypso.ts
+++ b/client/lib/url/is-outside-calypso.ts
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
 import { getUrlParts } from '@automattic/calypso-url';
-import isExternal from './is-external';
 import { URL as URLString } from 'calypso/types';
+import isExternal from './is-external';
 
 export default function isOutsideCalypso( url: URLString ): boolean {
 	if ( isExternal( url ) ) {

--- a/client/lib/url/omit-url-params.ts
+++ b/client/lib/url/omit-url-params.ts
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import { URL as URLString } from 'calypso/types';
-import { Falsy } from 'utility-types';
-
-/**
- * Internal dependencies
- */
 import { format, determineUrlType, URL_TYPE } from '@automattic/calypso-url';
+import { Falsy } from 'utility-types';
+import { URL as URLString } from 'calypso/types';
 
 const BASE_URL = 'http://__domain__.invalid';
 

--- a/client/lib/url/resolve-relative-path.ts
+++ b/client/lib/url/resolve-relative-path.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { determineUrlType, URL_TYPE } from '@automattic/calypso-url';
 
 const DUMMY_URL = 'http://__domain__.invalid/';

--- a/client/lib/url/scheme-utils.ts
+++ b/client/lib/url/scheme-utils.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { URL as URLString, Scheme } from 'calypso/types';
 
 const schemeRegex = /^\w+:\/\//;

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 const root = localizeUrl( 'https://wordpress.com/support/' ).replace( /\/$/, '' );

--- a/client/lib/url/test/add-query-args.js
+++ b/client/lib/url/test/add-query-args.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import addQueryArgs from '../add-query-args';
 
 describe( '#addQueryArgs()', () => {

--- a/client/lib/url/test/decode-utils.js
+++ b/client/lib/url/test/decode-utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { decodeURIIfValid, decodeURIComponentIfValid } from '../decode-utils';
 
 describe( 'decodeURIIfValid', () => {

--- a/client/lib/url/test/http-utils.js
+++ b/client/lib/url/test/http-utils.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { withoutHttp, urlToSlug, urlToDomainAndPath } from '../http-utils';
 
 describe( 'withoutHttp', () => {

--- a/client/lib/url/test/is-external.js
+++ b/client/lib/url/test/is-external.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import isExternal from '../is-external';
 
 describe( 'isExternal', () => {

--- a/client/lib/url/test/is-outside-calypso.js
+++ b/client/lib/url/test/is-outside-calypso.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import isOutsideCalypso from '../is-outside-calypso';
 
 describe( 'isOutsideCalypso', () => {

--- a/client/lib/url/test/omit-url-params.js
+++ b/client/lib/url/test/omit-url-params.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import omitUrlParams from '../omit-url-params';
 
 describe( 'omitUrlParams()', () => {

--- a/client/lib/url/test/resembles-url.js
+++ b/client/lib/url/test/resembles-url.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import resemblesUrl from '../resembles-url';
 
 describe( 'resemblesUrl()', () => {

--- a/client/lib/url/test/resolve-relative-path.js
+++ b/client/lib/url/test/resolve-relative-path.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import resolveRelativePath from '../resolve-relative-path';
 
 describe( 'resolveRelativePath()', () => {

--- a/client/lib/url/test/scheme-utils.js
+++ b/client/lib/url/test/scheme-utils.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/**
- * Internal dependencies
- */
 import { addSchemeIfMissing, setUrlScheme } from '../scheme-utils';
 
 describe( 'addSchemeIfMissing()', () => {

--- a/client/lib/user-agent/index.js
+++ b/client/lib/user-agent/index.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import UserAgent from 'express-useragent';
 
 /*

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { decodeEntities } from 'calypso/lib/formatting/decode-entities';
 import { getComputedAttributes } from './get-computed-attributes';
 

--- a/client/lib/user/shared-utils/get-computed-attributes.js
+++ b/client/lib/user/shared-utils/get-computed-attributes.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getLanguage } from 'calypso/lib/i18n-utils/utils';
 import { withoutHttp } from 'calypso/lib/url';
 

--- a/client/lib/user/shared-utils/get-logout-url.js
+++ b/client/lib/user/shared-utils/get-logout-url.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
 
 export function getLogoutUrl( userData, redirect ) {

--- a/client/lib/user/shared-utils/initialize-current-user.js
+++ b/client/lib/user/shared-utils/initialize-current-user.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import {
 	isSupportUserSession,
 	isSupportNextSession,

--- a/client/lib/user/shared-utils/raw-current-user-fetch.js
+++ b/client/lib/user/shared-utils/raw-current-user-fetch.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 export function rawCurrentUserFetch() {

--- a/client/lib/user/store.js
+++ b/client/lib/user/store.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import store from 'store';
-
-/**
- * Internal dependencies
- */
 import { clearStorage } from 'calypso/lib/browser-storage';
 
 /**

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-import debugModule from 'debug';
-
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
 import config from '@automattic/calypso-config';
+import debugModule from 'debug';
 import { bypassPersistentStorage } from 'calypso/lib/browser-storage';
 import localStorageBypass from 'calypso/lib/local-storage-bypass';
+import wpcom from 'calypso/lib/wp';
 
 /**
  * Connects the Redux store and the low-level support user functions

--- a/client/lib/user/test/shared-utils.js
+++ b/client/lib/user/test/shared-utils.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
-
-/**
- * Internal dependencies
- */
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 
 jest.mock( '@automattic/calypso-config', () => {

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -1,6 +1,3 @@
-/**
- * External Dependencies
- */
 import { URL } from '../../types';
 
 export type UserMetaData = {

--- a/client/lib/user/verification-checker.js
+++ b/client/lib/user/verification-checker.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 const debug = debugFactory( 'calypso:user' );
 const storageKey = '__email_verified_signal__';

--- a/client/lib/web-payment/index.js
+++ b/client/lib/web-payment/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
 
 /**

--- a/client/lib/webauthn/index.js
+++ b/client/lib/webauthn/index.js
@@ -1,10 +1,7 @@
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
-import { translate } from 'i18n-calypso';
 import config from '@automattic/calypso-config';
 import { create, supported } from '@github/webauthn-json';
+import { translate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
 
 const POST = 'POST';
 

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -1,13 +1,6 @@
-/**
- * External Dependencies
- */
-import React from 'react';
-import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import PropTypes from 'prop-types';
+import React from 'react';
 import afterLayoutFlush from 'calypso/lib/after-layout-flush';
 
 const OVERFLOW_BUFFER = 4; // fairly arbitrary. feel free to tweak

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
-import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
-import wpcomUndocumented from 'calypso/lib/wpcom-undocumented';
 import config from '@automattic/calypso-config';
-import wpcomSupport from 'calypso/lib/wp/support';
-import { injectLocalization } from './localization';
-import { injectGuestSandboxTicketHandler } from './handlers/guest-sandbox-ticket';
-import * as oauthToken from 'calypso/lib/oauth-token';
-import wpcomXhrWrapper from 'calypso/lib/wpcom-xhr-wrapper';
+import debugFactory from 'debug';
 import wpcomProxyRequest from 'wpcom-proxy-request';
+import * as oauthToken from 'calypso/lib/oauth-token';
+import wpcomSupport from 'calypso/lib/wp/support';
+import wpcomUndocumented from 'calypso/lib/wpcom-undocumented';
+import wpcomXhrWrapper from 'calypso/lib/wpcom-xhr-wrapper';
+import { injectGuestSandboxTicketHandler } from './handlers/guest-sandbox-ticket';
+import { injectLocalization } from './localization';
 
 const debug = debugFactory( 'calypso:wp' );
 

--- a/client/lib/wp/handlers/guest-sandbox-ticket.js
+++ b/client/lib/wp/handlers/guest-sandbox-ticket.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import { parse, stringify } from 'qs';
 import store from 'store';
 

--- a/client/lib/wp/handlers/test/guest-sandbox-ticket.js
+++ b/client/lib/wp/handlers/test/guest-sandbox-ticket.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import store from 'store';
-
-/**
- * Internal dependencies
- */
 import {
 	deleteOldTicket,
 	GUEST_TICKET_LOCALFORAGE_KEY,

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -1,8 +1,5 @@
-/**
- * External dependencies
- */
-import { parse, stringify } from 'qs';
 import i18n from 'i18n-calypso';
+import { parse, stringify } from 'qs';
 
 /**
  * Given a WPCOM parameter set, modifies the query such that a non-default

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
 import { addLocaleQueryParam, injectLocalization } from '../';
 
 describe( 'index', () => {

--- a/client/lib/wp/node.js
+++ b/client/lib/wp/node.js
@@ -1,12 +1,8 @@
-/**
- * Internal dependencies
- */
-
-import wpcomUndocumented from 'calypso/lib/wpcom-undocumented';
 import config from '@automattic/calypso-config';
-import { injectLocalization } from './localization';
-import wpSupportWrapper from 'calypso/lib/wp/support';
 import wpcomXhrRequest from 'wpcom-xhr-request';
+import wpSupportWrapper from 'calypso/lib/wp/support';
+import wpcomUndocumented from 'calypso/lib/wpcom-undocumented';
+import { injectLocalization } from './localization';
 
 let wpcom = wpcomUndocumented( wpcomXhrRequest );
 

--- a/client/lib/wp/offline-library/index.js
+++ b/client/lib/wp/offline-library/index.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import stringify from 'fast-json-stable-stringify';
 import { parse } from 'qs';
 

--- a/client/lib/wp/support.js
+++ b/client/lib/wp/support.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { parse, stringify } from 'qs';
 
 export default function wpcomSupport( wpcom ) {

--- a/client/lib/wpcom-undocumented/index.js
+++ b/client/lib/wpcom-undocumented/index.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
-import wpcomFactory from 'wpcom';
-import inherits from 'inherits';
 import debugFactory from 'debug';
-
-/**
- * Internal dependencies
- */
+import inherits from 'inherits';
+import wpcomFactory from 'wpcom';
 import Undocumented from './lib/undocumented';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented' );

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-import WPCOM from 'wpcom';
-import inherits from 'inherits';
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
+import inherits from 'inherits';
+import WPCOM from 'wpcom';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:me' );
-
-/**
- * Internal dependencies.
- */
-import config from '@automattic/calypso-config';
 
 /**
  * Create an UndocumentedMe instance
@@ -114,7 +107,6 @@ UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback
  *
  * @param {object} [cardToken] Payment key
  * @param {object} [additionalData] Any additional data to send in the request
- *
  * @returns {Promise} A promise for the request
  */
 UndocumentedMe.prototype.storedCardAdd = function ( cardToken, additionalData = {} ) {
@@ -280,8 +272,43 @@ UndocumentedMe.prototype.deletePurchase = function ( purchaseId, fn ) {
  *  {string} user_name - (Optional) The user name associated with this connection, in case it's not part of id_token.
  *  {string} user_email - (Optional) The user name associated with this connection, in case it's not part of id_token.
  *  {string} redirect_to - The URL to redirect to after connecting.
+ * @param An.access_token
+ * @param An.service
+ * @param An.access_token
+ * @param An.service
+ * @param An.access_token
+ * @param An.service
+ * @param An.access_token
+ * @param An.service
+ * @param An.access_token
+ * @param An.service
+ * @param An.access_token
+ * @param An.service
  * @param {Function} fn - The callback for the request.
- *
+ * @param An.id_token
+ * @param An.user_name
+ * @param An.user_email
+ * @param An.redirect_to
+ * @param An.id_token
+ * @param An.user_name
+ * @param An.user_email
+ * @param An.redirect_to
+ * @param An.id_token
+ * @param An.user_name
+ * @param An.user_email
+ * @param An.redirect_to
+ * @param An.id_token
+ * @param An.user_name
+ * @param An.user_email
+ * @param An.redirect_to
+ * @param An.id_token
+ * @param An.user_name
+ * @param An.user_email
+ * @param An.redirect_to
+ * @param An.id_token
+ * @param An.user_name
+ * @param An.user_email
+ * @param An.redirect_to
  * @returns {Promise} A promise for the request
  */
 UndocumentedMe.prototype.socialConnect = function (
@@ -324,7 +351,6 @@ UndocumentedMe.prototype.socialConnect = function (
  *
  * @param {string} service - Social service associated with token, e.g. google.
  * @param {Function} fn - callback
- *
  * @returns {Promise} A promise for the request
  */
 UndocumentedMe.prototype.socialDisconnect = function ( service, fn ) {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-undocumented:site' );
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { camelCase, isPlainObject, omit, pick, snakeCase, set } from 'lodash';
 import { stringify } from 'qs';
-
-/**
- * Internal dependencies.
- */
-import Site from './site';
-import Me from './me';
-import config from '@automattic/calypso-config';
 import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
 import readerContentWidth from 'calypso/reader/lib/content-width';
+import Me from './me';
+import Site from './site';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?

--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import { clearStore } from 'calypso/lib/user/store';
 import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
+import { clearStore } from 'calypso/lib/user/store';
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
+import languages from '@automattic/languages';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { find } from 'lodash';
 import { stringify as stringifyQs } from 'qs';
-
-/**
- * Internal dependencies
- */
-import languages from '@automattic/languages';
 import jsonp from './jsonp';
 
 const debug = debugFactory( 'wporg' );

--- a/client/lib/wporg/jsonp.js
+++ b/client/lib/wporg/jsonp.js
@@ -3,13 +3,10 @@
  *
  */
 
-/**
- * External dependencies
- */
 import debugFactory from 'debug';
+import { stringify } from 'qs';
 
 const debug = debugFactory( 'jsonp' );
-import { stringify } from 'qs';
 
 /**
  * Module exports.
@@ -32,6 +29,7 @@ function noop() {}
  * @param {string} url
  * @param {object} query params
  * @param {Function} optional callback
+ * @param fn
  */
 function jsonp( url, query, fn ) {
 	const prefix = '__jp';

--- a/client/lib/wrap-in-site-offset.tsx
+++ b/client/lib/wrap-in-site-offset.tsx
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import React from 'react';
-
-/**
- * Internal dependencies
- */
 import { SiteOffsetProvider } from 'calypso/components/site-offset/context';
 import { Context } from './types';
 


### PR DESCRIPTION
#### Background

See #54448

#### Changes proposed in this Pull Request

Migrate `client/lib` to use `import/order`

#### Testing instructions

N/A

Note: there are quite a few eslint failures but none of them should be related to the `import/order` rule
