### PR TITLE
safeImageUrl: Require a hostname to enter the query specific block

### DIFF
--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -71,7 +71,7 @@ export default function safeImageUrl( url ) {
 	}
 
 	// If there's a query string, bail out because Photon doesn't support them on external URLs
-	if ( parsedUrl.search ) {
+	if ( parsedUrl.search && ( parsedUrl.host || parsedUrl.hostname || parsedUrl.origin ) ) {
 		// If it's just size parameters, let's remove them
 		SIZE_PARAMS.forEach( ( param ) => parsedUrl.searchParams.delete( param ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When `safeImageUrl("?v=1606128664")` runs, calypso crashes.
* Fix this.
  * When safeImageUrl encounters a (url -> parsedUrl) with a query string, it goes into a special if block: https://github.com/Automattic/wp-calypso/blob/ef59bea7038931c61f63839df801adfd5d8d77a8/client/lib/safe-image-url/index.js#L74
    * That block later calls getUrlParts on the url: https://github.com/Automattic/wp-calypso/blob/ef59bea7038931c61f63839df801adfd5d8d77a8/client/lib/safe-image-url/index.js#L96
      * getUrlParts throws an exception if all 3 of host, hostname and origin are missing: https://github.com/Automattic/wp-calypso/blob/ef59bea7038931c61f63839df801adfd5d8d77a8/packages/calypso-url/src/url-parts.ts#L122
  * The root cause of the problem is that the "Query String If Block" is expecting a url like `http://google.com?abc=def`. It is not expecting an invalid url like `?abc=def`.
  * My fix: Skip the if block unless we have at least one of host, hostname or origin.


#### Testing instructions

* Apply this patch to trunk:
```diff
diff --git a/client/my-sites/post-type-list/post-thumbnail.jsx b/client/my-sites/post-type-list/post-thumbnail.jsx
index bcd685b02a..f2538f8459 100644
--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -23,6 +23,8 @@ function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
                'has-image': !! thumbnail,
        } );
 
+       thumbnail = '?v=1606128664';
+
        return (
                <div className={ classes }>
                        { thumbnail && (
```
* Visit the `/posts/<site>` url with at least one post that contains a thumbnail image.
* Calypso should white-screen crash.
* Repeat steps on this branch (also with additional patch). It should no longer crash.

Related to p9F6qB-7jl-p2