### PR TITLE
desktop: fix magic link notice

### DIFF
--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -21,7 +21,7 @@ module.exports = function ( { view } ) {
 	// to set a password on the account to log in that way.
 	view.webContents.on( 'will-navigate', function ( event, url ) {
 		const urlToLoad =
-			url === Config.loginURL() + 'link'
+			url === Config.baseURL() + 'log-in/link'
 				? 'file://' + assets.getPath( 'magic-links-unsupported.html' )
 				: url;
 		view.webContents.loadURL( urlToLoad );


### PR DESCRIPTION
### Description

Some refactorings were done around the base URL in #55323. I think the magic-link check might have gotten borked as a result, so am patching it here.

### To Test

Attempt to sign in with an account that's set up as passwordless or was created via third-party social login.