### PR TITLE
Livechat: Remove ES/PT-BR languages

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -38,7 +38,7 @@
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"support_site_locales": [
 		"ar",
 		"de",

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"features": {
 		"activity-log/retention-policies": false,

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"livechat_support_locales": [ "en" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"features": {
 		"activity-log/retention-policies": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"features": {
 		"automated-transfer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"features": {
 		"automated-transfer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"livechat_support_locales": [ "en" ],
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"features": {

--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"features": {

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"features": {
 		"ad-tracking": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en" ],
 	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"features": {
 		"ad-tracking": false,

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,7 +14,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en", "es", "pt-br" ],
+	"livechat_support_locales": [ "en" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,7 +14,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"livechat_support_locales": [ "en" ],
 	"features": {
 		"ad-tracking": false,
 		"async-payments": false,

--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -25,7 +25,7 @@ export const localesToSubdomains: Record< string, LocaleSubdomain > = {
 export const englishLocales: Locale[] = [ 'en', 'en-gb' ];
 
 // replaces config( 'livechat_support_locales' )
-export const livechatSupportLocales: Locale[] = [ 'en', 'es', 'pt-br' ];
+export const livechatSupportLocales: Locale[] = [ 'en' ];
 
 // replaces config( 'support_site_locales' )
 export const supportSiteLocales: Locale[] = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're switching to offering livechat only in English.

#### Testing instructions

Go to http://calypso.localhost:3000/help/contact. If your user's locale is set to anything else than `en`, you'll see a `Note: Support is only available in English at the moment.` message at the bottom:

<img width="744" alt="Screenshot 2021-08-13 at 10 19 16" src="https://user-images.githubusercontent.com/3392497/129342882-bb284d8e-6a43-4054-8f19-ddb8392e2851.png">

If it's `en`, the message should not be there:

<img width="743" alt="Screenshot 2021-08-13 at 10 20 33" src="https://user-images.githubusercontent.com/3392497/129343057-d0bcc562-8c70-4233-9fd1-ae09307bb413.png">

Be sure to specifically test with `es` and `pt-br` locales.

