### PR TITLE
Checkout: Move Sofort payment method to wpcom-checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -1,10 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	createAlipayMethod,
-	createAlipayPaymentMethodStore,
-	createSofortMethod,
-	createSofortPaymentMethodStore,
-} from '@automattic/composite-checkout';
+import { createAlipayMethod, createAlipayPaymentMethodStore } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	createApplePayMethod,
@@ -20,6 +15,8 @@ import {
 	createPayPalMethod,
 	createIdealMethod,
 	createIdealPaymentMethodStore,
+	createSofortMethod,
+	createSofortPaymentMethodStore,
 } from '@automattic/wpcom-checkout';
 import { useMemo } from 'react';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -210,13 +210,9 @@ function useCreateWeChat( {
 function useCreateIdeal( {
 	isStripeLoading,
 	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	stripeConfiguration: StripeConfiguration | null;
-	stripe: Stripe | null;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createIdealPaymentMethodStore(), [] );
@@ -225,24 +221,18 @@ function useCreateIdeal( {
 			shouldLoad
 				? createIdealMethod( {
 						store: paymentMethodStore,
-						stripe,
-						stripeConfiguration,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+		[ shouldLoad, paymentMethodStore ]
 	);
 }
 
 function useCreateSofort( {
 	isStripeLoading,
 	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	stripeConfiguration: StripeConfiguration | null;
-	stripe: Stripe | null;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createSofortPaymentMethodStore(), [] );
@@ -251,24 +241,18 @@ function useCreateSofort( {
 			shouldLoad
 				? createSofortMethod( {
 						store: paymentMethodStore,
-						stripe,
-						stripeConfiguration,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+		[ shouldLoad, paymentMethodStore ]
 	);
 }
 
 function useCreateEps( {
 	isStripeLoading,
 	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	stripeConfiguration: StripeConfiguration | null;
-	stripe: Stripe | null;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createEpsPaymentMethodStore(), [] );
@@ -277,11 +261,9 @@ function useCreateEps( {
 			shouldLoad
 				? createEpsMethod( {
 						store: paymentMethodStore,
-						stripe,
-						stripeConfiguration,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+		[ shouldLoad, paymentMethodStore ]
 	);
 }
 
@@ -402,8 +384,6 @@ export default function useCreatePaymentMethods( {
 	const idealMethod = useCreateIdeal( {
 		isStripeLoading,
 		stripeLoadingError,
-		stripeConfiguration,
-		stripe,
 	} );
 
 	const alipayMethod = useCreateAlipay( {
@@ -431,8 +411,6 @@ export default function useCreatePaymentMethods( {
 	const epsMethod = useCreateEps( {
 		isStripeLoading,
 		stripeLoadingError,
-		stripeConfiguration,
-		stripe,
 	} );
 
 	const ebanxTefMethod = useCreateEbanxTef();
@@ -442,8 +420,6 @@ export default function useCreatePaymentMethods( {
 	const sofortMethod = useCreateSofort( {
 		isStripeLoading,
 		stripeLoadingError,
-		stripeConfiguration,
-		stripe,
 	} );
 
 	const wechatMethod = useCreateWeChat( {

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -45,7 +45,6 @@ import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
 import { createAlipayPaymentMethodStore, createAlipayMethod } from './lib/payment-methods/alipay';
 import PaymentLogo from './lib/payment-methods/payment-logo';
-import { createSofortPaymentMethodStore, createSofortMethod } from './lib/payment-methods/sofort';
 import {
 	createStripeMethod,
 	createStripePaymentMethodStore,
@@ -105,8 +104,6 @@ export {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createRegistry,
-	createSofortMethod,
-	createSofortPaymentMethodStore,
 	createStripeMethod,
 	createStripePaymentMethodStore,
 	defaultRegistry,

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -12,6 +12,7 @@ export { default as styled } from './styled';
 export * from './payment-methods/bancontact';
 export * from './payment-methods/giropay';
 export * from './payment-methods/ideal';
+export * from './payment-methods/sofort';
 export * from './payment-methods/p24';
 export * from './payment-methods/eps';
 export * from './use-is-web-payment-available';

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -1,39 +1,64 @@
-import styled from '@emotion/styled';
+import {
+	Button,
+	FormStatus,
+	useLineItems,
+	useFormStatus,
+	registerStore,
+	useSelect,
+	useDispatch,
+} from '@automattic/composite-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import React from 'react';
-import Button from '../../components/button';
-import Field from '../../components/field';
-import { registerStore, useSelect, useDispatch } from '../../lib/registry';
-import { FormStatus, useLineItems } from '../../public-api';
-import { useFormStatus } from '../form-status';
-import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import Field from '../field';
+import { PaymentMethodLogos } from '../payment-method-logos';
+import styled from '../styled';
+import { SummaryLine, SummaryDetails } from '../summary-details';
+import type {
+	PaymentMethodStore,
+	StoreSelectors,
+	StoreSelectorsWithState,
+	StoreActions,
+	StoreState,
+} from '../payment-method-store';
+import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
-const debug = debugFactory( 'composite-checkout:sofort-payment-method' );
+const debug = debugFactory( 'wpcom-checkout:sofort-payment-method' );
 
-export function createSofortPaymentMethodStore() {
+// Disabling this to make migration easier
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+type StoreKey = 'sofort';
+type NounsInStore = 'customerName';
+type SofortStore = PaymentMethodStore< NounsInStore >;
+
+declare module '@wordpress/data' {
+	function select( key: StoreKey ): StoreSelectors< NounsInStore >;
+	function dispatch( key: StoreKey ): StoreActions< NounsInStore >;
+}
+
+const actions: StoreActions< NounsInStore > = {
+	changeCustomerName( payload ) {
+		return { type: 'CUSTOMER_NAME_SET', payload };
+	},
+};
+
+const selectors: StoreSelectorsWithState< NounsInStore > = {
+	getCustomerName( state ) {
+		return state.customerName || '';
+	},
+};
+
+export function createSofortPaymentMethodStore(): SofortStore {
 	debug( 'creating a new sofort payment method store' );
-	const actions = {
-		changeCustomerName( payload ) {
-			return { type: 'CUSTOMER_NAME_SET', payload };
-		},
-	};
-
-	const selectors = {
-		getCustomerName( state ) {
-			return state.customerName || '';
-		},
-	};
-
 	const store = registerStore( 'sofort', {
 		reducer(
-			state = {
+			state: StoreState< NounsInStore > = {
 				customerName: { value: '', isTouched: false },
 			},
 			action
-		) {
+		): StoreState< NounsInStore > {
 			switch ( action.type ) {
 				case 'CUSTOMER_NAME_SET':
 					return { ...state, customerName: { value: action.payload, isTouched: true } };
@@ -44,23 +69,17 @@ export function createSofortPaymentMethodStore() {
 		selectors,
 	} );
 
-	return { ...store, actions, selectors };
+	return store;
 }
 
-export function createSofortMethod( { store, stripe, stripeConfiguration } ) {
+export function createSofortMethod( { store }: { store: SofortStore } ): PaymentMethod {
 	return {
 		id: 'sofort',
 		label: <SofortLabel />,
-		activeContent: <SofortFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />,
-		submitButton: (
-			<SofortPayButton
-				store={ store }
-				stripe={ stripe }
-				stripeConfiguration={ stripeConfiguration }
-			/>
-		),
+		activeContent: <SofortFields />,
+		submitButton: <SofortPayButton store={ store } />,
 		inactiveContent: <SofortSummary />,
-		getAriaLabel: ( __ ) => __( 'Sofort' ),
+		getAriaLabel: () => 'Sofort',
 	};
 }
 
@@ -118,10 +137,27 @@ const SofortField = styled( Field )`
 	}
 `;
 
-function SofortPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
+function SofortPayButton( {
+	disabled,
+	onClick,
+	store,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+	store: SofortStore;
+} ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; SofortPayButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
 
 	return (
 		<Button
@@ -130,11 +166,9 @@ function SofortPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 				if ( isFormValid( store ) ) {
 					debug( 'submitting sofort payment' );
 					onClick( 'sofort', {
-						stripe,
 						name: customerName?.value,
 						items,
 						total,
-						stripeConfiguration,
 					} );
 				}
 			} }
@@ -147,16 +181,16 @@ function SofortPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 	);
 }
 
-function ButtonContents( { formStatus, total } ) {
+function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
-		return __( 'Processing…' );
+		return <>{ __( 'Processing…' ) }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		/* translators: %s is the total to be paid in localized currency */
-		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
+		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
 	}
-	return __( 'Please wait…' );
+	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function SofortSummary() {
@@ -169,12 +203,12 @@ function SofortSummary() {
 	);
 }
 
-function isFormValid( store ) {
-	const customerName = store.selectors.getCustomerName( store.getState() );
+function isFormValid( store: SofortStore ): boolean {
+	const customerName = selectors.getCustomerName( store.getState() );
 
 	if ( ! customerName?.value.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( store.actions.changeCustomerName( '' ) );
+		store.dispatch( actions.changeCustomerName( '' ) );
 		return false;
 	}
 	return true;
@@ -196,6 +230,6 @@ const SofortLogo = styled( SofortLogoImg )`
 	width: 64px;
 `;
 
-function SofortLogoImg( { className } ) {
+function SofortLogoImg( { className }: { className?: string } ) {
 	return <img src="/calypso/images/upgrades/sofort.svg" alt="Sofort" className={ className } />;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the Sofort payment method from the `@automattic/composite-checkout` package into the `@automattic/wpcom-checkout` package and converts it to TypeScript. This is similar to how Bancontact was moved in https://github.com/Automattic/wp-calypso/pull/51690, Giropay in https://github.com/Automattic/wp-calypso/pull/53346, iDEAL in https://github.com/Automattic/wp-calypso/pull/54940, and p24 in https://github.com/Automattic/wp-calypso/pull/53510 This is related to the refactoring of https://github.com/Automattic/wp-calypso/issues/52215

#### Background

The `composite-checkout` package is intended to be a fairly generic checkout-building toolkit. As part of this we originally envisioned it containing various payment methods, but that quickly became a problem as it became clear that the payment methods we use on WordPress.com are pretty specific to our platform. To reduce leaky abstractions, we moved many of our payment methods over to calypso, but some have remained because the cost of moving them seemed too high for the benefit.

As we prepare to publish version 1.0.0 of the `@automattic/composite-checkout` package on npm, I think it's a good time to clean up extraneous parts of the package. The payment methods are the only part of the package that are not fully TypeScript and are also still pretty specific to our WordPress.com infrastructure. Eventually it would be nice to convert them all to TypeScript and put them in a package like `@automattic/wpcom-checkout` (which is intended to be WordPress.com specific). This PR converts one such payment method and moves it there.

#### Testing instructions

- Apply D45520-code to your sandbox and sandbox the API to force Sofort to be available.
- Set your user's currency to `EUR`.
- Visit checkout with a product in your cart.
- Verify that Sofort shows up as an available payment method.
- Select Sofort, fill in any string as the name.
- Click to submit the purchase.
- Verify that you're redirected to the Stripe test page.
- Verify that the information in the Stripe test page shows the correct total, name, and bank. (No need to confirm the payment.)