### PR TITLE
chore: migrate `client/state/activity-log` to `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -215,6 +215,7 @@ module.exports = {
 				'client/state/action-log/**/*',
 				'client/state/action-watchers/**/*',
 				'client/state/active-promotions/**/*',
+				'client/state/activity-log/**/*',
 				'client/state/checklist/**/*',
 				'client/state/data-getters/**/*',
 				'client/state/editor/**/*',

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import page from 'page';
-
-/**
- * Internal dependencies
- */
+import { addQueryArgs } from 'calypso/lib/url';
 import {
 	ACTIVITY_LOG_FILTER_SET,
 	ACTIVITY_LOG_FILTER_UPDATE,
@@ -31,9 +25,8 @@ import {
 	REWIND_BACKUP_UPDATE_PROGRESS,
 	REWIND_BACKUP_DISMISS_PROGRESS,
 } from 'calypso/state/action-types';
-import { addQueryArgs } from 'calypso/lib/url';
-import { filterStateToQuery } from './utils';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import { filterStateToQuery } from './utils';
 
 import 'calypso/state/data-layer/wpcom/activity-log/activate';
 import 'calypso/state/data-layer/wpcom/activity-log/deactivate';

--- a/client/state/activity-log/activation/reducer.js
+++ b/client/state/activity-log/activation/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	REWIND_ACTIVATE_FAILURE,
 	REWIND_ACTIVATE_REQUEST,

--- a/client/state/activity-log/activation/test/reducer.js
+++ b/client/state/activity-log/activation/test/reducer.js
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
-import { activationRequesting } from '../reducer';
 import {
 	REWIND_ACTIVATE_FAILURE,
 	REWIND_ACTIVATE_REQUEST,
 	REWIND_ACTIVATE_SUCCESS,
 } from 'calypso/state/action-types';
+import { activationRequesting } from '../reducer';
 
 /**
  * Constants

--- a/client/state/activity-log/backup/reducer.js
+++ b/client/state/activity-log/backup/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	REWIND_BACKUP,
 	REWIND_BACKUP_DISMISS,

--- a/client/state/activity-log/init.js
+++ b/client/state/activity-log/init.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import { registerReducer } from 'calypso/state/redux-store';
 import reducer from './reducer';
 

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -1,13 +1,10 @@
-/**
- * Internal dependencies
- */
 import { withStorageKey } from '@automattic/state-utils';
 import { ACTIVITY_LOG_FILTER_SET, ACTIVITY_LOG_FILTER_UPDATE } from 'calypso/state/action-types';
 import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import { activationRequesting } from './activation/reducer';
-import retentionPolicy from './retention-policy/reducer';
-import { restoreProgress, restoreRequest } from './restore/reducer';
 import { backupRequest, backupProgress } from './backup/reducer';
+import { restoreProgress, restoreRequest } from './restore/reducer';
+import retentionPolicy from './retention-policy/reducer';
 
 export const emptyFilter = {
 	page: 1,

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import {
 	REWIND_RESTORE,
 	REWIND_RESTORE_DISMISS,

--- a/client/state/activity-log/restore/test/reducer.js
+++ b/client/state/activity-log/restore/test/reducer.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import deepFreeze from 'deep-freeze';
-
-/**
- * Internal dependencies
- */
 import {
 	dismissRewindRestoreProgress,
 	rewindRequestDismiss,

--- a/client/state/activity-log/retention-policy/actions.ts
+++ b/client/state/activity-log/retention-policy/actions.ts
@@ -1,12 +1,5 @@
-/**
- * Internal dependencies
- */
 import { ACTIVITY_LOG_RETENTION_POLICY_REQUEST } from 'calypso/state/action-types';
 import 'calypso/state/data-layer/wpcom/activity-log/get-retention-policy';
-
-/**
- * Type dependencies
- */
 import type { Action } from 'redux';
 
 const trackRequests = {

--- a/client/state/activity-log/retention-policy/reducer.ts
+++ b/client/state/activity-log/retention-policy/reducer.ts
@@ -1,17 +1,10 @@
-/**
- * Internal dependencies
- */
-import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import {
 	ACTIVITY_LOG_RETENTION_POLICY_REQUEST,
 	ACTIVITY_LOG_RETENTION_POLICY_REQUEST_FAILURE,
 	ACTIVITY_LOG_RETENTION_POLICY_REQUEST_SUCCESS,
 	ACTIVITY_LOG_RETENTION_POLICY_SET,
 } from 'calypso/state/action-types';
-
-/**
- * Type dependencies
- */
+import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import type { AppState } from 'calypso/types';
 
 export const requestStatus = ( state: AppState = null, { type } ): AppState | string => {


### PR DESCRIPTION
#### Background

See #54448

stacked upon #55439 to prevent merge conflicts

#### Changes proposed in this Pull Request

Migrate `client/state/activity-log` to use `import/order`

#### Testing instructions

N/A

