### PR TITLE
Incorporate feedback from HEs in the GitHub issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -88,7 +88,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Reproducibility Information
+        ----
   - type: dropdown
     id: reproducibility
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -5,11 +5,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Thanks for contributing to calypso! Pick a clear title and proceed.
+        ### Thanks for contributing to calypso! Pick a clear title and proceed.
+        
+        &nbsp;
+        
   - type: textarea
     id: summary
     attributes:
-        label: Summary
+        label: Quick summary
+
   - type: textarea
     id: steps
     attributes:
@@ -19,17 +23,32 @@ body:
         2. Click on View Site.
         3. Click on 'Like' button.
         ...
+
     validations:
       required: true
-  - type: textarea
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
+ - type: textarea
     id: expected
     attributes:
       label: What I expected to happen
       placeholder: |
-        eg. Post should be liked.
+        e.g. Post should be liked.
     validations:
       required: true
-  - type: textarea
+ 
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
+ - type: textarea
     id: actual
     attributes:
       label: What actually happened
@@ -39,19 +58,49 @@ body:
         Attach screenshot(s) or recording(s) by dragging into this field.
     validations:
       required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
   - type: textarea
     id: issue_context
     attributes:
       label: Context
       placeholder: |
         eg. Customer report, exploratory testing...
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
   - type: markdown
     attributes:
       value: |
         ---
 
-        <br>
-  - type: dropdown
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+
+   - type: markdown
+    attributes:
+      value: |
+        ### Screenshots
+        
+        &nbsp;
+
+        Please complete submit this form then upload your screenshots as a reply.
+        
+        &nbsp;
+        
+ - type: dropdown
     id: os
     attributes:
       label: OS
@@ -63,6 +112,13 @@ body:
         - Android
         - iOS
       multiple: true
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
   - type: dropdown
     id: browser
     attributes:
@@ -75,21 +131,42 @@ body:
         - Microsoft Edge (legacy)
         - Safari
       multiple: true
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
   - type: dropdown
     id: site-type
     attributes:
-      label: Simple/Atomic
+      label: Simple or Atomic
       description: Multiple selection is supported.
       options:
         - Simple
         - Atomic
       multiple: true
   - type: input
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
     id: theme
     attributes:
       label: Theme-specific issue?
       placeholder: |
         If yes - what is the theme name?
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
   - type: textarea
     id: other_notes
     attributes:
@@ -97,12 +174,26 @@ body:
       placeholder: |
         Logs, console errors, notes, observations, etc.
   - type: markdown
+
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+        
+  - type: markdown
     attributes:
       value: |
         ---
 
-        <br>
+  - type: markdown
+    attributes:
+      value: |
+        
+        &nbsp;
+
   - type: dropdown
+
     id: reproducibility
     attributes:
       label: Reproducibility
@@ -111,19 +202,21 @@ body:
         - Intermittent
         - Once
   - type: dropdown
-    id: users-affected
+
+    id: users-affected 
     attributes:
-      label: Number of Users Impacted
+      label: Number of users impacted
       description: How many users do you think might encounter this bug? Best guesses are fine!
       options:
         - One user
         - Some users (<50%)
         - Most users (>50%)
         - All users
+
   - type: textarea
     id: workarounds
     attributes:
-      label: Available Workarounds
-      description: Are there any workarounds to this bug? How difficult are those workarounds?
+      label: Any available workarounds?
+      description: Are there any workarounds to this bug? How difficult are those workarounds to implement?
       placeholder: |
-        eg. There is alternative access to this setting in the sidebar, but it's not readily apparent.
+        e.g. There is alternative access to this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,17 +7,17 @@ body:
       value: |
         <br>
          
-        ### Thanks for contributing your report! 
-        
-        Please write a clear title, then fill in the fields fields below and submit.
-        
-        There are only **3 required fields**, but please provide as much additional information and context as you are able to.
-        
-        You can attach screenshot(s) or recording(s) in any large text field below. 
-        
-        Click to activate it then drag and drop file(s) in. For better privacy and security, please avoid image hosting servies to link to media.
-        
-        If you have any questions, please ask in: `slack-bug-herders`.
+        > ### Thanks for contributing your report! 
+        >
+        > Please write a clear title, then fill in the fields fields below and submit.
+        >
+        > There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
+        >
+        > Attach screenshot(s) or recording(s) in any large text field below. 
+        >
+        > Click it then drag and drop file(s). Please avoid image hosting servies to link to media.
+        >
+        > If you have any questions, please ask in: `slack-bug-herders`.
         
         <br>
         

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -8,10 +8,14 @@ body:
         ### Thanks for contributing your report! 
         
         Please write a clear title, then fill in the fields fields below and submit.
+        
         There are only **3 required fields**, but please provide as much additional information and context as you are able to.
         
         You can attach screenshot(s) or recording(s) in any large text field below. Click to activate it then drag you file(s) into them. for better privacy and security, please avoid image hosting servies to link to media.
         <br>
+        
+        ---
+        
         <br>
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -6,14 +6,12 @@ body:
     attributes:
       value: |
         ### Thanks for contributing to calypso! Pick a clear title and proceed.
-        
+
         &nbsp;
-        
   - type: textarea
     id: summary
     attributes:
         label: Quick summary
-
   - type: textarea
     id: steps
     attributes:
@@ -23,83 +21,49 @@ body:
         2. Click on View Site.
         3. Click on 'Like' button.
         ...
-
     validations:
       required: true
-
   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
  - type: textarea
     id: expected
     attributes:
       label: What I expected to happen
       placeholder: |
-        e.g. Post should be liked.
+        eg. Post should be liked.
     validations:
       required: true
- 
   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
- - type: textarea
+  - type: textarea
     id: actual
     attributes:
       label: What actually happened
       placeholder: |
-        eg. Clicking the button does nothing visibly.
+        e.g. Clicking the button does nothing visibly.
 
         Attach screenshot(s) or recording(s) by dragging into this field.
     validations:
       required: true
-
-  - type: markdown
+   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
-  - type: textarea
+ - type: textarea
     id: issue_context
     attributes:
       label: Context
       placeholder: |
-        eg. Customer report, exploratory testing...
-
-  - type: markdown
-    attributes:
-      value: |
-        
-        &nbsp;
-        
+        e.g. Customer report, exploratory testing...
   - type: markdown
     attributes:
       value: |
         ---
-
-  - type: markdown
-    attributes:
-      value: |
-        
         &nbsp;
-
-   - type: markdown
-    attributes:
-      value: |
-        ### Screenshots
-        
-        &nbsp;
-
-        Please complete submit this form then upload your screenshots as a reply.
-        
-        &nbsp;
-        
  - type: dropdown
     id: os
     attributes:
@@ -112,61 +76,49 @@ body:
         - Android
         - iOS
       multiple: true
-
   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
   - type: dropdown
     id: browser
     attributes:
       label: Browser
       description: Multiple selection is supported.
       options:
-        - Chrome/Chromium
-        - Firefox
+        - Google Chrome/Chromium
+        - Mozilla Firefox
         - Microsoft Edge
         - Microsoft Edge (legacy)
-        - Safari
+        - Apple Safari
       multiple: true
-
   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
   - type: dropdown
     id: site-type
     attributes:
-      label: Simple or Atomic
+      label: Simple, Atomic, or both?
       description: Multiple selection is supported.
       options:
         - Simple
         - Atomic
       multiple: true
-  - type: input
-
   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
+  - type: input
     id: theme
     attributes:
       label: Theme-specific issue?
       placeholder: |
         If yes - what is the theme name?
-
   - type: markdown
     attributes:
       value: |
-        
         &nbsp;
-        
   - type: textarea
     id: other_notes
     attributes:
@@ -174,26 +126,11 @@ body:
       placeholder: |
         Logs, console errors, notes, observations, etc.
   - type: markdown
-
-  - type: markdown
     attributes:
       value: |
-        
-        &nbsp;
-        
-  - type: markdown
-    attributes:
-      value: |
-        ---
-
-  - type: markdown
-    attributes:
-      value: |
-        
-        &nbsp;
-
+          ----
+          &nbsp;
   - type: dropdown
-
     id: reproducibility
     attributes:
       label: Reproducibility
@@ -201,22 +138,28 @@ body:
         - Consistent
         - Intermittent
         - Once
+  - type: markdown
+    attributes:
+      value: |
+          &nbsp;
   - type: dropdown
-
-    id: users-affected 
+    id: users-affected
     attributes:
       label: Number of users impacted
       description: How many users do you think might encounter this bug? Best guesses are fine!
       options:
         - One user
-        - Some users (<50%)
-        - Most users (>50%)
+        - Some users - < 50%
+        - Most users - > 50%
         - All users
-
+  - type: markdown
+    attributes:
+      value: |
+          &nbsp;
   - type: textarea
     id: workarounds
     attributes:
-      label: Any available workarounds?
-      description: Are there any workarounds to this bug? How difficult are those workarounds to implement?
+      label: Available workarounds
+      description: Are there any workarounds to this bug? How difficult are they to implement?
       placeholder: |
-        e.g. There is alternative access to this setting in the sidebar, but it's not readily apparent.
+        e.g. There is alternative way to access to this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         <br>
          
-        ## Thanks for contributing your report! 
+        ### Thanks for contributing your report! 
         
         Please write a clear title, then fill in the fields fields below and submit.
         
@@ -85,9 +85,15 @@ body:
         
         ---
         
-        ## Optional details
+        <br>
+         
+        ### Optional details below
         
         Please provide whatever additional information you have available. If not, scroll to the bottom and submit your issue. 
+        
+        <br>
+        
+        ---
         
         <br>
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -13,7 +13,7 @@ body:
         There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
         
         Avoid using image hosting services such as Cloudup, Droplr, Imgur, etc., to link to media.
-        Instead, attach screenshot(s)/recording(s) *directly* in any of the text  areas below: click a field, then drag and drop.
+        Instead, attach screenshot(s) or recording(s) directly in any of the text  areas below: click, then drag and drop.
                 
         If you have any questions, please ask in: `slack-bug-herders`.
         
@@ -114,7 +114,7 @@ body:
     id: workarounds
     attributes:
       label: Available workarounds?
-      description: Is a workaround possible? What is the impact of this issue?
+      description: Is a workaround possible? What is the impact of this issue to users?
       options:
         - No and the platform is unusable
         - No but the platform is still usable 

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -85,7 +85,9 @@ body:
   - type: input
     id: theme
     attributes:
-      label: Is this specific to applied theme? If so, what is the theme name?
+      label: Theme-specific issue?
+      placeholder: |
+        If yes - what is the theme name?
   - type: textarea
     id: other_notes
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -6,9 +6,11 @@ body:
     attributes:
       value: |
         ### Thanks for contributing your report! 
-        Please write a clear title, then fill in at least the three required fields below.
-        <br>
-        If you can, please providing as much additional information and context, then hit Submit.
+        
+        Please write a clear title, then fill in the fields fields below and submit.
+        There are only **3 required fields**, but please provide as much additional information and context as you are able to.
+        
+        You can attach screenshot(s) or recording(s) in any large text field below. Click to activate it then drag you file(s) into them. for better privacy and security, please avoid image hosting servies to link to media.
         <br>
         <br>
   - type: textarea
@@ -39,7 +41,7 @@ body:
     attributes:
       label: What I expected to happen
       placeholder: |
-        eg. Post should be liked.
+        eg. The post should be liked but is not.
     validations:
       required: true
   - type: markdown
@@ -52,10 +54,7 @@ body:
       label: What actually happened
       placeholder: |
         e.g. Clicking the button does nothing visibly.
-        <br>
-        Please attach screenshot(s) or recording(s) by dragging them into this field.
-        <br>
-        No externally hosted image servies, please.
+        
     validations:
       required: true
   - type: markdown
@@ -72,13 +71,15 @@ body:
     attributes:
       value: |
         <br>
+        
         ---
+        
         <br>
   - type: dropdown
     id: os
     attributes:
-      label: OS
-      description: Multiple selection is supported.
+      label: Operating System
+      description: (You may select more than one)
       options:
         - Windows
         - macOS
@@ -94,7 +95,7 @@ body:
     id: browser
     attributes:
       label: Browser
-      description: Multiple selection is supported.
+      description: (You may select more than one)
       options:
         - Google Chrome/Chromium
         - Mozilla Firefox
@@ -110,7 +111,7 @@ body:
     id: site-type
     attributes:
       label: Simple, Atomic, or both?
-      description: Multiple selection is supported.
+      description: (You may select more than one)
       options:
         - Simple
         - Atomic
@@ -124,7 +125,7 @@ body:
     attributes:
       label: Theme-specific issue?
       placeholder: |
-        If yes - what is the theme name?
+        If yes, what is the theme name?
   - type: markdown
     attributes:
       value: |
@@ -134,12 +135,14 @@ body:
     attributes:
       label: Other notes
       placeholder: |
-        Logs, console errors, notes, observations, etc.
+        e.g. Logs, CLI or console errors, notes, observations, etc.
   - type: markdown
     attributes:
       value: |
         <br>
+        
         ---
+        
         <br>
   - type: dropdown
     id: reproducibility
@@ -157,12 +160,11 @@ body:
     id: users-affected
     attributes:
       label: Number of users impacted
-      description: How many users do you think might encounter this bug? Best guesses are fine!
       options:
-        - One user
-        - Some users - < 50%
-        - Most users - > 50%
-        - All users
+        - One
+        - Some - < 50%
+        - Most - > 50%
+        - All
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -5,13 +5,18 @@ body:
   - type: markdown
     attributes:
       value: |
+        <br>
+         
         ### Thanks for contributing your report! 
         
         Please write a clear title, then fill in the fields fields below and submit.
         
         There are only **3 required fields**, but please provide as much additional information and context as you are able to.
         
-        You can attach screenshot(s) or recording(s) in any large text field below. Click to activate it then drag you file(s) into them. for better privacy and security, please avoid image hosting servies to link to media.
+        You can attach screenshot(s) or recording(s) in any large text field below. Click to activate it then drag and drop file(s) in. For better privacy and security, please avoid image hosting servies to link to media.
+        
+        If you have any questions, please ask in slack-bug-herders.
+        
         <br>
         
         ---
@@ -28,12 +33,12 @@ body:
   - type: textarea
     id: steps
     attributes:
-      label: Steps to Reproduce
+      label: Steps to reproduce
       placeholder: |
-        1. Start at /home.
-        2. Click on 'View Site'.
-        3. Click on 'Like' button.
-        ...
+        1. Start at `site-domain.com/blog`.
+        2. Click on any blog post.
+        3. Click on the 'Like' button.
+        4. ...
     validations:
       required: true
   - type: markdown
@@ -45,7 +50,7 @@ body:
     attributes:
       label: What I expected to happen
       placeholder: |
-        eg. The post should be liked but is not.
+        e.g. The post should be liked.
     validations:
       required: true
   - type: markdown
@@ -70,10 +75,23 @@ body:
     attributes:
       label: Context
       placeholder: |
-        e.g. Customer report, exploratory testing...
+        e.g. Customer report, details of your exploratory testing, etc.
   - type: markdown
     attributes:
       value: |
+        <br>
+        
+        ---
+        
+        <br>
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+        ### Optional details
+        
+        Please provide whatever additional information you have available. If not, scroll to the bottom and submit your issue. 
+        
         <br>
         
         ---
@@ -114,7 +132,7 @@ body:
   - type: dropdown
     id: site-type
     attributes:
-      label: Simple, Atomic, or both?
+      label: Simple, Atomic or both?
       description: (You may select more than one)
       options:
         - Simple
@@ -163,20 +181,36 @@ body:
   - type: dropdown
     id: users-affected
     attributes:
-      label: Number of users impacted
+      label: Severity
+      description: Approximately how many users are impacted?
       options:
         - One
-        - Some - < 50%
-        - Most - > 50%
+        - Some (< 50%)
+        - Most (> 50%)
         - All
   - type: markdown
     attributes:
       value: |
           <br>
-  - type: textarea
-    id: workarounds
+  - type: dropdown
+    id: users-affected
     attributes:
-      label: Available workarounds
-      description: Are there any workarounds to this bug? How difficult are they to implement?
+      label: Available workarounds?
+      description: Is a workaround possible? What is the impact of this issue?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable 
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+  - type: markdown
+    attributes:
+      value: |
+          <br>
+  - type: textarea
+    id: workaround-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
       placeholder: |
-        e.g. There is alternative way to access to this setting in the sidebar, but it's not readily apparent.
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,17 +7,15 @@ body:
       value: |
         <br>
          
-        > ### Thanks for contributing your report! 
-        >
-        > Please write a clear title, then fill in the fields fields below and submit.
-        >
-        > There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
-        >
-        > Attach screenshot(s) or recording(s) in any large text field below. 
-        >
-        > Click it then drag and drop file(s). Please avoid image hosting servies to link to media.
-        >
-        > If you have any questions, please ask in: `slack-bug-herders`.
+        ### Thanks for contributing your report! 
+        
+        Please write a clear title, then fill in the fields fields below and submit.
+        There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
+        
+        Attach screenshot(s) or recording(s) in any large text field below. 
+        Click it then drag and drop file(s). Please avoid image hosting servies to link to media.
+        
+        If you have any questions, please ask in: `slack-bug-herders`.
         
         <br>
         

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -5,13 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### Thanks for contributing to calypso! Pick a clear title and proceed.
-
-        <br>
+        ## Thanks for contributing to calypso! Pick a clear title and proceed.
   - type: textarea
     id: summary
     attributes:
-        label: Quick summary
+        label: Summary
   - type: textarea
     id: steps
     attributes:
@@ -23,11 +21,7 @@ body:
         ...
     validations:
       required: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
- - type: textarea
+  - type: textarea
     id: expected
     attributes:
       label: What I expected to happen
@@ -35,36 +29,29 @@ body:
         eg. Post should be liked.
     validations:
       required: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
   - type: textarea
     id: actual
     attributes:
       label: What actually happened
       placeholder: |
-        e.g. Clicking the button does nothing visibly.
+        eg. Clicking the button does nothing visibly.
 
         Attach screenshot(s) or recording(s) by dragging into this field.
     validations:
       required: true
-   - type: markdown
-    attributes:
-      value: |
-        <br>
- - type: textarea
+  - type: textarea
     id: issue_context
     attributes:
       label: Context
       placeholder: |
-        e.g. Customer report, exploratory testing...
+        eg. Customer report, exploratory testing...
   - type: markdown
     attributes:
       value: |
         ---
+
         <br>
- - type: dropdown
+  - type: dropdown
     id: os
     attributes:
       label: OS
@@ -76,49 +63,33 @@ body:
         - Android
         - iOS
       multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
   - type: dropdown
     id: browser
     attributes:
       label: Browser
       description: Multiple selection is supported.
       options:
-        - Google Chrome/Chromium
-        - Mozilla Firefox
+        - Chrome/Chromium
+        - Firefox
         - Microsoft Edge
         - Microsoft Edge (legacy)
-        - Apple Safari
+        - Safari
       multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
   - type: dropdown
     id: site-type
     attributes:
-      label: Simple, Atomic, or both?
+      label: Simple/Atomic
       description: Multiple selection is supported.
       options:
         - Simple
         - Atomic
       multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
   - type: input
     id: theme
     attributes:
       label: Theme-specific issue?
       placeholder: |
         If yes - what is the theme name?
-  - type: markdown
-    attributes:
-      value: |
-        <br>
   - type: textarea
     id: other_notes
     attributes:
@@ -128,8 +99,9 @@ body:
   - type: markdown
     attributes:
       value: |
-          ----
-          <br>
+        ---
+
+        <br>
   - type: dropdown
     id: reproducibility
     attributes:
@@ -138,28 +110,20 @@ body:
         - Consistent
         - Intermittent
         - Once
-  - type: markdown
-    attributes:
-      value: |
-          <br>
   - type: dropdown
     id: users-affected
     attributes:
-      label: Number of users impacted
+      label: Number of Users Impacted
       description: How many users do you think might encounter this bug? Best guesses are fine!
       options:
         - One user
-        - Some users - < 50%
-        - Most users - > 50%
+        - Some users (<50%)
+        - Most users (>50%)
         - All users
-  - type: markdown
-    attributes:
-      value: |
-          <br>
   - type: textarea
     id: workarounds
     attributes:
-      label: Available workarounds
-      description: Are there any workarounds to this bug? How difficult are they to implement?
+      label: Available Workarounds
+      description: Are there any workarounds to this bug? How difficult are those workarounds?
       placeholder: |
-        e.g. There is alternative way to access to this setting in the sidebar, but it's not readily apparent.
+        eg. There is alternative access to this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,15 +7,17 @@ body:
       value: |
         <br>
          
-        ### Thanks for contributing your report! 
+        ## Thanks for contributing your report! 
         
         Please write a clear title, then fill in the fields fields below and submit.
         
         There are only **3 required fields**, but please provide as much additional information and context as you are able to.
         
-        You can attach screenshot(s) or recording(s) in any large text field below. Click to activate it then drag and drop file(s) in. For better privacy and security, please avoid image hosting servies to link to media.
+        You can attach screenshot(s) or recording(s) in any large text field below. 
         
-        If you have any questions, please ask in slack-bug-herders.
+        Click to activate it then drag and drop file(s) in. For better privacy and security, please avoid image hosting servies to link to media.
+        
+        If you have any questions, please ask in: `slack-bug-herders`.
         
         <br>
         
@@ -83,18 +85,9 @@ body:
         
         ---
         
-        <br>
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-        ### Optional details
+        ## Optional details
         
         Please provide whatever additional information you have available. If not, scroll to the bottom and submit your issue. 
-        
-        <br>
-        
-        ---
         
         <br>
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -5,11 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Thanks for contributing to calypso! Pick a clear title and proceed.
+        ### Thanks for contributing to calypso! Pick a clear title and proceed.
+        <br>
   - type: textarea
     id: summary
     attributes:
-        label: Summary
+        label: Quick summary
   - type: textarea
     id: steps
     attributes:
@@ -21,7 +22,11 @@ body:
         ...
     validations:
       required: true
-  - type: textarea
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+ - type: textarea
     id: expected
     attributes:
       label: What I expected to happen
@@ -29,29 +34,36 @@ body:
         eg. Post should be liked.
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
   - type: textarea
     id: actual
     attributes:
       label: What actually happened
       placeholder: |
-        eg. Clicking the button does nothing visibly.
+        e.g. Clicking the button does nothing visibly.
 
         Attach screenshot(s) or recording(s) by dragging into this field.
     validations:
       required: true
-  - type: textarea
+   - type: markdown
+    attributes:
+      value: |
+        <br>
+ - type: textarea
     id: issue_context
     attributes:
       label: Context
       placeholder: |
-        eg. Customer report, exploratory testing...
+        e.g. Customer report, exploratory testing...
   - type: markdown
     attributes:
       value: |
         ---
-
         <br>
-  - type: dropdown
+ - type: dropdown
     id: os
     attributes:
       label: OS
@@ -63,33 +75,49 @@ body:
         - Android
         - iOS
       multiple: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
   - type: dropdown
     id: browser
     attributes:
       label: Browser
       description: Multiple selection is supported.
       options:
-        - Chrome/Chromium
-        - Firefox
+        - Google Chrome/Chromium
+        - Mozilla Firefox
         - Microsoft Edge
         - Microsoft Edge (legacy)
-        - Safari
+        - Apple Safari
       multiple: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
   - type: dropdown
     id: site-type
     attributes:
-      label: Simple/Atomic
+      label: Simple, Atomic, or both?
       description: Multiple selection is supported.
       options:
         - Simple
         - Atomic
       multiple: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
   - type: input
     id: theme
     attributes:
       label: Theme-specific issue?
       placeholder: |
         If yes - what is the theme name?
+  - type: markdown
+    attributes:
+      value: |
+        <br>
   - type: textarea
     id: other_notes
     attributes:
@@ -99,9 +127,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        ---
-
-        <br>
+          ----
+          <br>
   - type: dropdown
     id: reproducibility
     attributes:
@@ -110,20 +137,28 @@ body:
         - Consistent
         - Intermittent
         - Once
+  - type: markdown
+    attributes:
+      value: |
+          <br>
   - type: dropdown
     id: users-affected
     attributes:
-      label: Number of Users Impacted
+      label: Number of users impacted
       description: How many users do you think might encounter this bug? Best guesses are fine!
       options:
         - One user
-        - Some users (<50%)
-        - Most users (>50%)
+        - Some users - < 50%
+        - Most users - > 50%
         - All users
+  - type: markdown
+    attributes:
+      value: |
+          <br>
   - type: textarea
     id: workarounds
     attributes:
-      label: Available Workarounds
-      description: Are there any workarounds to this bug? How difficult are those workarounds?
+      label: Available workarounds
+      description: Are there any workarounds to this bug? How difficult are they to implement?
       placeholder: |
-        eg. There is alternative access to this setting in the sidebar, but it's not readily apparent.
+        e.g. There is alternative way to access to this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -5,19 +5,27 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### Thanks for contributing to calypso! Pick a clear title and proceed.
+        ### Thanks for contributing your report! 
+        Please write a clear title, then fill in at least the three required fields below.
+        <br>
+        If you can, please providing as much additional information and context, then hit Submit.
+        <br>
         <br>
   - type: textarea
     id: summary
     attributes:
         label: Quick summary
+  - type: markdown
+    attributes:
+      value: |
+        <br>
   - type: textarea
     id: steps
     attributes:
       label: Steps to Reproduce
       placeholder: |
         1. Start at /home.
-        2. Click on View Site.
+        2. Click on 'View Site'.
         3. Click on 'Like' button.
         ...
     validations:
@@ -44,7 +52,10 @@ body:
       label: What actually happened
       placeholder: |
         e.g. Clicking the button does nothing visibly.
-        Attach screenshot(s) or recording(s) by dragging into this field.
+        <br>
+        Please attach screenshot(s) or recording(s) by dragging them into this field.
+        <br>
+        No externally hosted image servies, please.
     validations:
       required: true
   - type: markdown
@@ -60,6 +71,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        <br>
         ---
         <br>
   - type: dropdown
@@ -126,8 +138,9 @@ body:
   - type: markdown
     attributes:
       value: |
-          ----
-          <br>
+        <br>
+        ---
+        <br>
   - type: dropdown
     id: reproducibility
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for contributing to calypso! Pick a clear title and proceed.
+        ## Thanks for contributing to calypso! Pick a clear title and proceed.
   - type: textarea
     id: summary
     attributes:
@@ -46,11 +46,13 @@ body:
   - type: markdown
     attributes:
       value: |
+        <br>
         ----
+        <br>
   - type: dropdown
     id: os
     attributes:
-      label: Operating System
+      label: OS
       description: Multiple selection is supported.
       options:
         - Windows
@@ -71,15 +73,6 @@ body:
         - Microsoft Edge (legacy)
         - Safari
       multiple: true
-  - type: input
-    id: theme
-    attributes:
-      label: Is this specific to applied theme? If so, what is the theme name?
-  - type: textarea
-    id: other_notes
-    attributes:
-      label: Other notes
-      description: Logs, console errors, notes, observations, etc.
   - type: dropdown
     id: site-type
     attributes:
@@ -89,6 +82,15 @@ body:
         - Simple
         - Atomic
       multiple: true
+  - type: input
+    id: theme
+    attributes:
+      label: Is this specific to applied theme? If so, what is the theme name?
+  - type: textarea
+    id: other_notes
+    attributes:
+      label: Other notes
+      description: Logs, console errors, notes, observations, etc.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       value: |
         <br>
- - type: textarea
+  - type: textarea
     id: expected
     attributes:
       label: What I expected to happen
@@ -44,15 +44,14 @@ body:
       label: What actually happened
       placeholder: |
         e.g. Clicking the button does nothing visibly.
-
         Attach screenshot(s) or recording(s) by dragging into this field.
     validations:
       required: true
-   - type: markdown
+  - type: markdown
     attributes:
       value: |
         <br>
- - type: textarea
+  - type: textarea
     id: issue_context
     attributes:
       label: Context
@@ -63,7 +62,7 @@ body:
       value: |
         ---
         <br>
- - type: dropdown
+  - type: dropdown
     id: os
     attributes:
       label: OS

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -68,6 +68,7 @@ body:
         - Safari
       multiple: true
   - type: input
+    id: browser_versions
     attributes:
       label: Browser Version(s)
   - type: input
@@ -88,6 +89,9 @@ body:
         - Simple
         - Atomic
       multiple: true
+  - type: markdown
+        attributes:
+          value: Reproducibility Information
   - type: dropdown
     id: reproducibility
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -90,8 +90,9 @@ body:
         - Atomic
       multiple: true
   - type: markdown
-        attributes:
-          value: Reproducibility Information
+    attributes:
+      value: |
+        Reproducibility Information
   - type: dropdown
     id: reproducibility
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -43,6 +43,10 @@ body:
       label: Context
       placeholder: |
         eg. Customer report, exploratory testing...
+  - type: markdown
+    attributes:
+      value: |
+        ----
   - type: dropdown
     id: os
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,6 +7,10 @@ body:
       value: |
         Thanks for contributing to calypso! Pick a clear title and proceed.
   - type: textarea
+    id: summary
+    attributes:
+        label: Summary
+  - type: textarea
     id: steps
     attributes:
       label: Steps to Reproduce
@@ -39,8 +43,6 @@ body:
       label: Context
       placeholder: |
         eg. Customer report, exploratory testing...
-    validations:
-      required: true
   - type: dropdown
     id: os
     attributes:
@@ -53,12 +55,6 @@ body:
         - Android
         - iOS
       multiple: true
-    validations:
-      required: true
-  - type: input
-    id: os_version
-    attributes:
-      label: OS Version
   - type: dropdown
     id: browser
     attributes:
@@ -71,8 +67,6 @@ body:
         - Microsoft Edge (legacy)
         - Safari
       multiple: true
-    validations:
-      required: true
   - type: input
     attributes:
       label: Browser Version(s)
@@ -90,10 +84,10 @@ body:
         - Atomic
       multiple: true
   - type: textarea
-    id: errors
+    id: other_notes
     attributes:
-      label: Console and/or error logs
-      description: If there are any console logs or errors, paste it below.
+      label: Other notes
+      description: Logs, console errors, notes, observations, etc.
   - type: dropdown
     id: users-affected
     attributes:
@@ -120,8 +114,3 @@ body:
         - Intermittent
         - Once
         - Never
-  - type: textarea
-    id: other
-    attributes:
-      label: Other information
-      placeholder: additional logs, notes, etc.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -92,11 +92,16 @@ body:
     id: other_notes
     attributes:
       label: Other notes
-      description: Logs, console errors, notes, observations, etc.
+      placeholder: |
+        Logs, console errors, notes, observations, etc.
   - type: markdown
     attributes:
       value: |
-        ----
+        <br>
+
+        ---
+
+        <br>
   - type: dropdown
     id: reproducibility
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -68,10 +68,6 @@ body:
         - Safari
       multiple: true
   - type: input
-    id: browser_versions
-    attributes:
-      label: Browser Version(s)
-  - type: input
     id: theme
     attributes:
       label: Is this specific to applied theme? If so, what is the theme name?

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -74,6 +74,11 @@ body:
     id: theme
     attributes:
       label: Is this specific to applied theme? If so, what is the theme name?
+  - type: textareas
+    id: other_notes
+    attributes:
+      label: Other notes
+      description: Logs, console errors, notes, observations, etc.
   - type: dropdown
     id: site-type
     attributes:
@@ -83,11 +88,15 @@ body:
         - Simple
         - Atomic
       multiple: true
-  - type: textarea
-    id: other_notes
+  - type: dropdown
+    id: reproducibility
     attributes:
-      label: Other notes
-      description: Logs, console errors, notes, observations, etc.
+      label: Reproducibility
+      options:
+        - Consistent
+        - Intermittent
+        - Once
+        - Never
   - type: dropdown
     id: users-affected
     attributes:
@@ -105,12 +114,3 @@ body:
       description: Are there any workarounds to this bug? How difficult are those workarounds?
       placeholder: |
         eg. There is alternative access to this setting in the sidebar, but it's not readily apparent.
-  - type: dropdown
-    id: reproducibility
-    attributes:
-      label: Reproducibility
-      options:
-        - Consistent
-        - Intermittent
-        - Once
-        - Never

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,14 +7,14 @@ body:
       value: |
         <br>
          
-        ### Thanks for contributing your report! 
+        ### Thanks for contributing! 
         
-        Please write a clear title, then fill in the fields fields below and submit.
+        Please write a clear title, then fill in the fields below and submit.
         There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
         
-        Attach screenshot(s) or recording(s) in any large text field below. 
-        Click it then drag and drop file(s). Please avoid image hosting servies to link to media.
-        
+        Avoid using image hosting services such as Cloudup, Droplr, Imgur, etc., to link to media.
+        Instead, attach screenshot(s)/recording(s) *directly* in any of the text  areas below: click a field, then drag and drop.
+                
         If you have any questions, please ask in: `slack-bug-herders`.
         
         <br>
@@ -48,7 +48,7 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: What I expected to happen
+      label: What you expected to happen
       placeholder: |
         e.g. The post should be liked.
     validations:
@@ -76,85 +76,6 @@ body:
       label: Context
       placeholder: |
         e.g. Customer report, details of your exploratory testing, etc.
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-        
-        ---
-        
-        <br>
-         
-        ### Optional details below
-        
-        Please provide whatever additional information you have available. If not, scroll to the bottom and submit your issue. 
-        
-        <br>
-        
-        ---
-        
-        <br>
-  - type: dropdown
-    id: os
-    attributes:
-      label: Operating System
-      description: (You may select more than one)
-      options:
-        - Windows
-        - macOS
-        - Linux
-        - Android
-        - iOS
-      multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-  - type: dropdown
-    id: browser
-    attributes:
-      label: Browser
-      description: (You may select more than one)
-      options:
-        - Google Chrome/Chromium
-        - Mozilla Firefox
-        - Microsoft Edge
-        - Microsoft Edge (legacy)
-        - Apple Safari
-      multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-  - type: dropdown
-    id: site-type
-    attributes:
-      label: Simple, Atomic or both?
-      description: (You may select more than one)
-      options:
-        - Simple
-        - Atomic
-      multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-  - type: input
-    id: theme
-    attributes:
-      label: Theme-specific issue?
-      placeholder: |
-        If yes, what is the theme name?
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-  - type: textarea
-    id: other_notes
-    attributes:
-      label: Other notes
-      placeholder: |
-        e.g. Logs, CLI or console errors, notes, observations, etc.
   - type: markdown
     attributes:
       value: |
@@ -211,3 +132,82 @@ body:
       description: If you are aware of a workaround, please describe it below.
       placeholder: |
         e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+        
+        ---
+        
+        <br>
+         
+        ### Additional context
+        
+        Please provide whatever additional information you have available to you. If not, please scroll to the bottom and submit the issue. 
+        
+        <br>
+        
+        ---
+        
+        <br>
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: (You may select more than one)
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Android
+        - iOS
+      multiple: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: (You may select more than one)
+      options:
+        - Google Chrome/Chromium
+        - Mozilla Firefox
+        - Microsoft Edge
+        - Microsoft Edge (legacy)
+        - Apple Safari
+      multiple: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: dropdown
+    id: site-type
+    attributes:
+      label: Simple, Atomic or both?
+      description: (You may select more than one)
+      options:
+        - Simple
+        - Atomic
+      multiple: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: textarea
+    id: theme
+    attributes:
+      label: Theme-specific issue?
+      placeholder: |
+        If yes, what is the theme name?
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: textarea
+    id: other_notes
+    attributes:
+      label: Other notes
+      placeholder: |
+        e.g. Logs, CLI or console errors, notes, observations, etc.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -193,7 +193,7 @@ body:
       value: |
           <br>
   - type: dropdown
-    id: users-affected
+    id: workarounds
     attributes:
       label: Available workarounds?
       description: Is a workaround possible? What is the impact of this issue?
@@ -208,7 +208,7 @@ body:
       value: |
           <br>
   - type: textarea
-    id: workaround-detail
+    id: workarounds-detail
     attributes:
       label: Workaround details
       description: If you are aware of a workaround, please describe it below.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -71,7 +71,7 @@ body:
     id: theme
     attributes:
       label: Is this specific to applied theme? If so, what is the theme name?
-  - type: textareas
+  - type: textarea
     id: other_notes
     attributes:
       label: Other notes

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -47,7 +47,9 @@ body:
     attributes:
       value: |
         <br>
-        ----
+
+        ---
+
         <br>
   - type: dropdown
     id: os

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -84,62 +84,6 @@ body:
         ---
         
         <br>
-  - type: dropdown
-    id: reproducibility
-    attributes:
-      label: Reproducibility
-      options:
-        - Consistent
-        - Intermittent
-        - Once
-  - type: markdown
-    attributes:
-      value: |
-          <br>
-  - type: dropdown
-    id: users-affected
-    attributes:
-      label: Severity
-      description: Approximately how many users are impacted?
-      options:
-        - One
-        - Some (< 50%)
-        - Most (> 50%)
-        - All
-  - type: markdown
-    attributes:
-      value: |
-          <br>
-  - type: dropdown
-    id: workarounds
-    attributes:
-      label: Available workarounds?
-      description: Is a workaround possible? What is the impact of this issue to users?
-      options:
-        - No and the platform is unusable
-        - No but the platform is still usable 
-        - Yes, difficult to implement
-        - Yes, easy to implement
-        - There is no user impact
-  - type: markdown
-    attributes:
-      value: |
-          <br>
-  - type: textarea
-    id: workarounds-detail
-    attributes:
-      label: Workaround details
-      description: If you are aware of a workaround, please describe it below.
-      placeholder: |
-        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.
-  - type: markdown
-    attributes:
-      value: |
-        <br>
-        
-        ---
-        
-        <br>
          
         ### Additional context
         
@@ -211,3 +155,59 @@ body:
       label: Other notes
       placeholder: |
         e.g. Logs, CLI or console errors, notes, observations, etc.
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+        
+        ---
+        
+        <br>
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      options:
+        - Consistent
+        - Intermittent
+        - Once
+  - type: markdown
+    attributes:
+      value: |
+          <br>
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Severity
+      description: Approximately how many users are impacted?
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
+  - type: markdown
+    attributes:
+      value: |
+          <br>
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      description: Is a workaround possible? What is the impact of this issue to users?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable 
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+  - type: markdown
+    attributes:
+      value: |
+          <br>
+  - type: textarea
+    id: workarounds-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
+      placeholder: |
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -35,6 +35,8 @@ body:
       label: What actually happened
       placeholder: |
         eg. Clicking the button does nothing visibly.
+
+        Attach screenshot(s) or recording(s) by dragging into this field.
     validations:
       required: true
   - type: textarea
@@ -108,7 +110,6 @@ body:
         - Consistent
         - Intermittent
         - Once
-        - Never
   - type: dropdown
     id: users-affected
     attributes:

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -46,8 +46,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        <br>
-
         ---
 
         <br>
@@ -97,8 +95,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        <br>
-
         ---
 
         <br>

--- a/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/happiness-bug-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         ### Thanks for contributing to calypso! Pick a clear title and proceed.
 
-        &nbsp;
+        <br>
   - type: textarea
     id: summary
     attributes:
@@ -26,7 +26,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
  - type: textarea
     id: expected
     attributes:
@@ -38,7 +38,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
   - type: textarea
     id: actual
     attributes:
@@ -52,7 +52,7 @@ body:
    - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
  - type: textarea
     id: issue_context
     attributes:
@@ -63,7 +63,7 @@ body:
     attributes:
       value: |
         ---
-        &nbsp;
+        <br>
  - type: dropdown
     id: os
     attributes:
@@ -79,7 +79,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
   - type: dropdown
     id: browser
     attributes:
@@ -95,7 +95,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
   - type: dropdown
     id: site-type
     attributes:
@@ -108,7 +108,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
   - type: input
     id: theme
     attributes:
@@ -118,7 +118,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        &nbsp;
+        <br>
   - type: textarea
     id: other_notes
     attributes:
@@ -129,7 +129,7 @@ body:
     attributes:
       value: |
           ----
-          &nbsp;
+          <br>
   - type: dropdown
     id: reproducibility
     attributes:
@@ -141,7 +141,7 @@ body:
   - type: markdown
     attributes:
       value: |
-          &nbsp;
+          <br>
   - type: dropdown
     id: users-affected
     attributes:
@@ -155,7 +155,7 @@ body:
   - type: markdown
     attributes:
       value: |
-          &nbsp;
+          <br>
   - type: textarea
     id: workarounds
     attributes:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the GitHub issue template after feedback from HEs.

Key changes:

- several fields are no longer required (Browser, OS, Context).
- OS version field removed.
- Summary field added immediately below the welcome text.
- Notes/Error log fields merged into one.

Threads: p1628894017128700-slack-C01UW7SB411 and p1629133543059100/1628098234.020300-slack-C02FMH4G8

#### Testing instructions

Browse around [here](https://github.com/Automattic/wp-calypso/blob/update/github-issue-template/.github/ISSUE_TEMPLATE/happiness-bug-report.yml).

Related to #