### PR TITLE
Sharing Buttons: Update private site notice

### DIFF
--- a/client/my-sites/marketing/buttons/tray.jsx
+++ b/client/my-sites/marketing/buttons/tray.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -161,11 +162,21 @@ class SharingButtonsTray extends React.Component {
 	getLimitedButtonsNoticeElement = () => {
 		if ( this.props.limited ) {
 			return (
-				<em className="sharing-buttons-preview__panel-notice">
-					{ this.props.translate( 'Sharing options are limited on private sites.', {
-						context: 'Sharing: Buttons',
-					} ) }
-				</em>
+				<p className="sharing-buttons-preview__panel-notice">
+					<em>
+						{ this.props.translate(
+							'It looks like your site is Private. To get more sharing options make your site Public.',
+							{
+								context: 'Sharing: Buttons',
+							}
+						) }
+					</em>
+					<a href="https://wordpress.com/support/settings/privacy-settings/">
+						{ this.props.translate( 'Check out our guide for more details.', {
+							context: 'Sharing: Buttons',
+						} ) }
+					</a>
+				</p>
 			);
 		}
 	};

--- a/client/my-sites/marketing/buttons/tray.jsx
+++ b/client/my-sites/marketing/buttons/tray.jsx
@@ -165,13 +165,17 @@ class SharingButtonsTray extends React.Component {
 				<p className="sharing-buttons-preview__panel-notice">
 					<em>
 						{ this.props.translate(
-							'It looks like your site is Private. To get more sharing options make your site Public.',
+							'It looks like your site is Private. Make it Public to take advantage of more sharing options.',
 							{
 								context: 'Sharing: Buttons',
 							}
 						) }
 					</em>
-					<a href="https://wordpress.com/support/settings/privacy-settings/">
+					<a
+						href="https://wordpress.com/support/settings/privacy-settings/"
+						target="_blank"
+						rel="noreferrer"
+					>
 						{ this.props.translate( 'Check out our guide for more details.', {
 							context: 'Sharing: Buttons',
 						} ) }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -1043,7 +1043,7 @@
 
 .sharing-buttons-preview__panel-notice > * {
 	display: block;
-    margin: 8px 0;
+	margin: 8px 0;
 }
 
 .sharing-buttons-preview__panel-instruction-text {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -1035,11 +1035,15 @@
 	color: var( --color-neutral-70 );
 }
 
-.sharing-buttons-preview__panel-instructions,
-.sharing-buttons-preview__panel-notice {
+.sharing-buttons-preview__panel-instructions {
 	display: block;
 	color: var( --color-neutral-light );
 	margin: 8px 0;
+}
+
+.sharing-buttons-preview__panel-notice > * {
+	display: block;
+    margin: 8px 0;
 }
 
 .sharing-buttons-preview__panel-instruction-text {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Update the notice that is shown for the sharing buttons when a site is set to private. By default, we remove all the `sharedaddy` buttons available if the site is set to private. The previous message was very discreet and left room for confusion. Per [the original issue](https://github.com/Automattic/wp-calypso/issues/49505), I changed the wording and added a link to a relevant guide.

I opted to space this out on separate lines because it looked better that way in my opinion. Let me know if that is not the case.

## Testing instructions

1. Set site to private from `Settings ⇢ General`
2. Edit the sharing buttons from `Tools ⇢ Marketing ⇢ Sharing buttons`
3. Click the "Edit sharing buttons" button and view the notice why there are not more sharing options available.

## Screenshots

#### Mobile
<img width="411" alt="Markup 2021-08-09 at 17 45 04" src="https://user-images.githubusercontent.com/33258733/128786246-3fe6459d-12fb-4255-825e-14b342be0221.png">

#### Desktop
<img width="1005" alt="Markup 2021-08-09 at 17 45 18" src="https://user-images.githubusercontent.com/33258733/128786267-c8dd834e-e667-451c-9209-650f36186584.png">


Fixes #49505