### PR TITLE
Media Library: Don't show 0.00 B file sizes

### DIFF
--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -80,7 +80,7 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 	renderFileSize = () => {
 		const fileSize = this.getItemValue( 'size' );
 
-		if ( ! fileSize || fileSize === 0 ) {
+		if ( ! fileSize || fileSize === 0 || fileSize === '0.00 B' ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check for `0.00 B` string which is what's returned from the API when requesting a media item we can't get file metadata for. 
* I considered fixing this in the API, but figured this way the API always returns a string (rather than an int or a string) and we have the benefit of `filesize` PHP method for formatting (I'm not sure if there's an equivalent in JS).
* This doesn't solve the underlying issue of why we can't get file information for WP.com Simple sites using core's `wp_get_attachment_metadata` -- I suspect something to do with how we host user files, maybe a cross-site origin issue? -- but it should reduce confusion for folks seeing a file incorrectly has `0.00 B`

**Before**

<img width="1286" alt="Screen Shot 2021-08-17 at 12 25 55 PM" src="https://user-images.githubusercontent.com/2124984/129764148-1d0977f3-4ac8-4305-a80f-e308bb39d4a4.png">

**After**

<img width="1280" alt="Screen Shot 2021-08-17 at 12 00 29 PM" src="https://user-images.githubusercontent.com/2124984/129763027-1a8e294a-05ee-46ad-8559-5558a4d9a38f.png">


Fixes #54434

#### Testing instructions

* Switch to this PR on a WP.com simple site
* Upload a non-image file (PPT, PDF, DOC, etc.) to your Media Library
* Edit the upload and you should not see a "File size"
* Edit an image file in the same Media Library; you should see a "File size"