### PR TITLE
Use the sans font for modal text and not a serif font

### DIFF
--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -124,7 +124,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 .modal__text {
 	padding: 1em 2em 1em 0;
 	margin: 0;
-	font-family: $serif;
+	font-family: $sans;
 	font-size: $font-body-small;
 
 	button,a {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the modal text to use a sans font instead of a serif font.