### PR TITLE
Desktop: Fix social logins so they can function in the Desktop app

### DIFF
--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -32,6 +32,7 @@ function showAppWindow() {
 	const windowConfig = Settings.getSettingGroup( Config.mainWindow, null );
 	windowConfig.webPreferences.spellcheck = Settings.getSetting( 'spellcheck-enabled' );
 	windowConfig.webPreferences.preload = preloadFile;
+	windowConfig.webPreferences.nativeWindowOpen = true;
 
 	const bounds = {
 		...{ width: 800, height: 600 },

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -1,3 +1,4 @@
+const { BrowserWindow } = require( 'electron' );
 const assets = require( '../../lib/assets' );
 const Config = require( '../../lib/config' );
 const log = require( '../../lib/logger' )( 'desktop:external-links' );
@@ -7,24 +8,69 @@ let targetURL = '';
 module.exports = function ( { view } ) {
 	// TODO: Replace the "new-window" event with webcontents.setWindowOpenHandler
 	// when Electron is updated to >= 13.x
-	view.webContents.on( 'new-window', function ( event, url ) {
-		// Check if the incoming URL is blank and if it is send to the targetURL instead
-		const urlToLoad = url.includes( 'about:blank' ) || url === '' ? targetURL : url;
-		log.info( `Navigating to URL: '${ urlToLoad }'` );
+	view.webContents.on(
+		'new-window',
+		function (
+			event,
+			url,
+			frameName,
+			disposition,
+			options,
+			additionalFeatures,
+			referrer,
+			postBody
+		) {
+			if ( url.includes( 'https://accounts.google.com' ) ) {
+				event.preventDefault();
+				const win = new BrowserWindow( {
+					webContents: options.webContents, // use existing webContents if provided
+					show: false,
+				} );
 
-		event.preventDefault();
-		view.webContents.loadURL( urlToLoad );
-		return;
-	} );
+				win.webContents.on( 'will-navigate', function ( e, u ) {
+					log.info( 'Google Window will navigate: ' + u );
+				} );
+
+				win.webContents.on( 'will-redirect', function ( e, u ) {
+					log.info( 'Google Window will redirect: ' + u );
+				} );
+
+				win.once( 'ready-to-show', () => win.show() );
+				if ( ! options.webContents ) {
+					const loadOptions = {
+						httpReferrer: referrer,
+					};
+					if ( postBody != null ) {
+						const { data, contentType, boundary } = postBody;
+						loadOptions.postData = postBody.data;
+						loadOptions.extraHeaders = `content-type: ${ contentType }; boundary=${ boundary }`;
+					}
+
+					win.loadURL( url, loadOptions ); // existing webContents will be navigated automatically
+				}
+				event.newGuest = win;
+			} else {
+				// Check if the incoming URL is blank and if it is send to the targetURL instead
+				const urlToLoad = url.includes( 'about:blank' ) || url === '' ? targetURL : url;
+				log.info( `Navigating to URL: '${ urlToLoad }'` );
+
+				event.preventDefault();
+				view.webContents.loadURL( urlToLoad );
+				return;
+			}
+		}
+	);
 
 	// Magic links aren't supported in the app currently. Instead we'll show a message about how
 	// to set a password on the account to log in that way.
 	view.webContents.on( 'will-navigate', function ( event, url ) {
-		const urlToLoad =
-			url === Config.baseURL() + 'log-in/link'
-				? 'file://' + assets.getPath( 'magic-links-unsupported.html' )
-				: url;
-		view.webContents.loadURL( urlToLoad );
+		log.info( 'Will navigate: ' + url );
+		if ( url === Config.baseURL() + 'log-in/link' ) {
+			const urlToLoad = 'file://' + assets.getPath( 'magic-links-unsupported.html' );
+			log.info( `Navigating to URL: '${ urlToLoad }'` );
+			view.webContents.loadURL( urlToLoad );
+		}
+
 		return;
 	} );
 
@@ -37,8 +83,9 @@ module.exports = function ( { view } ) {
 	} );
 
 	view.webContents.on( 'will-redirect', function ( _, url ) {
+		log.info( 'Will redirect: ' + url );
 		if ( url.includes( 'https://wordpress.com/log-in/apple/callback' ) ) {
-			log.info( 'Redirecting to URL: ', url );
+			//log.info( 'Redirecting to URL: ', url );
 			view.webContents.loadURL( url );
 		}
 	} );

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -24,7 +24,6 @@ module.exports = function ( { view } ) {
 	// Magic links aren't supported in the app currently. Instead we'll show a message about how
 	// to set a password on the account to log in that way.
 	view.webContents.on( 'will-navigate', function ( event, url ) {
-		log.info( 'Will navigate: ' + url );
 		if ( url === Config.baseURL() + 'log-in/link' ) {
 			const urlToLoad = 'file://' + assets.getPath( 'magic-links-unsupported.html' );
 			log.info( `Navigating to URL: '${ urlToLoad }'` );
@@ -43,9 +42,8 @@ module.exports = function ( { view } ) {
 	} );
 
 	view.webContents.on( 'will-redirect', function ( _, url ) {
-		log.info( 'Will redirect: ' + url );
 		if ( url.includes( 'https://wordpress.com/log-in/apple/callback' ) ) {
-			//log.info( 'Redirecting to URL: ', url );
+			log.info( 'Redirecting to URL: ', url );
 			view.webContents.loadURL( url );
 		}
 	} );

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -9,7 +9,7 @@ module.exports = function ( { view } ) {
 	// when Electron is updated to >= 13.x
 	view.webContents.on( 'new-window', function ( event, url ) {
 		// If the URL trying to open a new window is the Google Social login link, allow new window to open
-		if ( url.includes( 'https://accounts.google.com/o/oauth2/auth?redirect_uri=storagerelay' ) ) {
+		if ( url.includes( 'https://accounts.google.com/o/oauth2/auth' ) ) {
 			return;
 		}
 		// Check if the incoming URL is blank and if it is send to the targetURL instead

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -52,6 +52,10 @@ function fflagOverrides() {
 		const kv = fflags[ i ].split( ':' );
 		payload[ kv[ 0 ] ] = kv[ 1 ] === 'true' ? true : false;
 	}
+
+	// Manual override of feature flags for features not available in older app versions
+	payload[ 'sign-in-with-apple' ] = true;
+	payload[ 'signup/social' ] = true;
 	return payload;
 }
 

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -44,7 +44,12 @@ const receiveChannels = [
 ];
 
 function fflagOverrides() {
-	const payload = {};
+	// Manually overriding feature flags for features not available in older app versions.
+	// They aren't able to be added to the wp-calypso/packages/calypso-config/src/desktop.ts
+	// file as they would be applied to all app versions.
+	const payload = { 'sign-in-with-apple': true, 'signup/social': true };
+
+	// Override feature flags from enviroment variables at run time
 	const fflags = process.env.WP_DESKTOP_DEBUG_FEATURES
 		? process.env.WP_DESKTOP_DEBUG_FEATURES.split( ',' )
 		: [];
@@ -52,10 +57,6 @@ function fflagOverrides() {
 		const kv = fflags[ i ].split( ':' );
 		payload[ kv[ 0 ] ] = kv[ 1 ] === 'true' ? true : false;
 	}
-
-	// Manual override of feature flags for features not available in older app versions
-	payload[ 'sign-in-with-apple' ] = true;
-	payload[ 'signup/social' ] = true;
 	return payload;
 }
 

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -47,7 +47,10 @@ function fflagOverrides() {
 	// Manually overriding feature flags for features not available in older app versions.
 	// They aren't able to be added to the wp-calypso/packages/calypso-config/src/desktop.ts
 	// file as they would be applied to all app versions.
-	const payload = { 'sign-in-with-apple': true, 'signup/social': true };
+	const payload = {
+		'sign-in-with-apple': true,
+		'signup/social': true,
+	};
 
 	// Override feature flags from enviroment variables at run time
 	const fflags = process.env.WP_DESKTOP_DEBUG_FEATURES


### PR DESCRIPTION
### Description

This fixes issues that were causing social logins to not work properly in the Desktop App.

For Apple login our use of `webContents.loadURL` in the `will-navigate` event handler was causing some information to not be passed as it should.
This updates to only use the `webContents.loadURL` when needed instead of all the time.

For the Google login it requires to open a new window. We previously had this disabled so all windows open in the main window of the app. This makes an exception for the Google social login window. It also requires that we use `webPreferences.nativeWindowOpen = true;` to open the new window instead of the Electron default.

We also manually enable the feature flags for social login in the app so the features will only be available to versions of the app which support them.

### Testing
Run app from the Desktop directory with the command `yarn run dev`  to test:

- Attempt to log in with Apple social login 
- Attempt to log in with Google social login
- Both should log in as normal
- Ensure regular login works as well. 

