### PR TITLE
Add Reader Featured image alt text

### DIFF
--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,18 +1,24 @@
+/**
+ * External dependencies
+ */
 import PropTypes from 'prop-types';
 import React from 'react';
 
 export default class FeaturedImage extends React.Component {
 	constructor( props ) {
 		super();
-		this.state = { src: props.src };
+		this.state = { src: props.src, alt: props.alt };
 		this.handleImageError = () => {
-			this.setState( { src: '' } );
+			this.setState( { src: '', alt: '' } );
 		};
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.src !== this.props.src ) {
 			this.setState( { src: nextProps.src } );
+		}
+		if ( nextProps.alt !== this.props.alt ) {
+			this.setState( { alt: nextProps.alt } );
 		}
 	}
 
@@ -23,7 +29,7 @@ export default class FeaturedImage extends React.Component {
 
 		return (
 			<div className="reader-full-post__featured-image">
-				<img src={ this.state.src } onError={ this.handleImageError } alt="" />
+				<img src={ this.state.src } onError={ this.handleImageError } alt={ this.state.alt } />
 			</div>
 		);
 	}
@@ -31,4 +37,5 @@ export default class FeaturedImage extends React.Component {
 
 FeaturedImage.propTypes = {
 	src: PropTypes.string,
+	alt: PropTypes.string,
 };

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -7,18 +7,15 @@ import React from 'react';
 export default class FeaturedImage extends React.Component {
 	constructor( props ) {
 		super();
-		this.state = { src: props.src, alt: props.alt };
+		this.state = { src: props.src };
 		this.handleImageError = () => {
-			this.setState( { src: '', alt: '' } );
+			this.setState( { src: '' } );
 		};
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.src !== this.props.src ) {
 			this.setState( { src: nextProps.src } );
-		}
-		if ( nextProps.alt !== this.props.alt ) {
-			this.setState( { alt: nextProps.alt } );
 		}
 	}
 
@@ -29,7 +26,7 @@ export default class FeaturedImage extends React.Component {
 
 		return (
 			<div className="reader-full-post__featured-image">
-				<img src={ this.state.src } onError={ this.handleImageError } alt={ this.state.alt } />
+				<img src={ this.state.src } onError={ this.handleImageError } alt={ this.props.alt } />
 			</div>
 		);
 	}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -40,7 +40,12 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { isDiscoverPost, isDiscoverSitePick } from 'calypso/reader/discover/helper';
 import DiscoverSiteAttribution from 'calypso/reader/discover/site-attribution';
 import { READER_FULL_POST } from 'calypso/reader/follow-sources';
-import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
+import {
+	canBeMarkedAsSeen,
+	getSiteName,
+	isEligibleForUnseen,
+	getFeaturedImageAlt,
+} from 'calypso/reader/get-helpers';
 import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
@@ -411,6 +416,7 @@ export class FullPostView extends React.Component {
 		const startingCommentId = this.getCommentIdFromUrl();
 		const commentCount = get( post, 'discussion.comment_count' );
 		const postKey = { blogId, feedId, postId };
+		const featuredImageAlt = getFeaturedImageAlt( post );
 
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
@@ -489,7 +495,7 @@ export class FullPostView extends React.Component {
 							<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
 
 							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
-								<FeaturedImage src={ post.featured_image } />
+								<FeaturedImage src={ post.featured_image } alt={ featuredImageAlt } />
 							) }
 							{ isLoading && <ReaderFullPostContentPlaceholder /> }
 							{ post.use_excerpt ? (

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -179,7 +179,8 @@ export const getFeaturedImageAlt = ( post ) => {
 	// If there is no Featured image alt text available, return post title instead.
 	// This will make sure that the featured image has at least some relevant alt text.
 	if ( ! featuredImageAlt ) {
-		return postTitle;
+		// translators: Adds explanation to the Featured image alt text in Reader
+		return translate( '%(postTitle)s - featured image', { args: { postTitle } } );
 	}
 
 	return featuredImageAlt;

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -164,7 +164,7 @@ export const canBeMarkedAsSeen = ( { post = null, posts = [], currentRoute = '' 
 /**
  * Return Featured image alt text.
  *
- * @param {Object} post
+ * @param {Object} post object containing post information
  *
  * @returns {string} Featured image alt text
  */

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { translate } from 'i18n-calypso';
-import { trim, get } from 'lodash';
+import { trim } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isSiteDescriptionBlocked } from 'calypso/reader/lib/site-description-blocklist';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
@@ -172,8 +172,8 @@ export const getFeaturedImageAlt = ( post ) => {
 	// Each post can have multiple images attached. To make sure we are selecting
 	// the alt text of the correct image attachment, we get the ID of the post thumbnail first
 	// and then use it to get the alt text of the Featured image.
-	const postThumbnailId = get( post, 'post_thumbnail.ID' );
-	const featuredImageAlt = get( post, 'attachments.' + postThumbnailId + '.alt' );
+	const postThumbnailId = post?.post_thumbnail?.ID;
+	const featuredImageAlt = post?.attachments?.[ postThumbnailId ]?.alt;
 	const postTitle = post.title;
 
 	// If there is no Featured image alt text available, return post title instead.

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { translate } from 'i18n-calypso';
-import { trim } from 'lodash';
+import { trim, get } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { isSiteDescriptionBlocked } from 'calypso/reader/lib/site-description-blocklist';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
@@ -159,4 +159,28 @@ export const canBeMarkedAsSeen = ( { post = null, posts = [], currentRoute = '' 
 	}
 
 	return false;
+};
+
+/**
+ * Return Featured image alt text.
+ *
+ * @param {Object} post
+ *
+ * @returns {string} Featured image alt text
+ */
+export const getFeaturedImageAlt = ( post ) => {
+	// Each post can have multiple images attached. To make sure we are selecting
+	// the alt text of the correct image attachment, we get the ID of the post thumbnail first
+	// and then use it to get the alt text of the Featured image.
+	const postThumbnailId = get( post, 'post_thumbnail.ID' );
+	const featuredImageAlt = get( post, 'attachments.' + postThumbnailId + '.alt' );
+	const postTitle = post.title;
+
+	// If there is no Featured image alt text available, return post title instead.
+	// This will make sure that the featured image has at least some relevant alt text.
+	if ( ! featuredImageAlt ) {
+		return postTitle;
+	}
+
+	return featuredImageAlt;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The proposed code adds alt text to post Featured image in Reader at `read/feeds/[xxxxxxxx]/posts/[xxxxxxxxx]`:

![Markup on 2021-08-11 at 14:30:23](https://user-images.githubusercontent.com/25105483/129028898-b16065bc-5bf8-494b-b20f-47e948e70ff5.png)

The code tries to extract the alt text from `post.attachments` object first. If there is no post attachment available (e.g. when the Featured image was uploaded _before_ the time when the post was created) - OR - if the existing post attachment doesn't have any alt text, the post title will be used as the alt text instead.

#### Testing instructions

1. Create a new post with Featured image.
2. Add alt text to the Featured image through Media section in Calypso.
3. Navigate to Reader at https://wordpress.com/read.
4. Open the new post in Reader. You should be at `read/feeds/[xxxxxxxx]/posts/[xxxxxxxxx]` (not on the post page itself).
5. Open the Console and take a look if the Featured image has its alt text.
6. Try to remove alt text from the image through the Media section and go back to `read/feeds/[xxxxxxxx]/posts/[xxxxxxxxx]`.
7. When you open the Console this time, the alt text of the Featured image should be the same as the site title.

Related to https://github.com/Automattic/wp-calypso/issues/49226
