### PR TITLE
Update foreground color on domain premium badge

### DIFF
--- a/client/components/domains/premium-badge/style.scss
+++ b/client/components/domains/premium-badge/style.scss
@@ -1,14 +1,14 @@
 div.premium-badge {
 	background-color: var( --color-premium-domain );
 	padding-right: 6px;
-	color: var( --color-text-inverted );
+	color: var( --color-warning-80 );
 	.info-popover {
 		height: 16px;
 		vertical-align: middle;
 		margin-bottom: 1px;
 		margin-left: 5px;
 		.gridicon {
-			color: var( --color-text-inverted );
+			color: var( --color-warning-80 );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The text color on the premium domain badges was set to `#fff` which made it hard to read. This should match the domain "sale" badge color which is `var( --color-warning-80 )`.

Before:

<img width="422" alt="Screen Shot 2021-08-25 at 4 38 13 PM" src="https://user-images.githubusercontent.com/1379730/130861426-b4665d8d-3949-41c4-9c50-116404191483.png">


After:

<img width="422" alt="Screen Shot 2021-08-25 at 4 38 17 PM" src="https://user-images.githubusercontent.com/1379730/130861443-ad023bd5-5570-4157-bc89-e1826dd708e7.png">


#### Testing instructions

From domain search, select a premium domain such as "foods.blog" and make sure that the text and icon color are the dark brown color as in the example "After" screenshot above instead of white.