### PR TITLE
Add isValueTruthy to wpcom-checkout package and use it in calypso

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -1,4 +1,5 @@
 import { useStripe } from '@automattic/calypso-stripe';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -7,7 +8,6 @@ import {
 	useCreateExistingCards,
 	useCreatePayPal,
 } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods';
-import doesValueExist from 'calypso/my-sites/checkout/composite-checkout/lib/does-value-exist';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import { getStoredCards } from 'calypso/state/stored-cards/selectors';
 import useFetchAvailablePaymentMethods from './use-fetch-available-payment-methods';
@@ -53,7 +53,7 @@ export default function useCreateAssignablePaymentMethods(
 	const paymentMethods = useMemo(
 		() =>
 			[ ...existingCardMethods, stripeMethod, payPalMethod ]
-				.filter( doesValueExist )
+				.filter( isValueTruthy )
 				.filter( ( method ) => {
 					// If there's an error fetching allowed payment methods, just allow all of them.
 					if ( allowedPaymentMethodsError ) {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -10,7 +10,7 @@ import {
 	Button,
 } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { useIsWebPayAvailable } from '@automattic/wpcom-checkout';
+import { useIsWebPayAvailable, isValueTruthy } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { ThemeProvider } from 'emotion-theming';
 import { useTranslate } from 'i18n-calypso';
@@ -49,7 +49,6 @@ import useRecordCheckoutLoaded from './hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from './hooks/use-remove-from-cart-and-redirect';
 import useStoredCards from './hooks/use-stored-cards';
 import { useWpcomStore } from './hooks/wpcom-store';
-import doesValueExist from './lib/does-value-exist';
 import existingCardProcessor from './lib/existing-card-processor';
 import filterAppropriatePaymentMethods from './lib/filter-appropriate-payment-methods';
 import freePurchaseProcessor from './lib/free-purchase-processor';
@@ -299,13 +298,13 @@ export default function CompositeCheckout( {
 	useCachedDomainContactDetails( updateLocation );
 
 	// Record errors adding products to the cart
-	useActOnceOnStrings( [ cartProductPrepError ].filter( doesValueExist ), ( messages ) => {
+	useActOnceOnStrings( [ cartProductPrepError ].filter( isValueTruthy ), ( messages ) => {
 		messages.forEach( ( message ) =>
 			recordEvent( { type: 'PRODUCTS_ADD_ERROR', payload: message } )
 		);
 	} );
 
-	useActOnceOnStrings( [ cartLoadingError ].filter( doesValueExist ), ( messages ) => {
+	useActOnceOnStrings( [ cartLoadingError ].filter( isValueTruthy ), ( messages ) => {
 		messages.forEach( ( message ) =>
 			recordEvent( { type: 'CART_ERROR', payload: { type: cartLoadingErrorType, message } } )
 		);
@@ -318,7 +317,7 @@ export default function CompositeCheckout( {
 		cartLoadingError,
 		stripeLoadingError?.message,
 		cartProductPrepError,
-	].filter( doesValueExist );
+	].filter( isValueTruthy );
 	useActOnceOnStrings( errorsToDisplay, () => {
 		reduxDispatch(
 			errorNotice( errorsToDisplay.map( ( message ) => <p key={ message }>{ message }</p> ) )
@@ -327,7 +326,7 @@ export default function CompositeCheckout( {
 
 	const errors = responseCart.messages?.errors ?? [];
 	const areThereErrors =
-		[ ...errors, cartLoadingError, cartProductPrepError ].filter( doesValueExist ).length > 0;
+		[ ...errors, cartLoadingError, cartProductPrepError ].filter( isValueTruthy ).length > 0;
 
 	const siteSlugLoggedOutCart: string | undefined = select( 'wpcom' )?.getSiteSlug();
 	const {
@@ -344,7 +343,7 @@ export default function CompositeCheckout( {
 		Boolean( isLoggedOutCart )
 	);
 
-	useActOnceOnStrings( [ storedCardsError ].filter( doesValueExist ), ( messages ) => {
+	useActOnceOnStrings( [ storedCardsError ].filter( isValueTruthy ), ( messages ) => {
 		messages.forEach( ( message ) =>
 			recordEvent( { type: 'STORED_CARD_ERROR', payload: message } )
 		);

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -17,10 +17,10 @@ import {
 	createIdealPaymentMethodStore,
 	createSofortMethod,
 	createSofortPaymentMethodStore,
+	isValueTruthy,
 } from '@automattic/wpcom-checkout';
 import { useMemo } from 'react';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
-import doesValueExist from '../../lib/does-value-exist';
 import {
 	createCreditCardPaymentMethodStore,
 	createCreditCardMethod,
@@ -489,5 +489,5 @@ export default function useCreatePaymentMethods( {
 		epsMethod,
 		wechatMethod,
 		bancontactMethod,
-	].filter( doesValueExist );
+	].filter( isValueTruthy );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -502,7 +502,10 @@ function createRenewalItemToAddToCart(
  * about which type of site the user has.
  */
 function getJetpackSearchForSite( productAlias: string, isJetpackNotAtomic: boolean ): string {
-	if ( productAlias && JETPACK_SEARCH_PRODUCTS.includes( productAlias ) ) {
+	if (
+		productAlias &&
+		JETPACK_SEARCH_PRODUCTS.includes( productAlias as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
+	) {
 		if ( isJetpackNotAtomic ) {
 			productAlias = productAlias.includes( 'monthly' )
 				? PRODUCT_JETPACK_SEARCH_MONTHLY

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -7,7 +7,7 @@ import {
 	getPlanByPathSlug,
 } from '@automattic/calypso-products';
 import { createRequestCartProduct } from '@automattic/shopping-cart';
-import { decodeProductFromUrl } from '@automattic/wpcom-checkout';
+import { decodeProductFromUrl, isValueTruthy } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useReducer } from 'react';
@@ -15,7 +15,6 @@ import { useSelector } from 'react-redux';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import doesValueExist from '../lib/does-value-exist';
 import getCartFromLocalStorage from '../lib/get-cart-from-local-storage';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
 import useStripProductsFromUrl from './use-strip-products-from-url';
@@ -303,7 +302,7 @@ function useAddRenewalItems( {
 				}
 				return createRenewalItemToAddToCart( productSlug, product.product_id, subscriptionId );
 			} )
-			.filter( doesValueExist );
+			.filter( isValueTruthy );
 
 		if ( productsForCart.length < 1 ) {
 			debug( 'creating renewal products failed', productAlias );
@@ -380,7 +379,7 @@ function useAddProductFromSlug( {
 						? { ...validProduct, internal_product_alias: productAlias }
 						: undefined;
 				} )
-				.filter( doesValueExist ) ?? [],
+				.filter( isValueTruthy ) ?? [],
 		[ isJetpackNotAtomic, productAliasFromUrl, products ]
 	);
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -117,7 +117,8 @@ export default function usePrepareProductsForCart( {
 
 	// Do not strip products from url until the URL has been parsed
 	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInEditor;
-	useStripProductsFromUrl( siteSlug, ! areProductsRetrievedFromUrl || isJetpackCheckout );
+	const doNotStripProducts = Boolean( ! areProductsRetrievedFromUrl || isJetpackCheckout );
+	useStripProductsFromUrl( siteSlug, doNotStripProducts );
 
 	return state;
 }
@@ -441,6 +442,8 @@ function useAddProductFromSlug( {
 		validProducts,
 		isJetpackCheckout,
 		dispatch,
+		jetpackSiteSlug,
+		jetpackPurchaseToken,
 	] );
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/does-value-exist.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/does-value-exist.ts
@@ -1,3 +1,0 @@
-export default function doesValueExist< T >( value: T ): value is Exclude< T, null | undefined > {
-	return !! value;
-}

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -6,8 +6,8 @@ import {
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
 } from '@automattic/calypso-products';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import doesValueExist from './does-value-exist';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export default function getPlanFeatures(
@@ -47,7 +47,7 @@ export default function getPlanFeatures(
 			isMonthlyPlan ? annualPlanOnly( freeOneYearDomain ) : freeOneYearDomain,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
-		].filter( doesValueExist );
+		].filter( isValueTruthy );
 	}
 
 	if ( isWpComPremiumPlan( productSlug ) ) {
@@ -59,7 +59,7 @@ export default function getPlanFeatures(
 				? String( translate( 'Subscriber-only content and Pay with PayPal buttons' ) )
 				: String( translate( 'Subscriber-only content and payment buttons' ) ),
 			googleAnalytics,
-		].filter( doesValueExist );
+		].filter( isValueTruthy );
 	}
 
 	if ( isWpComBusinessPlan( productSlug ) ) {
@@ -70,7 +70,7 @@ export default function getPlanFeatures(
 			String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
 			String( translate( 'Track your stats with Google Analytics' ) ),
 			String( translate( 'Real-time backups and activity logs' ) ),
-		].filter( doesValueExist );
+		].filter( isValueTruthy );
 	}
 
 	if ( isWpComEcommercePlan( productSlug ) ) {
@@ -82,7 +82,7 @@ export default function getPlanFeatures(
 			String( translate( 'Integrations with top shipping carriers' ) ),
 			String( translate( 'Unlimited products or services for your online store' ) ),
 			String( translate( 'eCommerce marketing tools for emails and social networks' ) ),
-		].filter( doesValueExist );
+		].filter( isValueTruthy );
 	}
 
 	return [];

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -10,11 +10,14 @@ import {
 	isP2Plus,
 	isJetpackSearch,
 } from '@automattic/calypso-products';
-import { getTotalLineItemFromCart, tryToGuessPostalCodeFormat } from '@automattic/wpcom-checkout';
+import {
+	getTotalLineItemFromCart,
+	tryToGuessPostalCodeFormat,
+	isValueTruthy,
+} from '@automattic/wpcom-checkout';
 import { translate } from 'i18n-calypso';
 import { isRenewal } from 'calypso/lib/cart-values/cart-items';
 import { isGSuiteOrGoogleWorkspaceProductSlug } from 'calypso/lib/gsuite';
-import doesValueExist from './does-value-exist';
 import {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
@@ -49,7 +52,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 
 	const allowedPaymentMethods = [ ...allowed_payment_methods, ...alwaysEnabledPaymentMethods ]
 		.map( readWPCOMPaymentMethodClass )
-		.filter( doesValueExist )
+		.filter( isValueTruthy )
 		.map( translateWpcomPaymentMethodToCheckoutPaymentMethod );
 
 	return {

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React, { useCallback, useMemo, useEffect } from 'react';
@@ -18,7 +19,6 @@ import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import titles from 'calypso/me/purchases/titles';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods';
-import doesValueExist from 'calypso/my-sites/checkout/composite-checkout/lib/does-value-exist';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import SiteLevelPurchasesErrorBoundary from 'calypso/my-sites/purchases/site-level-purchases-error-boundary';
 import MySitesSidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -97,7 +97,7 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ):
 		shouldShowTaxFields: true,
 		activePayButtonText: translate( 'Save card' ),
 	} );
-	const paymentMethodList = useMemo( () => [ stripeMethod ].filter( doesValueExist ), [
+	const paymentMethodList = useMemo( () => [ stripeMethod ].filter( isValueTruthy ), [
 		stripeMethod,
 	] );
 	const reduxDispatch = useDispatch();

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -19,3 +19,4 @@ export * from './use-is-web-payment-available';
 export * from './payment-methods/google-pay';
 export * from './payment-methods/existing-credit-card';
 export { isWpComProductRenewal } from './is-wpcom-product-renewal';
+export { isValueTruthy } from './is-value-truthy';

--- a/packages/wpcom-checkout/src/is-value-truthy.ts
+++ b/packages/wpcom-checkout/src/is-value-truthy.ts
@@ -1,3 +1,5 @@
-export function isValueTruthy< T >( value: T ): value is Exclude< T, null | undefined | false > {
+export function isValueTruthy< T >(
+	value: T
+): value is Exclude< T, null | undefined | false | 0 | '' > {
 	return !! value;
 }

--- a/packages/wpcom-checkout/src/is-value-truthy.ts
+++ b/packages/wpcom-checkout/src/is-value-truthy.ts
@@ -1,0 +1,3 @@
+export function isValueTruthy< T >( value: T ): value is Exclude< T, null | undefined | false > {
+	return !! value;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Many parts of calypso (particularly checkout and payment management) use a helper called `doesValueExist` which is a TypeScript guard that is equivalent to using `Boolean` or an identity function to filter out falsy values from an array. For example:

```ts
const filtered = [ x, y, false ].filter( doesValueExist ); // Works in TypeScript
```

is the same as:

```js
const filtered = [ x, y, false ].filter( Boolean ); // Does not work in TypeScript
```

To make that helper more widely available, this PR moves it to the `@automattic/wpcom-checkout` package and renames it to `isValueTruthy` to be more accurate.

This will also be helpful for https://github.com/Automattic/wp-calypso/pull/52890

#### Testing instructions

First, verify that `doesValueExist` is not used anywhere.

Since this is all TypeScript, a type check on each of the changed files should be sufficient. Because we don't type check calypso (😭), you'll have to do this manually by opening each of the changed files in a TypeScript-capable editor.