### PR TITLE
State: Selector to get current route path and query

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -33,6 +33,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getCurrentRouteUrl from 'calypso/state/selectors/get-current-route-url';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import './style.scss';
@@ -86,6 +87,7 @@ export class UserStep extends Component {
 		subHeaderText: PropTypes.string,
 		isSocialSignupEnabled: PropTypes.bool,
 		initialContext: PropTypes.object,
+		currentRouteUrl: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -148,6 +150,7 @@ export class UserStep extends Component {
 			sectionName,
 			from,
 			locale,
+			currentRouteUrl,
 		} = props;
 
 		let subHeaderText = props.subHeaderText;
@@ -215,7 +218,7 @@ export class UserStep extends Component {
 					oauth2ClientId: oauth2Client?.id,
 					wccomFrom,
 					isWhiteLogin: isReskinned,
-					signupUrl: window.location.pathname + window.location.search,
+					signupUrl: currentRouteUrl,
 				} );
 
 				subHeaderText = translate(
@@ -519,6 +522,7 @@ export default connect(
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		from: get( getCurrentQueryArguments( state ), 'from' ),
 		userLoggedIn: isUserLoggedIn( state ),
+		currentRouteUrl: getCurrentRouteUrl( state ),
 	} ),
 	{
 		errorNotice,

--- a/client/state/selectors/get-current-route-url.js
+++ b/client/state/selectors/get-current-route-url.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { createSelector } from '@automattic/state-utils';
+
+/**
+ * Gets the current route and query string concatenated e.g. '/test/url?foo=bar'
+ */
+export default createSelector(
+	( state ) => {
+		const route = getCurrentRoute( state );
+		const { _timestamp, ...queryArgs } = getCurrentQueryArguments( state ) || {};
+		const queryString = new URLSearchParams( queryArgs ).toString();
+
+		if ( ! route ) {
+			return;
+		}
+
+		return queryString ? `${ route }?${ queryString }` : route;
+	},
+	[ getCurrentRoute, getCurrentQueryArguments ]
+);

--- a/client/state/selectors/get-current-route-url.ts
+++ b/client/state/selectors/get-current-route-url.ts
@@ -1,10 +1,12 @@
 /**
+ * External dependencies
+ */
+import { createSelector } from '@automattic/state-utils';
+/**
  * Internal dependencies
  */
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import { createSelector } from '@automattic/state-utils';
-
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 /**
  * Type dependencies
  */

--- a/client/state/selectors/get-current-route-url.ts
+++ b/client/state/selectors/get-current-route-url.ts
@@ -6,12 +6,17 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import { createSelector } from '@automattic/state-utils';
 
 /**
+ * Type dependencies
+ */
+import type { AppState } from 'calypso/types';
+
+/**
  * Gets the current route and query string concatenated e.g. '/test/url?foo=bar'
  */
 export default createSelector(
-	( state ) => {
+	( state: AppState ): string | undefined => {
 		const route = getCurrentRoute( state );
-		const { _timestamp, ...queryArgs } = getCurrentQueryArguments( state ) || {};
+		const { _timestamp, ...queryArgs } = { ...getCurrentQueryArguments( state ) };
 		const queryString = new URLSearchParams( queryArgs ).toString();
 
 		if ( ! route ) {

--- a/client/state/selectors/get-current-route-url.ts
+++ b/client/state/selectors/get-current-route-url.ts
@@ -17,7 +17,7 @@ export default createSelector(
 	( state: AppState ): string | undefined => {
 		const route = getCurrentRoute( state );
 		const { _timestamp, ...queryArgs } = { ...getCurrentQueryArguments( state ) };
-		const queryString = new URLSearchParams( queryArgs ).toString();
+		const queryString = new URLSearchParams( queryArgs as Record< string, string > ).toString();
 
 		if ( ! route ) {
 			return;

--- a/client/state/selectors/test/get-current-route-url.js
+++ b/client/state/selectors/test/get-current-route-url.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getCurrentRouteUrl from 'calypso/state/selectors/get-current-route-url';
+
+describe( 'getCurrentRouteUrl()', () => {
+	const route = {
+		path: {
+			current: '/test/url/testsite.blog',
+		},
+		query: {
+			current: {
+				_timestamp: Date.now(),
+				foo: 'bar',
+				bar: 'foo',
+			},
+		},
+	};
+
+	test( 'it returns the full path & query when defined', () => {
+		const state = {
+			route,
+		};
+
+		expect( getCurrentRouteUrl( state ) ).to.equal( '/test/url/testsite.blog?foo=bar&bar=foo' );
+	} );
+
+	test( 'it returns undefined when current path is falsely', () => {
+		const state = {
+			route: {
+				...route,
+				path: {
+					current: null,
+				},
+			},
+		};
+
+		expect( getCurrentRouteUrl( state ) ).to.equal( undefined );
+	} );
+
+	test( 'it returns the path when current query is falsely', () => {
+		const state = {
+			route: {
+				...route,
+				query: {
+					current: null,
+				},
+			},
+		};
+
+		expect( getCurrentRouteUrl( state ) ).to.equal( '/test/url/testsite.blog' );
+	} );
+} );

--- a/client/state/selectors/test/get-current-route-url.js
+++ b/client/state/selectors/test/get-current-route-url.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses #57109
Adds a new selector to get the current route path & query as a string e.g. `test/url?foo=bar`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #57109
