### PR TITLE
refine changelog script

### DIFF
--- a/desktop/bin/make-changelog.sh
+++ b/desktop/bin/make-changelog.sh
@@ -26,7 +26,11 @@ function get_desktop_tags() {
 
 # fetch all tags in descending lexicographical order
 # (exclude current tag with `awk`)
-tags=$(get_desktop_tags | tr - \~ | sort -V -r | tr \~ - | awk '{if(NR>1)print}')
+all_tags=$(get_desktop_tags | tr - \~ | sort -V -r | tr \~ -)
+tags=$all_tags
+if [ ! -z "$VERSION" ]; then
+  tags=$(echo "$all_tags" | awk '{if( !(/^'"$VERSION"'/) )print}')
+fi
 
 # get tag for previous stable release from the sorted list
 # (first match without `-`, e.g. v1.2.3, not v1.2.3-alpha1)


### PR DESCRIPTION
### Description

This change makes ensures that if the `VERSION` environment variable is omitted, the desktop changelog script will return changes since the last stable version through the current HEAD commit. This is useful for inspecting/gathering/compiling changes since the last stable release at any point in time.

### To Test

1. Try retrieving changes for the latest/last desktop stable tag like `VERSION=desktop-v7.1.0 ./desktop/bin/make-changelog.sh`
2. Try retrieving changes _since_ the latest desktop tag through the current HEAD with `./desktop/bin/make-changelog.sh` (i.e. omit the `VERSION` variable)