### PR TITLE
Purchases: Adjust modal message when deleting a Domain Mapping subscription. 

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -110,6 +110,9 @@ function getDisplayName( purchase ) {
 	if ( jetpackProductsDisplayNames[ purchase.productSlug ] ) {
 		return jetpackProductsDisplayNames[ purchase.productSlug ];
 	}
+	if ( isDomainRegistration( purchase ) || isDomainMapping( purchase ) ) {
+		return purchase.productName;
+	}
 	return getName( purchase );
 }
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -110,9 +110,6 @@ function getDisplayName( purchase ) {
 	if ( jetpackProductsDisplayNames[ purchase.productSlug ] ) {
 		return jetpackProductsDisplayNames[ purchase.productSlug ];
 	}
-	if ( isDomainRegistration( purchase ) || isDomainMapping( purchase ) ) {
-		return purchase.productName;
-	}
 	return getName( purchase );
 }
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -101,7 +101,6 @@ function getName( purchase ) {
 	if ( isDomainRegistration( purchase ) || isDomainMapping( purchase ) ) {
 		return purchase.meta;
 	}
-
 	return purchase.productName;
 }
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -219,6 +219,53 @@ class RemovePurchase extends Component {
 		);
 	}
 
+	renderDomainMappingDialog() {
+		const { purchase, site } = this.props;
+
+		return (
+			<CancelPurchaseForm
+				disableButtons={ this.state.isRemoving }
+				defaultContent={ this.renderDomainMappingDialogText() }
+				purchase={ purchase }
+				selectedSite={ site }
+				isVisible={ this.state.isDialogVisible }
+				onClose={ this.closeDialog }
+				onClickFinalConfirm={ this.removePurchase }
+				flowType={ CANCEL_FLOW_TYPE.REMOVE }
+			/>
+		);
+	}
+
+	renderDomainMappingDialogText() {
+		const { purchase, translate } = this.props;
+		const productName = getName( purchase );
+		const domainProductName = getDisplayName( purchase );
+
+		return (
+			<div>
+				<p>
+					{
+						/* translators: "productName" is a product name (in this case, Domain Mapping). "domain" is something like example.wordpress.com */
+						translate( 'Are you sure you want to remove %(productName)s from {{domain/}}?', {
+							args: { productName },
+							components: { domain: <em>{ purchase.domain }</em> },
+							// ^ is the internal WPcom domain i.e. example.wordpress.com
+							// if we want to use the purchased domain we can swap with the below line
+							//{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
+						} )
+					}{ ' ' }
+					{ translate(
+						'You will not be able to reuse it again without starting a new %(domainProductName)s subscription.',
+						{
+							args: { productName, domainProductName },
+							comment: "'domainProductName' refers to Domain Mapping in this case.",
+						}
+					) }
+				</p>
+			</div>
+		);
+	}
+
 	renderPlanDialog() {
 		const { purchase, site } = this.props;
 
@@ -266,7 +313,7 @@ class RemovePurchase extends Component {
 					}{ ' ' }
 					{ isDomainRegistration &&
 						translate(
-							'You will not be able to reuse %(productName)s again without starting a new %(domainProductName)s subscription.',
+							'You will not be able to reuse it again without starting a new subscription.',
 							{
 								args: { productName, domainProductName },
 								comment: "'it' refers to a product purchased by a user",
@@ -324,7 +371,11 @@ class RemovePurchase extends Component {
 			return this.renderDomainDialog();
 		}
 
-		if ( isDomainMapping( purchase ) || isDomainTransfer( purchase ) || isTitanMail( purchase ) ) {
+		if ( isDomainMapping( purchase ) ) {
+			return this.renderDomainMappingDialog();
+		}
+
+		if ( isDomainTransfer( purchase ) || isTitanMail( purchase ) ) {
 			return this.renderPlanDialog();
 		}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -1,4 +1,16 @@
 import config from '@automattic/calypso-config';
+import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
+import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
+import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
+import {
+	getIncludedDomain,
+	getName,
+	getDisplayName,
+	hasIncludedDomain,
+	isRemovable,
+} from 'calypso/lib/purchases';
+import { isDataLoading } from '../utils';
 import {
 	isDomainMapping,
 	isDomainRegistration,
@@ -227,6 +239,7 @@ class RemovePurchase extends Component {
 	renderPlanDialogText() {
 		const { purchase, translate } = this.props;
 		const productName = getName( purchase );
+		const domainProductName = getDisplayName( purchase );
 		const includedDomainText = (
 			<p>
 				{ translate(
@@ -252,8 +265,11 @@ class RemovePurchase extends Component {
 						} )
 					}{ ' ' }
 					{ translate(
-						'You will not be able to reuse it again without purchasing a new subscription.',
-						{ comment: "'it' refers to a product purchased by a user" }
+						'You will not be able to reuse %(productName)s again without starting a new %(domainProductName)s subscription.',
+						{
+							args: { productName, domainProductName },
+							comment: "'it' refers to a product purchased by a user",
+						}
 					) }
 				</p>
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -1,16 +1,4 @@
 import config from '@automattic/calypso-config';
-import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
-import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
-import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
-import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
-import {
-	getIncludedDomain,
-	getName,
-	getDisplayName,
-	hasIncludedDomain,
-	isRemovable,
-} from 'calypso/lib/purchases';
-import { isDataLoading } from '../utils';
 import {
 	isDomainMapping,
 	isDomainRegistration,
@@ -36,7 +24,13 @@ import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-pur
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'calypso/lib/purchases';
+import {
+	getIncludedDomain,
+	getName,
+	getDisplayName,
+	hasIncludedDomain,
+	isRemovable,
+} from 'calypso/lib/purchases';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -24,13 +24,7 @@ import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-pur
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import {
-	getIncludedDomain,
-	getName,
-	getDisplayName,
-	hasIncludedDomain,
-	isRemovable,
-} from 'calypso/lib/purchases';
+import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'calypso/lib/purchases';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -232,26 +226,24 @@ class RemovePurchase extends Component {
 
 	renderDomainMappingDialogText() {
 		const { purchase, translate } = this.props;
-		const productName = getName( purchase );
+		const domainName = getName( purchase );
 		const domainProductName = purchase.productName;
 
 		return (
 			<div>
 				<p>
 					{
-						/* translators: "productName" is a product name (in this case, Domain Mapping). "domain" is something like example.wordpress.com */
-						translate( 'Are you sure you want to remove %(productName)s from {{domain/}}?', {
-							args: { productName },
-							components: { domain: <em>{ purchase.domain }</em> },
-							// ^ is the internal WPcom domain i.e. example.wordpress.com
-							// if we want to use the purchased domain we can swap with the below line
-							//{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
+						/* translators: "domainName" is the URL of the Domain Connection being removed (example: "mygroovysite.com"). "domainProductName" is a product name (in this case, Domain Connection).  */
+						translate( 'Are you sure you want to remove %(domainName)s from {{site/}}?', {
+							args: { domainName },
+							components: { site: <em>{ purchase.domain }</em> },
+							/* translators:  ^ "site" is the internal WPcom domain i.e. example.wordpress.com */
 						} )
 					}{ ' ' }
 					{ translate(
 						'You will not be able to reuse it again without starting a new %(domainProductName)s subscription.',
 						{
-							args: { productName, domainProductName },
+							args: { domainProductName },
 							comment: "'domainProductName' refers to Domain Mapping in this case.",
 						}
 					) }
@@ -280,7 +272,6 @@ class RemovePurchase extends Component {
 	renderPlanDialogText() {
 		const { purchase, translate } = this.props;
 		const productName = getName( purchase );
-		const domainProductName = getDisplayName( purchase );
 		const includedDomainText = (
 			<p>
 				{ translate(
@@ -309,7 +300,6 @@ class RemovePurchase extends Component {
 						translate(
 							'You will not be able to reuse it again without starting a new subscription.',
 							{
-								args: { productName, domainProductName },
 								comment: "'it' refers to a product purchased by a user",
 							}
 						) }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -239,7 +239,7 @@ class RemovePurchase extends Component {
 	renderDomainMappingDialogText() {
 		const { purchase, translate } = this.props;
 		const productName = getName( purchase );
-		const domainProductName = getDisplayName( purchase );
+		const domainProductName = purchase.productName;
 
 		return (
 			<div>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -264,13 +264,14 @@ class RemovePurchase extends Component {
 							//{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
 						} )
 					}{ ' ' }
-					{ translate(
-						'You will not be able to reuse %(productName)s again without starting a new %(domainProductName)s subscription.',
-						{
-							args: { productName, domainProductName },
-							comment: "'it' refers to a product purchased by a user",
-						}
-					) }
+					{ isDomainRegistration &&
+						translate(
+							'You will not be able to reuse %(productName)s again without starting a new %(domainProductName)s subscription.',
+							{
+								args: { productName, domainProductName },
+								comment: "'it' refers to a product purchased by a user",
+							}
+						) }
 				</p>
 
 				{ isPlan( purchase ) && hasIncludedDomain( purchase ) && includedDomainText }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As suggested in #49043, this PR will adjust the messaging when deleting a Domain Mapping subscription in order to better communicate the ramifications of removing it.

#### Testing instructions

1. Add a domain mapping to any plan.
2. Navigate through Upgrades > Domains > click on the domain mapping.
3. Click Delete Domain Mapping at the bottom.

You should be presented with a modal showing an updated message:

> Are you sure you want to remove `DOMAIN` from `SITEADDRESS`? You will not be able to reuse `DOMAIN` again without starting a new Domain Mapping subscription.

<img width="546" alt="Screen Shot 2021-08-11 at 3 38 15 PM" src="https://user-images.githubusercontent.com/8002138/129113801-c1361740-e18f-425f-9e80-135c35ce1249.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #49043
