### PR TITLE
Activity Log: Fall back to moment when applySiteOffset isn't available

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -58,9 +58,7 @@ class ActivityCardList extends Component {
 		let logsAdded = 0;
 
 		for ( const log of logs ) {
-			const activityDateMoment = applySiteOffset
-				? applySiteOffset( moment( log.activityDate ) )
-				: moment( log.activityDate );
+			const activityDateMoment = ( applySiteOffset ?? moment )( log.activityDate );
 
 			if ( logsAdded >= pageSize ) {
 				if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
@@ -82,9 +80,9 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( pageLogs ) {
-		const { applySiteOffset, showDateSeparators, translate, userLocale } = this.props;
+		const { applySiteOffset, moment, showDateSeparators, translate, userLocale } = this.props;
 
-		const today = applySiteOffset ? applySiteOffset() : null;
+		const today = ( applySiteOffset ?? moment )();
 
 		const getPrimaryCardClassName = ( hasMore, dateLogsLength ) =>
 			hasMore && dateLogsLength === 1
@@ -126,6 +124,7 @@ class ActivityCardList extends Component {
 	renderData() {
 		const {
 			applySiteOffset,
+			moment,
 			retentionPoliciesEnabled,
 			retentionDays,
 			filter,
@@ -138,11 +137,14 @@ class ActivityCardList extends Component {
 		} = this.props;
 
 		const retentionLimitCutoffDate = retentionPoliciesEnabled
-			? applySiteOffset().subtract( retentionDays, 'days' )
+			? ( applySiteOffset ?? moment )().subtract( retentionDays, 'days' )
 			: null;
 		const logsWithRetention = retentionPoliciesEnabled
 			? logs.filter( ( log ) =>
-					applySiteOffset( log.activityDate ).isSameOrAfter( retentionLimitCutoffDate, 'day' )
+					( applySiteOffset ?? moment )( log.activityDate ).isSameOrAfter(
+						retentionLimitCutoffDate,
+						'day'
+					)
 			  )
 			: logs;
 


### PR DESCRIPTION
Related to #54900.

#### Changes proposed in this Pull Request

* Add a fallback (null-coalesce) to use `moment` when `applySiteOffset` isn't defined.

#### Known issues

By using `moment` we're showing dates and times in the browser's time zone instead of the site's timezone. This should only happen as long as the selected site's timezone information is loading. I have plans to refactor `ActivityCardList` so this will no longer be an issue, but it may be a while before I have time to do so.

#### Testing instructions

1. Load `cloud.jetpack.com/activity-log/<your-site>?flags=activity-log/retention-policies` for any Jetpack site.
2. Observe that the page fails to load, and that there's an error in your browser console: `TypeError: e is not a function`
3. Load the same page in your testing environment.
4. Verify the browser console no longer shows any errors about `applySiteOffset` being undefined, or not being a function, and that the page loads correctly.
