### PR TITLE
Fix drafts are not shown in the WordPress menu in the editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -298,7 +298,7 @@ function useNavItems(): NavItemRecord {
 			getCurrentPostType,
 			getEditedPostAttribute,
 		} = select( 'core/editor' );
-		const statuses = select( 'core' ).getEntityRecords( 'root', 'status' );
+		const statuses = select( 'core' ).getEntityRecords( 'root', 'status', { context: 'edit' } );
 
 		if ( ! statuses ) {
 			return { current: [], drafts: [], recent: [] };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* According to the definition, `show_in_list` property is only for edit mode, so I add this parameter.

<img width="300" src="https://user-images.githubusercontent.com/13596067/128502287-0947154f-13b6-4bbb-85bd-ca5beb337ab4.png" />

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync`
* Sandbox your API
* Open your local calypso
* Create a post and save it as a draft
* Click on the WordPress icon in the top-left of the editor to open the menu
* Click on Add new post
* Click on WordPress icon in the top-left of the editor
* Check draft shows or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close #54676
