### PR TITLE
Domains: Fix domain suggestions layout for tablet resolutions

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -256,13 +256,9 @@
 
 	@include break-mobile {
 		width: auto;
-	}
-
-	&.is-primary {
-		@include breakpoint-deprecated( '>480px' ) {
-			margin-left: 1em;
-			margin-top: 0;
-		}
+		flex: 1 0 auto;
+		margin-left: 1em;
+		margin-top: 0;
 	}
 
 	.is-placeholder & {
@@ -279,22 +275,6 @@
 		color: var( --color-primary );
 		margin-top: 0;
 		padding: 0;
-	}
-
-	.is-section-signup & {
-		@include breakpoint-deprecated( '>480px' ) {
-			flex: 1 0 auto;
-			margin-left: 1em;
-			margin-top: 0;
-		}
-	}
-
-	.is-section-domains & {
-		@include breakpoint-deprecated( '>800px' ) {
-			flex: 1 0 auto;
-			margin-left: 1em;
-			margin-top: 0;
-		}
 	}
 }
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -174,7 +174,7 @@
 	flex-direction: column-reverse;
 	flex-wrap: nowrap;
 
-	@include break-xlarge {
+	@include break-mobile {
 		flex-direction: row;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a layout bug introduced by #55034 - domain suggestions were misaligned when viewed in tablet resolutions (> 480px and < 1080px). It affected both the domain suggestions list in the "Add a domain to this site" page and in the signup flow. Reported in p1628779410064200-slack-C020919TDRA.

#### Screenshots

Before correction:

<img width="596" alt="Screenshot 2021-08-12 at 17 34 54" src="https://user-images.githubusercontent.com/5324818/129223696-1d92ef80-2fd7-40b6-9cea-e7c035af8010.png">

After correction:

<img width="586" alt="Screen Shot 2021-08-12 at 12 24 36" src="https://user-images.githubusercontent.com/5324818/129223863-a2be9b66-e227-4ad7-819d-a174a64b44b8.png">

#### Testing instructions

Open the live Calypso link, change your browser resolution to "iPad" (768 x 1024 px), go to the `/start` signup flow, search for domains and ensure the domain suggestions are not misaligned.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

