### PR TITLE
Fix the get your domain button alignment so it works correctly on mobile and desktop

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -299,13 +299,10 @@
 	}
 
 	.empty-domains-list-card__actions {
-		text-align: center;
-		& > .button {
-			margin: 16px 16px 0 0;
-		}
-		& > .button:last-child {
-			margin-right: 0;
-		}
+		display: inline-flex;
+		justify-content: center;
+		flex-wrap: wrap;
+		gap: 16px;
 	}
 
 	@include break-small {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -302,7 +302,9 @@
 		display: inline-flex;
 		justify-content: center;
 		flex-wrap: wrap;
-		gap: 16px;
+		& > .button {
+			margin: 16px 8px 0;
+		}
 	}
 
 	@include break-small {


### PR DESCRIPTION
As reported in https://github.com/Automattic/wp-calypso/pull/54615#issuecomment-895804245 there is a margin 

#### Changes proposed in this Pull Request

* Change the style of the action buttons so they're properly aligned on mobile even if they need to wrap around

Before:

<img width="388" alt="Screenshot 2021-08-17 at 15 49 03" src="https://user-images.githubusercontent.com/1355045/129728466-91c698d3-c132-4d92-8b17-3fadd799c17d.png">

After:

<img width="381" alt="Screenshot 2021-08-17 at 15 48 39" src="https://user-images.githubusercontent.com/1355045/129728484-efae3a2a-79b4-4e95-9876-4ffc466c200e.png">


#### Testing instructions

* Open up this branch of Calypso and check that the buttons are properly aligned when you open them on mobile (iPhone 6/7/8)
