### PR TITLE
Use A Domain I Own: Adding in transfer and connect actions

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
  */
 import FormattedHeader from 'calypso/components/formatted-header';
 import Gridicon from 'calypso/components/gridicon';
-import { checkDomainAvailability } from 'calypso/lib/domains';
+import wpcom from 'calypso/lib/wp';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import UseMyDomainInput from './domain-input';
 import DomainTransferOrConnect from './transfer-or-connect';
@@ -21,7 +21,15 @@ import { getAvailabilityErrorMessage, getDomainNameValidationErrorMessage } from
  */
 import './style.scss';
 
-function UseMyDomain( { goBack, initialQuery, selectedSite } ) {
+function UseMyDomain( {
+	goBack,
+	initialQuery,
+	isSignupStep,
+	onConnect,
+	onTransfer,
+	selectedSite,
+	transferDomainUrl,
+} ) {
 	const inputMode = {
 		domainInput: 'domain-input',
 		transferOrConnect: 'transfer-or-connect',
@@ -58,20 +66,10 @@ function UseMyDomain( { goBack, initialQuery, selectedSite } ) {
 		setIsFetchingAvailability( true );
 		setDomainAvailabilityData( {} );
 
-		checkDomainAvailability(
-			{
-				domainName,
-				blogId: selectedSite.ID,
-				isCartPreCheck: false,
-			},
-			( error, availabilityData ) => {
-				setIsFetchingAvailability( false );
-
-				if ( error ) {
-					setDomainNameValidationError( error );
-					return;
-				}
-
+		wpcom
+			.domain( domainName )
+			.isAvailable( { apiVersion: '1.3', blog_id: selectedSite.ID, is_cart_pre_check: false } )
+			.then( ( availabilityData ) => {
 				const availabilityErrorMessage = getAvailabilityErrorMessage( {
 					availabilityData,
 					domainName,
@@ -80,13 +78,13 @@ function UseMyDomain( { goBack, initialQuery, selectedSite } ) {
 
 				if ( availabilityErrorMessage ) {
 					setDomainNameValidationError( availabilityErrorMessage );
-					return;
+				} else {
+					setMode( inputMode.transferOrConnect );
+					setDomainAvailabilityData( availabilityData );
 				}
-
-				setMode( inputMode.transferOrConnect );
-				setDomainAvailabilityData( availabilityData );
-			}
-		);
+			} )
+			.catch( ( error ) => setDomainNameValidationError( error ) )
+			.finally( () => setIsFetchingAvailability( false ) );
 	}, [ domainName, inputMode.transferOrConnect, selectedSite, validateDomainName ] );
 
 	const onDomainNameChange = ( event ) => {
@@ -125,7 +123,14 @@ function UseMyDomain( { goBack, initialQuery, selectedSite } ) {
 
 	const renderTransferOrConnect = () => {
 		return (
-			<DomainTransferOrConnect domain={ domainName } availability={ domainAvailabilityData } />
+			<DomainTransferOrConnect
+				availability={ domainAvailabilityData }
+				domain={ domainName }
+				isSignupStep={ isSignupStep }
+				onConnect={ onConnect }
+				onTransfer={ onTransfer }
+				transferDomainUrl={ transferDomainUrl }
+			/>
 		);
 	};
 
@@ -156,7 +161,11 @@ function UseMyDomain( { goBack, initialQuery, selectedSite } ) {
 UseMyDomain.propTypes = {
 	goBack: PropTypes.func.isRequired,
 	initialQuery: PropTypes.string,
+	isSignupStep: PropTypes.bool,
+	onConnect: PropTypes.func,
+	onTransfer: PropTypes.func,
 	selectedSite: PropTypes.object,
+	transferDomainUrl: PropTypes.string,
 };
 
 export default connect( ( state ) => ( { selectedSite: getSelectedSite( state ) } ) )(

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -6,7 +6,7 @@ import { withShoppingCart } from '@automattic/shopping-cart';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 /**
  * Internal dependencies
@@ -49,18 +49,21 @@ function DomainTransferOrConnect( {
 	siteIsOnPaidPlan,
 	transferDomainUrl,
 } ) {
+	const [ actionClicked, setActionClicked ] = useState( false );
+
 	const handleConnect = () => {
 		recordMappingButtonClickInUseYourDomain( domain );
+		setActionClicked( true );
 
 		const connectHandler = onConnect ?? defaultConnectHandler;
-		connectHandler( { domain, selectedSite } );
+		connectHandler( { domain, selectedSite }, () => setActionClicked( false ) );
 	};
 
 	const handleTransfer = () => {
 		recordTransferButtonClickInUseYourDomain( domain );
 
 		const transferHandler = onTransfer ?? defaultTransferHandler;
-		transferHandler( { domain, selectedSite, transferDomainUrl } );
+		transferHandler( { domain, selectedSite, transferDomainUrl }, () => setActionClicked( false ) );
 	};
 
 	const content = getOptionInfo( {
@@ -85,7 +88,7 @@ function DomainTransferOrConnect( {
 			<QueryProductsList />
 			<Card className={ baseClassName + '__content' }>
 				{ content.map( ( optionProps, index ) => (
-					<OptionContent key={ 'option-' + index } { ...optionProps } />
+					<OptionContent key={ 'option-' + index } disabled={ actionClicked } { ...optionProps } />
 				) ) }
 				<div className={ baseClassName + '__support-link' }>
 					{ createInterpolateElement(

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -132,7 +132,6 @@ export default connect(
 	},
 	{
 		defaultConnectHandler: connectDomainAction,
-		// defaultTransferHandler: transferDomainAction,
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -20,7 +20,11 @@ import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getOptionInfo } from '../utilities/get-option-info';
+import {
+	getOptionInfo,
+	connectDomainAction,
+	transferDomainAction as defaultTransferHandler,
+} from '../utilities';
 import OptionContent from './option-content';
 
 /**
@@ -32,23 +36,31 @@ function DomainTransferOrConnect( {
 	availability,
 	cart,
 	currencyCode,
+	defaultConnectHandler,
 	domain,
 	isSignupStep,
+	onConnect,
+	onTransfer,
 	primaryWithPlansOnly,
 	productsList,
 	recordMappingButtonClickInUseYourDomain,
 	recordTransferButtonClickInUseYourDomain,
 	selectedSite,
 	siteIsOnPaidPlan,
+	transferDomainUrl,
 } ) {
 	const handleConnect = () => {
 		recordMappingButtonClickInUseYourDomain( domain );
-		// TODO: Go to the next step in mapping the domain
+
+		const connectHandler = onConnect ?? defaultConnectHandler;
+		connectHandler( { domain, selectedSite } );
 	};
 
 	const handleTransfer = () => {
 		recordTransferButtonClickInUseYourDomain( domain );
-		// TODO: Go to the next step in transferring the domain
+
+		const transferHandler = onTransfer ?? defaultTransferHandler;
+		transferHandler( { domain, selectedSite, transferDomainUrl } );
 	};
 
 	const content = getOptionInfo( {
@@ -63,6 +75,7 @@ function DomainTransferOrConnect( {
 		productsList,
 		selectedSite,
 		siteIsOnPaidPlan,
+		transferDomainUrl,
 	} );
 
 	const baseClassName = 'domain-transfer-or-connect';
@@ -87,8 +100,14 @@ function DomainTransferOrConnect( {
 
 DomainTransferOrConnect.propTypes = {
 	availability: PropTypes.object.isRequired,
+	defaultConnectHandler: PropTypes.func,
+	defaultTransferHandler: PropTypes.func,
 	domain: PropTypes.string.isRequired,
+	isSignupStep: PropTypes.bool,
+	onConnect: PropTypes.func,
+	onTransfer: PropTypes.func,
 	selectedSite: PropTypes.object.isRequired,
+	transferDomainUrl: PropTypes.string,
 };
 
 const recordTransferButtonClickInUseYourDomain = ( domain_name ) =>
@@ -108,5 +127,10 @@ export default connect(
 			siteIsOnPaidPlan: isSiteOnPaidPlan( state, selectedSite?.ID ),
 		};
 	},
-	{ recordTransferButtonClickInUseYourDomain, recordMappingButtonClickInUseYourDomain }
+	{
+		defaultConnectHandler: connectDomainAction,
+		// defaultTransferHandler: transferDomainAction,
+		recordTransferButtonClickInUseYourDomain,
+		recordMappingButtonClickInUseYourDomain,
+	}
 )( withShoppingCart( DomainTransferOrConnect ) );

--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -18,6 +18,7 @@ import '../style.scss';
 
 export default function OptionContent( {
 	benefits,
+	disabled,
 	illustration,
 	learnMoreLink,
 	onSelect,
@@ -81,7 +82,7 @@ export default function OptionContent( {
 			</div>
 			<div className="option-content__action">
 				{ onSelect && (
-					<Button primary={ primary } onClick={ onSelect }>
+					<Button primary={ primary } disabled={ disabled } onClick={ onSelect }>
 						{ __( 'Select' ) }
 					</Button>
 				) }
@@ -92,6 +93,7 @@ export default function OptionContent( {
 
 OptionContent.propTypes = {
 	benefits: PropTypes.array,
+	disabled: PropTypes.bool,
 	illustration: PropTypes.string.isRequired,
 	learnMoreLink: PropTypes.string.isRequired,
 	onSelect: PropTypes.func,

--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -11,7 +11,10 @@ import { domainManagementList, domainMappingSetup } from 'calypso/my-sites/domai
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 
-export const connectDomainAction = ( { domain, selectedSite } ) => ( dispatch, getState ) => {
+export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {} ) => (
+	dispatch,
+	getState
+) => {
 	const siteHasPaidPlan = isSiteOnPaidPlan( getState(), selectedSite.ID );
 
 	if ( selectedSite.is_vip ) {
@@ -19,7 +22,10 @@ export const connectDomainAction = ( { domain, selectedSite } ) => ( dispatch, g
 			.site( selectedSite.ID )
 			.addVipDomainMapping( domain )
 			.then( () => page( domainManagementList( selectedSite.slug ) ) )
-			.catch( ( error ) => dispatch( errorNotice( error.message ) ) );
+			.catch( ( error ) => {
+				dispatch( errorNotice( error.message ) );
+				onDone();
+			} );
 	} else if ( siteHasPaidPlan ) {
 		wpcom
 			.site( selectedSite.ID )
@@ -36,7 +42,10 @@ export const connectDomainAction = ( { domain, selectedSite } ) => ( dispatch, g
 				);
 				page( domainMappingSetup( selectedSite.slug, domain ) );
 			} )
-			.catch( ( error ) => dispatch( errorNotice( error.message ) ) );
+			.catch( ( error ) => {
+				dispatch( errorNotice( error.message ) );
+				onDone();
+			} );
 	} else {
 		page( '/checkout/' + selectedSite.slug + '/domain-mapping:' + domain );
 	}

--- a/client/components/domains/use-my-domain/utilities/index.js
+++ b/client/components/domains/use-my-domain/utilities/index.js
@@ -1,3 +1,4 @@
+export { connectDomainAction } from './connect-domain-action';
 export { getAvailabilityErrorMessage } from './get-availability-error-message';
 export { getDomainNameValidationErrorMessage } from './get-domain-name-validation-error-message';
 export { getMappingFreeText } from './get-mapping-free-text';
@@ -8,3 +9,4 @@ export { getTransferPriceText } from './get-transfer-price-text';
 export { getTransferSalePriceText } from './get-transfer-sale-price-text';
 export { isFreeTransfer } from './is-free-transfer';
 export { optionInfo } from './option-info';
+export { transferDomainAction } from './transfer-domain-action';

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.js
@@ -1,0 +1,10 @@
+import page from 'page';
+import { domainManagementTransferInPrecheck } from 'calypso/my-sites/domains/paths';
+
+export const transferDomainAction = ( { domain, selectedSite, transferDomainUrl } ) => {
+	const defaultTransferUrl =
+		domainManagementTransferInPrecheck( selectedSite.slug, domain ) + '?goBack=use-my-domain';
+	const transferUrl = transferDomainUrl ?? defaultTransferUrl;
+
+	page( transferUrl );
+};

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.js
@@ -1,10 +1,9 @@
 import page from 'page';
-import { domainManagementTransferInPrecheck } from 'calypso/my-sites/domains/paths';
+import { domainTransferIn } from 'calypso/my-sites/domains/paths';
 
 export const transferDomainAction = ( { domain, selectedSite, transferDomainUrl } ) => {
-	const defaultTransferUrl =
-		domainManagementTransferInPrecheck( selectedSite.slug, domain ) + '?goBack=use-my-domain';
+	// TODO: This will be replaced with a new transfer in flow in a near-term future update.
+	const defaultTransferUrl = domainTransferIn( selectedSite.slug, domain, true );
 	const transferUrl = transferDomainUrl ?? defaultTransferUrl;
-
 	page( transferUrl );
 };

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -215,6 +215,10 @@ const transferDomainPrecheck = ( context, next ) => {
 	const domain = get( context, 'params.domain', '' );
 
 	const handleGoBack = () => {
+		if ( context.query.goBack === 'use-my-domain' ) {
+			page( domainUseMyDomain( siteSlug, domain ) );
+			return;
+		}
 		page( domainManagementTransferIn( siteSlug, domain ) );
 	};
 	context.primary = (

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -30,7 +30,7 @@ class Site {
 	 * Create a Site instance
 	 *
 	 * @param {string} id - site id
-	 * @param {WPCOM} wpcom - wpcom instance
+	 * @param wpcom - wpcom instance
 	 * @returns {null} null
 	 */
 	constructor( id, wpcom ) {
@@ -248,7 +248,7 @@ class Site {
 	/**
 	 * Get number of posts in the post type groups by post status
 	 *
-	 * *Example:*
+	 * Example:*
 	 *   // Get number post of pages
 	 *    wpcom
 	 *    .site( 'my-blog.wordpress.com' )
@@ -387,7 +387,7 @@ class Site {
 	/**
 	 * Return a `SiteWordAds` instance.
 	 *
-	 * *Example:*
+	 * Example:*
 	 *    // Create a SiteWordAds instance
 	 *
 	 *    const wordAds = wpcom
@@ -398,6 +398,30 @@ class Site {
 	 */
 	wordAds() {
 		return new SiteWordAds( this._id, this.wpcom );
+	}
+
+	/**
+	 * Add a domain mapping to a site.
+	 *
+	 * @param {string} domain - donain to map
+	 * @param {object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @returns {Function} request handler
+	 */
+	addDomainMapping( domain, query, fn ) {
+		return this.wpcom.req.post( `${ this.path }/add-domain-mapping`, query, { domain }, fn );
+	}
+
+	/**
+	 * Add a VIP domain mapping
+	 *
+	 * @param {string} domain - donain to map
+	 * @param {object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @returns {Function} request handler
+	 */
+	addVipDomainMapping( domain, query, fn ) {
+		return this.wpcom.req.post( `${ this.path }/vip-domain-mapping`, query, { domain }, fn );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the next step in the new "Use a domain I own" flow.

Once the "Transfer or Connect" pages are complete, we will need to allow the user to purchase the transfer or mapping or to add the mapping without a purchase in cases where the site is already on a paid plan.

#### Testing instructions

Load the page at `/domains/add/use-my-domain/[blog slug]` with an optional query string to specify the domain that will be mapped or transferred: `?initialQuery=[domain name]`

When you get to the page that shows the options to transfer or connect, try both options on sites both with and without a paid plan.

When connecting a site with a paid plan, make sure that the domain is connected without going through the purchase step.
When connecting a site without a paid plan, make sure that the mapping is added to the cart and you are redirected to the purchase page.
When selecting transfers, you should be redirected to the transfer pre check page. Make sure you can properly start a transfer.

Screen capture of connecting a domain without going through the purchase flow:

https://user-images.githubusercontent.com/1379730/130503501-a30d31aa-e5f3-472b-9d5e-41da88637d61.mov

Screen capture of connecting a domain by purchasing a mapping:

https://user-images.githubusercontent.com/1379730/130503596-ce7f58c0-e5bf-4fda-8fec-b8b49ffef544.mov


Screen capture of transferring a domain (Yes, domain has been locked and auth code has been changed after recording):

https://user-images.githubusercontent.com/1379730/130497235-98a5298a-378e-4898-bb35-fdd6935f2ae5.mov

For translators.
This is a screenshot including the notice in the top right of the screen with the new translation that is shown once the domain is successfully mapped:

<img width="1690" alt="Screen Shot 2021-08-25 at 3 15 05 PM" src="https://user-images.githubusercontent.com/1379730/130851396-77d41314-9c3a-48da-9ed3-999794de108b.png">
