### PR TITLE
Remove translation checks from PR #55104

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,4 +1,4 @@
-import i18nCalypso, { getLocaleSlug, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import React from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
@@ -214,11 +214,7 @@ export const getTask = (
 				description: translate(
 					'Complete your Professional Email setup to start sending and receiving emails from your custom domain today.'
 				),
-				/* Make sure we show a translated string while we wait for the new string to be translated. */
-				actionText:
-					'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
-						? translate( 'Set up mailbox' )
-						: translate( 'Complete setup' ),
+				actionText: translate( 'Set up mailbox' ),
 				isSkippable: false,
 				actionUrl: emailManagementTitanSetupMailbox( siteSlug, task.domain ),
 			};

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@automattic/components';
 import { connect } from 'react-redux';
-import i18nCalypso, { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -38,9 +38,7 @@ class EmailPlanWarnings extends React.Component {
 
 		return (
 			<Button compact primary href={ setupMailboxUrl }>
-				{ 'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
-					? translate( 'Set up mailbox' )
-					: translate( 'Activate Mailbox' ) }
+				{ translate( 'Set up mailbox' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,34 +25,19 @@ const TitanUnusedMailboxesNotice = ( { domain, maxTitanMailboxCount, onFinishSet
 		return null;
 	}
 
-	const translateOptions = {
-		count: numberOfUnusedMailboxes,
-		args: {
-			numberOfMailboxes: numberOfUnusedMailboxes,
-		},
-		comment: 'This refers to the number of mailboxes purchased that have not been set up yet',
-	};
+	const text = translate(
+		'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
+		'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
+		{
+			count: numberOfUnusedMailboxes,
+			args: {
+				numberOfMailboxes: numberOfUnusedMailboxes,
+			},
+			comment: 'This refers to the number of mailboxes purchased that have not been set up yet',
+		}
+	);
 
-	const text =
-		'en' === getLocaleSlug() ||
-		i18nCalypso.hasTranslation(
-			'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?'
-		)
-			? translate(
-					'You have %(numberOfMailboxes)d unused mailbox. Do you want to set it up now instead of purchasing new ones?',
-					'You have %(numberOfMailboxes)d unused mailboxes. Do you want to set one of them up now instead of purchasing new ones?',
-					translateOptions
-			  )
-			: translate(
-					'You have %(numberOfMailboxes)d unused mailbox. Do you want to configure it now instead?',
-					'You have %(numberOfMailboxes)d unused mailboxes. Do you want to configure them now instead?',
-					translateOptions
-			  );
-
-	const ctaText =
-		'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
-			? translate( 'Set up mailbox' )
-			: translate( 'Finish Setup' );
+	const ctaText = translate( 'Set up mailbox' );
 
 	return (
 		<Notice icon="notice" showDismiss={ false } status="is-warning" text={ text }>

--- a/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice.jsx
@@ -37,11 +37,9 @@ const TitanUnusedMailboxesNotice = ( { domain, maxTitanMailboxCount, onFinishSet
 		}
 	);
 
-	const ctaText = translate( 'Set up mailbox' );
-
 	return (
 		<Notice icon="notice" showDismiss={ false } status="is-warning" text={ text }>
-			<NoticeAction onClick={ onFinishSetupClick }>{ ctaText }</NoticeAction>
+			<NoticeAction onClick={ onFinishSetupClick }>{ translate( 'Set up mailbox' ) }</NoticeAction>
 		</Notice>
 	);
 };

--- a/client/my-sites/email/titan-setup-mailbox/index.js
+++ b/client/my-sites/email/titan-setup-mailbox/index.js
@@ -5,7 +5,7 @@ import page from 'page';
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import i18nCalypso, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -62,10 +62,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 		return null;
 	}
 
-	const title =
-		'en' === getLocaleSlug() || i18nCalypso.hasTranslation( 'Set up mailbox' )
-			? translate( 'Set up mailbox' )
-			: translate( 'Set up your Professional Email' );
+	const title = translate( 'Set up mailbox' );
 
 	return (
 		<>

--- a/client/my-sites/email/titan-setup-mailbox/index.js
+++ b/client/my-sites/email/titan-setup-mailbox/index.js
@@ -4,6 +4,7 @@
 import page from 'page';
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import titleCase from 'to-title-case';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
@@ -71,7 +72,7 @@ const TitanSetupMailbox = ( { selectedDomainName } ) => {
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 			<Main wideLayout={ true }>
-				<DocumentHead title={ title } />
+				<DocumentHead title={ titleCase( title ) } />
 
 				<EmailHeader currentRoute={ currentRoute } selectedSite={ selectedSite } />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the conditional logic that was added in #55104 to ensure that we showed translated strings to our users, as we now have all of the relevant strings translated into our fully supported languages as per [this deliverable](https://translate.wordpress.com/deliverables/overview/6340885).

#### Testing instructions

* Run this branch locally or via the live branch
* Ensure that you have a site that has at least one Professional Email subscription where you have at least one unused mailbox
* For that site, navigate to `/home/[siteSlug]?dev=true&view=view_site_setup`
* Verify that you get the site setup checklist
* Click on the "Set up your Professional Email" item in the checklist (it may be complete already)
* Verify that the button has the text "Set up mailbox" (though it may be disabled)
* Navigate to `/email/[siteSlug]` or Upgrades -> Emails
* Select your domain from the list
* Verify that you see a warning about one (or more) unused mailboxes, and that the button has the text "Set up mailbox"
* Click on "Add new mailboxes"
* Verify that you see a notice towards the top of the page with an exclamation icon and a yellow/orange background that includes the text "You have 1 unused mailbox. Do you want to set it up now instead of purchasing new ones?" (It may be adjusted for multiple mailboxes.)
* Verify that the CTA on the right of that notice is "Set up mailbox"

Related to #55104