### PR TITLE
Test new tracks event for Add New Page/Post button

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -17,7 +17,7 @@ export class NewPostFlow {
 		this.page = page;
 	}
 
-	/**1
+	/**
 	 * Starts a new post from the navbar/masterbar button.
 	 *
 	 * @returns {Promise<void>} No return value.

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import { Page, Frame, ElementHandle } from 'playwright';
 
+type ClickOptions = Parameters< Frame[ 'click' ] >[ 1 ];
+
 const selectors = {
 	// iframe and editor
 	editorFrame: '.calypsoify.is-iframe iframe.is-loaded',
@@ -30,6 +32,7 @@ const selectors = {
 	// Publish panel (including post-publish)
 	publishPanel: '.editor-post-publish-panel',
 	viewButton: '.editor-post-publish-panel a:has-text("View")',
+	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 };
 
 /**
@@ -265,9 +268,20 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 * Creates a new page/post using the post-publish panel.
+	 *
+	 * @param options will be forwarded to the button click action
+	 */
+	async postPublishAddNewItem( options: ClickOptions = {} ): Promise< void > {
+		const frame = await this.getEditorFrame();
+		await frame.waitForSelector( selectors.publishPanel );
+		await frame.click( selectors.addNewButton, options );
+	}
+
+	/**
 	 * Saves the currently open post as draft.
 	 */
-	async saveDraft() {
+	async saveDraft(): Promise< void > {
 		const frame = await this.getEditorFrame();
 
 		await frame.click( selectors.saveDraftButton );

--- a/test/e2e/lib/gutenberg/tracking/playwright-utils.ts
+++ b/test/e2e/lib/gutenberg/tracking/playwright-utils.ts
@@ -1,0 +1,27 @@
+import type { Frame } from 'playwright';
+
+export type TracksEvent = [
+	string, // event name
+	{
+		_en: string; // event name
+		blog_id: number;
+		site_type: string; // e.g. 'simple'
+		user_locale: string;
+		post_type?: string;
+		editor_type?: string;
+
+		// Events can have their own custom properties
+		[ key: string ]: any;
+	}
+];
+
+export async function getLatestEvent( frame: Frame ): Promise< TracksEvent | undefined > {
+	const stack = await getEventsStack( frame );
+	return stack.length ? stack[ 0 ] : undefined;
+}
+
+export async function getEventsStack( frame: Frame ): Promise< TracksEvent[] > {
+	return await frame.evaluate( () => {
+		return ( window as any )._e2eEventsStack;
+	} );
+}

--- a/test/e2e/specs/specs-playwright/wp-editor__tracks-events.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__tracks-events.ts
@@ -1,0 +1,60 @@
+import {
+	DataHelper,
+	LoginFlow,
+	NewPostFlow,
+	GutenbergEditorPage,
+	setupHooks,
+} from '@automattic/calypso-e2e';
+import { Page, Frame } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( `Tracks Events for Post Editor` ), function () {
+	let page: Page;
+	const mainUser = 'gutenbergSimpleSiteUser';
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginFlow = new LoginFlow( page, mainUser );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+	} );
+
+	it( 'Enter post title', async function () {
+		const gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.enterTitle( DataHelper.getRandomPhrase() );
+	} );
+
+	it( 'Tracks "wpcom_block_editor_post_publish_add_new_click" event', async function () {
+		const gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.publish();
+		// Get the frame before creating the new post because we won't be able to access it once navigation starts
+		const frame = await gutenbergEditorPage.waitUntilLoaded();
+		await gutenbergEditorPage.postPublishAddNewItem( { noWaitAfter: true } );
+
+		expect( await getLatestEvent( frame ) ).toMatchObject( [
+			'wpcom_block_editor_post_publish_add_new_click',
+			expect.objectContaining( {
+				_en: 'wpcom_block_editor_post_publish_add_new_click',
+				editor_type: 'post',
+				post_type: 'post',
+			} ),
+		] );
+	} );
+} );
+
+async function getLatestEvent( frame: Frame ) {
+	const stack = await getEventsStack( frame );
+	return stack.length ? stack[ 0 ] : undefined;
+}
+
+async function getEventsStack( frame: Frame ) {
+	return await frame.evaluate( () => {
+		return ( window as any )._e2eEventsStack;
+	} );
+}

--- a/test/e2e/specs/specs-playwright/wp-editor__tracks-events.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__tracks-events.ts
@@ -5,7 +5,8 @@ import {
 	GutenbergEditorPage,
 	setupHooks,
 } from '@automattic/calypso-e2e';
-import { Page, Frame } from 'playwright';
+import { Page } from 'playwright';
+import { getLatestEvent } from '../../lib/gutenberg/tracking/playwright-utils';
 
 describe( DataHelper.createSuiteTitle( `Tracks Events for Post Editor` ), function () {
 	let page: Page;
@@ -47,14 +48,3 @@ describe( DataHelper.createSuiteTitle( `Tracks Events for Post Editor` ), functi
 		] );
 	} );
 } );
-
-async function getLatestEvent( frame: Frame ) {
-	const stack = await getEventsStack( frame );
-	return stack.length ? stack[ 0 ] : undefined;
-}
-
-async function getEventsStack( frame: Frame ) {
-	return await frame.evaluate( () => {
-		return ( window as any )._e2eEventsStack;
-	} );
-}

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "@automattic/calypso-build/typescript/ts-package.json",
 	"compilerOptions": {
 		"noEmit": true, // just type checking, no output. The output is handled by babel.
-        "types": [ "jest" ] // no mocha - we are only using TypeScript for the new Playwright scripts
-    },
-	"include": [ "specs/specs-playwright" ] // TypeScript is scoped only for the new Playwright scripts
+		"types": [ "jest" ] // no mocha - we are only using TypeScript for the new Playwright scripts
+	},
+	// TypeScript is scoped only for the new Playwright scripts
+	"include": [ "specs/specs-playwright", "lib/gutenberg/tracking" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#55419 adds a `wpcom_block_editor_post_publish_add_new_click` tracks event to the block editor. Because it relies on a CSS selector it is likely to break in the future. This e2e test will notify us if that happens.

Our other tests for block editor analytics are in the Selenium tests, and support testing both page and post editors. This test is just to get things started in playwright.

- Add support for the new "add new" post-publish button to the `GutenbergEditorPage.publish()` test method
- Add `waitForNavigation` flag to `GutenbergEditorPage.publish()` test method so that we can test for tracks events before page navigation completes
- Test the `wpcom_block_editor_post_publish_add_new_click` event is being sent in the post editor

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the `Tracks "wpcom_block_editor_post_publish_add_new_click" event` test is being run in CI

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

