### PR TITLE
Domains: Update "add a domain" button appearance

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -54,9 +54,9 @@ import DomainItem from './domain-item';
 import ListHeader from './list-header';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
-import AddDomainButton from 'calypso/my-sites/domains/domain-management/list/add-domain-button';
 import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/list/empty-domains-list-card';
 import WpcomDomainItem from 'calypso/my-sites/domains/domain-management/list/wpcom-domain-item';
+import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
 
 /**
  * Style dependencies
@@ -133,8 +133,11 @@ export class List extends React.Component {
 						align="left"
 					/>
 					<div className="domains__header-buttons">
-						<HeaderCart selectedSite={ selectedSite } currentRoute={ currentRoute } />
-						{ this.addDomainButton() }
+						<HeaderCart
+							selectedSite={ this.props.selectedSite }
+							currentRoute={ this.props.currentRoute }
+						/>
+						{ this.optionsDomainButton() }
 					</div>
 				</div>
 
@@ -247,12 +250,12 @@ export class List extends React.Component {
 		);
 	}
 
-	addDomainButton() {
+	optionsDomainButton() {
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
 			return null;
 		}
 
-		return <AddDomainButton />;
+		return <OptionsDomainButton />;
 	}
 
 	setPrimaryDomain( domainName ) {

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  */
 import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
-import AddDomainButton from 'calypso/my-sites/domains/domain-management/list/add-domain-button';
+import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
 import { ListAllActions } from 'calypso/my-sites/domains/domain-management/list/utils';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import SectionHeader from 'calypso/components/section-header';
@@ -54,7 +54,7 @@ class ListHeader extends React.PureComponent {
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
 			return null;
 		}
-		return <AddDomainButton specificSiteActions={ true } />;
+		return <OptionsDomainButton specificSiteActions={ true } />;
 	}
 
 	renderDefaultHeaderContent() {

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -17,8 +17,16 @@ import PopoverMenuItem from 'calypso/components/popover/menu-item';
 import Gridicon from 'calypso/components/gridicon';
 import { composeAnalytics, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { domainAddNew, domainUseYourDomain } from 'calypso/my-sites/domains/paths';
+import {
+	domainAddNew,
+	domainManagementAllRoot,
+	domainUseYourDomain,
+} from 'calypso/my-sites/domains/paths';
 
+/**
+ * Style dependencies
+ */
+import './options-domain-button.scss';
 class AddDomainButton extends React.Component {
 	static propTypes = {
 		selectedSiteSlug: PropTypes.string,
@@ -33,7 +41,10 @@ class AddDomainButton extends React.Component {
 		isAddMenuVisible: false,
 	};
 
-	addDomainButtonRef = React.createRef();
+	constructor( props ) {
+		super( props );
+		this.addDomainButtonRef = React.createRef();
+	}
 
 	clickAddDomain = () => {
 		this.props.trackAddDomainClick();
@@ -73,19 +84,17 @@ class AddDomainButton extends React.Component {
 
 		return (
 			<React.Fragment>
-				{ this.props.selectedSiteSlug && (
-					<PopoverMenuItem onClick={ this.clickAddDomain }>
-						{ translate( 'to this site' ) }
-					</PopoverMenuItem>
-				) }
+				<PopoverMenuItem href={ domainManagementAllRoot() } onClick={ this.trackMenuClick }>
+					{ translate( 'Manage all domains' ) }
+				</PopoverMenuItem>
 				<PopoverMenuItem href="/new" onClick={ this.trackMenuClick }>
-					{ translate( 'to a new site' ) }
+					{ translate( 'Add a domain to a new site' ) }
 				</PopoverMenuItem>
 				<PopoverMenuItem href="/domains/add" onClick={ this.trackMenuClick }>
-					{ translate( 'to a different site' ) }
+					{ translate( 'Add a domain to a different site' ) }
 				</PopoverMenuItem>
 				<PopoverMenuItem href="/start/domain" onClick={ this.trackMenuClick }>
-					{ translate( 'without a site' ) }
+					{ translate( 'Add a domain without a site' ) }
 				</PopoverMenuItem>
 			</React.Fragment>
 		);
@@ -96,20 +105,26 @@ class AddDomainButton extends React.Component {
 
 		const label = this.props.specificSiteActions
 			? translate( 'Add a domain to this site' )
-			: translate( 'Add a domain' );
+			: translate( 'Other domain options' );
 
 		return (
 			<React.Fragment>
-				<Button primary compact className={ 'add-domain-button' } onClick={ this.toggleAddMenu }>
+				<Button
+					primary={ this.props.specificSiteActions }
+					compact
+					className="options-domain-button"
+					onClick={ this.toggleAddMenu }
+					ref={ this.addDomainButtonRef }
+				>
 					{ label }
-					<Gridicon icon="chevron-down" ref={ this.addDomainButtonRef } />
+					<Gridicon icon="chevron-down" />
 				</Button>
 				<PopoverMenu
+					className="options-domain-button__popover"
 					isVisible={ this.state.isAddMenuVisible }
 					onClose={ this.closeAddMenu }
 					context={ this.addDomainButtonRef.current }
 					position="bottom"
-					relativePosition={ { left: -162 } }
 				>
 					{ this.renderOptions() }
 				</PopoverMenu>

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -1,0 +1,9 @@
+.options-domain-button {
+	& > .gridicon {
+		margin-left: 5px;
+	}
+
+	&__popover {
+		margin-top: 5px;
+	}
+}

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .domains__header {
 	display: flex;
 	justify-content: space-between;
@@ -30,5 +33,9 @@
 	.cart__count-badge .count {
 		top: -7px;
 		right: -3px;
+	}
+
+	@include breakpoint-deprecated('<660px') {
+		margin: 16px;
 	}
 }

--- a/test/e2e/lib/pages/domains-page.js
+++ b/test/e2e/lib/pages/domains-page.js
@@ -8,7 +8,7 @@ export default class DomainsPage extends AsyncBaseContainer {
 	}
 
 	async clickAddDomain() {
-		return await driverHelper.clickWhenClickable( this.driver, By.css( '.add-domain-button' ) );
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.options-domain-button' ) );
 	}
 
 	async clickPopoverItem( name ) {

--- a/test/e2e/lib/pages/domains-page.js
+++ b/test/e2e/lib/pages/domains-page.js
@@ -4,11 +4,46 @@ import * as driverHelper from '../driver-helper.js';
 
 export default class DomainsPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.empty-domains-list-card' ) );
+		super( driver, By.css( '.domain-management-list__items' ) );
 	}
 
 	async clickAddDomain() {
-		return await driverHelper.clickWhenClickable( this.driver, By.css( '.options-domain-button' ) );
+		const hasCustomDomain = await driverHelper.isElementLocated(
+			this.driver,
+			By.xpath( "//button[text()='Add a domain to this site']" )
+		);
+
+		if ( hasCustomDomain ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.xpath( "//button[text()='I have a domain']" )
+			);
+			return await this.clickPopoverItem( 'Search for a domain' );
+		}
+
+		const hasDomainCredit = await driverHelper.isElementLocated(
+			this.driver,
+			By.xpath(
+				"//div[@class='empty-domains-list-card__text']/h2[text()='Claim your free domain']"
+			)
+		);
+
+		const hasPaidPlan = await driverHelper.isElementLocated(
+			this.driver,
+			By.xpath( "//div[@class='empty-domains-list-card__text']/h2[text()='Add your domain']" )
+		);
+
+		if ( hasDomainCredit || hasPaidPlan ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.xpath( "//a[text()='Search for a domain']" )
+			);
+		}
+
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.xpath( "//a[text()='Just search for a domain']" )
+		);
 	}
 
 	async clickPopoverItem( name ) {

--- a/test/e2e/specs/specs-calypso/wp-manage-domains__add-a-domain-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains__add-a-domain-spec.js
@@ -45,7 +45,6 @@ describe( `[${ host }] Manage Domains - Add a Domain: (${ screenSize }) @paralle
 	it( 'Add a domain', async function () {
 		const domainsPage = await DomainsPage.Expect( this.driver );
 		await domainsPage.clickAddDomain();
-		await domainsPage.clickPopoverItem( 'to this site' );
 	} );
 
 	it( 'Search for a blog name', async function () {

--- a/test/e2e/specs/specs-calypso/wp-manage-domains__map-a-domain-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains__map-a-domain-spec.js
@@ -23,7 +23,6 @@ describe( `[${ host }] Manage Domains - Map a Domain: (${ screenSize }) @paralle
 	it( 'Add a domain', async function () {
 		const domainsPage = await DomainsPage.Expect( this.driver );
 		await domainsPage.clickAddDomain();
-		await domainsPage.clickPopoverItem( 'to this site' );
 	} );
 
 	it( 'Use own domain', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Reverts #55129 (it was dependent on #54649 merge) and adds back the changes on the domain options button. 
All the previous discussions on the last PR were also added. 

#### Testing instructions
- Use the "Link to Calypso live" link below to view the build for this branch.
- Go to the site domains page (My Sites -> Manage -> Domains).
- Make sure that the domain button (on the header) looks like the "New" version shown in the screenshot below:
- Check that the E2E tests are passing.

Old:
![image](https://user-images.githubusercontent.com/18705930/128934794-0100ecd9-80c5-4314-9df9-5759931eee55.png)

New:
![image](https://user-images.githubusercontent.com/18705930/128934850-4b1e9763-f269-48b1-8580-68bf3842a1c5.png)