### PR TITLE
Introduce a WIP `/start/setup-site` flow that will appear after checkout

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -412,6 +412,16 @@ export function generateFlows( {
 			lastModified: '2021-03-29',
 			showRecaptcha: true,
 		},
+		{
+			name: 'setup-site',
+			steps: [ 'design' ],
+			destination: getChecklistThemeDestination,
+			description:
+				'Sets up a site that has already been created and paid for (if purchases were made)',
+			lastModified: '2021-08-26',
+			providesDependenciesInQuery: [ 'siteSlug' ],
+			pageTitle: translate( 'Setup your site' ),
+		},
 	];
 
 	// convert the array to an object keyed by `name`

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -149,7 +149,7 @@
 	],
 	"restricted_me_access": true,
 	"theme_color": "#055d9c",
-	"reskinned_flows": [ "launch-site", "onboarding", "onboarding-with-email" ],
+	"reskinned_flows": [ "launch-site", "onboarding", "onboarding-with-email", "setup-site" ],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"calendly_jetpack_appointment_url": ""
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a new `setup-site` flow in the signup framework
* The only step is the design picker
* Accepts a `?siteSlug=` query param to an existing site
* Ensure the flow is styled using the "new" style (the white background)

In the short term we'll create a flow like this:
`Signup -> domain -> plan -> checkout -> design picker (with optional preview) -> Either My Home or straight to the Site Editor (TBA)`
p1629948346001400-slack-C029SB8JT8S

My idea is that we'll create a flow in the signup framework that handles the steps between checkout and My Home (or Site Editor). So after completing checkout (or directly after the plan step if they haven't purchased anything) we take the user to `/start/setup-site`.

In the longer term there's a multi-intent capture step: p1629949711005500/1629948346.001400-slack-C029SB8JT8S. So the `setup-site` flow would be somewhere to add those steps too.

Because this flow isn't linked to from anywhere, I think we can merge it and then all have a common place to work on the flow together. So this PR is the bare minimum to get things going, the flow doesn't actually work yet.

<img width="1344" alt="Screenshot 2021-08-26 at 6 31 56 PM" src="https://user-images.githubusercontent.com/1500769/130913472-90ca02cf-9843-471e-90d8-b2381aeef7fa.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choose an existing test site
* Go to `start/setup-site?siteSlug=<your test site>.wordpress.com`
* Nothing else works yet

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55604