### PR TITLE
chore: migrate `client/state/editor` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -218,6 +218,8 @@ module.exports = {
 				'client/state/checklist/**/*',
 				'client/state/data-getters/**/*',
 				'client/state/editor/**/*',
+				'client/state/google-my-business/**/*',
+				'client/state/happychat/**/*',
 				'client/support/**/*',
 				'client/test-helpers/**/*',
 				'client/types.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -217,6 +217,7 @@ module.exports = {
 				'client/state/active-promotions/**/*',
 				'client/state/checklist/**/*',
 				'client/state/data-getters/**/*',
+				'client/state/editor/**/*',
 				'client/support/**/*',
 				'client/test-helpers/**/*',
 				'client/types.ts',

--- a/client/state/editor/actions.js
+++ b/client/state/editor/actions.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import { filter } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { EDITOR_IFRAME_LOADED, EDITOR_START, EDITOR_STOP } from 'calypso/state/action-types';
-import { ModalViews } from 'calypso/state/ui/media-modal/constants';
-import { setMediaModalView } from 'calypso/state/ui/media-modal/actions';
 import { withAnalytics, bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import { setMediaModalView } from 'calypso/state/ui/media-modal/actions';
+import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 
 import 'calypso/state/editor/init';
 import 'calypso/state/ui/init';

--- a/client/state/editor/image-editor/actions.js
+++ b/client/state/editor/image-editor/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	IMAGE_EDITOR_CROP,
 	IMAGE_EDITOR_COMPUTED_CROP,

--- a/client/state/editor/image-editor/reducer.js
+++ b/client/state/editor/image-editor/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	IMAGE_EDITOR_CROP,
 	IMAGE_EDITOR_COMPUTED_CROP,

--- a/client/state/editor/image-editor/selectors.js
+++ b/client/state/editor/image-editor/selectors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/editor/init';
 
 /**

--- a/client/state/editor/image-editor/test/actions.js
+++ b/client/state/editor/image-editor/test/actions.js
@@ -1,11 +1,17 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import {
+	IMAGE_EDITOR_CROP,
+	IMAGE_EDITOR_COMPUTED_CROP,
+	IMAGE_EDITOR_ROTATE_COUNTERCLOCKWISE,
+	IMAGE_EDITOR_FLIP,
+	IMAGE_EDITOR_SET_ASPECT_RATIO,
+	IMAGE_EDITOR_SET_DEFAULT_ASPECT_RATIO,
+	IMAGE_EDITOR_SET_FILE_INFO,
+	IMAGE_EDITOR_SET_CROP_BOUNDS,
+	IMAGE_EDITOR_STATE_RESET,
+	IMAGE_EDITOR_STATE_RESET_ALL,
+	IMAGE_EDITOR_IMAGE_HAS_LOADED,
+} from 'calypso/state/action-types';
 import {
 	resetImageEditorState,
 	resetAllImageEditorState,
@@ -20,19 +26,6 @@ import {
 	setImageEditorImageHasLoaded,
 } from '../actions';
 import { AspectRatios } from '../constants';
-import {
-	IMAGE_EDITOR_CROP,
-	IMAGE_EDITOR_COMPUTED_CROP,
-	IMAGE_EDITOR_ROTATE_COUNTERCLOCKWISE,
-	IMAGE_EDITOR_FLIP,
-	IMAGE_EDITOR_SET_ASPECT_RATIO,
-	IMAGE_EDITOR_SET_DEFAULT_ASPECT_RATIO,
-	IMAGE_EDITOR_SET_FILE_INFO,
-	IMAGE_EDITOR_SET_CROP_BOUNDS,
-	IMAGE_EDITOR_STATE_RESET,
-	IMAGE_EDITOR_STATE_RESET_ALL,
-	IMAGE_EDITOR_IMAGE_HAS_LOADED,
-} from 'calypso/state/action-types';
 
 describe( 'actions', () => {
 	describe( '#resetImageEditorState()', () => {

--- a/client/state/editor/image-editor/test/reducer.js
+++ b/client/state/editor/image-editor/test/reducer.js
@@ -1,23 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
-import { AspectRatios } from '../constants';
-import reducer, {
-	hasChanges,
-	fileInfo,
-	transform,
-	cropBounds,
-	crop,
-	aspectRatio,
-	imageIsLoading,
-	originalAspectRatio,
-} from '../reducer';
 import {
 	IMAGE_EDITOR_CROP,
 	IMAGE_EDITOR_COMPUTED_CROP,
@@ -31,6 +13,17 @@ import {
 	IMAGE_EDITOR_STATE_RESET_ALL,
 	IMAGE_EDITOR_IMAGE_HAS_LOADED,
 } from 'calypso/state/action-types';
+import { AspectRatios } from '../constants';
+import reducer, {
+	hasChanges,
+	fileInfo,
+	transform,
+	cropBounds,
+	crop,
+	aspectRatio,
+	imageIsLoading,
+	originalAspectRatio,
+} from '../reducer';
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {

--- a/client/state/editor/image-editor/test/selectors.js
+++ b/client/state/editor/image-editor/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { AspectRatios } from '../constants';
 import {
 	getImageEditorTransform,

--- a/client/state/editor/init.js
+++ b/client/state/editor/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 

--- a/client/state/editor/last-draft/actions.js
+++ b/client/state/editor/last-draft/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { EDITOR_LAST_DRAFT_SET } from 'calypso/state/action-types';
 
 import 'calypso/state/editor/init';

--- a/client/state/editor/last-draft/reducer.js
+++ b/client/state/editor/last-draft/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { EDITOR_LAST_DRAFT_SET } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
 

--- a/client/state/editor/last-draft/selectors.js
+++ b/client/state/editor/last-draft/selectors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getEditedPost } from 'calypso/state/posts/selectors';
 
 import 'calypso/state/editor/init';

--- a/client/state/editor/last-draft/test/actions.js
+++ b/client/state/editor/last-draft/test/actions.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { setEditorLastDraft, resetEditorLastDraft } from '../actions';
 import { EDITOR_LAST_DRAFT_SET } from 'calypso/state/action-types';
+import { setEditorLastDraft, resetEditorLastDraft } from '../actions';
 
 describe( 'actions', () => {
 	describe( '#setEditorLastDraft()', () => {

--- a/client/state/editor/last-draft/test/reducer.js
+++ b/client/state/editor/last-draft/test/reducer.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import reducer, { siteId, postId } from '../reducer';
 import { EDITOR_LAST_DRAFT_SET } from 'calypso/state/action-types';
+import reducer, { siteId, postId } from '../reducer';
 
 describe( 'reducer', () => {
 	test( 'should include expected keys in return value', () => {

--- a/client/state/editor/last-draft/test/selectors.js
+++ b/client/state/editor/last-draft/test/selectors.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import PostQueryManager from 'calypso/lib/query-manager/post';
 import {
 	getEditorLastDraftPost,
 	getEditorLastDraftSiteId,
 	getEditorLastDraftPostId,
 } from '../selectors';
-import PostQueryManager from 'calypso/lib/query-manager/post';
 
 describe( 'selectors', () => {
 	describe( '#getEditorLastDraftPost()', () => {

--- a/client/state/editor/reducer.js
+++ b/client/state/editor/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
 import {
 	EDITOR_IFRAME_LOADED,
@@ -10,8 +7,8 @@ import {
 } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
 import imageEditor from './image-editor/reducer';
-import videoEditor from './video-editor/reducer';
 import lastDraft from './last-draft/reducer';
+import videoEditor from './video-editor/reducer';
 
 /**
  * Returns the updated editor post ID state after an action has been

--- a/client/state/editor/selectors.js
+++ b/client/state/editor/selectors.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { addQueryArgs } from 'calypso/lib/route';
 import { getEditedPost } from 'calypso/state/posts/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
-import { addQueryArgs } from 'calypso/lib/route';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 import 'calypso/state/editor/init';
 

--- a/client/state/editor/test/actions.js
+++ b/client/state/editor/test/actions.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { forEach } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { MODAL_VIEW_STATS, setEditorMediaModalView } from '../actions';
 import { ANALYTICS_STAT_BUMP } from 'calypso/state/action-types';
 import { setMediaModalView } from 'calypso/state/ui/media-modal/actions';
+import { MODAL_VIEW_STATS, setEditorMediaModalView } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'setEditorMediaModalView()', () => {

--- a/client/state/editor/test/reducer.js
+++ b/client/state/editor/test/reducer.js
@@ -1,8 +1,5 @@
-/**
- * Internal dependencies
- */
-import reducer, { postId, iframePort } from '../reducer';
 import { EDITOR_START, POST_SAVE_SUCCESS, EDITOR_IFRAME_LOADED } from 'calypso/state/action-types';
+import reducer, { postId, iframePort } from '../reducer';
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {

--- a/client/state/editor/test/selectors.js
+++ b/client/state/editor/test/selectors.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import PostQueryManager from 'calypso/lib/query-manager/post';
 import {
 	getEditorPostId,
 	isEditorNewPost,
 	getEditorNewPostPath,
 	getEditorPath,
 } from '../selectors';
-import PostQueryManager from 'calypso/lib/query-manager/post';
 
 describe( 'selectors', () => {
 	describe( '#getEditorPostId()', () => {

--- a/client/state/editor/video-editor/actions.js
+++ b/client/state/editor/video-editor/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	VIDEO_EDITOR_SET_POSTER_URL,
 	VIDEO_EDITOR_SHOW_ERROR,

--- a/client/state/editor/video-editor/reducer.js
+++ b/client/state/editor/video-editor/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	VIDEO_EDITOR_SET_POSTER_URL,
 	VIDEO_EDITOR_SHOW_ERROR,

--- a/client/state/editor/video-editor/test/actions.js
+++ b/client/state/editor/video-editor/test/actions.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { setPosterUrl, showError, showUploadProgress, updatePoster } from '../actions';
 import {
 	VIDEO_EDITOR_SET_POSTER_URL,
 	VIDEO_EDITOR_SHOW_ERROR,
 	VIDEO_EDITOR_SHOW_UPLOAD_PROGRESS,
 	VIDEO_EDITOR_UPDATE_POSTER,
 } from 'calypso/state/action-types';
+import { setPosterUrl, showError, showUploadProgress, updatePoster } from '../actions';
 
 describe( 'actions', () => {
 	describe( '#updatePoster()', () => {

--- a/client/state/editor/video-editor/test/reducer.js
+++ b/client/state/editor/video-editor/test/reducer.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import reducer, { showError, uploadProgress, url } from '../reducer';
 import {
 	VIDEO_EDITOR_SET_POSTER_URL,
 	VIDEO_EDITOR_SHOW_ERROR,
 	VIDEO_EDITOR_SHOW_UPLOAD_PROGRESS,
 } from 'calypso/state/action-types';
+import reducer, { showError, uploadProgress, url } from '../reducer';
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {

--- a/client/state/google-my-business/actions.js
+++ b/client/state/google-my-business/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	GOOGLE_MY_BUSINESS_STATS_FAILURE,
 	GOOGLE_MY_BUSINESS_STATS_RECEIVE,

--- a/client/state/google-my-business/init.js
+++ b/client/state/google-my-business/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 

--- a/client/state/google-my-business/reducer.js
+++ b/client/state/google-my-business/reducer.js
@@ -1,14 +1,11 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
-import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import {
 	GOOGLE_MY_BUSINESS_STATS_FAILURE,
 	GOOGLE_MY_BUSINESS_STATS_RECEIVE,
 	GOOGLE_MY_BUSINESS_STATS_REQUEST,
 } from 'calypso/state/action-types';
 import { statsInterval } from 'calypso/state/google-my-business/ui/reducer';
+import { combineReducers, keyedReducer } from 'calypso/state/utils';
 
 const stats = ( state = null, action ) => {
 	switch ( action.type ) {

--- a/client/state/google-my-business/test/index.js
+++ b/client/state/google-my-business/test/index.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import googleMyBusinessReducer from '../reducer';
 import {
 	GOOGLE_MY_BUSINESS_STATS_RECEIVE,
 	GOOGLE_MY_BUSINESS_STATS_REQUEST,
 } from 'calypso/state/action-types';
+import googleMyBusinessReducer from '../reducer';
 
 describe( 'reducer', () => {
 	describe( '#stats', () => {

--- a/client/state/google-my-business/ui/actions.js
+++ b/client/state/google-my-business/ui/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { GOOGLE_MY_BUSINESS_STATS_CHANGE_INTERVAL } from 'calypso/state/action-types';
 
 import 'calypso/state/google-my-business/init';

--- a/client/state/google-my-business/ui/reducer.js
+++ b/client/state/google-my-business/ui/reducer.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 import { GOOGLE_MY_BUSINESS_STATS_CHANGE_INTERVAL } from 'calypso/state/action-types';
 
 export const statsInterval = ( state = 'week', action ) => {

--- a/client/state/google-my-business/ui/selectors.js
+++ b/client/state/google-my-business/ui/selectors.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/google-my-business/init';
 
 /**

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,12 +1,6 @@
 /* eslint-disable no-case-declarations */
-/**
- * External dependencies
- */
-import { concat, filter, find, findIndex, map, get, sortBy } from 'lodash';
 
-/**
- * Internal dependencies
- */
+import { concat, filter, find, findIndex, map, get, sortBy } from 'lodash';
 import {
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE_UPDATE,

--- a/client/state/happychat/chat/test/reducer.js
+++ b/client/state/happychat/chat/test/reducer.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { lastActivityTimestamp } from '../reducer';
 import {
 	HAPPYCHAT_IO_RECEIVE_INIT,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE,
 } from 'calypso/state/action-types';
+import { lastActivityTimestamp } from '../reducer';
 
 // Simulate the time Feb 27, 2017 05:25 UTC
 const NOW = 1488173100125;

--- a/client/state/happychat/connection/actions.js
+++ b/client/state/happychat/connection/actions.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { v4 as uuid } from 'uuid';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_IO_INIT,
 	HAPPYCHAT_IO_RECEIVE_ACCEPT,

--- a/client/state/happychat/connection/reducer.js
+++ b/client/state/happychat/connection/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_IO_INIT,
 	HAPPYCHAT_IO_RECEIVE_ACCEPT,

--- a/client/state/happychat/connection/test/actions.js
+++ b/client/state/happychat/connection/test/actions.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { HAPPYCHAT_IO_RECEIVE_INIT } from 'calypso/state/action-types';
 import { receiveInit } from '../actions';
 

--- a/client/state/happychat/connection/test/reducer.js
+++ b/client/state/happychat/connection/test/reducer.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { localizedSupport } from '../reducer';
 import {
 	HAPPYCHAT_IO_RECEIVE_INIT,
 	HAPPYCHAT_IO_RECEIVE_LOCALIZED_SUPPORT,
 } from 'calypso/state/action-types';
+import { localizedSupport } from '../reducer';
 
 describe( 'reducers', () => {
 	describe( '#localizedSupport', () => {

--- a/client/state/happychat/init.js
+++ b/client/state/happychat/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { has } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	ANALYTICS_EVENT_RECORD,
 	HELP_CONTACT_FORM_SITE_SELECT,
@@ -25,28 +18,28 @@ import {
 	PURCHASE_REMOVE_COMPLETED,
 	SITE_SETTINGS_SAVE_SUCCESS,
 } from 'calypso/state/action-types';
-import { JETPACK_CONNECT_AUTHORIZE } from 'calypso/state/jetpack-connect/action-types';
-import {
-	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
-	HAPPYCHAT_CHAT_STATUS_PENDING,
-} from 'calypso/state/happychat/constants';
+import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import {
 	sendEvent,
 	sendLog,
 	sendPreferences,
 	setChatCustomFields,
 } from 'calypso/state/happychat/connection/actions';
-import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
+import {
+	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
+} from 'calypso/state/happychat/constants';
 import getGroups from 'calypso/state/happychat/selectors/get-groups';
+import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
 import getSkills from 'calypso/state/happychat/selectors/get-skills';
 import isHappychatChatAssigned from 'calypso/state/happychat/selectors/is-happychat-chat-assigned';
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
-import getSectionName from 'calypso/state/ui/selectors/get-section-name';
+import { JETPACK_CONNECT_AUTHORIZE } from 'calypso/state/jetpack-connect/action-types';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
+import getSectionName from 'calypso/state/ui/selectors/get-section-name';
 
 const noop = () => {};
 

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
+import buildConnection from 'calypso/lib/happychat/connection-async';
 import {
 	HAPPYCHAT_BLUR,
 	HAPPYCHAT_FOCUS,
@@ -20,9 +14,8 @@ import {
 	HAPPYCHAT_IO_SET_CUSTOM_FIELDS,
 } from 'calypso/state/action-types';
 import { sendEvent, setChatCustomFields } from 'calypso/state/happychat/connection/actions';
-import buildConnection from 'calypso/lib/happychat/connection-async';
-import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 import isHappychatChatAssigned from 'calypso/state/happychat/selectors/is-happychat-chat-assigned';
+import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 
 const noop = () => {};
 const eventMessage = {

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
 import { combineReducers } from 'calypso/state/utils';
 import chat from './chat/reducer';

--- a/client/state/happychat/selectors/can-user-send-messages.js
+++ b/client/state/happychat/selectors/can-user-send-messages.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_BLOCKED,
@@ -13,7 +6,6 @@ import {
 	HAPPYCHAT_CHAT_STATUS_MISSED,
 	HAPPYCHAT_CHAT_STATUS_PENDING,
 } from 'calypso/state/happychat/constants';
-
 import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 

--- a/client/state/happychat/selectors/get-geolocation.js
+++ b/client/state/happychat/selectors/get-geolocation.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/get-groups.js
+++ b/client/state/happychat/selectors/get-groups.js
@@ -1,10 +1,7 @@
-/**
- * Internal dependencies
- */
-import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'calypso/state/happychat/constants';
 import { isEnabled } from '@automattic/calypso-config';
-import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import { isATEnabled } from 'calypso/lib/automated-transfer';
+import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'calypso/state/happychat/constants';
+import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 /**

--- a/client/state/happychat/selectors/get-happychat-chat-status.js
+++ b/client/state/happychat/selectors/get-happychat-chat-status.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/get-happychat-connection-status.js
+++ b/client/state/happychat/selectors/get-happychat-connection-status.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/get-happychat-current-message.js
+++ b/client/state/happychat/selectors/get-happychat-current-message.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 export default ( state ) => get( state, 'happychat.ui.currentMessage' );

--- a/client/state/happychat/selectors/get-happychat-lastactivitytimestamp.js
+++ b/client/state/happychat/selectors/get-happychat-lastactivitytimestamp.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/get-happychat-userinfo.js
+++ b/client/state/happychat/selectors/get-happychat-userinfo.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import getGeoLocation from 'calypso/state/happychat/selectors/get-geolocation';
 
 export default ( state ) => ( { site, howCanWeHelp, howYouFeel } ) => {

--- a/client/state/happychat/selectors/get-lostfocus-timestamp.js
+++ b/client/state/happychat/selectors/get-lostfocus-timestamp.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 export default ( state ) => get( state, 'happychat.ui.lostFocusAt' );

--- a/client/state/happychat/selectors/get-skills.js
+++ b/client/state/happychat/selectors/get-skills.js
@@ -1,12 +1,9 @@
-/**
- * Internal dependencies
- */
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import {
 	HAPPYCHAT_SKILL_PRODUCT,
 	HAPPYCHAT_SKILL_LANGUAGE,
 } from 'calypso/state/happychat/constants';
 import getGroups from 'calypso/state/happychat/selectors/get-groups';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 
 /**
  * Returns an object of happychat skills array ( product - before known as groups and language )

--- a/client/state/happychat/selectors/has-active-happychat-session.js
+++ b/client/state/happychat/selectors/has-active-happychat-session.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { createSelector } from '@automattic/state-utils';
 import { includes } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CHAT_STATUS_BLOCKED,
 	HAPPYCHAT_CHAT_STATUS_CLOSED,
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 	HAPPYCHAT_CHAT_STATUS_NEW,
 } from 'calypso/state/happychat/constants';
-import { createSelector } from '@automattic/state-utils';
 
 import 'calypso/state/happychat/init';
 

--- a/client/state/happychat/selectors/has-happychat-localized-support.js
+++ b/client/state/happychat/selectors/has-happychat-localized-support.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 
 import 'calypso/state/happychat/init';

--- a/client/state/happychat/selectors/has-unread-messages.js
+++ b/client/state/happychat/selectors/has-unread-messages.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { get, last } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { createSelector } from '@automattic/state-utils';
+import { get, last } from 'lodash';
 import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happychat-timeline';
 import getLostFocusTimestamp from 'calypso/state/happychat/selectors/get-lostfocus-timestamp';
 

--- a/client/state/happychat/selectors/is-happychat-available.js
+++ b/client/state/happychat/selectors/is-happychat-available.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import isHappychatClientConnected from 'calypso/state/happychat/selectors/is-happychat-client-connected';
 
 import 'calypso/state/happychat/init';

--- a/client/state/happychat/selectors/is-happychat-chat-assigned.js
+++ b/client/state/happychat/selectors/is-happychat-chat-assigned.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { HAPPYCHAT_CHAT_STATUS_ASSIGNED } from 'calypso/state/happychat/constants';
 
 import 'calypso/state/happychat/init';

--- a/client/state/happychat/selectors/is-happychat-client-connected.js
+++ b/client/state/happychat/selectors/is-happychat-client-connected.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { HAPPYCHAT_CONNECTION_STATUS_CONNECTED } from 'calypso/state/happychat/constants';
 import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
 

--- a/client/state/happychat/selectors/is-happychat-connection-uninitialized.js
+++ b/client/state/happychat/selectors/is-happychat-connection-uninitialized.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED } from 'calypso/state/happychat/constants';
 import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
 

--- a/client/state/happychat/selectors/is-happychat-minimizing.js
+++ b/client/state/happychat/selectors/is-happychat-minimizing.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/is-happychat-open.js
+++ b/client/state/happychat/selectors/is-happychat-open.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { createSelector } from '@automattic/state-utils';
 import { getSectionName } from 'calypso/state/ui/selectors';
 

--- a/client/state/happychat/selectors/is-happychat-server-reachable.js
+++ b/client/state/happychat/selectors/is-happychat-server-reachable.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT } from 'calypso/state/happychat/constants';
 
 import 'calypso/state/happychat/init';

--- a/client/state/happychat/selectors/is-happychat-user-eligible.js
+++ b/client/state/happychat/selectors/is-happychat-user-eligible.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/is-precancellation-chat-available.js
+++ b/client/state/happychat/selectors/is-precancellation-chat-available.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/is-presales-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-chat-available.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
 import 'calypso/state/happychat/init';
 
 /**

--- a/client/state/happychat/selectors/test/can-user-send-messages.js
+++ b/client/state/happychat/selectors/test/can-user-send-messages.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,

--- a/client/state/happychat/selectors/test/get-geolocation.js
+++ b/client/state/happychat/selectors/test/get-geolocation.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import getGeoLocation from '../get-geolocation';
 
 describe( 'getGeoLocation', () => {

--- a/client/state/happychat/selectors/test/get-groups.js
+++ b/client/state/happychat/selectors/test/get-groups.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'calypso/state/happychat/constants';

--- a/client/state/happychat/selectors/test/get-happychat-connection-status.js
+++ b/client/state/happychat/selectors/test/get-happychat-connection-status.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,

--- a/client/state/happychat/selectors/test/get-happychat-userinfo.js
+++ b/client/state/happychat/selectors/test/get-happychat-userinfo.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
 import getUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
 
 describe( 'HAPPYCHAT_IO_SEND_MESSAGE_USERINFO action', () => {

--- a/client/state/happychat/selectors/test/get-lostfocus-timestamp.js
+++ b/client/state/happychat/selectors/test/get-lostfocus-timestamp.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import getLostFocusTimestamp from '../get-lostfocus-timestamp';
 
 // Simulate the time Feb 27, 2017 05:25 UTC

--- a/client/state/happychat/selectors/test/get-skills.js
+++ b/client/state/happychat/selectors/test/get-skills.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_GROUP_WPCOM,
 	HAPPYCHAT_GROUP_JPOP,

--- a/client/state/happychat/selectors/test/has-active-happychat-session.js
+++ b/client/state/happychat/selectors/test/has-active-happychat-session.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,

--- a/client/state/happychat/selectors/test/has-happychat-localized-support.js
+++ b/client/state/happychat/selectors/test/has-happychat-localized-support.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,

--- a/client/state/happychat/selectors/test/has-unread-messages.js
+++ b/client/state/happychat/selectors/test/has-unread-messages.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import hasUnreadMessages from '../has-unread-messages';
 
 // Simulate the time Feb 27, 2017 05:25 UTC

--- a/client/state/happychat/selectors/test/is-happychat-available.js
+++ b/client/state/happychat/selectors/test/is-happychat-available.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,

--- a/client/state/happychat/selectors/test/is-happychat-client-connected.js
+++ b/client/state/happychat/selectors/test/is-happychat-client-connected.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,

--- a/client/state/happychat/selectors/test/is-happychat-connection-uninitialized.js
+++ b/client/state/happychat/selectors/test/is-happychat-connection-uninitialized.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,

--- a/client/state/happychat/selectors/test/is-happychat-server-reachable.js
+++ b/client/state/happychat/selectors/test/is-happychat-server-reachable.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_CONNECTION_ERROR_FORCED_CLOSE,
 	HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT,

--- a/client/state/happychat/selectors/test/is-precancellation-chat-available.js
+++ b/client/state/happychat/selectors/test/is-precancellation-chat-available.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import isPrecancellationChatAvailable from '../is-precancellation-chat-available';
 
 describe( '#isPrecancellationChatAvailable()', () => {

--- a/client/state/happychat/selectors/test/is-presales-chat-available.js
+++ b/client/state/happychat/selectors/test/is-presales-chat-available.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import isPresalesChatAvailable from '../is-presales-chat-available';
 
 describe( '#isPresalesChatAvailable()', () => {

--- a/client/state/happychat/selectors/test/was-happychat-recently-active.js
+++ b/client/state/happychat/selectors/test/was-happychat-recently-active.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import wasHappychatRecentlyActive from 'calypso/state/happychat/selectors/was-happychat-recently-active';
 
 const TIME_SECOND = 1000;

--- a/client/state/happychat/selectors/was-happychat-recently-active.js
+++ b/client/state/happychat/selectors/was-happychat-recently-active.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import getHappychatLastActivityTimestamp from 'calypso/state/happychat/selectors/get-happychat-lastactivitytimestamp';
 
 // How much time needs to pass before we consider the session inactive:

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -1,21 +1,12 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
-import middleware, {
-	sendActionLogsAndEvents,
-	sendAnalyticsLogEvent,
-	getEventMessageFromTracksData,
-} from '../middleware-calypso';
-import getSkills from 'calypso/state/happychat/selectors/get-skills';
-import { selectSiteId } from 'calypso/state/help/actions';
-import { setRoute } from 'calypso/state/route/actions';
+import {
+	ANALYTICS_EVENT_RECORD,
+	HAPPYCHAT_IO_SEND_MESSAGE_EVENT,
+	HAPPYCHAT_IO_SEND_MESSAGE_LOG,
+	HAPPYCHAT_IO_SET_CUSTOM_FIELDS,
+	SITE_SETTINGS_SAVE_SUCCESS,
+} from 'calypso/state/action-types';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import getGroups from 'calypso/state/happychat/selectors/get-groups';
 import { receiveStatus, sendPreferences } from 'calypso/state/happychat/connection/actions';
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
@@ -26,13 +17,15 @@ import {
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
 	HAPPYCHAT_CONNECTION_STATUS_DISCONNECTED,
 } from 'calypso/state/happychat/constants';
-import {
-	ANALYTICS_EVENT_RECORD,
-	HAPPYCHAT_IO_SEND_MESSAGE_EVENT,
-	HAPPYCHAT_IO_SEND_MESSAGE_LOG,
-	HAPPYCHAT_IO_SET_CUSTOM_FIELDS,
-	SITE_SETTINGS_SAVE_SUCCESS,
-} from 'calypso/state/action-types';
+import getGroups from 'calypso/state/happychat/selectors/get-groups';
+import getSkills from 'calypso/state/happychat/selectors/get-skills';
+import { selectSiteId } from 'calypso/state/help/actions';
+import { setRoute } from 'calypso/state/route/actions';
+import middleware, {
+	sendActionLogsAndEvents,
+	sendAnalyticsLogEvent,
+	getEventMessageFromTracksData,
+} from '../middleware-calypso';
 
 describe( 'middleware', () => {
 	let actionMiddleware;

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-import { socketMiddleware as middleware } from '../middleware';
 import { HAPPYCHAT_IO_SET_CUSTOM_FIELDS } from 'calypso/state/action-types';
 import {
 	initConnection,
@@ -15,7 +11,6 @@ import {
 	sendNotTyping,
 	setChatCustomFields,
 } from 'calypso/state/happychat/connection/actions';
-import { blur, focus } from 'calypso/state/happychat/ui/actions';
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
@@ -33,6 +28,8 @@ import {
 	HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED,
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 } from 'calypso/state/happychat/constants';
+import { blur, focus } from 'calypso/state/happychat/ui/actions';
+import { socketMiddleware as middleware } from '../middleware';
 
 describe( 'middleware', () => {
 	let actionMiddleware;

--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -1,10 +1,7 @@
-/**
- * Internal dependencies
- */
-import { getHappychatAuth } from '../utils';
 import config from '@automattic/calypso-config';
 import * as wpcom from 'calypso/lib/wp';
 import * as selectedSite from 'calypso/state/help/selectors';
+import { getHappychatAuth } from '../utils';
 
 jest.mock( 'calypso/state/help/selectors', () => ( {
 	getHelpSelectedSite: jest.fn(),

--- a/client/state/happychat/ui/actions.js
+++ b/client/state/happychat/ui/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_OPEN,
 	HAPPYCHAT_MINIMIZING,

--- a/client/state/happychat/ui/reducer.js
+++ b/client/state/happychat/ui/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_OPEN,
 	HAPPYCHAT_MINIMIZING,

--- a/client/state/happychat/ui/test/index.js
+++ b/client/state/happychat/ui/test/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_BLUR,
 	HAPPYCHAT_FOCUS,

--- a/client/state/happychat/user/actions.js
+++ b/client/state/happychat/user/actions.js
@@ -1,15 +1,12 @@
-/**
- * Internal dependencies
- */
 import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 import {
 	HAPPYCHAT_ELIGIBILITY_SET,
 	PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET,
 } from 'calypso/state/action-types';
-import { errorNotice } from 'calypso/state/notices/actions';
 import { setSupportLevel } from 'calypso/state/help/actions';
 import { logToLogstash } from 'calypso/state/logstash/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 import 'calypso/state/happychat/init';
 

--- a/client/state/happychat/user/reducer.js
+++ b/client/state/happychat/user/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	HAPPYCHAT_IO_RECEIVE_INIT,
 	HAPPYCHAT_ELIGIBILITY_SET,

--- a/client/state/happychat/user/test/reducer.js
+++ b/client/state/happychat/user/test/reducer.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { deserialize } from 'calypso/state/utils';
 import { HAPPYCHAT_IO_RECEIVE_INIT } from 'calypso/state/action-types';
+import { deserialize } from 'calypso/state/utils';
 import { geoLocation } from '../reducer';
 
 describe( '#geoLocation()', () => {

--- a/client/state/happychat/utils.js
+++ b/client/state/happychat/utils.js
@@ -1,12 +1,9 @@
-/**
- * Internal dependencies
- */
-import wpcom from 'calypso/lib/wp';
 import config from '@automattic/calypso-config';
-import getGroups from 'calypso/state/happychat/selectors/get-groups';
+import wpcom from 'calypso/lib/wp';
 import { getCurrentUser, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { getHelpSelectedSite } from 'calypso/state/help/selectors';
+import getGroups from 'calypso/state/happychat/selectors/get-groups';
 import getSkills from 'calypso/state/happychat/selectors/get-skills';
+import { getHelpSelectedSite } from 'calypso/state/help/selectors';
 
 const sign = ( payload ) => wpcom.req.post( '/jwt/sign', { payload: JSON.stringify( payload ) } );
 


### PR DESCRIPTION
#### Background

See #54448

stacked upon #55446 to prevent merge conflicts

#### Changes proposed in this Pull Request

Migrate `client/state/editor` to use `import/order`

#### Testing instructions

N/A
