### PR TITLE
[WIP] Marketplace: Adds ups shipping method

### DIFF
--- a/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
+++ b/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+import { YOAST_PREMIUM, YOAST_FREE, UPS_SHIPPING_METHOD } from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -16,8 +16,9 @@ import { marketplaceDebugger } from 'calypso/my-sites/marketplace/constants';
 /**
  * A set of logical product groups, grouped by actual products, to be shown in one product (group) page
  * i.e. : YOAST_PREMIUM, YOAST_FREE are 2 products that belong to the product group YOAST
- * */
+ */
 export const YOAST = 'YOAST';
+export const WOOCOMMERCE = 'WOOCOMMERCE';
 
 export const productGroups: IProductGroupCollection = {
 	[ YOAST ]: {
@@ -33,6 +34,15 @@ export const productGroups: IProductGroupCollection = {
 				defaultPluginSlug: 'wordpress-seo',
 				pluginsToBeInstalled: [ 'wordpress-seo' ],
 				isPurchasableProduct: false,
+			},
+		},
+	},
+	[ WOOCOMMERCE ]: {
+		products: {
+			[ UPS_SHIPPING_METHOD ]: {
+				productName: 'UPS Shipping Method',
+				pluginsToBeInstalled: [ UPS_SHIPPING_METHOD ],
+				isPurchasableProduct: true,
 			},
 		},
 	},

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -7,7 +7,7 @@ import page from 'page';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { Button, Card, CompactCard } from '@automattic/components';
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+import { YOAST_PREMIUM, YOAST_FREE, UPS_SHIPPING_METHOD } from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ import { isAtomicSiteWithoutBusinessPlan } from 'calypso/blocks/eligibility-warn
 import Notice from 'calypso/components/notice';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
-import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import { YOAST, WOOCOMMERCE } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 
 export const Container = styled.div`
 	margin: 0 25px;
@@ -79,6 +79,10 @@ export default function MarketplaceTest(): JSX.Element {
 	const transferDetails = useSelector( ( state ) => getAutomatedTransfer( state, selectedSiteId ) );
 	const eligibilityDetails = useSelector( ( state ) => getEligibility( state, selectedSiteId ) );
 	const marketplacePages = [
+		{
+			name: 'UPS WooCommerce Shipping Details Page',
+			path: `/marketplace/product/details/${ WOOCOMMERCE }/${ UPS_SHIPPING_METHOD }`,
+		},
 		{
 			name: 'Yoast Premium Details Page',
 			path: `/marketplace/product/details/${ YOAST }/${ YOAST_PREMIUM }`,

--- a/client/my-sites/marketplace/types.ts
+++ b/client/my-sites/marketplace/types.ts
@@ -1,25 +1,25 @@
 /**
  * External dependencies
  */
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+import { YOAST_PREMIUM, YOAST_FREE, UPS_SHIPPING_METHOD } from '@automattic/calypso-products';
 
 /**
  * Internal dependencies
  */
-import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import { YOAST, WOOCOMMERCE } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 export interface IProductDefinition {
 	productName: string;
 
 	/**
 	 * Some plugins may not be available in the calypso product library ( i.e. wordpress-seo-premium ) so we specify a default plugin that is accessible in the product library
 	 * so that relevant details can be shown
-	 * */
-	defaultPluginSlug: string;
+	 */
+	defaultPluginSlug?: string;
 
 	/**
 	 * While this array is not in use right now, it indicates the plugins that need to be installed as part of the product
 	 * Eventually when moving this logic to the backend this can be part of the Market Place product entity
-	 * */
+	 */
 	pluginsToBeInstalled: string[];
 
 	/**
@@ -27,20 +27,28 @@ export interface IProductDefinition {
 	 * We have however introduced dummy products in the calypso product library so that we can maintain a product details in declarative data structure.
 	 * Hence the product is not purchasable ( and is a dummy product i.e. yoast_free ) we maintain a flag to indicate this.
 	 *
-	 * */
+	 */
 	isPurchasableProduct: boolean;
 }
 
-export interface IProductCollection {
+interface IYoastProductCollection {
 	[ YOAST_PREMIUM ]: IProductDefinition;
 	[ YOAST_FREE ]: IProductDefinition;
 }
 
+interface IWooCommerceProductCollection {
+	[ UPS_SHIPPING_METHOD ]: IProductDefinition;
+}
+
+export type IProductCollection = IYoastProductCollection | IWooCommerceProductCollection;
 /**
  * IProductGroupCollection is a one-to-many mapping between logical product groups and actual products
- * */
+ */
 export interface IProductGroupCollection {
 	[ YOAST ]?: {
-		products: IProductCollection;
+		products: IYoastProductCollection;
+	};
+	[ WOOCOMMERCE ]?: {
+		products: IWooCommerceProductCollection;
 	};
 }

--- a/packages/calypso-products/src/constants/marketplace.ts
+++ b/packages/calypso-products/src/constants/marketplace.ts
@@ -1,3 +1,4 @@
 export const YOAST_PREMIUM = 'yoast_premium';
 export const YOAST_FREE = 'yoast_free';
-export const MARKETPLACE_PRODUCTS = [ YOAST_PREMIUM, YOAST_FREE ];
+export const UPS_SHIPPING_METHOD = 'woocommerce-shipping-ups';
+export const MARKETPLACE_PRODUCTS = [ YOAST_PREMIUM, YOAST_FREE, UPS_SHIPPING_METHOD ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit `http://calypso.localhost:3000/marketplace/test/[DOMAIN]` of an atomic business site which doesn't have the **UPS Shipping Method** plugin
* click **UPS WooCommerce Shipping Details Page**
* click **UPS Shipping Method** 
* continue with the free domain
* pay
* go to `/wp-admin/plugins.php`, **UPS Shipping Method** should be active

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55575
