### PR TITLE
Connect a domain typos

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-done.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-done.jsx
@@ -1,27 +1,25 @@
 /**
  * External dependencies
  */
+import { Button, Card } from '@automattic/components';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { __, sprintf } from '@wordpress/i18n';
-import { Button, Card } from '@automattic/components';
-
 /**
  * Internal dependencies
  */
+import domainConnectedIllustration from 'calypso/assets/images/illustrations/domain-connected.svg';
 import CardHeading from 'calypso/components/card-heading';
 import Gridicon from 'calypso/components/gridicon';
-import domainConnectedIllustration from 'calypso/assets/images/illustrations/domain-connected.svg';
-import { stepType } from './constants';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
-
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { stepType } from './constants';
 /**
  * Style dependencies
  */
 import './style.scss';
-import { createElement, createInterpolateElement } from '@wordpress/element';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 function ConnectDomainStepDone( { className, domain, step, selectedSiteSlug } ) {
 	const siteDomainsUrl = domainManagementList( selectedSiteSlug );
@@ -44,7 +42,7 @@ function ConnectDomainStepDone( { className, domain, step, selectedSiteSlug } ) 
 	let contentLines = [
 		sprintf(
 			/* translators: %s: the domain name that was connected to the user's site (ex.: example.com) */
-			__( "That's it %s has been successfully connected." ),
+			__( "That's it. %s has been successfully connected." ),
 			domain
 		),
 	];

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -1,18 +1,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import React from 'react';
-import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-
+import { __, sprintf } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+import React from 'react';
 /**
  * Internal dependencies
  */
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
 import { modeType, stepSlug } from './constants';
-
 /**
  * Style dependencies
  */
@@ -31,7 +29,7 @@ export default function ConnectDomainStepLogin( {
 			<p className={ className + '__text' }>
 				{ createInterpolateElement(
 					__(
-						'Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.) If you can’t remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider.'
+						'Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.). If you can’t remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider.'
 					),
 					{
 						em: createElement( 'em' ),
@@ -43,7 +41,7 @@ export default function ConnectDomainStepLogin( {
 				{ sprintf(
 					/* translators: %s: the domain name that the user is connecting to WordPress.com (ex.: example.com) */
 					__(
-						'On your domain provider’s site go to the domains page. Find %s and go to it’s settings page.'
+						'On your domain provider’s site go to the domains page. Find %s and go to its settings page.'
 					),
 					domain
 				) }

--- a/client/components/domains/connect-domain-step/connect-domain-step-verification-status-parsing.js
+++ b/client/components/domains/connect-domain-step/connect-domain-step-verification-status-parsing.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -60,9 +59,7 @@ export function getMappingVerificationErrorMessage( mode, verificationStatus ) {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: %s: the list of IP addresses. (Ex.: "192.168.0.1, 192.168.0.2") */
-				__(
-					'The name A records for your domain are set to: <em>%s</em>. Please try this step again.'
-				),
+				__( 'The A records for your domain are set to: <em>%s</em>. Please try this step again.' ),
 				hostIpAddresses.join( ', ' )
 			),
 			{ em: createElement( 'em' ) }

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -1,16 +1,24 @@
 /**
  * External dependencies
  */
+import { BackButton } from '@automattic/onboarding';
+import { __, sprintf } from '@wordpress/i18n';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { __, sprintf } from '@wordpress/i18n';
 import { connect } from 'react-redux';
-import page from 'page';
-import { BackButton } from '@automattic/onboarding';
-
 /**
  * Internal dependencies
  */
+import ConnectDomainStepSupportInfoLink from 'calypso/components/domains/connect-domain-step/connect-domain-step-support-info-link';
+import DomainTransferRecommendation from 'calypso/components/domains/domain-transfer-recommendation';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Gridicon from 'calypso/components/gridicon';
+import wpcom from 'calypso/lib/wp';
+import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import ConnectDomainStepSwitchSetupInfoLink from './connect-domain-step-switch-setup-info-link';
+import { isMappingVerificationSuccess } from './connect-domain-step-verification-status-parsing.js';
 import { modeType, stepType, stepSlug, defaultDomainSetupInfo } from './constants';
 import {
 	defaultStepsDefinition,
@@ -18,16 +26,6 @@ import {
 	getProgressStepList,
 	getStepsDefinition,
 } from './page-definitions';
-import ConnectDomainStepSwitchSetupInfoLink from './connect-domain-step-switch-setup-info-link';
-import ConnectDomainStepSupportInfoLink from 'calypso/components/domains/connect-domain-step/connect-domain-step-support-info-link';
-import DomainTransferRecommendation from 'calypso/components/domains/domain-transfer-recommendation';
-import Gridicon from 'calypso/components/gridicon';
-import FormattedHeader from 'calypso/components/formatted-header';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { domainManagementList } from 'calypso/my-sites/domains/paths';
-import { isMappingVerificationSuccess } from './connect-domain-step-verification-status-parsing.js';
-import wpcom from 'calypso/lib/wp';
-
 /**
  * Style dependencies
  */
@@ -96,8 +94,8 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 			setVerificationStatus( {} );
 			setVerificationInProgress( true );
 			wpcom
-				.domain()
-				.mappingStatus( domain )
+				.domain( domain )
+				.mappingStatus()
 				.then( ( data ) => {
 					setVerificationStatus( { data } );
 					if ( setStepAfterVerify ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There were several typos identified by the translators and one bug that I noticed while fixing the typos:

* That's it %s has been successfully connected. - Full stop missing after “That's it”
* Find %s and go to it's settings page. - it's should be its
* Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.)- full stop missing after the parentheses.
* Instead of passing the `domain` variable in to `wpcom.domain()`, I was incorrectly passing it in to `wpcom.domain().mappingStatus()` which meant that we always got `undefined` for the domain in the http request.


#### Testing instructions

Go through the connect a domain flow and make sure that these typos are fixed. Also, make sure that the domain name is included in the call to get the mapping status when clicking on the "verify" button.
