### PR TITLE
Create new onboarding-with-email signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -122,7 +122,8 @@ export function generateFlows( {
 			name: 'onboarding-with-email',
 			steps: [ 'user', 'domains', 'emails', 'plans' ],
 			destination: getSignupDestination,
-			description: 'Copy of the onboarding flow that includes an email step',
+			description:
+				'Copy of the onboarding flow that always includes an email step; the flow is used by the Professional Email landing page',
 			lastModified: '2021-08-11',
 			showRecaptcha: true,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -119,6 +119,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'onboarding-with-email',
+			steps: [ 'user', 'domains', 'emails', 'plans' ],
+			destination: getSignupDestination,
+			description: 'Copy of the onboarding flow that includes an email step',
+			lastModified: '2021-08-11',
+			showRecaptcha: true,
+		},
+		{
 			name: 'onboarding-registrationless',
 			steps: [ 'domains', 'plans-new', 'user-new' ],
 			destination: getSignupDestination,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -149,7 +149,7 @@
 	],
 	"restricted_me_access": true,
 	"theme_color": "#055d9c",
-	"reskinned_flows": [ "onboarding", "launch-site", "onboarding-with-email" ],
+	"reskinned_flows": [ "launch-site", "onboarding", "onboarding-with-email" ],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"calendly_jetpack_appointment_url": ""
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -149,7 +149,7 @@
 	],
 	"restricted_me_access": true,
 	"theme_color": "#055d9c",
-	"reskinned_flows": [ "onboarding", "launch-site" ],
+	"reskinned_flows": [ "onboarding", "launch-site", "onboarding-with-email" ],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"calendly_jetpack_appointment_url": ""
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As a result of us disabling the recently added email step in the `onboarding` flow in #55318, we do need some way to allow users coming in from our Professional Email landing page to purchase email from us. This PR aims to achieve that goal by adding a new `onboarding-with-email` signup flow that always shows the email step to users.
* At a technical level, this PR replicates the existing `onboarding` flow but always includes the `emails` step (rather than it being conditional on a feature flag), and ensures that the new `onboarding-with-email` flow is reskinned.

#### Testing instructions

* Run this branch locally or access the live branch (link is in [this comment](https://github.com/Automattic/wp-calypso/pull/55368#issuecomment-896619731))
* Navigate to `/start/onboarding-with-email`
* Work through various options for the signup flow, ensuring that you see the emails step whenever you select a paid domain registration, and don't see the emails step when you pick a free wordpress.com subdomain.

Related to #55318, #55097, #54641