### PR TITLE
Site Editor tracking e2e - Fix broken template part test

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -1153,7 +1153,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 					);
 				} );
 				const quickInserterSearchInputLocator = By.css(
-					'.block-editor-inserter__quick-inserter .block-editor-inserter__search-input'
+					'.block-editor-inserter__quick-inserter .components-search-control__input'
 				);
 				const blockItemLocator = By.css(
 					'.block-editor-inserter__quick-inserter .block-editor-block-types-list__item'

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -756,9 +756,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 			it( 'Tracks "wpcom_block_editor_template_part_choose_existing"', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
-				// Undo the template part creation to go back to the placeholder.  Use store api to
-				// trigger undo since the UI is not present in mobile viewport.
-				await this.driver.executeScript( `return window.wp.data.dispatch( 'core' ).undo()` );
+
+				await editor.addBlock( 'Header', 'template-part\\/header', 'Block: Template Part' );
 
 				await editor.runInCanvas( async () => {
 					const chooseExistingHeaderLocator = driverHelper.createTextLocator(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Due to a change in our Header patterns combined with a bug in core causing an undo trap (related https://github.com/WordPress/gutenberg/issues/33908), the "choose existing" template part test is now failing since it relied on the 'undo' action to get to its starting state.

Here, the simple fix is to just insert a new Header block instead of relying on undo.

Update - I found a later test failing due to the selector for the search input changing.  We update that selector to the new class name as well.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the updated test file and verify the 'choose existing' template part test no longer fails.  NOTE - the change from https://github.com/Automattic/wp-calypso/pull/55245 is required for these tests to run correctly, otherwise the `addBlock` actions will fail.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
