### PR TITLE
Render hierarchical pages before last page loads

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -273,17 +273,13 @@ class Pages extends Component {
 	}
 
 	renderPagesList( { pages } ) {
-		const { site, lastPage, query, showPublishedStatus } = this.props;
+		const { site, query, showPublishedStatus } = this.props;
 
 		// Pages only display hierarchically for published pages on single-sites when
-		// there are 100 or fewer pages and no more pages to load (last page).
+		// there are 100 or fewer pages.
 		// Pages are not displayed hierarchically for search.
 		const showHierarchical =
-			site &&
-			query.status === 'publish,private' &&
-			lastPage &&
-			pages.length <= 100 &&
-			! query.search;
+			site && query.status === 'publish,private' && pages.length <= 100 && ! query.search;
 
 		return showHierarchical
 			? this.renderHierarchical( { pages, site, showPublishedStatus } )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the current design, the pages are not rendered hierarchically, unless last page loads. Last page is loaded by simply scrolling to the end. This makes the UI jump from linear to hierarchical linear by merely scrolling. This PR decouples this from scrolling.

### Testing 

1. Run Calypso locally.
2. Go to pages on a site with many pages<sup>1</sup>.
3. Make sure the UI is stable after scrolling.

<sup>1</sup> you can see a site with the issue here: 19733443-hc

Fixes https://github.com/Automattic/wp-calypso/issues/51610