### PR TITLE
ci(e2e): Refactor Media helper to better handle concurrency

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -646,7 +646,6 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
-				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
 			}
 			bashNodeScript {
 				name = "Collect results"

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -21,11 +21,9 @@
 	},
 	"devDependencies": {
 		"@types/config": "^0.0.39",
-		"@types/fs-extra": "^9.0.12",
 		"@types/jest": "^25.2.3",
 		"@types/node": "^15.0.2",
 		"asana-phrase": "^0.0.8",
-		"fs-extra": "^10.0.0",
 		"mockdate": "^3.0.5"
 	},
 	"scripts": {

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -23,8 +23,7 @@
 		"@types/config": "^0.0.39",
 		"@types/jest": "^25.2.3",
 		"@types/node": "^15.0.2",
-		"asana-phrase": "^0.0.8",
-		"mockdate": "^3.0.5"
+		"asana-phrase": "^0.0.8"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -25,7 +25,8 @@
 		"@types/jest": "^25.2.3",
 		"@types/node": "^15.0.2",
 		"asana-phrase": "^0.0.8",
-		"fs-extra": "3.0.1"
+		"fs-extra": "^10.0.0",
+		"mockdate": "^3.0.5"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && npx rimraf dist",

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -1,3 +1,4 @@
+import cp from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import config from 'config';
@@ -84,6 +85,11 @@ export function createTestFile( {
 	const testFilePath = path.join( sourceFileDir, fileName );
 
 	// Copy the source file specified to testFilePath, creating a clone differing only by name.
+	console.log( cp.execSync( `ls -la ${ sourceFileDir }` ) );
+	console.log( cp.execSync( `ls -la ${ sourceFilePath }` ) );
+	console.log( cp.execSync( `ls -la ${ testFilePath }` ) );
+	console.log( cp.execSync( `cp ${ sourceFilePath } ${ testFilePath }` ) );
+
 	fs.copyFileSync( sourceFilePath, testFilePath );
 
 	return testFilePath;

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -82,6 +82,12 @@ export function createTestFile( {
 	// Attempting to copy the file elsewhere will trigger the following error on TeamCity:
 	// EPERM: operation not permitted
 	const testFilePath = path.join( sourceFileDir, fileName );
+
+	console.dir( require( 'os' ).userInfo() );
+	console.dir( fs.statSync( sourceFilePath ) );
+	console.dir( fs.statSync( sourceFileDir ) );
+	console.dir( fs.statSync( testFilePath ) );
+
 	// Copy the source file specified to testFilePath, creating a clone differing only by name.
 	fs.copySync( sourceFilePath, testFilePath );
 

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -1,6 +1,6 @@
+import fs from 'fs';
 import path from 'path';
 import config from 'config';
-import fs from 'fs-extra';
 import { getTimestamp } from './data-helper';
 
 const artifacts: { [ key: string ]: string } = config.get( 'artifacts' );
@@ -48,7 +48,7 @@ export function getVideoDir(): string {
  * @returns {void} No return value.
  */
 export function deleteFile( filePath: string ): void {
-	fs.removeSync( filePath );
+	fs.unlinkSync( filePath );
 }
 
 /**
@@ -83,13 +83,8 @@ export function createTestFile( {
 	// EPERM: operation not permitted
 	const testFilePath = path.join( sourceFileDir, fileName );
 
-	console.dir( require( 'os' ).userInfo() );
-	console.dir( fs.statSync( sourceFilePath ) );
-	console.dir( fs.statSync( sourceFileDir ) );
-	console.dir( fs.statSync( testFilePath ) );
-
 	// Copy the source file specified to testFilePath, creating a clone differing only by name.
-	fs.copySync( sourceFilePath, testFilePath );
+	fs.copyFileSync( sourceFilePath, testFilePath );
 
 	return testFilePath;
 }

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -79,7 +79,7 @@ export async function createTestFile( {
 	const sourceFileDir = path.join( __dirname, '../../../../../test/e2e/image-uploads/' );
 	const sourceFilePath = path.join( sourceFileDir, sourceFileName );
 
-	const tempDir = await fs.mkdtemp( path.join( os.tmpdir(), 'foo-' ) );
+	const tempDir = await fs.mkdtemp( path.join( os.tmpdir(), 'e2e-' ) );
 	const testFilePath = path.join( tempDir, fileName );
 
 	await fs.copyFile( sourceFilePath, testFilePath );

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -86,19 +86,19 @@ export function createTestFile( {
 
 	// Copy the source file specified to testFilePath, creating a clone differing only by name.
 	try {
-		console.log( cp.execSync( `ls -la ${ sourceFileDir }` ) );
+		console.log( cp.execSync( `ls -la ${ sourceFileDir }` ).toString() );
 	} catch {}
 	try {
-		console.log( cp.execSync( `ls -la ${ sourceFilePath }` ) );
+		console.log( cp.execSync( `ls -la ${ sourceFilePath }` ).toString() );
 	} catch {}
 	try {
-		console.log( cp.execSync( `ls -la ${ testFilePath }` ) );
+		console.log( cp.execSync( `ls -la ${ testFilePath }` ).toString() );
 	} catch {}
 	try {
-		console.log( cp.execSync( `cp ${ sourceFilePath } ${ testFilePath }` ) );
+		console.log( cp.execSync( `cp ${ sourceFilePath } ${ testFilePath }` ).toString() );
 	} catch {}
 	try {
-		console.log( cp.execSync( `ls -la ${ testFilePath }` ) );
+		console.log( cp.execSync( `ls -la ${ testFilePath }` ).toString() );
 	} catch {}
 
 	fs.copyFileSync( sourceFilePath, testFilePath );

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -85,10 +85,21 @@ export function createTestFile( {
 	const testFilePath = path.join( sourceFileDir, fileName );
 
 	// Copy the source file specified to testFilePath, creating a clone differing only by name.
-	console.log( cp.execSync( `ls -la ${ sourceFileDir }` ) );
-	console.log( cp.execSync( `ls -la ${ sourceFilePath }` ) );
-	console.log( cp.execSync( `ls -la ${ testFilePath }` ) );
-	console.log( cp.execSync( `cp ${ sourceFilePath } ${ testFilePath }` ) );
+	try {
+		console.log( cp.execSync( `ls -la ${ sourceFileDir }` ) );
+	} catch {}
+	try {
+		console.log( cp.execSync( `ls -la ${ sourceFilePath }` ) );
+	} catch {}
+	try {
+		console.log( cp.execSync( `ls -la ${ testFilePath }` ) );
+	} catch {}
+	try {
+		console.log( cp.execSync( `cp ${ sourceFilePath } ${ testFilePath }` ) );
+	} catch {}
+	try {
+		console.log( cp.execSync( `ls -la ${ testFilePath }` ) );
+	} catch {}
 
 	fs.copyFileSync( sourceFilePath, testFilePath );
 

--- a/packages/calypso-e2e/src/media-helper.ts
+++ b/packages/calypso-e2e/src/media-helper.ts
@@ -43,16 +43,6 @@ export function getVideoDir(): string {
 }
 
 /**
- * Given a full path to file on disk, remove the file.
- *
- * @param {string} filePath Full path on disk.
- * @returns {Promise< void >} No return value.
- */
-export async function deleteFile( filePath: string ): Promise< void > {
-	await fs.unlink( filePath );
-}
-
-/**
  * Creates a temporary test file by cloning a source file under a new name.
  *
  * @param {{[key: string]: string}} param0 Parameter object.

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -18,16 +18,20 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), () => {
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let pricingTableBlock: PricingTableBlock;
 	let page: Page;
+	let logoImage: string;
 
 	// Test data
 	const pricingTableBlockPrice = 888;
 	const heroBlockHeading = 'Hero heading';
 	const clicktoTweetBlockTweet =
 		'The foolish man seeks happiness in the distance. The wise grows it under his feet. — James Oppenheim';
-	const logoImage = MediaHelper.createTestImage();
 
 	setupHooks( ( args ) => {
 		page = args.page;
+	} );
+
+	beforeAll( async () => {
+		logoImage = await MediaHelper.createTestImage();
 	} );
 
 	it( 'Log in', async function () {
@@ -87,7 +91,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), () => {
 		${ DynamicHRBlock }    | ${ null }
 		${ HeroBlock }         | ${ [ heroBlockHeading ] }
 		${ ClicktoTweetBlock } | ${ [ clicktoTweetBlockTweet ] }
-		${ LogosBlock }        | ${ [ path.parse( logoImage ).name ] }
 	`(
 		`Confirm $block.blockName block is visible in published post`,
 		async ( { block, content } ) => {
@@ -95,4 +98,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), () => {
 			await block.validatePublishedContent( page, content );
 		}
 	);
+
+	it( `Confirm Logso block is visible in published post`, async () => {
+		await LogosBlock.validatePublishedContent( page, path.parse( logoImage ).name );
+	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -99,7 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), () => {
 		}
 	);
 
-	it( `Confirm Logso block is visible in published post`, async () => {
+	it( `Confirm Logos block is visible in published post`, async () => {
 		await LogosBlock.validatePublishedContent( page, path.parse( logoImage ).name );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -87,10 +87,10 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), () => {
 	} );
 
 	it( `Confirm Audio block is visible in published post`, async () => {
-		await ImageBlock.validatePublishedContent( page, path.parse( testFiles.audio ).base );
+		await AudioBlock.validatePublishedContent( page );
 	} );
 
 	it( `Confirm File block is visible in published post`, async () => {
-		await ImageBlock.validatePublishedContent( page, path.parse( testFiles.audio ).name );
+		await FileBlock.validatePublishedContent( page, path.parse( testFiles.audio ).name );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -15,18 +15,21 @@ import { Page } from 'playwright';
 describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), () => {
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let page: Page;
-
-	const testFiles = {
-		image: MediaHelper.createTestImage(),
-		image_reserved_name: MediaHelper.createTestFile( {
-			sourceFileName: 'image0.jpg',
-			testFileName: 'filewith#?#?reservedurlchars',
-		} ),
-		audio: MediaHelper.createTestAudio(),
-	};
+	let testFiles: { image: string; image_reserved_name: string; audio: string };
 
 	setupHooks( ( args ) => {
 		page = args.page;
+	} );
+
+	beforeAll( async () => {
+		testFiles = {
+			image: await MediaHelper.createTestImage(),
+			image_reserved_name: await MediaHelper.createTestFile( {
+				sourceFileName: 'image0.jpg',
+				testFileName: 'filewith#?#?reservedurlchars',
+			} ),
+			audio: await MediaHelper.createTestAudio(),
+		};
 	} );
 
 	it( 'Log in', async function () {
@@ -72,20 +75,22 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), () => {
 		await gutenbergEditorPage.publish( { visit: true } );
 	} );
 
-	// Pass in a 1D array of values or text strings to validate each block.
-	// The full filename (name.extension) is not used within the Image block, but the file name is.
-	// `path.parse` is called to trim the extension.
-	it.each`
-		block           | content
-		${ ImageBlock } | ${ [ path.parse( testFiles.image ).name ] }
-		${ ImageBlock } | ${ [ path.parse( testFiles.image_reserved_name ).name.replace( /[^a-zA-Z ]/g, '' ) ] }
-		${ AudioBlock } | ${ [ path.parse( testFiles.audio ).base ] }
-		${ FileBlock }  | ${ [ path.parse( testFiles.audio ).name ] }
-	`(
-		`Confirm $block.blockName block is visible in published post`,
-		async ( { block, content } ) => {
-			// Pass the Block object class here then call the static method to validate.
-			await block.validatePublishedContent( page, content );
-		}
-	);
+	it( `Confirm Image block is visible in published post`, async () => {
+		await ImageBlock.validatePublishedContent( page, path.parse( testFiles.image ).name );
+	} );
+
+	it( `Confirm Image block is visible in published post (reserved name)`, async () => {
+		await ImageBlock.validatePublishedContent(
+			page,
+			path.parse( testFiles.image_reserved_name ).name.replace( /[^a-zA-Z ]/g, '' )
+		);
+	} );
+
+	it( `Confirm Audio block is visible in published post`, async () => {
+		await ImageBlock.validatePublishedContent( page, path.parse( testFiles.audio ).base );
+	} );
+
+	it( `Confirm File block is visible in published post`, async () => {
+		await ImageBlock.validatePublishedContent( page, path.parse( testFiles.audio ).name );
+	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -8,11 +8,15 @@ import {
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
-	const testImage = MediaHelper.createTestImage();
+	let testImage;
 	let page;
 
 	setupHooks( ( args ) => {
 		page = args.page;
+	} );
+
+	beforeAll( async () => {
+		testImage = await MediaHelper.createTestImage();
 	} );
 
 	describe.each`

--- a/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
@@ -9,15 +9,19 @@ import {
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
-	const testFiles = [
-		{ type: 'image', filepath: MediaHelper.createTestImage() },
-		{ type: 'audio', filepath: MediaHelper.createTestAudio() },
-	];
-	const invalidFile = MediaHelper.createInvalidFile();
+	let testFiles;
 	let page;
 
 	setupHooks( ( args ) => {
 		page = args.page;
+	} );
+
+	beforeAll( async () => {
+		testFiles = {
+			image: await MediaHelper.createTestImage(),
+			audio: await MediaHelper.createTestAudio(),
+			invalid: await MediaHelper.createInvalidFile(),
+		};
 	} );
 
 	// Parametrized test.
@@ -42,17 +46,19 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 			mediaPage = new MediaPage( page );
 		} );
 
-		it.each( testFiles )(
-			'Upload $type and confirm addition to gallery',
-			async ( { filepath } ) => {
-				const uploadedItem = await mediaPage.upload( filepath );
-				assert.strictEqual( await uploadedItem.isVisible(), true );
-			}
-		);
+		it( 'Upload image and confirm addition to gallery', async () => {
+			const uploadedItem = await mediaPage.upload( testFiles.image );
+			assert.strictEqual( await uploadedItem.isVisible(), true );
+		} );
+
+		it( 'Upload audio and confirm addition to gallery', async () => {
+			const uploadedItem = await mediaPage.upload( testFiles.audio );
+			assert.strictEqual( await uploadedItem.isVisible(), true );
+		} );
 
 		it( 'Upload an unsupported file type and see the rejection notice', async function () {
 			try {
-				await mediaPage.upload( invalidFile );
+				await mediaPage.upload( testFiles.invalid );
 			} catch ( error ) {
 				assert.match( error.message, /could not be uploaded/i );
 			}
@@ -60,10 +66,9 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 	} );
 
 	// Clean up test files.
-	afterAll( () => {
+	afterAll( async () => {
 		for ( const testFile of Object.values( testFiles ) ) {
-			MediaHelper.deleteFile( testFile.filepath );
+			await MediaHelper.deleteFile( testFile.filepath );
 		}
-		MediaHelper.deleteFile( invalidFile );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
@@ -64,11 +64,4 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 			}
 		} );
 	} );
-
-	// Clean up test files.
-	afterAll( async () => {
-		for ( const testFile of Object.values( testFiles ) ) {
-			await MediaHelper.deleteFile( testFile.filepath );
-		}
-	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3926,13 +3926,6 @@
   resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
   integrity sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
 
-"@types/fs-extra@^9.0.12":
-  version "9.0.12"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.12.tgz#9b8f27973df8a7a3920e8461517ebf8a7d4fdfaf"
-  integrity sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -13318,15 +13311,6 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
-
-fs-extra@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
-  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs-extra@^7.0.1:
   version "7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13299,15 +13299,6 @@ fs-exists-sync@^0.1.0:
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
   integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
-fs-extra@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  integrity sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^0.22.1:
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.22.1.tgz#5fd6f8049dc976ca19eb2355d658173cabcce056"
@@ -13327,6 +13318,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^7.0.1:
   version "7.0.1"
@@ -17348,13 +17348,6 @@ jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
   integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
-  integrity sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=
   optionalDependencies:
     graceful-fs "^4.1.6"
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Refactor Media Helper for Playwright tests to handle concurrency better:

* `createTestFile` will use the temp directory
* `createTestFile` is now async
* Refactor usages of those methods to ensure they are called asynchronously inside a hook or a test
* Drop code to delete files. They are saved in a tmp directory and disposed as soon as the docker container is killed.

After those changes, copying files was still breaking. Looks like removing `--security-opt seccomp=.teamcity/docker-seccomp.json` fixed the problem. I believe we added it for Electron 11 (https://github.com/Automattic/wp-calypso/pull/47555/files) but it is not required here.

#### Testing instructions

Verify e2e still pass