### PR TITLE
Shopping Cart: Add refetchOnWindowFocus tests

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -12,10 +12,14 @@ export * from './shopping-cart-endpoint';
 
 export interface ShoppingCartManagerArguments {
 	cartKey: string | undefined;
-	setCart: ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
-	getCart: ( cartKey: string ) => Promise< ResponseCart >;
+	setCart: SetCart;
+	getCart: GetCart;
 	options?: ShoppingCartManagerOptions;
 }
+
+export type GetCart = ( cartKey: string ) => Promise< ResponseCart >;
+
+export type SetCart = ( cartKey: string, requestCart: RequestCart ) => Promise< ResponseCart >;
 
 export interface ShoppingCartManagerOptions {
 	refetchOnWindowFocus?: boolean;

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -14,6 +14,9 @@ import type {
 	RequestCart,
 	ResponseCart,
 	MinimalRequestCartProduct,
+	GetCart,
+	SetCart,
+	ShoppingCartManagerOptions,
 } from '../src/types';
 
 // This is required to fix the "regeneratorRuntime is not defined" error
@@ -120,10 +123,11 @@ function createProduct( productProps: RequestCartProduct ): ResponseCartProduct 
 }
 
 async function setCart( cartKey: string, newCart: RequestCart ): Promise< ResponseCart > {
-	if ( cartKey === mainCartKey ) {
+	if ( [ 'no-site', 'no-user', mainCartKey ].includes( cartKey ) ) {
 		// Mock the shopping-cart endpoint response here
 		return {
 			...emptyResponseCart,
+			cart_key: cartKey,
 			products: newCart.products.map( createProduct ),
 			coupon: newCart.coupon,
 			is_coupon_applied: !! newCart.coupon,
@@ -145,7 +149,13 @@ function ProductList( {
 	initialProductsForReplace?: MinimalRequestCartProduct[];
 	initialCoupon?: string;
 } ) {
-	const { responseCart, addProductsToCart, replaceProductsInCart, applyCoupon } = useShoppingCart();
+	const {
+		isPendingUpdate,
+		responseCart,
+		addProductsToCart,
+		replaceProductsInCart,
+		applyCoupon,
+	} = useShoppingCart();
 	const hasAddedProduct = useRef( false );
 	useEffect( () => {
 		if ( initialProducts && ! hasAddedProduct.current ) {
@@ -167,7 +177,7 @@ function ProductList( {
 		}
 	}, [ applyCoupon, initialCoupon ] );
 	if ( responseCart.products.length === 0 ) {
-		return null;
+		return <div>No products</div>;
 	}
 	const coupon = responseCart.is_coupon_applied ? <div>Coupon: { responseCart.coupon }</div> : null;
 	const location = responseCart.tax.location.postal_code ? (
@@ -178,6 +188,7 @@ function ProductList( {
 	) : null;
 	return (
 		<ul data-testid="product-list">
+			{ isPendingUpdate && <div>Loading...</div> }
 			{ coupon }
 			{ location }
 			{ responseCart.products.map( ( product ) => {
@@ -192,9 +203,26 @@ function ProductList( {
 	);
 }
 
-function MockProvider( { children } ) {
+function MockProvider( {
+	children,
+	setCartOverride,
+	getCartOverride,
+	options,
+	cartKeyOverride,
+}: {
+	children: React.ReactNode;
+	setCartOverride?: SetCart;
+	getCartOverride?: GetCart;
+	options?: ShoppingCartManagerOptions;
+	cartKeyOverride?: string | undefined;
+} ) {
 	return (
-		<ShoppingCartProvider cartKey={ mainCartKey } getCart={ getCart } setCart={ setCart }>
+		<ShoppingCartProvider
+			setCart={ setCartOverride ?? setCart }
+			getCart={ getCartOverride ?? getCart }
+			cartKey={ cartKeyOverride ?? mainCartKey }
+			options={ options }
+		>
 			{ children }
 		</ShoppingCartProvider>
 	);
@@ -635,4 +663,200 @@ describe( 'useShoppingCart', () => {
 			} );
 		} );
 	} );
+
+	describe( 'when refetchOnWindowFocus is disabled', () => {
+		const mockGetCart = jest.fn();
+
+		it( 'does not trigger a refetch when the window is focused', async () => {
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planOne ] } );
+
+			render(
+				<MockProvider getCartOverride={ mockGetCart } options={ { refetchOnWindowFocus: false } }>
+					<ProductList />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planTwo ] } );
+
+			fireEvent( window, new Event( 'focus' ) );
+
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+			} );
+		} );
+	} );
+
+	describe( 'when refetchOnWindowFocus is enabled', () => {
+		const mockGetCart = jest.fn();
+
+		beforeEach( () => {
+			mockGetCart.mockReset();
+			jest.restoreAllMocks();
+		} );
+
+		it( 'triggers a refetch when the window is focused', async () => {
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planOne ] } );
+
+			render(
+				<MockProvider getCartOverride={ mockGetCart } options={ { refetchOnWindowFocus: true } }>
+					<ProductList />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planTwo ] } );
+
+			fireEvent( window, new Event( 'focus' ) );
+
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planTwo.product_name );
+			} );
+		} );
+
+		it( 'triggers only one refetch when the window is focused and there are multiple consumers', async () => {
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planOne ] } );
+
+			render(
+				<MockProvider getCartOverride={ mockGetCart } options={ { refetchOnWindowFocus: true } }>
+					<ProductList />
+					<ProductList />
+					<ProductList />
+					<ProductList />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getAllByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planTwo ] } );
+
+			mockGetCart.mockClear();
+			fireEvent( window, new Event( 'focus' ) );
+
+			await verifyThatNever( () => expect( mockGetCart.mock.calls.length ).toBeGreaterThan( 1 ) );
+			expect( mockGetCart ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not trigger a refetch when the window is focused and the last fetch was very recent', async () => {
+			const recentTime = convertMsToSecs( Date.now() );
+			mockGetCart.mockResolvedValue( {
+				...emptyResponseCart,
+				products: [ planOne ],
+				cart_generated_at_timestamp: recentTime,
+			} );
+
+			render(
+				<MockProvider getCartOverride={ mockGetCart } options={ { refetchOnWindowFocus: true } }>
+					<ProductList />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( {
+				...emptyResponseCart,
+				products: [ planTwo ],
+				cart_generated_at_timestamp: recentTime,
+			} );
+
+			fireEvent( window, new Event( 'focus' ) );
+
+			await verifyThatTextNeverAppears( planTwo.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+			} );
+		} );
+
+		it( 'does not trigger a refetch when the window is focused and the cart key is no-site', async () => {
+			mockGetCart.mockResolvedValue( emptyResponseCart );
+
+			render(
+				<MockProvider
+					getCartOverride={ mockGetCart }
+					cartKeyOverride="no-site"
+					options={ { refetchOnWindowFocus: true } }
+				>
+					<ProductList initialProducts={ [ planOne ] } />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planTwo ] } );
+
+			fireEvent( window, new Event( 'focus' ) );
+
+			await verifyThatTextNeverAppears( planTwo.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+			} );
+		} );
+
+		it( 'does not trigger a refetch when the window is focused and the cart key is no-user', async () => {
+			mockGetCart.mockResolvedValue( emptyResponseCart );
+
+			render(
+				<MockProvider
+					getCartOverride={ mockGetCart }
+					cartKeyOverride="no-user"
+					options={ { refetchOnWindowFocus: true } }
+				>
+					<ProductList initialProducts={ [ planOne ] } />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planTwo ] } );
+
+			fireEvent( window, new Event( 'focus' ) );
+
+			await verifyThatTextNeverAppears( planTwo.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+			} );
+		} );
+
+		it( 'does not trigger a refetch when the window is focused and the network is offline', async () => {
+			mockGetCart.mockResolvedValue( emptyResponseCart );
+
+			render(
+				<MockProvider getCartOverride={ mockGetCart } options={ { refetchOnWindowFocus: true } }>
+					<ProductList initialProducts={ [ planOne ] } />
+				</MockProvider>
+			);
+
+			await waitFor( () => screen.getByTestId( 'product-list' ) );
+
+			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planTwo ] } );
+
+			jest.spyOn( navigator, 'onLine', 'get' ).mockReturnValueOnce( false );
+			fireEvent( window, new Event( 'focus' ) );
+
+			await verifyThatTextNeverAppears( planTwo.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+			} );
+		} );
+	} );
 } );
+
+function convertMsToSecs( ms: number ): number {
+	return Math.floor( ms / 1000 );
+}
+
+// This is a little tricky because we need to verify that text never appears,
+// even after some time passes, so we use this slightly convoluted technique:
+// https://stackoverflow.com/a/68318058/2615868
+async function verifyThatTextNeverAppears( text: string ) {
+	await expect( screen.findByText( text ) ).rejects.toThrow();
+}
+
+// This is a little tricky because we need to verify something never happens,
+// even after some time passes, so we use this slightly convoluted technique:
+// https://stackoverflow.com/a/68318058/2615868
+async function verifyThatNever( expectCallback: () => void ) {
+	await expect( waitFor( expectCallback ) ).rejects.toThrow();
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds unit tests for the `refetchOnWindowFocus` behavior of the shopping cart.

#### Testing instructions

Automated tests should be sufficient.