### PR TITLE
Fix: Business upgrade upsell shows incorrect price

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -35,6 +35,7 @@ import {
 	isTitanMail,
 	isP2Plus,
 	isMonthlyProduct,
+	isBiennially,
 	getTermDuration,
 	getPlan,
 	isBloggerPlan,
@@ -126,6 +127,10 @@ export function hasDomainCredit( cart ) {
 
 export function hasMonthlyCartItem( cart ) {
 	return getAllCartItems( cart ).some( isMonthlyProduct );
+}
+
+export function hasBiennialCartItem( cart ) {
+	return getAllCartItems( cart ).some( isBiennially );
 }
 
 /**

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -24,8 +24,6 @@ import {
 	hasPremiumPlan,
 	hasBusinessPlan,
 	hasEcommercePlan,
-	hasMonthlyCartItem,
-	hasBiennialCartItem,
 	hasTrafficGuide,
 } from 'calypso/lib/cart-values/cart-items';
 import { managePurchase } from 'calypso/me/purchases/paths';
@@ -34,7 +32,12 @@ import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_RESET_PLANS,
 	JETPACK_REDIRECT_URL,
+	PLAN_BUSINESS,
 	redirectCheckoutToWpAdmin,
+	findFirstSimilarPlanKey,
+	getPlan,
+	isPlan,
+	isWpComPremiumPlan,
 } from '@automattic/calypso-products';
 import { persistSignupDestination, retrieveSignupDestination } from 'calypso/signup/storageUtils';
 import { badNaiveClientSideRollout } from 'calypso/lib/naive-client-side-rollout';
@@ -362,6 +365,30 @@ function getFallbackDestination( {
 	return '/';
 }
 
+/**
+ * This function returns the product slug of the next higher plan of the plan item in the cart.
+ * Currently, it only supports premium plans.
+ *
+ * @param {ResponseCart} cart the cart object
+ * @returns {string|undefined} the product slug of the next higher plan if it exists, undefined otherwise.
+ */
+function getNextHigherPlanSlug( cart: ResponseCart ): string | undefined {
+	const currentPlanSlug = cart && getAllCartItems( cart ).filter( isPlan )[ 0 ]?.product_slug;
+	if ( ! currentPlanSlug ) {
+		return;
+	}
+
+	const currentPlan = getPlan( currentPlanSlug );
+
+	if ( isWpComPremiumPlan( currentPlanSlug ) ) {
+		return getPlan(
+			findFirstSimilarPlanKey( PLAN_BUSINESS, { term: currentPlan.term } )
+		)?.getPathSlug();
+	}
+
+	return;
+}
+
 function maybeShowPlanBumpOffer( {
 	pendingOrReceiptId,
 	cart,
@@ -376,17 +403,11 @@ function maybeShowPlanBumpOffer( {
 	if ( orderId ) {
 		return;
 	}
-	if ( hasPremiumPlan( cart ) ) {
-		const upgradeItem = ( () => {
-			if ( hasMonthlyCartItem( cart ) ) {
-				return 'business-monthly';
-			}
-			if ( hasBiennialCartItem( cart ) ) {
-				return 'business-2-years';
-			}
-			return 'business';
-		} )();
-		return `/checkout/${ siteSlug }/offer-plan-upgrade/${ upgradeItem }/${ pendingOrReceiptId }`;
+	if ( cart && hasPremiumPlan( cart ) ) {
+		const upgradeItem = getNextHigherPlanSlug( cart );
+		if ( upgradeItem ) {
+			return `/checkout/${ siteSlug }/offer-plan-upgrade/${ upgradeItem }/${ pendingOrReceiptId }`;
+		}
 	}
 
 	return;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -25,6 +25,7 @@ import {
 	hasBusinessPlan,
 	hasEcommercePlan,
 	hasMonthlyCartItem,
+	hasBiennialCartItem,
 	hasTrafficGuide,
 } from 'calypso/lib/cart-values/cart-items';
 import { managePurchase } from 'calypso/me/purchases/paths';
@@ -376,7 +377,15 @@ function maybeShowPlanBumpOffer( {
 		return;
 	}
 	if ( hasPremiumPlan( cart ) ) {
-		const upgradeItem = hasMonthlyCartItem( cart ) ? 'business-monthly' : 'business';
+		const upgradeItem = ( () => {
+			if ( hasMonthlyCartItem( cart ) ) {
+				return 'business-monthly';
+			}
+			if ( hasBiennialCartItem( cart ) ) {
+				return 'business-2-years';
+			}
+			return 'business';
+		} )();
 		return `/checkout/${ siteSlug }/offer-plan-upgrade/${ upgradeItem }/${ pendingOrReceiptId }`;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -966,6 +966,62 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/jetpack/thank-you/foo.bar/no_product' );
 	} );
 
+	describe( 'Plan Upgrade Upsell Nudge', () => {
+		it( 'offers discounted business plan upgrade when premium plan is purchased.', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: 'value_bundle',
+						bill_period: 365,
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: 'foo.bar',
+				receiptId: '1234abcd',
+				cart,
+			} );
+			expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/1234abcd' );
+		} );
+
+		it( 'offers discounted biennial business plan upgrade when biennial premium plan is purchased.', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: 'value_bundle-2y',
+						bill_period: 730,
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: 'foo.bar',
+				receiptId: '1234abcd',
+				cart,
+			} );
+			expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business-2-years/1234abcd' );
+		} );
+
+		it( 'offers discounted monthly business plan upgrade when monthly premium plan is purchased.', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: 'value_bundle_monthly',
+						bill_period: 31,
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: 'foo.bar',
+				receiptId: '1234abcd',
+				cart,
+			} );
+			expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business-monthly/1234abcd' );
+		} );
+	} );
+
 	describe( 'Jetpack Siteless Checkout Thank You', () => {
 		it( 'redirects when jetpack checkout arg is set, but siteSlug is undefined.', () => {
 			const cart = {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -252,9 +252,10 @@ export function upsellNudge( context, next ) {
 
 		switch ( upgradeItem ) {
 			case 'business':
+			case 'business-2-years':
+			case 'business-monthly':
 				upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
 				break;
-
 			default:
 				upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the bug that the Business upgrade upsell nudge shows incorrect price to those who purchased biennial Premium plan. The issue has been reported on p1627688007013700-slack-C042CJ2NH by @CodeAllNightNDay 

For more details, check out pau2Xa-3gl-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase/renew _biennial_ Premium plan.
* The discounted plan price in the post purchase screen should not be zero in any currency.
  <img width="735" alt="Checkout_‹_Plan_Upgrade_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/129474423-0b4dda11-0c57-4998-a0cf-f9ea20e024a9.png">