### PR TITLE
Remove wpcom.undocumented() methods for NPS survey

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2254,66 +2254,6 @@ Undocumented.prototype.transferStatus = function ( siteId, transferId ) {
 };
 
 /**
- * Submit a response to the NPS Survey.
- *
- * @param {string}     surveyName     The name of the NPS survey being submitted
- * @param {number}        score          The value for the survey response
- * @param {Function}   fn             The callback function
- * @returns {Promise} A promise representing the request.
- */
-Undocumented.prototype.submitNPSSurvey = function ( surveyName, score, fn ) {
-	return this.wpcom.req.post(
-		{ path: `/nps/${ surveyName }` },
-		{ apiVersion: '1.2' },
-		{ score },
-		fn
-	);
-};
-
-/**
- * Dismiss the NPS Survey.
- *
- * @param {string}     surveyName     The name of the NPS survey being submitted
- * @param {Function}   fn             The callback function
- * @returns {Promise} A promise representing the request.
- */
-Undocumented.prototype.dismissNPSSurvey = function ( surveyName, fn ) {
-	return this.wpcom.req.post(
-		{ path: `/nps/${ surveyName }` },
-		{ apiVersion: '1.2' },
-		{ dismissed: true },
-		fn
-	);
-};
-
-/**
- * Check the eligibility status for the NPS Survey.
- *
- * @param {Function}   fn             The callback function
- * @returns {Promise} A promise representing the request.
- */
-Undocumented.prototype.checkNPSSurveyEligibility = function ( fn ) {
-	return this.wpcom.req.get( { path: '/nps' }, { apiVersion: '1.2' }, {}, fn );
-};
-
-/**
- * Send the optional feedback for the NPS Survey.
- *
- * @param {string}   surveyName   The name of the NPS survey being submitted
- * @param {string}   feedback     The content
- * @param {Function} fn           The callback function
- * @returns {Promise} A promise representing the request.
- */
-Undocumented.prototype.sendNPSSurveyFeedback = function ( surveyName, feedback, fn ) {
-	return this.wpcom.req.post(
-		{ path: `/nps/${ surveyName }` },
-		{ apiVersion: '1.2' },
-		{ feedback },
-		fn
-	);
-};
-
-/**
  * Get OAuth2 Client data for a given client ID
  *
  * @param {string}     clientId       The client ID

--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -46,9 +46,8 @@ export function setupNpsSurveyEligibility() {
 	return ( dispatch ) => {
 		debug( 'Checking NPS eligibility...' );
 
-		return wpcom
-			.undocumented()
-			.checkNPSSurveyEligibility()
+		return wpcom.req
+			.get( '/nps', { apiVersion: '1.2' } )
 			.then( ( data ) => {
 				debug( '...Eligibility returned from endpoint.', data );
 				dispatch( setNpsSurveyEligibility( data.display_survey ) );
@@ -76,9 +75,8 @@ export function submitNpsSurvey( surveyName, score ) {
 		bumpStat( 'calypso_nps_survey', 'survey_submitted' );
 		recordTracksEvent( 'calypso_nps_survey_submitted' );
 
-		return wpcom
-			.undocumented()
-			.submitNPSSurvey( surveyName, score )
+		return wpcom.req
+			.post( `/nps/${ surveyName }`, { apiVersion: '1.2' }, { score } )
 			.then( () => {
 				debug( '...Successfully submitted NPS survey.' );
 				dispatch( submitNpsSurveyRequestSuccess() );
@@ -98,9 +96,8 @@ export function submitNpsSurveyWithNoScore( surveyName ) {
 		bumpStat( 'calypso_nps_survey', 'survey_dismissed' );
 		recordTracksEvent( 'calypso_nps_survey_dismissed' );
 
-		return wpcom
-			.undocumented()
-			.dismissNPSSurvey( surveyName )
+		return wpcom.req
+			.post( `/nps/${ surveyName }`, { apiVersion: '1.2' }, { dismissed: true } )
 			.then( () => {
 				debug( '...Successfully submitted NPS survey with no score.' );
 				dispatch( submitNpsSurveyWithNoScoreRequestSuccess() );
@@ -120,9 +117,8 @@ export function sendNpsSurveyFeedback( surveyName, feedback ) {
 		bumpStat( 'calypso_nps_survey', 'feedback_submitted' );
 		recordTracksEvent( 'calypso_nps_survey_feedback_submitted' );
 
-		return wpcom
-			.undocumented()
-			.sendNPSSurveyFeedback( surveyName, feedback )
+		return wpcom.req
+			.post( `/nps/${ surveyName }`, { apiVersion: '1.2' }, { feedback } )
 			.then( () => {
 				debug( '...Successfully sent NPS survey feedback.' );
 				dispatch( sendNpsSurveyFeedbackSuccess() );

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -19,12 +19,10 @@ import {
 
 // mock modules
 jest.mock( 'calypso/lib/wp', () => ( {
-	undocumented: () => ( {
-		// TODO: use mockResolvedValue instead when we update jest to 22.2 or later
-		submitNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),
-		dismissNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),
-		sendNPSSurveyFeedback: jest.fn().mockReturnValue( Promise.resolve() ),
-	} ),
+	req: {
+		get: jest.fn().mockResolvedValue(),
+		post: jest.fn().mockResolvedValue(),
+	},
 } ) );
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),


### PR DESCRIPTION
Migrates `wpcom.undocumented()` methods for the `/nps` endpoints to direct calls to `wpcom.req.get` and `wpcom.req.post`.

**How to test:**
In dev mode, trigger the NPS survey modal by navigating outside the Home section (to Stats, for example) and calling `npsSurvey()` in console.

Verify that the modal is displayed and a score can be submitted. In Network panel, verify that the REST requests are OK.