### PR TITLE
e2e: Add initial reader Playwright test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -3,7 +3,7 @@ import { ElementHandle, Page } from 'playwright';
 const selectors = {
 	comment: '.wpnc__comment',
 	singleViewPanel: '.wpnc__single-view',
-	undoLocator: '.wpnc__summary.wpnc__undo-item',
+	undoLocator: '.wpnc__undo-item',
 };
 /**
  * Component representing the notifications panel and notifications themselves.
@@ -55,10 +55,6 @@ export class NotificationsComponent {
 	async clickNotificationAction( action: 'Trash' ): Promise< void > {
 		const selector = `*css=button >> text=${ action }`;
 		await this.page.click( selector );
-
-		if ( action === 'Trash' ) {
-			await this.page.waitForSelector( ':text("Comment trashed")', { state: 'hidden' } );
-		}
 	}
 
 	/**
@@ -67,7 +63,7 @@ export class NotificationsComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async waitForUndoMessage(): Promise< void > {
-		await this.page.$( selectors.undoLocator );
+		await this.page.waitForSelector( selectors.undoLocator );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -3,6 +3,7 @@ import { ElementHandle, Page } from 'playwright';
 const selectors = {
 	comment: '.wpnc__comment',
 	singleViewPanel: '.wpnc__single-view',
+	undoLocator: '.wpnc__summary.wpnc__undo-item',
 };
 /**
  * Component representing the notifications panel and notifications themselves.
@@ -58,5 +59,23 @@ export class NotificationsComponent {
 		if ( action === 'Trash' ) {
 			await this.page.waitForSelector( ':text("Comment trashed")', { state: 'hidden' } );
 		}
+	}
+
+	/**
+	 * Waits for undo message to appear
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async waitForUndoMessage(): Promise< void > {
+		await this.page.$( selectors.undoLocator );
+	}
+
+	/**
+	 * Waits for undo message to disappear
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async waitForUndoMessageToDisappear(): Promise< void > {
+		await this.page.waitForSelector( selectors.undoLocator, { state: 'hidden' } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -14,3 +14,4 @@ export * from './stats-page';
 export * from './site-import-page';
 export * from './invite-people-page';
 export * from './people-page';
+export * from './reader-page';

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -26,7 +26,6 @@ export class ReaderPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
-		this.verifyReaderPage();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -1,6 +1,7 @@
 import { Page } from 'playwright';
 
 const selectors = {
+	readerPageLocator: '.reader__content',
 	readerVisitLink: '.reader-visit-link',
 	shareButtonLocator: '.reader-share__button',
 	firstComboCardPostLocator: '.reader-combined-card__post-title-link',
@@ -25,6 +26,16 @@ export class ReaderPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		this.verifyReaderPage();
+	}
+
+	/**
+	 * Verifies that we are actually on the Reader Page
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	private async verifyReaderPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.readerPageLocator );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -7,7 +7,7 @@ const selectors = {
 	siteContentLocator: '.site-selector__sites .site__content',
 	commentButtonLocator: '.comment-button',
 	commentTextAreaLocator: '.comments__form textarea',
-	commentSubmitLocator: '.comments__form button',
+	commentSubmitLocator: '.comments__form button:text("Send")',
 	commentContentLocator: ( commentText: string ) =>
 		`.comments__comment-content :text( '${ commentText }' )`,
 };

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -8,7 +8,8 @@ const selectors = {
 	commentButtonLocator: '.comment-button',
 	commentTextAreaLocator: '.comments__form textarea',
 	commentSubmitLocator: '.comments__form button',
-	commentContentLocator: '.comments__comment-content',
+	commentContentLocator: ( commentText: string ) =>
+		`.comments__comment-content :text( '${ commentText }' )`,
 };
 
 /**
@@ -42,14 +43,7 @@ export class ReaderPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async shareLatestPost(): Promise< void > {
-		const hasSharablePost = await this.page.$( selectors.shareButtonLocator );
-		if ( ! hasSharablePost ) {
-			// no shareable posts on this screen. try moving into a combined card
-			await this.page.click( selectors.firstComboCardPostLocator );
-		}
-
 		await this.page.click( selectors.shareButtonLocator );
-		await this.page.waitForSelector( selectors.siteContentLocator );
 		await this.page.click( selectors.siteContentLocator );
 	}
 
@@ -72,8 +66,6 @@ export class ReaderPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async waitForCommentToAppear( comment: string ): Promise< void > {
-		await this.page.waitForSelector(
-			selectors.commentContentLocator + ' :text("' + comment + '")'
-		);
+		await this.page.waitForSelector( selectors.commentContentLocator( comment ) );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -1,0 +1,79 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	readerVisitLink: '.reader-visit-link',
+	shareButtonLocator: '.reader-share__button',
+	firstComboCardPostLocator: '.reader-combined-card__post-title-link',
+	siteContentLocator: '.site-selector__sites .site__content',
+	commentButtonLocator: '.comment-button',
+	commentTextAreaLocator: '.comments__form textarea',
+	commentSubmitLocator: '.comments__form button',
+	commentContentLocator: '.comments__comment-content',
+};
+
+/**
+ * Page representing the Reader Page.
+ */
+export class ReaderPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Get the URL of the latest post in Reader
+	 *
+	 * @returns {Promise<string>} String of URL for latest post.
+	 */
+	async siteOfLatestPost(): Promise< string > {
+		const href = await this.page.getAttribute( selectors.readerVisitLink, 'href' );
+		return new URL( href ? href : '' ).host;
+	}
+
+	/**
+	 * Share latest post in Reader
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async shareLatestPost(): Promise< void > {
+		const hasSharablePost = await this.page.$( selectors.shareButtonLocator );
+		if ( ! hasSharablePost ) {
+			// no shareable posts on this screen. try moving into a combined card
+			await this.page.click( selectors.firstComboCardPostLocator );
+		}
+
+		await this.page.click( selectors.shareButtonLocator );
+		await this.page.waitForSelector( selectors.siteContentLocator );
+		await this.page.click( selectors.siteContentLocator );
+	}
+
+	/**
+	 * Sets and submits comment on latest post
+	 *
+	 * @param {string} comment Text of the comment.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async commentOnLatestPost( comment: string ): Promise< void > {
+		await this.page.click( selectors.commentButtonLocator );
+		await this.page.fill( selectors.commentTextAreaLocator, comment );
+		await this.page.click( selectors.commentSubmitLocator );
+	}
+
+	/**
+	 * Wait for the comment with the specified text to display.
+	 *
+	 * @param {string} comment Text of the comment.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async waitForCommentToAppear( comment: string ): Promise< void > {
+		await this.page.waitForSelector(
+			selectors.commentContentLocator + ' :text("' + comment + '")'
+		);
+	}
+}

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -12,7 +12,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 	let page: Page;
 	let readerPage: ReaderPage;
 	let notificationsComponent: NotificationsComponent;
-	const comment = DataHelper.randomPhrase();
+	const comment = DataHelper.getRandomPhrase();
 
 	setupHooks( ( args ) => {
 		page = args.page;

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -1,0 +1,55 @@
+import {
+	DataHelper,
+	LoginFlow,
+	setupHooks,
+	ReaderPage,
+	NotificationsComponent,
+	NavbarComponent,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function () {
+	let page: Page;
+	const comment = DataHelper.randomPhrase();
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log In', async function () {
+		const loginFlow = new LoginFlow( page, 'commentingUser' );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Can see the Reader stream', async function () {
+		const readerPage = new ReaderPage( page );
+	} );
+
+	it( 'The latest post is on the expected test site', async function () {
+		const testSiteForNotifications = DataHelper.config.get( 'testSiteForNotifications' );
+		const readerPage = new ReaderPage( page );
+		const siteOfLatestPost = await readerPage.siteOfLatestPost();
+		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
+	} );
+
+	it( 'Can comment on the latest post and see the comment appear', async function () {
+		const readerPage = new ReaderPage( page );
+		await readerPage.commentOnLatestPost( comment );
+		await readerPage.waitForCommentToAppear( comment );
+	} );
+
+	it( 'Can log in as test site owner', async function () {
+		const loginFlow = new LoginFlow( page, 'notificationsUser' );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Can delete the new comment (and wait for UNDO grace period so step is actually deleted)', async function () {
+		const navBarComponent = new NavbarComponent( page );
+		await navBarComponent.openNotificationsPanel();
+		const notificationsComponent = new NotificationsComponent( page );
+		await notificationsComponent.clickNotification( comment );
+		await notificationsComponent.clickNotificationAction( 'Trash' );
+		await notificationsComponent.waitForUndoMessage();
+		await notificationsComponent.waitForUndoMessageToDisappear();
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -10,6 +10,7 @@ import { Page } from 'playwright';
 
 describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function () {
 	let page: Page;
+	let readerPage: ReaderPage;
 	const comment = DataHelper.randomPhrase();
 
 	setupHooks( ( args ) => {
@@ -22,18 +23,18 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 	} );
 
 	it( 'Can see the Reader stream', async function () {
-		const readerPage = new ReaderPage( page );
+		readerPage = new ReaderPage( page );
 	} );
 
 	it( 'The latest post is on the expected test site', async function () {
 		const testSiteForNotifications = DataHelper.config.get( 'testSiteForNotifications' );
-		const readerPage = new ReaderPage( page );
+		readerPage = new ReaderPage( page );
 		const siteOfLatestPost = await readerPage.siteOfLatestPost();
 		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
 	} );
 
 	it( 'Can comment on the latest post and see the comment appear', async function () {
-		const readerPage = new ReaderPage( page );
+		readerPage = new ReaderPage( page );
 		await readerPage.commentOnLatestPost( comment );
 		await readerPage.waitForCommentToAppear( comment );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -25,6 +25,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 
 	it( 'View the Reader stream', async function () {
 		readerPage = new ReaderPage( page );
+		await readerPage.verifyReaderPage();
 	} );
 
 	it( 'The latest post is on the expected test site', async function () {

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -11,6 +11,7 @@ import { Page } from 'playwright';
 describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function () {
 	let page: Page;
 	let readerPage: ReaderPage;
+	let notificationsComponent: NotificationsComponent;
 	const comment = DataHelper.randomPhrase();
 
 	setupHooks( ( args ) => {
@@ -22,34 +23,41 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 		await loginFlow.logIn();
 	} );
 
-	it( 'Can see the Reader stream', async function () {
+	it( 'View the Reader stream', async function () {
 		readerPage = new ReaderPage( page );
 	} );
 
 	it( 'The latest post is on the expected test site', async function () {
 		const testSiteForNotifications = DataHelper.config.get( 'testSiteForNotifications' );
-		readerPage = new ReaderPage( page );
 		const siteOfLatestPost = await readerPage.siteOfLatestPost();
 		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
 	} );
 
-	it( 'Can comment on the latest post and see the comment appear', async function () {
-		readerPage = new ReaderPage( page );
+	it( 'Comment on the latest post', async function () {
 		await readerPage.commentOnLatestPost( comment );
+	} );
+
+	it( 'Wait for the comment to appear', async function () {
 		await readerPage.waitForCommentToAppear( comment );
 	} );
 
-	it( 'Can log in as test site owner', async function () {
+	it( 'Log in as test site owner', async function () {
 		const loginFlow = new LoginFlow( page, 'notificationsUser' );
 		await loginFlow.logIn();
 	} );
 
-	it( 'Can delete the new comment (and wait for UNDO grace period so step is actually deleted)', async function () {
+	it( 'Open Notifications panel', async function () {
 		const navBarComponent = new NavbarComponent( page );
 		await navBarComponent.openNotificationsPanel();
-		const notificationsComponent = new NotificationsComponent( page );
+	} );
+
+	it( 'Delete the new comment', async function () {
+		notificationsComponent = new NotificationsComponent( page );
 		await notificationsComponent.clickNotification( comment );
 		await notificationsComponent.clickNotificationAction( 'Trash' );
+	} );
+
+	it( 'Wait for Undo Message to display and then disappear', async function () {
 		await notificationsComponent.waitForUndoMessage();
 		await notificationsComponent.waitForUndoMessageToDisappear();
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR migrates the Reader test to Playwright and adds the necessary page objects and new functions

#### Testing instructions

* Make sure the `Reader: View and Comment` runs and passes with the other Playwright tests in TC

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55128
