### PR TITLE
Use Full Jetpack Filter to only manage site with the Full Plugin in Calypso

### DIFF
--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -114,18 +114,18 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.2/sites/2916284' )
+				.get( '/rest/v1.2/sites/2916284?filters=wpcom%2Catomic%2Cjetpack-full' )
 				.reply( 200, {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
 					capabilities: {},
 				} )
-				.get( '/rest/v1.2/sites/77203074' )
+				.get( '/rest/v1.2/sites/77203074?filters=wpcom%2Catomic%2Cjetpack-full' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',
 				} )
-				.get( '/rest/v1.2/sites/8894098' )
+				.get( '/rest/v1.2/sites/8894098?filters=wpcom%2Catomic%2Cjetpack-full' )
 				.reply( 200, {
 					ID: 8894098,
 					name: 'Some random site I dont have access to',

--- a/config/development.json
+++ b/config/development.json
@@ -28,6 +28,7 @@
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
+	"site_filter": [ "wpcom", "atomic", "jetpack-full" ],
 	"features": {
 		"activity-log/retention-policies": false,
 		"ad-tracking": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -14,6 +14,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
+	"site_filter": [ "wpcom", "atomic", "jetpack-full" ],
 	"features": {
 		"automated-transfer": true,
 		"async-payments": false,

--- a/config/production.json
+++ b/config/production.json
@@ -16,6 +16,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
+	"site_filter": [ "wpcom", "atomic", "jetpack-full" ],
 	"features": {
 		"ad-tracking": true,
 		"async-payments": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -15,6 +15,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
+	"site_filter": [ "wpcom", "atomic", "jetpack-full" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/config/test.json
+++ b/config/test.json
@@ -25,6 +25,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"site_filter": [ "wpcom", "atomic", "jetpack-full" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"site_filter": [ "wpcom", "atomic", "jetpack-full" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use site filters for Calypso Blue/WordPress.com
   * wpcom
   * atomic
   * jetpack-full
* This will suppress Jetpack all sites that are NOT connected to a Full Jetpack Plugin

#### Testing instructions
 * Boot Branch
 * Open All Sites
 * Verify that ( vs production )
    * All WordPress.com Sites appear
    * All Atomic sites
    * Only Jetpack sites connected to the full plugin appear

