### PR TITLE
chore: migrate `client/state/comments` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -216,6 +216,7 @@ module.exports = {
 				'client/state/action-watchers/**/*',
 				'client/state/active-promotions/**/*',
 				'client/state/checklist/**/*',
+				'client/state/comments/**/*',
 				'client/state/data-getters/**/*',
 				'client/state/editor/**/*',
 				'client/state/google-my-business/**/*',

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	COMMENT_COUNTS_REQUEST,
@@ -19,9 +16,9 @@ import {
 	COMMENTS_UNLIKE,
 	COMMENTS_WRITE,
 } from 'calypso/state/action-types';
+import { getSiteComment } from 'calypso/state/comments/selectors';
 import { READER_EXPAND_COMMENTS } from 'calypso/state/reader/action-types';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from './constants';
-import { getSiteComment } from 'calypso/state/comments/selectors';
 
 import 'calypso/state/data-layer/wpcom/comments';
 import 'calypso/state/data-layer/wpcom/sites/comment-counts';

--- a/client/state/comments/from-api.js
+++ b/client/state/comments/from-api.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { pickBy } from 'lodash';
 
 export const toAuthor = ( { avatar_URL, email, ID, name } ) => {

--- a/client/state/comments/init.js
+++ b/client/state/comments/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import commentsReducer from './reducer';
 

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,6 +1,4 @@
-/**
- * External dependencies
- */
+import { withStorageKey } from '@automattic/state-utils';
 import {
 	filter,
 	orderBy,
@@ -14,11 +12,6 @@ import {
 	omit,
 	startsWith,
 } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { withStorageKey } from '@automattic/state-utils';
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_CHANGE_STATUS,

--- a/client/state/comments/selectors/comments-fetching-status.js
+++ b/client/state/comments/selectors/comments-fetching-status.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { size } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { fetchStatusInitialState } from 'calypso/state/comments/reducer';
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 import { getStateKey } from 'calypso/state/comments/utils';

--- a/client/state/comments/selectors/get-active-reply-comment-id.js
+++ b/client/state/comments/selectors/get-active-reply-comment-id.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getStateKey } from 'calypso/state/comments/utils';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-comment-by-id.js
+++ b/client/state/comments/selectors/get-comment-by-id.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { filter, find, flatMap } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { deconstructStateKey, getErrorKey } from 'calypso/state/comments/utils';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-comment-errors.js
+++ b/client/state/comments/selectors/get-comment-errors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/comments/init';
 
 export function getCommentErrors( state ) {

--- a/client/state/comments/selectors/get-comment-like.js
+++ b/client/state/comments/selectors/get-comment-like.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import treeSelect from '@automattic/tree-select';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-date-sorted-post-comments.js
+++ b/client/state/comments/selectors/get-date-sorted-post-comments.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import treeSelect from '@automattic/tree-select';
 import { sortBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-expansions-for-post.js
+++ b/client/state/comments/selectors/get-expansions-for-post.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getStateKey } from 'calypso/state/comments/utils';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-hidden-comments-for-post.js
+++ b/client/state/comments/selectors/get-hidden-comments-for-post.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import treeSelect from '@automattic/tree-select';
 import { keyBy, pickBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getExpansionsForPost } from 'calypso/state/comments/selectors/get-expansions-for-post';
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 

--- a/client/state/comments/selectors/get-parent-comment.js
+++ b/client/state/comments/selectors/get-parent-comment.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { getPostCommentsTree } from 'calypso/state/comments/selectors/get-post-comments-tree';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-post-comment-items.js
+++ b/client/state/comments/selectors/get-post-comment-items.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/comments/init';
 
 /**

--- a/client/state/comments/selectors/get-post-comments-count-at-date.js
+++ b/client/state/comments/selectors/get-post-comments-count-at-date.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { filter, size } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getStateKey } from 'calypso/state/comments/utils';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-post-comments-tree.js
+++ b/client/state/comments/selectors/get-post-comments-tree.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import treeSelect from '@automattic/tree-select';
 import { filter, groupBy, keyBy, map, mapValues, partition } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-post-newest-comment-date.js
+++ b/client/state/comments/selectors/get-post-newest-comment-date.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import treeSelect from '@automattic/tree-select';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-post-oldest-comment-date.js
+++ b/client/state/comments/selectors/get-post-oldest-comment-date.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import treeSelect from '@automattic/tree-select';
 import { findLast } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getPostCommentItems } from 'calypso/state/comments/selectors/get-post-comment-items';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-post-total-comments-count.js
+++ b/client/state/comments/selectors/get-post-total-comments-count.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/comments/init';
 
 /**

--- a/client/state/comments/selectors/get-site-comment-counts.js
+++ b/client/state/comments/selectors/get-site-comment-counts.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/comments/init';
 
 /**

--- a/client/state/comments/selectors/get-site-comment-parent-depth.js
+++ b/client/state/comments/selectors/get-site-comment-parent-depth.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { createSelector } from '@automattic/state-utils';
 import { getSiteComment } from 'calypso/state/comments/selectors';
 

--- a/client/state/comments/selectors/get-site-comment-replies-tree.js
+++ b/client/state/comments/selectors/get-site-comment-replies-tree.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { createSelector } from '@automattic/state-utils';
+import { filter } from 'lodash';
 import { getSiteCommentsTree } from 'calypso/state/comments/selectors';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-site-comment.js
+++ b/client/state/comments/selectors/get-site-comment.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { getSiteComments } from 'calypso/state/comments/selectors';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/selectors/get-site-comments-tree.js
+++ b/client/state/comments/selectors/get-site-comments-tree.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { createSelector } from '@automattic/state-utils';
+import { filter } from 'lodash';
 
 import 'calypso/state/comments/init';
 

--- a/client/state/comments/selectors/get-site-comments.js
+++ b/client/state/comments/selectors/get-site-comments.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
-import { filter, orderBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { createSelector } from '@automattic/state-utils';
+import { filter, orderBy } from 'lodash';
 
 import 'calypso/state/comments/init';
 

--- a/client/state/comments/selectors/is-comments-tree-initialized.js
+++ b/client/state/comments/selectors/is-comments-tree-initialized.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/comments/init';
 
 /**

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -1,6 +1,4 @@
-/**
- * Internal dependencies
- */
+import { setFeatureFlag } from 'calypso/test-helpers/config';
 import {
 	COMMENTS_DELETE,
 	COMMENTS_REQUEST,
@@ -22,7 +20,6 @@ import {
 	changeCommentStatus,
 } from '../actions';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from '../constants';
-import { setFeatureFlag } from 'calypso/test-helpers/config';
 
 const SITE_ID = 91750058;
 const POST_ID = 287;

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
 import { map, forEach } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	COMMENT_COUNTS_UPDATE,
 	COMMENTS_LIKE,

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	getPostOldestCommentDate,
 	getPostNewestCommentDate,

--- a/client/state/comments/trees/reducer.js
+++ b/client/state/comments/trees/reducer.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get, map, reject } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,

--- a/client/state/comments/ui/actions.js
+++ b/client/state/comments/ui/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { COMMENTS_QUERY_UPDATE } from 'calypso/state/action-types';
 
 import 'calypso/state/comments/init';

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get, includes, map, without, has } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -13,9 +6,9 @@ import {
 	COMMENTS_QUERY_UPDATE,
 	COMMENTS_TREE_SITE_REQUEST,
 } from 'calypso/state/action-types';
-import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import { getFiltersKey } from 'calypso/state/comments/ui/utils';
 import { getRequestKey } from 'calypso/state/data-layer/wpcom-http/utils';
+import { combineReducers, keyedReducer } from 'calypso/state/utils';
 
 const deepUpdateComments = ( state, comments, query ) => {
 	const { page = 1, postId } = query;

--- a/client/state/comments/ui/test/actions.js
+++ b/client/state/comments/ui/test/actions.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { COMMENTS_QUERY_UPDATE } from 'calypso/state/action-types';
 import { updateCommentsQuery } from 'calypso/state/comments/ui/actions';
 

--- a/client/state/comments/ui/test/reducer.js
+++ b/client/state/comments/ui/test/reducer.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,

--- a/client/state/comments/utils.js
+++ b/client/state/comments/utils.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { domForHtml } from 'calypso/lib/post-normalizer/utils';
 
 export const getStateKey = ( siteId, postId ) => `${ siteId }-${ postId }`;


### PR DESCRIPTION
#### Background

See #54448

stacked upon #55439 to prevent merge conflicts

#### Changes proposed in this Pull Request

Migrate `client/state/comments` to use `import/order`

#### Testing instructions

N/A
