### PR TITLE
Jetpack Activity Log: Move backup/restore from ellipsis menu to buttons

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -252,6 +252,7 @@ class ActivityLogItem extends Component {
 		}
 
 		const showCredentialsButton = disableRestore && missingRewindCredentials;
+		const isCompact = showCredentialsButton;
 
 		const classes = classNames( 'activity-log-item__action', {
 			'activity-log-item__action-credentials': showCredentialsButton,
@@ -260,13 +261,14 @@ class ActivityLogItem extends Component {
 		return (
 			<div className={ classes }>
 				{ ! showCredentialsButton && (
-					<Button disabled={ disableRestore } onClick={ createRewind }>
+					<Button compact={ isCompact } disabled={ disableRestore } onClick={ createRewind }>
 						<Gridicon icon="history" size={ 18 } /> { translate( 'Restore' ) }
 					</Button>
 				) }
 
 				{ disableRestore && missingRewindCredentials && (
 					<Button
+						compact={ isCompact }
 						href={
 							canAutoconfigure
 								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
@@ -279,7 +281,7 @@ class ActivityLogItem extends Component {
 					</Button>
 				) }
 
-				<Button disabled={ disableBackup } onClick={ createBackup }>
+				<Button compact={ isCompact } disabled={ disableBackup } onClick={ createBackup }>
 					<Gridicon icon="cloud-download" size={ 18 } /> { translate( 'Download' ) }
 				</Button>
 			</div>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -158,10 +158,6 @@ class ActivityLogItem extends Component {
 
 		const rewindAction = this.renderRewindAction();
 
-		const descriptionClasses = classNames( 'activity-log-item__description', {
-			'activity-log-item__description-credentials': this.showCredentialsButton(),
-		} );
-
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
@@ -178,7 +174,7 @@ class ActivityLogItem extends Component {
 						fullImage={ false }
 					/>
 				) }
-				<div className={ descriptionClasses }>
+				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-text">
 						<div className="activity-log-item__description-content">
 							<ActivityDescription

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -20,13 +20,10 @@ import ActivityDescription from './activity-description';
 import ActivityMedia from './activity-media';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import Gridicon from 'calypso/components/gridicon';
 import HappychatButton from 'calypso/components/happychat/button';
 import { Button } from '@automattic/components';
 import FoldableCard from 'calypso/components/foldable-card';
-import PopoverMenuItem from 'calypso/components/popover/menu-item';
-import PopoverMenuSeparator from 'calypso/components/popover/menu-separator';
 import {
 	rewindBackup,
 	rewindBackupDismiss,
@@ -235,14 +232,14 @@ class ActivityLogItem extends Component {
 
 	performCloneAction = () => this.props.cloneOnClick( this.props.activity.activityTs );
 
-	renderRewindAction() {
+	renderRewindAction = () => {
 		const {
 			activity,
 			canAutoconfigure,
 			createBackup,
 			createRewind,
-			disableRestore,
 			disableBackup,
+			disableRestore,
 			missingRewindCredentials,
 			siteId,
 			siteSlug,
@@ -254,40 +251,40 @@ class ActivityLogItem extends Component {
 			return null;
 		}
 
+		const showCredentialsButton = disableRestore && missingRewindCredentials;
+
+		const classes = classNames( 'activity-log-item__action', {
+			'activity-log-item__action-credentials': showCredentialsButton,
+		} );
+
 		return (
-			<div className="activity-log-item__action">
-				<EllipsisMenu>
-					<PopoverMenuItem disabled={ disableRestore } icon="history" onClick={ createRewind }>
-						{ translate( 'Restore to this point' ) }
-					</PopoverMenuItem>
+			<div className={ classes }>
+				{ ! showCredentialsButton && (
+					<Button disabled={ disableRestore } onClick={ createRewind }>
+						<Gridicon icon="history" size={ 18 } /> { translate( 'Restore' ) }
+					</Button>
+				) }
 
-					{ disableRestore && missingRewindCredentials && (
-						<PopoverMenuItem
-							icon="plus"
-							href={
-								canAutoconfigure
-									? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
-									: `${ settingsPath( siteSlug ) }#credentials`
-							}
-							onClick={ trackAddCreds }
-						>
-							{ translate( 'Add server credentials to enable restoring' ) }
-						</PopoverMenuItem>
-					) }
-
-					<PopoverMenuSeparator />
-
-					<PopoverMenuItem
-						disabled={ disableBackup }
-						icon="cloud-download"
-						onClick={ createBackup }
+				{ disableRestore && missingRewindCredentials && (
+					<Button
+						href={
+							canAutoconfigure
+								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
+								: `${ settingsPath( siteSlug ) }#credentials`
+						}
+						onClick={ trackAddCreds }
 					>
-						{ translate( 'Download backup' ) }
-					</PopoverMenuItem>
-				</EllipsisMenu>
+						<Gridicon icon="plus" size={ 18 } />{ ' ' }
+						{ translate( 'Add server credentials to enable restoring' ) }
+					</Button>
+				) }
+
+				<Button disabled={ disableBackup } onClick={ createBackup }>
+					<Gridicon icon="cloud-download" size={ 18 } /> { translate( 'Download' ) }
+				</Button>
 			</div>
 		);
-	}
+	};
 
 	/**
 	 * Displays a button for users to get help. Tracks button click.

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -267,12 +267,8 @@ class ActivityLogItem extends Component {
 		const showCredentialsButton = this.showCredentialsButton();
 		const isCompact = showCredentialsButton;
 
-		const classes = classNames( 'activity-log-item__action', {
-			'activity-log-item__action-credentials': showCredentialsButton,
-		} );
-
 		return (
-			<div className={ classes }>
+			<div className="activity-log-item__action">
 				{ ! showCredentialsButton && (
 					<Button compact={ isCompact } disabled={ disableRestore } onClick={ createRewind }>
 						<Gridicon icon="history" size={ 18 } /> { translate( 'Restore' ) }

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -155,6 +155,13 @@ class ActivityLogItem extends Component {
 				isBreakpointActive: isDesktop,
 			},
 		} = this.props;
+
+		const rewindAction = this.renderRewindAction();
+
+		const descriptionClasses = classNames( 'activity-log-item__description', {
+			'activity-log-item__description-credentials': this.showCredentialsButton(),
+		} );
+
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
@@ -171,14 +178,19 @@ class ActivityLogItem extends Component {
 						fullImage={ false }
 					/>
 				) }
-				<div className="activity-log-item__description">
-					<div className="activity-log-item__description-content">
-						<ActivityDescription
-							activity={ this.props.activity }
-							rewindIsActive={ this.props.rewindIsActive }
-						/>
+				<div className={ descriptionClasses }>
+					<div className="activity-log-item__description-text">
+						<div className="activity-log-item__description-content">
+							<ActivityDescription
+								activity={ this.props.activity }
+								rewindIsActive={ this.props.rewindIsActive }
+							/>
+						</div>
+						<div className="activity-log-item__description-summary">{ activityTitle }</div>
 					</div>
-					<div className="activity-log-item__description-summary">{ activityTitle }</div>
+					{ rewindAction && (
+						<div className="activity-log-item__description-actions">{ rewindAction }</div>
+					) }
 				</div>
 				{ activityMedia && ! isDesktop && (
 					<ActivityMedia
@@ -232,6 +244,8 @@ class ActivityLogItem extends Component {
 
 	performCloneAction = () => this.props.cloneOnClick( this.props.activity.activityTs );
 
+	showCredentialsButton = () => this.props.disableRestore && this.props.missingRewindCredentials;
+
 	renderRewindAction = () => {
 		const {
 			activity,
@@ -240,7 +254,6 @@ class ActivityLogItem extends Component {
 			createRewind,
 			disableBackup,
 			disableRestore,
-			missingRewindCredentials,
 			siteId,
 			siteSlug,
 			trackAddCreds,
@@ -251,7 +264,7 @@ class ActivityLogItem extends Component {
 			return null;
 		}
 
-		const showCredentialsButton = disableRestore && missingRewindCredentials;
+		const showCredentialsButton = this.showCredentialsButton();
 		const isCompact = showCredentialsButton;
 
 		const classes = classNames( 'activity-log-item__action', {
@@ -266,7 +279,7 @@ class ActivityLogItem extends Component {
 					</Button>
 				) }
 
-				{ disableRestore && missingRewindCredentials && (
+				{ showCredentialsButton && (
 					<Button
 						compact={ isCompact }
 						href={
@@ -409,7 +422,7 @@ class ActivityLogItem extends Component {
 						className="activity-log-item__card"
 						expandedSummary={ this.renderItemAction() }
 						header={ this.renderHeader() }
-						actionButton={ this.renderRewindAction() }
+						actionButton={ null }
 						summary={ this.renderItemAction() }
 					/>
 				</div>

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -468,6 +468,9 @@
 	}
 	.activity-log-item__description-actions {
 		padding-top: 8px;
+		display: flex;
+		align-items: center;
+		justify-content: flex-start;
 	}
 
 	@include break-wide {
@@ -478,6 +481,7 @@
 		}
 		.activity-log-item__description-actions {
 			padding-top: 0;
+			justify-content: flex-end;
 		}
 	}
 }

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -324,14 +324,6 @@
 	}
 }
 
-// When showing the "Add server credentials" button, stack the buttons
-// instead of showing them side-by-side.
-// But only on wide widths, when the buttons are to the right
-// of the description
-// .activity-log-item__action-credentials {
-// 	flex-direction: column;
-// }
-
 .activity-log-item__clone-action {
 	flex-shrink: 0;
 }
@@ -460,12 +452,6 @@
 	a.button, button {
 		margin-right: 8px;
 	}
-	// .activity-log-item__action-credentials {
-	// 	a.button, button {
-	// 		margin-top: 4px;
-	// 		margin-right: 0;
-	// 	}
-	// }
 }
 
 .activity-log-item__description {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .activity-log-item {
 	display: flex;
 	position: relative;
@@ -47,14 +50,11 @@
 	}
 }
 
+// Right side of <FoldableCard> is hidden.
+// We set up our right side action buttons in .foldable-card__main,
+// which gives us more flexibilty with responsive design
 .activity-log-item .foldable-card__secondary {
-	flex-grow: 1;
-
-	.foldable-card__summary {
-		display: flex;
-		align-items: center;
-		margin-right: 0;
-	}
+	display: none;
 }
 
 .activity-log-item__type {
@@ -196,7 +196,7 @@
 	margin-right: 32px;
 	align-items: center;
 
-	@include breakpoint-deprecated( '>960px' ) {
+	@include break-wide {
 		flex: 0 0 180px;
 		margin-left: -56px;
 	}
@@ -317,7 +317,6 @@
 
 .activity-log-item__action {
 	display: flex;
-	justify-content: flex-end;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		margin-top: 16px;
@@ -327,9 +326,11 @@
 
 // When showing the "Add server credentials" button, stack the buttons
 // instead of showing them side-by-side.
-.activity-log-item__action-credentials {
-	flex-direction: column;
-}
+// But only on wide widths, when the buttons are to the right
+// of the description
+// .activity-log-item__action-credentials {
+// 	flex-direction: column;
+// }
 
 .activity-log-item__clone-action {
 	flex-shrink: 0;
@@ -459,10 +460,54 @@
 	a.button, button {
 		margin-right: 8px;
 	}
-	.activity-log-item__action-credentials {
-		a.button, button {
-			margin-top: 4px;
-			margin-right: 0;
+	// .activity-log-item__action-credentials {
+	// 	a.button, button {
+	// 		margin-top: 4px;
+	// 		margin-right: 0;
+	// 	}
+	// }
+}
+
+.activity-log-item__description {
+	display: flex;
+
+	// Mobile-Medium: Action buttons under description
+	flex-direction: column;
+	.activity-log-item__action {
+		justify-content: normal;
+	}
+	.activity-log-item__description-actions {
+		padding-top: 8px;
+	}
+
+	@include break-wide {
+		// Wide+: Action buttons right of description
+		flex-direction: row;
+		.activity-log-item__action {
+			justify-content: flex-end;
+		}
+		.activity-log-item__description-actions {
+			padding-top: 0;
 		}
 	}
+
+	&.activity-log-item__description-credentials {
+		// When long button exists: "Add server credentials to enable restoring":
+		// Always put under description, no matter screen size
+		flex-direction: column;
+		.activity-log-item__action {
+			justify-content: normal;
+		}
+		.activity-log-item__description-actions {
+			padding-top: 8px;
+		}
+	}
+}
+
+// When side by side, desc = [    text 66%    | act %33 ]
+.activity-log-item__description-text {
+	flex-grow: 2;
+}
+.activity-log-item__description-actions {
+	flex-grow: 1;
 }

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -56,6 +56,10 @@
 .activity-log-item .foldable-card__secondary {
 	display: none;
 }
+// Therefore, we no longer need to reserve 36px for the main section
+.activity-log-item .foldable-card__main {
+	max-width: 100%;
+}
 
 .activity-log-item__type {
 	display: flex;
@@ -474,18 +478,6 @@
 		}
 		.activity-log-item__description-actions {
 			padding-top: 0;
-		}
-	}
-
-	&.activity-log-item__description-credentials {
-		// When long button exists: "Add server credentials to enable restoring":
-		// Always put under description, no matter screen size
-		flex-direction: column;
-		.activity-log-item__action {
-			justify-content: normal;
-		}
-		.activity-log-item__description-actions {
-			padding-top: 8px;
 		}
 	}
 }

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -48,7 +48,7 @@
 }
 
 .activity-log-item .foldable-card__secondary {
-	flex-grow: 0;
+	flex-grow: 1;
 
 	.foldable-card__summary {
 		display: flex;
@@ -323,20 +323,12 @@
 		margin-top: 16px;
 		text-align: left;
 	}
+}
 
-	.ellipsis-menu {
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		right: 0;
-
-		.button {
-			position: relative;
-			top: 50%;
-			width: 48px;
-			transform: translateY( -50% );
-		}
-	}
+// When showing the "Add server credentials" button, stack the buttons
+// instead of showing them side-by-side.
+.activity-log-item__action-credentials {
+	flex-direction: column;
 }
 
 .activity-log-item__clone-action {
@@ -454,5 +446,23 @@
 	}
 	100% {
 		opacity: 0;
+	}
+}
+
+.activity-log-item .foldable-card__action {
+	display: flex;
+	align-items: center;
+	position: static;
+}
+
+.activity-log-item {
+	a.button, button {
+		margin-right: 8px;
+	}
+	.activity-log-item__action-credentials {
+		a.button, button {
+			margin-top: 4px;
+			margin-right: 0;
+		}
 	}
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Jetpack Activity Log: Move backup/restore from ellipsis menu to buttons

![106399338-52700d80-6418-11eb-89b1-be8e46b591b4](https://user-images.githubusercontent.com/937354/128759053-14d4a3d5-ff38-473a-93a0-9961ecb902ca.gif)

^ Before

![2021-08-09_13-36_1](https://user-images.githubusercontent.com/937354/128759103-1390d9fb-c6db-4ec2-a5ae-b7d678f66a54.png)

^ After (w/ Credentials)

![2021-08-09_13-36](https://user-images.githubusercontent.com/937354/128759121-ad3fc25a-0142-41f8-bf4d-2bc61630f6dd.png)


^ After (Missing credentials)


#### Testing instructions

* Create 2 jetpack ninja sites
* Store the credentials to each of them in a text file
* Visit the /wp-admin on both of them, press the green jetpack button to connect to your wp.com account
* Buy the backup daily jetpack plan while connecting (use store credits on your wp.com account)
* Add a post to each of the sites
* Visit Calypso for one of the sites. Go to Jetpack -> Backup in the sidebar, then click "Enable Restores"
![2021-08-09_13-57](https://user-images.githubusercontent.com/937354/128759381-a9426cb7-6f1b-45c6-9f71-52c582c64038.png)
* Enter the SSH credentials for this site here. You should only need to enter the username/password.
* Don't do this to your other site. Now you have one site with credentials, one without, and you can check both forms of the activity log display.
* Wait for a backup to be created.. although it might have already been while you did the credential dance.
* Visit Jetpack -> Activity Log for each of the sites and examine the backup and restore buttons for the backups.
* Also try adjusting browser width.
* Buttons should continue to function as before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/49528

#### Lint

These existing lint items were picked up, but I'm not working in this
area:

client/my-sites/activity/activity-log-item/style.scss
 108:17  ✖  Unexpected unit "%" for property "border-radius"   declaration-property-unit-allowed-list
 228:18  ✖  Unexpected unit "%" for property "border-radius"   declaration-property-unit-allowed-list
 242:18  ✖  Unexpected unit "%" for property "border-radius"   declaration-property-unit-allowed-list

Used --no-verify.
