### PR TITLE
My Home log tracks event only when a primary card is viewed

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -68,7 +68,7 @@ export const DotPager = ( {
 	hasDynamicHeight = false,
 	children,
 	className,
-	onSetCurrentPage,
+	onPageSelected,
 	...props
 } ) => {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
@@ -76,10 +76,6 @@ export const DotPager = ( {
 	const pagesRef = useRef();
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const numPages = Children.count( children );
-
-	useEffect( () => {
-		onSetCurrentPage && onSetCurrentPage( currentPage );
-	}, [ currentPage, onSetCurrentPage ] );
 
 	useEffect( () => {
 		if ( ! hasDynamicHeight ) {
@@ -104,7 +100,10 @@ export const DotPager = ( {
 				showControlLabels={ showControlLabels }
 				currentPage={ currentPage }
 				numberOfPages={ numPages }
-				setCurrentPage={ setCurrentPage }
+				setCurrentPage={ ( index ) => {
+					onPageSelected && onPageSelected( index );
+					setCurrentPage( index );
+				} }
 			/>
 			<div className="dot-pager__pages" ref={ pagesRef } style={ pagesStyle }>
 				{ Children.map( children, ( child, index ) => (

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -68,6 +68,7 @@ export const DotPager = ( {
 	hasDynamicHeight = false,
 	children,
 	className,
+	onSetCurrentPage,
 	...props
 } ) => {
 	const [ currentPage, setCurrentPage ] = useState( 0 );
@@ -75,6 +76,10 @@ export const DotPager = ( {
 	const pagesRef = useRef();
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const numPages = Children.count( children );
+
+	useEffect( () => {
+		onSetCurrentPage && onSetCurrentPage( currentPage );
+	}, [ currentPage, onSetCurrentPage ] );
 
 	useEffect( () => {
 		if ( ! hasDynamicHeight ) {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -69,19 +69,19 @@ const cardComponents = {
 };
 
 const Primary = ( { cards, trackCard } ) => {
-	const [ currentPage, setCurrentPage ] = useState( 0 );
-	const [ viewedCards, setViewedCards ] = useState( {} );
+	const viewedCards = useRef( new Set() );
 
-	useEffect( () => {
-		const currentCard = cards && cards[ currentPage ];
-		if ( ! viewedCards[ currentCard ] ) {
-			setViewedCards( {
-				...viewedCards,
-				[ currentCard ]: true,
-			} );
-			trackCard( currentCard );
+	const handlePageSelected = ( index ) => {
+		const selectedCard = cards && cards[ index ];
+		if ( viewedCards.current.has( selectedCard ) ) {
+			return;
 		}
-	}, [ currentPage, cards.length, trackCard ] );
+
+		viewedCards.current.add( selectedCard );
+		trackCard( selectedCard );
+	};
+
+	useEffect( () => handlePageSelected( 0 ) );
 
 	if ( ! cards || ! cards.length ) {
 		return null;
@@ -96,7 +96,7 @@ const Primary = ( { cards, trackCard } ) => {
 			} ) }
 			showControlLabels="true"
 			hasDynamicHeight
-			onSetCurrentPage={ setCurrentPage }
+			onPageSelected={ handlePageSelected }
 		>
 			{ cards.map(
 				( card, index ) =>


### PR DESCRIPTION
Currently if multiple primary cards are loaded into the primary cards pager on my-home, a tracks event will be sent for each one even if the user never views them.

This hooks into the current page on the dot-pager component to only fire the tracks event the first time that a user views a primary card.

If they slide back and forth over the cards, it will only log one impression of each card

fixes https://github.com/Automattic/wp-calypso/issues/55180
### Testing instructions:
Apply D64878-code 
filter the network logs for `t.gif`
Notice that the `calypso_customer_home_card_impression` is logged for secondary/tertiary cards but only for the currently shown primary card.
Slide to the next primary card. a `calypso_customer_home_card_impression` will be sent for that card.
Slide back to the first card
No new event will be sent