### PR TITLE
Add electron to browserlist

### DIFF
--- a/client/server/middleware/build-target.js
+++ b/client/server/middleware/build-target.js
@@ -8,13 +8,12 @@ import { matchesUA } from 'browserslist-useragent';
  * @returns {boolean} Whether the user agent is included in the browser list.
  */
 function isUAInBrowserslist( userAgentString, environment = 'defaults' ) {
-	// If the user agent string includes Electron, it probably comes from the
-	// desktop app. Unfortunately, browserslist then parses the UA family to be
-	// "WordPress". We need to make sure we test against the Electron version
-	// instead, or the desktop app won't be considered a supported browser.
-	const electronUA = userAgentString.match( /(Electron\/[0-9.]*\S)/ );
-
-	return matchesUA( electronUA ? electronUA[ 0 ] : userAgentString, {
+	// The desktop app sends a UserAgent including WordPress, Electron and Chrome.
+	// We need to check if the chrome portion is supported, but the UA library
+	// will select WordPress and Electron before Chrome, giving a result not
+	// based on the chrome version.
+	const sanitizedUA = userAgentString.replace( / (WordPressDesktop|Electron)\/[.\d]+/g, '' );
+	return matchesUA( sanitizedUA, {
 		env: environment,
 		ignorePatch: true,
 		ignoreMinor: true,

--- a/client/server/middleware/build-target.js
+++ b/client/server/middleware/build-target.js
@@ -5,11 +5,16 @@ import { matchesUA } from 'browserslist-useragent';
  *
  * @param {string} userAgentString The user agent string.
  * @param {string} environment The `browserslist` environment.
- *
  * @returns {boolean} Whether the user agent is included in the browser list.
  */
 function isUAInBrowserslist( userAgentString, environment = 'defaults' ) {
-	return matchesUA( userAgentString, {
+	// If the user agent string includes Electron, it probably comes from the
+	// desktop app. Unfortunately, browserslist then parses the UA family to be
+	// "WordPress". We need to make sure we test against the Electron version
+	// instead, or the desktop app won't be considered a supported browser.
+	const electronUA = userAgentString.match( /(Electron\/[0-9.]*\S)/ );
+
+	return matchesUA( electronUA ? electronUA[ 0 ] : userAgentString, {
 		env: environment,
 		ignorePatch: true,
 		ignoreMinor: true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -134,7 +134,8 @@
 		"woocommerce/extension-referrers": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true,
-		"wordpress-action-search": false
+		"wordpress-action-search": false,
+		"redirect-fallback-browsers": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 			"last 2 Edge versions",
 			"last 2 Opera versions",
 			"Firefox ESR",
+			"Electron >= 11",
 			"unreleased Chrome versions",
 			"unreleased ChromeAndroid versions",
 			"unreleased Firefox versions",


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Add electron as a supported browser. I did versions >= to 11.0, which should support people using current and recently previous versions of the desktop app. This could be anything really, like 12.0.

- How do we ensure that this is updated when electron is updated?

### Testing:

**This does not solve the redirect problem yet.**

- Double check bundle size increase.
- Desktop tests should pass. (If they fail and the last visit URL is browsehappy in desktop e2e > artifacts > logs > electron, the redirect still exists)