### PR TITLE
Format locale from the @wordpress/i18n locale data to ISO 639

### DIFF
--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,6 +1,7 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import * as i18n from '@wordpress/i18n';
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Locale } from './locales';
 
 export const localeContext = createContext< string | null >( null );
 
@@ -17,6 +18,22 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
  */
 function getWpI18nLocaleSlug(): string | undefined {
 	return i18n.getLocaleData && i18n.getLocaleData()?.[ '' ]?.language;
+}
+
+/**
+ * Returns ISO 639 conforming locale string.
+ *
+ * @param {string} locale locale to be converted e.g. "en_US".
+ * @returns string ISO 639 locale string e.g. "en"
+ */
+function formatLocale( locale: Locale = '' ): Locale {
+	const TARGET_LOCALES = [ 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ];
+	const lowerCaseLocale = locale.toLowerCase();
+	const formattedLocale = TARGET_LOCALES.includes( lowerCaseLocale )
+		? lowerCaseLocale.replace( '_', '-' )
+		: lowerCaseLocale.replace( /([-_].*)$/i, '' );
+
+	return formattedLocale || 'en';
 }
 
 /**
@@ -52,7 +69,7 @@ export function useLocale(): string {
 		} );
 	}, [ providerHasLocale ] );
 
-	return fromProvider || fromWpI18n || 'en';
+	return fromProvider || formatLocale( fromWpI18n ) || 'en';
 }
 
 /**

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -14,26 +14,32 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
 );
 
 /**
- * Get the current locale slug from the @wordpress/i18n locale data
- */
-function getWpI18nLocaleSlug(): string | undefined {
-	return i18n.getLocaleData && i18n.getLocaleData()?.[ '' ]?.language;
-}
-
-/**
- * Returns ISO 639 conforming locale string.
+ * Returns locale slug
  *
  * @param {string} locale locale to be converted e.g. "en_US".
- * @returns string ISO 639 locale string e.g. "en"
+ * @returns locale string e.g. "en"
  */
-function formatLocale( locale: Locale = '' ): Locale {
-	const TARGET_LOCALES = [ 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ];
+function mapWpI18nLangToLocaleSlug( locale: Locale = '' ): Locale {
+	if ( ! locale ) {
+		return '';
+	}
+
+	const TARGET_LOCALES = [ 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn', 'zh_sg', 'zh-sg' ];
 	const lowerCaseLocale = locale.toLowerCase();
 	const formattedLocale = TARGET_LOCALES.includes( lowerCaseLocale )
 		? lowerCaseLocale.replace( '_', '-' )
 		: lowerCaseLocale.replace( /([-_].*)$/i, '' );
 
 	return formattedLocale || 'en';
+}
+
+/**
+ * Get the current locale slug from the @wordpress/i18n locale data
+ */
+function getWpI18nLocaleSlug(): string | undefined {
+	const language = i18n.getLocaleData ? i18n.getLocaleData()?.[ '' ]?.language : '';
+
+	return mapWpI18nLangToLocaleSlug( language );
 }
 
 /**
@@ -69,7 +75,7 @@ export function useLocale(): string {
 		} );
 	}, [ providerHasLocale ] );
 
-	return fromProvider || formatLocale( fromWpI18n ) || 'en';
+	return fromProvider || fromWpI18n || 'en';
 }
 
 /**

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,7 +1,7 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import * as i18n from '@wordpress/i18n';
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { Locale } from './locales';
+import type { Locale } from './locales';
 
 export const localeContext = createContext< string | null >( null );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the `localizeUrl` might not get the correct localized URL because the locale format from `@wordpress/i18n` might not be ISO 639 if <LocaleProvider> wasn't anywhere in the tree.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D65529-code in your sandbox
* Follow the Testing instructions of https://github.com/Automattic/wp-calypso/pull/55436
* Remove the second parameter of `localizeUrl` in https://github.com/Automattic/wp-calypso/blob/8cb72ff31d21658a5ba5d352e71f096e3f15d6b6/apps/editing-toolkit/editing-toolkit-plugin/tags-education/src/add-tags-education-link.js#L30
* Check the "Build your audience with tags" link to correct locale document

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/55436