### PR TITLE
Redux persistence: decouple user ID from store state

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -419,7 +419,7 @@ const boot = ( currentUser, registerRoutes ) => {
 	loadAllState().then( () => {
 		const initialState = getInitialState( initialReducer, currentUser?.ID );
 		const reduxStore = createReduxStore( initialState, initialReducer );
-		setStore( reduxStore );
+		setStore( reduxStore, currentUser?.ID );
 		onDisablePersistence( persistOnChange( reduxStore, currentUser?.ID ) );
 		setupLocale( currentUser, reduxStore );
 		configureReduxStore( currentUser, reduxStore );

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -3,7 +3,6 @@
  */
 import 'calypso/boot/polyfills';
 
-import debugFactory from 'debug';
 import page from 'page';
 import { setupLocale } from 'calypso/boot/locale';
 import { render } from 'calypso/controller/web-util';
@@ -13,19 +12,13 @@ import { setStore } from 'calypso/state/redux-store';
 import { setupMiddlewares, configureReduxStore } from './common';
 import createStore from './store';
 
-const debug = debugFactory( 'calypso' );
-
 import 'calypso/assets/stylesheets/style.scss';
 // goofy import for environment badge, which is SSR'd
 import 'calypso/components/environment-badge/style.scss';
 
-// Create Redux store
-const store = createStore();
-setStore( store );
-
 const boot = ( currentUser ) => {
-	debug( "Starting Calypso. Let's do this." );
-
+	const store = createStore();
+	setStore( store, currentUser?.ID );
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
 	setupLocale( currentUser, store );

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import page from 'page';
 import * as LoadingError from 'calypso/layout/error';
 import { performanceTrackerStart } from 'calypso/lib/performance-tracking';
-import { addReducerToStore } from 'calypso/state/add-reducer';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { setSectionLoading } from 'calypso/state/ui/actions';
 import { activateNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -31,7 +30,7 @@ async function loadSection( context, sectionDefinition ) {
 		// load the section module, i.e., its webpack chunk
 		const requiredModule = await load( sectionDefinition.name, sectionDefinition.module );
 		// call the module initialization function (possibly async, registers page.js handlers etc.)
-		await requiredModule.default( controller.clientRouter, addReducerToStore( context.store ) );
+		await requiredModule.default( controller.clientRouter );
 	} finally {
 		context.store.dispatch( setSectionLoading( false ) );
 

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -33,7 +33,7 @@ function initializeState(
 	store: Store & WithAddReducer,
 	storageKey: string,
 	reducer: Reducer & OptionalStorageKey,
-	currentUserId: number
+	currentUserId: number | undefined
 ) {
 	const storedState = getStateFromCache( reducer, storageKey, currentUserId );
 
@@ -46,7 +46,7 @@ function initializeState(
 // and loads (asynchronously) and applies the persisted state for it.
 export const addReducerToStore = < T extends Reducer & OptionalStorageKey >(
 	store: Store & WithAddReducer,
-	currentUserId: number
+	currentUserId: number | undefined
 ) => ( key: string[], reducer: T ): void => {
 	const storageKey: string | undefined = reducer.storageKey;
 	const normalizedKey = normalizeKey( key );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -104,7 +104,7 @@ export async function clearAllState() {
 }
 
 function getPersistenceKey( userId, subkey ) {
-	return 'redux-state-' + userId ?? 'logged-out' + ( subkey ? ':' + subkey : '' );
+	return 'redux-state-' + ( userId ?? 'logged-out' ) + ( subkey ? ':' + subkey : '' );
 }
 
 async function persistentStoreState( reduxStateKey, storageKey, state, _timestamp ) {
@@ -236,8 +236,7 @@ function getInitialPersistedState( initialReducer, currentUserId ) {
 // This function handles both legacy and modularized Redux state.
 // `loadAllState` must have completed first.
 function getStateFromPersistence( reducer, subkey, currentUserId ) {
-	const reduxStateKey = getPersistenceKey( subkey, currentUserId );
-
+	const reduxStateKey = getPersistenceKey( currentUserId, subkey );
 	const state = stateCache[ reduxStateKey ] ?? null;
 	return deserializeState( subkey, state, reducer, false );
 }

--- a/client/state/redux-store.ts
+++ b/client/state/redux-store.ts
@@ -15,10 +15,10 @@ export type ReduxDispatch = ThunkDispatch< ReturnType< typeof getInitialState >,
 type QueueEntry = [ string[], Reducer ];
 
 let applicationStore: ( Store & WithAddReducer ) | undefined;
-let applicationUserId: number | null;
+let applicationUserId: number | undefined;
 const reducerRegistrationQueue: QueueEntry[] = [];
 
-export function setStore( store: Store & WithAddReducer, currentUserId: number | null ): void {
+export function setStore( store: Store & WithAddReducer, currentUserId: number | undefined ): void {
 	// Clear any previously added reducers when replacing an existing store.
 	if ( applicationStore ) {
 		clearReducers();

--- a/client/state/redux-store.ts
+++ b/client/state/redux-store.ts
@@ -15,28 +15,30 @@ export type ReduxDispatch = ThunkDispatch< ReturnType< typeof getInitialState >,
 type QueueEntry = [ string[], Reducer ];
 
 let applicationStore: ( Store & WithAddReducer ) | undefined;
+let applicationUserId: number | null;
 const reducerRegistrationQueue: QueueEntry[] = [];
 
-export function setStore( store: Store & WithAddReducer ) {
+export function setStore( store: Store & WithAddReducer, currentUserId: number | null ): void {
 	// Clear any previously added reducers when replacing an existing store.
 	if ( applicationStore ) {
 		clearReducers();
 	}
 
 	applicationStore = store;
+	applicationUserId = currentUserId;
 
 	// Synchronously add all pending reducers.
 	// These include reducers registered to previous stores, since their code has
 	// already been loaded.
 	for ( const [ key, reducer ] of reducerRegistrationQueue ) {
-		addReducerToStore( applicationStore )( key, reducer );
+		addReducerToStore( applicationStore, applicationUserId )( key, reducer );
 	}
 }
 
-export function registerReducer( key: string[], reducer: Reducer ) {
+export function registerReducer( key: string[], reducer: Reducer ): void {
 	if ( applicationStore ) {
 		// Register immediately.
-		addReducerToStore( applicationStore )( key, reducer );
+		addReducerToStore( applicationStore, applicationUserId )( key, reducer );
 	}
 
 	// Add to queue, for future stores.

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -894,7 +894,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer, 123456789 );
+		const userId = 123456789;
+		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -906,7 +907,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const aReducer = withStorageKey( 'A', withKeyPrefix( 'A' ) );
-		addReducerToStore( store )( [ 'a' ], aReducer );
+		addReducerToStore( store, userId )( [ 'a' ], aReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -928,7 +929,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer, 123456789 );
+		const userId = 123456789;
+		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -940,7 +942,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const cdReducer = withStorageKey( 'CD', withKeyPrefix( 'CD' ) );
-		addReducerToStore( store )( [ 'c', 'd' ], cdReducer );
+		addReducerToStore( store, userId )( [ 'c', 'd' ], cdReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -964,7 +966,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer, 123456789 );
+		const userId = 123456789;
+		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -976,8 +979,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const eReducer = withStorageKey( 'E', withKeyPrefix( 'E' ) );
-		addReducerToStore( store )( [ 'e' ], eReducer );
-		addReducerToStore( store )( [ 'e' ], eReducer );
+		addReducerToStore( store, userId )( [ 'e' ], eReducer );
+		addReducerToStore( store, userId )( [ 'e' ], eReducer );
 
 		// verify that the Redux store contains the stored state for `E` now
 		expect( store.getState() ).toEqual( {
@@ -999,7 +1002,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load initial state and create Redux store with it
 		await loadAllState();
-		const state = getInitialState( reducer, 123456789 );
+		const userId = 123456789;
+		const state = getInitialState( reducer, userId );
 		const store = createReduxStore( state, reducer );
 
 		// verify that the initial Redux store loaded state only for `currentUser`
@@ -1014,8 +1018,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		const cReducer = withStorageKey( 'C', withKeyPrefix( 'C' ) );
 
 		expect( () => {
-			addReducerToStore( store )( [ 'b' ], bReducer );
-			addReducerToStore( store )( [ 'b' ], cReducer );
+			addReducerToStore( store, userId )( [ 'b' ], bReducer );
+			addReducerToStore( store, userId )( [ 'b' ], cReducer );
 		} ).toThrow();
 	} );
 } );

--- a/docs/modularized-state.md
+++ b/docs/modularized-state.md
@@ -155,7 +155,7 @@ import Thing from '../';
 describe( 'Thing', () => {
 	test( 'renders correctly', () => {
 		const store = createReduxStore();
-		setStore( store );
+		setStore( store, currentUserId );
 		// Instantiate and test component
 	} );
 } );


### PR DESCRIPTION
When adding a dynamic reducer with the `addReducerToStore( store )` function, this function internally relies that the current user ID is stored in the `store`'s root reducer and can be always retrieved with `getCurrentUserId( store.getState() )`. This user ID is used to determine the key prefix (`redux-state-1234`) under which state is persisted in the IndexedDB database. But what if the root reducer doesn't contain `state.currentUser.id` or if the `currentUser` state is not persisted? Then the modular Redux framework cannot be used.

This PR decouples the user ID from the Redux state by adding a `currentUserId` parameter to `addReducerToStore` and initializing it on boot by calling the `setStore` function from `calypso/state/redux-store` with an extra parameter.

I discovered this issue when trying to reorganize the `state.currentUser` reducer and trying to remove persistence from it. As `state.currentUser` is always initialized from an authoritative source, it doesn't need to be persisted at all.

**How to test:**
Verify that dynamic reducer state is still correctly persisted -- saved and loaded -- after this change.