### PR TITLE
Pages: Place Homepage at Top of List

### DIFF
--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -49,8 +49,8 @@ export const sortPagesHierarchically = ( pages, homepageId = 0 ) => {
 	} );
 
 	// Places the Homepage at the top of the list.
-	if ( homepageId !== 0 ) {
-		const homepage = sortedPages.findIndex( ( page ) => page.ID == homepageId );
+	const homepage = sortedPages.findIndex( ( page ) => page.ID === homepageId );
+	if ( homepage !== -1 ) {
 		sortedPages.unshift( sortedPages.splice( homepage, 1 )[ 0 ] );
 	}
 

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -14,7 +14,7 @@ export const statsLinkForPage = ( { ID: pageId } = {}, { ID: siteId, slug } ) =>
 export const isFrontPage = ( { ID: pageId } = {}, { options } = {} ) =>
 	pageId && options && options.page_on_front === pageId;
 
-export const sortPagesHierarchically = ( pages ) => {
+export const sortPagesHierarchically = ( pages, homepageId = 0 ) => {
 	const pageIds = map( pages, 'ID' );
 
 	const pagesByParent = reduce(
@@ -47,6 +47,12 @@ export const sortPagesHierarchically = ( pages ) => {
 		sortedPages.push( topLevelPage );
 		insertChildren( topLevelPage.ID, 1 );
 	} );
+
+	// Places the Homepage at the top of the list.
+	if ( homepageId !== 0 ) {
+		const homepage = sortedPages.findIndex( ( page ) => page.ID == homepageId );
+		sortedPages.unshift( sortedPages.splice( homepage, 1 )[ 0 ] );
+	}
 
 	return sortedPages;
 };

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -27,7 +27,7 @@ import {
 	isRequestingPostsForQuery,
 	isPostsLastPageForQuery,
 } from 'calypso/state/posts/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
+import { getSite, getSiteFrontPage } from 'calypso/state/sites/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import SectionHeader from 'calypso/components/section-header';
 import { Button } from '@automattic/components';
@@ -299,7 +299,7 @@ class Pages extends Component {
 	}
 
 	renderHierarchical( { pages, site, showPublishedStatus } ) {
-		pages = sortPagesHierarchically( pages );
+		pages = sortPagesHierarchically( pages, this.props.homepageId );
 		const rows = pages.map( function ( page ) {
 			return (
 				<Page
@@ -397,6 +397,7 @@ const mapState = ( state, { query, siteId } ) => ( {
 	hasSites: hasInitializedSites( state ),
 	loading: isRequestingPostsForQuery( state, siteId, query ),
 	lastPage: isPostsLastPageForQuery( state, siteId, query ),
+	homepageId: getSiteFrontPage( state, siteId ),
 	pages: getPostsForQueryIgnoringPage( state, siteId, query ) || [],
 	site: getSite( state, siteId ),
 	newPageLink: getEditorUrl( state, siteId, null, 'page' ),

--- a/client/my-sites/pages/test/helpers.js
+++ b/client/my-sites/pages/test/helpers.js
@@ -177,5 +177,111 @@ describe( 'helpers', () => {
 				},
 			] );
 		} );
+
+		test( 'should place homepage at top', () => {
+			const testData = [
+				{
+					ID: 1,
+					menu_order: 0,
+					parent: false,
+				},
+				{
+					ID: 2,
+					menu_order: 5,
+					parent: {
+						ID: 1,
+					},
+				},
+				{
+					ID: 3,
+					menu_order: 2,
+					parent: {
+						ID: 1,
+					},
+				},
+				{
+					ID: 4,
+					menu_order: 6,
+					parent: false,
+				},
+			];
+
+			const homepageId = 4;
+			const sortedPages = sortPagesHierarchically( testData, 4 );
+
+			expect( sortedPages ).to.deep.equal( [
+				{
+					ID: 4,
+					menu_order: 6,
+					parent: false,
+				},
+				{
+					ID: 1,
+					menu_order: 0,
+					parent: false,
+				},
+				{
+					ID: 3,
+					indentLevel: 1,
+					menu_order: 2,
+					parent: {
+						ID: 1,
+					},
+				},
+				{
+					ID: 2,
+					indentLevel: 1,
+					menu_order: 5,
+					parent: {
+						ID: 1,
+					},
+				},
+			] );
+		} );
+
+		test( 'should still function without a valid homepage set', () => {
+			const testData = [
+				{
+					ID: 1,
+					parent: {
+						ID: 2,
+					},
+				},
+				{
+					ID: 2,
+					parent: false,
+				},
+				{
+					ID: 3,
+					parent: {
+						ID: 1,
+					},
+				},
+			];
+
+			const homepageId = 0;
+			const sortedPages = sortPagesHierarchically( testData, homepageId );
+
+			expect( sortedPages ).to.deep.equal( [
+				{
+					ID: 2,
+					parent: false,
+				},
+				{
+					ID: 1,
+					indentLevel: 1,
+					parent: {
+						ID: 2,
+					},
+				},
+				{
+					ID: 3,
+					indentLevel: 2,
+					parent: {
+						ID: 1,
+					},
+				},
+			] );
+		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Places the user's Homepage at the top of the Pages list if it exists.

#### Testing instructions

Mark a page as your Homepage and verify that it appears at the top of the list at `/pages` 

<img width="1074" alt="Screenshot 2021-08-13 at 20 33 09" src="https://user-images.githubusercontent.com/43215253/129409745-1c7e143d-d49e-45a4-9248-f6a78e9fc3fb.png">

cc @mmtr

Fixes #35935