### PR TITLE
Importer: Fix Broken Support Document

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -40,8 +40,8 @@ function getConfig( { siteTitle = '' } = {} ) {
 				components: {
 					supportLink: (
 						<InlineSupportLink
-							supportPostId={ 67084 }
-							supportLink="https://wordpress.com/support/coming-from-self-hosted/"
+							supportPostId={ 102755 }
+							supportLink="https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com/"
 							showIcon={ false }
 						>
 							{ translate( 'Need help exporting your content?' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the broken link on the WordPress.com importer

https://wordpress.com/support/coming-from-self-hosted now redirects to https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com, but this needs updating for the modal to appear.

#### Testing instructions

* Go the Importer 
* Select the WordPress one
* Press the "upload it to import content" link
* Click "Need help exporting your content?"

The document should display properly now.

**Before:**
<img width="1125" alt="Screenshot 2021-08-08 at 17 21 21" src="https://user-images.githubusercontent.com/43215253/128638663-cab1029f-4a68-4731-8fbd-4b06adceac8b.png">

**After:**
<img width="1193" alt="Screenshot 2021-08-08 at 17 20 47" src="https://user-images.githubusercontent.com/43215253/128638650-628abea7-9159-4d5f-9a62-e96ed971a77c.png">

cc @sixhours
