### PR TITLE
Experiment: Convert package to ESM

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -246,6 +246,7 @@ const webpackConfig = {
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
+		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 		alias: Object.assign(
 			{
 				debug: path.resolve( __dirname, '../node_modules/debug' ),

--- a/packages/accessible-focus/jest.config.js
+++ b/packages/accessible-focus/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
 	preset: '../../test/packages/jest-preset.js',
 };

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -6,9 +6,15 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
 	"sideEffects": false,
-	"main": "dist/cjs/index.js",
-	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.ts",
+	"type": "module",
+	"exports": {
+		"calypso:src": "./src/index.ts",
+		"import": "./dist/esm/index.js",
+		"require": "./dist/cjs/index.js"
+	},
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR converts a very simple package into a module.

Useful reads:
* https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
* https://2ality.com/2021/06/typescript-esm-nodejs.html


Note this doesn't change Jest custom resolver yet (https://github.com/Automattic/wp-calypso/blob/trunk/test/module-resolver.js). That's only used when testing a package that imports another package from the repo.

#### Testing instructions

Check all builds are green