### PR TITLE
Marketing Survey: Add survey for improved Jetpack cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useCallback, ReactElement } from 'react';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import classnames from 'classnames';
+import Gridicon from 'calypso/components/gridicon';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+interface Choice {
+	id: string;
+	answerText: TranslateResult;
+	hasTextInput?: boolean;
+}
+
+interface JetpackCancellationSurveyProps {
+	onAnswerChange: ( answerId: string | null, answerText: TranslateResult | string ) => void;
+}
+
+export default function JetpackCancellationSurvey( {
+	onAnswerChange,
+}: JetpackCancellationSurveyProps ): ReactElement {
+	const translate = useTranslate();
+	const [ selectedAnswerId, setSelectedAnswerId ] = useState< string | null >( null );
+	const [ customAnswerText, setCustomAnswerText ] = useState< string >( '' );
+	const customAnswerInputRef = React.useRef< HTMLInputElement | null >();
+
+	const choices: Choice[] = [
+		{
+			id: 'too-expensive',
+			answerText: translate( 'The plan was too expensive.' ),
+		},
+		{
+			id: 'want-to-downgrade',
+			answerText: translate( "I'd like to downgrade to another plan." ),
+		},
+		{
+			id: 'upgrade-by-mistake',
+			answerText: translate( "This upgrade didn't include what I needed." ),
+		},
+		{
+			id: 'could-not-activate',
+			answerText: translate( 'I was unable to activate or use the product.' ),
+		},
+	];
+
+	const choiceOther: Choice = {
+		id: 'another-reason',
+		answerText: translate( 'Other:' ),
+	};
+
+	const selectAnswer = useCallback(
+		( answerId: string, answerText: TranslateResult | string ) => {
+			// prevent from changing the answer text to choiceOther.answerText just by clicking on it
+			const surveyAnswerText =
+				choiceOther.id === answerId && customAnswerText ? customAnswerText : answerText;
+
+			setSelectedAnswerId( answerId );
+			onAnswerChange( answerId, surveyAnswerText );
+		},
+		[ choiceOther.id, customAnswerText, onAnswerChange, setSelectedAnswerId ]
+	);
+
+	const onChangeCustomAnswerText = useCallback(
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const { value } = event.target;
+
+			onAnswerChange( selectedAnswerId, value );
+			setCustomAnswerText( value );
+		},
+		[ selectedAnswerId, onAnswerChange, setCustomAnswerText ]
+	);
+
+	const renderChoiceCard = ( choice: Choice ): ReactElement => {
+		return (
+			<Card
+				className={ classnames( 'jetpack-cancellation-survey__card', {
+					'is-selected': choice.id === selectedAnswerId,
+				} ) }
+				tagName="button"
+				onClick={ () => selectAnswer( choice.id, choice.answerText ) }
+				key={ choice.id }
+			>
+				<div className="jetpack-cancellation-survey__card-content">
+					<span>{ choice.answerText }</span>
+				</div>
+				<Gridicon icon="chevron-right" size={ 12 } />
+			</Card>
+		);
+	};
+
+	return (
+		<div className="jetpack-cancellation-survey__content">
+			<FormattedHeader
+				headerText={ translate( 'Before you go, help us improve Jetpack' ) }
+				subHeaderText={ translate( 'Please let us know why you are cancelling.' ) }
+				align="center"
+			/>
+			{ choices.map( renderChoiceCard ) }
+
+			{ /* The card for the 'other' option */ }
+			<Card
+				className={ classnames( 'jetpack-cancellation-survey__card', {
+					'is-selected': choiceOther.id === selectedAnswerId,
+				} ) }
+				tagName="button"
+				onClick={ () => {
+					selectAnswer( choiceOther.id, choiceOther.answerText );
+					customAnswerInputRef?.current?.focus();
+				} }
+				key={ choiceOther.id }
+			>
+				<div className="jetpack-cancellation-survey__card-content">
+					<span>{ choiceOther.answerText }</span>
+					<FormTextInput
+						inputRef={ customAnswerInputRef }
+						className="jetpack-cancellation-survey__choice-item-text-input"
+						value={ customAnswerText }
+						onChange={ onChangeCustomAnswerText }
+						placeholder={ translate( 'share your experience' ) }
+					/>
+				</div>
+				<Gridicon icon="chevron-right" size={ 12 } />
+			</Card>
+		</div>
+	);
+}

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import React, { useState, useCallback, ReactElement } from 'react';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
-import classnames from 'classnames';
-import Gridicon from 'calypso/components/gridicon';
-
-/**
- * Internal dependencies
- */
 import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import React, { useState, useCallback, ReactElement } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Gridicon from 'calypso/components/gridicon';
 
 interface Choice {
 	id: string;
@@ -20,14 +13,15 @@ interface Choice {
 }
 
 interface JetpackCancellationSurveyProps {
+	selectedAnswerId: string | null;
 	onAnswerChange: ( answerId: string | null, answerText: TranslateResult | string ) => void;
 }
 
 export default function JetpackCancellationSurvey( {
+	selectedAnswerId,
 	onAnswerChange,
 }: JetpackCancellationSurveyProps ): ReactElement {
 	const translate = useTranslate();
-	const [ selectedAnswerId, setSelectedAnswerId ] = useState< string | null >( null );
 	const [ customAnswerText, setCustomAnswerText ] = useState< string >( '' );
 	const customAnswerInputRef = React.useRef< HTMLInputElement | null >();
 
@@ -56,15 +50,14 @@ export default function JetpackCancellationSurvey( {
 	};
 
 	const selectAnswer = useCallback(
-		( answerId: string, answerText: TranslateResult | string ) => {
-			// prevent from changing the answer text to choiceOther.answerText just by clicking on it
+		( answerId: string ) => {
+			// prevent from sending the answer text if it's not a custom answer
 			const surveyAnswerText =
-				choiceOther.id === answerId && customAnswerText ? customAnswerText : answerText;
+				choiceOther.id === answerId && customAnswerText ? customAnswerText : '';
 
-			setSelectedAnswerId( answerId );
 			onAnswerChange( answerId, surveyAnswerText );
 		},
-		[ choiceOther.id, customAnswerText, onAnswerChange, setSelectedAnswerId ]
+		[ choiceOther.id, customAnswerText, onAnswerChange ]
 	);
 
 	const onChangeCustomAnswerText = useCallback(
@@ -84,7 +77,7 @@ export default function JetpackCancellationSurvey( {
 					'is-selected': choice.id === selectedAnswerId,
 				} ) }
 				tagName="button"
-				onClick={ () => selectAnswer( choice.id, choice.answerText ) }
+				onClick={ () => selectAnswer( choice.id ) }
 				key={ choice.id }
 			>
 				<div className="jetpack-cancellation-survey__card-content">
@@ -107,15 +100,15 @@ export default function JetpackCancellationSurvey( {
 
 			{ /* The card for the 'other' option */ }
 			<Card
+				key={ choiceOther.id }
 				className={ classnames( 'jetpack-cancellation-survey__card', {
 					'is-selected': choiceOther.id === selectedAnswerId,
 				} ) }
 				tagName="button"
 				onClick={ () => {
-					selectAnswer( choiceOther.id, choiceOther.answerText );
+					selectAnswer( choiceOther.id );
 					customAnswerInputRef?.current?.focus();
 				} }
-				key={ choiceOther.id }
 			>
 				<div className="jetpack-cancellation-survey__card-content">
 					<span>{ choiceOther.answerText }</span>

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -96,11 +96,12 @@ export default function JetpackCancellationSurvey( {
 	};
 
 	return (
-		<div className="jetpack-cancellation-survey__content">
+		<React.Fragment>
 			<FormattedHeader
 				headerText={ translate( 'Before you go, help us improve Jetpack' ) }
 				subHeaderText={ translate( 'Please let us know why you are cancelling.' ) }
 				align="center"
+				isSecondary={ true }
 			/>
 			{ choices.map( renderChoiceCard ) }
 
@@ -128,6 +129,6 @@ export default function JetpackCancellationSurvey( {
 				</div>
 				<Gridicon icon="chevron-right" size={ 12 } />
 			</Card>
-		</div>
+		</React.Fragment>
 	);
 }

--- a/client/components/marketing-survey/cancel-jetpack-form/style.scss
+++ b/client/components/marketing-survey/cancel-jetpack-form/style.scss
@@ -1,0 +1,84 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.cancel-jetpack-form__section-header {
+	text-align: center;
+	margin-bottom: 2rem;
+}
+
+.cancel-jetpack-form__step-headline {
+	font-size: 1.5rem;
+	color: #000000;
+	line-height: 1.11;
+	margin-bottom: 1.5rem;
+	text-align: center;
+	font-weight: 700;
+}
+
+.cancel-jetpack-form__step-summary {
+	font-size: 1.25rem;
+	color: #000000;
+	line-height: 1.25;
+	margin-bottom: 2rem;
+}
+
+.cancel-jetpack-form__jetpack-general-benefits {
+	margin-top: 2rem;
+}
+
+.cancel-jetpack-form__jetpack-general-benefits-title {
+	font-size: 1.25rem;
+	margin-bottom: 0.5rem;
+}
+
+.jetpack-cancellation-survey {
+	&__content {
+		box-sizing: border-box;
+
+		@include break-medium {
+			padding: 1rem 4rem;
+		}
+
+		@include break-wide {
+			width: 1128px;
+			padding: 3rem 12rem;
+		}
+	}
+
+	&__card {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 1rem;
+		width: 100%;
+		font-weight: 600;
+		color: var( --studio-black );
+		border: 1px solid var( --studio-white );
+		transition: border 0.2s ease-in-out;
+
+		&:hover, &:focus {
+			box-shadow: 0 0 0 1px var( --studio-gray-50 );
+		}
+
+		&.is-selected {
+			box-shadow: 0 0 0 1px var( --studio-black );
+			border: 1px solid var( --studio-black );
+		}
+
+		& > svg {
+			margin-left: auto;
+		}
+	}
+
+	&__card-content {
+		display: flex;
+		align-items: center;
+		width: 100%;
+	}
+}
+
+input[type='text'].form-text-input.jetpack-cancellation-survey__choice-item-text-input {
+	border: none;
+	padding: 0;
+	margin-left: 1rem;
+}

--- a/client/components/marketing-survey/cancel-jetpack-form/style.scss
+++ b/client/components/marketing-survey/cancel-jetpack-form/style.scss
@@ -1,50 +1,51 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-.cancel-jetpack-form__section-header {
-	text-align: center;
-	margin-bottom: 2rem;
+.cancel-jetpack-form__dialog {
+	// dialog panel
+
+	.formatted-header__title {
+		font-size: 1.5rem;
+		color: #000000;
+		line-height: 1.11;
+		margin-bottom: 1.5rem;
+		text-align: center;
+		font-weight: 700;
+	}
+
+	.formatted-header__subtitle {
+		font-size: 1.25rem;
+		color: #000000;
+		line-height: 1.25;
+		margin-bottom: 2rem;
+	}
 }
 
-.cancel-jetpack-form__step-headline {
-	font-size: 1.5rem;
-	color: #000000;
-	line-height: 1.11;
-	margin-bottom: 1.5rem;
-	text-align: center;
-	font-weight: 700;
+.cancel-jetpack-form__dialog-content {
+	box-sizing: border-box;
+
+	@include break-medium {
+		padding: 1rem 4rem;
+	}
+
+	@include break-wide {
+		width: 1128px;
+		padding: 3rem 12rem;
+	}
 }
 
-.cancel-jetpack-form__step-summary {
-	font-size: 1.25rem;
-	color: #000000;
-	line-height: 1.25;
-	margin-bottom: 2rem;
-}
-
+// List of benefits at the bottom of the fist step
 .cancel-jetpack-form__jetpack-general-benefits {
 	margin-top: 2rem;
 }
 
 .cancel-jetpack-form__jetpack-general-benefits-title {
 	font-size: 1.25rem;
-	margin-bottom: 0.5rem;
+	margin-bottom: 1rem;
 }
 
+// survey step of the flow
 .jetpack-cancellation-survey {
-	&__content {
-		box-sizing: border-box;
-
-		@include break-medium {
-			padding: 1rem 4rem;
-		}
-
-		@include break-wide {
-			width: 1128px;
-			padding: 3rem 12rem;
-		}
-	}
-
 	&__card {
 		display: flex;
 		justify-content: space-between;
@@ -55,6 +56,7 @@
 		color: var( --studio-black );
 		border: 1px solid var( --studio-white );
 		transition: border 0.2s ease-in-out;
+		font-size: 1rem;
 
 		&:hover, &:focus {
 			box-shadow: 0 0 0 1px var( --studio-gray-50 );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* This component adds the survey that will be used as a step of the new Jetpack cancellation flow via Calypso.
* This PR is related to/ a sub-part of https://github.com/Automattic/wp-calypso/pull/54669 which introduces a new cancellation flow for Jetpack plans/ products

#### Testing instructions

The visual output of this component can be seen by testing PR #54669
* Either check out the branch from PR #54669 locally or use the Calypso live link on that branch to get a preview. 
* Review the testing instructions on PR #54669 to check the visual output
* Make sure it looks like the screenshot below

![image](https://user-images.githubusercontent.com/5714212/128713392-47930dd5-6d9b-4f68-aa84-804bb8f5184a.png)


