### PR TITLE
Themes: show Universal Themes to all sites

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -70,6 +70,7 @@ export class Theme extends Component {
 			PropTypes.func,
 			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
+		isSiteFSE: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -78,6 +79,7 @@ export class Theme extends Component {
 		onMoreButtonClick: noop,
 		actionLabel: '',
 		active: false,
+		isSiteFSE: false,
 	};
 
 	shouldComponentUpdate( nextProps ) {
@@ -113,6 +115,10 @@ export class Theme extends Component {
 		const { theme } = this.props;
 		const features = get( theme, [ 'taxonomies', 'theme_feature' ] );
 		return some( features, { slug: 'block-templates' } );
+	}
+
+	shouldShowBetaBadge() {
+		return this.props.isSiteFSE && this.isFullSiteEditingTheme();
 	}
 
 	renderPlaceholder() {
@@ -246,7 +252,7 @@ export class Theme extends Component {
 					<div className="theme__info">
 						<h2 className="theme__info-title">
 							{ name }
-							{ this.isFullSiteEditingTheme() && (
+							{ this.shouldShowBetaBadge() && (
 								<Badge type="warning-clear" className="theme__badge-beta">
 									{ translate( 'Beta' ) }
 								</Badge>

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -6,8 +6,10 @@ import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
 
@@ -88,6 +90,7 @@ export class ThemesList extends React.Component {
 				installing={ this.props.isInstalling( theme.id ) }
 				upsellUrl={ this.props.upsellUrl }
 				bookmarkRef={ bookmarkRef }
+				isSiteFSE={ this.props.isSiteFSE }
 			/>
 		);
 	}
@@ -139,8 +142,12 @@ export class ThemesList extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state ) => ( {
-	themesBookmark: getThemesBookmark( state ),
-} );
+const mapStateToProps = ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		isSiteFSE: isSiteUsingCoreSiteEditor( state, siteId ),
+		themesBookmark: getThemesBookmark( state ),
+	};
+};
 
 export default connect( mapStateToProps )( localize( ThemesList ) );

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -14,7 +14,6 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import isSiteEligibleForFullSiteEditing from 'calypso/state/selectors/is-site-eligible-for-full-site-editing';
-import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor.js';
 
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 
@@ -47,12 +46,10 @@ registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 			const state = store.getState();
 			const selectedSiteId = getSelectedSiteId( state );
 			const isFse = isSiteEligibleForFullSiteEditing( state, selectedSiteId );
-			const isCoreFse = isSiteUsingCoreSiteEditor( state, selectedSiteId );
 
 			return themeFiltersHandlers( store, {
 				...action,
 				isFse,
-				isCoreFse,
 			} );
 		},
 	],

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -29,8 +29,7 @@ const fetchFilters = ( action ) =>
 	);
 
 const storeFilters = ( action, data ) => {
-	let filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
-	filters = action.isCoreFse ? filters : omit( filters, 'feature.block-templates' );
+	const filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
 	return { type: THEME_FILTERS_ADD, filters };
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* un-hide `block-templates` filter from non-FSE sites

Test along with D65502-code to also un-hide FSE themes from the "All Themes" tab.

#### Testing instructions
On a non-FSE site, check that you can see the `Block Templates` filter in the search bar on the themes page

<img width="986" alt="Screen Shot 2021-08-13 at 14 29 00" src="https://user-images.githubusercontent.com/195089/129409319-ab068847-0882-44d5-9403-6876f6d713d0.png">

Also, ensure that the (Beta) badge is only shown on FSE themes when the Site Editor is active.
