### PR TITLE
Playwright: Extend timeout of the SupportComponent's `waitForResponse` call to 60000ms.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -247,7 +247,8 @@ export class SupportComponent {
 			// Wait for the response to the request and ensure the status is HTTP 200.
 			await Promise.all( [
 				this.page.waitForResponse(
-					( response ) => response.url().includes( 'search?' ) && response.status() === 200
+					( response ) => response.url().includes( 'search?' ) && response.status() === 200,
+					{ timeout: 60000 }
 				),
 				this.page.fill( selectors.searchInput, text ),
 			] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to restore the extended timeout for the `waitForResponse` call within `SupportComponent.search` method.

Key changes:
- restore the `60000ms` timeout that was present in the [original iteration](https://github.com/Automattic/wp-calypso/commit/5bcb720e0320b3ca63de56fd322508f5e30747b9#diff-a7a204549c7cd411d47349ba3f4494568945403e0537d8122a8abf483c8ca9b5L234) of SupportComponent.

Background details:

For the most part, searching for an invalid search string like `;;;ppp;;;` resolves within the default timeout of 30000ms. However, in the CI environment where tasks are run on all branches, the 'rare' instance where it does not resolve within the allotted time is quite frequent due to sheer number of runs.

This change will extend the timeout to twice the default value.

#### Testing instructions

- [ ] Support spec on Playwright mobile does not time out.
- [ ] Support sped on Playwright desktop does not time out.

Related to #
