### PR TITLE
Add account-only SSO signup flow

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -128,5 +128,12 @@ export function getSignupUrl(
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 	}
 
+	if ( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) ) {
+		const params = new URLSearchParams( {
+			redirect_to: redirectTo,
+		} );
+		signupUrl = `/start/account?${ params.toString() }`;
+	}
+
 	return signupUrl;
 }

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -48,7 +48,9 @@ export function login( {
 	}
 
 	if ( redirectTo ) {
-		url = addQueryArgs( { redirect_to: redirectTo }, url );
+		url = redirectTo.includes( 'jetpack-sso' )
+			? redirectTo
+			: addQueryArgs( { redirect_to: redirectTo }, url );
 	}
 
 	if ( emailAddress ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,7 +16,7 @@ export function generateFlows( {
 		{
 			name: 'account',
 			steps: [ 'user' ],
-			destination: '/',
+			destination: getRedirectDestination,
 			description: 'Create an account without a blog.',
 			lastModified: '2020-08-12',
 			pageTitle: translate( 'Create an account' ),

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -47,6 +47,8 @@ function getRedirectDestination( dependencies ) {
 			new URL( dependencies.oauth2_redirect ).host === 'public-api.wordpress.com'
 		) {
 			return dependencies.oauth2_redirect;
+		} else if ( dependencies.redirect ) {
+			return dependencies.redirect;
 		}
 	} catch {
 		return '/';

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -139,7 +139,7 @@ export function generateSteps( {
 				'marketing_price_group',
 				'plans_reorder_abtest_variation',
 			],
-			optionalDependencies: [ 'plans_reorder_abtest_variation' ],
+			optionalDependencies: [ 'plans_reorder_abtest_variation', 'redirect' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -138,6 +138,7 @@ export function generateSteps( {
 				'username',
 				'marketing_price_group',
 				'plans_reorder_abtest_variation',
+				'redirect',
 			],
 			optionalDependencies: [ 'plans_reorder_abtest_variation', 'redirect' ],
 			props: {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -50,6 +50,9 @@ function getRedirectToAfterLoginUrl( {
 	) {
 		return initialContext.query.oauth2_redirect;
 	}
+	if ( initialContext?.canonicalPath?.startsWith( '/start/account' ) ) {
+		return initialContext.query.redirect_to;
+	}
 
 	const stepAfterRedirect =
 		getNextStepName( flowName, stepName, userLoggedIn ) ||
@@ -404,32 +407,6 @@ export class UserStep extends Component {
 		}
 
 		return headerText;
-	}
-
-	getRedirectToAfterLoginUrl() {
-		if (
-			this.props.oauth2Signup &&
-			this.props.initialContext &&
-			this.props.initialContext.query.oauth2_redirect &&
-			this.isOauth2RedirectValid( this.props.initialContext.query.oauth2_redirect )
-		) {
-			return this.props.initialContext.query.oauth2_redirect;
-		}
-		if ( this.props.initialContext?.canonicalPath?.startsWith( '/start/account' ) ) {
-			return this.props.initialContext.query.redirect_to;
-		}
-
-		const stepAfterRedirect =
-			getNextStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn ) ||
-			getPreviousStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn );
-		const queryArgs = new URLSearchParams( this.props?.initialContext?.query );
-		const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
-
-		return (
-			window.location.origin +
-			getStepUrl( this.props.flowName, stepAfterRedirect ) +
-			queryArgsString
-		);
 	}
 
 	submitButtonText() {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -255,6 +255,8 @@ export class UserStep extends Component {
 		if ( oauth2Signup ) {
 			dependencies.oauth2_client_id = data.queryArgs.oauth2_client_id;
 			dependencies.oauth2_redirect = data.queryArgs.oauth2_redirect;
+		} else if ( data.queryArgs.redirect_to ) {
+			dependencies.redirect = data.queryArgs.redirect_to;
 		}
 
 		this.props.submitSignupStep(
@@ -402,6 +404,32 @@ export class UserStep extends Component {
 		}
 
 		return headerText;
+	}
+
+	getRedirectToAfterLoginUrl() {
+		if (
+			this.props.oauth2Signup &&
+			this.props.initialContext &&
+			this.props.initialContext.query.oauth2_redirect &&
+			this.isOauth2RedirectValid( this.props.initialContext.query.oauth2_redirect )
+		) {
+			return this.props.initialContext.query.oauth2_redirect;
+		}
+		if ( this.props.initialContext?.canonicalPath?.startsWith( '/start/account' ) ) {
+			return this.props.initialContext.query.redirect_to;
+		}
+
+		const stepAfterRedirect =
+			getNextStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn ) ||
+			getPreviousStepName( this.props.flowName, this.props.stepName, this.props.userLoggedIn );
+		const queryArgs = new URLSearchParams( this.props?.initialContext?.query );
+		const queryArgsString = queryArgs.toString() ? '?' + queryArgs.toString() : '';
+
+		return (
+			window.location.origin +
+			getStepUrl( this.props.flowName, stepAfterRedirect ) +
+			queryArgsString
+		);
 	}
 
 	submitButtonText() {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -77,6 +77,8 @@ export const redirectTo = combineReducers( {
 				const { path, query } = action;
 				if ( startsWith( path, '/log-in' ) ) {
 					return query.redirect_to || state;
+				} else if ( startsWith( path, '/start/account' ) ) {
+					return query.redirect_to || state;
 				} else if ( '/jetpack/connect/authorize' === path ) {
 					return addQueryArgs( query, path );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a case for user-only account flow for Jetpack SSO.
* It's a follow-up to #54715, which was reverted due to a regression.
* This PR fixes that regression by making `redirect` an optional dependency.
* Details about the regression are at p58i-b21-p2.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso
* Open `https://clear-tiglon.jurassic.ninja/wp-admin/`  in an Incognito window.
* Click "Log in with WordPress.com"
* Click "Create a new account" and confirm that you're taken to /start/account/PARAMS
* Grab that path, including params, and paste add it onto calypso.localhost:3000
* Confirm that you're taken through the user-only flow and redirected to the expected site.
* Test the core signup, account, and site creation flow to ensure those still work as expected.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54715
