### PR TITLE
Bump the shopping-cart package version to 1.1 and add a changelog

### DIFF
--- a/packages/shopping-cart/CHANGELOG.md
+++ b/packages/shopping-cart/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## v1.1.0
+
+- Improve offline errors.
+- Use middleware to sync cart with server.
+- Add refetchOnWindowFocus option.
+- Add total_tax_breakdown to ResponseCart.
+- Export convertResponseCartToRequestCart.
+- Remove 'invalid' coupon type.
+- Add jetpackSiteSlug, isJetpackCheckout, jetpackPurchaseToken to RequestCartProductExtra.
+- Add current_quantity to ResponseCartProduct.
+- Allow cart products to include a redirect URL.
+
+## v1.0.1
+
+- Initial functioning release.
+- Fix module importing.
+
+## v1.0.0
+
+- Initial release. This actually didn't work outside of the monorepo because of an invalid TS configuration (see https://github.com/Automattic/wp-calypso/pull/51519)
+
+

--- a/packages/shopping-cart/CHANGELOG.md
+++ b/packages/shopping-cart/CHANGELOG.md
@@ -19,6 +19,6 @@
 
 ## v1.0.0
 
-- Initial release. This actually didn't work outside of the monorepo because of an invalid TS configuration (see https://github.com/Automattic/wp-calypso/pull/51519)
+- Initial release. This actually didn't work outside of the monorepo because of an invalid TS configuration.
 
 

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/shopping-cart",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "A library to use the WordPress.com shopping cart",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This bumps the version number of `@automattic/shopping-cart` from `1.0.1` (last updated by https://github.com/Automattic/wp-calypso/pull/51519) to `1.1.0`. 

#### Testing instructions

None.