### PR TITLE
chore: migrate `client/state/gsuite-users` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -219,6 +219,7 @@ module.exports = {
 				'client/state/data-getters/**/*',
 				'client/state/editor/**/*',
 				'client/state/google-my-business/**/*',
+				'client/state/gsuite-users/**/*',
 				'client/state/happychat/**/*',
 				'client/support/**/*',
 				'client/test-helpers/**/*',

--- a/client/state/gsuite-users/actions.js
+++ b/client/state/gsuite-users/actions.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	GSUITE_USERS_REQUEST,
 	GSUITE_USERS_REQUEST_SUCCESS,

--- a/client/state/gsuite-users/init.js
+++ b/client/state/gsuite-users/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 

--- a/client/state/gsuite-users/reducer.js
+++ b/client/state/gsuite-users/reducer.js
@@ -1,13 +1,10 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
-import { combineReducers, keyedReducer, withSchemaValidation } from 'calypso/state/utils';
 import {
 	GSUITE_USERS_REQUEST,
 	GSUITE_USERS_REQUEST_FAILURE,
 	GSUITE_USERS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'calypso/state/utils';
 import { usersSchema } from './schema';
 
 export const usersReducer = withSchemaValidation( usersSchema, ( state = null, action ) => {

--- a/client/state/gsuite-users/test/reducer.js
+++ b/client/state/gsuite-users/test/reducer.js
@@ -1,14 +1,6 @@
-/**
- * External dependencies
- */
 import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
-import { usersReducer } from '../reducer';
-
 import { GSUITE_USERS_REQUEST_SUCCESS } from 'calypso/state/action-types';
+import { usersReducer } from '../reducer';
 
 describe( "gsuiteUsersReducer's", () => {
 	const account = {


### PR DESCRIPTION
#### Background

See #54448

stacked upon #55439 to prevent merge conflicts

#### Changes proposed in this Pull Request

Migrate `client/state/gsuite-users` to use `import/order`

#### Testing instructions

N/A
