### PR TITLE
Full Site Editing: Fix template part editing for legacy FSE

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -195,6 +195,10 @@ function hide_fse_blocks( $editor_settings ) {
  * @return void
  */
 function hide_template_cpts() {
+	// This can interfere with Legacy FSE, bail if it's active.
+	if ( is_full_site_editing_active() ) {
+		return;
+	}
 	global $wp_post_types;
 	if ( isset( $wp_post_types['wp_template'] ) ) {
 		$wp_post_types['wp_template']->show_ui = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow template part editing for Legacy FSE

#### Testing instructions

1. Load this on a legacy FSE site
2. Try to edit a Template Part
3. You don't get a "Sorry, you are not allowed to edit posts in this post type" error