### PR TITLE
Only apply changes when needed in will-navigate event handling

### DIFF
--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -20,11 +20,11 @@ module.exports = function ( { view } ) {
 	// Magic links aren't supported in the app currently. Instead we'll show a message about how
 	// to set a password on the account to log in that way.
 	view.webContents.on( 'will-navigate', function ( event, url ) {
-		const urlToLoad =
-			url === Config.baseURL() + 'log-in/link'
-				? 'file://' + assets.getPath( 'magic-links-unsupported.html' )
-				: url;
-		view.webContents.loadURL( urlToLoad );
+		if ( url === Config.baseURL() + 'log-in/link' ) {
+			const urlToLoad = 'file://' + assets.getPath( 'magic-links-unsupported.html' );
+			log.info( `Navigating to URL: '${ urlToLoad }'` );
+			view.webContents.loadURL( urlToLoad );
+		}
 		return;
 	} );
 


### PR DESCRIPTION
### Description

We shouldn't override the default behavior unless needed in events like `will-navigate`. There are some cases it seems when using the `loadURL` method breaks functionality like with social logins.

This fixes that so we only use it when necessary. 

### Testing

One good way to test will be to run the app from the Desktop directory with the following command and ensure you can sign in with Apple as expected. 
`WP_DESKTOP_DEBUG_FEATURES='sign-in-with-apple:true,signup/social:true' yarn run dev`