### PR TITLE
Remove copy fallback now that translation is complete

### DIFF
--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -1,4 +1,4 @@
-import i18nCalypso, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -11,7 +11,7 @@ import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mod
 import SiteSettingsNavigation from 'calypso/my-sites/site-settings/navigation';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const SiteSettingsWriting = ( { site, locale, translate } ) => (
+const SiteSettingsWriting = ( { site, translate } ) => (
 	<Main className="settings-writing site-settings">
 		<ScreenOptionsTab wpAdminPath="options-writing.php" />
 		<DocumentHead title={ translate( 'Writing Settings' ) } />
@@ -21,16 +21,7 @@ const SiteSettingsWriting = ( { site, locale, translate } ) => (
 			brandFont
 			className="settings-writing__page-heading"
 			headerText={ translate( 'Writing Settings' ) }
-			subHeaderText={
-				// TODO: Remove fallback after translation is ready
-				locale === 'en' ||
-				locale === 'en-gb' ||
-				i18nCalypso.hasTranslation( "Manage settings related to your site's content." )
-					? translate( "Manage settings related to your site's content." )
-					: translate(
-							"Manage categories, tags, and other settings related to your site's content."
-					  )
-			}
+			subHeaderText={ translate( "Manage settings related to your site's content." ) }
 			align="left"
 			hasScreenOptions
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1. New copy for Writing settings was added in #55474
2. Fallback code was added in #55496 so that non-en users wouldn't see untranslated text
3. Translations are now complete https://github.com/Automattic/wp-calypso/pull/55496#issuecomment-902261962
4. This PR removes the fallback code

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Settings > Writing and confirm the sub heading is `Manage settings related to your site's content.`
* Switch to a mag16 language and check

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
