### PR TITLE
ETK: Add 80px bottom padding to post-publish footer

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -12,6 +12,15 @@ body.slider-width-workaround {
 	}
 }
 
+/*
+ * Override bottom padding on post-publish footer
+ * to account for inline help FAB
+ * See https://github.com/Automattic/wp-calypso/issues/55345
+ */
+.editor-post-publish-panel__footer {
+	padding-bottom: 80px;
+}
+
 @mixin font-smoothing-antialiased {
 	text-rendering: optimizeLegibility;
 	-moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add padding to post-publish footer to account for the inline help FAB and avoid it overlapping footer settings as noted in #55345

**Before**

<img width="1666" alt="Screen Shot 2021-08-16 at 2 56 53 PM" src="https://user-images.githubusercontent.com/2124984/129617362-8ce33592-2ac0-49e7-ab06-48c34bb38252.png">

**After**

<img width="1666" alt="Screen Shot 2021-08-16 at 2 56 18 PM" src="https://user-images.githubusercontent.com/2124984/129617377-8cd8f121-1ed8-48ea-be49-8301a8f94646.png">


#### Testing instructions=

* Switch to this PR and `yarn dev --sync` to your sandbox
* Open your sandboxed site, create a new post or page
* Hit "Publish" to open the post-publish sidebar; scroll to the bottom
* You should have plenty of space between the "Always show pre-publish checks." checkbox and the floating help button (question mark) in the lower right corner
