### PR TITLE
Checkout: Create existing card payment methods only when stripe has loaded

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -51,6 +51,8 @@ export default function useCreateAssignablePaymentMethods(
 
 	const storedCards = useSelector( getStoredCards );
 	const existingCardMethods = useCreateExistingCards( {
+		isStripeLoading,
+		stripeLoadingError,
 		storedCards,
 		activePayButtonText: String( translate( 'Use this card' ) ),
 	} );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -493,6 +493,8 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const existingCardMethods = useCreateExistingCards( {
+		isStripeLoading,
+		stripeLoadingError,
 		storedCards,
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -2,15 +2,24 @@ import { createExistingCardMethod } from '@automattic/wpcom-checkout';
 import { useMemo } from 'react';
 import useMemoCompare from '../use-memo-compare';
 import type { StoredCard } from '../../types/stored-cards';
+import type { StripeLoadingError } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
 
 export default function useCreateExistingCards( {
+	isStripeLoading,
+	stripeLoadingError,
 	storedCards,
 	activePayButtonText = undefined,
 }: {
+	isStripeLoading: boolean;
+	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredCard[];
 	activePayButtonText?: string;
 } ): PaymentMethod[] {
+	// The existing card payment methods do not require stripe, but the existing
+	// card processor does require it (for 3DS cards), so we wait to create the
+	// payment methods until stripe is loaded.
+	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	// Memoize the cards by comparing their stored_details_id values, in case the
 	// objects themselves are recreated on each render.
 	const memoizedStoredCards: StoredCard[] | undefined = useMemoCompare(
@@ -42,5 +51,6 @@ export default function useCreateExistingCards( {
 			) ?? []
 		);
 	}, [ memoizedStoredCards, activePayButtonText ] );
-	return existingCardMethods;
+
+	return shouldLoad ? existingCardMethods : [];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "existing card" payment methods (aka saved cards, stored cards, etc.) do not require Stripe because they already have tokenized Stripe data. Therefore, they can load in checkout before Stripe finishes loading or if Stripe encounters a loading error. However, the "existing card" processor function _does_ require Stripe in case the server requests a 3DS authentication. 

This means that it's possible to end up in a situation where a customer clicks to pay in checkout with an existing card and ends up with the cryptic error `Stripe configuration is required` (the error is also not localized because it's just a guard; this is intended to be impossible).

This PR modifies the "existing card" payment method creation hook so that (like nearly all the other payment method creation hooks) it will not return anything until Stripe has finished loading.

#### Testing instructions

For this testing, use an account with at least two existing saved cards. If you do not have enough, you can add a card at https://wordpress.com/me/purchases/add-payment-method (be careful of the checkbox at the bottom that assigns the card to existing subscriptions!).

First test that normal usage works correctly.

- Add a product to your cart and visit checkout.
- On the last step of checkout, select a saved card.
- Submit checkout.
- Verify that the purchase is successful.
- Visit the purchase page for the recent purchase. This page has a URL like either `me/purchases/example.com/XXXXXXX` or `purchases/subscriptions/example.com/XXXXXXX`.
- Click the "Add Payment Method" or "Change Payment Method" button.
- In the following form, select the _other_ saved card and press "Use this card".
- Verify that the assignment is successful.

Then it's also worth testing what happens if Stripe does not load. You can do this by applying the following patch onto this PR. Once applied, checkout should always load without any stored cards.

<details>

```diff
diff --git a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
index cd3134bb12..178ac0edf4 100644
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -500,7 +500,7 @@ export default function useCreatePaymentMethods( {
        } );

        const existingCardMethods = useCreateExistingCards( {
-               isStripeLoading,
+               isStripeLoading: true,
                stripeLoadingError,
                storedCards,
        } );
```

</details>

