### PR TITLE
Filter out Jetpack sites without full Plugin from Sidebar

### DIFF
--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -85,8 +85,8 @@ class SitePicker extends React.Component {
 	};
 
 	filterSites = ( site ) => {
-		return site.jetpack
-			? ( site?.options?.jetpack_connection_active_plugins ?? [] ).includes( 'jetpack' )
+		return site?.options?.jetpack_connection_active_plugins
+			? site.options.jetpack_connection_active_plugins.includes( 'jetpack' )
 			: true;
 	};
 

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -84,6 +84,12 @@ class SitePicker extends React.Component {
 		this.closePicker( null );
 	};
 
+	filterSites = ( site ) => {
+		return site.jetpack
+			? ( site?.options?.jetpack_connection_active_plugins ?? [] ).includes( 'jetpack' )
+			: true;
+	};
+
 	render() {
 		return (
 			<div>
@@ -98,6 +104,7 @@ class SitePicker extends React.Component {
 					autoFocus={ this.state.isAutoFocused }
 					onClose={ this.onClose }
 					groups={ true }
+					filter={ this.filterSites }
 				/>
 			</div>
 		);

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -101,6 +101,7 @@ class SitePicker extends React.Component {
 					showAllSites={ true }
 					allSitesPath={ this.props.allSitesPath }
 					siteBasePath={ this.props.siteBasePath }
+					/* eslint-disable-next-line jsx-a11y/no-autofocus */
 					autoFocus={ this.state.isAutoFocused }
 					onClose={ this.onClose }
 					groups={ true }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -40,8 +40,8 @@ class Sites extends Component {
 	filterSites = ( site ) => {
 		// only show Jetpack sites with the full Plugin
 		if (
-			site.jetpack &&
-			! ( site?.options?.jetpack_connection_active_plugins ?? [] ).includes( 'jetpack' )
+			site?.options?.jetpack_connection_active_plugins &&
+			site.options.jetpack_connection_active_plugins.includes( 'jetpack' )
 		) {
 			return false;
 		}

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -38,6 +38,14 @@ class Sites extends Component {
 	}
 
 	filterSites = ( site ) => {
+		// only show Jetpack sites with the full Plugin
+		if (
+			site.jetpack &&
+			! ( site?.options?.jetpack_connection_active_plugins ?? [] ).includes( 'jetpack' )
+		) {
+			return false;
+		}
+
 		const path = this.props.siteBasePath;
 
 		// Domains can be managed on Simple and Atomic sites.

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -41,7 +41,7 @@ class Sites extends Component {
 		// only show Jetpack sites with the full Plugin
 		if (
 			site?.options?.jetpack_connection_active_plugins &&
-			site.options.jetpack_connection_active_plugins.includes( 'jetpack' )
+			! site.options.jetpack_connection_active_plugins.includes( 'jetpack' )
 		) {
 			return false;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Filter Site Picker and Selector to remove Jetpack instances that do not have the full plugin connected.

#### Testing instructions

 1. Connect a backup-only site ( avoid connecting the full plugin ) to a test account
 2. boot branch and navigate to any page
 3. Open the site selector ( click "Switch Site" )
 4. Verify the new backup-only site does not appear in the  list
 5. Navigate to a page without a site slug ( i.e. `calypso.localhost:3000/backup` )
 6. Verify that the backup only site does not appear in the "Select a site to open X" list
