### PR TITLE
ETK: Restrict HEIC image uploads

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -1,16 +1,23 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { createElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 
 const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 	return ( props ) => {
 		props.onFilesPreUpload = ( files ) => {
 			if ( files ) {
-				return Object.values( files ).filter( ( file ) => {
-					if ( 'image/heic' !== file.type ) {
-						return file;
+				const error = __(
+					'HEIC images are not viewable in the editor. Please convert to a JPG, PNG, or GIF and try again.',
+					'full-site-editing'
+				);
+				Object.values( files ).filter( ( file ) => {
+					if ( 'image/heic' === file.type ) {
+						props.onError( error );
+						throw Error( error );
 					}
 				} );
+				return files;
 			}
 		};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -1,0 +1,21 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { createElement } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+
+const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
+	return ( props ) => {
+		props.onFilesPreUpload = ( files ) => {
+			if ( files ) {
+				return Object.values( files ).filter( ( file ) => {
+					if ( 'image/heic' !== file.type ) {
+						return file;
+					}
+				} );
+			}
+		};
+
+		return createElement( MediaPlaceholder, props );
+	};
+}, 'DisableHEICImages' );
+
+addFilter( 'editor.MediaPlaceholder', 'wpcom/DisableHEICImages', DisableHEICImages );

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -12,7 +12,7 @@ const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 					'full-site-editing'
 				);
 				Object.values( files ).filter( ( file ) => {
-					if ( 'image/heic' === file.type ) {
+					if ( 'image/heic' === file.type || 'image/heif' === file.type ) {
 						props.onError( error );
 						throw Error( error );
 					}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -7,22 +7,15 @@ const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 	return ( props ) => {
 		props.onFilesPreUpload = ( files ) => {
 			if ( files ) {
-				const error = __(
-					'HEIC images are not viewable in the editor. Please convert to a JPG, PNG, or GIF and try again.',
-					'full-site-editing'
-				);
-				Object.values( files ).filter( ( file ) => {
+				Object.values( files ).forEach( ( file ) => {
 					const filename = file.name;
-					const extension = filename
-						.split('.').pop();
-						.toLowerCase();
+					const extension = filename.split( '.' ).pop().toLowerCase();
 
-					if (
-						'image/heic' === file.type ||
-						'image/heif' === file.type ||
-						'heic' === extension ||
-						'heif' === extension
-					) {
+					if ( 'heic' === extension || 'heif' === extension ) {
+						const error = __(
+							'HEIC images are not viewable in the editor. Please convert to a JPG, PNG, or GIF and try again.',
+							'full-site-editing'
+						);
 						props.onError( error );
 						throw Error( error );
 					}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -14,7 +14,7 @@ const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 				Object.values( files ).filter( ( file ) => {
 					const filename = file.name;
 					const extension = filename
-						.substring( filename.lastIndexOf( '.' ) + 1, filename.length )
+						.split('.').pop();
 						.toLowerCase();
 
 					if (

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -12,7 +12,17 @@ const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 					'full-site-editing'
 				);
 				Object.values( files ).filter( ( file ) => {
-					if ( 'image/heic' === file.type || 'image/heif' === file.type ) {
+					const filename = file.name;
+					const extension = filename
+						.substring( filename.lastIndexOf( '.' ) + 1, filename.length )
+						.toLowerCase();
+
+					if (
+						'image/heic' === file.type ||
+						'image/heif' === file.type ||
+						'heic' === extension ||
+						'heif' === extension
+					) {
 						props.onError( error );
 						throw Error( error );
 					}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -9,7 +9,7 @@ const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 			if ( files ) {
 				Object.values( files ).forEach( ( file ) => {
 					const filename = file.name;
-					const extension = filename.split( '.' ).pop().toLowerCase();
+					const extension = filename.split( '.' ).pop()?.toLowerCase();
 
 					if ( 'heic' === extension || 'heif' === extension ) {
 						const error = __(

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -223,3 +223,22 @@ function enqueue_hide_plugin_buttons_mobile_style() {
 	}
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_hide_plugin_buttons_mobile_style' );
+
+/**
+ * Prevent HEIC images from being uploaded by drag and drop
+ * See: https://github.com/Automattic/wp-calypso/issues/55102
+ *
+ * Can be disabled with the `a8c_disable_heic_images` filter.
+ */
+function enqueue_disable_heic_images_script() {
+	if ( apply_filters( 'a8c_disable_heic_images', true ) ) {
+		wp_enqueue_script(
+			'a8c-disable-heic-images',
+			plugins_url( 'dist/disable-heic-images.js', __FILE__ ),
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/disable-heic-images.js' ),
+			true
+		);
+	}
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_disable_heic_images_script' );

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -22,7 +22,7 @@
 		"posts-list-block": "BROWSERSLIST_ENV=wpcom calypso-build --env source='posts-list-block'",
 		"dev:posts-list-block": "yarn run posts-list-block",
 		"build:posts-list-block": "NODE_ENV=production yarn run posts-list-block",
-		"common": "BROWSERSLIST_ENV=wpcom calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile'",
+		"common": "BROWSERSLIST_ENV=wpcom calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images'",
 		"dev:common": "yarn run common",
 		"build:common": "NODE_ENV=production yarn run common",
 		"editor-site-launch": "npm-run-all --parallel 'editor-site-launch-*'",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent users from uploading HEIC images via drag and drop to media areas, patching a bug in Gutenberg (see https://github.com/WordPress/gutenberg/issues/34181)
* Filters `MediaPlaceholder` to check the file type with `onFilesPreUpload`
* This is for Atomic sites, as HEIC uploads fail on drag-and-drop for Simple sites because we don't allow that file format.
* Throwing an error feels extreme 😬 but I'm not sure how to extend the editor to add a Notice component. 

**Before**

<img width="840" alt="Screen Shot 2021-08-20 at 3 38 01 PM" src="https://user-images.githubusercontent.com/2124984/130285247-8be2fe05-7519-4866-baa0-befef7cb732e.png">

**After**

<img width="800" alt="Screen Shot 2021-08-20 at 3 25 31 PM" src="https://user-images.githubusercontent.com/2124984/130285152-eb8257d8-9ebf-4d7b-95ae-f830fb5af106.png">

Fixes #55102

#### Testing instructions

* [Grab the artifact from this build](https://teamcity.a8c.com/buildConfiguration/calypso_WPComPlugins_EditorToolKit/6593369?) and upload it to your Atomic site as a plugin
* Go to Plugins and Activate this version of the ETK
* Go to the editor and add an Image block; try to drag and drop an HEIC image to the block
* It should return an error message like the above.
* Other types of images should upload without issue.