### PR TITLE
remove `from` param from `/browsehappy` page

### DIFF
--- a/client/document/browsehappy.jsx
+++ b/client/document/browsehappy.jsx
@@ -3,11 +3,11 @@ import Head from 'calypso/components/head';
 import BrowsehappyBody from 'calypso/landing/browsehappy';
 import { chunkCssLinks } from './utils';
 
-export default function Browsehappy( { entrypoint } ) {
+export default function Browsehappy( { dashboardUrl, entrypoint } ) {
 	return (
 		<html lang="en">
 			<Head title="Unsupported Browser — WordPress.com">{ chunkCssLinks( entrypoint ) }</Head>
-			<BrowsehappyBody />
+			<BrowsehappyBody dashboardUrl={ dashboardUrl } />
 		</html>
 	);
 }

--- a/client/document/browsehappy.jsx
+++ b/client/document/browsehappy.jsx
@@ -3,11 +3,11 @@ import Head from 'calypso/components/head';
 import BrowsehappyBody from 'calypso/landing/browsehappy';
 import { chunkCssLinks } from './utils';
 
-export default function Browsehappy( { entrypoint, from } ) {
+export default function Browsehappy( { entrypoint } ) {
 	return (
 		<html lang="en">
 			<Head title="Unsupported Browser — WordPress.com">{ chunkCssLinks( entrypoint ) }</Head>
-			<BrowsehappyBody from={ from } />
+			<BrowsehappyBody />
 		</html>
 	);
 }

--- a/client/landing/browsehappy/index.jsx
+++ b/client/landing/browsehappy/index.jsx
@@ -9,9 +9,8 @@ import './style.scss';
 
 const SUPPORTED_BROWSERS_LINK = 'https://wordpress.com/support/browser-issues/#supported-browsers';
 
-export default function Browsehappy( { from } ) {
-	const isValidUrl = /^(https?:\/\/|\/)/.test( from );
-	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, isValidUrl ? from : '/' );
+export default function Browsehappy() {
+	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, '/' );
 
 	return (
 		<body className="browsehappy__body">

--- a/client/landing/browsehappy/index.jsx
+++ b/client/landing/browsehappy/index.jsx
@@ -9,8 +9,8 @@ import './style.scss';
 
 const SUPPORTED_BROWSERS_LINK = 'https://wordpress.com/support/browser-issues/#supported-browsers';
 
-export default function Browsehappy() {
-	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, '/' );
+export default function Browsehappy( { dashboardUrl } ) {
+	const continueUrl = addQueryArgs( { bypassTargetRedirection: true }, dashboardUrl ?? '/' );
 
 	return (
 		<body className="browsehappy__body">

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import config from '@automattic/calypso-config';
-import { addQueryArgs } from 'calypso/lib/url';
 
 export default () => ( req, res, next ) => {
 	if ( ! config.isEnabled( 'redirect-fallback-browsers' ) ) {
@@ -36,5 +35,5 @@ export default () => ( req, res, next ) => {
 		return;
 	}
 
-	res.redirect( addQueryArgs( { from: req.url }, '/browsehappy' ) );
+	res.redirect( '/browsehappy' );
 };

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -745,8 +745,14 @@ export default function pages() {
 		}
 	);
 
-	app.get( '/browsehappy', ( req, res ) => {
-		req.context.entrypoint = req.getFilesForEntrypoint( 'entry-browsehappy' );
+	app.get( '/browsehappy', setupDefaultContext( 'entry-browsehappy' ), setUpRoute, ( req, res ) => {
+		const wpcomRe = /^https?:\/\/[A-z0-9_-]+\.wordpress\.com$/;
+		const primaryBlogUrl = req.context.user?.primary_blog_url ?? '';
+		const isWpcom = wpcomRe.test( primaryBlogUrl );
+
+		req.context.dashboardUrl = isWpcom
+			? primaryBlogUrl + '/wp-admin'
+			: 'https://dashboard.wordpress.com/wp-admin/';
 		res.send( renderJsx( 'browsehappy', req.context ) );
 	} );
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -747,7 +747,6 @@ export default function pages() {
 
 	app.get( '/browsehappy', ( req, res ) => {
 		req.context.entrypoint = req.getFilesForEntrypoint( 'entry-browsehappy' );
-		req.context.from = req.query.from;
 		res.send( renderJsx( 'browsehappy', req.context ) );
 	} );
 


### PR DESCRIPTION
Remove the `from=` param from the `/browsehappy` page and just redirect users to `/` in case they decide to load Calypso anyway.

Background: 200&cid=CRA4UEQQ3-slack-CRA4UEQQ3

### Testing instructions

1. Open calypso.live and go to `/browsehappy?from=<arbitrary-url>`
2. Make sure you're redirected to `/` no matter what `from` is set to

Try this for both Calypso and Jetpack Cloud.