### PR TITLE
Update receipt wording from 'Total' to 'Total Paid'

### DIFF
--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -318,7 +318,7 @@ function ReceiptLineItems( { transaction } ) {
 				<tfoot>
 					<tr>
 						<td className="billing-history__receipt-desc">
-							<strong>{ translate( 'Total' ) }:</strong>
+							<strong>{ translate( 'Total Paid' ) }:</strong>
 						</td>
 						<td
 							className={

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -318,7 +318,9 @@ function ReceiptLineItems( { transaction } ) {
 				<tfoot>
 					<tr>
 						<td className="billing-history__receipt-desc">
-							<strong>{ translate( 'Total Paid' ) }:</strong>
+							<strong>
+								{ translate( 'Total paid:', { context: 'Total amount paid for product' } ) }
+							</strong>
 						</td>
 						<td
 							className={


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change will update the billing receipt in https://wordpress.com/me/purchases/billing from "Total" to "Total Paid".

#### Testing instructions

- Go to http://calypso.localhost:3000/me/purchases/billing
- Click on View Receipt
- Observe the line item is now written as "Total Paid" (should not say just 'Total' anymore)
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![image](https://user-images.githubusercontent.com/16580129/129280889-29dfb5af-2140-4b02-9e78-09a2f6e5c22e.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 192-gh-Automattic/payments-shilling