### PR TITLE
Add Jetpack Google Ads Conversion to Checkout

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -88,7 +88,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	jetpackGoogleAnalyticsGtag: 'UA-52447-43', // Jetpack Gtag (Analytics) for use in Jetpack x WordPress.com Flows
-	jetpackGoogleAdsPurchase: 'AW-946162814/kIF1CL3ApfsBEP6YlcMD',
+	jetpackGoogleAdsGtagPurchase: 'AW-946162814/kIF1CL3ApfsBEP6YlcMD',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -17,6 +17,7 @@ export const isFacebookEnabled = true;
 export const isBingEnabled = true;
 export const isGeminiEnabled = false;
 export const isWpcomGoogleAdsGtagEnabled = true;
+export const isJetpackGoogleAdsGtagEnabled = true;
 export const isQuantcastEnabled = false;
 export const isExperianEnabled = true;
 export const isOutbrainEnabled = true;
@@ -86,7 +87,8 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagSignup: 'AW-946162814/5-NnCKy3xZQBEP6YlcMD', // "All Calypso Signups (WordPress.com)"
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
-	jetpackGoogleAnalyticsGtag: 'UA-52447-43', // Jetpack Gtag for use in Jetpack x WordPress.com Flows
+	jetpackGoogleAnalyticsGtag: 'UA-52447-43', // Jetpack Gtag (Analytics) for use in Jetpack x WordPress.com Flows
+	jetpackGoogleAdsPurchase: 'AW-946162814/kIF1CL3ApfsBEP6YlcMD',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -14,6 +14,7 @@ import {
 	isBingEnabled,
 	isQuantcastEnabled,
 	isWpcomGoogleAdsGtagEnabled,
+	isJetpackGoogleAdsGtagEnabled,
 	isFloodlightEnabled,
 	isTwitterEnabled,
 	isPinterestEnabled,
@@ -76,7 +77,7 @@ export async function recordOrder( cart, orderId ) {
 	const wpcomJetpackCartInfo = splitWpcomJetpackCartInfo( cart );
 	debug( 'recordOrder: wpcomJetpackCartInfo:', wpcomJetpackCartInfo );
 
-	recordOrderInGoogleAds( cart, orderId );
+	recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInBing( cart, orderId, wpcomJetpackCartInfo );
@@ -426,9 +427,10 @@ function recordOrderInBing( cart, orderId, wpcomJetpackCartInfo ) {
  *
  * @param {object} cart - cart as `ResponseCart` object
  * @param {number} orderId - the order id
+ * @param {object} wpcomJetpackCartInfo - info about WPCOM and Jetpack in the cart
  * @returns {void}
  */
-function recordOrderInGoogleAds( cart, orderId ) {
+function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 	if ( ! isAdTrackingAllowed() ) {
 		debug( 'recordOrderInGoogleAds: skipping as ad tracking is disallowed' );
 		return;
@@ -443,6 +445,21 @@ function recordOrderInGoogleAds( cart, orderId ) {
 			{
 				send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
 				value: cart.total_cost,
+				currency: cart.currency,
+				transaction_id: orderId,
+			},
+		];
+		debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );
+		window.gtag( ...params );
+	}
+
+	if ( isJetpackGoogleAdsGtagEnabled && wpcomJetpackCartInfo.containsJetpackProducts ) {
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.isJetpackGoogleAdsGtagEnabled,
+				value: wpcomJetpackCartInfo.jetpackCost,
 				currency: cart.currency,
 				transaction_id: orderId,
 			},

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -458,13 +458,13 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 			'event',
 			'conversion',
 			{
-				send_to: TRACKING_IDS.isJetpackGoogleAdsGtagEnabled,
+				send_to: TRACKING_IDS.jetpackGoogleAdsGtagPurchase,
 				value: wpcomJetpackCartInfo.jetpackCost,
 				currency: cart.currency,
 				transaction_id: orderId,
 			},
 		];
-		debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );
+		debug( 'recordOrderInGoogleAds: Record Jetpack Purchase', params );
 		window.gtag( ...params );
 	}
 }


### PR DESCRIPTION
## Changes

* Add Jetpack Google Ads Conversion to checkout

## Testing

1. Boot branch with `ad-tracking` enabled in `development.json`
2. enabled `localStorage.setItem( 'debug', 'calypso:analytics:ad-tracking' );` in the browser dev console
3. Use store sandbox method ( PCYsg-IA-p2 ) to make a test Jetpack purchase with "real" money
4. Verify a Google "conversion" event is sent to `AW-946162814/taG8CPW8spQBEP6YlcMD`. 
example : 
``` 
{
    "0": "event",
    "1": "conversion",
    "2": {
      "send_to": "AW-946162814/kIF1CL3ApfsBEP6YlcMD",
      "value": 57.24,
      "currency": "USD",
      "transaction_id": "19995244"
   }
``` 