### PR TITLE
People list banner

### DIFF
--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -25,6 +25,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import P2TeamBanner from 'calypso/my-sites/people/p2-team-banner';
 
 class People extends React.Component {
 	renderPeopleList() {
@@ -103,6 +104,7 @@ class People extends React.Component {
 					align="left"
 					hasScreenOptions
 				/>
+				<P2TeamBanner />
 				<div>
 					{
 						<PeopleSectionNav

--- a/client/my-sites/people/p2-team-banner/index.tsx
+++ b/client/my-sites/people/p2-team-banner/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Banner from 'calypso/components/banner';
+
+const P2TeamBanner: FunctionComponent = () => {
+	return (
+		<div>
+			<pre>Before Banner</pre>
+			{ /*For whatever reason, the banner below will not always render*/ }
+			<Banner
+				callToAction="Update"
+				description="This is the description."
+				disableHref
+				showIcon
+				title="Simple banner with description and call to action"
+			/>
+			<pre>After Banner</pre>
+		</div>
+	);
+};
+
+export default P2TeamBanner;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a proof of concent/WIP trying to add a banner to the people list.

The problem is that the banner will render on some sites but not all. 

Go to http://calypso.localhost:3000/people/team/<site> on a P2 site using the P2020 theme – you will not see the banner
<img width="796" alt="nope" src="https://user-images.githubusercontent.com/193283/129088726-6d25a406-40ce-4e77-89fb-361b4c8227c7.png">

Go to http://calypso.localhost:3000/people/team/<site> on any other site than a P2020 P2 and the banner renders.
<img width="769" alt="yas" src="https://user-images.githubusercontent.com/193283/129088777-d6cffec9-fdb2-44ed-8673-5118c53a3c50.png">

#### Testing instructions


