### PR TITLE
Revert "Goodbye, IE 11 (#55142)"

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -129,8 +129,7 @@
 		"use-translation-chunks": true,
 		"woocommerce/extension-referrers": false,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"wordpress-action-search": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -130,8 +130,7 @@
 		"woocommerce/extension-referrers": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"wordpress-action-search": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -93,7 +93,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": false,
-		"wordpress-action-search": false,
-		"redirect-fallback-browsers": true
+		"wordpress-action-search": false
 	}
 }

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -22,6 +22,10 @@ For example: `ENTRY_LIMIT=entry-login,entry-main yarn start` would start Calypso
 
 To find all available entry points, you can refer to the `entry` option in Calypso's primary `webpack.config.js` file.
 
+### Internet Explorer
+
+It's possible to debug/fix IE issues using the [fallback development workflow](./fallback-development-workflow.md).
+
 ## Tests
 
 If you want to run the tests for a specific library in `client/` use:

--- a/docs/fallback-development-workflow.md
+++ b/docs/fallback-development-workflow.md
@@ -1,0 +1,33 @@
+# Fallback Development Workflow
+
+The Calypso build has two outputs: **evergreen**, for browsers that are always kept up to date aka "evergreen"; and **fallback**, for all other browsers.
+
+## Build
+
+Running `yarn start-fallback` will do the "fallback" build of all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
+
+You may need to run `yarn clean` between evergreen and fallback debug sessions.
+
+## Debugging with Internet Explorer
+
+If you aren't running Windows, it's possible to run the fallback build in IE using a free VM.
+
+### 1. Install Microsoft's testing VM
+
+Install Virtual Box and grab a copy of [Microsoft’s testing VM for IE and legacy Edge](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).
+
+This is a Windows image that can be used for development and testing purposes. **The password for the VM is on the download page**.
+
+### 2. Edit `hosts` file
+
+The VM's network uses NAT mode by default, which means the host machine is accessible at `10.0.2.2` (this is the Virtual Box default).
+
+1. Launch the VM
+2. Open the Start menu and search for "Notepad"
+3. Right-click Notepad and "Run as administrator"
+4. Use the "File" menu to open `C:\Windows\System32\drivers\etc\hosts` (you may need to change the "Text Documents" filter to "All Files")
+5. Add a `10.0.2.2 calypso.localhost` entry and save.
+
+### 3. View in IE
+
+Run `yarn start-fallback` on the host machine. Open Internet Explorer in the your VM (you'll need to search using the Start menu because Edge is the default browser) and navigate to `calypso.localhost:3000`.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -14,7 +14,7 @@ This document aims to provide a list of things to check and test whenever you ar
 It's also important to keep the general WP.com commit checklist at hand (modified for Calypso):
 
 1. It must be responsive on phone, tablet, and desktop; interactions must be fluid on a touch device.
-2. Test in Chrome, Firefox, Mac/Win on the desktop.
+2. Test in IE11+, Chrome, Firefox, Mac/Win on the desktop.
 3. Collect relevant and useful stats/events. What questions do they answer? How do you expect them to change over time?
 4. All strings must be fully translatable (without concatenation, handling plurals), and you should be aware of how long strings affect layout.
 5. Any visual assets involved must be HiDPI optimized and/or scalable.


### PR DESCRIPTION
there seem to be problems with the desktop app as well as desktop e2e tests where it would wrongly redirect those browsers as well. electron 12 which we use to build the desktop app seems to still use chrome 89 which is not included in evergreen.

/cc @noahtallen 