### PR TITLE
Add UPS Shipping hardcoded Woo extension to Calypso test marketplace

### DIFF
--- a/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
+++ b/client/my-sites/marketplace/marketplace-product-definitions/index.tsx
@@ -1,4 +1,4 @@
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+import { YOAST_PREMIUM, YOAST_FREE, WOO_UPS_SHIPPING } from '@automattic/calypso-products';
 import { marketplaceDebugger } from 'calypso/my-sites/marketplace/constants';
 import {
 	IProductDefinition,
@@ -9,8 +9,9 @@ import {
 /**
  * A set of logical product groups, grouped by actual products, to be shown in one product (group) page
  * i.e. : YOAST_PREMIUM, YOAST_FREE are 2 products that belong to the product group YOAST
- * */
+ */
 export const YOAST = 'YOAST';
+export const WOO = 'WOO';
 
 export const productGroups: IProductGroupCollection = {
 	[ YOAST ]: {
@@ -26,6 +27,16 @@ export const productGroups: IProductGroupCollection = {
 				defaultPluginSlug: 'wordpress-seo',
 				pluginsToBeInstalled: [ 'wordpress-seo' ],
 				isPurchasableProduct: false,
+			},
+		},
+	},
+	[ WOO ]: {
+		products: {
+			[ WOO_UPS_SHIPPING ]: {
+				productName: 'UPS Shipping',
+				defaultPluginSlug: 'woocommerce-shipping-ups',
+				pluginsToBeInstalled: [ 'woocommerce-shipping-ups', 'woocommerce' ],
+				isPurchasableProduct: true,
 			},
 		},
 	},

--- a/client/my-sites/marketplace/pages/marketplace-test/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.tsx
@@ -1,4 +1,4 @@
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
+import { YOAST_PREMIUM, YOAST_FREE, WOO_UPS_SHIPPING } from '@automattic/calypso-products';
 import { Button, Card, CompactCard } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -11,7 +11,7 @@ import { WarningList } from 'calypso/blocks/eligibility-warnings/warning-list';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
-import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import { YOAST, WOO } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import AdminMenuFetch from 'calypso/my-sites/marketplace/pages/marketplace-test/admin-menu-fetch';
 import ComponentDemo from 'calypso/my-sites/marketplace/pages/marketplace-test/component-demo';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
@@ -79,6 +79,10 @@ export default function MarketplaceTest(): JSX.Element {
 		{
 			name: 'Yoast Free Details Page',
 			path: `/marketplace/product/details/${ YOAST }/${ YOAST_FREE }`,
+		},
+		{
+			name: 'UPS Shipping Details Page',
+			path: `/marketplace/product/details/${ WOO }/${ WOO_UPS_SHIPPING }`,
 		},
 		{ name: 'Loading Page', path: '/marketplace/product/setup' },
 		{ name: 'Domains Page', path: '/marketplace/domain' },

--- a/client/my-sites/marketplace/types.ts
+++ b/client/my-sites/marketplace/types.ts
@@ -1,18 +1,18 @@
-import { YOAST_PREMIUM, YOAST_FREE } from '@automattic/calypso-products';
-import { YOAST } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
+import { YOAST_PREMIUM, YOAST_FREE, WOO_UPS_SHIPPING } from '@automattic/calypso-products';
+import { YOAST, WOO } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 export interface IProductDefinition {
 	productName: string;
 
 	/**
 	 * Some plugins may not be available in the calypso product library ( i.e. wordpress-seo-premium ) so we specify a default plugin that is accessible in the product library
 	 * so that relevant details can be shown
-	 * */
+	 */
 	defaultPluginSlug: string;
 
 	/**
 	 * While this array is not in use right now, it indicates the plugins that need to be installed as part of the product
 	 * Eventually when moving this logic to the backend this can be part of the Market Place product entity
-	 * */
+	 */
 	pluginsToBeInstalled: string[];
 
 	/**
@@ -20,20 +20,24 @@ export interface IProductDefinition {
 	 * We have however introduced dummy products in the calypso product library so that we can maintain a product details in declarative data structure.
 	 * Hence the product is not purchasable ( and is a dummy product i.e. yoast_free ) we maintain a flag to indicate this.
 	 *
-	 * */
+	 */
 	isPurchasableProduct: boolean;
 }
 
 export interface IProductCollection {
-	[ YOAST_PREMIUM ]: IProductDefinition;
-	[ YOAST_FREE ]: IProductDefinition;
+	[ YOAST_PREMIUM ]?: IProductDefinition;
+	[ YOAST_FREE ]?: IProductDefinition;
+	[ WOO_UPS_SHIPPING ]?: IProductDefinition;
 }
 
 /**
  * IProductGroupCollection is a one-to-many mapping between logical product groups and actual products
- * */
+ */
 export interface IProductGroupCollection {
 	[ YOAST ]?: {
+		products: IProductCollection;
+	};
+	[ WOO ]?: {
 		products: IProductCollection;
 	};
 }

--- a/packages/calypso-products/src/constants/marketplace.ts
+++ b/packages/calypso-products/src/constants/marketplace.ts
@@ -1,3 +1,4 @@
 export const YOAST_PREMIUM = 'yoast_premium';
 export const YOAST_FREE = 'yoast_free';
-export const MARKETPLACE_PRODUCTS = [ YOAST_PREMIUM, YOAST_FREE ];
+export const WOO_UPS_SHIPPING = 'woocommerce-shipping-ups';
+export const MARKETPLACE_PRODUCTS = [ YOAST_PREMIUM, YOAST_FREE, WOO_UPS_SHIPPING ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add UPS Shipping to test marketplace

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/marketplace/test/[domain]` with a domain that has a domain name
* Click UPS Shipping and add it to cart
* Go through to the checkout and purchase the extension
* You will notice it won't complete the "Install & Activation" steps because the infrastructure isn't in place for this yet
* Check in Store Admin you've now got a subscription for UPS Shipping on your site

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/55586