### PR TITLE
Issue Template: Include iOS and Android in the OS list.

### DIFF
--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -45,10 +45,13 @@ body:
     id: os
     attributes:
       label: Operating System
+      description: Multiple selection is supported.
       options:
         - Windows
         - macOS
         - Linux
+        - Android
+        - iOS
       multiple: true
     validations:
       required: true
@@ -60,6 +63,7 @@ body:
     id: browser
     attributes:
       label: Browser
+      description: Multiple selection is supported.
       options:
         - Chrome/Chromium
         - Firefox
@@ -79,7 +83,8 @@ body:
   - type: dropdown
     id: site-type
     attributes:
-      label: Simple, Atomic or both?
+      label: Simple/Atomic
+      description: Multiple selection is supported.
       options:
         - Simple
         - Atomic


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add `iOS` and `Android` to the OS list when making a bug report as requested [here](p1628670439050300/1628098234.020300-slack-C02FMH4G8).

Key changes:
- addition of mobile OS into the list.
- addition of description text to inform reporters that multiple dropdown selections are supported.

#### Testing instructions

Please take a look at the rendered template [here](https://github.com/Automattic/wp-calypso/blob/update/happiness-bug-report-add-browsers/.github/ISSUE_TEMPLATE/happiness-bug-report.yml).