### PR TITLE
Change translation context into a comment

### DIFF
--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -312,7 +312,7 @@ function ReceiptLineItems( { transaction } ) {
 					<tr>
 						<td className="billing-history__receipt-desc">
 							<strong>
-								{ translate( 'Total paid:', { context: 'Total amount paid for product' } ) }
+								{ translate( 'Total paid:', { comment: 'Total amount paid for product' } ) }
 							</strong>
 						</td>
 						<td


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The 'Total paid:' line item in the billing receipt is currently using the context property, it was proposed that this be [changed into a comment](https://github.com/Automattic/wp-calypso/pull/55481#discussion_r692374440) instead. 

#### Testing instructions

Open this file, ensure the translation function on line 322 is using a comment rather than a context property.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55481
