### PR TITLE
Site Editor Tracks - skip nav sidebar tests

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -833,6 +833,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 		} );
 
 		// Skip theses tests as nav sidebar is temporarily disabled on dotcom.
+		// Related Issue - https://github.com/Automattic/wp-calypso/issues/54460
+		// Related PR - https://github.com/Automattic/wp-calypso/pull/55471
 		describe.skip( 'Navigation sidebar', function () {
 			it( 'should track "wpcom_block_editor_nav_sidebar_open" when sidebar is opened', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -832,7 +832,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 		} );
 
-		describe( 'Navigation sidebar', function () {
+		// Skip theses tests as nav sidebar is temporarily disabled on dotcom.
+		describe.skip( 'Navigation sidebar', function () {
 			it( 'should track "wpcom_block_editor_nav_sidebar_open" when sidebar is opened', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/55471 temporarily hides the navigation sidebar in the site editor.  While this sidebar is hidden, we should skip the corresponding tracks tests that would then fail.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the navigation sidebar tests are skipped.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
