### PR TITLE
Signup - Fix wrong props used in user step component methods

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -49,22 +49,28 @@ function getLoginLink( props ) {
 	} );
 }
 
-function getRedirectToAfterLoginUrl( props ) {
+function getRedirectToAfterLoginUrl( {
+	oauth2Signup,
+	initialContext,
+	flowName,
+	stepName,
+	userLoggedIn,
+} ) {
 	if (
-		props.oauth2Signup &&
-		props.initialContext?.query?.oauth2_redirect &&
-		isOauth2RedirectValid( props.initialContext.query.oauth2_redirect )
+		oauth2Signup &&
+		initialContext?.query?.oauth2_redirect &&
+		isOauth2RedirectValid( initialContext.query.oauth2_redirect )
 	) {
-		return props.initialContext.query.oauth2_redirect;
+		return initialContext.query.oauth2_redirect;
 	}
 
 	const stepAfterRedirect =
-		getNextStepName( props.flowName, props.stepName, props.userLoggedIn ) ||
-		getPreviousStepName( props.flowName, props.stepName, props.userLoggedIn );
-	const queryArgs = new URLSearchParams( props.initialContext?.query );
+		getNextStepName( flowName, stepName, userLoggedIn ) ||
+		getPreviousStepName( flowName, stepName, userLoggedIn );
+	const queryArgs = new URLSearchParams( initialContext?.query );
 	const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
 
-	return window.location.origin + getStepUrl( props.flowName, stepAfterRedirect ) + queryArgsString;
+	return window.location.origin + getStepUrl( flowName, stepAfterRedirect ) + queryArgsString;
 }
 
 function isOauth2RedirectValid( oauth2Redirect ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -36,6 +36,51 @@ import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import './style.scss';
 
+function getLoginLink( props ) {
+	// TODO: If Reskin signup experiment wins, then refactor to remove duplicate definition of this function
+	// in <SignupForm> component
+	return login( {
+		isJetpack: 'jetpack-connect' === props.sectionName,
+		from: props.from,
+		redirectTo: getRedirectToAfterLoginUrl( props ),
+		locale: props.locale,
+		oauth2ClientId: props.oauth2Client?.id,
+		wccomFrom: props.wccomFrom,
+	} );
+}
+
+function getRedirectToAfterLoginUrl( props ) {
+	if (
+		props.oauth2Signup &&
+		props.initialContext?.query?.oauth2_redirect &&
+		isOauth2RedirectValid( props.initialContext.query.oauth2_redirect )
+	) {
+		return props.initialContext.query.oauth2_redirect;
+	}
+
+	const stepAfterRedirect =
+		getNextStepName( props.flowName, props.stepName, props.userLoggedIn ) ||
+		getPreviousStepName( props.flowName, props.stepName, props.userLoggedIn );
+	const queryArgs = new URLSearchParams( props.initialContext?.query );
+	const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
+
+	return window.location.origin + getStepUrl( props.flowName, stepAfterRedirect ) + queryArgsString;
+}
+
+function isOauth2RedirectValid( oauth2Redirect ) {
+	// Allow Google sign-up to work.
+	// See: https://github.com/Automattic/wp-calypso/issues/49572
+	if ( oauth2Redirect === undefined ) {
+		return true;
+	}
+
+	try {
+		const url = new URL( oauth2Redirect );
+		return url.host === 'public-api.wordpress.com';
+	} catch {
+		return false;
+	}
+}
 export class UserStep extends Component {
 	static propTypes = {
 		flowName: PropTypes.string,
@@ -94,21 +139,16 @@ export class UserStep extends Component {
 		this.setSubHeaderText( this.props );
 	};
 
-	getLoginLink() {
-		// TODO: If Reskin signup experiment wins, then refactor to remove duplicate definition of this function
-		// in <SignupForm> component
-		return login( {
-			isJetpack: 'jetpack-connect' === this.props.sectionName,
-			from: this.props.from,
-			redirectTo: this.getRedirectToAfterLoginUrl(),
-			locale: this.props.locale,
-			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-			wccomFrom: this.props.wccomFrom,
-		} );
-	}
-
 	setSubHeaderText( props ) {
-		const { flowName, oauth2Client, positionInFlow, translate, userLoggedIn, wccomFrom } = props;
+		const {
+			flowName,
+			oauth2Client,
+			positionInFlow,
+			translate,
+			userLoggedIn,
+			wccomFrom,
+			isReskinned,
+		} = props;
 
 		let subHeaderText = props.subHeaderText;
 
@@ -166,8 +206,8 @@ export class UserStep extends Component {
 		if ( positionInFlow === 0 && flowName === 'onboarding' ) {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 
-			if ( this.props.isReskinned ) {
-				const loginUrl = this.getLoginLink();
+			if ( isReskinned ) {
+				const loginUrl = getLoginLink( props );
 				subHeaderText = translate(
 					'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
 					{
@@ -202,21 +242,6 @@ export class UserStep extends Component {
 			form,
 		} );
 	};
-
-	isOauth2RedirectValid( oauth2Redirect ) {
-		// Allow Google sign-up to work.
-		// See: https://github.com/Automattic/wp-calypso/issues/49572
-		if ( oauth2Redirect === undefined ) {
-			return true;
-		}
-
-		try {
-			const url = new URL( oauth2Redirect );
-			return url.host === 'public-api.wordpress.com';
-		} catch {
-			return false;
-		}
-	}
 
 	submit = ( data ) => {
 		const { flowName, stepName, oauth2Signup } = this.props;
@@ -274,7 +299,7 @@ export class UserStep extends Component {
 		this.submit( {
 			userData,
 			form: formWithoutPassword,
-			queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
+			queryArgs: this.props.initialContext?.query || {},
 			recaptchaDidntLoad,
 			recaptchaFailed,
 			recaptchaToken: recaptchaToken || undefined,
@@ -291,9 +316,9 @@ export class UserStep extends Component {
 	 * @param {object} userData     (Optional) extra user information that can be used to create a new account
 	 */
 	handleSocialResponse = ( service, access_token, id_token = null, userData = null ) => {
-		const { translate } = this.props;
+		const { translate, initialContext } = this.props;
 
-		if ( ! this.isOauth2RedirectValid( this.props.initialContext.query.oauth2_redirect ) ) {
+		if ( ! isOauth2RedirectValid( initialContext?.query?.oauth2_redirect ) ) {
 			this.props.errorNotice(
 				translate( 'An unexpected error occurred. Please try again later.' )
 			);
@@ -305,7 +330,7 @@ export class UserStep extends Component {
 			access_token,
 			id_token,
 			userData,
-			queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
+			queryArgs: initialContext?.query || {},
 		} );
 	};
 
@@ -373,29 +398,6 @@ export class UserStep extends Component {
 		return headerText;
 	}
 
-	getRedirectToAfterLoginUrl() {
-		if (
-			this.props.oauth2Signup &&
-			this.props.initialContext &&
-			this.props.initialContext.query.oauth2_redirect &&
-			this.isOauth2RedirectValid( this.props.initialContext.query.oauth2_redirect )
-		) {
-			return this.props.initialContext.query.oauth2_redirect;
-		}
-
-		const stepAfterRedirect =
-			getNextStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn ) ||
-			getPreviousStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn );
-		const queryArgs = new URLSearchParams( this.props?.initialContext?.query );
-		const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
-
-		return (
-			window.location.origin +
-			getStepUrl( this.props.flowName, stepAfterRedirect ) +
-			queryArgsString
-		);
-	}
-
 	submitButtonText() {
 		const { translate } = this.props;
 
@@ -433,7 +435,7 @@ export class UserStep extends Component {
 			<>
 				<SignupForm
 					{ ...omit( this.props, [ 'translate' ] ) }
-					redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
+					redirectToAfterLoginUrl={ getRedirectToAfterLoginUrl( this.props ) }
 					disabled={ this.userCreationStarted() }
 					submitting={ this.userCreationStarted() }
 					save={ this.save }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -36,19 +36,6 @@ import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import './style.scss';
 
-function getLoginLink( props ) {
-	// TODO: If Reskin signup experiment wins, then refactor to remove duplicate definition of this function
-	// in <SignupForm> component
-	return login( {
-		isJetpack: 'jetpack-connect' === props.sectionName,
-		from: props.from,
-		redirectTo: getRedirectToAfterLoginUrl( props ),
-		locale: props.locale,
-		oauth2ClientId: props.oauth2Client?.id,
-		wccomFrom: props.wccomFrom,
-	} );
-}
-
 function getRedirectToAfterLoginUrl( {
 	oauth2Signup,
 	initialContext,
@@ -154,6 +141,9 @@ export class UserStep extends Component {
 			userLoggedIn,
 			wccomFrom,
 			isReskinned,
+			sectionName,
+			from,
+			locale,
 		} = props;
 
 		let subHeaderText = props.subHeaderText;
@@ -213,7 +203,15 @@ export class UserStep extends Component {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 
 			if ( isReskinned ) {
-				const loginUrl = getLoginLink( props );
+				const loginUrl = login( {
+					isJetpack: 'jetpack-connect' === sectionName,
+					from,
+					redirectTo: getRedirectToAfterLoginUrl( props ),
+					locale,
+					oauth2ClientId: oauth2Client?.id,
+					wccomFrom,
+				} );
+
 				subHeaderText = translate(
 					'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
 					{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is fixing (or cleaning up) what may potentially be a logical inconsistency in the signup step. It hasn't escalated to an actual bug yet per se.

The gist of it: In `componentWillReceiveProps` we make a call to `setSubHeaderText` where we pass the new props (`nextProps`). `setSubHeaderText` makes a call to `getLoginLink`, which reverts back to using props from the class context (`this.props`). This looks like an oversight and propagates further down to `getRedirectToAfterLoginUrl`, etc. 

The code changes move these methods outside of the class, in effect also decoupling them from further `this.props` uses. They can now evolve a little more functionally with their own params.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the `/start` while logged out (eg: incognito window).
* Make sure the link to log-in works as before with the same `redirect_to` query arg.
* Change the browser's language, check again the log-in link. It should contain the locale suffix (fr for French).