### PR TITLE
Jetpack site-less Checkout: trigger ticket update from `ThankYouCompleted` page after scheduling call

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hooks.ts
+++ b/client/my-sites/checkout/checkout-thank-you/hooks.ts
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { addOnboardingCallInternalNote } from './utils';
+
+interface CalendlyEvent {
+	data: {
+		event: string;
+		payload: {
+			event: {
+				uri: string;
+			};
+		};
+	};
+}
+
+interface CalendlyListenerProps {
+	productSlug: string;
+	receiptId: number;
+	jetpackTemporarySiteId: number;
+}
+
+export function useSetCalendlyListenerEffect( {
+	productSlug,
+	receiptId,
+	jetpackTemporarySiteId,
+}: CalendlyListenerProps ) {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		const dispatchCalendlyEventScheduled = async ( event: CalendlyEvent ) => {
+			if ( event && event.data?.event === 'calendly.event_scheduled' ) {
+				const eventUri = event.data.payload?.event?.uri || '';
+				// The last part of the pathname is the ID of the Calendly event
+				const eventId = new URL( eventUri ).pathname.split( '/' ).pop();
+				const result = await addOnboardingCallInternalNote(
+					receiptId,
+					jetpackTemporarySiteId,
+					eventId
+				);
+				if ( result ) {
+					dispatch(
+						recordTracksEvent( 'calypso_siteless_checkout_schedule_onboarding_call', {
+							product_slug: productSlug,
+							receipt_id: receiptId,
+							event_id: eventId,
+						} )
+					);
+				}
+			}
+		};
+
+		window.addEventListener( 'message', dispatchCalendlyEventScheduled );
+
+		return () => {
+			window.removeEventListener( 'message', dispatchCalendlyEventScheduled );
+		};
+	}, [] );
+}

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -11,12 +11,14 @@ import { Card } from '@automattic/components';
  */
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isProductsListFetching as getIsProductListFetching,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { useSetCalendlyListenerEffect } from './hooks';
 
 /**
  * Style dependencies
@@ -25,9 +27,15 @@ import './style.scss';
 
 interface Props {
 	productSlug: string | 'no_product';
+	receiptId?: number;
+	jetpackTemporarySiteId?: number;
 }
 
-const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } ) => {
+const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
+	productSlug,
+	receiptId = 0,
+	jetpackTemporarySiteId = 0,
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -39,7 +47,19 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( { productSlug } 
 
 	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
 
-	const happinessAppointmentLink = '/checkout/jetpack/schedule-happiness-appointment';
+	const happinessAppointmentLink = addQueryArgs(
+		{
+			receiptId,
+			jetpackTemporarySiteId,
+		},
+		'/checkout/jetpack/schedule-happiness-appointment'
+	);
+
+	useSetCalendlyListenerEffect( {
+		productSlug,
+		receiptId,
+		jetpackTemporarySiteId,
+	} );
 
 	return (
 		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -50,7 +50,7 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 	const happinessAppointmentLink = addQueryArgs(
 		{
 			receiptId,
-			jetpackTemporarySiteId,
+			siteId: jetpackTemporarySiteId,
 		},
 		'/checkout/jetpack/schedule-happiness-appointment'
 	);

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -153,7 +153,6 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 			const thankYouCompletedUrl = addQueryArgs(
 				{
 					jetpackTemporarySiteId,
-					productSlug,
 					receiptId,
 				},
 				`/checkout/jetpack/thank-you-completed/no-site/${ productSlug }`

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -152,7 +152,7 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 		if ( supportTicketStatus === 'success' ) {
 			const thankYouCompletedUrl = addQueryArgs(
 				{
-					jetpackTemporarySiteId,
+					siteId: jetpackTemporarySiteId,
 					receiptId,
 				},
 				`/checkout/jetpack/thank-you-completed/no-site/${ productSlug }`

--- a/client/my-sites/checkout/checkout-thank-you/utils.js
+++ b/client/my-sites/checkout/checkout-thank-you/utils.js
@@ -13,12 +13,13 @@ export function getDomainManagementUrl( { slug }, domain ) {
  * Send a POST request to update the ZD ticket linked to the given receiptId.
  *
  * @param receiptId number – Receipt unique identifier.
+ * @param jetpackTemporarySiteId number – Receipt unique identifier.
  * @param eventId number – Calendly event unique identifier.
  */
-export async function addOnboardingCallInternalNote( receiptId, eventId ) {
+export async function addOnboardingCallInternalNote( receiptId, jetpackTemporarySiteId, eventId ) {
 	return await wpcom.req.post( {
 		path: addQueryArgs(
-			{ receipt_id: receiptId, event_id: eventId },
+			{ receipt_id: receiptId, temporary_blog_id: jetpackTemporarySiteId, event_id: eventId },
 			'/jetpack-checkout/support-ticket/onboarding-call'
 		),
 		apiNamespace: 'wpcom/v2',

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -151,7 +151,7 @@ export default function getThankYouPageUrl( {
 		return addQueryArgs(
 			{
 				receiptId: isValidReceiptId ? pendingOrReceiptId : undefined,
-				jetpackTemporarySiteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
+				siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
 			},
 			thankYouUrlSiteLess
 		);

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -1021,7 +1021,7 @@ describe( 'getThankYouPageUrl', () => {
 				jetpackTemporarySiteId: 123456789,
 			} );
 			expect( url ).toBe(
-				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=80023&jetpackTemporarySiteId=123456789'
+				'/checkout/jetpack/thank-you/no-site/jetpack_backup_daily?receiptId=80023&siteId=123456789'
 			);
 		} );
 	} );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -292,7 +292,7 @@ export function jetpackCheckoutThankYou( context, next ) {
 	const isSitelessCheckoutFlow =
 		context.path.includes( '/checkout/jetpack/thank-you/no-site' ) || forSitelessScheduling;
 
-	const { receiptId, source, jetpackTemporarySiteId } = context.query;
+	const { receiptId, source, siteId } = context.query;
 
 	context.primary = isSitelessCheckoutFlow ? (
 		<JetpackCheckoutSitelessThankYou
@@ -300,7 +300,7 @@ export function jetpackCheckoutThankYou( context, next ) {
 			receiptId={ receiptId }
 			forScheduling={ forSitelessScheduling }
 			source={ source }
-			jetpackTemporarySiteId={ jetpackTemporarySiteId }
+			jetpackTemporarySiteId={ siteId }
 		/>
 	) : (
 		<JetpackCheckoutThankYou
@@ -314,11 +314,11 @@ export function jetpackCheckoutThankYou( context, next ) {
 }
 
 export function jetpackCheckoutThankYouCompleted( context, next ) {
-	const { jetpackTemporarySiteId, receiptId } = context.query;
+	const { siteId, receiptId } = context.query;
 	context.primary = (
 		<JetpackCheckoutSitelessThankYouCompleted
 			productSlug={ context.params.product }
-			jetpackTemporarySiteId={ jetpackTemporarySiteId }
+			jetpackTemporarySiteId={ siteId }
 			receiptId={ receiptId }
 		/>
 	);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -314,10 +314,11 @@ export function jetpackCheckoutThankYou( context, next ) {
 }
 
 export function jetpackCheckoutThankYouCompleted( context, next ) {
-	const { receiptId } = context.query;
+	const { jetpackTemporarySiteId, receiptId } = context.query;
 	context.primary = (
 		<JetpackCheckoutSitelessThankYouCompleted
 			productSlug={ context.params.product }
+			jetpackTemporarySiteId={ jetpackTemporarySiteId }
 			receiptId={ receiptId }
 		/>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Motivation**
Currently, when a user submits a URL, they are redirected to the `ThankYouCompleted` page. From there, they can choose to schedule an onboarding call. Unfortunately, if they decide to do that, Calypso doesn't have the necessary information to trigger a Zendesk ticket update (it is missing both the receipt id and the temporary blog id).

**Changes**
* Add both the receipt id and temporary blog id to the URL that shows the `ThankYouCompleted` page. 
* Add the `useSetCalendlyListenerEffect` hook to the `ThankYouCompleted` page, which triggers the Zendesk ticket update.

#### Testing instructions

* Download this PR and start Calypso with `yarn start`.
* Complete a site-less purchase (from `calypso.localhost:3000`).
* Submit a site URL.
* Verify that in the `ThankYourCompleted` page, the URL includes both the `receiptId` and `siteId` query parameter.
* Schedule a call.
* Verify that the ticket was updated after you scheduled the call.

Related to 1200479326344990-as-1200731339177900

#### Demo
<img src="https://user-images.githubusercontent.com/3418513/128581175-d12a9f89-e65e-4ee9-a300-21790f112852.png" width="500" />
<img src="https://user-images.githubusercontent.com/3418513/128581187-e42a92bf-3b33-4189-aa20-00cea90c59f7.png" width="500" />
<img src="https://user-images.githubusercontent.com/3418513/128581240-b8ba8d5b-5e86-4277-bbc1-a4da54a8bf86.png" width="500" />
