### PR TITLE
Emails: Fix warning not displayed in sidebar for Google Workspace accounts pending ToS acceptance

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -22,7 +22,7 @@ import {
 	transferStatus,
 	gdprConsentStatus,
 } from 'calypso/lib/domains/constants';
-import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
+import { hasPendingGSuiteUsers, isPendingGSuiteTOSAcceptance } from 'calypso/lib/gsuite';
 import { isSubdomain } from 'calypso/lib/domains';
 import {
 	CHANGE_NAME_SERVERS,
@@ -821,17 +821,22 @@ export class DomainWarnings extends React.PureComponent {
 	};
 
 	pendingGSuiteTosAcceptanceDomains = () => {
-		const pendingDomains = this.getDomains().filter( hasPendingGSuiteUsers );
+		const domains = this.getDomains().filter(
+			( domain ) => hasPendingGSuiteUsers( domain ) || isPendingGSuiteTOSAcceptance( domain )
+		);
+
+		if ( domains.length === 0 ) {
+			return null;
+		}
+
 		return (
-			pendingDomains.length !== 0 && (
-				<PendingGSuiteTosNotice
-					isCompact={ this.props.isCompact }
-					key="pending-gsuite-tos-notice"
-					siteSlug={ this.props.selectedSite && this.props.selectedSite.slug }
-					domains={ pendingDomains }
-					section="domain-management"
-				/>
-			)
+			<PendingGSuiteTosNotice
+				isCompact={ this.props.isCompact }
+				key="pending-gsuite-tos-notice"
+				siteSlug={ this.props.selectedSite && this.props.selectedSite.slug }
+				domains={ domains }
+				section="domain-management"
+			/>
 		);
 	};
 

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -93,7 +93,6 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 	};
 
 	compactNotice() {
-		const severity = this.getNoticeSeverity();
 		const href =
 			this.props.domains.length === 1
 				? emailManagement( this.props.siteSlug, this.props.domains[ 0 ].name )
@@ -102,7 +101,7 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 		return (
 			<Notice
 				isCompact={ this.props.isCompact }
-				status={ `is-${ severity }` }
+				status={ `is-${ this.getNoticeSeverity() }` }
 				showDismiss={ false }
 				key="pending-gapps-tos-acceptance-domain-compact"
 				text={ this.props.translate( 'Email requires action', 'Emails require action', {
@@ -110,7 +109,7 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 				} ) }
 			>
 				<NoticeAction href={ href } onClick={ this.finishSetupClickHandler }>
-					{ this.props.translate( 'Finish Setup' ) }
+					{ this.props.translate( 'Go' ) }
 				</NoticeAction>
 			</Notice>
 		);

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -134,7 +134,7 @@ class TitanManageMailboxes extends Component {
 
 						<VerticalNavItemEnhanced
 							description={ translate(
-								'Download our Android and iOS apps to access your emails on the go'
+								"Download Titan's Android and iOS apps to access your emails on the go"
 							) }
 							external={ true }
 							materialIcon="smartphone"


### PR DESCRIPTION
This pull request fixes the (edge) case where an `Email requires action` warning would not be displayed in the sidebar for G Suite and Google Workspace accounts that are pending ToS acceptance but have no pending users. It also makes the CTA from this warning more consistent with the one used for the domains warning: 

<img width="622" alt="screenshot" src="https://user-images.githubusercontent.com/594356/128842541-e79c1cca-b577-4082-b3fb-c64890c56f3b.png">

Finally, it updates a string in the `Manage All Mailboxes` page to be consistent with the one shown in the `Setup Thank You` page:

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/128841768-3887793b-0e06-4792-bcaf-6996d8e0c41e.png">

#### Testing instructions

1. Run `git checkout fix/gsuite-sidebar-warning` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gsuite-sidebar-warning)
2. Log into a WordPress.com with a Google account pending ToS but with no pending users
3. Navigate to the [`My Site` section](http://calypso.localhost:3000/home)
4. Assert that a warning is now shown in the sidebar for your Google account
5. Assert that its CTA is `Go`