### PR TITLE
Playwright: migrate Media Blocks (Upload) spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/audio-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/audio-block.ts
@@ -1,0 +1,50 @@
+import { Page, ElementHandle } from 'playwright';
+
+const selectors = {
+	block: '.wp-block-audio',
+	fileInput: '.components-form-file-upload input[type="file"]',
+	spinner: '.components-spinner',
+};
+
+/**
+ * Represents the Audio block.
+ */
+export class AudioBlock {
+	static blockName = 'Audio';
+	block: ElementHandle;
+
+	/**
+	 * Constructs an instance of this block.
+	 *
+	 * @param {ElementHandle} block Handle referencing the block as inserted on the Gutenberg editor.
+	 */
+	constructor( block: ElementHandle ) {
+		this.block = block;
+	}
+
+	/**
+	 * Uplaods the target file at the supplied path to WPCOM.
+	 *
+	 * @param {string} path Path to the file on disk.
+	 */
+	async upload( path: string ): Promise< void > {
+		// The `input` element has a display:none style set and it cannot be found normally even if
+		// waitForSelector({state: 'hidden'}) is used.
+		const input = ( await this.block.$( selectors.fileInput ) ) as ElementHandle;
+		await input?.setInputFiles( path );
+		await Promise.all( [
+			this.block.waitForSelector( selectors.spinner, { state: 'hidden' } ),
+			this.block.waitForElementState( 'stable' ),
+		] );
+	}
+
+	/**
+	 * Validates block on the page.
+	 *
+	 * @param {Page} page Page on which to verify the presence of the block.
+	 * @returns {Promise<void>} No return value.
+	 */
+	static async validatePublishedContent( page: Page ): Promise< void > {
+		await page.waitForSelector( `${ selectors.block } audio` );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/audio-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/audio-block.ts
@@ -28,10 +28,8 @@ export class AudioBlock {
 	 * @param {string} path Path to the file on disk.
 	 */
 	async upload( path: string ): Promise< void > {
-		// The `input` element has a display:none style set and it cannot be found normally even if
-		// waitForSelector({state: 'hidden'}) is used.
-		const input = ( await this.block.$( selectors.fileInput ) ) as ElementHandle;
-		await input?.setInputFiles( path );
+		const input = await this.block.waitForSelector( selectors.fileInput, { state: 'attached' } );
+		await input.setInputFiles( path );
 		await Promise.all( [
 			this.block.waitForSelector( selectors.spinner, { state: 'hidden' } ),
 			this.block.waitForElementState( 'stable' ),

--- a/packages/calypso-e2e/src/lib/blocks/file-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/file-block.ts
@@ -33,9 +33,7 @@ export class FileBlock {
 		const frame = ( await this.block.ownerFrame() ) as Frame;
 		const page = frame.page() as Page;
 
-		// The `input` element has a display:none style set and it cannot be found normally even if
-		// waitForSelector({state: 'hidden'}) is used.
-		const input = ( await this.block.$( selectors.fileInput ) ) as ElementHandle;
+		const input = await this.block.waitForSelector( selectors.fileInput, { state: 'attached' } );
 		// Wait for the request complete instead of looking for the spinner and/or loading animation.
 		// Waiting on the animation class to be detached is not a reliable method for this block.
 		// It can lead to the filename placeholder text not being replaced with the uploaded file name.

--- a/packages/calypso-e2e/src/lib/blocks/file-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/file-block.ts
@@ -52,10 +52,7 @@ export class FileBlock {
 	 * @param {(string|number)} contents Contents used to validate the block.
 	 * @returns {Promise<void>} No return value.
 	 */
-	static async validatePublishedContent(
-		page: Page,
-		contents: ( string | number )[]
-	): Promise< void > {
+	static async validatePublishedContent( page: Page, contents: string[] ): Promise< void > {
 		await page.waitForSelector( 'a:text("Download")' );
 		for await ( const content of contents ) {
 			await page.waitForSelector( `a:has-text("${ content }")` );

--- a/packages/calypso-e2e/src/lib/blocks/file-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/file-block.ts
@@ -1,0 +1,66 @@
+import { Page, ElementHandle, Response, Frame } from 'playwright';
+
+const selectors = {
+	block: '.wp-block-file',
+	fileInput: '.components-form-file-upload input[type="file"]',
+	loadingAnimation: '.components-animate__loading.is-transient',
+};
+
+/**
+ * Represents the File block.
+ */
+export class FileBlock {
+	static blockName = 'File';
+	block: ElementHandle;
+
+	/**
+	 * Constructs an instance of this block.
+	 *
+	 * @param {ElementHandle} block Handle referencing the block as inserted on the Gutenberg editor.
+	 */
+	constructor( block: ElementHandle ) {
+		this.block = block;
+	}
+
+	/**
+	 * Uplaods the target file at the supplied path to WPCOM.
+	 *
+	 * @param {string} path Path to the file on disk.
+	 */
+	async upload( path: string ): Promise< void > {
+		// Obtain the page that this block resides on by first obtaining the frame then the page on which
+		// the frame belongs to.
+		const frame = ( await this.block.ownerFrame() ) as Frame;
+		const page = frame.page() as Page;
+
+		// The `input` element has a display:none style set and it cannot be found normally even if
+		// waitForSelector({state: 'hidden'}) is used.
+		const input = ( await this.block.$( selectors.fileInput ) ) as ElementHandle;
+		// Wait for the request complete instead of looking for the spinner and/or loading animation.
+		// Waiting on the animation class to be detached is not a reliable method for this block.
+		// It can lead to the filename placeholder text not being replaced with the uploaded file name.
+		await Promise.all( [
+			page.waitForResponse(
+				( response: Response ) => response.url().includes( 'media?' ) && response.status() === 200
+			),
+			input.setInputFiles( path ),
+		] );
+	}
+
+	/**
+	 * Validates block on the page.
+	 *
+	 * @param {Page} page Page on which to verify the presence of the block.
+	 * @param {(string|number)} contents Contents used to validate the block.
+	 * @returns {Promise<void>} No return value.
+	 */
+	static async validatePublishedContent(
+		page: Page,
+		contents: ( string | number )[]
+	): Promise< void > {
+		await page.waitForSelector( 'a:text("Download")' );
+		for await ( const content of contents ) {
+			await page.waitForSelector( `a:has-text("${ content }")` );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -28,9 +28,7 @@ export class ImageBlock {
 	 * @param {string} path Path to the file on disk.
 	 */
 	async upload( path: string ): Promise< void > {
-		// The `input` element has a display:none style set and it cannot be found normally even if
-		// waitForSelector({state: 'hidden'}) is used.
-		const input = ( await this.block.$( selectors.fileInput ) ) as ElementHandle;
+		const input = await this.block.waitForSelector( selectors.fileInput, { state: 'attached' } );
 		await input.setInputFiles( path );
 		await Promise.all( [
 			this.block.waitForSelector( selectors.spinner, { state: 'hidden' } ),

--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -4,6 +4,12 @@ const selectors = {
 	block: '.wp-block-image',
 	fileInput: '.components-form-file-upload input[type="file"]',
 	spinner: '.components-spinner',
+
+	// Use the attribute CSS selector to perform partial match, beginning with the filename.
+	// If a file with the same name already exists in the Media Gallery, WPCOM resolves this clash
+	// by appending a numerical postfix (eg. <original-filename>-2).
+	imageTitleData: ( filename: string ) =>
+		`${ selectors.block } img[data-image-title*="${ filename }" i]`,
 };
 
 /**
@@ -43,15 +49,9 @@ export class ImageBlock {
 	 * @param {(string|number)} contents Contents used to validate the block.
 	 * @returns {Promise<void>} No return value.
 	 */
-	static async validatePublishedContent(
-		page: Page,
-		contents: ( string | number )[]
-	): Promise< void > {
+	static async validatePublishedContent( page: Page, contents: string[] ): Promise< void > {
 		for await ( const content of contents ) {
-			// Use the attribute CSS selector to perform partial match.
-			// If a file with the same name already exists in the Media Gallery, this clash is resolved by
-			// appending a numerical postfix (eg. <original-filename>-2).
-			await page.waitForSelector( `${ selectors.block } img[data-image-title*="${ content }" i]` );
+			await page.waitForSelector( selectors.imageTitleData( content ) );
 		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -1,0 +1,59 @@
+import { Page, ElementHandle } from 'playwright';
+
+const selectors = {
+	block: '.wp-block-image',
+	fileInput: '.components-form-file-upload input[type="file"]',
+	spinner: '.components-spinner',
+};
+
+/**
+ * Represents the Image block.
+ */
+export class ImageBlock {
+	static blockName = 'Image';
+	block: ElementHandle;
+
+	/**
+	 * Constructs an instance of this block.
+	 *
+	 * @param {ElementHandle} block Handle referencing the block as inserted on the Gutenberg editor.
+	 */
+	constructor( block: ElementHandle ) {
+		this.block = block;
+	}
+
+	/**
+	 * Uplaods the target file at the supplied path to WPCOM.
+	 *
+	 * @param {string} path Path to the file on disk.
+	 */
+	async upload( path: string ): Promise< void > {
+		// The `input` element has a display:none style set and it cannot be found normally even if
+		// waitForSelector({state: 'hidden'}) is used.
+		const input = ( await this.block.$( selectors.fileInput ) ) as ElementHandle;
+		await input.setInputFiles( path );
+		await Promise.all( [
+			this.block.waitForSelector( selectors.spinner, { state: 'hidden' } ),
+			this.block.waitForElementState( 'stable' ),
+		] );
+	}
+
+	/**
+	 * Validates block on the page.
+	 *
+	 * @param {Page} page Page on which to verify the presence of the block.
+	 * @param {(string|number)} contents Contents used to validate the block.
+	 * @returns {Promise<void>} No return value.
+	 */
+	static async validatePublishedContent(
+		page: Page,
+		contents: ( string | number )[]
+	): Promise< void > {
+		for await ( const content of contents ) {
+			// Use the attribute CSS selector to perform partial match.
+			// If a file with the same name already exists in the Media Gallery, this clash is resolved by
+			// appending a numerical postfix (eg. <original-filename>-2).
+			await page.waitForSelector( `${ selectors.block } img[data-image-title*="${ content }" i]` );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/index.ts
@@ -2,3 +2,6 @@ export * from './click-to-tweet-block';
 export * from './pricing-table-block';
 export * from './dynamic-hr-block';
 export * from './hero-block';
+export * from './image-block';
+export * from './audio-block';
+export * from './file-block';

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -197,9 +197,9 @@ export class GutenbergEditorPage {
 		await frame.click( selectors.editorTitle );
 		await this.openBlockInserter();
 		await frame.fill( selectors.blockSearch, blockName );
-		await frame.click( `${ selectors.blockInserterResultItem }:has-text("${ blockName }")` );
+		await frame.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );
 		// Confirm the block has been added to the editor body.
-		return await frame.waitForSelector( `[aria-label="Block: ${ blockName }"]` );
+		return await frame.waitForSelector( `*[aria-label="Block: ${ blockName }"].is-selected` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -117,15 +117,27 @@ export function deleteFile( filePath: string ): void {
  * @param {string} param0.sourceFileName Basename of the source file to be cloned.
  * @returns {string} Full path to the generated test file.
  */
-export function createTestFile( { sourceFileName }: { sourceFileName: string } ): string {
-	const testFileName = `${ createTimestamp() }.${ sourceFileName.split( '.' ).pop() }`;
+export function createTestFile( {
+	sourceFileName,
+	testFileName,
+}: {
+	sourceFileName: string;
+	testFileName?: string;
+} ): string {
+	// If the output `testFileName` is defined, use that as part of the final filename.
+	let fileName =
+		testFileName === undefined ? createTimestamp() : `${ createTimestamp() }-${ testFileName }`;
+
+	// Reassign the variable with the final name to be used, including the extension.
+	fileName = `${ fileName }.${ sourceFileName.split( '.' ).pop() }`;
+
 	const sourceFileDir = path.join( __dirname, '../../../../../test/e2e/image-uploads/' );
 	const sourceFilePath = path.join( sourceFileDir, sourceFileName );
 
 	// Generated test file will also go under the source directory.
 	// Attempting to copy the file elsewhere will trigger the following error on TeamCity:
 	// EPERM: operation not permitted
-	const testFilePath = path.join( sourceFileDir, testFileName );
+	const testFilePath = path.join( sourceFileDir, fileName );
 	// Copy the source file specified to testFilePath, creating a clone differing only by name.
 	fs.copySync( sourceFilePath, testFilePath );
 

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -113,8 +113,8 @@ export function deleteFile( filePath: string ): void {
  * Creates a temporary test file by cloning a source file under a new name.
  *
  * @param {{[key: string]: string}} param0 Parameter object.
- * @param {string} param0.testFileName Basename of the test file to be generated.
  * @param {string} param0.sourceFileName Basename of the source file to be cloned.
+ * @param {string} [param0.testFileName] Basename of the test file to be generated.
  * @returns {string} Full path to the generated test file.
  */
 export function createTestFile( {
@@ -124,9 +124,11 @@ export function createTestFile( {
 	sourceFileName: string;
 	testFileName?: string;
 } ): string {
+	let fileName = createTimestamp();
 	// If the output `testFileName` is defined, use that as part of the final filename.
-	let fileName =
-		testFileName === undefined ? createTimestamp() : `${ createTimestamp() }-${ testFileName }`;
+	if ( testFileName ) {
+		fileName += `-${ testFileName }`;
+	}
 
 	// Reassign the variable with the final name to be used, including the extension.
 	fileName = `${ fileName }.${ sourceFileName.split( '.' ).pop() }`;

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -1,0 +1,91 @@
+import path from 'path';
+import {
+	setupHooks,
+	DataHelper,
+	LoginFlow,
+	MediaHelper,
+	NewPostFlow,
+	GutenbergEditorPage,
+	ImageBlock,
+	AudioBlock,
+	FileBlock,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), () => {
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let page: Page;
+
+	const testFiles = {
+		image: MediaHelper.createTestImage(),
+		image_reserved_name: MediaHelper.createTestFile( {
+			sourceFileName: 'image0.jpg',
+			testFileName: 'filewith#?#?reservedurlchars',
+		} ),
+		audio: MediaHelper.createTestAudio(),
+	};
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+	} );
+
+	it( 'Enter post title', async function () {
+		await gutenbergEditorPage.enterTitle( DataHelper.randomPhrase() );
+	} );
+
+	it( `${ ImageBlock.blockName } block: upload image file`, async function () {
+		const blockHandle = await gutenbergEditorPage.addBlock( ImageBlock.blockName );
+		const imageBlock = new ImageBlock( blockHandle );
+		await imageBlock.upload( testFiles.image );
+	} );
+
+	it( `${ ImageBlock.blockName } block: upload image file with reserved URL characters`, async function () {
+		const blockHandle = await gutenbergEditorPage.addBlock( ImageBlock.blockName );
+		const imageBlock = new ImageBlock( blockHandle );
+		await imageBlock.upload( testFiles.image_reserved_name );
+	} );
+
+	it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
+		const blockHandle = await gutenbergEditorPage.addBlock( AudioBlock.blockName );
+		const audioBlock = new AudioBlock( blockHandle );
+		await audioBlock.upload( testFiles.audio );
+	} );
+
+	it( `${ FileBlock.blockName } block: upload audio file`, async function () {
+		const blockHandle = await gutenbergEditorPage.addBlock( FileBlock.blockName );
+		const fileBlock = new FileBlock( blockHandle );
+		await fileBlock.upload( testFiles.audio );
+	} );
+
+	it( 'Publish and visit post', async function () {
+		await gutenbergEditorPage.publish( { visit: true } );
+	} );
+
+	// Pass in a 1D array of values or text strings to validate each block.
+	// The full filename (name.extension) is not used within the Image block, but the file name is.
+	// `path.parse` is called to trim the extension.
+	it.each`
+		block           | content
+		${ ImageBlock } | ${ [ path.parse( testFiles.image ).name ] }
+		${ ImageBlock } | ${ [ path.parse( testFiles.image_reserved_name ).name.replace( /[^a-zA-Z ]/g, '' ) ] }
+		${ AudioBlock } | ${ [ path.parse( testFiles.audio ).base ] }
+		${ FileBlock }  | ${ [ path.parse( testFiles.audio ).name ] }
+	`(
+		`Confirm $block.blockName block is visible in published post`,
+		async ( { block, content } ) => {
+			// Pass the Block object class here then call the static method to validate.
+			await block.validatePublishedContent( page, content );
+		}
+	);
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to migrate the Gutenberg Media Block related tests contained in [wp-editor__media-upload-spec.js](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/specs-calypso/wp-editor__media-upload-spec.js).

Key changes:
- implementation of new blocks.
- changes to test file generation method to accept a custom filename.
- block insertion method made more robust.

Background details:

This spec was a challenging one to migrate.

New classes were implemented for Images, Audio and File blocks. They overall have a very similar look and feel, containing a method for `upload` and the static method for `validatePublishedContent`.

`GutenbergEditorComponent.addBlock` had its selectors tweaked for better behavior when the target block to be inserted has a more generic name eg. Images.

This migrated spec is larger in scope than the original Selenium spec, as the post is actually published and the resulting content checked for accuracy.

The `removeBlock` portion of the test will be implemented in a follow-up PR.

#### Testing instructions

- [x] Playwright desktop tests pass.
- [x] Playwright mobile tests pass.
- [x] No intermittent failures resulting from `wp-blocks__media-spec.ts`.

Related to #
