### PR TITLE
Refactor titan mailbox and mailbox-list components

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -70,7 +70,7 @@ import forwardingIcon from 'calypso/assets/images/email-providers/forwarding.svg
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
-import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
+import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import HeaderCake from 'calypso/components/header-cake';
 

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -51,7 +51,7 @@ import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import SectionHeader from 'calypso/components/section-header';
 import TitanMailboxPricingNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-mailbox-pricing-notice';
 import { titanMailMonthly } from 'calypso/lib/cart-values/cart-items';
-import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
+import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 

--- a/client/my-sites/email/titan-add-mailboxes/style.scss
+++ b/client/my-sites/email/titan-add-mailboxes/style.scss
@@ -1,111 +1,12 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.titan-add-mailboxes__new-mailbox .form-label .form-text-input-with-affixes__suffix {
-	font-weight: normal;
-}
-.titan-add-mailboxes__new-mailbox-email-and-password,
-.titan-add-mailboxes__new-mailbox-password-and-is-admin {
-	display: flex;
-	flex-direction: column;
-
-	@include break-mobile {
-		align-items: flex-start;
-		flex-direction: row;
-		justify-content: space-between;
-
-		.form-fieldset:first-child {
-			flex-grow: 2;
-			margin-right: 1em;
-		}
-	}
-}
-
-.titan-add-mailboxes__new-mailbox-name-and-remove {
-	display: flex;
-	flex-direction: column-reverse;
-
-	@include break-mobile {
-		flex-direction: row;
-
-		.form-fieldset:first-child {
-			flex-grow: 2;
-		}
-
-		.titan-add-mailboxes__new-mailbox-remove-mailbox-button {
-			height: 40px;
-			margin-left: 1em;
-			width: 50px;
-
-			.gridicon {
-				margin-right: 0;
-			}
-
-			span {
-				display: none;
-			}
-		}
+@include break-mobile {
+	.titan-add-mailboxes__action-cancel {
+		margin-left: auto;
 	}
 
-	.titan-add-mailboxes__new-mailbox-remove-mailbox-button,
-	.form-fieldset:not( :first-child ) {
-		margin-bottom: 1em;
-		margin-left: 1em;
-		margin-top: 0;
-
-		.components-toggle-control p {
-			margin-bottom: 0;
-		}
-	}
-}
-
-.titan-add-mailboxes__new-mailbox.show-labels {
-	.form-fieldset .form-label {
-		color: var( --color-text );
-
-		> div, > input {
-			margin-top: 5px;
-		}
-	}
-
-	.titan-add-mailboxes__new-mailbox-remove-mailbox-button {
-		margin-top: calc( 1.5em + 5px );
-	}
-
-}
-
-.titan-add-mailboxes__new-mailbox-separator {
-	margin-top: 1.5em;
-}
-
-.titan-new-mailbox-list__main {
-
-	.form-fieldset .form-label {
-		margin-bottom: 0;
-	}
-
-	.titan-new-mailbox-list__actions {
-		display: flex;
-		flex-direction: column;
-
-		@include break-mobile {
-			flex-direction: row;
-
-			.titan-add-mailboxes__action-cancel {
-				margin-left: auto;
-			}
-
-			.titan-add-mailboxes__action-continue {
-				margin-left: 1.5em;
-			}
-		}
-
-		> button {
-			margin-bottom: 1em;
-
-			@include break-mobile {
-				margin-bottom: 0;
-			}
-		}
+	.titan-add-mailboxes__action-continue {
+		margin-left: 1.5em;
 	}
 }

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -16,7 +16,12 @@ import {
 } from 'calypso/lib/titan/new-mailbox';
 import { Button } from '@automattic/components';
 import Gridicon from 'calypso/components/gridicon';
-import TitanNewMailbox from './titan-new-mailbox';
+import TitanNewMailbox from 'calypso/my-sites/email/titan-new-mailbox';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const noop = () => {};
 
@@ -85,7 +90,7 @@ const TitanNewMailboxList = ( {
 
 			<div className="titan-new-mailbox-list__actions">
 				{ showAddAnotherMailboxButton && (
-					<Button className="titan-new-mailbox-list__add-mailbox-button" onClick={ onMailboxAdd }>
+					<Button onClick={ onMailboxAdd }>
 						<Gridicon icon="plus" />
 						<span>{ translate( 'Add another mailbox' ) }</span>
 					</Button>

--- a/client/my-sites/email/titan-new-mailbox-list/style.scss
+++ b/client/my-sites/email/titan-new-mailbox-list/style.scss
@@ -1,0 +1,25 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.titan-new-mailbox-list__main {
+	.form-fieldset .form-label {
+		margin-bottom: 0;
+	}
+
+	.titan-new-mailbox-list__actions {
+		display: flex;
+		flex-direction: column;
+
+		@include break-mobile {
+			flex-direction: row;
+		}
+
+		> button {
+			margin-bottom: 1em;
+
+			@include break-mobile {
+				margin-bottom: 0;
+			}
+		}
+	}
+}

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -20,6 +20,11 @@ import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-w
 import Gridicon from 'calypso/components/gridicon';
 import { getMailboxPropTypeShape } from 'calypso/lib/titan/new-mailbox';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const noop = () => {};
 
 const TitanNewMailbox = ( {
@@ -67,11 +72,11 @@ const TitanNewMailbox = ( {
 	return (
 		<>
 			<div
-				className={ classNames( 'titan-add-mailboxes__new-mailbox', {
+				className={ classNames( 'titan-new-mailbox', {
 					'show-labels': showLabels,
 				} ) }
 			>
-				<div className="titan-add-mailboxes__new-mailbox-name-and-remove">
+				<div className="titan-new-mailbox__name-and-remove">
 					<FormFieldset>
 						<FormLabel>
 							{ showLabels && translate( 'Full name' ) }
@@ -95,7 +100,7 @@ const TitanNewMailbox = ( {
 
 					{ showTrashButton && (
 						<Button
-							className="titan-add-mailboxes__new-mailbox-remove-mailbox-button"
+							className="titan-new-mailbox__remove-mailbox-button"
 							onClick={ onMailboxRemove }
 						>
 							<Gridicon icon="trash" />
@@ -187,7 +192,7 @@ const TitanNewMailbox = ( {
 					) }
 				</FormFieldset>
 			</div>
-			<hr className="titan-add-mailboxes__new-mailbox-separator" />
+			<hr className="titan-new-mailbox__separator" />
 		</>
 	);
 };

--- a/client/my-sites/email/titan-new-mailbox/style.scss
+++ b/client/my-sites/email/titan-new-mailbox/style.scss
@@ -1,0 +1,63 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.titan-new-mailbox .form-label .form-text-input-with-affixes__suffix {
+	font-weight: normal;
+}
+
+.titan-new-mailbox__name-and-remove {
+	display: flex;
+	flex-direction: column-reverse;
+
+	@include break-mobile {
+		flex-direction: row;
+
+		.form-fieldset:first-child {
+			flex-grow: 2;
+		}
+
+		.titan-new-mailbox__remove-mailbox-button {
+			height: 40px;
+			margin-left: 1em;
+			width: 50px;
+
+			.gridicon {
+				margin-right: 0;
+			}
+
+			span {
+				display: none;
+			}
+		}
+	}
+
+	.titan-new-mailbox__remove-mailbox-button,
+	.form-fieldset:not( :first-child ) {
+		margin-bottom: 1em;
+		margin-left: 1em;
+		margin-top: 0;
+
+		.components-toggle-control p {
+			margin-bottom: 0;
+		}
+	}
+}
+
+.titan-new-mailbox.show-labels {
+	.form-fieldset .form-label {
+		color: var( --color-text );
+
+		> div,
+		> input {
+			margin-top: 5px;
+		}
+	}
+
+	.titan-new-mailbox__remove-mailbox-button {
+		margin-top: calc( 1.5em + 5px );
+	}
+}
+
+.titan-new-mailbox__separator {
+	margin-top: 1.5em;
+}

--- a/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
+++ b/client/my-sites/email/titan-setup-mailbox/titan-setup-mailbox-form.jsx
@@ -22,7 +22,7 @@ import { emailManagementTitanSetupThankYou } from 'calypso/my-sites/email/paths'
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import TitanNewMailboxList from 'calypso/my-sites/email/titan-add-mailboxes/titan-new-mailbox-list';
+import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { useCreateTitanMailboxMutation } from 'calypso/data/emails/use-create-titan-mailbox-mutation';
 import { useGetTitanMailboxAvailability } from 'calypso/data/emails/use-get-titan-mailbox-availability';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR extracts out the styles for `TitanNewMailbox` and `TitanNewMailboxList` components and moves them to their own directories so that they can be easily imported and reused in other places.

Presently, the styles for these are clubbed together inside `TitanAddMailboxes` component's `style.scss` file. For the work being done in #55183, the `EmailProvidersComparison` component which in turn imports these components need to be used inside `my-sites/domains`. But the styles are broken since they are clubbed as mentioned before.

#### Testing instructions

With a domain associated with your site, test the following URLs:

- `http://calypso.localhost:3000/email/<domain>/titan/new/<site-slug>`
- `http://calypso.localhost:3000/email/<domain>/purchase/<site-slug>`

Or wherever the associated components are being used and check their layout/styles at desktop and mobile widths.

Related to #55183
