### PR TITLE
Backup: Display when the site's retention period limit has been reached

### DIFF
--- a/client/components/activity-card-list/retention-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/retention-limit-upsell/index.tsx
@@ -5,15 +5,11 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
-
-/**
- * Internal dependencies
- */
+import ActivityCard from 'calypso/components/activity-card';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import ActivityCard from 'calypso/components/activity-card';
 import { useTrackUpsellView, useTrackUpgradeClick } from './hooks';
 
 /**

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -11,7 +11,7 @@ import {
 	isSuccessfulRealtimeBackup,
 } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
-import { useIsDateBeyondRetentionPeriod } from 'calypso/my-sites/backup/status/hooks';
+import { useIsDateBeyondRetentionPeriod } from 'calypso/my-sites/backup/hooks';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite, siteHasRealtimeBackups } from 'calypso/state/rewind/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';

--- a/client/components/jetpack/daily-backup-status/status-card/beyond-retention-period.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/beyond-retention-period.tsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import Button from 'calypso/components/forms/form-button';
+
+/**
+ * Type dependencies
+ */
+import { MomentInput } from 'moment';
+
+/**
+ * Style dependencies
+ */
+import cloudSuccessIcon from './icons/cloud-success.svg';
+import './style.scss';
+
+type OwnProps = {
+	selectedDate: MomentInput;
+};
+
+// Slightly different from the implementation in ../use-get-display-date,
+// this version only returns the date (i.e., time is excluded)
+const useDisplayDate = ( date: MomentInput ) => {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+
+	return useMemo( () => {
+		const dateWithOffset = applySiteOffset( date, { gmtOffset, timezone } );
+		const now = applySiteOffset( Date.now(), { gmtOffset, timezone } );
+
+		return dateWithOffset.isSame( now, 'year' )
+			? dateWithOffset.format( 'MMM D' )
+			: dateWithOffset.format( 'll' );
+	}, [ date, gmtOffset, timezone ] );
+};
+
+const BeyondRetentionPeriod: React.FC< OwnProps > = ( { selectedDate } ) => {
+	const translate = useTranslate();
+	const displayDate = useDisplayDate( selectedDate );
+
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const retentionDays = useSelector( ( state ) =>
+		getSiteActivityLogRetentionDays( state, siteId )
+	) as number;
+
+	const dispatch = useDispatch();
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_backup_retentionlimit_view', { site_id: siteId } ) );
+	}, [ dispatch, siteId ] );
+	const recordUpsellButtonClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_backup_retentionlimit_upgrade_click', { site_id: siteId } )
+		);
+	}, [ dispatch, siteId ] );
+
+	return (
+		<div className="beyond-retention-period">
+			<div className="status-card__message-head">
+				<img src={ cloudSuccessIcon } alt="" role="presentation" />
+				<div>{ displayDate }</div>
+			</div>
+			<div className="status-card__title">
+				{ translate(
+					'Restore backups older than %(days)d day',
+					'Restore backups older than %(days)d days',
+					{ count: retentionDays, args: { days: retentionDays } }
+				) }
+			</div>
+			<div className="status-card__label">
+				<p>
+					{ translate(
+						'Your activity log spans more than %(days)d day. Upgrade your backup storage to access activity older than %(days)d day.',
+						'Your activity log spans more than %(days)d days. Upgrade your backup storage to access activity older than %(days)d days.',
+						{ count: retentionDays, args: { days: retentionDays } }
+					) }
+				</p>
+				<Button
+					className="status-card__button"
+					href={ '/pricing' }
+					onClick={ recordUpsellButtonClick }
+				>
+					{ translate( 'Upgrade storage' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default BeyondRetentionPeriod;

--- a/client/components/jetpack/daily-backup-status/status-card/beyond-retention-period.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/beyond-retention-period.tsx
@@ -8,12 +8,13 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Button from 'calypso/components/forms/form-button';
 
 /**
@@ -67,6 +68,8 @@ const BeyondRetentionPeriod: React.FC< OwnProps > = ( { selectedDate } ) => {
 		);
 	}, [ dispatch, siteId ] );
 
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
 	return (
 		<div className="beyond-retention-period">
 			<div className="status-card__message-head">
@@ -90,7 +93,7 @@ const BeyondRetentionPeriod: React.FC< OwnProps > = ( { selectedDate } ) => {
 				</p>
 				<Button
 					className="status-card__button"
-					href={ '/pricing' }
+					href={ isJetpackCloud() ? `/pricing/${ siteSlug }` : `/plans/${ siteSlug }` }
 					onClick={ recordUpsellButtonClick }
 				>
 					{ translate( 'Upgrade storage' ) }

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -71,11 +71,14 @@
 }
 
 .status-card__label {
-	max-width: 500px;
 	margin-top: 24px;
 
 	color: var( --studio-gray-80 );
 	text-align: left;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		max-width: 500px;
+	}
 }
 
 .status-card__meta {

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -102,7 +102,11 @@
 
 /* Buttons */
 .daily-backup-status .form-button.status-card__support-button {
-	margin: 32px 0;
+	margin: 32px auto;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 32px 0;
+	}
 }
 
 /* Status-specific rules */

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -1,3 +1,37 @@
+.beyond-retention-period {
+	text-align: center;
+
+	.status-card__message-head {
+		margin-block-end: 24px;
+	}
+
+	.status-card__label {
+		text-align: center;
+	}
+
+	.status-card__button.form-button {
+		max-width: 240px;
+		margin: 32px auto;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-block-end: initial;
+		text-align: initial;
+
+		.status-card__message-head {
+			margin-block-end: initial;
+		}
+
+		.status-card__label {
+			text-align: initial;
+		}
+
+		.status-card__button.form-button {
+			margin: 32px 0;
+		}
+	}
+}
+
 .status-card__message-head {
 	color: var( --studio-gray-80 );
 

--- a/client/my-sites/backup/backup-date-picker/hooks.ts
+++ b/client/my-sites/backup/backup-date-picker/hooks.ts
@@ -9,32 +9,48 @@ import { useCallback } from 'react';
  */
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useFirstMatchingBackupAttempt } from '../hooks';
+import { useIsDateBeyondRetentionPeriod, useFirstMatchingBackupAttempt } from '../hooks';
 
 type CanGoToDateHook = (
+	siteId: number,
 	selectedDate: Moment,
 	oldestDateAvailable?: Moment
 ) => ( desiredDate: Moment ) => boolean;
 
-export const useCanGoToDate: CanGoToDateHook = ( selectedDate, oldestDateAvailable ) => {
+export const useCanGoToDate: CanGoToDateHook = ( siteId, selectedDate, oldestDateAvailable ) => {
 	const moment = useLocalizedMoment();
 	const today = useDateWithOffset( moment() );
+	const alreadyBeyondRetentionPeriod = useIsDateBeyondRetentionPeriod( siteId )( selectedDate );
 
 	return useCallback(
 		( desiredDate ) => {
 			const goingForwardInTime = desiredDate.isAfter( selectedDate, 'day' );
 			const goingBackwardInTime = desiredDate.isBefore( selectedDate, 'day' );
 
-			// If we're going backward in time, only go as far back as
-			// the oldest date we have information on; if we don't know
-			// the oldest date with data, always allow backward navigation.
 			if ( goingBackwardInTime ) {
-				return ! oldestDateAvailable || desiredDate.isSameOrAfter( oldestDateAvailable, 'day' );
+				// If we're already further back in time than this site's
+				// retention period allows, don't go any further
+				//
+				// NOTE: We intentionally allow navigation to one day
+				// past the retention period, so we can show eligible
+				// users the opportunity to upgrade
+				if ( alreadyBeyondRetentionPeriod ) {
+					return false;
+				}
+
+				// If we don't know the oldest date with data,
+				// always allow backward navigation
+				if ( ! oldestDateAvailable ) {
+					return true;
+				}
+
+				// Only go as far back as the oldest date we have information on
+				return desiredDate.isSameOrAfter( oldestDateAvailable, 'day' );
 			}
 
-			// If we're going forward in time, just make sure we don't
-			// let anyone accidentally slip into the future
 			if ( goingForwardInTime ) {
+				// Just make sure we don't let anyone accidentally slip
+				// into the future
 				return desiredDate.isSameOrBefore( today );
 			}
 
@@ -42,7 +58,7 @@ export const useCanGoToDate: CanGoToDateHook = ( selectedDate, oldestDateAvailab
 			// then everything's fine (this should never happen)
 			return true;
 		},
-		[ selectedDate, today, oldestDateAvailable ]
+		[ alreadyBeyondRetentionPeriod, selectedDate, today, oldestDateAvailable ]
 	);
 };
 

--- a/client/my-sites/backup/backup-date-picker/index.tsx
+++ b/client/my-sites/backup/backup-date-picker/index.tsx
@@ -55,7 +55,7 @@ const BackupDatePicker: React.FC< Props > = ( { selectedDate, onDateChange } ) =
 		{ shouldExecute: !! firstKnownBackupAttempt.backupAttempt }
 	);
 
-	const canGoToDate = useCanGoToDate( selectedDate, oldestDateAvailable );
+	const canGoToDate = useCanGoToDate( siteId, selectedDate, oldestDateAvailable );
 
 	const { previousDisplayDate, nextDisplayDate } = useMemo( () => {
 		const yesterday = moment( today ).subtract( 1, 'day' );

--- a/client/my-sites/backup/backup-date-picker/test/hooks.js
+++ b/client/my-sites/backup/backup-date-picker/test/hooks.js
@@ -126,4 +126,26 @@ describe( 'useCanGoToDate', () => {
 
 		expect( canGoToDate( theUnixEpoch ) ).toEqual( true );
 	} );
+
+	test( 'Allows backward navigation to one day past the retention period', () => {
+		const today = moment().startOf( 'day' );
+
+		useIsDateBeyondRetentionPeriod.mockImplementation( () => ( date ) => date.isBefore( today ) );
+		const canGoToDate = useCanGoToDate( 0, today );
+
+		const yesterday = moment( today ).subtract( 1, 'day' );
+		expect( canGoToDate( yesterday ) ).toEqual( true );
+	} );
+
+	test( 'Disallows backward navigation to >1 day past the retention period', () => {
+		const today = moment().startOf( 'day' );
+
+		useIsDateBeyondRetentionPeriod.mockImplementation( () => ( date ) =>
+			date.isSameOrBefore( today )
+		);
+		const canGoToDate = useCanGoToDate( 0, today );
+
+		const yesterday = moment( today ).subtract( 1, 'day' );
+		expect( canGoToDate( yesterday ) ).toEqual( false );
+	} );
 } );

--- a/client/my-sites/backup/backup-date-picker/test/hooks.js
+++ b/client/my-sites/backup/backup-date-picker/test/hooks.js
@@ -7,6 +7,10 @@ jest.mock( 'react', () => ( {
 } ) );
 jest.mock( 'calypso/components/localized-moment' );
 jest.mock( 'calypso/lib/jetpack/hooks/use-date-with-offset' );
+jest.mock( 'calypso/my-sites/backup/hooks', () => ( {
+	...jest.requireActual( 'calypso/my-sites/backup/hooks' ),
+	useIsDateBeyondRetentionPeriod: jest.fn(),
+} ) );
 
 /**
  * External dependencies
@@ -19,6 +23,7 @@ import { useCallback } from 'react';
  */
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
+import { useIsDateBeyondRetentionPeriod } from 'calypso/my-sites/backup/hooks';
 import { useCanGoToDate } from '../hooks';
 
 describe( 'useCanGoToDate', () => {
@@ -28,6 +33,7 @@ describe( 'useCanGoToDate', () => {
 		useCallback.mockImplementation( ( fn ) => fn );
 		useLocalizedMoment.mockImplementation( () => moment );
 		useDateWithOffset.mockImplementation( ( date ) => date );
+		useIsDateBeyondRetentionPeriod.mockImplementation( () => () => false );
 	} );
 
 	test( 'Allows both forward and backward navigation between the oldest date and the present (inclusive)', () => {
@@ -40,7 +46,7 @@ describe( 'useCanGoToDate', () => {
 		// The selected date is a week before now;
 		// the furthest back we can go is a year before now,
 		// and the furthest forward is, of course, the present
-		const canGoToDate = useCanGoToDate( aWeekAgo, aYearAgo );
+		const canGoToDate = useCanGoToDate( 0, aWeekAgo, aYearAgo );
 
 		expect( canGoToDate( today ) ).toEqual( true );
 		expect( canGoToDate( aDayAgo ) ).toEqual( true );
@@ -57,7 +63,7 @@ describe( 'useCanGoToDate', () => {
 		// The selected date is currently one week in the future... somehow.
 		// Really this should never happen, but sometimes people try to
 		// play around by changing the browser URL, etc.
-		const canGoToDate = useCanGoToDate( oneWeekInTheFuture );
+		const canGoToDate = useCanGoToDate( 0, oneWeekInTheFuture );
 
 		// We can move in the correct direction (backward) toward a valid date,
 		// but no further away (forward) than we are right now.
@@ -75,7 +81,7 @@ describe( 'useCanGoToDate', () => {
 		// The selected date is currently one week prior to the oldest valid
 		// date... somehow. Really this should never happen, but sometimes
 		// people try to play around by changing the browser URL, etc.
-		const canGoToDate = useCanGoToDate( aWeekBeforeThat, oldestDate );
+		const canGoToDate = useCanGoToDate( 0, aWeekBeforeThat, oldestDate );
 
 		// We can move in the correct direction (forward) toward a valid date,
 		// but no further away (backward) than we are right now.
@@ -92,7 +98,7 @@ describe( 'useCanGoToDate', () => {
 		// No matter what the currently selected date is,
 		// if we're inside the valid range of dates (oldestAvailable to now),
 		// navigation into the future isn't allowed
-		const canGoToDate = useCanGoToDate( anArbitraryDate );
+		const canGoToDate = useCanGoToDate( 0, anArbitraryDate );
 
 		expect( canGoToDate( today ) ).toEqual( true );
 		expect( canGoToDate( tomorrow ) ).toEqual( false );
@@ -107,7 +113,7 @@ describe( 'useCanGoToDate', () => {
 		// and we can go as far back as a week;
 		// if we attempt to go back any further,
 		// the function should return false
-		const canGoToDate = useCanGoToDate( today, oneWeekAgo );
+		const canGoToDate = useCanGoToDate( 0, today, oneWeekAgo );
 
 		expect( canGoToDate( oneWeekAgo ) ).toEqual( true );
 		expect( canGoToDate( aDayBeforeThat ) ).toEqual( false );
@@ -116,7 +122,7 @@ describe( 'useCanGoToDate', () => {
 	test( 'Always allows backward navigation if no oldest date is known', () => {
 		const theUnixEpoch = moment( 0 );
 
-		const canGoToDate = useCanGoToDate( moment() );
+		const canGoToDate = useCanGoToDate( 0, moment() );
 
 		expect( canGoToDate( theUnixEpoch ) ).toEqual( true );
 	} );

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -1,15 +1,12 @@
 /**
  * External dependencies
  */
-import { isEnabled } from '@automattic/calypso-config';
-import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
 
 /**
  * Internal dependencies
  */
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { applySiteOffset } from 'calypso/lib/site/timezone';
 import {
 	DELTA_ACTIVITIES,
 	getDeltaActivities,
@@ -17,41 +14,7 @@ import {
 	isActivityBackup,
 	isSuccessfulRealtimeBackup,
 } from 'calypso/lib/jetpack/backup-utils';
-import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
-import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
-import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { useActivityLogs, useFirstMatchingBackupAttempt } from '../hooks';
-
-/**
- * A React hook that creates a callback to test whether or not a given date is
- * within a site's Backup retention period (if retention periods are enabled).
- *
- * @param {number|null} siteId The site whose retention period we'll be testing against.
- * @returns A callback that returns true if a given date is outside the site's retention period, and false otherwise.
- */
-export const useIsDateBeyondRetentionPeriod = ( siteId ) => {
-	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
-	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
-	const retentionDays = useSelector( ( state ) =>
-		getSiteActivityLogRetentionDays( state, siteId )
-	);
-
-	return useCallback(
-		( date ) => {
-			if ( ! isEnabled( 'activity-log/retention-policies' ) ) {
-				return false;
-			}
-
-			if ( retentionDays === undefined ) {
-				return false;
-			}
-
-			const today = applySiteOffset( Date.now(), { gmtOffset, timezone } ).startOf( 'day' );
-			return today.diff( date, 'days' ) > retentionDays;
-		},
-		[ gmtOffset, timezone, retentionDays ]
-	);
-};
 
 const useLatestBackupAttempt = ( siteId, { before, after, successOnly = false } = {} ) => {
 	return useFirstMatchingBackupAttempt( siteId, {

--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { isEnabled } from '@automattic/calypso-config';
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
 import {
 	DELTA_ACTIVITIES,
 	getDeltaActivities,
@@ -14,7 +17,41 @@ import {
 	isActivityBackup,
 	isSuccessfulRealtimeBackup,
 } from 'calypso/lib/jetpack/backup-utils';
+import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { useActivityLogs, useFirstMatchingBackupAttempt } from '../hooks';
+
+/**
+ * A React hook that creates a callback to test whether or not a given date is
+ * within a site's Backup retention period (if retention periods are enabled).
+ *
+ * @param {number|null} siteId The site whose retention period we'll be testing against.
+ * @returns A callback that returns true if a given date is outside the site's retention period, and false otherwise.
+ */
+export const useIsDateBeyondRetentionPeriod = ( siteId ) => {
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+	const retentionDays = useSelector( ( state ) =>
+		getSiteActivityLogRetentionDays( state, siteId )
+	);
+
+	return useCallback(
+		( date ) => {
+			if ( ! isEnabled( 'activity-log/retention-policies' ) ) {
+				return false;
+			}
+
+			if ( retentionDays === undefined ) {
+				return false;
+			}
+
+			const today = applySiteOffset( Date.now(), { gmtOffset, timezone } ).startOf( 'day' );
+			return today.diff( date, 'days' ) > retentionDays;
+		},
+		[ gmtOffset, timezone, retentionDays ]
+	);
+};
 
 const useLatestBackupAttempt = ( siteId, { before, after, successOnly = false } = {} ) => {
 	return useFirstMatchingBackupAttempt( siteId, {

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -13,7 +13,11 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupDelta from 'calypso/components/jetpack/backup-delta';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import MostRecentStatus from 'calypso/components/jetpack/daily-backup-status';
-import { useDailyBackupStatus, useRealtimeBackupStatus } from './hooks';
+import {
+	useIsDateBeyondRetentionPeriod,
+	useDailyBackupStatus,
+	useRealtimeBackupStatus,
+} from './hooks';
 
 /**
  * Style dependencies
@@ -56,6 +60,7 @@ export const DailyStatus = ( { selectedDate } ) => {
 
 export const RealtimeStatus = ( { selectedDate } ) => {
 	const siteId = useSelector( getSelectedSiteId );
+	const isDateBeyondRetentionPeriod = useIsDateBeyondRetentionPeriod( siteId );
 
 	const moment = useLocalizedMoment();
 
@@ -89,7 +94,7 @@ export const RealtimeStatus = ( { selectedDate } ) => {
 				} }
 			/>
 
-			{ lastBackupAttemptOnDate && (
+			{ ! isDateBeyondRetentionPeriod( selectedDate ) && lastBackupAttemptOnDate && (
 				<BackupDelta
 					{ ...{
 						realtimeBackups: backupAttemptsOnDate,

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -13,11 +13,8 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupDelta from 'calypso/components/jetpack/backup-delta';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import MostRecentStatus from 'calypso/components/jetpack/daily-backup-status';
-import {
-	useIsDateBeyondRetentionPeriod,
-	useDailyBackupStatus,
-	useRealtimeBackupStatus,
-} from './hooks';
+import { useIsDateBeyondRetentionPeriod } from '../hooks';
+import { useDailyBackupStatus, useRealtimeBackupStatus } from './hooks';
 
 /**
  * Style dependencies


### PR DESCRIPTION
Resolves `1200412004370260-as-1200657131060106`.
Depends on #54900.

#### Changes proposed in this Pull Request

* Add a new `BeyondRetentionPeriod` backup status card, to be shown when the selected date is at least one day past the selected site's retention period.
* Disallow navigation to dates that would fall further beyond the selected site's retention period than 1 day.
* On narrow screens, center the call-to-action button on the Backup page if one is present.
* Make the `useCanGoToDate` hook aware of retention policies.
* Move the `useIsDateBeyondRetentionPeriod` hook up into the root `my-sites/backup` directory, since its scope of use is now wider.

#### Testing instructions

***Recommended:** In order to test using the Activity Log retention policy API endpoint, you'll need a WordPress.com sandbox with `D64586-code` applied to it, and you'll need to point `public-api.wordpress.com` to that sandbox in your testing environment's DNS settings. To see testing instructions for a similar PR, reference #54900.*

1. Open Calypso Blue or Green and select a site with Backup Real-time.
2. Verify that without enabling any feature flags, the Backup page looks and behaves exactly as in production. You should see no outgoing requests to `activity/retention` in your browser's Network panel.
3. If you're testing locally, enable the `activity-log/retention-policies` flag in `development.json` and `jetpack-cloud-development.json` and restart Calypso. Then, refresh the page. (Alternatively, or if you're using calypso.live, add `?flags=activity-log/retention-policies` to your browser's URL.)
4. Set your selected site's retention period to a small number of days (e.g., 1-3), either by modifying your sandbox's retention policy API endpoint or by manually altering the application state in the your browser console like so:

```js
state.activityLog.retentionPolicy[ state.ui.selectedSiteId ].days = 1;
```

5. Start navigating backward in time using the date picker on the Backup page. Verify you're allowed to navigate to no more than one day past your selected site's retention period.
6. Alter your site's retention period as in step 4, but set it to `null` this time. Verify you're allowed to navigate backward in time without restriction.

#### Reference captures

##### Design mock screenshot

![image](https://user-images.githubusercontent.com/670067/128379148-dac71d88-2b48-41c2-8559-c4afc2488db4.png)

##### Backup page date navigation, retention period = 1 day

https://user-images.githubusercontent.com/670067/128377191-fa297608-703b-4b2a-a642-47fb2e19804a.mp4

##### Screen sizing: Calypso Blue

https://user-images.githubusercontent.com/670067/128377209-18ddd709-8857-4ba7-8827-ba11b35d2956.mp4

##### Screen sizing: Calypso Green

https://user-images.githubusercontent.com/670067/128377232-bd2b8cf8-cf79-4ec7-ad9e-5c67c9a90b52.mp4