### PR TITLE
Show proper error on the domain suggestions screen when the customer is blocked

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1022,6 +1022,7 @@ class RegisterDomainStep extends React.Component {
 				} else if ( error && error.error ) {
 					this.showSuggestionErrorMessage( domain, error.error, {
 						maintenanceEndTime: get( error, 'data.maintenance_end_time', null ),
+						site: this.props?.selectedSite,
 					} );
 				}
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -382,6 +382,18 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			);
 			break;
 
+		case 'blocked':
+			const supportURL = 'https://wordpress.com/error-report/?url=495@' + ( site?.slug || '' );
+			message = translate(
+				"You're blocked from purchasing domains on WordPress.com. Please {{a}}contact our support{{/a}} to find out why.",
+				{
+					components: {
+						a: <a rel="noopener noreferrer" href={ supportURL } />,
+					},
+				}
+			);
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'


### PR DESCRIPTION
Show proper error message when the domain suggestions endpoint returns `blocked`. This can happen in case the customer is marked because of violation of our ToS

#### Changes proposed in this Pull Request

* Add separate error message when the domain suggestions endpoint returns that the customer is `blocked`

Before:

<img width="946" alt="Screenshot 2021-08-12 at 14 10 24" src="https://user-images.githubusercontent.com/1355045/129187283-c1eabbea-0f0b-4fc8-a308-43b26a67fd4f.png">

After:

<img width="1006" alt="Screenshot 2021-08-12 at 14 10 32" src="https://user-images.githubusercontent.com/1355045/129187291-d2684a9c-4738-4c54-a3d1-92808fa5da91.png">


#### Testing instructions

* You'll need to be logged in as customer that's blocked (or change the backend to return blocked error). Then try to get domain suggestions in all the flows and verify that you see the proper error message.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
