### PR TITLE
Issue Templates: Add more granular fields for impact

### DIFF
--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -89,15 +89,22 @@ body:
       label: Console and/or error logs
       description: If there are any console logs or errors, paste it below.
   - type: dropdown
-    id: impact
+    id: users-affected
     attributes:
-      label: Level of impact
-      description: Does it block a core feature? Does it impact more than one site?
+      label: Number of Users Impacted
+      description: How many users do you think might encounter this bug? Best guesses are fine!
       options:
-        - Low
-        - Normal
-        - High
-        - Blocker
+        - One user
+        - Some users (<50%)
+        - Most users (>50%)
+        - All users
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Available Workarounds
+      description: Are there any workarounds to this bug? How difficult are those workarounds?
+      placeholder: |
+        eg. There is alternative access to this setting in the sidebar, but it's not readily apparent.
   - type: dropdown
     id: reproducibility
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -63,14 +63,15 @@ body:
       options:
         - Chrome/Chromium
         - Firefox
-        - Safari
+        - Microsoft Edge
         - Microsoft Edge (legacy)
+        - Safari
       multiple: true
     validations:
       required: true
   - type: input
     attributes:
-      label: Browser Version
+      label: Browser Version(s)
   - type: input
     id: theme
     attributes:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the HE issue template, this replaces the previous impact field (low, normal, hi, blocker) with two fields that ask about:
- the number of anticipated users impacted
- whether there are good workarounds available

This should align with the criteria we use to assess priority during triage, as outlined in pciE2j-oG-p2. 

This should offload the burden of priority bucketing from users and allow us to get more consistent priorities during triage.

#### Testing instructions

- Check the user template by clicking on the file in the branch. Does it look good and are the prompts clear?
