### PR TITLE
Fix/45004 thank you page load without scrolltop

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -257,6 +257,7 @@ export default function useCreatePaymentCompleteCallback( {
 
 function performRedirect( url: string ): void {
 	try {
+		window.scrollTo( 0, 0 );
 		page( url );
 	} catch ( err ) {
 		window.location.href = url;

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -27,8 +27,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						'That includes new domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. Does not apply to premium domains. Domain name should be' +
 						' registered within one year of the purchase of the plan to use this promotion. Registered' +
-						' domain names will renew at regular prices. The domain credit for a free domain for the' +
-						' first year is only included with the annual or two-year plans. {{a}}Find out more about domains.{{/a}}',
+						' domain names will renew at regular prices. {{a}}Find out more about domains.{{/a}}',
 					{
 						components: {
 							a: (

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -27,7 +27,8 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						'That includes new domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. Does not apply to premium domains. Domain name should be' +
 						' registered within one year of the purchase of the plan to use this promotion. Registered' +
-						' domain names will renew at regular prices. {{a}}Find out more about domains.{{/a}}',
+						' domain names will renew at regular prices. The domain credit for a free domain for the' +
+						' first year is only included with the annual or two-year plans. {{a}}Find out more about domains.{{/a}}',
 					{
 						components: {
 							a: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a scrollTo top statement so that post-checkout on thank you page it should scroll at the top.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing steps can be followed as mentioned in the issue. Here is the link to the comment: [Testing Instruction link](https://github.com/Automattic/wp-calypso/issues/45004#issuecomment-891311005)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoids
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #45004
Fixes #45004 

cc @sirbrillig 