### PR TITLE
Protect mutation observer call

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -744,10 +744,12 @@ async function openLinksInParentFrame( calypsoPort ) {
 					const componentsPanel = node.querySelector(
 						'.interface-interface-skeleton__sidebar .components-panel, .edit-post-sidebar .components-panel'
 					);
-					createNewPostLinkObserver.observe( componentsPanel, {
-						childList: true,
-						subtree: true,
-					} );
+					if ( componentsPanel ) {
+						createNewPostLinkObserver.observe( componentsPanel, {
+							childList: true,
+							subtree: true,
+						} );
+					}
 					// If a Query block is selected, then the sidebar will
 					// directly open on the block settings tab
 					tryToReplaceCreateNewPostLink();


### PR DESCRIPTION
### Changes proposed in this Pull Request
@adamziel brought this error to our attention:

```
TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
&nbsp; &nbsp; at MutationObserver.<anonymous> (https://widgets.wp.com/wpcom-block-editor/calypso.editor.min.js?ver=20210815225617:1:16630)
```

It happens on the call to `observe` at this line in the code, so I assume the `querySelector` sometimes doesn't find the object it's looking for. I think the easiest option is to protect the call. Since I don't really know what this code does, I'm not sure how to make it more reliable. 

### Testing instructions
This should have no impact on testing flows, but you can copy wpcom-block-editor to your sandbox, sandbox widgets.wp.com, and test that the editor works.