### PR TITLE
Disable email step in signup

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -149,7 +149,7 @@
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/professional-email-step": true,
+		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"sign-in-with-apple": false,
-		"signup/professional-email-step": true,
+		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -107,7 +107,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/professional-email-step": true,
+		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,7 +109,7 @@
 		"settings/theme-setup": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/professional-email-step": true,
+		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,11 +14,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [
-		"en",
-		"es",
-		"pt-br"
-	],
+	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,
@@ -122,7 +118,7 @@
 		"settings/theme-setup": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/professional-email-step": true,
+		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
 		"site-indicator": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR disables the email step that was enabled in #55097

The decision to disable the step was taken in this discussion: pau2Xa-3cp-p2#comment-10705

The primary driver was that the flow is having an overly adverse impact on our key signup metrics.

#### Testing instructions

* Open up a new incognito/private browsing tab/window
* Verify that if you go to `/start` locally or via the live branch, and select a custom domain, you do not see the Professional Email step

Related to #55907