### PR TITLE
Playwright: migrate the `Import Site` spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -11,3 +11,4 @@ export * from './plans-page';
 export * from './individual-purchase-page';
 export * from './cart-checkout-page';
 export * from './stats-page';
+export * from './site-import-page';

--- a/packages/calypso-e2e/src/lib/pages/site-import-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-import-page.ts
@@ -1,0 +1,73 @@
+import { Page } from 'playwright';
+
+export type SourceService = typeof SiteImportPage.services[ number ];
+
+const selectors = {
+	// Listing
+	service: ( name: SourceService ) => `h1:text("${ name }")`,
+
+	// Importer screen buttons and pseudo-buttons
+	backButton: 'a:text("Back")',
+	cancelButton: 'button:text("Cancel")',
+	continueButton: 'button:text("Continue")',
+
+	// Inputs
+	siteInput: '[placeholder="example.com"]',
+	fileInput: 'input[name="exportFile"]',
+	fileInputText: 'text=Drag a file here, or click to upload a file',
+};
+
+/**
+ * Class representing the Site Import page.
+ */
+export class SiteImportPage {
+	static services = [ 'WordPress', 'Blogger', 'Medium', 'Squarespace', 'Wix' ] as const;
+	private page: Page;
+
+	/**
+	 * Constructs an instance.
+	 *
+	 * @param {Page} page Underlying page on which interactions take place.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Select the target service from which site import should take place.
+	 *
+	 * @param {SourceService} service Allowed list of services.
+	 */
+	async selectService( service: SourceService ): Promise< void > {
+		await this.page.click( selectors.service( service ) );
+		await this.page.waitForLoadState( 'load' );
+	}
+
+	/**
+	 * Verify the importer screen is shown.
+	 *
+	 * @param {SourceService} service Allowed list of services.
+	 */
+	async verifyImporter( service: SourceService ): Promise< void > {
+		if ( [ 'WordPress', 'Wix' ].includes( service ) ) {
+			await this.page.waitForSelector( selectors.siteInput );
+			await this.page.waitForSelector( selectors.continueButton );
+		} else {
+			await this.page.waitForSelector( selectors.fileInputText );
+			await this.page.waitForSelector( `:has-text("from a ${ service } export file")` );
+		}
+	}
+
+	/**
+	 * Cancel the import process and return to the main Site Import screen.
+	 */
+	async cancel(): Promise< void > {
+		await this.page.waitForLoadState( 'load' );
+
+		if ( await this.page.isVisible( selectors.backButton ) ) {
+			await this.page.click( selectors.backButton );
+		} else {
+			await this.page.click( selectors.cancelButton );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/site-import-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-import-page.ts
@@ -39,21 +39,29 @@ export class SiteImportPage {
 	 * @param {SourceService} service Allowed list of services.
 	 */
 	async selectService( service: SourceService ): Promise< void > {
-		await this.page.click( selectors.service( service ) );
-		await this.page.waitForLoadState( 'load' );
+		await Promise.all( [
+			this.page.waitForLoadState( 'load' ),
+			this.page.click( selectors.service( service ) ),
+		] );
 	}
 
 	/**
 	 * Verify the importer screen is shown.
 	 *
+	 * Note, there are two types of importers available in WPCOM:
+	 * 	- URL based importer, where the target service's site URL is pasted.
+	 * 	- File based importer, where the target service's file export is uploaded.
+	 *
 	 * @param {SourceService} service Allowed list of services.
 	 */
 	async verifyImporter( service: SourceService ): Promise< void > {
+		//
 		if ( [ 'WordPress', 'Wix' ].includes( service ) ) {
 			await this.page.waitForSelector( selectors.siteInput );
 			await this.page.waitForSelector( selectors.continueButton );
 		} else {
 			await this.page.waitForSelector( selectors.fileInputText );
+			// Description text for the file uploader.
 			await this.page.waitForSelector( `:has-text("from a ${ service } export file")` );
 		}
 	}
@@ -62,8 +70,6 @@ export class SiteImportPage {
 	 * Cancel the import process and return to the main Site Import screen.
 	 */
 	async cancel(): Promise< void > {
-		await this.page.waitForLoadState( 'load' );
-
 		if ( await this.page.isVisible( selectors.backButton ) ) {
 			await this.page.click( selectors.backButton );
 		} else {

--- a/test/e2e/specs/specs-playwright/wp-site-import__verify-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-site-import__verify-spec.ts
@@ -1,0 +1,34 @@
+import {
+	setupHooks,
+	DataHelper,
+	LoginFlow,
+	SidebarComponent,
+	SiteImportPage,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
+	let siteImportPage: SiteImportPage;
+	let page: Page;
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log In', async function () {
+		const loginFlow = new LoginFlow( page );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Navigate to Tools > Import', async function () {
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.gotoMenu( { item: 'Tools', subitem: 'Import' } );
+	} );
+
+	it.each( SiteImportPage.services )( 'Select service provider: %s', async function ( service ) {
+		siteImportPage = new SiteImportPage( page );
+		await siteImportPage.selectService( service );
+		await siteImportPage.verifyImporter( service );
+		await siteImportPage.cancel();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `Import Site` spec from Selenium to Playwright.

Key changes:

- new `SiteImportPage` object.
- test spec written with TypeScript.

#### Testing instructions

- [x] Playwright mobile tests pass.
- [x] Playwright desktop tests pass.

Related to #
