### PR TITLE
Fix password field in RTL locales, in signup.

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -508,6 +508,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		.form-password-input .form-password-input__toggle-visibility {
+			/*!rtl:ignore*/
 			right: 17px;
 		}
 


### PR DESCRIPTION
Fixes the password field in signup for RTL locales.

How to test the fix:

- http://calypso.localhost:3000/start/ar
  - or https://container-beautiful-bassi.calypso.live/start/ar
- Confirm that you can click on the password field and focus.
- Confirm that you can click the toggle icon in the password field to show/hide plain text pass.
  - When password is shown as plain text, it is aligned right and covered by the icon, that's a separate matter, and we can do a follow-up to resolve.

Regression testing:

- http://calypso.localhost:3000/start
  - or https://container-beautiful-bassi.calypso.live/start
- Confirm that you can click on the password field and focus.
- Confirm that you can click the toggle icon in the password field to show/hide plain text pass.

---

The issue prior to this PR was that you couldn't click to focus this field, because the toggle was covering the entire field due to there being both a `left` and `right` position given. It appears to have been introduced by the reskin deployed May 26th. https://github.com/Automattic/wp-calypso/pull/50512

![Screen Shot on 2021-08-13 at 16:49:04](https://user-images.githubusercontent.com/1563559/129420445-0c6f4b9d-5c8f-4f56-a51f-2d58fe3f422d.png)

![Screen Shot on 2021-08-13 at 16:55:44](https://user-images.githubusercontent.com/1563559/129420450-5e881626-84b2-4622-b780-9cbc387a3688.png)
