### PR TITLE
Write button: tweak Write button font style

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -99,6 +99,7 @@
 
 		.masterbar__item-content {
 			color: $nav-unification-primary;
+			font-weight: 500;
 		}
 	}
 
@@ -113,10 +114,12 @@
 		margin-left: -8px;
 		color: $nav-unification-primary;
 		background: #fafafa;
+		font-size: $nav-unification-masterbar-font-size;
 
 		.gridicon {
 			width: 14px;
 			color: var( --studio-gray-20 );
+			transform: translateY( -1px );
 		}
 
 		&:hover,

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -548,7 +548,7 @@ $autobar-height: 20px;
 	border-radius: 0 2px 2px 0;
 	position: relative;
 	transition: all 0.2s ease-out;
-	font-weight: 600;
+	font-weight: 500;
 	color: var( --color-text );
 	border-left: 1px solid var( --studio-gray-5 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A couple font tweaks to the Write button from @ollierozdarz 

* Bump button label weight from 400 to 500
* Increase draft number font size to 13px (now matches the "Write" label text)
* Decrease draft number font weight from 600 to 500 (the larger font made 600 feel very heavy)
* Tweak the chevron position to re-centre it since bumping the font size moved it

Before:
<img width="229" alt="Screenshot 2021-08-23 at 2 29 13 PM" src="https://user-images.githubusercontent.com/1500769/130381798-86489c3c-2a52-40f7-9273-c8dff7bc7f08.png">

After:
<img width="229" alt="Screenshot 2021-08-23 at 2 28 51 PM" src="https://user-images.githubusercontent.com/1500769/130381819-474ee5c6-26b3-4dcf-be22-4d39d8a84cd6.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Can be tested in calypso.live

- Test in Calypso (these changes don't appear in wp-admin)
- With and without drafts
- Various browser sizes

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55525
