### PR TITLE
Add site name to invite people header text

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -727,7 +727,11 @@ class InvitePeople extends React.Component {
 
 				<SidebarNavigation />
 				<HeaderCake isCompact onClick={ this.goBack }>
-					{ translate( 'Invite People' ) }
+					{ translate( 'Invite People to %(sitename)s', {
+						args: {
+							sitename: site.name,
+						},
+					} ) }
 				</HeaderCake>
 				{ this.renderInviteForm() }
 				{ isWPForTeamsSite && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To make it a bit more clear to the user what site they are inviting users to, we could add the site name in the header closer to where the user is doing actions. 

* Add the site's name to the header text on the invite screen. (The "My Blog of Things" in the "after" screenshot).

#### Testing instructions

Go to the users section and click "Invites" in the top tabs. There, click on the button that says "invite". Verify that the site's name is shown in the header.

**Before**
<img width="849" alt="before" src="https://user-images.githubusercontent.com/193283/128516974-baaad7fc-a4a0-496a-ab2d-d0289ee44454.png">

**After**
<img width="804" alt="header-invite" src="https://user-images.githubusercontent.com/193283/128516671-a81c9384-ee26-4a72-8567-f4fbd759dd36.png">


