### PR TITLE
Jetpack Cloud: Change text for spam feature

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1083,7 +1083,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_ANTISPAM_V2 ]: {
 		getSlug: () => FEATURE_ANTISPAM_V2,
-		getTitle: () => i18n.translate( 'Comment and form protection' ),
+		getTitle: () => i18n.translate( 'Comment and form spam protection' ),
 	},
 
 	[ FEATURE_ACTIVITY_LOG_1_YEAR_V2 ]: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* on `cloud.jetpack.com/pricing` use "Comment and form spam protection" for spam feature description

#### Testing instructions

1. boot branch on calypso green
2. go to `/pricing`
3. verify the `Security Daily` and `Anti-spam` plans have a feature listed as "Comment and form spam protection"

