### PR TITLE
Fallback description on the 'Writing' settings page

### DIFF
--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import i18nCalypso, { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import WritingForm from 'calypso/my-sites/site-settings/form-writing';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 
-const SiteSettingsWriting = ( { site, translate } ) => (
+const SiteSettingsWriting = ( { site, locale, translate } ) => (
 	<Main className="settings-writing site-settings">
 		<ScreenOptionsTab wpAdminPath="options-writing.php" />
 		<DocumentHead title={ translate( 'Writing Settings' ) } />
@@ -28,7 +28,16 @@ const SiteSettingsWriting = ( { site, translate } ) => (
 			brandFont
 			className="settings-writing__page-heading"
 			headerText={ translate( 'Writing Settings' ) }
-			subHeaderText={ translate( "Manage settings related to your site's content." ) }
+			subHeaderText={
+				// TODO: Remove fallback after translation is ready
+				locale === 'en' ||
+				locale === 'en-gb' ||
+				i18nCalypso.hasTranslation( "Manage settings related to your site's content." )
+					? translate( "Manage settings related to your site's content." )
+					: translate(
+							"Manage categories, tags, and other settings related to your site's content."
+					  )
+			}
 			align="left"
 			hasScreenOptions
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, the description on Settings > Writing page might not have the translation, so use local and hasTranslation to check. If the translation is not ready, fallback to the original description.

##### Before

![image](https://user-images.githubusercontent.com/13596067/129323247-14f27385-e804-4ff3-9973-10aecc0a78f0.png)

##### After

###### NON-ENGLISH

![image](https://user-images.githubusercontent.com/13596067/129324038-ac4a284b-0a84-46f6-a4aa-dc99d5334fa6.png)

###### ENGLISH

![image](https://user-images.githubusercontent.com/13596067/129324100-cf8a9ade-49c6-4ccf-8c47-d67118969608.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings > Writing page
* Check description is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/55474
