### PR TITLE
Sidebar: Add more bottom padding

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -712,7 +712,7 @@ $font-size: rem( 14px );
 		// client/layout/sidebar/style.scss
 		.sidebar {
 			position: absolute;
-			padding-bottom: 70px;
+			padding-bottom: 120px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Related to #55539, as I was prepping demo videos I noticed there was still an inaccessible area at the bottom of the browser window on some devices, so I'm adding a little more padding.

**Before**

https://user-images.githubusercontent.com/2124984/130663158-d8d5a068-e26a-49b6-99d8-5f533f41fb87.mp4


**After**

https://user-images.githubusercontent.com/2124984/130663173-b43d555d-166e-4e6f-8db9-b8efafc19a89.mp4


#### Testing instructions

* Switch to this PR
* Check out the sidebar on a mobile device, or on a very narrow screen less than 660px
* You should be able to scroll to the bottom of the sidebar and access the last menu item
