### PR TITLE
Playwright: Re-enable the plans manage tests in mobile

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -6,7 +6,6 @@ import {
 	PlansPage,
 	IndividualPurchasePage,
 	CartCheckoutPage,
-	BrowserHelper,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
@@ -47,10 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 		} );
 	} );
 
-	const describeDesktopOnly =
-		BrowserHelper.getViewportName() === 'desktop' ? describe : describe.skip;
-	// The manage button is currently broken on mobile - see issue #55046. TODO: remove the if check when that issue is fixed.
-	describeDesktopOnly( 'Manage current plan (Premium)', function () {
+	describe( 'Manage current plan (Premium)', function () {
 		const cartItemForPremiumPlan = 'WordPress.com Premium';
 		it( 'Click on "Manage Plan" button for the active Premium plan', async function () {
 			// This navigation also validates that we correctly identify the active plan in the Plans table.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, the section of the Playwright plans specs that dealt with managing an existing plan was disabled in mobile due to issue #55046.

That issue has been fixed, so we can re-enable these tests!

#### Testing instructions

- [x] All Playwright tests should pass
- [x] The mobile run of the Playwright tests should have a test group titled `Manage current plan (Premium)`

Related to #55046.
