### PR TITLE
Domains: Link domain connection error status with the new "connect a domain" flow

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -13,7 +13,7 @@ import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 import { hasPendingGSuiteUsers } from 'calypso/lib/gsuite';
 import { shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
-import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
 
 export function resolveDomainStatus(
 	domain,
@@ -60,7 +60,7 @@ export function resolveDomainStatus(
 							strong: <strong />,
 							a: (
 								<a
-									href={ domainManagementEdit( siteSlug, domain.domain ) }
+									href={ domainMappingSetup( siteSlug, domain.domain, 'suggested_update' ) }
 									onClick={ ( e ) => e.stopPropagation() }
 								/>
 							),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the link in the "connection error" domain status message to take the user to the `suggested_update` step of the new "connect a domain" flow, added in #54685. Previously, the link took the user to the old domain mapping instructions page. The "connection error" domain status was introduced by #54649 and is shown for connected domains that don't resolve to WPCOM after 72 hours.

This is part of the domains pages redesign work described in pcYYhz-e4-p2.

#### Screenshots

This is the link that was modified:

![Annotation on 2021-08-11 at 19-48-49](https://user-images.githubusercontent.com/5324818/129113763-3f636960-4a7a-441c-a254-9c9f406d8155.png)

#### Testing instructions

Open the live Calypso link, select a site where you have a connected domain that isn't resolving to WPCOM and ensure the "follow this setup again" link  takes you to the `suggested_update` step of the new "connect a domain" flow (the URL should look like `/domains/mapping/<site_slug>/setup/<connected_domain>?step=suggested_update`).

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
