### PR TITLE
Remove usages of _.partialRight

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -14,7 +14,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import debugFactory from 'debug';
 import $ from 'jquery';
-import { filter, find, forEach, get, map, partialRight } from 'lodash';
+import { filter, find, forEach, get, map } from 'lodash';
 import { Component, useEffect, useState } from 'react';
 import tinymce from 'tinymce/tinymce';
 import { STORE_KEY as NAV_SIDEBAR_STORE_KEY } from '../../../../editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants';
@@ -308,14 +308,12 @@ function handleUpdateImageBlocks( calypsoPort ) {
 	calypsoPort.start();
 
 	const imageBlocks = {
-		'core/cover': updateSingeImageBlock,
-		'core/image': updateSingeImageBlock,
-		'core/file': partialRight( updateSingeImageBlock, { url: 'href' } ),
+		'core/cover': updateSingleImageBlock,
+		'core/image': updateSingleImageBlock,
+		'core/file': ( block, image ) => updateSingleImageBlock( block, image, { url: 'href' } ),
 		'core/gallery': updateMultipleImagesBlock,
-		'core/media-text': partialRight( updateSingeImageBlock, {
-			id: 'mediaId',
-			url: 'mediaUrl',
-		} ),
+		'core/media-text': ( block, image ) =>
+			updateSingleImageBlock( block, image, { id: 'mediaId', url: 'mediaUrl' } ),
 		'jetpack/tiled-gallery': updateMultipleImagesBlock,
 	};
 
@@ -349,7 +347,7 @@ function handleUpdateImageBlocks( calypsoPort ) {
 		} );
 	}
 
-	function updateSingeImageBlock( block, image, attrNames ) {
+	function updateSingleImageBlock( block, image, attrNames ) {
 		const blockImageId = get( block, 'attributes.id' );
 		if ( blockImageId !== image.id && blockImageId !== image.transientId ) {
 			return;

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { partialRight } from 'lodash';
 import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 import ActionPanelCta from 'calypso/components/action-panel/cta';
@@ -81,7 +80,7 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 	isPrimary,
 	hasPlanFeature,
 } ) => {
-	const ctaBtnProps = partialRight( buttonProps, true === isPrimary );
+	const ctaBtnProps = ( button: CtaButton ) => buttonProps( button, true === isPrimary );
 	let ctaBtn;
 	const translate = useTranslate();
 	let learnMore = null;

--- a/client/components/text-diff/index.jsx
+++ b/client/components/text-diff/index.jsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { isEmpty, map, partialRight } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -29,10 +29,10 @@ const renderOperation = ( operation, operationIndex, splitLines ) => {
 	);
 };
 
-const renderSplitLineOperations = partialRight( renderOperation, true );
-
 const TextDiff = ( { operations, splitLines } ) =>
-	map( operations, splitLines ? renderSplitLineOperations : renderOperation );
+	map( operations, ( operation, operationIndex ) =>
+		renderOperation( operation, operationIndex, splitLines )
+	);
 
 TextDiff.propTypes = {
 	operations: PropTypes.arrayOf(

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { flatten, partialRight } from 'lodash';
+import { flatten } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -26,7 +26,7 @@ import { withEnhancers } from 'calypso/state/utils';
 const withToolTip = ( WrappedComponent ) => ( props ) => {
 	// inject interval props to renderTooltipForDatanum
 	const renderTooltipForDatanum = props.renderTooltipForDatanum
-		? partialRight( props.renderTooltipForDatanum, props.tooltipInterval )
+		? ( datanum ) => props.renderTooltipForDatanum( datanum, props.tooltipInterval )
 		: null;
 
 	const newProps = {

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { flowRight, partialRight, pick } from 'lodash';
+import { pick } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
@@ -106,21 +106,20 @@ const connectComponent = connect( ( state ) => {
 	};
 } );
 
-const getFormSettings = partialRight( pick, [
-	'stats',
-	'admin_bar',
-	'hide_smile',
-	'count_roles',
-	'roles',
-	'jetpack_relatedposts_allowed',
-	'jetpack_relatedposts_enabled',
-	'jetpack_relatedposts_show_headline',
-	'jetpack_relatedposts_show_thumbnails',
-	'blog_public',
-] );
+const getFormSettings = ( settings ) =>
+	pick( settings, [
+		'stats',
+		'admin_bar',
+		'hide_smile',
+		'count_roles',
+		'roles',
+		'jetpack_relatedposts_allowed',
+		'jetpack_relatedposts_enabled',
+		'jetpack_relatedposts_show_headline',
+		'jetpack_relatedposts_show_thumbnails',
+		'blog_public',
+	] );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	wrapSettingsForm( getFormSettings )
-)( SiteSettingsTraffic );
+export default connectComponent(
+	localize( wrapSettingsForm( getFormSettings )( SiteSettingsTraffic ) )
+);

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
-import { flowRight, partialRight, pick } from 'lodash';
+import { pick } from 'lodash';
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudflare-logo-small.svg';
@@ -257,9 +257,8 @@ const mapDispatchToProps = {
 
 const connectComponent = connect( mapStateToProps, mapDispatchToProps );
 
-const getFormSettings = partialRight( pick, [ 'jetpack_cloudflare_analytics' ] );
+const getFormSettings = ( settings ) => pick( settings, [ 'jetpack_cloudflare_analytics' ] );
 
-export default flowRight(
-	connectComponent,
-	wrapSettingsForm( getFormSettings )
-)( CloudflareAnalyticsSettings );
+export default connectComponent(
+	wrapSettingsForm( getFormSettings )( CloudflareAnalyticsSettings )
+);

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -1,5 +1,5 @@
 import { FEATURE_GOOGLE_ANALYTICS } from '@automattic/calypso-products';
-import { flowRight, partialRight, pick } from 'lodash';
+import { pick } from 'lodash';
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -120,9 +120,6 @@ const mapDispatchToProps = {
 
 const connectComponent = connect( mapStateToProps, mapDispatchToProps );
 
-const getFormSettings = partialRight( pick, [ 'wga' ] );
+const getFormSettings = ( settings ) => pick( settings, [ 'wga' ] );
 
-export default flowRight(
-	connectComponent,
-	wrapSettingsForm( getFormSettings )
-)( GoogleAnalyticsForm );
+export default connectComponent( wrapSettingsForm( getFormSettings )( GoogleAnalyticsForm ) );

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { flowRight, partialRight, pick } from 'lodash';
+import { pick } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -118,18 +118,17 @@ const connectComponent = connect( ( state ) => {
 	};
 } );
 
-const getFormSettings = partialRight( pick, [
-	'akismet',
-	'protect',
-	'jetpack_protect_global_whitelist',
-	'sso',
-	'jetpack_sso_match_by_email',
-	'jetpack_sso_require_two_step',
-	'wordpress_api_key',
-] );
+const getFormSettings = ( settings ) =>
+	pick( settings, [
+		'akismet',
+		'protect',
+		'jetpack_protect_global_whitelist',
+		'sso',
+		'jetpack_sso_match_by_email',
+		'jetpack_sso_require_two_step',
+		'wordpress_api_key',
+	] );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	wrapSettingsForm( getFormSettings )
-)( SiteSettingsFormSecurity );
+export default connectComponent(
+	localize( wrapSettingsForm( getFormSettings )( SiteSettingsFormSecurity ) )
+);

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { flowRight, partialRight, pick } from 'lodash';
+import { pick } from 'lodash';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
@@ -152,19 +152,18 @@ const connectComponent = connect( ( state ) => {
 	};
 } );
 
-const getFormSettings = partialRight( pick, [
-	'amp_is_enabled',
-	'amp_is_supported',
-	'instant_search_enabled',
-	'jetpack_search_enabled',
-	'jetpack_search_supported',
-	'lazy-images',
-	'photon',
-	'photon-cdn',
-] );
+const getFormSettings = ( settings ) =>
+	pick( settings, [
+		'amp_is_enabled',
+		'amp_is_supported',
+		'instant_search_enabled',
+		'jetpack_search_enabled',
+		'jetpack_search_supported',
+		'lazy-images',
+		'photon',
+		'photon-cdn',
+	] );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	wrapSettingsForm( getFormSettings )
-)( SiteSettingsPerformance );
+export default connectComponent(
+	localize( wrapSettingsForm( getFormSettings )( SiteSettingsPerformance ) )
+);


### PR DESCRIPTION
Removes usages of `_.partialRight` from the codebase.

**How to test:**
Verify that all the replacements are OK and that unit tests pass.