### PR TITLE
Fix RTL alignment issue on input boxes in signup and login pages

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -130,6 +130,10 @@
 	input {
 		margin-bottom: 20px;
 		transition: none;
+		text-align: left;
+		/*!rtl:ignore*/
+		direction: ltr;
+
 		&.is-error {
 			margin-bottom: 0;
 		}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -130,10 +130,6 @@
 	input {
 		margin-bottom: 20px;
 		transition: none;
-
-		/*!rtl:ignore*/
-		direction: ltr;
-
 		&.is-error {
 			margin-bottom: 0;
 		}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -11,11 +11,6 @@
 	&[name='password'] {
 		margin-bottom: 0;
 	}
-
-	&[name='username'] {
-		/*!rtl:ignore*/
-		direction: ltr;
-	}
 }
 
 .signup-form__terms-of-service-link {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -11,6 +11,8 @@
 	&[name='password'] {
 		margin-bottom: 0;
 		text-align: left;
+		/*!rtl:ignore*/
+		direction: ltr;
 	}
 
 	&[name='username'] {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -10,6 +10,13 @@
 	&[type='password'],
 	&[name='password'] {
 		margin-bottom: 0;
+		text-align: left;
+	}
+
+	&[name='username'] {
+		text-align: left;
+		/*!rtl:ignore*/
+		direction: ltr;
 	}
 }
 

--- a/client/components/forms/form-password-input/style.scss
+++ b/client/components/forms/form-password-input/style.scss
@@ -14,7 +14,6 @@
 		display: block;
 		cursor: pointer;
 		position: absolute;
-		/*!rtl:ignore*/
 		right: 8px;
 		top: 8px;
 		user-select: none;

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -11,13 +11,6 @@
 		}
 
 		input[type='url']#{&},
-		input[type='password']#{&},
-		input[type='email']#{&} {
-			/*!rtl:ignore*/
-			direction: ltr;
-		}
-
-		input[type='url']#{&},
 		input[type='search']#{&} {
 			appearance: none;
 		}

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -11,6 +11,14 @@
 		}
 
 		input[type='url']#{&},
+		input[type='password']#{&},
+		input[type='email']#{&} {
+			text-align: left;
+			/*!rtl:ignore*/
+			direction: ltr;
+		}
+
+		input[type='url']#{&},
 		input[type='search']#{&} {
 			appearance: none;
 		}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -508,7 +508,6 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		.form-password-input .form-password-input__toggle-visibility {
-			/*!rtl:ignore*/
 			right: 17px;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The input boxes  in the signup and login in RTL locales are not aligned correctly. They need to directionally RTL but are LTR. 

This is also described in [Google's Material Design suggestions](https://material.io/design/usability/bidirectionality.html#mirroring-layout). In other places in Calypso, like in the Checkout page, or in the Gutenberg editor, we correctly align input areas RTL. 

The input box in domain step of signup also needs to be fixed for RTL, and I'll follow it up in a separate PR. 

**BEFORE**

![rtlinput](https://user-images.githubusercontent.com/1269602/130926896-29b7e046-8520-40d1-ba84-044dad74f4c1.gif)


**AFTER**

![rtlinput](https://user-images.githubusercontent.com/1269602/130926779-1c09b274-e6c1-4e6c-9936-da58c2589b7a.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Testing instructions
1. Visit /start/ar logged out and verify that the input boxes are RTL aligned.
2. In /start/ar, verify that toggling the password view/hide icon retains the RTL alignment for the password input.

![rtlinput](https://user-images.githubusercontent.com/1269602/130927615-351938d3-b937-4b21-8f1e-81adefe19628.gif)

3. Verify (1) and (2) steps above also work in the paid plan signup flows - e.g. `/start/premium/user/ar`
4. Verify username and password input boxes are RTL aligned in the login page at `/log-in/new/ar`. You can get to the login page by clicking on the link in the signup page `/start/ar` as shown in the image below:
<img width="1295" alt="Screenshot 2021-08-26 at 1 35 06 PM" src="https://user-images.githubusercontent.com/1269602/130939599-26a6158c-0aa6-4807-a0c1-1022013fbe96.png">
5. Verify the blue login page also has input boxes RTL aligned at `/log-in/ar`.

6. Visit an LTR locale like `en` and verify that all input boxes(username, email, and password) are unaffected, i.e LTR aligned in signup page and login page.