### PR TITLE
Substack Importer: Fix custom domain

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -186,7 +186,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				args: { exampleUrl: 'https://example-newsletter.substack.com/' },
 			} ),
 			validate: ( urlInput ) => {
-				return /^(http|https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
+				return /^(https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
 			},
 		},
 		weight: 0,

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -186,7 +186,7 @@ function getConfig( { siteTitle = '' } = {} ) {
 				args: { exampleUrl: 'https://example-newsletter.substack.com/' },
 			} ),
 			validate: ( urlInput ) => {
-				return /^https:\/\/[\w-]+\.substack\.com\/?$/.test( urlInput.trim() );
+				return /^(http|https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
 			},
 		},
 		weight: 0,

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -185,9 +185,6 @@ function getConfig( { siteTitle = '' } = {} ) {
 			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
 				args: { exampleUrl: 'https://example-newsletter.substack.com/' },
 			} ),
-			validate: ( urlInput ) => {
-				return /^(https):\/\/[^ "]+$/.test( urlInput.trim() ) && urlInput.length <= 255;
-			},
 		},
 		weight: 0,
 	};

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -173,7 +173,9 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	validateUrl = ( urlInput ) => {
-		return ! urlInput || urlInput === '' || this.props.optionalUrl.validate( urlInput );
+		const validationFn = this.props.optionalUrl.validate;
+
+		return ! urlInput || urlInput === '' || ( validationFn ? validationFn( urlInput ) : true );
 	};
 
 	setUrl = ( event ) => {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -173,7 +173,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	validateUrl = ( urlInput ) => {
-		const validationFn = this.props.optionalUrl.validate;
+		const validationFn = this.props?.optionalUrl?.validate;
 
 		return ! urlInput || urlInput === '' || ( validationFn ? validationFn( urlInput ) : true );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a followup to https://github.com/Automattic/wp-calypso/pull/55149 that got reverted due to it throwing errors on other importers.

#### Testing instructions

1. You need to have async jobs enabled on your Sandbox to test this. See this: PCYsg-3Ri-p2.
2. Go to Tools > Import.
3. Choose Substack, and enter a custom domain configured Substack URL.
4. Make sure everything goes off fine.
5. Make sure that other importers also work fine!

See:
* https://github.com/Automattic/wp-calypso/pull/55149 for test file
* https://github.com/Automattic/wp-calypso/issues/55251
