### PR TITLE
Add feature flag for License-based Checkout, Milestone 1

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
@@ -281,6 +282,13 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 				{ calendlyUrl !== null && (
 					<div className="jetpack-checkout-siteless-thank-you__card-footer">
 						<div>
+							{ /* This is a feature-flag test and can be removed. Please remove me! */ }
+							{ isEnabled( 'jetpack/user-licensing-m1' ) && (
+								<p>
+									<code>jetpack/user-licensing-m1</code>:<br />
+									is enabled!
+								</p>
+							) }
 							<h2>{ translate( 'Do you need help?' ) }</h2>
 							<p>{ translate( 'Setup Jetpack with the help of our Happiness Engineers.' ) }</p>
 							<Button

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -176,6 +176,13 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 			/>
 			<Card className="jetpack-checkout-siteless-thank-you__card">
 				<div className="jetpack-checkout-siteless-thank-you__card-main">
+					{ /* This is a feature-flag test and can be removed. Please remove me! */ }
+					{ isEnabled( 'jetpack/user-licensing-m1' ) && (
+						<p>
+							<code>jetpack/user-licensing-m1</code>:<br />
+							is enabled!
+						</p>
+					) }
 					<JetpackLogo size={ 45 } />
 					{ hasProductInfo && <QueryProducts type="jetpack" /> }
 					<h1 className="jetpack-checkout-siteless-thank-you__main-message">
@@ -282,13 +289,6 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 				{ calendlyUrl !== null && (
 					<div className="jetpack-checkout-siteless-thank-you__card-footer">
 						<div>
-							{ /* This is a feature-flag test and can be removed. Please remove me! */ }
-							{ isEnabled( 'jetpack/user-licensing-m1' ) && (
-								<p>
-									<code>jetpack/user-licensing-m1</code>:<br />
-									is enabled!
-								</p>
-							) }
 							<h2>{ translate( 'Do you need help?' ) }</h2>
 							<p>{ translate( 'Setup Jetpack with the help of our Happiness Engineers.' ) }</p>
 							<Button

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
@@ -176,13 +175,6 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 			/>
 			<Card className="jetpack-checkout-siteless-thank-you__card">
 				<div className="jetpack-checkout-siteless-thank-you__card-main">
-					{ /* This is a feature-flag test and can be removed. Please remove me! */ }
-					{ isEnabled( 'jetpack/user-licensing-m1' ) && (
-						<p>
-							<code>jetpack/user-licensing-m1</code>:<br />
-							is enabled!
-						</p>
-					) }
 					<JetpackLogo size={ 45 } />
 					{ hasProductInfo && <QueryProducts type="jetpack" /> }
 					<h1 className="jetpack-checkout-siteless-thank-you__main-message">

--- a/config/development.json
+++ b/config/development.json
@@ -94,6 +94,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/siteless-checkout": true,
+		"jetpack/user-licensing-m1": true,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -62,6 +62,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/magic-link-signup": true,
 		"jetpack/siteless-checkout": true,
+		"jetpack/user-licensing-m1": true,
 		"jetpack/userless-checkout": true,
 		"jetpack/redirect-legacy-plans": true,
 		"jitms": true,

--- a/config/production.json
+++ b/config/production.json
@@ -65,6 +65,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/siteless-checkout": true,
+		"jetpack/user-licensing-m1": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -64,6 +64,7 @@
 		"jetpack/personal-plan": false,
 		"jetpack/redirect-legacy-plans": true,
 		"jetpack/siteless-checkout": true,
+		"jetpack/user-licensing-m1": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,6 +70,7 @@
 		"jetpack/happychat": true,
 		"jetpack/only-realtime-products": false,
 		"jetpack/siteless-checkout": true,
+		"jetpack/user-licensing-m1": false,
 		"jetpack/userless-checkout": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add feature flag: `jetpack/user-licensing-m1`
- Enabled by default in `development` and `horizon` environments.
- Disabled by default in **all other** environments.

Asana task: 1200738571375997-as-1200794056860711

#### Testing instructions

1. Checkout and run this PR (`yarn start`).
1. Go to: http://calypso.localhost:3000/checkout/jetpack/thank-you/no-site/jetpack_security_daily?receiptId=9999&siteId=9999
1. Verify you see the text: `jetpack/user-licensing-m1: is enabled!` at the top of the page, just above the main page heading. (see screenshot)
1. In Staging environment (proxied), go to: https://wordpress.com/checkout/jetpack/thank-you/no-site/jetpack_security_daily?receiptId=9999&siteId=9999
1. Verify you **do not** see the text: `jetpack/user-licensing-m1: is enabled!`
1. In Production environment (Turn proxy off), go to: https://wordpress.com/checkout/jetpack/thank-you/no-site/jetpack_security_daily?receiptId=9999&siteId=9999
1. Verify you **do not** see the text: `jetpack/user-licensing-m1: is enabled!`

#### Screenshot

![Markup 2021-08-30 at 09 10 54 (1)](https://user-images.githubusercontent.com/11078128/131344607-63b66158-03af-4cc4-ba56-ccfe345561a7.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->