### PR TITLE
Desktop CI: Add dependency on calypso build

### DIFF
--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -26,6 +26,11 @@ object E2ETests : BuildType({
 	name = "Run e2e tests"
 	description = "Run wp-desktop e2e tests in Linux"
 
+	dependencies {
+		snapshot(BuildDockerImage) {
+		}
+	}
+
 	artifactRules = """
 		desktop/release => release
 		desktop/e2e/logs => logs


### PR DESCRIPTION
#### Changes proposed in this Pull Request
For desktop tests, we want to use the calypso.live URL for the branch instead of production.

To accomplish that, we should just need to add a snapshot dependency on the build which creates the calypso.live URL, and then reference it in the desktop app.

The other half of this is #55323, which adds the ability to consume such a URL.

#### Testing instructions
Verify that the correct calypso.live URL is logged in the output for the desktop build
