### PR TITLE
Revert "Support custom domains by removing .substack.com validation"

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -185,6 +185,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
 				args: { exampleUrl: 'https://example-newsletter.substack.com/' },
 			} ),
+			validate: ( urlInput ) => {
+				return /^https:\/\/[\w-]+\.substack\.com\/?$/.test( urlInput.trim() );
+			},
 		},
 		weight: 0,
 	};

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -173,9 +173,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	validateUrl = ( urlInput ) => {
-		const validationFn = this.props.optionalUrl.validate;
-
-		return ! urlInput || urlInput === '' || ( validationFn ? validationFn( urlInput ) : true );
+		return ! urlInput || urlInput === '' || this.props.optionalUrl.validate( urlInput );
 	};
 
 	setUrl = ( event ) => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#55149

This causes a white screen of doom for imports other than WordPress -- see #55251