### PR TITLE
Ensure we query for products from email comparison

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -59,6 +59,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import PromoCard from 'calypso/components/promo-section/promo-card';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import Gridicon from 'calypso/components/gridicon';
@@ -600,6 +601,8 @@ class EmailProvidersComparison extends React.Component {
 
 		return (
 			<Main wideLayout>
+				<QueryProductsList />
+
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 				<QueryEmailForwards domainName={ selectedDomainName } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses a bug where we show a 0.00 price for products in the Email Comparison page. The fix is simply to ensure that we query for an updated products list from within the component.

#### Testing instructions

* Open this branch up locally or via the live branch
* Open up an incognito window and navigate directly to `/domains/manage`
* Click on "Add Email" for a domain in the list
* Confirm that you see the correct prices for the email products -- you should either see the price as "Free" or a non-zero amount
* Now navigate to `/email/[siteSlug]` for a site with domains that don't have email
* Navigate to the email comparison page for a domain on that site
* Verify that you see the correct prices for the email products

This was originally reported in this issue: pcyqBp-6X-p2