### PR TITLE
Shopping Cart: Make sure that errors thrown by add/replace are rejections

### DIFF
--- a/packages/shopping-cart/src/use-shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/use-shopping-cart-manager.ts
@@ -93,7 +93,7 @@ export default function useShoppingCartManager( {
 	);
 
 	const addProductsToCart: AddProductsToCart = useCallback(
-		( products ) =>
+		async ( products ) =>
 			dispatchAndWaitForValid( {
 				type: 'CART_PRODUCTS_ADD',
 				products: createRequestCartProducts( products ),
@@ -102,7 +102,7 @@ export default function useShoppingCartManager( {
 	);
 
 	const replaceProductsInCart: ReplaceProductsInCart = useCallback(
-		( products ) =>
+		async ( products ) =>
 			dispatchAndWaitForValid( {
 				type: 'CART_PRODUCTS_REPLACE_ALL',
 				products: createRequestCartProducts( products ),

--- a/packages/shopping-cart/test/use-shopping-cart.tsx
+++ b/packages/shopping-cart/test/use-shopping-cart.tsx
@@ -44,10 +44,6 @@ describe( 'useShoppingCart', () => {
 			);
 		};
 
-		afterEach( () => {
-			jest.restoreAllMocks();
-		} );
-
 		it( 'adds a product to the cart if the cart is empty', async () => {
 			render(
 				<MockProvider>
@@ -83,9 +79,10 @@ describe( 'useShoppingCart', () => {
 				</MockProvider>
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
-			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planTwo.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planTwo.product_name );
+			} );
 		} );
 
 		it( 'adds a product to the cart if the existing products are renewals and the new products are also', async () => {
@@ -99,9 +96,10 @@ describe( 'useShoppingCart', () => {
 				</MockProvider>
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
-			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( renewalTwo.product_name );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( renewalOne.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( renewalTwo.product_name );
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( renewalOne.product_name );
+			} );
 		} );
 
 		it( 'replaces the cart if the existing products are not renewals and any of the new products is a renewal', async () => {
@@ -115,9 +113,12 @@ describe( 'useShoppingCart', () => {
 				</MockProvider>
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
-			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByTestId( 'product-list' ) ).not.toHaveTextContent( planOne.product_name );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( renewalTwo.product_name );
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).not.toHaveTextContent(
+					planOne.product_name
+				);
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( renewalTwo.product_name );
+			} );
 		} );
 
 		it( 'replaces the cart if any of the existing products is a renewal and the new products are not', async () => {
@@ -131,11 +132,12 @@ describe( 'useShoppingCart', () => {
 				</MockProvider>
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
-			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
-			expect( screen.getByTestId( 'product-list' ) ).not.toHaveTextContent(
-				renewalTwo.product_name
-			);
+			await waitFor( () => {
+				expect( screen.getByTestId( 'product-list' ) ).toHaveTextContent( planOne.product_name );
+				expect( screen.getByTestId( 'product-list' ) ).not.toHaveTextContent(
+					renewalTwo.product_name
+				);
+			} );
 		} );
 
 		it( 'returns a Promise that resolves after the update completes', async () => {
@@ -146,8 +148,9 @@ describe( 'useShoppingCart', () => {
 			);
 			fireEvent.click( screen.getByText( 'Click me' ) );
 			expect( markUpdateComplete ).not.toHaveBeenCalled();
-			await waitFor( () => screen.getByTestId( 'product-list' ) );
-			expect( markUpdateComplete ).toHaveBeenCalled();
+			await waitFor( () => {
+				expect( markUpdateComplete ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 
@@ -220,10 +223,6 @@ describe( 'useShoppingCart', () => {
 				</div>
 			);
 		};
-
-		afterEach( () => {
-			jest.restoreAllMocks();
-		} );
 
 		it( 'replaces all products in the cart', async () => {
 			mockGetCart.mockResolvedValue( {
@@ -590,13 +589,6 @@ describe( 'useShoppingCart', () => {
 	} );
 
 	describe( 'when refetchOnWindowFocus is enabled', () => {
-		const mockGetCart = jest.fn();
-
-		beforeEach( () => {
-			mockGetCart.mockReset();
-			jest.restoreAllMocks();
-		} );
-
 		it( 'triggers a refetch when the window is focused', async () => {
 			mockGetCart.mockResolvedValue( { ...emptyResponseCart, products: [ planOne ] } );
 

--- a/packages/shopping-cart/test/utils/mock-components.tsx
+++ b/packages/shopping-cart/test/utils/mock-components.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useShoppingCart, ShoppingCartProvider } from '../../src/index';
 import { getCart, setCart, mainCartKey } from './mock-cart-api';
 import type {
 	RequestCartProduct,
-	MinimalRequestCartProduct,
 	GetCart,
 	SetCart,
 	WithShoppingCartProps,
@@ -12,40 +11,13 @@ import type {
 
 export function ProductList( {
 	initialProducts,
-	initialProductsForReplace,
-	initialCoupon,
 }: {
-	initialProducts?: MinimalRequestCartProduct[];
-	initialProductsForReplace?: MinimalRequestCartProduct[];
-	initialCoupon?: string;
+	initialProducts?: RequestCartProduct[];
 } ): JSX.Element {
-	const {
-		isPendingUpdate,
-		responseCart,
-		addProductsToCart,
-		replaceProductsInCart,
-		applyCoupon,
-	} = useShoppingCart();
-	const hasAddedProduct = useRef( false );
+	const { isPendingUpdate, responseCart, addProductsToCart } = useShoppingCart();
 	useEffect( () => {
-		if ( initialProducts && ! hasAddedProduct.current ) {
-			hasAddedProduct.current = true;
-			addProductsToCart( initialProducts );
-		}
+		initialProducts && addProductsToCart( initialProducts );
 	}, [ addProductsToCart, initialProducts ] );
-	useEffect( () => {
-		if ( initialProductsForReplace && ! hasAddedProduct.current ) {
-			hasAddedProduct.current = true;
-			replaceProductsInCart( initialProductsForReplace );
-		}
-	}, [ replaceProductsInCart, initialProductsForReplace ] );
-	const hasAddedCoupon = useRef( false );
-	useEffect( () => {
-		if ( initialCoupon && ! hasAddedCoupon.current ) {
-			hasAddedCoupon.current = true;
-			applyCoupon( initialCoupon );
-		}
-	}, [ applyCoupon, initialCoupon ] );
 	if ( responseCart.products.length === 0 ) {
 		return <div>No products</div>;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Actions in the shopping-cart manager return a Promise that resolves when the cart finishes its current operations. Two shopping-cart actions, `addProductsToCart` and `replaceProductsInCart`, have a special requirement: the product objects passed in must be minimally valid products, meaning that they must have both a `product_slug` and a `product_id`. This requirement is enforced by `createRequestCartProduct`, which throws an Error if it fails. 

However, even though the action creators normally return the Promise from the dispatcher, if `createRequestCartProduct` throws, it does so inside the _action creator itself_, meaning that the result will not be a rejected Promise, it will be a thrown Error. This distinction is subtle since Promise rejections _are_ thrown Errors (both can be handled with try/catch, for example), but thrown Errors _are not_ Promise rejections (they cannot be handled by `Promise.prototype.catch`).

As an example, before this PR the following code will throw an Error and `handleError` will _not_ be called.

```js
addProductsToCart( [ { product_slug: 'foobar' }  ] ).catch( handleError )
```

Fortunately, the solution is quite simple: an Error thrown inside an `async` function gets automatically converted into a Promise rejection, and these functions are already supposed to be `async` functions (they return a Promise), so we just need to explicitly declare the functions as `async` to make sure the errors are made into rejections.

To make sure we test this properly, and to make the tests generally more reliable, this PR also refactors the `useShoppingCart` tests to bring the test assertions closer to the tests themselves.

#### Testing instructions

Automated tests should be sufficient.