### PR TITLE
Refactor how plans add CTA buttons

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -535,7 +535,7 @@ export class PlanFeatures extends Component {
 		} );
 	}
 
-	handleUpgradeClick( singlePlanProperties ) {
+	handleUpgradeClick = ( singlePlanProperties ) => {
 		const {
 			isInSignup,
 			onUpgradeClick: ownPropsOnUpgradeClick,
@@ -610,7 +610,7 @@ export class PlanFeatures extends Component {
 		);
 
 		page( checkoutUrlWithArgs );
-	}
+	};
 
 	renderTopButtons() {
 		const {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -80,6 +81,7 @@ import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import PlanFeaturesActionsWrapper from './plan-features-action-wrapper';
 
 /**
  * Style dependencies
@@ -617,73 +619,32 @@ export class PlanFeatures extends Component {
 			isInSignup,
 			isLandingPage,
 			isLaunchPage,
+			nonDotBlogDomains,
 			planProperties,
+			redirectToAddDomainFlow,
 			selectedPlan,
 			selectedSiteSlug,
 			purchaseId,
-			translate,
 		} = this.props;
 
-		return map( planProperties, ( properties ) => {
-			let { availableForPurchase } = properties;
-			const {
-				current,
-				planName,
-				primaryUpgrade,
-				isPlaceholder,
-				planConstantObj,
-				popular,
-			} = properties;
-
-			const classes = classNames(
-				'plan-features__table-item',
-				'has-border-bottom',
-				'is-top-buttons'
-			);
-
-			let forceDisplayButton = false;
-			let buttonText = null;
-
-			if ( this.props.redirectToAddDomainFlow ) {
-				buttonText = translate( 'Add to Cart' );
-				forceDisplayButton = true;
-			}
-
-			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
-				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
-					availableForPurchase = false;
-					forceDisplayButton = true;
-					buttonText = translate( 'Only with .blog domains' );
-				}
-			}
-
+		return planProperties.map( ( planPropertiesPlan ) => {
 			return (
-				<td key={ planName } className={ classes }>
-					<PlanFeaturesActions
-						availableForPurchase={ availableForPurchase }
-						buttonText={ buttonText }
-						canPurchase={ canPurchase }
-						className={ getPlanClass( planName ) }
-						current={ current }
-						freePlan={ isFreePlan( planName ) }
-						forceDisplayButton={ forceDisplayButton }
-						isPlaceholder={ isPlaceholder }
-						isPopular={ popular }
-						isInSignup={ isInSignup }
-						isLandingPage={ isLandingPage }
-						isLaunchPage={ isLaunchPage }
-						manageHref={
-							purchaseId
-								? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-								: `/plans/my-plan/${ selectedSiteSlug }`
-						}
-						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
-						planName={ planConstantObj.getTitle() }
-						planType={ planName }
-						primaryUpgrade={ primaryUpgrade }
-						selectedPlan={ selectedPlan }
-					/>
-				</td>
+				<PlanFeaturesActionsWrapper
+					canPurchase={ canPurchase }
+					className={ 'is-top-buttons' }
+					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+					handleUpgradeClick={ this.handleUpgradeClick }
+					isInSignup={ isInSignup }
+					isLandingPage={ isLandingPage }
+					isLaunchPage={ isLaunchPage }
+					nonDotBlogDomains={ nonDotBlogDomains }
+					planPropertiesPlan={ planPropertiesPlan }
+					key={ planPropertiesPlan.productSlug }
+					redirectToAddDomainFlow={ redirectToAddDomainFlow }
+					selectedPlan={ selectedPlan }
+					selectedSiteSlug={ selectedSiteSlug }
+					purchaseId={ purchaseId }
+				/>
 			);
 		} );
 	}
@@ -788,69 +749,32 @@ export class PlanFeatures extends Component {
 			isInSignup,
 			isLandingPage,
 			isLaunchPage,
+			nonDotBlogDomains,
 			planProperties,
+			redirectToAddDomainFlow,
 			selectedPlan,
 			selectedSiteSlug,
 			purchaseId,
 		} = this.props;
 
-		return map( planProperties, ( properties ) => {
-			let { availableForPurchase } = properties;
-			const {
-				current,
-				planName,
-				primaryUpgrade,
-				isPlaceholder,
-				planConstantObj,
-				popular,
-			} = properties;
-			const classes = classNames(
-				'plan-features__table-item',
-				'has-border-bottom',
-				'is-bottom-buttons'
-			);
-
-			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
-				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
-					availableForPurchase = false;
-				}
-			}
-
-			let buttonText;
-			let forceDisplayButton = false;
-
-			if ( this.props.redirectToAddDomainFlow ) {
-				buttonText = this.props.translate( 'Add to Cart' );
-				forceDisplayButton = true;
-			}
-
+		return planProperties.map( ( planPropertiesPlan ) => {
 			return (
-				<td key={ planName } className={ classes }>
-					<PlanFeaturesActions
-						availableForPurchase={ availableForPurchase }
-						forceDisplayButton={ forceDisplayButton }
-						buttonText={ buttonText }
-						canPurchase={ canPurchase }
-						className={ getPlanClass( planName ) }
-						current={ current }
-						freePlan={ isFreePlan( planName ) }
-						isInSignup={ isInSignup }
-						isLandingPage={ isLandingPage }
-						isLaunchPage={ isLaunchPage }
-						isPlaceholder={ isPlaceholder }
-						isPopular={ popular }
-						manageHref={
-							purchaseId
-								? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-								: `/plans/my-plan/${ selectedSiteSlug }`
-						}
-						planName={ planConstantObj.getTitle() }
-						planType={ planName }
-						primaryUpgrade={ primaryUpgrade }
-						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
-						selectedPlan={ selectedPlan }
-					/>
-				</td>
+				<PlanFeaturesActionsWrapper
+					canPurchase={ canPurchase }
+					className={ 'is-bottom-buttons' }
+					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+					handleUpgradeClick={ this.handleUpgradeClick }
+					isInSignup={ isInSignup }
+					isLandingPage={ isLandingPage }
+					isLaunchPage={ isLaunchPage }
+					nonDotBlogDomains={ nonDotBlogDomains }
+					planPropertiesPlan={ planPropertiesPlan }
+					key={ planPropertiesPlan.productSlug }
+					redirectToAddDomainFlow={ redirectToAddDomainFlow }
+					selectedPlan={ selectedPlan }
+					selectedSiteSlug={ selectedSiteSlug }
+					purchaseId={ purchaseId }
+				/>
 			);
 		} );
 	}

--- a/client/my-sites/plan-features/plan-features-action-wrapper.jsx
+++ b/client/my-sites/plan-features/plan-features-action-wrapper.jsx
@@ -1,0 +1,82 @@
+/**
+ * Internal dependencies
+ */
+import React from 'react';
+import PlanFeaturesActions from './actions';
+import classNames from 'classnames';
+import { TYPE_BLOGGER, planMatches, isFreePlan, getPlanClass } from '@automattic/calypso-products';
+import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import { useTranslate } from 'i18n-calypso';
+
+export default function PlanFeaturesActionsWrapper( {
+	canPurchase,
+	className,
+	disableBloggerPlanWithNonBlogDomain,
+	handleUpgradeClick,
+	isInSignup,
+	isLandingPage,
+	isLaunchPage,
+	nonDotBlogDomains,
+	planPropertiesPlan,
+	redirectToAddDomainFlow,
+	selectedPlan,
+	selectedSiteSlug,
+	purchaseId,
+} ) {
+	const translate = useTranslate();
+	let { availableForPurchase } = planPropertiesPlan;
+	const {
+		current,
+		planName,
+		primaryUpgrade,
+		isPlaceholder,
+		planConstantObj,
+		popular,
+	} = planPropertiesPlan;
+
+	const classes = classNames( 'plan-features__table-item', 'has-border-bottom', className );
+	let buttonText;
+	let forceDisplayButton = false;
+
+	if ( disableBloggerPlanWithNonBlogDomain || nonDotBlogDomains.length > 0 ) {
+		if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
+			availableForPurchase = false;
+			forceDisplayButton = true;
+			buttonText = translate( 'Only with .blog domains' );
+		}
+	}
+
+	if ( redirectToAddDomainFlow ) {
+		buttonText = translate( 'Add to Cart' );
+		forceDisplayButton = true;
+	}
+
+	return (
+		<td key={ planName } className={ classes }>
+			<PlanFeaturesActions
+				availableForPurchase={ availableForPurchase }
+				forceDisplayButton={ forceDisplayButton }
+				buttonText={ buttonText }
+				canPurchase={ canPurchase }
+				className={ getPlanClass( planName ) }
+				current={ current }
+				freePlan={ isFreePlan( planName ) }
+				isInSignup={ isInSignup }
+				isLandingPage={ isLandingPage }
+				isLaunchPage={ isLaunchPage }
+				isPlaceholder={ isPlaceholder }
+				isPopular={ popular }
+				manageHref={
+					purchaseId
+						? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
+						: `/plans/my-plan/${ selectedSiteSlug }`
+				}
+				planName={ planConstantObj.getTitle() }
+				planType={ planName }
+				primaryUpgrade={ primaryUpgrade }
+				onUpgradeClick={ () => handleUpgradeClick( planPropertiesPlan ) }
+				selectedPlan={ selectedPlan }
+			/>
+		</td>
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Deduplicate the `PlanFeaturesActions` component and extract it into a wrapper component called `PlanFeaturesActionsWrapper`.

#### Testing instructions

Ideally this will not affect how the Manage Plans buttons work on https://wordpress.com/plans/. To test that these buttons continue to work as expected, please do the following:

- Go to https://wordpress.com/plans/
- Click on the Manage Plan button at the top of the plan features column
- Click on the Manage Plan button at the bottom of the plan features column
- Both buttons should redirect you to the plan management page as shown

![image](https://user-images.githubusercontent.com/16580129/129084379-9e2a4547-0fab-4ff0-ab2b-8d66928e7f62.png)

@pottedmeat Please take a look at the code and check if this is close to what you were describing

