### PR TITLE
Domains: Update a domain's connection mode when retrieving its mapping status

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -95,7 +95,7 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 			setVerificationInProgress( true );
 			wpcom
 				.domain( domain )
-				.mappingStatus()
+				.updateConnectionModeAndGetMappingStatus( mode )
 				.then( ( data ) => {
 					setVerificationStatus( { data } );
 					if ( setStepAfterVerify ) {

--- a/packages/wpcom.js/src/lib/domain.js
+++ b/packages/wpcom.js/src/lib/domain.js
@@ -175,6 +175,19 @@ class Domain {
 	mappingStatus( query, fn ) {
 		return this.wpcom.req.get( root + this._id + '/mapping-status', query, fn );
 	}
+
+	/**
+	 * Update the connection mode used to connect this domain and retrieve its mapping status.
+	 *
+	 * @param {string} mode - connection mode used to connect this domain (can be "suggested" or "advanced")
+	 * @param {object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @returns {Function} request handler
+	 */
+	updateConnectionModeAndGetMappingStatus( mode, query, fn ) {
+		const body = { mode };
+		return this.wpcom.req.post( root + this._id + '/mapping-status', query, body, fn );
+	}
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the domain pages redesign work (detailed on pcYYhz-e4-p2) we want to show more specific error messages for domains which were connected (FKA mapped) to a site but did not resolve to WPCOM in 72 hours. We want to show different messages depending on whether the user followed the `suggested` setup instructions or the `advanced` ones - that information is stored in domain flags in the backend.

This PR adds a new method `updateConnectionModeAndGetMappingStatus` in `wpcom.domain()` to call the `POST /domains/%s/mapping-status` backend endpoint, which updates a domain's connection mode and retrieves its mapping status.

#### Testing instructions

Open the live Calypso link and navigate to the new domain connection page at `/domains/mapping/${ siteName }/setup/${ domainNameToConnect }`. Take the suggested setup route and reach the "Verify connection" step, open your network tab, click the button and ensure a `POST` call is made to the `/domains/%s/mapping-status` endpoint, with an object `{ mode: "suggested" }`. Try the same for the advanced setup and check if the posted object is `{ mode: "advanced" }`.
