### PR TITLE
Playwright: refactor helper classes.

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -25,8 +25,7 @@
 		"@types/jest": "^25.2.3",
 		"@types/node": "^15.0.2",
 		"asana-phrase": "^0.0.8",
-		"fs-extra": "3.0.1",
-		"mockdate": "^3.0.5"
+		"fs-extra": "3.0.1"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -2,6 +2,7 @@ import phrase from 'asana-phrase';
 import config from 'config';
 import { getViewportName } from './browser-helper';
 
+export type DateFormat = 'ISO';
 export { config };
 
 /**
@@ -15,6 +16,28 @@ export function getRandomInteger( min: number, max: number ): number {
 	min = Math.ceil( min );
 	max = Math.floor( max );
 	return Math.floor( Math.random() * ( max - min ) + min );
+}
+
+/**
+ * Returns the current date as a time stamp.
+ *
+ * @returns {string} Date represented as a timestamp.
+ */
+export function getTimestamp(): string {
+	return new Date().getTime().toString();
+}
+
+/**
+ * Returns the date string in the requested format.
+ *
+ * @param {DateFormat} format Date format supported by NodeJS.
+ * @returns {string|null} If valid date format string is supplied, string is returned. Otherwise, null.
+ */
+export function getDateString( format: DateFormat ): string | null {
+	if ( format === 'ISO' ) {
+		return new Date().toISOString();
+	}
+	return null;
 }
 
 /**
@@ -121,7 +144,7 @@ export function toTitleCase( words: string[] | string ): string {
  *
  * @returns {string} Generated text.
  */
-export function randomPhrase(): string {
+export function getRandomPhrase(): string {
 	const generated: Array< string > = phrase.default32BitFactory().randomPhrase();
 	return toTitleCase( generated );
 }

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -1,22 +1,28 @@
-/**
- * External dependencies
- */
-import { beforeAll, afterAll } from '@jest/globals';
-import type { Page, Video } from 'playwright';
-import path from 'path';
 import { mkdtemp, mkdir, rename, appendFile } from 'fs/promises';
+import path from 'path';
+import { beforeAll, afterAll } from '@jest/globals';
 import { getState } from 'expect';
-
-import { getTestNameWithTime } from './media-helper';
-
-/**
- * Internal dependencies
- */
 import { start, close } from './browser-manager';
+import { getDateString } from './data-helper';
+import type { Page, Video } from 'playwright';
 
 // These are defined in our custom Jest environment (test/e2e/lib/jest/environment.js)
 declare const __CURRENT_TEST_FAILED__: boolean;
 declare const __CURRENT_TEST_NAME__: string;
+
+/**
+ * Generates a filename using the test name and a date string.
+ *
+ * @param {string} testName The test name.
+ * @returns The filename.
+ */
+function getTestNameWithTime( testName: string ): string {
+	// Clean up the test name to be entirely lowercase and removing whitespace.
+	const currentTestName = testName.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
+	// Obtain the ISO date string and replace non-supported filename chars with hyphens.
+	const dateTime = getDateString( 'ISO' )!.split( '.' )[ 0 ].replace( /:/g, '-' );
+	return `${ currentTestName }-${ dateTime }`;
+}
 
 /**
  * Set up hoooks used for Jest tests.

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import config from 'config';
 import fs from 'fs-extra';
-import { getLocale, getViewportName } from './browser-helper';
+import { getTimestamp } from './data-helper';
 
 const artifacts: { [ key: string ]: string } = config.get( 'artifacts' );
 
@@ -42,64 +42,6 @@ export function getVideoDir(): string {
 }
 
 /**
- * Returns a descriptive file name for the requested artifact type.
- *
- * @param {{[key: string]: string}} param0 Object assembled by the caller.
- * @param {string} param0.name Name of the test suite or step that failed.
- * @param {string} param0.type Target type of the file name.
- * @returns {string} A Path-like string.
- * @throws {Error} If target type is not one of supported types.
- */
-export function getFileName( {
-	name,
-	type,
-}: {
-	name: string;
-	type: 'video' | 'screenshot';
-} ): string {
-	const suiteName = name.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	const viewportName = getViewportName().toUpperCase();
-	const locale = getLocale().toUpperCase();
-	const date = createTimestamp();
-	const fileName = `FAILED-${ locale }-${ viewportName }-${ suiteName }-${ date }`;
-
-	let dir;
-	let extension;
-
-	if ( type.toLowerCase() === 'screenshot' ) {
-		dir = getScreenshotDir();
-		extension = 'png';
-	} else if ( type.toLowerCase() === 'video' ) {
-		dir = getVideoDir();
-		extension = 'webm';
-	} else {
-		throw new Error( `Unsupported type specified, received ${ type }` );
-	}
-	return `${ dir }/${ fileName }.${ extension }`;
-}
-
-/**
- * Returns the current date as a time stamp.
- *
- * @returns {string} Date represented as a timestamp.
- */
-export function createTimestamp(): string {
-	return new Date().getTime().toString();
-}
-
-/**
- * Generates a valid filanem using the test name and a time stamp
- *
- * @param {string} testName The test name.
- * @returns The filename.
- */
-export function getTestNameWithTime( testName: string ): string {
-	const currentTestName = testName.replace( /[^a-z0-9]/gi, '-' ).toLowerCase();
-	const dateTime = new Date().toISOString().split( '.' )[ 0 ].replace( /:/g, '-' );
-	return `${ currentTestName }-${ dateTime }`;
-}
-
-/**
  * Given a full path to file on disk, remove the file.
  *
  * @param {string} filePath Full path on disk.
@@ -124,7 +66,7 @@ export function createTestFile( {
 	sourceFileName: string;
 	testFileName?: string;
 } ): string {
-	let fileName = createTimestamp();
+	let fileName = getTimestamp();
 	// If the output `testFileName` is defined, use that as part of the final filename.
 	if ( testFileName ) {
 		fileName += `-${ testFileName }`;

--- a/packages/calypso-e2e/test/media-helper.test.ts
+++ b/packages/calypso-e2e/test/media-helper.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { describe, expect, test, beforeAll, afterAll } from '@jest/globals';
-import mockdate from 'mockdate';
-import { getAssetDir, getScreenshotDir, getVideoDir, getFileName } from '../src/media-helper';
+import { getAssetDir, getScreenshotDir, getVideoDir } from '../src/media-helper';
 
 let env: NodeJS.ProcessEnv;
 
@@ -84,45 +83,6 @@ describe( 'MediaHelper Tests', function () {
 			const expected = path.resolve( __dirname, '..', 'screenshots/videos' );
 			expect( getVideoDir() ).toBe( expected );
 		} );
-	} );
-
-	describe( `Test: getFileName`, function () {
-		let timestamp: number;
-
-		beforeAll( function () {
-			process.env.TEMP_ASSET_PATH = '/tmp';
-			process.env.VIDEODIR = 'recording';
-			process.env.SCREENSHOTDIR = 'screenshots';
-			process.env.LOCALE = 'en';
-			process.env.VIEWPORT_NAME = 'desktop';
-			timestamp = 1500000000;
-			mockdate.set( timestamp );
-		} );
-
-		test.each`
-			name                            | type              | expected
-			${ 'Log in' }                   | ${ 'screenshot' } | ${ path.resolve( '/tmp/screenshots', `FAILED-EN-DESKTOP-log-in-1500000000.png` ) }
-			${ 'Check for likes (manage)' } | ${ 'video' }      | ${ path.resolve( '/tmp/recording', `FAILED-EN-DESKTOP-check-for-likes--manage--1500000000.webm` ) }
-			${ '何でしょう' }               | ${ 'screenshot' } | ${ path.resolve( '/tmp/screenshots', `FAILED-EN-DESKTOP-------1500000000.png` ) }
-		`(
-			'Returns $expected when test name and artifact type is specified.',
-			function ( { name, type, expected } ) {
-				expect( getFileName( { name: name, type: type } ) ).toBe( expected );
-			}
-		);
-
-		test.each`
-			type               | expected
-			${ 'invalid' }     | ${ Error }
-			${ '' }            | ${ Error }
-			${ 'screenshots' } | ${ Error }
-			${ 'recordings' }  | ${ Error }
-		`(
-			'Throws $expected when unsupported artifact type is specified.',
-			function ( { type, expected } ) {
-				expect( () => getFileName( { name: 'test', type: type } ) ).toThrow( expected );
-			}
-		);
 	} );
 } );
 

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -42,7 +42,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), () => {
 	} );
 
 	it( 'Enter post title', async function () {
-		await gutenbergEditorPage.enterTitle( DataHelper.randomPhrase() );
+		await gutenbergEditorPage.enterTitle( DataHelper.getRandomPhrase() );
 	} );
 
 	it( `Insert ${ PricingTableBlock.blockName } block and enter price to left table`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), () => {
 	} );
 
 	it( 'Enter post title', async function () {
-		await gutenbergEditorPage.enterTitle( DataHelper.randomPhrase() );
+		await gutenbergEditorPage.enterTitle( DataHelper.getRandomPhrase() );
 	} );
 
 	it( `${ ImageBlock.blockName } block: upload image file`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-likes__comment-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__comment-spec.js
@@ -22,7 +22,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 	describe( 'Comment and like on a new post', function () {
 		let commentsComponent;
 		let gutenbergEditorPage;
-		const comment = DataHelper.randomPhrase();
+		const comment = DataHelper.getRandomPhrase();
 
 		it( 'Log in', async function () {
 			const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
@@ -36,7 +36,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 
 		it( 'Enter post title', async function () {
 			gutenbergEditorPage = new GutenbergEditorPage( page );
-			const title = DataHelper.randomPhrase();
+			const title = DataHelper.getRandomPhrase();
 			await gutenbergEditorPage.enterTitle( title );
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 
 		it( 'Enter post title', async function () {
 			gutenbergEditorPage = new GutenbergEditorPage( page );
-			const title = DataHelper.randomPhrase();
+			const title = DataHelper.getRandomPhrase();
 			await gutenbergEditorPage.enterTitle( title );
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -16,7 +16,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 
 	const commentingUser = 'commentingUser';
 	const notificationsUser = 'notificationsUser';
-	const comment = DataHelper.randomPhrase() + ' TBD';
+	const comment = DataHelper.getRandomPhrase() + ' TBD';
 
 	setupHooks( ( args ) => {
 		page = args.page;

--- a/yarn.lock
+++ b/yarn.lock
@@ -19143,11 +19143,6 @@ mockdate@^2.0.5:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
   integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
 
-mockdate@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
-  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
-
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR propose to clean up and refactor helper classes..

Key changes:
- methods that produce data such as strings, arrays, etc. are moved to the `DataHelper` class.
- methods that produce data for the filesystem, such as media files, are placed in the `MediaHelper` class.
- methods used only by the hooks are moved to the hook file itself.
- removal of dead and unused code.

Background details:

Cruft has formed through iterations of the Playwright project and for the helper classes MediaHelper and DataHelper there was no longer a clean separation of concerns.

Furthermore, with the move to Jest, some code and test for the code were no longer needed. They have been removed.

#### Testing instructions

- [x]  Unit tests continue to pass.
- [x] Playwright mobile tests pass.
- [x] Playwright desktop tests pass.

'Related to #
