### PR TITLE
Import the style.scss so that the popover menu items are rendered correctly

### DIFF
--- a/client/components/popover-menu/index.jsx
+++ b/client/components/popover-menu/index.jsx
@@ -2,6 +2,8 @@ import { Popover } from '@automattic/components';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+import './style.scss';
+
 const isInvalidTarget = ( target ) => {
 	return target.tagName === 'HR';
 };
@@ -73,6 +75,7 @@ class PopoverMenu extends Component {
 					ref={ this.menu }
 					id={ id }
 					role="menu"
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 					className="popover__menu"
 					onKeyDown={ this._onKeyDown }
 					tabIndex="-1"


### PR DESCRIPTION
After the popover component was moved in #55238 the menu items in the domain section (and probably elsewhere) didn't render correctly.

#### Changes proposed in this Pull Request

* Import the style.scss file in the popover menu component

Before:

<img width="747" alt="Screenshot 2021-08-24 at 10 39 10" src="https://user-images.githubusercontent.com/1355045/130577088-4ccd46db-b3e6-4ac9-8436-89ac654d4a6c.png">
<img width="285" alt="Screenshot 2021-08-24 at 10 39 14" src="https://user-images.githubusercontent.com/1355045/130577090-0179e503-cb23-4df4-ab46-1c7bf0e28e95.png">

After:
<img width="288" alt="Screenshot 2021-08-24 at 10 39 22" src="https://user-images.githubusercontent.com/1355045/130577099-b69c627d-cdd0-46a3-96ea-7fed51f4e127.png">
<img width="266" alt="Screenshot 2021-08-24 at 10 39 27" src="https://user-images.githubusercontent.com/1355045/130577101-4016387f-31be-464f-a72e-02bee5a4c908.png">

#### Testing instructions

* Spin up this branch and go to Upgrades > Domains and click on "Add domain to this site" or "Other domain options" buttons - you should see the menus render properly.

