### PR TITLE
Fix/collapsible menu items labelled incorrectly

### DIFF
--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -27,11 +27,18 @@ const SidebarCustomIcon = ( { icon, ...rest } ) => {
 			<span
 				className={ 'sidebar__menu-icon dashicons' + ( isSVG ? ' sidebar__menu-icon-img' : '' ) }
 				style={ imgStyles }
+				aria-hidden={ true }
 				{ ...rest }
 			/>
 		);
 	}
 
-	return <span className={ 'sidebar__menu-icon dashicons-before ' + icon } { ...rest } />;
+	return (
+		<span
+			className={ 'sidebar__menu-icon dashicons-before ' + icon }
+			aria-hidden={ true }
+			{ ...rest }
+		/>
+	);
 };
 export default SidebarCustomIcon;

--- a/client/layout/sidebar/heading.jsx
+++ b/client/layout/sidebar/heading.jsx
@@ -18,7 +18,7 @@ const SidebarHeading = ( { children, onClick, ...props } ) => {
 	/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 	return (
 		<li>
-			<h2
+			<a
 				tabIndex={ tabIndex }
 				className="sidebar__heading"
 				onKeyDown={ onKeyDown }
@@ -26,7 +26,7 @@ const SidebarHeading = ( { children, onClick, ...props } ) => {
 				{ ...props }
 			>
 				{ children }
-			</h2>
+			</a>
 		</li>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changed sidebar heading html tag from h2 to anchors for simpler screen reader readings.
* Added `aria-hidden={ true }` attribute to sidebar menu icons to ensure that they are hidden from screen readers.

#### Testing instructions

1. Use a screen reader to navigate through the sidebar items under My Site.
2. Listen to what the screen reader calls the collapsible menu items (Site, Manage, Tools, etc.).

Before:
![image](https://user-images.githubusercontent.com/30727666/80781949-9f883000-8bb7-11ea-87a3-1ee770c6a093.gif)

After:
![image](https://user-images.githubusercontent.com/50002894/128602390-3b36c0f0-7538-4f83-ad97-e3ba4fa8cacc.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #41706
