### PR TITLE
Purchases: Request removals through `wpcom/v2` endpoints

### DIFF
--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -20,6 +20,7 @@ export function cancelAndRefundPurchase( purchaseId, data, onComplete ) {
 		{
 			path: `/upgrades/${ purchaseId }/cancel`,
 			body: data,
+			apiNamespace: 'wpcom/v2',
 		},
 		onComplete
 	);

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -18,7 +18,7 @@ export function cancelPurchase( purchaseId, onComplete ) {
 export function cancelAndRefundPurchase( purchaseId, data, onComplete ) {
 	wpcom.req.post(
 		{
-			path: `/upgrades/${ purchaseId }/cancel`,
+			path: `/purchases/${ purchaseId }/cancel`,
 			body: data,
 			apiNamespace: 'wpcom/v2',
 		},

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -16,7 +16,13 @@ export function cancelPurchase( purchaseId, onComplete ) {
 }
 
 export function cancelAndRefundPurchase( purchaseId, data, onComplete ) {
-	wpcom.undocumented().cancelAndRefundPurchase( purchaseId, data, onComplete );
+	wpcom.req.post(
+		{
+			path: `/upgrades/${ purchaseId }/cancel`,
+			body: data,
+		},
+		onComplete
+	);
 }
 
 export function submitSurvey( surveyName, siteID, surveyData ) {

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -250,50 +250,14 @@ UndocumentedMe.prototype.newValidationAccountRecoveryEmail = function ( callback
 /**
  * Connect the current account with a social service (e.g. Google/Facebook).
  *
- * @param {object} An object containing the keys:
- *	{string} service - Social service associated with token, e.g. google.
- *  {string} access_token - OAuth2 Token returned from service.
- *  {string} id_token - (Optional) OpenID Connect Token returned from service.
- *  {string} user_name - (Optional) The user name associated with this connection, in case it's not part of id_token.
- *  {string} user_email - (Optional) The user name associated with this connection, in case it's not part of id_token.
- *  {string} redirect_to - The URL to redirect to after connecting.
- * @param An.access_token
- * @param An.service
- * @param An.access_token
- * @param An.service
- * @param An.access_token
- * @param An.service
- * @param An.access_token
- * @param An.service
- * @param An.access_token
- * @param An.service
- * @param An.access_token
- * @param An.service
+ * @param {object} config Object containing the config.
+ * @param {string} config.service Social service associated with token, e.g. google.
+ * @param {string} config.access_token OAuth2 Token returned from service.
+ * @param {string} config.id_token (Optional) OpenID Connect Token returned from service.
+ * @param {string} config.user_name (Optional) The user name associated with this connection, in case it's not part of id_token.
+ * @param {string} config.user_email (Optional) The user name associated with this connection, in case it's not part of id_token.
+ * @param {string} config.redirect_to - The URL to redirect to after connecting.
  * @param {Function} fn - The callback for the request.
- * @param An.id_token
- * @param An.user_name
- * @param An.user_email
- * @param An.redirect_to
- * @param An.id_token
- * @param An.user_name
- * @param An.user_email
- * @param An.redirect_to
- * @param An.id_token
- * @param An.user_name
- * @param An.user_email
- * @param An.redirect_to
- * @param An.id_token
- * @param An.user_name
- * @param An.user_email
- * @param An.redirect_to
- * @param An.id_token
- * @param An.user_name
- * @param An.user_email
- * @param An.redirect_to
- * @param An.id_token
- * @param An.user_name
- * @param An.user_email
- * @param An.redirect_to
  * @returns {Promise} A promise for the request
  */
 UndocumentedMe.prototype.socialConnect = function (

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1845,18 +1845,6 @@ Undocumented.prototype.enableAutoRenew = function ( purchaseId, fn ) {
 	);
 };
 
-Undocumented.prototype.cancelAndRefundPurchase = function ( purchaseId, data, fn ) {
-	debug( 'upgrades/{purchaseId}/cancel' );
-
-	return this.wpcom.req.post(
-		{
-			path: `/upgrades/${ purchaseId }/cancel`,
-			body: data,
-		},
-		fn
-	);
-};
-
 Undocumented.prototype.cancelPlanTrial = function ( planId, fn ) {
 	debug( '/upgrades/{planId}/cancel-plan-trial' );
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -164,13 +164,15 @@ class CancelPurchaseButton extends Component {
 					return;
 				}
 
-				this.props.successNotice( response.message, { displayOnNextPage: true } );
+				if ( response.status === 'completed' ) {
+					this.props.successNotice( response.message, { displayOnNextPage: true } );
 
-				this.props.refreshSitePlans( purchase.siteId );
+					this.props.refreshSitePlans( purchase.siteId );
 
-				this.props.clearPurchases();
+					this.props.clearPurchases();
 
-				page.redirect( this.props.purchaseListUrl );
+					page.redirect( this.props.purchaseListUrl );
+				}
 			}
 		);
 	};
@@ -199,13 +201,15 @@ class CancelPurchaseButton extends Component {
 					return;
 				}
 
-				this.props.successNotice( response.message, { displayOnNextPage: true } );
+				if ( response.status === 'completed' ) {
+					this.props.successNotice( response.message, { displayOnNextPage: true } );
 
-				this.props.refreshSitePlans( purchase.siteId );
+					this.props.refreshSitePlans( purchase.siteId );
 
-				this.props.clearPurchases();
+					this.props.clearPurchases();
 
-				page.redirect( this.props.purchaseListUrl );
+					page.redirect( this.props.purchaseListUrl );
+				}
 			}
 		);
 	};

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -114,7 +114,7 @@ class ConfirmCancelDomain extends React.Component {
 
 		this.setState( { submitting: true } );
 
-		cancelAndRefundPurchase( purchase.id, data, ( error ) => {
+		cancelAndRefundPurchase( purchase.id, data, ( error, response ) => {
 			this.setState( { submitting: false } );
 
 			const { isDomainOnlySite, translate, selectedSite } = this.props;
@@ -135,22 +135,24 @@ class ConfirmCancelDomain extends React.Component {
 				return;
 			}
 
-			this.props.successNotice(
-				translate( '%(purchaseName)s was successfully cancelled and refunded.', {
-					args: { purchaseName },
-				} ),
-				{ displayOnNextPage: true }
-			);
+			if ( response.status === 'completed' ) {
+				this.props.successNotice(
+					translate( '%(purchaseName)s was successfully cancelled and refunded.', {
+						args: { purchaseName },
+					} ),
+					{ displayOnNextPage: true }
+				);
 
-			this.props.refreshSitePlans( purchase.siteId );
+				this.props.refreshSitePlans( purchase.siteId );
 
-			this.props.clearPurchases();
+				this.props.clearPurchases();
 
-			recordTracksEvent( 'calypso_domain_cancel_form_submit', {
-				product_slug: purchase.productSlug,
-			} );
+				recordTracksEvent( 'calypso_domain_cancel_form_submit', {
+					product_slug: purchase.productSlug,
+				} );
 
-			page.redirect( this.props.purchaseListUrl );
+				page.redirect( this.props.purchaseListUrl );
+			}
 		} );
 	};
 

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -72,7 +72,7 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
 	return wpcom.req
 		.post( {
-			path: `/me/purchases/${ purchaseId }/delete`,
+			path: `/purchases/${ purchaseId }/delete`,
 			apiNamespace: 'wpcom/v2',
 		} )
 		.then( ( data ) => {

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -71,15 +71,20 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 
 export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
 	return wpcom.req
-		.post( `/me/purchases/${ purchaseId }/delete` )
+		.post( {
+			path: `/me/purchases/${ purchaseId }/delete`,
+			apiNamespace: 'wpcom/v2',
+		} )
 		.then( ( data ) => {
-			dispatch( {
-				type: PURCHASE_REMOVE_COMPLETED,
-				purchases: data.purchases,
-				userId,
-			} );
+			if ( data.status === 'completed' ) {
+				dispatch( {
+					type: PURCHASE_REMOVE_COMPLETED,
+					purchases: data.purchases,
+					userId,
+				} );
 
-			dispatch( requestHappychatEligibility() );
+				dispatch( requestHappychatEligibility() );
+			}
 		} )
 		.catch( ( error ) => {
 			dispatch( {

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -91,7 +91,7 @@ describe( 'actions', () => {
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.post( `/wpcom/v2/me/purchases/${ purchaseId }/delete` )
+				.post( `/wpcom/v2/purchases/${ purchaseId }/delete` )
 				.reply( 200, response );
 		} );
 
@@ -113,7 +113,7 @@ describe( 'actions', () => {
 		const errorMessage = 'Unable to delete the purchase because of internal error';
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.post( `/wpcom/v2/me/purchases/${ purchaseId }/delete` )
+				.post( `/wpcom/v2/purchases/${ purchaseId }/delete` )
 				.reply( 400, {
 					error: 'server_error',
 					message: errorMessage,

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -87,11 +87,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#removePurchase success', () => {
-		const response = { purchases };
+		const response = { status: 'completed', purchases };
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.post( `/rest/v1.1/me/purchases/${ purchaseId }/delete` )
+				.post( `/wpcom/v2/me/purchases/${ purchaseId }/delete` )
 				.reply( 200, response );
 		} );
 
@@ -113,7 +113,7 @@ describe( 'actions', () => {
 		const errorMessage = 'Unable to delete the purchase because of internal error';
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.post( `/rest/v1.1/me/purchases/${ purchaseId }/delete` )
+				.post( `/wpcom/v2/me/purchases/${ purchaseId }/delete` )
 				.reply( 400, {
 					error: 'server_error',
 					message: errorMessage,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/55555

#### Changes proposed in this Pull Request

Updates the actions that trigger removal/cancellation of purchases so they are requested via the new `wpcom/v2` endpoints (introduced in D65705-code and D65870-code) which will include support for automatically reverting an Atomic site.

#### Testing instructions

- Test the cancellation and refund flows. Make sure there are no regressions.
- Test the removal flows. Make sure there are no regressions.