### PR TITLE
Update description on the 'Writing' settings page

### DIFF
--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -28,9 +28,7 @@ const SiteSettingsWriting = ( { site, translate } ) => (
 			brandFont
 			className="settings-writing__page-heading"
 			headerText={ translate( 'Writing Settings' ) }
-			subHeaderText={ translate(
-				"Manage categories, tags, and other settings related to your site's content."
-			) }
+			subHeaderText={ translate( "Manage settings related to your site's content." ) }
 			align="left"
 			hasScreenOptions
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update text description on Settings > Writing page to be "Manage settings related to your site's content."

#### Testing instructions

Visit Settings > Writing and confirm string is updated

Related to #55429

<img width="786" alt="Screenshot 2021-08-13 at 9 19 12 PM" src="https://user-images.githubusercontent.com/1500769/129335281-9c51f870-d244-4548-92e0-68d99cabd23a.png">

