### PR TITLE
Add a product check function to determine if a plan has at least one of a provided array of features

### DIFF
--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -114,6 +114,33 @@ export function getPlanClass( planKey ) {
  * @returns {boolean}               Whether the specified plan has the specified feature.
  */
 export function planHasFeature( plan, feature ) {
+	const allFeatures = getAllFeaturesForPlan( plan );
+	return allFeatures.includes( feature );
+}
+
+/**
+ * Determine if a plan has at least one of several features.
+ *
+ *
+ * @param {object|string} plan	Plan object or plan name
+ * @param {[string]} features	Array of feature names
+ *
+ * @returns {boolean}			Whether or not the specified plan has one of the features
+ */
+export function planHasAtLeastOneFeature( plan, features ) {
+	const allFeatures = getAllFeaturesForPlan( plan );
+	return features.some( ( feature ) => allFeatures.includes( feature ) );
+}
+
+/**
+ * Get all features for a plan
+ *
+ * Collects features for a plan by calling all possible feature methods for the plan.
+ *
+ * @param {object|string} plan	Plan object or plan name.
+ * @returns {Array}				An array of all the plan features (may have duplicates)
+ */
+export function getAllFeaturesForPlan( plan ) {
 	const planConstantObj = getPlan( plan );
 
 	// Collect features from all plan methods (may have duplicates)
@@ -132,7 +159,7 @@ export function planHasFeature( plan, feature ) {
 		[]
 	);
 
-	return allFeatures.includes( feature );
+	return allFeatures;
 }
 
 /**

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import {
+	FEATURE_ACTIVITY_LOG,
 	FEATURE_ALL_PERSONAL_FEATURES,
 	FEATURE_AUDIO_UPLOADS,
 	FEATURE_CUSTOM_DOMAIN,
@@ -76,6 +77,7 @@ import {
 	getMonthlyPlanByYearly,
 	getYearlyPlanByMonthly,
 	planHasFeature,
+	planHasAtLeastOneFeature,
 	planHasSuperiorFeature,
 } from '../src/index';
 
@@ -932,6 +934,26 @@ describe( 'planHasFeature', () => {
 
 	test( 'should return false when a plan does not have a feature', () => {
 		expect( planHasFeature( PLAN_PERSONAL, FEATURE_VIDEO_UPLOADS ) ).to.be.false;
+	} );
+} );
+
+describe( 'planHasAtLeastOneFeature', () => {
+	test( 'should return true when a plan has one of the provided features', () => {
+		expect(
+			planHasAtLeastOneFeature( PLAN_JETPACK_COMPLETE, [
+				FEATURE_JETPACK_BACKUP_REALTIME, // Jetpack Complete has realtime backup
+				FEATURE_ACTIVITY_LOG, // Activity log is not listed in Jetpack Complete features
+			] )
+		).to.be.true;
+	} );
+
+	test( 'should return false when a plan has none of the provided features', () => {
+		expect(
+			planHasAtLeastOneFeature( PLAN_JETPACK_SECURITY_DAILY, [
+				FEATURE_JETPACK_BACKUP_REALTIME,
+				FEATURE_VIDEO_UPLOADS,
+			] )
+		).to.be.false;
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR introduces a new product check function `planHasAtLeastOneFeature` that determines if a given plan has one of several passed features. 
* To facilitate this, the logic used to collect all features for a plan currently used by `planHasFeature` has been moved to a separate function named `getAllFeaturesForPlan`, which returns an array of the plan features.

#### Testing instructions

* Run the related automated tests for this change from the command line with `yarn run test-packages packages/calypso-products/test/plan-lookups.js` All tests should pass. This PR introduces two new tests for the new `planHasAtLeastOneFeature` function.
