### PR TITLE
Add tracks event for the "add new post" button post-publish

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -5,6 +5,7 @@ import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomBlockEditorDetailsOpen from './wpcom-block-editor-details-open';
 import wpcomBlockEditorGlobalStylesTabSelected from './wpcom-block-editor-global-styles-tab-selected';
 import wpcomBlockEditorListViewSelect from './wpcom-block-editor-list-view-select';
+import wpcomBlockEditorPostPublishAddNewClick from './wpcom-block-editor-post-publish-add-new-click';
 import wpcomBlockEditorTemplatePartDetachBlocks from './wpcom-block-editor-template-part-detach-blocks';
 import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-plan-upgrade';
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
@@ -57,6 +58,7 @@ const EVENTS_MAPPING = [
 	wpcomTemplatePartChooseExisting(),
 	wpcomBlockEditorListViewSelect(),
 	wpcomBlockEditorTemplatePartDetachBlocks(),
+	wpcomBlockEditorPostPublishAddNewClick(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-post-publish-add-new-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-post-publish-add-new-click.js
@@ -1,0 +1,13 @@
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_post_publish_add_new_click`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-block-editor-post-public-add-new-click',
+	selector: '.post-publish-panel__postpublish-buttons [href*="post-new.php"]',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_editor_post_publish_add_new_click' ),
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds tracking to the "Add new post/page" button

<img width="1070" alt="Screen Shot 2021-08-12 at 11 16 43 am" src="https://user-images.githubusercontent.com/1500769/129296889-ae454342-118b-4e79-a0fc-519ae0147808.png">

This button was added in WordPress/gutenberg#33276 and we want to know how much it gets used.

p1628731010423300-slack-C029SB8JT8S

Read more about testing tracks events in the block editor: PCYsg-nrf-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com`
* Run in your sandbox: `install-plugin.sh wpcom-block-editor add/tracks-new-post-button-after-publish`
* Open network tools and filter by `wpcom_block_editor_post_publish_add_new_click`
* Ensure the network tools are persisting logs (part of testing involves a page transition, so we don't want the event to disappear before we can verify it)
* Publish a post/page
* Check that the `wpcom_block_editor_post_publish_add_new_click` event was sent and that the `post_type` property is set to either `'post'` or `'page'`

Because this tracking depends on a CSS selector I'll add e2e test to we're notified if the selector breaks. I'll add the test in a follow up PR because the tests will just fail until this change has merged (tests are run against the production version of `widgets.wp.com`) #55483

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->