### PR TITLE
Domains: Remove "Manage all your domains" card

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -19,8 +19,7 @@ import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings'
 import DomainOnly from './domain-only';
 import ListItemPlaceholder from './item-placeholder';
 import Main from 'calypso/components/main';
-import { domainManagementRoot, domainManagementList } from 'calypso/my-sites/domains/paths';
-import { Card } from '@automattic/components';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import EmptyContent from 'calypso/components/empty-content';
@@ -362,7 +361,7 @@ export class List extends React.Component {
 			return times( 3, ( n ) => <ListItemPlaceholder key={ `item-${ n }` } /> );
 		}
 
-		const { currentRoute, translate, selectedSite, hasSingleSite } = this.props;
+		const { currentRoute, selectedSite } = this.props;
 
 		const { changePrimaryDomainModeEnabled, primaryDomainIndex, settingPrimaryDomain } = this.state;
 
@@ -393,12 +392,6 @@ export class List extends React.Component {
 			/>
 		) );
 
-		const manageAllDomainsLink = hasSingleSite ? null : (
-			<Card className="list__view-all" key="manage-all-domains" href={ domainManagementRoot() }>
-				{ translate( 'Manage all your domains' ) }
-			</Card>
-		);
-
 		return [
 			<QuerySitePurchases key="query-purchases" siteId={ selectedSite.ID } />,
 			domains.length > 0 && (
@@ -411,7 +404,6 @@ export class List extends React.Component {
 				/>
 			),
 			...domainListItems,
-			manageAllDomainsLink,
 		];
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is part of the domain pages redesign work detailed on pcYYhz-e4-p2. This PR removes the "Manage all your domains" card at the bottom of the site domains management page, as that option will be part of the "Other domain options" button being updated in #55337.

#### Screenshots

Before:

<img width="1062" alt="Screen Shot 2021-08-10 at 18 55 50" src="https://user-images.githubusercontent.com/5324818/128940410-216ea949-176a-4006-9f8d-1a6868aec582.png">

After (the only difference is the "Manage all your domains" card missing):

<img width="1062" alt="Screen Shot 2021-08-10 at 18 52 59" src="https://user-images.githubusercontent.com/5324818/128940063-d9faafe6-1fd6-4718-b22d-6a1c9324e9e2.png">

#### Testing instructions

Open the live Calypso link, select one of your sites, check the site domains management page (`Upgrades > Domains`) and ensure the "Manage all your domains" card is not present.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

