### PR TITLE
Support: Disable open tickets banner

### DIFF
--- a/client/state/help/actions.js
+++ b/client/state/help/actions.js
@@ -8,7 +8,9 @@ import {
 } from 'calypso/state/action-types';
 
 import 'calypso/state/data-layer/wpcom/help/search';
-import 'calypso/state/data-layer/wpcom/help/support-history';
+// Support History data needs to be disabled temporarily to avoid rate-limiting with our Zendesk API.
+// It is only used for non-essential read-only operations right now.
+// import 'calypso/state/data-layer/wpcom/help/support-history';
 import 'calypso/state/help/init';
 
 export const selectSiteId = ( siteId ) => ( {


### PR DESCRIPTION
We're experiencing rate-limiting in our Zendesk API. Calypso's contact page makes a call to the Zendesk API to check if the user has open tickets, and let them know. This PR disables that non-essential feature while we get a handle on our API volume.

### Testing
Open the contact form. You should see a Redux action `SUPPORT_HISTORY_REQUEST` but should not see a corresponding API call matching `support-history`.