### PR TITLE
Shopping Cart: Add tests for withShoppingCart

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -120,6 +120,11 @@ export type ShoppingCartState = {
 	queuedActions: ShoppingCartAction[];
 };
 
+export interface WithShoppingCartProps {
+	shoppingCartManager: ShoppingCartManager;
+	cart: ResponseCart;
+}
+
 export type CartValidCallback = ( cart: ResponseCart ) => void;
 
 export type DispatchAndWaitForValid = ( action: ShoppingCartAction ) => Promise< ResponseCart >;

--- a/packages/shopping-cart/src/with-shopping-cart.tsx
+++ b/packages/shopping-cart/src/with-shopping-cart.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import useShoppingCart from './use-shopping-cart';
+import type { WithShoppingCartProps } from './types';
 
-export default function withShoppingCart< P >( Component: React.ComponentType< P > ) {
-	return function ShoppingCartWrapper( props: P ): JSX.Element {
+export default function withShoppingCart< ComponentProps >(
+	Component: React.ComponentType< ComponentProps & WithShoppingCartProps >
+): React.FC< ComponentProps > {
+	return function ShoppingCartWrapper( props ): JSX.Element {
 		const shoppingCartManager = useShoppingCart();
 		return (
 			<Component

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -8,11 +8,17 @@ import {
 import React, { useEffect, useRef } from 'react';
 import { getEmptyResponseCart } from '../src/empty-carts';
 import { useShoppingCart, withShoppingCart, ShoppingCartProvider } from '../src/index';
+import {
+	getCart,
+	setCart,
+	planOne,
+	planTwo,
+	renewalOne,
+	renewalTwo,
+	mainCartKey,
+} from './utils/mock-cart-api';
 import type {
 	RequestCartProduct,
-	ResponseCartProduct,
-	RequestCart,
-	ResponseCart,
 	MinimalRequestCartProduct,
 	GetCart,
 	SetCart,
@@ -24,122 +30,7 @@ import type {
 import '@automattic/calypso-polyfills';
 import '@testing-library/jest-dom/extend-expect';
 
-const planOne: ResponseCartProduct = {
-	time_added_to_cart: Date.now(),
-	current_quantity: 1,
-	product_name: 'WordPress.com Personal',
-	product_slug: 'personal-bundle',
-	currency: 'BRL',
-	extra: {
-		context: 'signup',
-	},
-	meta: '',
-	product_id: 1009,
-	volume: 1,
-	quantity: null,
-	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
-	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
-	product_cost_integer: 14400,
-	product_cost_display: 'R$144',
-	item_subtotal_monthly_cost_display: 'R$144',
-	item_subtotal_monthly_cost_integer: 14400,
-	item_original_subtotal_integer: 14400,
-	item_original_subtotal_display: 'R$144',
-	is_domain_registration: false,
-	is_bundled: false,
-	is_sale_coupon_applied: false,
-	months_per_bill_period: null,
-	uuid: 'product001',
-	cost: 144,
-	price: 144,
-	product_type: 'test',
-	included_domain_purchase_amount: 0,
-};
-
-const planTwo: ResponseCartProduct = {
-	time_added_to_cart: Date.now(),
-	current_quantity: 1,
-	product_name: 'WordPress.com Business',
-	product_slug: 'business-bundle',
-	currency: 'BRL',
-	extra: {
-		context: 'signup',
-	},
-	meta: '',
-	product_id: 1010,
-	volume: 1,
-	quantity: null,
-	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
-	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
-	product_cost_integer: 14400,
-	product_cost_display: 'R$144',
-	item_subtotal_monthly_cost_display: 'R$144',
-	item_subtotal_monthly_cost_integer: 14400,
-	item_original_subtotal_integer: 14400,
-	item_original_subtotal_display: 'R$144',
-	is_domain_registration: false,
-	is_bundled: false,
-	is_sale_coupon_applied: false,
-	months_per_bill_period: null,
-	uuid: 'product002',
-	cost: 144,
-	price: 144,
-	product_type: 'test',
-	included_domain_purchase_amount: 0,
-};
-
-const renewalOne: ResponseCartProduct = {
-	...planOne,
-	extra: { purchaseType: 'renewal' },
-};
-
-const renewalTwo: ResponseCartProduct = {
-	...planTwo,
-	extra: { purchaseType: 'renewal' },
-};
-
-const mainCartKey = '1';
-
 const emptyResponseCart = getEmptyResponseCart();
-
-async function getCart( cartKey: string ) {
-	if ( cartKey === mainCartKey ) {
-		return emptyResponseCart;
-	}
-	throw new Error( 'Unknown cart key' );
-}
-
-function createProduct( productProps: RequestCartProduct ): ResponseCartProduct {
-	switch ( productProps.product_id ) {
-		case 1009:
-			return planOne;
-		case 1010:
-			return planTwo;
-	}
-	throw new Error( 'Unknown product' );
-}
-
-async function setCart( cartKey: string, newCart: RequestCart ): Promise< ResponseCart > {
-	if ( [ 'no-site', 'no-user', mainCartKey ].includes( cartKey ) ) {
-		// Mock the shopping-cart endpoint response here
-		return {
-			...emptyResponseCart,
-			cart_key: cartKey,
-			products: newCart.products.map( createProduct ),
-			coupon: newCart.coupon,
-			is_coupon_applied: !! newCart.coupon,
-			tax: {
-				display_taxes: !! newCart.tax?.location.postal_code,
-				location: newCart.tax?.location,
-			},
-		};
-	}
-	throw new Error( 'Unknown cart key' );
-}
 
 function ProductList( {
 	initialProducts,

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -17,6 +17,7 @@ import {
 	renewalTwo,
 	mainCartKey,
 } from './utils/mock-cart-api';
+import { convertMsToSecs, verifyThatNever, verifyThatTextNeverAppears } from './utils/utils';
 import type {
 	RequestCartProduct,
 	MinimalRequestCartProduct,
@@ -791,21 +792,3 @@ describe( 'withShoppingCart', () => {
 		} );
 	} );
 } );
-
-function convertMsToSecs( ms: number ): number {
-	return Math.floor( ms / 1000 );
-}
-
-// This is a little tricky because we need to verify that text never appears,
-// even after some time passes, so we use this slightly convoluted technique:
-// https://stackoverflow.com/a/68318058/2615868
-async function verifyThatTextNeverAppears( text: string ) {
-	await expect( screen.findByText( text ) ).rejects.toThrow();
-}
-
-// This is a little tricky because we need to verify something never happens,
-// even after some time passes, so we use this slightly convoluted technique:
-// https://stackoverflow.com/a/68318058/2615868
-async function verifyThatNever( expectCallback: () => void ) {
-	await expect( waitFor( expectCallback ) ).rejects.toThrow();
-}

--- a/packages/shopping-cart/test/cart-actions.tsx
+++ b/packages/shopping-cart/test/cart-actions.tsx
@@ -165,6 +165,10 @@ describe( 'useShoppingCart', () => {
 			);
 		};
 
+		afterEach( () => {
+			jest.restoreAllMocks();
+		} );
+
 		it( 'adds a product to the cart if the cart is empty', async () => {
 			render(
 				<MockProvider>
@@ -177,6 +181,7 @@ describe( 'useShoppingCart', () => {
 		} );
 
 		it( 'throws an error if the product is missing a product_id', async () => {
+			jest.spyOn( console, 'error' ).mockImplementation( () => undefined );
 			expect( () => {
 				render(
 					<MockProvider>
@@ -312,6 +317,10 @@ describe( 'useShoppingCart', () => {
 			);
 		};
 
+		afterEach( () => {
+			jest.restoreAllMocks();
+		} );
+
 		it( 'replaces all products in the cart', async () => {
 			render(
 				<MockProvider>
@@ -326,6 +335,7 @@ describe( 'useShoppingCart', () => {
 		} );
 
 		it( 'throws an error if a product is missing a product_id', async () => {
+			jest.spyOn( console, 'error' ).mockImplementation( () => undefined );
 			expect( () => {
 				render(
 					<MockProvider>

--- a/packages/shopping-cart/test/utils/mock-cart-api.ts
+++ b/packages/shopping-cart/test/utils/mock-cart-api.ts
@@ -1,0 +1,127 @@
+import { getEmptyResponseCart } from '../../src/empty-carts';
+import type {
+	RequestCart,
+	ResponseCart,
+	ResponseCartProduct,
+	RequestCartProduct,
+} from '../../src/types';
+
+export const mainCartKey = '1';
+
+const emptyResponseCart = getEmptyResponseCart();
+
+export const planOne: ResponseCartProduct = {
+	time_added_to_cart: Date.now(),
+	current_quantity: 1,
+	product_name: 'WordPress.com Personal',
+	product_slug: 'personal-bundle',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	meta: '',
+	product_id: 1009,
+	volume: 1,
+	quantity: null,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+	product_cost_integer: 14400,
+	product_cost_display: 'R$144',
+	item_subtotal_monthly_cost_display: 'R$144',
+	item_subtotal_monthly_cost_integer: 14400,
+	item_original_subtotal_integer: 14400,
+	item_original_subtotal_display: 'R$144',
+	is_domain_registration: false,
+	is_bundled: false,
+	is_sale_coupon_applied: false,
+	months_per_bill_period: null,
+	uuid: 'product001',
+	cost: 144,
+	price: 144,
+	product_type: 'test',
+	included_domain_purchase_amount: 0,
+};
+
+export const planTwo: ResponseCartProduct = {
+	time_added_to_cart: Date.now(),
+	current_quantity: 1,
+	product_name: 'WordPress.com Business',
+	product_slug: 'business-bundle',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	meta: '',
+	product_id: 1010,
+	volume: 1,
+	quantity: null,
+	item_original_cost_integer: 14400,
+	item_original_cost_display: 'R$144',
+	item_subtotal_integer: 14400,
+	item_subtotal_display: 'R$144',
+	product_cost_integer: 14400,
+	product_cost_display: 'R$144',
+	item_subtotal_monthly_cost_display: 'R$144',
+	item_subtotal_monthly_cost_integer: 14400,
+	item_original_subtotal_integer: 14400,
+	item_original_subtotal_display: 'R$144',
+	is_domain_registration: false,
+	is_bundled: false,
+	is_sale_coupon_applied: false,
+	months_per_bill_period: null,
+	uuid: 'product002',
+	cost: 144,
+	price: 144,
+	product_type: 'test',
+	included_domain_purchase_amount: 0,
+};
+
+export const renewalOne: ResponseCartProduct = {
+	...planOne,
+	extra: { purchaseType: 'renewal' },
+};
+
+export const renewalTwo: ResponseCartProduct = {
+	...planTwo,
+	extra: { purchaseType: 'renewal' },
+};
+
+export async function getCart( cartKey: string ): Promise< ResponseCart > {
+	if ( cartKey === mainCartKey ) {
+		return {
+			...emptyResponseCart,
+			cart_key: cartKey,
+		};
+	}
+	throw new Error( 'Unknown cart key' );
+}
+
+function createProduct( productProps: RequestCartProduct ): ResponseCartProduct {
+	switch ( productProps.product_id ) {
+		case planOne.product_id:
+			return planOne;
+		case planTwo.product_id:
+			return planTwo;
+	}
+	throw new Error( 'Unknown product' );
+}
+
+export async function setCart( cartKey: string, newCart: RequestCart ): Promise< ResponseCart > {
+	if ( [ 'no-site', 'no-user', mainCartKey ].includes( cartKey ) ) {
+		// Mock the shopping-cart endpoint response here
+		return {
+			...emptyResponseCart,
+			cart_key: cartKey,
+			products: newCart.products.map( createProduct ),
+			coupon: newCart.coupon,
+			is_coupon_applied: !! newCart.coupon,
+			tax: {
+				display_taxes: !! newCart.tax?.location.postal_code,
+				location: newCart.tax?.location,
+			},
+		};
+	}
+	throw new Error( 'Unknown cart key' );
+}

--- a/packages/shopping-cart/test/utils/mock-components.tsx
+++ b/packages/shopping-cart/test/utils/mock-components.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import {
-	useShoppingCart,
-	ShoppingCartProvider,
-	createShoppingCartManagerClient,
-} from '../../src/index';
+import { useShoppingCart, ShoppingCartProvider } from '../../src/index';
 import { getCart, setCart, mainCartKey } from './mock-cart-api';
 import type {
 	RequestCartProduct,
@@ -115,17 +111,14 @@ export function MockProvider( {
 	options?: ShoppingCartManagerOptions;
 	cartKeyOverride?: string | undefined;
 } ): JSX.Element {
-	const managerClient = createShoppingCartManagerClient( {
-		getCart: getCartOverride ?? getCart,
-		setCart: setCartOverride ?? setCart,
-	} );
 	return (
 		<ShoppingCartProvider
+			setCart={ setCartOverride ?? setCart }
+			getCart={ getCartOverride ?? getCart }
+			cartKey={ cartKeyOverride ?? mainCartKey }
 			options={ {
 				...( options ?? {} ),
-				defaultCartKey: cartKeyOverride ?? mainCartKey,
 			} }
-			managerClient={ managerClient }
 		>
 			{ children }
 		</ShoppingCartProvider>

--- a/packages/shopping-cart/test/utils/mock-components.tsx
+++ b/packages/shopping-cart/test/utils/mock-components.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef } from 'react';
+import {
+	useShoppingCart,
+	ShoppingCartProvider,
+	createShoppingCartManagerClient,
+} from '../../src/index';
+import { getCart, setCart, mainCartKey } from './mock-cart-api';
+import type {
+	RequestCartProduct,
+	MinimalRequestCartProduct,
+	GetCart,
+	SetCart,
+	WithShoppingCartProps,
+	ShoppingCartManagerOptions,
+} from '../../src/types';
+
+export function ProductList( {
+	initialProducts,
+	initialProductsForReplace,
+	initialCoupon,
+}: {
+	initialProducts?: MinimalRequestCartProduct[];
+	initialProductsForReplace?: MinimalRequestCartProduct[];
+	initialCoupon?: string;
+} ): JSX.Element {
+	const {
+		isPendingUpdate,
+		responseCart,
+		addProductsToCart,
+		replaceProductsInCart,
+		applyCoupon,
+	} = useShoppingCart();
+	const hasAddedProduct = useRef( false );
+	useEffect( () => {
+		if ( initialProducts && ! hasAddedProduct.current ) {
+			hasAddedProduct.current = true;
+			addProductsToCart( initialProducts );
+		}
+	}, [ addProductsToCart, initialProducts ] );
+	useEffect( () => {
+		if ( initialProductsForReplace && ! hasAddedProduct.current ) {
+			hasAddedProduct.current = true;
+			replaceProductsInCart( initialProductsForReplace );
+		}
+	}, [ replaceProductsInCart, initialProductsForReplace ] );
+	const hasAddedCoupon = useRef( false );
+	useEffect( () => {
+		if ( initialCoupon && ! hasAddedCoupon.current ) {
+			hasAddedCoupon.current = true;
+			applyCoupon( initialCoupon );
+		}
+	}, [ applyCoupon, initialCoupon ] );
+	if ( responseCart.products.length === 0 ) {
+		return <div>No products</div>;
+	}
+	const coupon = responseCart.is_coupon_applied ? <div>Coupon: { responseCart.coupon }</div> : null;
+	const location = responseCart.tax.location.postal_code ? (
+		<div>
+			Location: { responseCart.tax.location.postal_code },{ ' ' }
+			{ responseCart.tax.location.country_code }, { responseCart.tax.location.subdivision_code }
+		</div>
+	) : null;
+	return (
+		<ul data-testid="product-list">
+			{ isPendingUpdate && <div>Loading...</div> }
+			{ coupon }
+			{ location }
+			{ responseCart.products.map( ( product ) => {
+				return (
+					<li key={ product.uuid }>
+						<span>{ product.product_slug }</span>
+						<span>{ product.product_name }</span>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+}
+
+export function ProductListWithoutHook( {
+	shoppingCartManager,
+	cart,
+	productsToAddOnClick,
+}: { productsToAddOnClick: RequestCartProduct[] } & WithShoppingCartProps ): JSX.Element {
+	const { isPendingUpdate, addProductsToCart } = shoppingCartManager;
+	const onClick = () => {
+		addProductsToCart( productsToAddOnClick );
+	};
+	return (
+		<ul data-testid="product-list">
+			{ isPendingUpdate && <div>Loading...</div> }
+			{ cart.products.map( ( product ) => {
+				return (
+					<li key={ product.uuid }>
+						<span>{ product.product_slug }</span>
+						<span>{ product.product_name }</span>
+					</li>
+				);
+			} ) }
+			<button onClick={ onClick }>Click me</button>
+		</ul>
+	);
+}
+
+export function MockProvider( {
+	children,
+	setCartOverride,
+	getCartOverride,
+	options,
+	cartKeyOverride,
+}: {
+	children: React.ReactNode;
+	setCartOverride?: SetCart;
+	getCartOverride?: GetCart;
+	options?: ShoppingCartManagerOptions;
+	cartKeyOverride?: string | undefined;
+} ): JSX.Element {
+	const managerClient = createShoppingCartManagerClient( {
+		getCart: getCartOverride ?? getCart,
+		setCart: setCartOverride ?? setCart,
+	} );
+	return (
+		<ShoppingCartProvider
+			options={ {
+				...( options ?? {} ),
+				defaultCartKey: cartKeyOverride ?? mainCartKey,
+			} }
+			managerClient={ managerClient }
+		>
+			{ children }
+		</ShoppingCartProvider>
+	);
+}

--- a/packages/shopping-cart/test/utils/utils.ts
+++ b/packages/shopping-cart/test/utils/utils.ts
@@ -1,0 +1,19 @@
+import { screen, waitFor } from '@testing-library/react';
+
+export function convertMsToSecs( ms: number ): number {
+	return Math.floor( ms / 1000 );
+}
+
+// This is a little tricky because we need to verify that text never appears,
+// even after some time passes, so we use this slightly convoluted technique:
+// https://stackoverflow.com/a/68318058/2615868
+export async function verifyThatTextNeverAppears( text: string ): Promise< void > {
+	await expect( screen.findByText( text ) ).rejects.toThrow();
+}
+
+// This is a little tricky because we need to verify something never happens,
+// even after some time passes, so we use this slightly convoluted technique:
+// https://stackoverflow.com/a/68318058/2615868
+export async function verifyThatNever( expectCallback: () => void ): Promise< void > {
+	await expect( waitFor( expectCallback ) ).rejects.toThrow();
+}

--- a/packages/shopping-cart/test/with-shopping-cart.tsx
+++ b/packages/shopping-cart/test/with-shopping-cart.tsx
@@ -1,0 +1,59 @@
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { withShoppingCart } from '../src/index';
+import { planOne, mainCartKey } from './utils/mock-cart-api';
+import { MockProvider, ProductListWithoutHook } from './utils/mock-components';
+
+import '@testing-library/jest-dom/extend-expect';
+
+describe( 'withShoppingCart', () => {
+	it( 'provides both shoppingCartManager and cart props to the wrapped component', async () => {
+		const WrappedProductsList = withShoppingCart( ProductListWithoutHook );
+		const TestComponent = () => {
+			return (
+				<div>
+					<WrappedProductsList productsToAddOnClick={ [ planOne ] } />
+				</div>
+			);
+		};
+
+		render(
+			<MockProvider>
+				<TestComponent />
+			</MockProvider>
+		);
+		fireEvent.click( screen.getByText( 'Click me' ) );
+		await waitFor( () => {
+			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+		} );
+	} );
+
+	it( 'allows setting the cart key via the mapPropsToCartKey function', async () => {
+		const WrappedProductsList = withShoppingCart(
+			ProductListWithoutHook,
+			( { productsToAddOnClick } ) => {
+				if ( productsToAddOnClick.includes( planOne ) ) {
+					return mainCartKey;
+				}
+				return undefined;
+			}
+		);
+		const TestComponent = () => {
+			return (
+				<div>
+					<WrappedProductsList productsToAddOnClick={ [ planOne ] } />
+				</div>
+			);
+		};
+
+		render(
+			<MockProvider cartKeyOverride={ 'asjdasldjaldkjasldjsld' }>
+				<TestComponent />
+			</MockProvider>
+		);
+		fireEvent.click( screen.getByText( 'Click me' ) );
+		await waitFor( () => {
+			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+		} );
+	} );
+} );

--- a/packages/shopping-cart/test/with-shopping-cart.tsx
+++ b/packages/shopping-cart/test/with-shopping-cart.tsx
@@ -1,7 +1,7 @@
 import { screen, render, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { withShoppingCart } from '../src/index';
-import { planOne, mainCartKey } from './utils/mock-cart-api';
+import { planOne } from './utils/mock-cart-api';
 import { MockProvider, ProductListWithoutHook } from './utils/mock-components';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -19,35 +19,6 @@ describe( 'withShoppingCart', () => {
 
 		render(
 			<MockProvider>
-				<TestComponent />
-			</MockProvider>
-		);
-		fireEvent.click( screen.getByText( 'Click me' ) );
-		await waitFor( () => {
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
-		} );
-	} );
-
-	it( 'allows setting the cart key via the mapPropsToCartKey function', async () => {
-		const WrappedProductsList = withShoppingCart(
-			ProductListWithoutHook,
-			( { productsToAddOnClick } ) => {
-				if ( productsToAddOnClick.includes( planOne ) ) {
-					return mainCartKey;
-				}
-				return undefined;
-			}
-		);
-		const TestComponent = () => {
-			return (
-				<div>
-					<WrappedProductsList productsToAddOnClick={ [ planOne ] } />
-				</div>
-			);
-		};
-
-		render(
-			<MockProvider cartKeyOverride={ 'asjdasldjaldkjasldjsld' }>
 				<TestComponent />
 			</MockProvider>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR (extracted from https://github.com/Automattic/wp-calypso/pull/54667) adds unit tests for the `withShoppingCart` HOC and reorganizes the tests slightly to separate helpers into their own files.

#### Testing instructions

Automated tests should be sufficient.