### PR TITLE
Fix how we render notices in the domain suggestion screen in signup

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -82,6 +82,7 @@ class DomainSearchResults extends React.Component {
 			lastDomainSearched,
 			selectedSite,
 			translate,
+			isDomainOnly,
 		} = this.props;
 		const availabilityElementClasses = classNames( {
 			'domain-search-results__domain-is-available': availableDomain,
@@ -172,7 +173,7 @@ class DomainSearchResults extends React.Component {
 						}
 				  );
 
-			if ( ! selectedSite ) {
+			if ( isDomainOnly && ! [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus ) ) {
 				domainUnavailableMessage = translate(
 					'{{strong}}%(domain)s{{/strong}} is already registered. Please try another search.',
 					{

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -218,7 +218,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 
 	&.featured-domain-suggestion--is-placeholder {
 		margin-bottom: 12px;
-		margin-top: 40px;
+		margin-top: 0;
 		border-radius: 4px; /* stylelint-disable-line */
 	}
 }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -7,12 +7,16 @@
 	&.register-domain-step__search-domain-step:not( .is-sticky ) {
 		padding-bottom: 24px;
 
+		.is-white-signup & {
+			padding-bottom: 16px;
+		}
+
 		@include breakpoint-deprecated( '>660px' ) {
 			padding-top: 18px;
 
 			.is-white-signup & {
 				padding-top: 0;
-				padding-bottom: 20px;
+				padding-bottom: 16px;
 			}
 		}
 	}
@@ -139,6 +143,11 @@ body.is-section-signup.is-white-signup {
 		box-shadow: none;
 		padding: 0;
 		margin-bottom: 24px;
+		margin-left: 20px;
+
+		@include break-mobile {
+			margin-left: 0;
+		}
 	}
 	.domain-search-results__domain-availability svg,
 	.register-domain-step__notice svg {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -140,6 +140,7 @@ body.is-section-signup.is-white-signup {
 		padding: 0;
 		margin-bottom: 24px;
 	}
+	.domain-search-results__domain-availability svg,
 	.register-domain-step__notice svg {
 		margin: 0;
 		padding: 0;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -124,7 +124,6 @@ button.register-domain-step__next-page-button {
 	font-weight: 500; /* stylelint-disable-line */
 }
 
-
 body.is-section-domains {
 	.register-domain-step {
 		button.register-domain-step__next-page-button {
@@ -136,6 +135,15 @@ body.is-section-domains {
 }
 
 body.is-section-signup.is-white-signup {
+	.domain-search-results__domain-availability .card {
+		box-shadow: none;
+		padding: 0;
+		margin-bottom: 24px;
+	}
+	.register-domain-step__notice svg {
+		margin: 0;
+		padding: 0;
+	}
 	.register-domain-step__next-page {
 		background: none;
 		box-shadow: none;
@@ -155,4 +163,3 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 }
-


### PR DESCRIPTION
Fix how we render notices for registered, unsupported domains in the domain suggestion screen in signup

#### Changes proposed in this Pull Request

* Recently we've updated the notice we show when you enter a domain that is already registered in the suggestion screen ( see #54926 ) but it wasn't looking good in the signup flow so here's a fix for that

Here's how it looks:

Before:

<img width="960" alt="Screenshot 2021-08-06 at 13 41 05" src="https://user-images.githubusercontent.com/1355045/128499622-6ea25258-59d7-4ffd-9273-aec66684da5d.png">

After:

<img width="993" alt="Screenshot 2021-08-06 at 13 40 33" src="https://user-images.githubusercontent.com/1355045/128499655-cfc5866e-0fc0-4f1f-ba04-ae43c43e0055.png">

#### Testing instructions

* Open the calypso.live branch and go to `/start`. Then in the domain suggestion screen enter a domain that is already registered or try one with a TLD we don't support


