### PR TITLE
e2e tests - wp-site-editor-spec to handle GUTENBERG_EDGE environment appropriately

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-site-editor-spec.js
@@ -9,14 +9,18 @@ import SiteEditorPage from '../../lib/pages/site-editor-page.js';
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
-const gutenbergUser = 'siteEditorSimpleSiteUser';
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true'
+		? 'siteEditorSimpleSiteEdgeUser'
+		: 'siteEditorSimpleSiteUser';
 
 describe( `[${ host }] Site Editor (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	it( 'Can log in', async function () {
 		this.loginFlow = new LoginFlow( this.driver, gutenbergUser );
-		await this.loginFlow.loginAndSelectMySite();
+		const userConfig = dataHelper.getAccountConfig( gutenbergUser );
+		await this.loginFlow.loginAndSelectMySite( userConfig[ 2 ] );
 	} );
 
 	it( 'Can open site editor', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the wp-site-editor-spec to run tests on the edge enabled test site when the GUTENBERG_EDGE sticker is set.

Currently (on trunk), tests are run on the same site regardless of whether GUTENBERG_EDGE is specified int he environment.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
If you haven't done so very recently, decrypt the `encrypted.enc` e2e test config file by following these instructions PCYsg-vnR-p2

Verify that the correct sites are used for the test with and without the GUTENBERG_EDGE flag.

One way to do this is to run the test suite locally and visibly note which site is being used.  change directory to `test/e2e`, and run the following command `env GUTENBERG_EDGE=true ./node_modules/.bin/mocha specs/specs-wpcom/wp-site-editor-spec.js`

Verify the appropriate site is switched to and loaded in the editor.  A simple way to tell at this point in time is visually, as the edge site will have mayland blocks starter content in the body:

<img src="https://user-images.githubusercontent.com/28742426/130834339-074ca330-8dc0-4ce8-bcae-774d3aca1d30.png" width='400px' />

Now, run the tests again without the edge flag: `env GUTENBERG_EDGE=false ./node_modules/.bin/mocha specs/specs-wpcom/wp-site-editor-spec.js` and verify the non-edge site is loaded.  This can be noted visually as the body content of the non-edge site is that of tt1-blocks:

<img src="https://user-images.githubusercontent.com/28742426/130834815-f939badf-92d2-4cb0-a343-7c3976b9ebcc.png" width='400px' />


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #