### PR TITLE
Playwright: disable state-altering tests.

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -16,7 +16,6 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
-		"@types/mocha": "^8.2.3",
 		"config": "^1.28.0",
 		"playwright": "1.11.0"
 	},

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -65,16 +65,16 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 		await previewComponent.closePreview();
 	} );
 
-	it( 'Activate theme', async function () {
+	it.skip( 'Activate theme', async function () {
 		await themesDetailPage.activate();
 	} );
 
-	it( 'Open theme customizer', async function () {
+	it.skip( 'Open theme customizer', async function () {
 		popupTab = await themesDetailPage.customizeSite();
 		await popupTab.waitForLoadState( 'load' );
 	} );
 
-	it( 'Close theme customizer', async function () {
+	it.skip( 'Close theme customizer', async function () {
 		await popupTab.close();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to disable state-altering tests.

Key changes:
- remove dependency on types/mocha.
- skip the last three steps of Themes: Activate spec.

Background details:

The conversation in pMz3w-dAG-p2 has shown that the Quality Squad will not be able to achieve test isolation in the near term. As a result, state-altering tests must be disabled for the time being as multiple parallel executions of the test will result in unexpected failure of the test step.

#### Testing instructions

- [ ] ensure that steps that are skipped are no longer running.

Related to #