### PR TITLE
Add PageViews to Jetpack Checkout Thank-You Pages

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -44,9 +44,10 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } 
 	return (
 		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">
 			<PageViewTracker
+				options={ { useJetpackGoogleAnalytics: true } }
 				path="/checkout/jetpack/thank-you-completed/no-site/:product"
-				title="Checkout > Jetpack Siteless Thank You Completed"
 				properties={ { product_slug: productSlug } }
+				title="Checkout > Jetpack Siteless Thank You Completed"
 			/>
 			<Card className="jetpack-checkout-siteless-thank-you-completed__card">
 				<div className="jetpack-checkout-siteless-thank-you-completed__card-main">

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -204,7 +204,11 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 		<Main fullWidthLayout className="jetpack-checkout-siteless-thank-you">
 			<PageViewTracker
 				options={ { useJetpackGoogleAnalytics: true } }
-				path="/checkout/jetpack/thank-you/no-site/:product"
+				path={
+					forScheduling
+						? '/checkout/jetpack/schedule-happiness-appointment'
+						: '/checkout/jetpack/thank-you/no-site/:product'
+				}
 				properties={ { product_slug: productSlug } }
 				title="Checkout > Jetpack Siteless Thank You"
 			/>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -203,9 +203,10 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 	return (
 		<Main fullWidthLayout className="jetpack-checkout-siteless-thank-you">
 			<PageViewTracker
+				options={ { useJetpackGoogleAnalytics: true } }
 				path="/checkout/jetpack/thank-you/no-site/:product"
-				title="Checkout > Jetpack Siteless Thank You"
 				properties={ { product_slug: productSlug } }
+				title="Checkout > Jetpack Siteless Thank You"
 			/>
 			<Card className="jetpack-checkout-siteless-thank-you__card">
 				<div className="jetpack-checkout-siteless-thank-you__card-main">

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx
@@ -18,6 +18,7 @@ import {
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 interface Props {
 	site: number | string;
@@ -79,6 +80,12 @@ const JetpackCheckoutThankYou: FunctionComponent< Props > = ( {
 
 	return (
 		<Main className="jetpack-checkout-thank-you">
+			<PageViewTracker
+				options={ { useJetpackGoogleAnalytics: true } }
+				path="/checkout/jetpack/thank-you/:site/:product"
+				properties={ { product_slug: productSlug } }
+				title="Checkout > Jetpack Thank You"
+			/>
 			<Card className="jetpack-checkout-thank-you__card">
 				<JetpackLogo full size={ 45 } />
 				{ hasProductInfo && <QueryProducts type="jetpack" /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure Jetpack Siteless Thanks-yous are using Jetpack GA
* Add a Pageview to the normal Jetpack Thank-you 

#### Testing instructions

1. Set `ad-tracking` to true in `development.json` and boot Calypso Blue
2. Enter `localStorage.setItem( 'debug', 'calypso:analytics:ga' );` into the dev console
3. Navigate to `/checkout/jetpack/thank-you/no-site/jetpack_backup_daily` ( or any other jetpack product )
4. Verify the following is logged on the console: <img width="942" alt="Screen Shot 2021-08-05 at 11 22 48 AM" src="https://user-images.githubusercontent.com/2810519/128401495-ea43a8d9-a7f3-4a48-b9c0-7469c35698a6.png">
5. Navigate to `/checkout/jetpack/schedule-happiness-appointment`
6. Verify the following is logged on the console: <img width="956" alt="Screen Shot 2021-08-05 at 11 23 56 AM" src="https://user-images.githubusercontent.com/2810519/128401654-d667e8bd-bf0e-4097-92e9-48cbac7ce726.png">
7. Navigate to `/checkout/jetpack/thank-you-completed/no-site/jetpack_daily_backup`  ( or any other jetpack product )
8. Verify the following is logged on the console: <img width="945" alt="Screen Shot 2021-08-05 at 11 24 50 AM" src="https://user-images.githubusercontent.com/2810519/128401812-e442fcfe-4cfb-44ae-a137-010e111c4303.png">
9. Navigate to `/checkout/jetpack/thank-you/<siteSlug>/jetpack_backup_daily` for a jetpack site and product
10. Verify the following was logged to the console: <img width="943" alt="Screen Shot 2021-08-05 at 11 26 26 AM" src="https://user-images.githubusercontent.com/2810519/128402064-36cbbdfb-6f89-4434-9ffb-c4da5b63a78f.png">



