### PR TITLE
fix(browsehappy): ensure `from` is a valid url

### DIFF
--- a/client/landing/browsehappy/index.jsx
+++ b/client/landing/browsehappy/index.jsx
@@ -11,6 +11,7 @@ const SUPPORTED_BROWSERS_LINK = 'https://wordpress.com/support/browser-issues/#s
 
 export default function Browsehappy( { from } ) {
 	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, from ?? '/' );
+	const isValidUrl = /^(https?:\/\/|\/)/.test( from );
 
 	return (
 		<body className="browsehappy__body">
@@ -30,11 +31,13 @@ export default function Browsehappy( { from } ) {
 				<a class="components-button is-primary" href={ SUPPORTED_BROWSERS_LINK }>
 					{ __( 'View supported browsers' ) }
 				</a>
-				<p>
-					<a className="browsehappy__anyway" href={ continueUrl }>
-						{ __( 'Continue loading the page anyway' ) }
-					</a>
-				</p>
+				{ isValidUrl && (
+					<p>
+						<a className="browsehappy__anyway" href={ continueUrl }>
+							{ __( 'Continue loading the page anyway' ) }
+						</a>
+					</p>
+				) }
 				<Circle color="yellow" position="1" />
 				<Circle color="red" position="2" />
 				<Circle color="gray" position="3" />

--- a/client/landing/browsehappy/index.jsx
+++ b/client/landing/browsehappy/index.jsx
@@ -10,8 +10,8 @@ import './style.scss';
 const SUPPORTED_BROWSERS_LINK = 'https://wordpress.com/support/browser-issues/#supported-browsers';
 
 export default function Browsehappy( { from } ) {
-	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, from ?? '/' );
 	const isValidUrl = /^(https?:\/\/|\/)/.test( from );
+	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, isValidUrl ? from : '/' );
 
 	return (
 		<body className="browsehappy__body">
@@ -31,13 +31,11 @@ export default function Browsehappy( { from } ) {
 				<a class="components-button is-primary" href={ SUPPORTED_BROWSERS_LINK }>
 					{ __( 'View supported browsers' ) }
 				</a>
-				{ isValidUrl && (
-					<p>
-						<a className="browsehappy__anyway" href={ continueUrl }>
-							{ __( 'Continue loading the page anyway' ) }
-						</a>
-					</p>
-				) }
+				<p>
+					<a className="browsehappy__anyway" href={ continueUrl }>
+						{ __( 'Continue loading the page anyway' ) }
+					</a>
+				</p>
 				<Circle color="yellow" position="1" />
 				<Circle color="red" position="2" />
 				<Circle color="gray" position="3" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Browsehappy: Make sure we don't accept arbitrary user input for `from` but only valid URLs starting with `https?`

#### Testing instructions

* see p1628575428008200-slack-CRA4UEQQ3
