### PR TITLE
New "Already own a domain" component in the domain suggestions results

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -41,6 +41,7 @@ class DomainSearchResults extends React.Component {
 		buttonLabel: PropTypes.string,
 		mappingSuggestionLabel: PropTypes.string,
 		offerUnavailableOption: PropTypes.bool,
+		showAlreadyOwnADomain: PropTypes.bool,
 		onClickResult: PropTypes.func.isRequired,
 		onAddMapping: PropTypes.func,
 		onAddTransfer: PropTypes.func,
@@ -186,7 +187,7 @@ class DomainSearchResults extends React.Component {
 				);
 			}
 
-			if ( this.props.offerUnavailableOption ) {
+			if ( this.props.offerUnavailableOption || this.props.showAlreadyOwnADomain ) {
 				if ( this.props.siteDesignType !== DESIGN_TYPE_STORE && lastDomainIsTransferrable ) {
 					availabilityElement = (
 						<CompactCard className="domain-search-results__domain-available-notice">

--- a/client/components/domains/register-domain-step/already-own-a-domain.jsx
+++ b/client/components/domains/register-domain-step/already-own-a-domain.jsx
@@ -7,14 +7,16 @@ function AlreadyOwnADomain( { onClick } ) {
 	return (
 		<div className="already-own-a-domain">
 			<MaterialIcon icon="info" />
-			{ translate(
-				'Already own a domain? You can {{action}}use it as your site’s address{{/action}}',
-				{
-					components: {
-						action: <button onClick={ onClick } />,
-					},
-				}
-			) }
+			<span>
+				{ translate(
+					'Already own a domain? You can {{action}}use it as your site’s address{{/action}}',
+					{
+						components: {
+							action: <button onClick={ onClick } />,
+						},
+					}
+				) }
+			</span>
 		</div>
 	);
 }

--- a/client/components/domains/register-domain-step/already-own-a-domain.jsx
+++ b/client/components/domains/register-domain-step/already-own-a-domain.jsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import MaterialIcon from 'calypso/components/material-icon';
+
+function AlreadyOwnADomain( { onClick } ) {
+	const translate = useTranslate();
+	return (
+		<div className="already-own-a-domain">
+			<MaterialIcon icon="info" />
+			{ translate(
+				'Already own a domain? You can {{action}}use it as your site’s address{{/action}}',
+				{
+					components: {
+						action: <button onClick={ onClick } />,
+					},
+				}
+			) }
+		</div>
+	);
+}
+
+export default AlreadyOwnADomain;

--- a/client/components/domains/register-domain-step/already-own-a-domain.jsx
+++ b/client/components/domains/register-domain-step/already-own-a-domain.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -12,7 +13,7 @@ function AlreadyOwnADomain( { onClick } ) {
 					'Already own a domain? You can {{action}}use it as your site’s address{{/action}}',
 					{
 						components: {
-							action: <button onClick={ onClick } />,
+							action: <Button plain href="#" onClick={ onClick } />,
 						},
 					}
 				) }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -86,6 +86,7 @@ import {
 } from 'calypso/state/domains/suggestions/selectors';
 import { hideSitePreview, showSitePreview } from 'calypso/state/signup/preview/actions';
 import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
+import AlreadyOwnADomain from './already-own-a-domain';
 import SearchWithTyper from './search';
 import tip from './tip';
 
@@ -152,6 +153,7 @@ class RegisterDomainStep extends React.Component {
 		showSkipButton: PropTypes.bool,
 		onSkip: PropTypes.func,
 		promoTlds: PropTypes.array,
+		showAlreadyOwnADomain: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -405,7 +407,7 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
-		const { isSignupStep } = this.props;
+		const { isSignupStep, showAlreadyOwnADomain } = this.props;
 
 		const {
 			availabilityError,
@@ -440,41 +442,44 @@ class RegisterDomainStep extends React.Component {
 		} );
 
 		return (
-			<div className={ containerDivClassName }>
-				<StickyPanel className={ searchBoxClassName }>
-					<CompactCard className="register-domain-step__search-card">
-						{ this.renderSearchBar() }
-					</CompactCard>
-				</StickyPanel>
-				{ ! isSignupStep && isQueryInvalid && (
-					<Notice
-						className="register-domain-step__notice"
-						text={ `Please search for domains with more than ${ MIN_QUERY_LENGTH } characters length.` }
-						status={ `is-info` }
-						showDismiss={ false }
-					/>
-				) }
-				{ availabilityMessage && (
-					<Notice
-						className="register-domain-step__notice"
-						text={ availabilityMessage }
-						status={ `is-${ availabilitySeverity }` }
-						showDismiss={ false }
-					/>
-				) }
-				{ suggestionMessage && availabilityError !== suggestionError && (
-					<Notice
-						className="register-domain-step__notice"
-						text={ suggestionMessage }
-						status={ `is-${ suggestionSeverity }` }
-						showDismiss={ false }
-					/>
-				) }
-				{ this.renderFilterContent() }
-				{ this.renderSideContent() }
-				{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
-				<QueryContactDetailsCache />
-			</div>
+			<>
+				<div className={ containerDivClassName }>
+					<StickyPanel className={ searchBoxClassName }>
+						<CompactCard className="register-domain-step__search-card">
+							{ this.renderSearchBar() }
+						</CompactCard>
+					</StickyPanel>
+					{ ! isSignupStep && isQueryInvalid && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ `Please search for domains with more than ${ MIN_QUERY_LENGTH } characters length.` }
+							status={ `is-info` }
+							showDismiss={ false }
+						/>
+					) }
+					{ availabilityMessage && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ availabilityMessage }
+							status={ `is-${ availabilitySeverity }` }
+							showDismiss={ false }
+						/>
+					) }
+					{ suggestionMessage && availabilityError !== suggestionError && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ suggestionMessage }
+							status={ `is-${ suggestionSeverity }` }
+							showDismiss={ false }
+						/>
+					) }
+					{ this.renderFilterContent() }
+					{ this.renderSideContent() }
+					{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
+					<QueryContactDetailsCache />
+				</div>
+				{ showAlreadyOwnADomain && <AlreadyOwnADomain onClick={ this.useYourDomainFunction() } /> }
+			</>
 		);
 	}
 
@@ -1405,6 +1410,13 @@ class RegisterDomainStep extends React.Component {
 		}
 	};
 
+	useYourDomainFunction = () => {
+		const { lastDomainStatus } = this.state;
+		return domainAvailability.MAPPED === lastDomainStatus
+			? this.goToTransferDomainStep
+			: this.goToUseYourDomainStep;
+	};
+
 	renderSearchResults() {
 		const {
 			exactMatchDomain,
@@ -1435,11 +1447,6 @@ class RegisterDomainStep extends React.Component {
 			( Array.isArray( this.state.searchResults ) && this.state.searchResults.length ) > 0 &&
 			! this.state.loadingResults;
 
-		const useYourDomainFunction =
-			domainAvailability.MAPPED === lastDomainStatus
-				? this.goToTransferDomainStep
-				: this.goToUseYourDomainStep;
-
 		const isFreeDomainExplainerVisible =
 			! this.props.forceHideFreeDomainExplainerAndStrikeoutUi &&
 			this.props.isPlanSelectionAvailableInFlow;
@@ -1458,7 +1465,7 @@ class RegisterDomainStep extends React.Component {
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
 				onClickTransfer={ this.goToTransferDomainStep }
-				onClickUseYourDomain={ useYourDomainFunction }
+				onClickUseYourDomain={ this.useYourDomainFunction() }
 				tracksButtonClickSource="exact-match-top"
 				suggestions={ suggestions }
 				premiumDomains={ premiumDomains }
@@ -1466,6 +1473,7 @@ class RegisterDomainStep extends React.Component {
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
 				offerUnavailableOption={ this.props.offerUnavailableOption }
+				showAlreadyOwnADomain={ this.props.showAlreadyOwnADomain }
 				placeholderQuantity={ PAGE_SIZE }
 				isSignupStep={ this.props.isSignupStep }
 				showStrikedOutPrice={

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -268,9 +268,13 @@ body.is-section-signup.is-white-signup {
 		width: 16px;
 		height: 16px;
 		fill: var( --color-neutral-40 );
-		margin-right: 8px;
+		margin: 0 8px;
+		@include break-mobile {
+			margin-left: 0;
+		}
 	}
 	button {
+		display: contents;
 		margin-left: 5px;
 		color: var( --color-link );
 	}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -275,9 +275,7 @@ body.is-section-signup.is-white-signup {
 			margin-left: 0;
 		}
 	}
-	button {
-		display: contents;
-		margin-left: 5px;
+	.button-plain {
 		color: var( --color-link );
 	}
 }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -258,3 +258,20 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 }
+
+.already-own-a-domain {
+	font-size: $font-body-small;
+	color: var( --color-neutral-60 );
+	display: flex;
+	align-items: center;
+	svg {
+		width: 16px;
+		height: 16px;
+		fill: var( --color-neutral-40 );
+		margin-right: 8px;
+	}
+	button {
+		margin-left: 5px;
+		color: var( --color-link );
+	}
+}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -266,10 +266,11 @@ body.is-section-signup.is-white-signup {
 	align-items: center;
 	margin-top: 26px;
 	svg {
+		align-self: flex-start;
 		width: 16px;
 		height: 16px;
 		fill: var( --color-neutral-40 );
-		margin: 0 8px;
+		margin: 3px 8px 0;
 		@include break-mobile {
 			margin-left: 0;
 		}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -261,7 +261,7 @@ body.is-section-signup.is-white-signup {
 
 .already-own-a-domain {
 	font-size: $font-body-small;
-	color: var( --color-neutral-60 );
+	color: var( --color-text-subtle );
 	display: flex;
 	align-items: center;
 	margin-top: 26px;
@@ -269,7 +269,7 @@ body.is-section-signup.is-white-signup {
 		align-self: flex-start;
 		width: 16px;
 		height: 16px;
-		fill: var( --color-neutral-40 );
+		fill: var( --color-text-subtle );
 		margin: 3px 8px 0;
 		@include break-mobile {
 			margin-left: 0;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -264,6 +264,7 @@ body.is-section-signup.is-white-signup {
 	color: var( --color-neutral-60 );
 	display: flex;
 	align-items: center;
+	margin-top: 26px;
 	svg {
 		width: 16px;
 		height: 16px;

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -260,7 +260,7 @@ class DomainSearch extends Component {
 								onAddMapping={ this.handleAddMapping }
 								onAddTransfer={ this.handleAddTransfer }
 								isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
-								offerUnavailableOption
+								showAlreadyOwnADomain
 								selectedSite={ selectedSite }
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }

--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -65,6 +65,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 
 	async selectUseOwnDomain() {
 		const useOwnDomain = By.css( '.already-own-a-domain > span > button' );
+		await driverHelper.scrollIntoView( this.driver, useOwnDomain );
 		return await driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
 	}
 

--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -64,7 +64,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async selectUseOwnDomain() {
-		const useOwnDomain = By.css( '.already-own-a-domain > span > button' );
+		const useOwnDomain = By.css( '.already-own-a-domain > span > a' );
 		await driverHelper.scrollIntoView( this.driver, useOwnDomain );
 		return await driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
 	}

--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -64,7 +64,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 	}
 
 	async selectUseOwnDomain() {
-		const useOwnDomain = By.css( '.domain-suggestion.card.domain-transfer-suggestion' );
+		const useOwnDomain = By.css( '.already-own-a-domain > span > button' );
 		return await driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
 	}
 


### PR DESCRIPTION
Add new component to show the "Already own a domain" tip at the bottom of the domain suggestions according to our domains redesign

#### Changes proposed in this Pull Request

* This is a new component that'll render on the domain suggestions page below the suggestion results replacing the old card that we render within the suggestion results

Here's how it looks:

Before:
<img width="1089" alt="Screenshot 2021-08-20 at 13 50 07" src="https://user-images.githubusercontent.com/1355045/130222767-296c2634-db16-4c65-9e57-64bf231eb7ad.png">

After:
<img width="1086" alt="Screenshot 2021-08-20 at 13 49 40" src="https://user-images.githubusercontent.com/1355045/130222759-64818c3c-d0f9-4df6-8c3a-ab6fdfc324ee.png">


#### Testing instructions

* Open up the branch and go to a site and add a domain - you should not see the old row at the bottom of the domain suggestions results and you should see the new tip at the bottom after the results.
