### PR TITLE
Domains: Fix bulk email edit page

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -118,7 +118,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		const newContactDetails = {};
 
 		if ( id === 'legal-type' ) {
-			this.props.updateRequiredDomainFields( {
+			this.props.updateRequiredDomainFields?.( {
 				organization: this.isCorporationLegalType( value ),
 			} );
 		}

--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -77,6 +77,9 @@ export default function ContactDetailsContainer( {
 		} );
 	};
 
+	const getIsFieldRequired = ( field: Exclude< keyof ManagedContactDetails, 'tldExtraFields' > ) =>
+		contactInfo[ field ]?.isRequired ?? false;
+
 	switch ( contactDetailsType ) {
 		case 'domain':
 			return (
@@ -92,6 +95,7 @@ export default function ContactDetailsContainer( {
 						contactDetailsErrors={ contactDetailsErrors }
 						updateDomainContactFields={ updateDomainContactRelatedData }
 						updateRequiredDomainFields={ updateRequiredDomainFields }
+						getIsFieldRequired={ getIsFieldRequired }
 						shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 						isDisabled={ isDisabled }
 						isLoggedOutCart={ isLoggedOutCart }

--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -91,6 +91,7 @@ export default function ContactDetailsContainer( {
 						contactDetails={ contactDetails }
 						contactDetailsErrors={ contactDetailsErrors }
 						updateDomainContactFields={ updateDomainContactRelatedData }
+						updateRequiredDomainFields={ updateRequiredDomainFields }
 						shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 						isDisabled={ isDisabled }
 						isLoggedOutCart={ isLoggedOutCart }

--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -2,11 +2,16 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelect, useDispatch } from '@automattic/composite-checkout';
+import { useSelect } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
-import type { DomainContactDetailsErrors, ManagedValue } from '@automattic/wpcom-checkout';
+import type {
+	DomainContactDetailsErrors,
+	ManagedContactDetails,
+	ManagedContactDetailsRequiredMask,
+	ManagedValue,
+} from '@automattic/wpcom-checkout';
 
 /**
  * Internal dependencies
@@ -25,6 +30,7 @@ export default function DomainContactDetails( {
 	contactDetails,
 	contactDetailsErrors,
 	updateDomainContactFields,
+	updateRequiredDomainFields,
 	shouldShowContactDetailsValidationErrors,
 	isDisabled,
 	isLoggedOutCart,
@@ -34,6 +40,10 @@ export default function DomainContactDetails( {
 	contactDetails: DomainContactDetailsData;
 	contactDetailsErrors: DomainContactDetailsErrors;
 	updateDomainContactFields: ( details: DomainContactDetailsData ) => void;
+	updateRequiredDomainFields?: (
+		details: ManagedContactDetails,
+		requiredMask: ManagedContactDetailsRequiredMask
+	) => ManagedContactDetails;
 	shouldShowContactDetailsValidationErrors: boolean;
 	isDisabled: boolean;
 	isLoggedOutCart: boolean;
@@ -48,7 +58,6 @@ export default function DomainContactDetails( {
 	const getIsFieldDisabled = () => isDisabled;
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
-	const { updateRequiredDomainFields } = useDispatch( 'wpcom' );
 	const contactInfo = useSelect< Record< string, ManagedValue > >( ( select ) =>
 		select( 'wpcom' ).getContactInfo()
 	);

--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelect } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
@@ -10,7 +9,6 @@ import type {
 	DomainContactDetailsErrors,
 	ManagedContactDetails,
 	ManagedContactDetailsRequiredMask,
-	ManagedValue,
 } from '@automattic/wpcom-checkout';
 
 /**
@@ -31,6 +29,7 @@ export default function DomainContactDetails( {
 	contactDetailsErrors,
 	updateDomainContactFields,
 	updateRequiredDomainFields,
+	getIsFieldRequired,
 	shouldShowContactDetailsValidationErrors,
 	isDisabled,
 	isLoggedOutCart,
@@ -44,6 +43,9 @@ export default function DomainContactDetails( {
 		details: ManagedContactDetails,
 		requiredMask: ManagedContactDetailsRequiredMask
 	) => ManagedContactDetails;
+	getIsFieldRequired?: (
+		field: Exclude< keyof ManagedContactDetails, 'tldExtraFields' >
+	) => boolean;
 	shouldShowContactDetailsValidationErrors: boolean;
 	isDisabled: boolean;
 	isLoggedOutCart: boolean;
@@ -58,10 +60,6 @@ export default function DomainContactDetails( {
 	const getIsFieldDisabled = () => isDisabled;
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
-	const contactInfo = useSelect< Record< string, ManagedValue > >( ( select ) =>
-		select( 'wpcom' ).getContactInfo()
-	);
-	const getIsFieldRequired = ( field: string ) => contactInfo[ field ].isRequired;
 
 	return (
 		<React.Fragment>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fix to the bulk email edit page (`/domains/manage?site=all&action=edit-contact-email`). 
The PR https://github.com/Automattic/wp-calypso/pull/54327 indirectly introduced a dependency on the Checkout redux store by the `DomainContactDetails` component. 
Since the bulk email edit page also uses `DomainContactDetails` component, it breaks, since the Checkout store is not used either initialized in this case.

This PR removes the dependency by passing the functions as props to the component and making them optional for the children that use it.

#### Testing instructions
- Go to `/domains/manage?site=all&action=edit-contact-email`;
- Check that the page loads correctly;
- In the checkout page, check that the postal code field is still hidden properly when the country doesn't support postal codes (checking that there's no regression on https://github.com/Automattic/wp-calypso/pull/54327);
- Make sure that tests are passing.

#### Screenshots

##### Before
![image](https://user-images.githubusercontent.com/18705930/128763615-19b1cc80-5f21-429c-af2c-7c93c3258f0c.png)

##### After
![image](https://user-images.githubusercontent.com/18705930/128763647-ef62a136-887a-4168-9187-839cf425ab7c.png)