### PR TITLE
Dotcom FSE Beta: Add a feedback form to the inline help in the site editor

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -8,6 +8,7 @@ export const RESULT_VIDEO = 'video';
 export const RESULT_POST_ID = 'post_id';
 export const RESULT_BLOG_ID = 'blog_id';
 export const VIEW_CONTACT = 'contact';
+export const VIEW_DOTCOM_FSE_BETA_CONTACT = 'dotcom_fse_beta_contact';
 export const VIEW_RICH_RESULT = 'richresult';
 export const VIEW_FORUM = 'forums';
 export const SUPPORT_BLOG_ID = 9619154;

--- a/client/blocks/inline-help/inline-help-dotcom-fse-beta-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-dotcom-fse-beta-contact-view.jsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import config from '@automattic/calypso-config';
+import { useI18n } from '@wordpress/react-i18n';
+import React, { Fragment, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+/**
+ * Internal dependencies
+ */
+import FormButton from 'calypso/components/forms/form-button';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import wpcom from 'calypso/lib/wp';
+import HelpContactConfirmation from 'calypso/me/help/help-contact-confirmation';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export default function InlineHelpDotcomFseBetaContactView() {
+	const { __, _x } = useI18n();
+
+	const selectedSite = useSelector( getSelectedSite );
+	const currentUserLocale = useSelector( getCurrentUserLocale );
+	const dispatch = useDispatch();
+
+	const [ confirmation, setConfirmation ] = useState( null );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ message, setMessage ] = useState( '' );
+
+	// @see client/me/help/help-contact/index.jsx
+	const submitKayakoTicket = () => {
+		setIsSubmitting( true );
+
+		const kayakoMessage = `Site: ${ selectedSite ? selectedSite.URL : 'N/A' }\n\n${ message }`;
+
+		wpcom
+			.undocumented()
+			.submitKayakoTicket(
+				'[Dotcom FSE Beta]',
+				kayakoMessage,
+				currentUserLocale,
+				config( 'client_slug' ),
+				false,
+				( error ) => {
+					if ( error ) {
+						dispatch( errorNotice( error.message ) );
+						setIsSubmitting( false );
+						return;
+					}
+
+					setIsSubmitting( false );
+					setConfirmation( {
+						title: __( 'Got it!' ),
+						message: __(
+							"We've received your feedback. Thank you for helping us making WordPress.com awesome!"
+						),
+					} );
+				}
+			);
+	};
+
+	if ( confirmation ) {
+		return <HelpContactConfirmation { ...confirmation } />;
+	}
+
+	return (
+		<Fragment>
+			<FormLabel htmlFor="message">{ __( 'Leave feedback' ) }</FormLabel>
+			<FormTextarea
+				disabled={ isSubmitting }
+				id="message"
+				name="message"
+				onChange={ ( event ) => setMessage( event.target.value ) }
+				placeholder={ __( 'How can we improve the site editing experience?' ) }
+				value={ message }
+			/>
+			<FormButton
+				disabled={ isSubmitting || ! message }
+				type="button"
+				onClick={ submitKayakoTicket }
+			>
+				{ isSubmitting ? __( 'Sending…' ) : _x( 'Send', 'verb: imperative' ) }
+			</FormButton>
+		</Fragment>
+	);
+}

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -15,7 +15,10 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectResult, resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
 import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
+import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { VIEW_CONTACT, VIEW_DOTCOM_FSE_BETA_CONTACT, VIEW_RICH_RESULT } from './constants';
+import InlineHelpDotcomFseContactView from './inline-help-dotcom-fse-beta-contact-view';
 import InlineHelpRichResult from './inline-help-rich-result';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpSearchResults from './inline-help-search-results';
@@ -92,6 +95,10 @@ class InlineHelpPopover extends Component {
 		this.openSecondaryView( VIEW_CONTACT );
 	};
 
+	openDotcomFseBetaContactView = () => {
+		this.openSecondaryView( VIEW_DOTCOM_FSE_BETA_CONTACT );
+	};
+
 	renderPopoverFooter = () => {
 		const { translate } = this.props;
 		return (
@@ -140,6 +147,7 @@ class InlineHelpPopover extends Component {
 						searchQuery={ this.props.searchQuery }
 					/>
 				</div>
+				{ this.props.isUsingSiteEditor && this.renderDotcomFseBetaContactButton() }
 				{ this.renderSecondaryView() }
 			</Fragment>
 		);
@@ -170,11 +178,20 @@ class InlineHelpPopover extends Component {
 								closePopover={ onClose }
 							/>
 						),
+						[ VIEW_DOTCOM_FSE_BETA_CONTACT ]: <InlineHelpDotcomFseContactView />,
 					}[ this.state.activeSecondaryView ]
 				}
 			</section>
 		);
 	};
+
+	renderDotcomFseBetaContactButton = () => (
+		<div className="inline-help__dotcom-fse-beta-contact-button">
+			<Button primary onClick={ this.openDotcomFseBetaContactView }>
+				{ __( 'Leave Feedback' ) }
+			</Button>
+		</div>
+	);
 
 	render() {
 		const popoverClasses = {
@@ -197,7 +214,9 @@ class InlineHelpPopover extends Component {
 }
 
 function mapStateToProps( state ) {
+	const selectedSiteId = getSelectedSiteId( state );
 	return {
+		isUsingSiteEditor: isSiteUsingCoreSiteEditor( state, selectedSiteId ),
 		searchQuery: getSearchQuery( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
 	};

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -15,6 +15,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectResult, resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
 import getInlineHelpCurrentlySelectedResult from 'calypso/state/inline-help/selectors/get-inline-help-currently-selected-result';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isSiteUsingCoreSiteEditor from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { VIEW_CONTACT, VIEW_DOTCOM_FSE_BETA_CONTACT, VIEW_RICH_RESULT } from './constants';
@@ -214,9 +215,12 @@ class InlineHelpPopover extends Component {
 }
 
 function mapStateToProps( state ) {
+	const currentRoute = getCurrentRoute( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		isUsingSiteEditor: isSiteUsingCoreSiteEditor( state, selectedSiteId ),
+		isUsingSiteEditor:
+			isSiteUsingCoreSiteEditor( state, selectedSiteId ) &&
+			currentRoute.startsWith( '/site-editor/' ),
 		searchQuery: getSearchQuery( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
 	};

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -226,7 +226,6 @@
 }
 
 .inline-help__contact {
-
 	.inline-help__title {
 		@include hide-content-accessibly;
 	}
@@ -330,9 +329,7 @@
 	}
 }
 
-
 .inline-help__results {
-
 	padding: 8px 0;
 
 	.help-contact-form & {
@@ -412,7 +409,6 @@
 				color: var( --color-text-inverted );
 			}
 		}
-
 	}
 
 	.help-contact-form & {
@@ -451,7 +447,8 @@
 	border-radius: 16px; /* stylelint-disable-line scales/radii */
 	background-color: var( --color-neutral-0 );
 	color: transparent;
-	animation: inline-help__results-placeholder-loading 2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ) infinite;
+	animation: inline-help__results-placeholder-loading 2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 )
+		infinite;
 	animation-delay: 0s;
 
 	&:nth-child( 1 ) {
@@ -492,4 +489,11 @@
 		opacity: 0.3;
 		width: 65%;
 	}
+}
+
+.inline-help__dotcom-fse-beta-contact-button {
+	.is-secondary-view-active & {
+		display: none;
+	}
+	padding-bottom: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new screen to the `InlineHelp` component to send feedback about the Dotcom FSE Beta.

This PR inserts a new "Leave Feedback" button in the `InlineHelp`'s main screen when in the Site Editor.
This button opens a new screen containing a very stripped down version of `HelpContact` (as it doesn't need any special handling), which will open a Zendesk ticket titled `[Dotcom FSE Beta]`.
These tickets won't be handled by HEs, but will be triaged by the Beta stakeholders for its duration.

⚠️ **Note: the copy is temporary!** ⚠️

| Main Screen | Form | Confirmation |
| - | - | - |
| <img width="339" alt="Screenshot 2021-08-19 at 14 51 23" src="https://user-images.githubusercontent.com/2070010/130080693-2e58e0c5-b995-4c1e-acbe-b42df2b6fd8e.png"> | <img width="336" alt="Screenshot 2021-08-19 at 14 51 32" src="https://user-images.githubusercontent.com/2070010/130080706-f78c8f95-3d2d-43f9-af8e-ca5998a32d13.png"> | <img width="340" alt="Screenshot 2021-08-19 at 14 51 44" src="https://user-images.githubusercontent.com/2070010/130080722-8d17e230-0574-4fe1-bac3-aa076e5cb5e5.png"> |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an FSE site:
  * Open the Site Editor in Calypso.
  * Open the inline help, and check that the feedback button is there.
  * Try sending a message, and make sure the confirmation message shows up as expected. (I'm the only person with access to these messages on Zendesk right now, so I'll double check if the messages show up there myself)
  * Double check that the rest of the inline help is unaffected.
  * Leave the Site Editor and open any other screens with the inline help (such as Stats).
  * Check that the inline help does not contain the feedback button.
* On a "regular" site:
  * Make sure the feedback button never shows up in the inline help.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to paYE8P-108-p2
