### PR TITLE
Update  jetpack activity log padding

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -182,7 +182,9 @@
 	align-items: center;
 	width: 100%;
 	min-width: 0;
-	padding-left: 56px;
+	@include break-wide {
+		padding-left: 56px;
+	}
 
 	@include breakpoint-deprecated( '<960px' ) {
 		flex-direction: column;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -179,7 +179,7 @@
 
 .activity-log-item__card-header {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	width: 100%;
 	min-width: 0;
 	@include break-wide {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the jetpack activity log, change the responsive padding to fit previous designs

On production, in the jetpack activity log, sometimes the author is no longer left justified:

![2021-08-11-jetpack](https://user-images.githubusercontent.com/937354/129049899-0570e9b4-2265-41c7-8167-7fbe407b7ff7.png)
^ Production

This branch changes it such that the author is always left justified:
![2021-08-11_09-41](https://user-images.githubusercontent.com/937354/129050012-c86b8f78-faee-49b2-b014-469920998552.png)
^ This branch

#### Testing instructions
* Create 2 jetpack ninja sites
* Store the credentials to each of them in a text file
* Visit the /wp-admin on both of them, press the green jetpack button to connect to your wp.com account
* Buy the backup daily jetpack plan while connecting (use store credits on your wp.com account)
* Add a post to each of the sites
* Visit Calypso for one of the sites. Go to Jetpack -> Backup in the sidebar, then click "Enable Restores"
![2021-08-09_13-57](https://user-images.githubusercontent.com/937354/128759381-a9426cb7-6f1b-45c6-9f71-52c582c64038.png)
* Enter the SSH credentials for this site here. You should only need to enter the username/password.
* Don't do this to your other site. Now you have one site with credentials, one without, and you can check both forms of the activity log display.
* Wait for a backup to be created.. although it might have already been while you did the credential dance.
* Visit Jetpack -> Activity Log for each of the sites and examine the backup and restore buttons for the backups.
* Also try adjusting browser width.
* Buttons should continue to function as before.

Related to https://github.com/Automattic/wp-calypso/issues/49528
Related to https://github.com/Automattic/wp-calypso/pull/55295
