### PR TITLE
Browsehappy: Record tracks event when redirecting

### DIFF
--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -38,15 +38,16 @@ export default () => ( req, res, next ) => {
 		return;
 	}
 
-	// The UserAgent is automatically included.
-	analytics.tracks.recordEvent(
-		'calypso_redirect_unsupported_browser',
-		{ original_url: req.originalUrl },
-		req
-	);
-
 	// `req.originalUrl` contains the full path. It's tempting to use `req.url`, but that would
 	// fail in case of multiple Express.js routers nested with `app.use`, because `req.url` contains
 	// only the closest subpath.
-	res.redirect( addQueryArgs( { from: req.originalUrl }, '/browsehappy' ) );
+	const from = req.originalUrl;
+
+	// The UserAgent is automatically included.
+	analytics.tracks.recordEvent(
+		'calypso_redirect_unsupported_browser',
+		{ original_url: from },
+		req
+	);
+	res.redirect( addQueryArgs( { from }, '/browsehappy' ) );
 };

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -3,6 +3,7 @@
  */
 import config from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/url';
+import analytics from 'calypso/server/lib/analytics';
 
 export default () => ( req, res, next ) => {
 	if ( ! config.isEnabled( 'redirect-fallback-browsers' ) ) {
@@ -36,6 +37,13 @@ export default () => ( req, res, next ) => {
 		next();
 		return;
 	}
+
+	// The UserAgent is automatically included.
+	analytics.tracks.recordEvent(
+		'calypso_redirect_unsupported_browser',
+		{ original_url: req.originalUrl },
+		req
+	);
 
 	// `req.originalUrl` contains the full path. It's tempting to use `req.url`, but that would
 	// fail in case of multiple Express.js routers nested with `app.use`, because `req.url` contains


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Record a tracks event when we redirect an unsupported browser. Event registration here: 564-gh-Automattic/tracks-events-registration

#### Testing instructions
You should test after calypso finishes building. Otherwise, you'll log several redirects because you've been constantly pinging the server during the build. 
 
1. Run `ENABLE_FEATURES=redirect-fallback-browsers/test yarn start` locally
2. **Do not** open a browser until the build finishes.
3. _After_ calypso has finished build, open `calypso.localhost:3000`.
4. You will be redirected (because of the feature flag we enabled) to browsehappy
5. After several minutes (maybe 10-15 at the most), look for the event `calypso_redirect_unsupported_browser` in tracks. There should be a single entry corresponding to each attempt to load calypso.