### PR TITLE
Marketplace: fetch wpcom plugins query.

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -7,15 +7,12 @@ interface Options {
 	refetchOnMount?: boolean;
 }
 
-enum Type {
-	all = 'all',
-	featured = 'featured',
-}
+type Type = 'all' | 'featured';
 
-export const getCacheKey = ( type: string ): QueryKey => [ 'wpcom-plugins', type ];
+export const getCacheKey = ( type: Type ): QueryKey => [ 'wpcom-plugins', type ];
 
 const useWPCOMPlugins = (
-	type: string,
+	type: Type,
 	{ enabled = true, staleTime = 1000 * 60 * 60 * 24, refetchOnMount = false }: Options = {}
 ): UseQueryResult => {
 	return useQuery( getCacheKey( type ), () => fetchWPCOMPlugins( type ), {
@@ -25,51 +22,39 @@ const useWPCOMPlugins = (
 	} );
 };
 
-export function fetchWPCOMPlugins( type: string ) {
+export function fetchWPCOMPlugins( type: Type ) {
 	const query = {
 		type: type,
 	};
 
 	// return wpcom.req.get(
 	// 	{
-	// 		path: `wpcom-plugins`,
+	// 		path: `marketplace/plugins`,
 	// 		apiNamespace: 'wpcom/v2',
 	// 	},
 	// 	query
 	// );
 	return [
 		{
-			added: '2010-10-11',
-			author: '<a href="https://yoa.st/1uk">Team Yoast</a>',
-			author_profile: 'https://profiles.wordpress.org/joostdevalk',
-			banners: { low: 'https://ps.w.org/wordpress-seo/assets/banner-772x250.png?rev=1843435' },
-			compatibility: [],
-			donate_link: 'https://yoa.st/1up',
-			download_link: 'https://downloads.wordpress.org/plugin/wordpress-seo.16.8.zip',
-			downloaded: 345240282,
-			homepage: 'https://yoa.st/1uj',
-			icons: { '1x': 'https://ps.w.org/wordpress-seo/assets/icon.svg?rev=2363699' },
-			last_updated: '2021-07-27 6:55am GMT',
-			name: 'Yoast SEO Premium',
-			num_ratings: 27372,
-			rating: 96,
-			ratings: { 1: 717, 2: 123, 3: 170, 4: 616, 5: 25746 },
-			requires_php: '5.6.20',
-			screenshots: {
-				1: { src: 'https://ps.w.org/wordpress-seo/assets/screenshot-1.png?rev=2363699' },
-			},
-			short_description:
-				'Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.',
-			slug: 'wordpress-seo-premium',
-			support_threads: 575,
-			support_threads_resolved: 529,
-			tags: {
-				'content-analysis': 'Content analysis',
-				readability: 'Readability',
-				schema: 'schema',
-				seo: 'seo',
-			},
-			version: '16.8',
+			author: '<a href="https://yoast.com/">Team Yoast</a>',
+			author_name: 'Team Yoast',
+			author_url: 'https://yoast.com/',
+			icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png?rev=1550389',
+			name: 'Yoast SEO',
+			rating: 98,
+			slug: 'wordpress-seo',
+
+			raw_price: 70,
+			billed: 'annually',
+		},
+		{
+			author: '<a href="https://yoast.com/">Team Yoast</a>',
+			author_name: 'Team Yoast',
+			author_url: 'https://yoast.com/',
+			icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png?rev=1550389',
+			name: 'Yoast SEO',
+			rating: 98,
+			slug: 'wordpress-seo',
 
 			raw_price: 70,
 			billed: 'annually',

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -1,0 +1,80 @@
+import { useQuery, UseQueryResult, QueryKey } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface Options {
+	enabled?: boolean;
+	staleTime?: number;
+	refetchOnMount?: boolean;
+}
+
+enum Type {
+	all = 'all',
+	featured = 'featured',
+}
+
+export const getCacheKey = ( type: string ): QueryKey => [ 'wpcom-plugins', type ];
+
+const useWPCOMPlugins = (
+	type: string,
+	{ enabled = true, staleTime = 1000 * 60 * 60 * 24, refetchOnMount = false }: Options = {}
+): UseQueryResult => {
+	return useQuery( getCacheKey( type ), () => fetchWPCOMPlugins( type ), {
+		enabled: enabled,
+		staleTime: staleTime,
+		refetchOnMount: refetchOnMount,
+	} );
+};
+
+export function fetchWPCOMPlugins( type: string ) {
+	const query = {
+		type: type,
+	};
+
+	// return wpcom.req.get(
+	// 	{
+	// 		path: `wpcom-plugins`,
+	// 		apiNamespace: 'wpcom/v2',
+	// 	},
+	// 	query
+	// );
+	return [
+		{
+			added: '2010-10-11',
+			author: '<a href="https://yoa.st/1uk">Team Yoast</a>',
+			author_profile: 'https://profiles.wordpress.org/joostdevalk',
+			banners: { low: 'https://ps.w.org/wordpress-seo/assets/banner-772x250.png?rev=1843435' },
+			compatibility: [],
+			donate_link: 'https://yoa.st/1up',
+			download_link: 'https://downloads.wordpress.org/plugin/wordpress-seo.16.8.zip',
+			downloaded: 345240282,
+			homepage: 'https://yoa.st/1uj',
+			icons: { '1x': 'https://ps.w.org/wordpress-seo/assets/icon.svg?rev=2363699' },
+			last_updated: '2021-07-27 6:55am GMT',
+			name: 'Yoast SEO Premium',
+			num_ratings: 27372,
+			rating: 96,
+			ratings: { 1: 717, 2: 123, 3: 170, 4: 616, 5: 25746 },
+			requires_php: '5.6.20',
+			screenshots: {
+				1: { src: 'https://ps.w.org/wordpress-seo/assets/screenshot-1.png?rev=2363699' },
+			},
+			short_description:
+				'Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.',
+			slug: 'wordpress-seo-premium',
+			support_threads: 575,
+			support_threads_resolved: 529,
+			tags: {
+				'content-analysis': 'Content analysis',
+				readability: 'Readability',
+				schema: 'schema',
+				seo: 'seo',
+			},
+			version: '16.8',
+
+			raw_price: 70,
+			billed: 'annually',
+		},
+	];
+}
+
+export default useWPCOMPlugins;

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -27,7 +27,7 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
  *
  * @param {Type} type Optional The query type
  * @param {string} searchTerm Optional The term to search for
- * @param {object} {} Optional options to pass to the underlying query engine
+ * @param {{enabled: boolean, staleTime: number, refetchOnMount: boolean}} {} Optional options to pass to the underlying query engine
  * @returns {{ data, error, isLoading: boolean ...}} Returns various parameters piped from `useQuery`
  */
 export const useWPCOMPlugins = (
@@ -54,7 +54,7 @@ const fetchWPCOMPlugin = ( slug: string ) => {
  * Returns a marketplace plugin data
  *
  * @param {Type} slug The plugin slug to query
- * @param {object} {} Optional options to pass to the underlying query engine
+ * @param {{enabled: boolean, staleTime: number, refetchOnMount: boolean}} {} Optional options to pass to the underlying query engine
  * @returns {{ data, error, isLoading: boolean ...}} Returns various parameters piped from `useQuery`
  */
 export const useWPCOMPlugin = (

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -27,39 +27,13 @@ export function fetchWPCOMPlugins( type: Type ) {
 		type: type,
 	};
 
-	// return wpcom.req.get(
-	// 	{
-	// 		path: `marketplace/plugins`,
-	// 		apiNamespace: 'wpcom/v2',
-	// 	},
-	// 	query
-	// );
-	return [
+	return wpcom.req.get(
 		{
-			author: '<a href="https://yoast.com/">Team Yoast</a>',
-			author_name: 'Team Yoast',
-			author_url: 'https://yoast.com/',
-			icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png?rev=1550389',
-			name: 'Yoast SEO',
-			rating: 98,
-			slug: 'wordpress-seo',
-
-			raw_price: 70,
-			billed: 'annually',
+			path: `/marketplace/products`,
+			apiNamespace: 'wpcom/v2',
 		},
-		{
-			author: '<a href="https://yoast.com/">Team Yoast</a>',
-			author_name: 'Team Yoast',
-			author_url: 'https://yoast.com/',
-			icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png?rev=1550389',
-			name: 'Yoast SEO',
-			rating: 98,
-			slug: 'wordpress-seo',
-
-			raw_price: 70,
-			billed: 'annually',
-		},
-	];
+		query
+	);
 }
 
 export default useWPCOMPlugins;

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -8,8 +8,10 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
 	getBlockingMessages,
 	getBlockingMessages,
+	getBlockingMessages,
 } from 'calypso/blocks/eligibility-warnings/hold-list';
 import {
+	isAtomicSiteWithoutBusinessPlan,
 	isAtomicSiteWithoutBusinessPlan,
 	isAtomicSiteWithoutBusinessPlan,
 } from 'calypso/blocks/eligibility-warnings/utils';
@@ -18,10 +20,15 @@ import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
 import useWPCOMPlugins from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import { YOAST, WOO, YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import {
+	YOAST,
+	WOO,
+	YOAST,
+	YOAST,
+} from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
-import PluginItem from 'calypso/my-sites/plugins/plugin-item/plugin-item';
+import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
 	fetchAutomatedTransferStatus,
@@ -127,18 +134,14 @@ export default function MarketplaceTest(): JSX.Element {
 			{ selectedSiteId && <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> }
 			<SidebarNavigation />
 			<Card key="wpcom-plugins">
-				{ data.map( ( plugin ) => {
-					return (
-						<PluginItem
-							key={ plugin.slug }
-							plugin={ plugin }
-							sites={ [] }
-							pluginLink={ `/marketplace/product/details/${ encodeURIComponent(
-								plugin.slug
-							) }/${ selectedSiteSlug }` }
-						/>
-					);
-				} ) }
+				<PluginsBrowserList
+					plugins={ data }
+					listName={ 'paid' }
+					title={ 'Paid Plugins' }
+					site={ selectedSiteSlug }
+					showPlaceholders={ isFetching }
+					currentSites={ null }
+				/>
 			</Card>
 			<Card key="heading">
 				<CardHeading key="title" tagName="h1" size={ 24 }>

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -11,8 +11,7 @@ import { WarningList } from 'calypso/blocks/eligibility-warnings/warning-list';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
-import useWPCOMPlugins from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import { normalizePluginsList } from 'calypso/lib/plugins/utils';
+import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { YOAST, WOO } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
@@ -123,7 +122,7 @@ export default function MarketplaceTest(): JSX.Element {
 			<SidebarNavigation />
 			<Card key="wpcom-plugins">
 				<PluginsBrowserList
-					plugins={ normalizePluginsList( data.results ) }
+					plugins={ data }
 					listName={ 'paid' }
 					title={ 'Paid Plugins' }
 					site={ selectedSiteSlug }

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -109,7 +109,7 @@ export default function MarketplaceTest(): JSX.Element {
 	const allBlockingMessages = getBlockingMessages( translate );
 	const holds = eligibilityDetails.eligibilityHolds || [];
 	const raisedBlockingMessages = holds
-		.filter( ( message: any ) => allBlockingMessages[ message ] )
+		.filter( ( message: string ) => allBlockingMessages[ message ] )
 		.map( ( message: string ) => allBlockingMessages[ message ] );
 	const hardBlockSingleMessages = holds.filter(
 		( message: string ) => message !== 'TRANSFER_ALREADY_EXISTS' || ! allBlockingMessages[ message ]

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -5,27 +5,14 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import {
-	getBlockingMessages,
-	getBlockingMessages,
-	getBlockingMessages,
-} from 'calypso/blocks/eligibility-warnings/hold-list';
-import {
-	isAtomicSiteWithoutBusinessPlan,
-	isAtomicSiteWithoutBusinessPlan,
-	isAtomicSiteWithoutBusinessPlan,
-} from 'calypso/blocks/eligibility-warnings/utils';
+import { getBlockingMessages } from 'calypso/blocks/eligibility-warnings/hold-list';
+import { isAtomicSiteWithoutBusinessPlan } from 'calypso/blocks/eligibility-warnings/utils';
 import { WarningList } from 'calypso/blocks/eligibility-warnings/warning-list';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
 import useWPCOMPlugins from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import {
-	YOAST,
-	WOO,
-	YOAST,
-	YOAST,
-} from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import { YOAST, WOO } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
@@ -70,7 +57,6 @@ export default function MarketplaceTest(): JSX.Element {
 	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
 	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
 	const { data = [], isFetching } = useWPCOMPlugins( 'all' );
-	console.log( data, isFetching );
 
 	const isRequestingForSite = useSelector( ( state ) =>
 		isRequestingForSites( state, [ selectedSiteId ] )

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -5,15 +5,23 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { getBlockingMessages } from 'calypso/blocks/eligibility-warnings/hold-list';
-import { isAtomicSiteWithoutBusinessPlan } from 'calypso/blocks/eligibility-warnings/utils';
+import {
+	getBlockingMessages,
+	getBlockingMessages,
+} from 'calypso/blocks/eligibility-warnings/hold-list';
+import {
+	isAtomicSiteWithoutBusinessPlan,
+	isAtomicSiteWithoutBusinessPlan,
+} from 'calypso/blocks/eligibility-warnings/utils';
 import { WarningList } from 'calypso/blocks/eligibility-warnings/warning-list';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
-import { YOAST, WOO } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import useWPCOMPlugins from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { YOAST, WOO, YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
+import PluginItem from 'calypso/my-sites/plugins/plugin-item/plugin-item';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
 	fetchAutomatedTransferStatus,
@@ -54,6 +62,8 @@ export default function MarketplaceTest(): JSX.Element {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
 	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
+	const { data = [], isFetching } = useWPCOMPlugins( 'all' );
+	console.log( data, isFetching );
 
 	const isRequestingForSite = useSelector( ( state ) =>
 		isRequestingForSites( state, [ selectedSiteId ] )
@@ -116,6 +126,20 @@ export default function MarketplaceTest(): JSX.Element {
 		<Container>
 			{ selectedSiteId && <QueryJetpackPlugins siteIds={ [ selectedSiteId ] } /> }
 			<SidebarNavigation />
+			<Card key="wpcom-plugins">
+				{ data.map( ( plugin ) => {
+					return (
+						<PluginItem
+							key={ plugin.slug }
+							plugin={ plugin }
+							sites={ [] }
+							pluginLink={ `/marketplace/product/details/${ encodeURIComponent(
+								plugin.slug
+							) }/${ selectedSiteSlug }` }
+						/>
+					);
+				} ) }
+			</Card>
 			<Card key="heading">
 				<CardHeading key="title" tagName="h1" size={ 24 }>
 					Marketplace Test Page

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -12,10 +12,12 @@ import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
 import useWPCOMPlugins from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { normalizePluginsList } from 'calypso/lib/plugins/utils';
 import { YOAST, WOO } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
+import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import {
 	fetchAutomatedTransferStatus,
@@ -121,12 +123,14 @@ export default function MarketplaceTest(): JSX.Element {
 			<SidebarNavigation />
 			<Card key="wpcom-plugins">
 				<PluginsBrowserList
-					plugins={ data }
+					plugins={ normalizePluginsList( data.results ) }
 					listName={ 'paid' }
 					title={ 'Paid Plugins' }
 					site={ selectedSiteSlug }
 					showPlaceholders={ isFetching }
 					currentSites={ null }
+					variant={ PluginsBrowserListVariant.Fixed }
+					extended
 				/>
 			</Card>
 			<Card key="heading">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- [x] Returns all results `https://public-api.wordpress.com/wpcom/v2/marketplace/products`
- [x] Return filtered results `https://public-api.wordpress.com/wpcom/v2/marketplace/products?q=bookings`
- [x] Return single plugin `https://public-api.wordpress.com/wpcom/v2/marketplace/products/woocommerce-bookings`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/marketplace/test/[domain]`
* Make sure that you get a list with paid plugins on the top

<img width="1285" alt="SS 2021-11-18 at 16 09 03" src="https://user-images.githubusercontent.com/12430020/142430847-e0fe7732-5114-44a6-b7a8-e1ad02dc94a2.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #55309
