### PR TITLE
i18n: Fix DotPager navigation arrows direction for RTL languages

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -1,7 +1,7 @@
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, arrowRight } from '@wordpress/icons';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
 import React, { Children, useState, useEffect, useRef } from 'react';
 
@@ -9,6 +9,7 @@ import './style.scss';
 
 const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setCurrentPage } ) => {
 	const translate = useTranslate();
+	const isRtl = useRtl();
 	if ( numberOfPages < 2 ) {
 		return null;
 	}
@@ -43,7 +44,10 @@ const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setC
 						icon={ arrowRight }
 						size={ 18 }
 						fill="currentColor"
-						style={ { transform: 'scaleX(-1)' } }
+						style={
+							/* Flip the icon for languages with LTR direction. */
+							! isRtl ? { transform: 'scaleX(-1)' } : null
+						}
 					/>
 					{ showControlLabels && translate( 'Previous' ) }
 				</button>
@@ -56,7 +60,15 @@ const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setC
 					onClick={ () => setCurrentPage( currentPage + 1 ) }
 				>
 					{ showControlLabels && translate( 'Next' ) }
-					<Icon icon={ arrowRight } size={ 18 } fill="currentColor" />
+					<Icon
+						icon={ arrowRight }
+						size={ 18 }
+						fill="currentColor"
+						style={
+							/* Flip the icon for languages with RTL direction. */
+							isRtl ? { transform: 'scaleX(-1)' } : null
+						}
+					/>
 				</button>
 			</li>
 		</ul>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix DotPager navigation arrows direction for RTL languages.

**Before:**
![CleanShot 2021-08-25 at 13 05 47](https://user-images.githubusercontent.com/2722412/130771701-f060fcde-9ece-4a3a-ad76-866df8294420.png)

**After:**
![CleanShot 2021-08-25 at 13 07 25](https://user-images.githubusercontent.com/2722412/130771690-c1d7103c-9943-44de-a8ba-f29812a9204c.png)


#### Testing instructions

* Switch UI RTL language and confirm `DotPager` (e.g. `/home/{site}`) navigation arrows are pointing in the correct direction for RTL language.
* Switch UI LTR language and confirm are also in the correct direction.

Related to https://github.com/Automattic/wp-calypso/pull/55684#pullrequestreview-737608735
