### PR TITLE
WIP Blogger Experience: track tag eduction click in block editor

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -5,6 +5,7 @@ import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomBlockEditorDetailsOpen from './wpcom-block-editor-details-open';
 import wpcomBlockEditorGlobalStylesTabSelected from './wpcom-block-editor-global-styles-tab-selected';
 import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
+import wpcomBlockEditorTagEducationClick from './wpcom-block-editor-tag-education-click';
 import wpcomBlockEditorTemplatePartDetachBlocks from './wpcom-block-editor-template-part-detach-blocks';
 import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-plan-upgrade';
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
@@ -56,6 +57,7 @@ const EVENTS_MAPPING = [
 	wpcomTemplatePartReplaceBubble(),
 	wpcomTemplatePartChooseExisting(),
 	wpcomBlockEditorListViewSelect(),
+	wpcomBlockEditorTagEducationClick(),
 	wpcomBlockEditorTemplatePartDetachBlocks(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-tag-education-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-tag-education-click.js
@@ -1,0 +1,13 @@
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_tag_education_click`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-block-editor-tag-education-click',
+	selector: 'a[href="https://wordpress.com/blog/2014/04/21/better-tagging/"]',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_editor_tag_education_click' ),
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add event `wpcom-block-editor-tag-education-click` to track clicking on "Build your audience with tags"

![image](https://user-images.githubusercontent.com/13596067/129021754-24a64bda-c1e4-48f5-890e-3b731d0c5e67.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Run local Gutenberg](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md)
* Sandbox to local Gutenberg (see: pc9Uba-1F-p2)
* Sandbox your API
* Open another terminal and run `cd apps/wpcom-block-editor && yarn dev --sync`
* Open your local calypso
* Turn on debugging by running `localStorage.setItem( 'debug', 'wpcom-block-editor:*' )` within dev tools Console and reload the page
* Create or edit the post
* Click "Build your audience with tags" in the Tags section
* Check dev tools Console for `wpcom-block-editor:analytics:tracks Recording event "wpcom_block_editor_tag_education_click"`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55300