### PR TITLE
Revert "Welcome tour: fix footer alignment"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -86,8 +86,6 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	}
 
 	.components-card__footer {
-		width: auto;
-
 		.welcome-tour__end-text {
 			color: $gray-600;
 			font-size: 0.875rem;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#54455

Gutenberg 11.2.0 has been released (as a standalone plugin, and on both simple and atomic sites), which means that the original issue #54445 should now be fixed upstream, and that the hotfix applied in #54455 could be safely reverted.


## Testing instructions

- Apply the changes from this PR
- Follow the steps to reproduce the original issue (#54445) and verify that the issue can't be reproduced anymore
