### PR TITLE
Fix focusOnHover doesn't work on CopyLink

### DIFF
--- a/client/components/popover/menu-item-clipboard.jsx
+++ b/client/components/popover/menu-item-clipboard.jsx
@@ -1,13 +1,11 @@
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import Gridicon from 'calypso/components/gridicon';
+import PopoverMenuItem from './menu-item';
 
 const noop = () => {};
 
 function PopoverMenuItemClipboard( {
-	children,
 	className,
 	text,
 	onCopy = noop,
@@ -15,17 +13,14 @@ function PopoverMenuItemClipboard( {
 	...rest
 } ) {
 	return (
-		<ClipboardButton
+		<PopoverMenuItem
+			itemComponent={ ClipboardButton }
+			className={ className }
+			icon={ icon }
 			text={ text }
 			onCopy={ onCopy }
-			role="menuitem"
-			tabIndex="-1"
-			className={ classNames( 'popover__menu-item', className ) }
 			{ ...rest }
-		>
-			<Gridicon icon={ icon } size={ 18 } />
-			{ children }
-		</ClipboardButton>
+		/>
 	);
 }
 

--- a/client/components/popover/menu-item-clipboard.jsx
+++ b/client/components/popover/menu-item-clipboard.jsx
@@ -7,6 +7,7 @@ const noop = () => {};
 
 function PopoverMenuItemClipboard( {
 	className,
+	children,
 	text,
 	onCopy = noop,
 	icon = 'clipboard',
@@ -16,6 +17,7 @@ function PopoverMenuItemClipboard( {
 		<PopoverMenuItem
 			itemComponent={ ClipboardButton }
 			className={ className }
+			children={ children }
 			icon={ icon }
 			text={ text }
 			onCopy={ onCopy }
@@ -26,6 +28,7 @@ function PopoverMenuItemClipboard( {
 
 PopoverMenuItemClipboard.propTypes = {
 	className: PropTypes.string,
+	children: PropTypes.node,
 	icon: PropTypes.string,
 	onCopy: PropTypes.func,
 	text: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `focusOnHover` doesn't work on `CopyLink` component, so if the user is going from copy link to others or from others to copy link, the focus element is the same as the previous one. Therefore, the user will see highlights on multiple items at the same time.

https://user-images.githubusercontent.com/13596067/128664409-e508bc70-03ab-474b-b57d-2145e41faa1f.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Site (Calypso/Unified nav)
* Go to Posts section
* Click on three dots to the right of a certain post (which opens a drop-down sub-menu)
* Hold cursor over different sub-menu items
* When going from copy link to others or from others to copy link, make sure only one item will highlight at the same time

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/55103
