### PR TITLE
Activity Log: Limit visible Activities + add an upsell for Calypso Blue

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -18,18 +18,11 @@ import { updateFilter } from 'calypso/state/activity-log/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
+import getSiteActivityLogRetentionPolicyRequestStatus from 'calypso/state/selectors/get-site-activity-log-retention-policy-request-status';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import RetentionLimitUpsell from './retention-limit-upsell';
 
 import './style.scss';
-
-const getRetentionPolicyRequestStatus = ( state, siteId ) => {
-	if ( ! Number.isInteger( siteId ) ) {
-		return undefined;
-	}
-
-	return state.activityLog.retentionPolicy[ siteId ]?.requestStatus;
-};
 
 class ActivityCardList extends Component {
 	static propTypes = {
@@ -291,7 +284,10 @@ const mapStateToProps = ( state ) => {
 	const userLocale = getCurrentUserLocale( state );
 	const retentionDays = getSiteActivityLogRetentionDays( state, siteId );
 
-	const retentionPolicyRequestStatus = getRetentionPolicyRequestStatus( state, siteId );
+	const retentionPolicyRequestStatus = getSiteActivityLogRetentionPolicyRequestStatus(
+		state,
+		siteId
+	);
 
 	return {
 		filter,

--- a/client/components/activity-card-list/retention-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/retention-limit-upsell/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -8,6 +9,7 @@ import { useSelector } from 'react-redux';
 import ActivityCard from 'calypso/components/activity-card';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
 import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useTrackUpsellView, useTrackUpgradeClick } from './hooks';
@@ -27,6 +29,7 @@ const PLACEHOLDER_ACTIVITY = {
 	activityTs: 1609459200000,
 	activityGroup: 'rewind',
 	activityIcon: 'cloud',
+	activityStatus: 'success',
 	activityType: 'Backup',
 	activityTitle: '',
 	activityDescription: [],
@@ -52,11 +55,20 @@ const RetentionLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 		return null;
 	}
 
+	const card =
+		isJetpackCloud() || isEnabled( 'activity-log/v2' ) ? (
+			<ActivityCard className={ cardClassName } activity={ PLACEHOLDER_ACTIVITY } />
+		) : (
+			<ActivityLogItem
+				className={ cardClassName }
+				siteId={ siteId }
+				activity={ PLACEHOLDER_ACTIVITY }
+			/>
+		);
+
 	return (
 		<div className="retention-limit-upsell">
-			<div className="retention-limit-upsell__next-activity">
-				<ActivityCard className={ cardClassName } activity={ PLACEHOLDER_ACTIVITY } />
-			</div>
+			<div className="retention-limit-upsell__next-activity">{ card }</div>
 			<div className="retention-limit-upsell__call-to-action">
 				<h3 className="retention-limit-upsell__call-to-action-header">
 					{ preventWidows(

--- a/client/components/activity-card-list/retention-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/retention-limit-upsell/index.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';

--- a/client/components/activity-card-list/retention-limit-upsell/style.scss
+++ b/client/components/activity-card-list/retention-limit-upsell/style.scss
@@ -21,7 +21,8 @@
 	// This is a placeholder activity card with no information,
 	// and including the time would only disrupt the timeline's
 	// chronological sort, so don't show the time at all
-	.activity-card .activity-card__time-text {
+	.activity-card .activity-card__time-text,
+	.activity-log-item__time {
 		display: none;
 	}
 

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { isEnabled } from '@automattic/calypso-config';
 import { isMobile } from '@automattic/viewport';
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
@@ -31,6 +32,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import Pagination from 'calypso/components/pagination';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import RewindAlerts from './rewind-alerts';
+import QueryActivityLogRetentionPolicy from 'calypso/components/data/query-activity-log-retention-policy';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -65,6 +67,8 @@ import {
 	rewindBackup,
 	updateFilter,
 } from 'calypso/state/activity-log/actions';
+import getSiteActivityLogRetentionPolicyRequestStatus from 'calypso/state/selectors/get-site-activity-log-retention-policy-request-status';
+import getSiteActivityLogRetentionDays from 'calypso/state/selectors/get-site-activity-log-retention-days';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getBackupProgress from 'calypso/state/selectors/get-backup-progress';
 import getRequestedBackup from 'calypso/state/selectors/get-requested-backup';
@@ -84,6 +88,7 @@ import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
+import RetentionLimitUpsell from 'calypso/components/activity-card-list/retention-limit-upsell';
 
 /**
  * Style dependencies
@@ -374,6 +379,7 @@ class ActivityLog extends Component {
 			enableRewind,
 			filter: { page: requestedPage },
 			logs,
+			logsLimitedByRetentionPolicy,
 			moment,
 			rewindState,
 			siteId,
@@ -391,10 +397,8 @@ class ActivityLog extends Component {
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
-		const actualPage = Math.max(
-			1,
-			Math.min( requestedPage, Math.ceil( logs.length / PAGE_SIZE ) )
-		);
+		const pageCount = Math.ceil( logs.length / PAGE_SIZE );
+		const actualPage = Math.max( 1, Math.min( requestedPage, pageCount ) );
 		const theseLogs = logs.slice( ( actualPage - 1 ) * PAGE_SIZE, actualPage * PAGE_SIZE );
 
 		const timePeriod = ( () => {
@@ -418,6 +422,8 @@ class ActivityLog extends Component {
 				return null;
 			};
 		} )();
+
+		const showRetentionLimitUpsell = logsLimitedByRetentionPolicy && actualPage >= pageCount;
 
 		return (
 			<>
@@ -497,6 +503,9 @@ class ActivityLog extends Component {
 								)
 							) }
 						</section>
+						{ showRetentionLimitUpsell && (
+							<RetentionLimitUpsell cardClassName="activity-log-item__card" />
+						) }
 						{ siteHasNoLog && ! isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
 							compact={ isMobile() }
@@ -548,6 +557,7 @@ class ActivityLog extends Component {
 				<QuerySitePurchases siteId={ siteId } />
 				<PageViewTracker path="/activity-log/:site" title="Activity" />
 				<DocumentHead title={ translate( 'Activity' ) } />
+				{ siteId && <QueryActivityLogRetentionPolicy siteId={ siteId } /> }
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
 				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				{ siteId && <TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } /> }
@@ -573,7 +583,6 @@ export default connect(
 		const rewindState = getRewindState( state, siteId );
 		const restoreStatus = rewindState.rewind && rewindState.rewind.status;
 		const filter = getActivityLogFilter( state, siteId );
-		const logs = siteId && requestActivityLogs( siteId, filter );
 		const siteIsOnFreePlan =
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId );
@@ -583,6 +592,41 @@ export default connect(
 			! siteHasScanProductPurchase( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 
+		const retentionPoliciesEnabled = isEnabled( 'activity-log/retention-policies' );
+		const retentionPolicyLoaded = retentionPoliciesEnabled
+			? getSiteActivityLogRetentionPolicyRequestStatus( state, siteId ) === 'success'
+			: true;
+		const retentionDays = retentionPoliciesEnabled
+			? getSiteActivityLogRetentionDays( state, siteId )
+			: undefined;
+		const retentionLimitCutoffDate =
+			retentionPoliciesEnabled && Number.isFinite( retentionDays )
+				? applySiteOffset( Date.now(), { gmtOffset, timezone } )
+						.subtract( retentionDays, 'days' )
+						.startOf( 'day' )
+				: undefined;
+
+		const logs = siteId && requestActivityLogs( siteId, filter );
+		const logEntries = logs?.data ?? emptyList;
+		const logEntriesWithRetention =
+			retentionPoliciesEnabled && retentionLimitCutoffDate
+				? // This could slightly degrade performance, but it's likely
+				  // this entire component tree gets refactored or removed soon,
+				  // in favor of calypso/my-sites/activity/activity-log-v2.
+				  //
+				  // eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+				  logEntries.filter( ( log ) =>
+						applySiteOffset( log.activityDate, { gmtOffset, timezone } ).isSameOrAfter(
+							retentionLimitCutoffDate,
+							'day'
+						)
+				  )
+				: logEntries;
+
+		const logsLimitedByRetentionPolicy = retentionPoliciesEnabled
+			? logEntriesWithRetention.length < logEntries.length
+			: false;
+
 		return {
 			gmtOffset,
 			enableRewind:
@@ -591,8 +635,9 @@ export default connect(
 			filter,
 			isAtomic: isAtomicSite( state, siteId ),
 			isJetpack,
-			logs: ( siteId && logs.data ) || emptyList,
-			logLoadingState: logs && logs.state,
+			logs: logEntriesWithRetention,
+			logsLimitedByRetentionPolicy,
+			logLoadingState: retentionPolicyLoaded && logs && logs.state,
 			requestedRestore: find( logs, { activityId: requestedRestoreId } ),
 			requestedRestoreId,
 			requestedBackup: find( logs, { activityId: requestedBackupId } ),

--- a/client/state/selectors/get-site-activity-log-retention-policy-request-status.ts
+++ b/client/state/selectors/get-site-activity-log-retention-policy-request-status.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+const getSiteActivityLogRetentionPolicyRequestStatus = (
+	state: AppState,
+	siteId: number | null
+): string | undefined => {
+	if ( ! Number.isInteger( siteId ) ) {
+		return undefined;
+	}
+
+	return state.activityLog.retentionPolicy[ siteId as number ]?.requestStatus;
+};
+
+export default getSiteActivityLogRetentionPolicyRequestStatus;


### PR DESCRIPTION
Resolves `1200412004370260-as-1200715042882976`.
Relates to #54900.

#### Changes proposed in this Pull Request

* In the Calypso Blue Activity Log, hide events older than some number of days (defined by the site's purchases).
* When people reach the oldest visible event in their Activity Log, show an upsell prompt similar to that in Calypso Green (see #54900).
* Modify the Activity Log limit upsell so that it renders the appropriate faded-out Activity card for whichever experience is active (i.e., Calypso Blue or Green).
* Create a new top-level selector to retrieve the status of the request to fetch the current site's Activity Log visibility rules.

##### Implementation notes

* In a future PR, we'll be changing variables/functions/etc so that they refer to "visibility" or "visibility rules" instead of "retention" or "retention policies." This is to avoid confusion around the term "retention," which already has a separate, agreed-upon definition in the APIs that power the Activity Log.
* The name I chose for the new request status selector, `getSiteActivityLogRetentionPolicyRequestStatus`, is a bit unwieldy. I'm not super fond of it, but I wanted to be explicit in describing what it does. I'm open to suggestions to make it easier to type and/or say.

#### Testing instructions

NOTE: Testing this PR will be slightly easier if you have access to a site with Activity Log entries dating at least 30 days into the past. If this isn't feasible for you, testing instructions for #54900 outline a workaround.

##### Prerequisites

1. Configure a WordPress.com sandbox such that `D64586-code` has been applied.
2. Add a DNS alias on your local machine so that `public-api.wordpress.com` points to your patched sandbox.

##### Regression testing

3. Launch Calypso Blue, select a Jetpack site with Activity Log, and navigate to the Activity Log page.
4. Verify the page looks and behaves exactly as in production; there should be no changes whatsoever.

##### Enabling limits

5. If you're testing locally, shut down your Calypso build. In `config/development.json`, change the `activity-log/retention-policies` flag from `false` to `true` and restart the build. Alternatively, or for non-local testing, you can simply add `flags=activity-log/retention-policies` to your browser's URL query string on any page, then hit Return/Enter to load it with the flag enabled.

##### Limit behavior

6. On the Activity Log page, scroll back 30 days in your site's history, flipping through pages as necessary.
7. Verify that no Activities older than 30 days are visible, and that you see an upsell like the one in the first reference capture (see the bottom of this PR description).
8. Verify you're able to navigate at least one page toward the present day after seeing the upsell, and that the upsell is only visible on the last page of results.

##### Upsell behavior

9. Verify the upsell correctly states the number of days of Activity entries you're allowed to see (30, by default; change this value by either modifying the API endpoint in your sandbox or by modifying the Calypso app state directly).
10. Resize the browser window and verify that all screen sizes look correct, from mobile to full-width desktop.
11. Verify that clicking the upsell's call to action directs you to `/plans/<your site slug>` so that you can purchase an upgrade.

#### Reference captures

##### Limit behavior

https://user-images.githubusercontent.com/670067/128877606-7f56dda7-df6f-4822-9cb8-266672e1a1f3.mp4

##### Upsell sizing

https://user-images.githubusercontent.com/670067/128914143-261fbde9-1828-4e23-a662-e328eda2b851.mp4