### PR TITLE
fix #55587 mobile: top buttons doesn't show up of welcome tour

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -169,3 +169,4 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 	justify-content: center;
 	min-width: 85px;
 }
+

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/z-index';
+@import '@wordpress/base-styles/breakpoints';
 
 $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: replace with standard color
 
@@ -151,6 +152,13 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 		background: $welcome-tour-button-background-color;
 		opacity: 0;
 		transition: opacity 200ms;
+	}
+}
+
+@include break-mobile {
+	.wpcom-editor-welcome-tour-frame .welcome-tour-card__overlay-controls .components-button,
+	.welcome-tour-card__overlay-controls-visible .components-button {
+		opacity: 0.9 !important;
 	}
 }
 


### PR DESCRIPTION
In this PR I will be fixing icons of the welcome tour screen that are not
visible on mobile phones since styling is applied based on hover event.

#### Changes proposed in this Pull Request

* I have added a mobile query breakpoint in which I'm setting opacity to 0.9
* These changes will only be applied when a user is on mobile devices.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Switch to this PR and `yarn dev --sync` to your sandbox from the `/apps/editing-toolkit` plugin
* Goto pages and click on create a new page
* On the top right corner of the screen, there are three vertical dots.
* Now you can emulate your browser to render the page in mobile iPhone or similar or open it in actual mobile.
* Click on that 3 vertical dots.
* In the dropdown select welcome tour
* In the welcome tour modal you will see the top two icons always.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55587
fixes #55587
cc @sixhours 
Can you please take a look at this PR. I'm not able to test this locally I noticed there is a ssh command. Since I'm not a member of Automattic I won't be able to test it. But you can.