### PR TITLE
chore: migrate `client/state/help` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -220,6 +220,7 @@ module.exports = {
 				'client/state/editor/**/*',
 				'client/state/google-my-business/**/*',
 				'client/state/happychat/**/*',
+				'client/state/help/**/*',
 				'client/support/**/*',
 				'client/test-helpers/**/*',
 				'client/types.ts',

--- a/client/state/help/actions.js
+++ b/client/state/help/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	HELP_CONTACT_FORM_SITE_SELECT,
 	HELP_LINKS_RECEIVE,

--- a/client/state/help/courses/actions.js
+++ b/client/state/help/courses/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { HELP_COURSES_RECEIVE } from 'calypso/state/action-types';
 
 import 'calypso/state/help/init';

--- a/client/state/help/courses/reducer.js
+++ b/client/state/help/courses/reducer.js
@@ -1,9 +1,5 @@
-/**
- * Internal dependencies
- */
-
-import { combineReducers } from 'calypso/state/utils';
 import { HELP_COURSES_RECEIVE } from 'calypso/state/action-types';
+import { combineReducers } from 'calypso/state/utils';
 
 export const items = ( state = null, action ) => {
 	switch ( action.type ) {

--- a/client/state/help/courses/selectors.js
+++ b/client/state/help/courses/selectors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/help/init';
 
 /**

--- a/client/state/help/courses/test/actions.js
+++ b/client/state/help/courses/test/actions.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { receiveHelpCourses } from '../actions';
 import { HELP_COURSES_RECEIVE } from 'calypso/state/action-types';
+import { receiveHelpCourses } from '../actions';
 
 describe( 'actions', () => {
 	const sampleCourseList = [

--- a/client/state/help/courses/test/reducer.js
+++ b/client/state/help/courses/test/reducer.js
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
-import reducer, { items } from '../reducer';
 import { HELP_COURSES_RECEIVE } from 'calypso/state/action-types';
+import reducer, { items } from '../reducer';
 
 describe( 'reducer', () => {
 	test( 'should include expected keys in return value', () => {

--- a/client/state/help/courses/test/selectors.js
+++ b/client/state/help/courses/test/selectors.js
@@ -1,12 +1,5 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import { getHelpCourses } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/state/help/directly/actions.js
+++ b/client/state/help/directly/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -1,14 +1,10 @@
-/**
- * Internal dependencies
- */
-
-import { combineReducers } from 'calypso/state/utils';
 import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,
 	DIRECTLY_INITIALIZATION_ERROR,
 } from 'calypso/state/action-types';
+import { combineReducers } from 'calypso/state/utils';
 import { STATUS_UNINITIALIZED, STATUS_INITIALIZING, STATUS_READY, STATUS_ERROR } from './constants';
 
 export const questionAsked = ( state = null, action ) => {

--- a/client/state/help/directly/test/actions.js
+++ b/client/state/help/directly/test/actions.js
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { askQuestion, initialize, initializationCompleted, initializationFailed } from '../actions';
 import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,
 	DIRECTLY_INITIALIZATION_ERROR,
 } from 'calypso/state/action-types';
+import { askQuestion, initialize, initializationCompleted, initializationFailed } from '../actions';
 
 describe( 'actions', () => {
 	describe( '#askQuestion()', () => {

--- a/client/state/help/directly/test/reducer.js
+++ b/client/state/help/directly/test/reducer.js
@@ -1,11 +1,10 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
+import {
+	DIRECTLY_ASK_QUESTION,
+	DIRECTLY_INITIALIZATION_START,
+	DIRECTLY_INITIALIZATION_SUCCESS,
+	DIRECTLY_INITIALIZATION_ERROR,
+} from 'calypso/state/action-types';
 import {
 	STATUS_UNINITIALIZED,
 	STATUS_INITIALIZING,
@@ -13,12 +12,6 @@ import {
 	STATUS_ERROR,
 } from '../constants';
 import reducer, { questionAsked, status } from '../reducer';
-import {
-	DIRECTLY_ASK_QUESTION,
-	DIRECTLY_INITIALIZATION_START,
-	DIRECTLY_INITIALIZATION_SUCCESS,
-	DIRECTLY_INITIALIZATION_ERROR,
-} from 'calypso/state/action-types';
 
 describe( 'reducer', () => {
 	test( 'should include expected keys in return value', () => {

--- a/client/state/help/init.js
+++ b/client/state/help/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
 import {
 	HELP_CONTACT_FORM_SITE_SELECT,
@@ -8,8 +5,8 @@ import {
 	SUPPORT_HISTORY_SET,
 	SUPPORT_LEVEL_SET,
 } from 'calypso/state/action-types';
-import courses from './courses/reducer';
 import { combineReducers } from 'calypso/state/utils';
+import courses from './courses/reducer';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
 

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import getSelectedOrPrimarySiteId from 'calypso/state/selectors/get-selected-or-primary-site-id';
 import { getSite } from 'calypso/state/sites/selectors';
 

--- a/client/state/help/test/actions.js
+++ b/client/state/help/test/actions.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { selectSiteId } from '../actions';
 import { HELP_CONTACT_FORM_SITE_SELECT } from 'calypso/state/action-types';
+import { selectSiteId } from '../actions';
 
 describe( 'actions', () => {
 	describe( '#selectSiteId()', () => {

--- a/client/state/help/test/reducer.js
+++ b/client/state/help/test/reducer.js
@@ -1,13 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { selectedSiteId } from '../reducer';
 import { HELP_CONTACT_FORM_SITE_SELECT } from 'calypso/state/action-types';
+import { selectedSiteId } from '../reducer';
 
 describe( 'reducer', () => {
 	describe( '#selectedSiteId()', () => {

--- a/client/state/help/test/selectors.js
+++ b/client/state/help/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import { getHelpSiteId, getHelpSelectedSiteId } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/state/help/ticket/actions.js
+++ b/client/state/help/ticket/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,

--- a/client/state/help/ticket/reducer.js
+++ b/client/state/help/ticket/reducer.js
@@ -1,14 +1,10 @@
-/**
- * Internal dependencies
- */
-
-import { combineReducers } from 'calypso/state/utils';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
 	HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
 	HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'calypso/state/action-types';
+import { combineReducers } from 'calypso/state/utils';
 
 const isRequesting = ( state = false, action ) => {
 	switch ( action.type ) {

--- a/client/state/help/ticket/selectors.js
+++ b/client/state/help/ticket/selectors.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import 'calypso/state/help/init';
 
 export const isTicketSupportEligible = ( state ) => {

--- a/client/state/help/ticket/test/actions.js
+++ b/client/state/help/ticket/test/actions.js
@@ -1,19 +1,5 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
-import {
-	ticketSupportConfigurationRequest,
-	ticketSupportConfigurationRequestSuccess,
-	ticketSupportConfigurationRequestFailure,
-	ticketSupportConfigurationDismissError,
-} from '../actions';
-import { dummyConfiguration, dummyError } from './test-data';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
 	HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
@@ -22,6 +8,13 @@ import {
 } from 'calypso/state/action-types';
 import { useNock } from 'calypso/test-helpers/use-nock';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
+import {
+	ticketSupportConfigurationRequest,
+	ticketSupportConfigurationRequestSuccess,
+	ticketSupportConfigurationRequestFailure,
+	ticketSupportConfigurationDismissError,
+} from '../actions';
+import { dummyConfiguration, dummyError } from './test-data';
 
 describe( 'ticket-support/configuration actions', () => {
 	let spy;

--- a/client/state/help/ticket/test/reducer.js
+++ b/client/state/help/ticket/test/reducer.js
@@ -1,19 +1,12 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
-import reducer from '../reducer';
-import { dummyConfiguration, dummyError } from './test-data';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
 	HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
 	HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'calypso/state/action-types';
+import reducer from '../reducer';
+import { dummyConfiguration, dummyError } from './test-data';
 
 describe( 'ticket-support/configuration reducer', () => {
 	test( 'should default to the expected structure', () => {

--- a/client/state/help/ticket/test/selectors.js
+++ b/client/state/help/ticket/test/selectors.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	isTicketSupportEligible,
 	isTicketSupportConfigurationReady,


### PR DESCRIPTION
#### Background

See #54448

stacked upon #55439 to prevent merge conflicts

#### Changes proposed in this Pull Request

Migrate `client/state/help` to use `import/order`

#### Testing instructions

N/A
