### PR TITLE
Stats: Strip HTML on Content Title in Post Details

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -18,7 +18,7 @@ import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
 import StatsPlaceholder from '../stats-module/placeholder';
 import HeaderCake from 'calypso/components/header-cake';
-import { decodeEntities } from 'calypso/lib/formatting';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import Main from 'calypso/components/main';
 import titlecase from 'to-title-case';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -103,7 +103,7 @@ class StatsPostDetail extends Component {
 		let title;
 		if ( postOnRecord ) {
 			if ( typeof post.title === 'string' && post.title.length ) {
-				title = <Emojify>{ decodeEntities( post.title ) }</Emojify>;
+				title = <Emojify>{ decodeEntities( stripHTML( post.title ) ) }</Emojify>;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Quick change to strip the HTML of a post/page title in the Stats section in the one place where this has been forgotten

#### Testing instructions

Create a post with a HTML tag in the title and visit it in an incognito tab so it gains a view, then click that post title under the "Posts & Pages" section on the Stats page.

**Before:**

<img width="1116" alt="Screenshot 2021-08-13 at 08 41 22" src="https://user-images.githubusercontent.com/43215253/129322233-3c3807d1-e441-4c18-8b17-5465be5a4eed.png">

**After:**

<img width="1111" alt="Screenshot 2021-08-13 at 08 41 27" src="https://user-images.githubusercontent.com/43215253/129322234-93238555-69e8-49d8-9a08-6a1ff144df37.png">

cc @sixhours

Fixes #55477