### PR TITLE
i18n: Fix LearnGrow cards for non-English UI

### DIFF
--- a/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
+++ b/client/my-sites/customer-home/cards/education/wpcourses/index.jsx
@@ -1,12 +1,13 @@
 import config from '@automattic/calypso-config';
-import { getLocaleSlug } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import freePhotoLibraryVideoPrompt from 'calypso/assets/images/customer-home/illustration--secondary-wp-courses.svg';
 import { EDUCATION_WPCOURSES } from 'calypso/my-sites/customer-home/cards/constants';
 import EducationalContent from '../educational-content';
 
 const WpCourses = () => {
-	const isEnglish = config( 'english_locales' ).includes( getLocaleSlug() );
+	const { localeSlug } = useTranslate();
+	const isEnglish = config( 'english_locales' ).includes( localeSlug );
 
 	if ( ! isEnglish ) {
 		return null;

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
@@ -70,8 +72,15 @@ const LearnGrow = () => {
 function useLearnGrowCards() {
 	const siteId = useSelector( getSelectedSiteId );
 	const { data: layout } = useHomeLayoutQuery( siteId, { enabled: false } );
+	const { localeSlug } = useTranslate();
 
-	const allCards = layout?.[ 'secondary.learn-grow' ] ?? [];
+	let allCards = layout?.[ 'secondary.learn-grow' ] ?? [];
+
+	const isEnglish = config( 'english_locales' ).includes( localeSlug );
+
+	if ( ! isEnglish ) {
+		allCards = allCards.filter( ( card ) => card !== EDUCATION_WPCOURSES );
+	}
 
 	// Remove cards we don't know how to deal with on the client-side
 	return allCards.filter( ( card ) => !! cardComponents[ card ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Exclude `WpCourses` card from `LearnGrow` on non-English UI, as it would otherwise render as empty page in the `DotPager`.

**Before:**
![CleanShot 2021-08-24 at 16 42 38](https://user-images.githubusercontent.com/2722412/130627368-903dcdb2-2a8a-4450-bc9f-c6d67503f4ca.png)

**After:**
![CleanShot 2021-08-24 at 16 42 15](https://user-images.githubusercontent.com/2722412/130627387-c5f85c0e-e246-4172-885b-420abf17b70e.png)


#### Testing instructions

* Switch UI language to English and confirm the `LearnGrow` component renders the second page `WpCourses` as expected.
* Switch the UI to any non-English locale and confirm `LearnGrow` doesn't render a page for empty `WpCourses` component.

Related to 314-gh-Automattic/i18n-issues
