### PR TITLE
E2e abstract-editor-component - update class selector for editor wrapper

### DIFF
--- a/test/e2e/lib/components/abstract-editor-component.js
+++ b/test/e2e/lib/components/abstract-editor-component.js
@@ -35,11 +35,7 @@ export default class AbstractEditorComponent extends AsyncBaseContainer {
 
 	async openBlockInserterAndSearch( searchTerm ) {
 		await this.runInCanvas( async () => {
-			await driverHelper.scrollIntoView(
-				this.driver,
-				By.css( '.block-editor-writing-flow' ),
-				'start'
-			);
+			await driverHelper.scrollIntoView( this.driver, By.css( '.editor-styles-wrapper' ), 'start' );
 		} );
 
 		await this.openBlockInserter();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Site Editor based tests are now failing after the most recent Gutenberg update as `.block-editor-writing-flow` class seems to be no longer found in the site editor (it looks like it was removed from the site editor as part of https://github.com/WordPress/gutenberg/pull/33497):

![Screen Shot 2021-08-06 at 11 22 54 AM](https://user-images.githubusercontent.com/28742426/128534902-08db6dac-7261-4999-a70e-f664eb96423f.png)

Looking at both the post editor and site editor, we should be able to replace this with the `.editor-styles-wrapper` class and have it work for both.  As we can see in the post editor querySelector'ing for the editor-styles-wrapper finds the same element as the `.block-editor-writing-flow`:

![Screen Shot 2021-08-06 at 11 37 48 AM](https://user-images.githubusercontent.com/28742426/128535847-05234c10-7872-421a-90b5-5b80cd8c4a4f.png)

 If not, we may want to revert the DRY refactor of https://github.com/Automattic/wp-calypso/pull/55148 to handle the site editor separately from the post editor.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the site editor based tests and verify they are no longer failing due to not being able to find `.block-editor-writing-flow`
* Test the post editor based tests and verify they still work after this change.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
