### PR TITLE
Clean unused code from DomainItem and domain-management/List

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -90,8 +90,7 @@
 	}
 }
 
-.domain-management-list-item__upsell,
-.domain-item__upsell {
+.domain-management-list-item__upsell {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -274,12 +273,6 @@
 	@include placeholder( --color-neutral-5 );
 }
 
-.domain-item__enable-selection {
-	> .list__domain-options {
-		visibility: hidden;
-	}
-}
-
 .domain-item__overlay {
 	z-index: 2;
 	background-color: rgba( 255, 255, 255, 0.8 );
@@ -297,10 +290,6 @@
 		font-size: $font-body-small;
 		margin-left: auto;
 		margin-right: 5px;
-	}
-
-	.domain-item__upsell {
-		margin-left: auto;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -6,11 +6,6 @@
 	margin-bottom: 0;
 }
 
-.domain-management-list__cancel-change-primary-button {
-	margin-top: 1px;
-	margin-bottom: 2px;
-}
-
 .domain-management-list-item {
 	&.busy {
 		background-color: var( --color-neutral-0 );
@@ -87,27 +82,6 @@
 		@include placeholder( --color-neutral-10 );
 		display: inline-block;
 		width: 40%;
-	}
-}
-
-.domain-management-list-item__upsell {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-
-	span {
-		margin-right: 16px;
-		flex: 1;
-	}
-}
-
-.list-all__container .list-all__site {
-	margin-bottom: 10px;
-}
-
-.domain-management__claim-free-domain {
-	@include breakpoint-deprecated( '>660px' ) {
-		display: none;
 	}
 }
 
@@ -246,12 +220,6 @@
 	}
 }
 
-.list__domains-header {
-	flex: 1;
-	margin-right: 8px;
-	font-size: $font-body-small;
-}
-
 .list__domain-options {
 	width: 23px;
 	font-size: $font-body-small;
@@ -259,14 +227,6 @@
 	button {
 		width: 100%;
 	}
-}
-
-.domain-item__icon {
-	fill: var( --color-text-subtle );
-}
-
-.list__view-all {
-	margin-top: 24px;
 }
 
 .list__action_item_placeholder {


### PR DESCRIPTION
This PR removes code that became unused after #54649 was merged. The removed code is related to the old way of changing domains to primary, which was done by switching the domain list to a "set primary domain" mode and selecting the desired domain by clicking on a domain's radio button.

#### Testing instructions

Nothing should have broken 🙂 but it would be nice to take a look at the site domains management page (`Upgrades > Domains`) and check if the "Make primary domain" action is working correctly. If possible, also check the bulk contact editing page (`domains/manage?site=all&action=edit-contact-email`) and ensure it's working as well, because it uses the same component.
