### PR TITLE
Sidebar Nav: Add bottom padding on small screens

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -712,6 +712,7 @@ $font-size: rem( 14px );
 		// client/layout/sidebar/style.scss
 		.sidebar {
 			position: absolute;
+			padding-bottom: 70px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add bottom padding to the sidebar navigation on screens < 660px (the point at which the sidebar takes up the full width of the screen) so you can fully scroll to the bottom without browser chrome overlapping

**Before** | **After**
-----------|------------
<img src="https://user-images.githubusercontent.com/2124984/129620859-2da91ad2-2c81-4888-b486-91852b92e81d.PNG" width="300" /> | <img width="310" alt="Screen Shot 2021-08-16 at 3 55 43 PM" src="https://user-images.githubusercontent.com/2124984/129622039-870d2ca7-e889-49bb-a82e-18862a351809.png">


#### Testing instructions

* Switch to this PR, or view the live branch on a mobile device
* Open the sidebar navigation and scroll to the bottom
* You should be able to see the Settings menu and the link to WP-Admin, without them being obscured by the browser's navigation at the bottom


Fixes #53436
