### PR TITLE
Theme Showcase: Update wording and add InlineSupportLink for third-party themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -25,6 +25,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import Gridicon from 'calypso/components/gridicon';
 import HeaderCake from 'calypso/components/header-cake';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import SectionNav from 'calypso/components/section-nav';
@@ -501,11 +502,24 @@ class ThemeSheet extends React.Component {
 					<Card className="theme__sheet-card-support">
 						<Gridicon icon="notice-outline" size={ 48 } />
 						<div className="theme__sheet-card-support-details">
-							{ translate( 'This theme is unsupported' ) }
+							{ translate(
+								'Help and support for this theme is not offered by WordPress.com. {{InlineSupportLink/}}',
+								{
+									components: {
+										InlineSupportLink: (
+											<InlineSupportLink
+												showIcon={ false }
+												supportPostId={ 174865 }
+												supportLink={ localizeUrl(
+													'https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/'
+												) }
+											/>
+										),
+									},
+								}
+							) }
 							<small>
-								{ translate( "Maybe it's a custom theme? Sorry about that.", {
-									context: 'Support message when we no support links are available',
-								} ) }
+								{ translate( 'Contact the theme developer directly for help with this theme.' ) }
 							</small>
 						</div>
 					</Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy and add a support link to the individual theme support page when viewing a third-party theme.
* Fixes #51260

**Before**

<img width="968" alt="Screen Shot 2021-08-23 at 3 59 14 PM" src="https://user-images.githubusercontent.com/2124984/130511541-1f64666c-a1a0-4861-9b39-8dbe78de433f.png">

**After**

<img width="959" alt="Screen Shot 2021-08-23 at 3 58 52 PM" src="https://user-images.githubusercontent.com/2124984/130511553-2798f774-129b-45fe-a1f9-8ba31ebdd2c7.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]` on an Atomic site
* Install a third-party theme on your site, pick anything that isn't by Automattic from `wordpress.org/themes`
* Activate the theme or go to its information page at `/theme/[theme-slug]/[site]`
* Click the Support tab
* Note the copy change
* "Learn more" should link to this support doc: https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/