### PR TITLE
My Home: Parent of `TASK_RENEW_EXPIRED_PLAN` needs a dark background

### DIFF
--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
@@ -78,9 +79,13 @@ const Primary = ( { cards, trackCards } ) => {
 		return null;
 	}
 
+	const isUrgent = cards.length === 1 && cards[ 0 ] === TASK_RENEW_EXPIRED_PLAN;
+
 	return (
 		<DotPager
-			className="primary__customer-home-location-content"
+			className={ classnames( 'primary__customer-home-location-content', {
+				'primary__is-urgent': isUrgent,
+			} ) }
 			showControlLabels="true"
 			hasDynamicHeight
 		>

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -226,3 +226,8 @@ body.is-section-home {
 		}
 	}
 }
+
+.primary__is-urgent {
+	background: var( --color-neutral-80 );
+	color: var( --color-neutral-0 );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request


The expired plan card is broken because it has a dark background. This would have been broken when we started wrapping primary cards in a `<DotPager>`
<img width="1061" alt="Screenshot 2021-08-06 at 5 03 08 PM" src="https://user-images.githubusercontent.com/1500769/128459901-751e50ea-492c-4a4b-a028-aa98f0ba19a2.png">

Fixed it looks like this
<img width="1061" alt="Screenshot 2021-08-06 at 5 04 42 PM" src="https://user-images.githubusercontent.com/1500769/128459914-32d1ac0c-eff8-43c2-a102-64f7a02acea3.png">


This isn't a general fix because it only fixes one card. But the expired
plan card is currently the only card that uses the `isUrgent` flag.

It's a bit tricky to fix in the general case for any card. I had an idea to fix it in the general case, but I think it'd be a bit complicated and probably not worth it.



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `?view=VIEW_RENEW_EXPIRED_PLAN`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

