### PR TITLE
Checkout: Move CheckoutSummaryLineItem/Total to wpcom-checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -10,8 +10,10 @@ import {
 	getCouponLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
+	CheckoutSummaryLineItem,
+	CheckoutSummaryTotal,
+	pulse,
 } from '@automattic/wpcom-checkout';
-import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -272,14 +274,6 @@ function CheckoutSummaryPlanFeatures( { siteId } ) {
 	);
 }
 
-const pulse = keyframes`
-	0% { opacity: 1; }
-
-	70% { opacity: 0.25; }
-
-	100% { opacity: 1; }
-`;
-
 const CheckoutSummaryCard = styled( CheckoutSummaryCardUnstyled )`
 	border-bottom: none 0;
 `;
@@ -357,21 +351,6 @@ const CheckoutSummaryAmountWrapper = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	}
-`;
-
-const CheckoutSummaryLineItem = styled.div`
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	margin-bottom: 4px;
-
-	.is-loading & {
-		animation: ${ pulse } 1.5s ease-in-out infinite;
-	}
-`;
-
-const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
-	font-weight: ${ ( props ) => props.theme.weights.bold };
 `;
 
 const LoadingCopy = styled.p`

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -42,6 +42,7 @@
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/shopping-cart": "^1.0.0",
 		"@emotion/react": "^11.4.1",
+		"@emotion/serialize": "^1.0.2",
 		"@emotion/styled": "^11.3.0",
 		"@wordpress/i18n": "^3.20.0",
 		"@wordpress/react-i18n": "^1.0.3",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -41,6 +41,7 @@
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/shopping-cart": "^1.0.0",
+		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
 		"@wordpress/i18n": "^3.20.0",
 		"@wordpress/react-i18n": "^1.0.3",
@@ -54,9 +55,6 @@
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0",
 		"typescript": "^4.3.5"
-	},
-	"peerDependencies": {
-		"@emotion/react": "^11.4.1"
 	},
 	"private": true
 }

--- a/packages/wpcom-checkout/src/animations.ts
+++ b/packages/wpcom-checkout/src/animations.ts
@@ -1,0 +1,9 @@
+import { keyframes } from '@emotion/react';
+
+export const pulse = keyframes`
+	0% { opacity: 1; }
+
+	70% { opacity: 0.25; }
+
+	100% { opacity: 1; }
+`;

--- a/packages/wpcom-checkout/src/animations.ts
+++ b/packages/wpcom-checkout/src/animations.ts
@@ -1,6 +1,7 @@
 import { keyframes } from '@emotion/react';
+import type { Keyframes } from '@emotion/serialize';
 
-export const pulse = keyframes`
+export const pulse: Keyframes = keyframes`
 	0% { opacity: 1; }
 
 	70% { opacity: 0.25; }

--- a/packages/wpcom-checkout/src/checkout-summary-line-item.tsx
+++ b/packages/wpcom-checkout/src/checkout-summary-line-item.tsx
@@ -1,0 +1,17 @@
+import { pulse } from './animations';
+import styled from './styled';
+
+export const CheckoutSummaryLineItem = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin-bottom: 4px;
+
+	.is-loading & {
+		animation: ${ pulse } 1.5s ease-in-out infinite;
+	}
+`;
+
+export const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+`;

--- a/packages/wpcom-checkout/src/checkout-summary-line-item.tsx
+++ b/packages/wpcom-checkout/src/checkout-summary-line-item.tsx
@@ -1,5 +1,5 @@
+import styled from '@emotion/styled';
 import { pulse } from './animations';
-import styled from './styled';
 
 export const CheckoutSummaryLineItem = styled.div`
 	display: flex;

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -19,6 +19,8 @@ export * from './payment-methods/alipay';
 export * from './use-is-web-payment-available';
 export * from './payment-methods/google-pay';
 export * from './payment-methods/existing-credit-card';
+export * from './animations';
+export * from './checkout-summary-line-item';
 export { isWpComProductRenewal } from './is-wpcom-product-renewal';
 export { isValueTruthy } from './is-value-truthy';
 export * from './checkout-labels';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,6 +1123,7 @@ __metadata:
     "@automattic/composite-checkout": ^1.0.0
     "@automattic/shopping-cart": ^1.0.0
     "@emotion/react": ^11.4.1
+    "@emotion/serialize": ^1.0.2
     "@emotion/styled": ^11.3.0
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,6 +1122,7 @@ __metadata:
     "@automattic/calypso-stripe": ^1.0.0
     "@automattic/composite-checkout": ^1.0.0
     "@automattic/shopping-cart": ^1.0.0
+    "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.0.0
@@ -1133,8 +1134,6 @@ __metadata:
     react: ^16.12.0
     react-dom: ^16.12.0
     typescript: ^4.3.5
-  peerDependencies:
-    "@emotion/react": ^11.4.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the `CheckoutSummaryLineItem` and `CheckoutSummaryTotal` components to the `@automattic/wpcom-checkout` package. This is part of https://github.com/Automattic/wp-calypso/issues/52215 and will also be helpful for https://github.com/Automattic/wp-calypso/pull/52890 which could then use these dependencies outside of calypso.

![summary-line-item](https://user-images.githubusercontent.com/2036909/130873070-676f4b9e-f450-4f84-9c85-2c4728bdba68.png)


#### Testing instructions

- Add a product to the cart and visit checkout.
- Set a postal code and country that includes taxes (eg: 10001, United States)
- Verify that you see the "tax" and "total" items in the checkout summary; this is in the sidebar at large widths or collapsed at the top of the page at small widths.