### PR TITLE
Playwright: upload image used in Media (Edit) spec.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -1,5 +1,6 @@
 import {
 	DataHelper,
+	MediaHelper,
 	LoginFlow,
 	MediaPage,
 	SidebarComponent,
@@ -7,53 +8,56 @@ import {
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
-	// Parametrized test.
+	const testImage = MediaHelper.createTestImage();
 	let page;
 
 	setupHooks( ( args ) => {
 		page = args.page;
 	} );
 
-	[
-		[ 'Simple', 'defaultUser' ],
-		[ 'Atomic', 'wooCommerceUser' ],
-	].forEach( function ( [ siteType, user ] ) {
-		describe( `Edit Image (${ siteType })`, function () {
-			let mediaPage;
+	describe.each`
+		siteType      | user
+		${ 'Simple' } | ${ 'defaultUser' }
+		${ 'Atomic' } | ${ 'wooCommerceUser' }
+	`( 'Edit Image ($siteType)', function ( { user } ) {
+		let mediaPage;
 
-			it( 'Log In', async function () {
-				const loginFlow = new LoginFlow( page, user );
-				await loginFlow.logIn();
-			} );
+		it( 'Log In', async function () {
+			const loginFlow = new LoginFlow( page, user );
+			await loginFlow.logIn();
+		} );
 
-			it( 'Navigate to Media', async function () {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Media' );
-			} );
+		it( 'Navigate to Media', async function () {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Media' );
+		} );
 
-			it( 'See media gallery', async function () {
-				mediaPage = new MediaPage( page );
-			} );
+		it( 'See media gallery', async function () {
+			mediaPage = new MediaPage( page );
+		} );
 
-			it( 'Show only images', async function () {
-				await mediaPage.clickTab( 'Images' );
-			} );
+		it( 'Show only images', async function () {
+			await mediaPage.clickTab( 'Images' );
+		} );
 
-			it( 'Select the first image item', async function () {
-				await mediaPage.selectItem( 1 );
-			} );
+		it( 'Upload image', async function () {
+			// Ideally, we'd not want to upload an image (that's a separate test)
+			// but occasionally, the photo gallery is cleaned out leaving no images.
+			const uploadedImageHandle = await mediaPage.upload( testImage );
+			const isVisible = await uploadedImageHandle.isVisible();
+			expect( isVisible ).toBe( true );
+		} );
 
-			it( 'Click to edit selected image', async function () {
-				await mediaPage.editImage();
-			} );
+		it( 'Click to edit selected image', async function () {
+			await mediaPage.editImage();
+		} );
 
-			it( 'Rotate image', async function () {
-				await mediaPage.rotateImage();
-			} );
+		it( 'Rotate image', async function () {
+			await mediaPage.rotateImage();
+		} );
 
-			it( 'Cancel image edit', async function () {
-				await mediaPage.cancelImageEdit();
-			} );
+		it( 'Cancel image edit', async function () {
+			await mediaPage.cancelImageEdit();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the `Media (Edit)` spec to upload the image used in the test.

Background details:

Occasionally, the media gallery used for the Edit spec is cleared out, leaving no images behind. This trips up the spec, which expects the presence of a test file to be used.

The solution is to first upload a test image.

#### Testing instructions

- [x] Playwright mobile passes.
- [x] Playwright desktop passes.

Fixes #55673
