### PR TITLE
Signup: Add email from the signup form to the login URL

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import classNames from 'classnames';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { isEmpty, omit, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
@@ -10,6 +10,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceConnectCartHeader from 'calypso/extensions/woocommerce/components/woocommerce-connect-cart-header';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
+import formState from 'calypso/lib/form-state';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
@@ -17,6 +18,7 @@ import {
 	isJetpackCloudOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/url';
 import { WPCC } from 'calypso/lib/url/support';
 import flows from 'calypso/signup/config/flows';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -89,25 +91,12 @@ export class UserStep extends Component {
 	};
 
 	state = {
-		subHeaderText: '',
 		recaptchaClientId: null,
 	};
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			this.props.flowName !== nextProps.flowName ||
-			this.props.locale !== nextProps.locale ||
-			this.props.subHeaderText !== nextProps.subHeaderText
-		) {
-			this.setSubHeaderText( nextProps );
-		}
-	}
 
 	UNSAFE_componentWillMount() {
 		const { oauth2Signup, initialContext } = this.props;
 		const clientId = get( initialContext, 'query.oauth2_client_id', null );
-
-		this.setSubHeaderText( this.props );
 
 		if ( oauth2Signup && clientId ) {
 			this.props.fetchOAuth2ClientData( clientId );
@@ -120,33 +109,27 @@ export class UserStep extends Component {
 		}
 
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
-
-		i18n.on( 'change', this.handleI18nChange );
 	}
 
-	componentWillUnmount() {
-		i18n.off( 'change', this.handleI18nChange );
-	}
-
-	handleI18nChange = () => {
-		this.setSubHeaderText( this.props );
-	};
-
-	setSubHeaderText( props ) {
+	getSubHeaderText() {
 		const {
 			flowName,
+			initialContext,
 			oauth2Client,
+			oauth2Signup,
 			positionInFlow,
 			translate,
 			userLoggedIn,
 			wccomFrom,
 			isReskinned,
 			sectionName,
+			stepName,
 			from,
 			locale,
-		} = props;
+			step,
+		} = this.props;
 
-		let subHeaderText = props.subHeaderText;
+		let subHeaderText = this.props.subHeaderText;
 
 		if ( [ 'wpcc', 'crowdsignal' ].includes( flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
@@ -203,16 +186,27 @@ export class UserStep extends Component {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 
 			if ( isReskinned ) {
-				const loginUrl = login( {
+				let loginUrl = login( {
 					isJetpack: 'jetpack-connect' === sectionName,
 					from,
-					redirectTo: getRedirectToAfterLoginUrl( props ),
+					redirectTo: getRedirectToAfterLoginUrl( {
+						oauth2Signup,
+						initialContext,
+						flowName,
+						stepName,
+						userLoggedIn,
+					} ),
 					locale,
 					oauth2ClientId: oauth2Client?.id,
 					wccomFrom,
 					isWhiteLogin: isReskinned,
 					signupUrl: window.location.pathname + window.location.search,
 				} );
+
+				if ( step?.form ) {
+					const email = formState.getFieldValue( step.form, 'email' );
+					loginUrl = addQueryArgs( { email_address: email }, loginUrl );
+				}
 
 				subHeaderText = translate(
 					'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
@@ -223,7 +217,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		this.setState( { subHeaderText } );
+		return subHeaderText;
 	}
 
 	initGoogleRecaptcha() {
@@ -470,7 +464,7 @@ export class UserStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }
-				subHeaderText={ this.state.subHeaderText }
+				subHeaderText={ this.getSubHeaderText() }
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
 				stepContent={ this.renderSignupForm() }


### PR DESCRIPTION
While reviewing https://github.com/Automattic/wp-calypso/pull/55450, I've noticed that when pressing the _Log in_ link from the Signup form, the email address is passed through the URL. However, this doesn't happen if the user is pressing the _Log in_ link in the subheader.

#### Changes proposed in this Pull Request

* Get signup form email value from `props.step.form` by using `formState.getFieldValue` lib function. Add it to the login URL as `email_address` query arg.
* Cleanup UserStep by removing unnecessary methods and `subHeaderText` from state
* Compute `subHeaderText` when rendering the component (props change)

#### Testing instructions

* Go to `/start` while logged-out
* Enter an email address
* Press the "Log in" link from the subheader
* On the Login screen, the email field should have the value entered earlier in the signup form

#### Demo

https://user-images.githubusercontent.com/14192054/129226292-23206b5a-1ca4-4b23-9276-56686c54f3dd.mov
