### PR TITLE
Jetpack Sync: Don't show last synced time when the finished time is invalid

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -167,7 +167,7 @@ class JetpackSyncPanel extends React.Component {
 		const { translate } = this.props;
 		return (
 			<CompactCard className="jetpack-sync-panel">
-				<div className="jetpack-sync-panel__action">
+				<div className="jetpack-sync-panel__action" id="jetpackSyncPanelAction">
 					{ translate(
 						'Jetpack Sync keeps your WordPress.com dashboard up to date. ' +
 							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. '
@@ -178,7 +178,9 @@ class JetpackSyncPanel extends React.Component {
 							'If you suspect some data is missing, you can {{link}}initiate a sync manually{{/link}}.',
 							{
 								components: {
-									link: <a href="" onClick={ this.onSyncRequestButtonClick } />,
+									link: (
+										<a href="#jetpackSyncPanelAction" onClick={ this.onSyncRequestButtonClick } />
+									),
 								},
 							}
 						) }

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -132,17 +132,18 @@ class JetpackSyncPanel extends React.Component {
 
 		const finished = get( this.props, 'syncStatus.finished' );
 		const { isPendingSyncStart, isFullSyncing, moment, translate } = this.props;
-		const finishedTimestamp = moment( parseInt( finished, 10 ) * 1000 );
+		const finishedTimestamp = parseInt( finished, 10 ) * 1000;
+		const finishedTimestampObj = moment( finishedTimestamp );
 
 		let text = '';
 		if ( isPendingSyncStart ) {
 			text = translate( 'Full sync will begin shortly' );
 		} else if ( isFullSyncing ) {
 			text = translate( 'Full sync in progress' );
-		} else if ( finishedTimestamp.isValid() ) {
+		} else if ( finishedTimestamp > 1000 && finishedTimestampObj.isValid() ) {
 			text = translate( 'Last fully synced %(ago)s', {
 				args: {
-					ago: finishedTimestamp.fromNow(),
+					ago: finishedTimestampObj.fromNow(),
 				},
 			} );
 		}


### PR DESCRIPTION
Sometimes, when Full Sync is working, we don't have a valid "finish" time for Full Sync. This causes the Full Sync card under Settings to show that the site was last synced 52 years ago.

#### Changes proposed in this Pull Request

* Don't show the Last Synced label when the sync finished timestamp is invalid

#### Testing instructions

* Go to Settings -> Manage your connection
* Make sure the Last Synced label is showing sane values
