### PR TITLE
Domains: Fix alignment of success message in bulk email contact update

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -126,6 +126,10 @@
 			transform: translateY( 4px );
 		}
 	}
+
+	.domain-item__status .domain-notice {
+		margin-top: 0;
+	}
 }
 
 .domain-item__title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the alignment of the success message in the bulk email contact update page. This bug was introduced in #54649, which updated the components used in the bulk contact update too.

#### Screenshots

Misaligned message:
<img width="1056" alt="Screen Shot 2021-08-13 at 18 02 22" src="https://user-images.githubusercontent.com/5324818/129418633-f764f57b-c256-428b-98f7-7a2022fdf6b8.png">

Correctly aligned message:
<img width="1051" alt="Screen Shot 2021-08-13 at 18 00 31" src="https://user-images.githubusercontent.com/5324818/129418642-2bdf9e2a-1ecf-4108-935f-3d461f838d6c.png">

#### Testing instructions

Open the live Calypso link, go to the bulk email contact update page (`domains/manage?site=all&action=edit-contact-email`) and select at least one domain to update its email contact. Ensure that the message is vertically aligned with the domain name.
