### PR TITLE
Desktop: Add instructions when trying to login with an email link

### DIFF
--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -1,5 +1,5 @@
-const log = require( '../../lib/logger' )( 'desktop:external-links' );
 const assets = require( '../../lib/assets' );
+const log = require( '../../lib/logger' )( 'desktop:external-links' );
 
 let targetURL = '';
 

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -1,4 +1,6 @@
+// eslint-disable-next-line import/order
 const log = require( '../../lib/logger' )( 'desktop:external-links' );
+const assets = require( '../../lib/assets' );
 
 let targetURL = '';
 
@@ -11,6 +13,17 @@ module.exports = function ( { view } ) {
 		log.info( `Navigating to URL: '${ urlToLoad }'` );
 
 		event.preventDefault();
+		view.webContents.loadURL( urlToLoad );
+		return;
+	} );
+
+	// Magic links aren't supported in the app currently. Instead we'll show a message about how
+	// to set a password on the account to log in that way.
+	view.webContents.on( 'will-navigate', function ( event, url ) {
+		const urlToLoad =
+			url === 'https://wordpress.com/log-in/link'
+				? 'file://' + assets.getPath( 'magic-links-unsupported.html' )
+				: url;
 		view.webContents.loadURL( urlToLoad );
 		return;
 	} );

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 const log = require( '../../lib/logger' )( 'desktop:external-links' );
 const assets = require( '../../lib/assets' );
 

--- a/desktop/app/window-handlers/navigation/index.js
+++ b/desktop/app/window-handlers/navigation/index.js
@@ -1,4 +1,5 @@
-const { ipcMain, systemPreferences } = require( 'electron' );
+const { ipcMain, shell, systemPreferences } = require( 'electron' );
+const { stubObject } = require( 'lodash' );
 const ipc = require( '../../lib/calypso-commands' );
 const Config = require( '../../lib/config' );
 const isCalypso = require( '../../lib/is-calypso' );
@@ -24,6 +25,10 @@ module.exports = function ( { view, window } ) {
 		} else {
 			view.webContents.loadURL( webBase + 'stats/day' );
 		}
+	} );
+
+	ipcMain.on( 'magic-link-set-password', () => {
+		shell.openExternal( 'https://wordpress.com/me/security' );
 	} );
 
 	if ( process.platform === 'darwin' ) {

--- a/desktop/app/window-handlers/navigation/index.js
+++ b/desktop/app/window-handlers/navigation/index.js
@@ -1,5 +1,4 @@
 const { ipcMain, shell, systemPreferences } = require( 'electron' );
-const { stubObject } = require( 'lodash' );
 const ipc = require( '../../lib/calypso-commands' );
 const Config = require( '../../lib/config' );
 const isCalypso = require( '../../lib/is-calypso' );

--- a/desktop/public_desktop/magic-links-unsupported.html
+++ b/desktop/public_desktop/magic-links-unsupported.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html class="desktop-auth">
+	<head>
+		<title>WordPress.com account requires password</title>
+
+		<meta charset="utf-8" />
+
+		<link
+			rel="stylesheet"
+			href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,400,300,600|Merriweather:700,300,700italic,300italic"
+		/>
+		<link rel="stylesheet" href="wordpress-desktop.css" />
+	</head>
+	<body>
+		<div class="flex">
+			<div class="welcome">
+				<div class="large-icon">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="-2 -2 24 24"
+						width="36"
+						height="36"
+						role="img"
+						aria-hidden="true"
+						focusable="false"
+					>
+						<path
+							d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm1.13 9.38l.35-6.46H8.52l.35 6.46h2.26zm-.09 3.36c.24-.23.37-.55.37-.96 0-.42-.12-.74-.36-.97s-.59-.35-1.06-.35-.82.12-1.07.35-.37.55-.37.97c0 .41.13.73.38.96.26.23.61.34 1.06.34s.8-.11 1.05-.34z"
+						></path>
+					</svg>
+				</div>
+
+				<h3>Password Required</h3>
+				<p>
+					To use the WordPress.com Desktop app your account requires a password. Please log in to your account through your browser and set a password, then log in through the app.
+				</p>
+				<p><a class="button-emphasis" id="set-password" href="https://wordpress.com/me/security">Set Password</a></p>
+			</div>
+		</div>
+    <script>
+      const button = document.getElementById('set-password');
+      button.addEventListener('click', function () {
+        window.electron.send('magic-link-set-password');
+      });
+    </script>
+	</body>
+</html>

--- a/desktop/public_desktop/magic-links-unsupported.html
+++ b/desktop/public_desktop/magic-links-unsupported.html
@@ -32,7 +32,8 @@
 
 				<h3>Password Required</h3>
 				<p>
-					To use the WordPress.com Desktop app your account requires a password. Please log in to your account through your browser and set a password, then log in through the app.
+					To use the WordPress.com Desktop app your account requires a password. Please log in to your account through your browser, create a password for your account and use this password to log in
+          to the Desktop application.
 				</p>
 				<p><a class="button-emphasis" id="set-password" href="https://wordpress.com/me/security">Set Password</a></p>
 			</div>

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -18,6 +18,7 @@ const sendChannels = [
 	'secrets',
 	'toggle-dev-tools',
 	'title-bar-double-click',
+	'magic-link-set-password',
 ];
 
 // Incoming IPC message channels from Main process to Renderer.


### PR DESCRIPTION
#### Description

Currently, we aren't able to support email/magic link logins in the Desktop App. So if someone has a WP.com account they sign in to using a social login and have never set a password, they aren't able to use the app.

This attempts to add instructions asking them to set a password on their account in a browser which they can then use to log in to the app with.

#### Testing instructions

- Have an account created with a Google or Apple account and no password created
- Attempt to log into the app using the email associated with the social account
- Notice instructions to set a password
- Ensure the button opens in a browser window

