### PR TITLE
Domains: Show specific error messages for non-resolving connected domains

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -53,20 +53,38 @@ export function resolveDomainStatus(
 			}
 
 			if ( hasMappingError ) {
-				const status = translate(
-					"{{strong}}Connection error:{{/strong}} We couldn't verify your connection. Please {{a}}follow this setup again{{/a}}.",
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainMappingSetup( siteSlug, domain.domain, 'suggested_update' ) }
-									onClick={ ( e ) => e.stopPropagation() }
-								/>
-							),
-						},
-					}
-				);
+				let status;
+				if ( domain?.connectionMode === 'advanced' ) {
+					status = translate(
+						'{{strong}}Connection error:{{/strong}} The A records are incorrect. Please {{a}}try this step{{/a}} again.',
+						{
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ domainMappingSetup( siteSlug, domain.domain, 'advanced_update' ) }
+										onClick={ ( e ) => e.stopPropagation() }
+									/>
+								),
+							},
+						}
+					);
+				} else {
+					status = translate(
+						'{{strong}}Connection error:{{/strong}} The name servers are incorrect. Please {{a}}try this step{{/a}} again.',
+						{
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ domainMappingSetup( siteSlug, domain.domain, 'suggested_update' ) }
+										onClick={ ( e ) => e.stopPropagation() }
+									/>
+								),
+							},
+						}
+					);
+				}
 				return {
 					statusText: translate( 'Connection error' ),
 					statusClass: 'status-alert',

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -53,36 +53,30 @@ export function resolveDomainStatus(
 			}
 
 			if ( hasMappingError ) {
+				const setupStep =
+					domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
+				const options = {
+					components: {
+						strong: <strong />,
+						a: (
+							<a
+								href={ domainMappingSetup( siteSlug, domain.domain, setupStep ) }
+								onClick={ ( e ) => e.stopPropagation() }
+							/>
+						),
+					},
+				};
+
 				let status;
 				if ( domain?.connectionMode === 'advanced' ) {
 					status = translate(
 						'{{strong}}Connection error:{{/strong}} The A records are incorrect. Please {{a}}try this step{{/a}} again.',
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ domainMappingSetup( siteSlug, domain.domain, 'advanced_update' ) }
-										onClick={ ( e ) => e.stopPropagation() }
-									/>
-								),
-							},
-						}
+						options
 					);
 				} else {
 					status = translate(
 						'{{strong}}Connection error:{{/strong}} The name servers are incorrect. Please {{a}}try this step{{/a}} again.',
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ domainMappingSetup( siteSlug, domain.domain, 'suggested_update' ) }
-										onClick={ ( e ) => e.stopPropagation() }
-									/>
-								),
-							},
-						}
+						options
 					);
 				}
 				return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the connected domains error status messages, which are shown when a connected domain doesn't resolve to WPCOM in 72 hours. Now a specific message will be shown depending on whether the `suggested` or `advanced` setup was used to connect the domain. This is part of the domain pages redesign work detailed on pcYYhz-e4-p2.

#### Screenshots

Currently, when a connected domain doesn't resolve to WPCOM in 72 hours, this message is shown, regardless of the connection mode used to connect it:

<img width="1070" alt="Screen Shot 2021-08-20 at 14 55 10" src="https://user-images.githubusercontent.com/5324818/130274379-7c5b9f1e-310d-4c73-9417-7d6457b214f5.png">

With this PR, this message will be shown if the connection mode is `suggested` (which means name servers should be updated):

<img width="1063" alt="Screen Shot 2021-08-20 at 14 59 40" src="https://user-images.githubusercontent.com/5324818/130274814-c52c3266-e788-491c-98bd-70114bbb88bf.png">

And this one if the connection mode is `advanced` (which means A records should be updated):

<img width="1070" alt="Screen Shot 2021-08-20 at 14 57 04" src="https://user-images.githubusercontent.com/5324818/130274830-f58525d1-08b9-4ccd-98cd-136944a9883f.png">

#### Testing instructions

Open the live Calypso link and select a site where you have connected domains that don't resolve to WPCOM yet. Check if the error message was updated and shows the "update name servers" message, which is the default.

There's still no way to update the connection mode via Calypso, so to check the advanced "update A records" message you can run the following code in `wpsh` in your sandbox: `Domains_API::set_connection_mode_flag_setting( 'yourconnecteddomain.com', 'advanced' );` and then check the domains management page again.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
