### PR TITLE
Change how we show the transfer price when it is included in a plan

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -32,6 +32,7 @@ export default function OptionContent( {
 	} );
 	const pricingCostClasses = classNames( 'option-content__pricing-cost', {
 		[ 'has-sale-price' ]: pricing?.sale,
+		[ 'is-free' ]: pricing?.isFree,
 	} );
 
 	return (

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -135,7 +135,8 @@
 							}
 						}
 
-						&.has-sale-price {
+						&.has-sale-price,
+						&.is-free {
 							text-decoration: line-through;
 						}
 					}

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -13,7 +13,7 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	let domainProductFreeText = null;
 
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
-		domainProductFreeText = __( 'Free transfer with your plan' );
+		domainProductFreeText = __( 'Free one year renewal with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
 		domainProductFreeText = __( 'Included in paid plans' );
 	}

--- a/client/components/domains/use-my-domain/utilities/get-transfer-price-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-price-text.js
@@ -5,20 +5,14 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import { getDomainPrice, getDomainProductSlug } from 'calypso/lib/domains';
 
-export function getTransferPriceText( { cart, currencyCode, domain, productsList } ) {
+export function getTransferPriceText( { currencyCode, domain, productsList } ) {
 	const productSlug = getDomainProductSlug( domain );
 	const domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
 
 	if ( ! domainProductPrice ) {
 		return;
-	}
-
-	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
-		/* translators: %s - the domain renewal price formatted in the user's currency */
-		return sprintf( __( 'Renews at %s' ), domainProductPrice );
 	}
 
 	/* translators: %s - the domain price formatted in the user's currency */


### PR DESCRIPTION
We've discussed making more clear that the transfer will renew your domain for one year

#### Changes proposed in this Pull Request

* Change the text on the transfer page to show that you'll get renewal for free
* Change the price to be strikethrough since you won't be charged for the transfer

Before:
<img width="1053" alt="Screenshot 2021-08-25 at 11 30 43" src="https://user-images.githubusercontent.com/1355045/130756464-f6944a25-b047-47b2-84cf-4b1426be176f.png">

After:
<img width="1059" alt="Screenshot 2021-08-25 at 11 30 21" src="https://user-images.githubusercontent.com/1355045/130756479-a50b3e8b-3030-4a93-8e4e-d30f01086c31.png">


#### Testing instructions

* Spin up the Calypso branch and navigate to `domains/add/use-my-domain/{your-site-address}` with site that has an active plan but unused domain credit and verify that the transfer price will be rendered as strikethrough and that the text above it says "Free one year renewal with your plan"

