### PR TITLE
Server Analytics: remove lodash, improve tests, fix a bug

### DIFF
--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { omit, get, has } from 'lodash';
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
 import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
@@ -7,7 +6,7 @@ const URL = require( 'url' );
 
 function getUserFromRequest( request ) {
 	// if user has a cookie, lets use that
-	const encodedUserCookie = get( request, 'cookies.wordpress_logged_in', null );
+	const encodedUserCookie = request?.cookies?.wordpress_logged_in ?? null;
 
 	if ( encodedUserCookie ) {
 		try {
@@ -28,7 +27,7 @@ function getUserFromRequest( request ) {
 	// we'll use that, otherwise, we'll just use anonymous.
 
 	// If we have a full identity on query params - use it
-	if ( has( request, 'query._ut' ) && has( request, 'query._ui' ) ) {
+	if ( request?.query?._ut && request?.query?._ui ) {
 		return {
 			_ui: request.query._ui,
 			_ut: request.query._ut,
@@ -82,7 +81,9 @@ const analytics = {
 
 			// Remove properties that have an undefined value
 			// This allows a caller to easily remove properties from the recorded set by setting them to undefined
-			eventProperties = omit( eventProperties, ( prop ) => typeof prop === 'undefined' );
+			eventProperties = Object.fromEntries(
+				Object.entries( eventProperties ).filter( ( entry ) => entry[ 1 ] !== undefined )
+			);
 
 			const date = new Date();
 			const acceptLanguageHeader = req.get( 'Accept-Language' ) || '';

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -1,85 +1,118 @@
 import config from '@automattic/calypso-config';
-import { expect } from 'chai';
-import sinon from 'sinon';
+import UserAgent from 'express-useragent';
 import superagent from 'superagent';
 import { statsdTimingUrl, statsdCountingUrl } from 'calypso/lib/analytics/statsd-utils';
 import analytics from '../index';
-jest.mock( '@automattic/calypso-config', () => require( 'sinon' ).stub() );
+jest.mock( '@automattic/calypso-config', () => jest.fn() );
 jest.mock( 'calypso/lib/analytics/statsd-utils', () => ( {
-	statsdTimingUrl: require( 'sinon' ).stub(),
-	statsdCountingUrl: require( 'sinon' ).stub(),
+	statsdTimingUrl: jest.fn(),
+	statsdCountingUrl: jest.fn(),
 } ) );
 
 describe( 'Server-Side Analytics', () => {
-	describe( 'tracks.recordEvent', () => {} );
-
-	describe( 'statsd.recordTiming', () => {
+	describe( 'tracks.recordEvent', () => {
 		beforeAll( function () {
-			sinon.stub( superagent, 'get' ).returns( { end: () => {} } );
+			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
 		} );
 
 		afterEach( () => {
-			config.reset();
-			statsdTimingUrl.reset();
-			superagent.get.reset();
+			superagent.get.mockClear();
 		} );
 
-		afterAll( () => {
-			sinon.restore();
+		const req = {
+			get: ( header ) => {
+				switch ( header.toLowerCase() ) {
+					case 'accept-language':
+						return 'cs';
+					case 'referer':
+						return 'test';
+					case 'x-forwarded-for':
+						return '1.1.1.1';
+				}
+				throw 'no ' + header;
+			},
+			useragent: UserAgent.parse(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
+			),
+		};
+
+		test( 'sends an HTTP request to the tracks URL', () => {
+			analytics.tracks.recordEvent( 'calypso_test', { a: 'foo' }, req );
+
+			expect( superagent.get ).toHaveBeenCalled();
+			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			expect( url.origin ).toBe( 'http://pixel.wp.com' );
+			expect( url.pathname ).toBe( '/t.gif' );
+			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
+			expect( url.searchParams.get( 'a' ) ).toBe( 'foo' );
+		} );
+
+		test( 'omits an undefined event property', () => {
+			analytics.tracks.recordEvent( 'calypso_test', { a: undefined }, req );
+
+			expect( superagent.get ).toHaveBeenCalled();
+			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			expect( url.searchParams.get( 'a' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'statsd.recordTiming', () => {
+		beforeAll( function () {
+			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
+		} );
+
+		afterEach( () => {
+			statsdTimingUrl.mockClear();
+			superagent.get.mockClear();
 		} );
 
 		test( 'sends an HTTP request to the statsd URL', () => {
-			config.withArgs( 'server_side_boom_analytics_enabled' ).returns( true );
-			statsdTimingUrl.returns( 'http://example.com/boom.gif' );
+			config.mockReturnValue( true ); // server_side_boom_analytics_enabled
+			statsdTimingUrl.mockReturnValue( 'http://example.com/boom.gif' );
 
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
 
-			expect( statsdTimingUrl ).to.have.been.calledWith( 'reader', 'page-render', 150 );
-			expect( superagent.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
+			expect( statsdTimingUrl ).toHaveBeenCalledWith( 'reader', 'page-render', 150 );
+			expect( superagent.get ).toHaveBeenCalledWith( 'http://example.com/boom.gif' );
 		} );
 
 		test( 'does nothing if statsd analytics is not allowed', () => {
-			config.withArgs( 'server_side_boom_analytics_enabled' ).returns( false );
+			config.mockReturnValue( false ); // server_side_boom_analytics_enabled
 
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
 
-			expect( statsdTimingUrl ).not.to.have.been.called;
-			expect( superagent.get ).not.to.have.been.called;
+			expect( statsdTimingUrl ).not.toHaveBeenCalled();
+			expect( superagent.get ).not.toHaveBeenCalled();
 		} );
 	} );
 
 	describe( 'statsd.recordCounting', () => {
 		beforeAll( function () {
-			sinon.stub( superagent, 'get' ).returns( { end: () => {} } );
+			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
 		} );
 
 		afterEach( () => {
-			config.reset();
-			statsdCountingUrl.reset();
-			superagent.get.reset();
-		} );
-
-		afterAll( () => {
-			sinon.restore();
+			statsdCountingUrl.mockClear();
+			superagent.get.mockClear();
 		} );
 
 		test( 'sends an HTTP request to the statsd URL', () => {
-			config.withArgs( 'server_side_boom_analytics_enabled' ).returns( true );
-			statsdCountingUrl.returns( 'http://example.com/boom.gif' );
+			config.mockReturnValue( true ); // server_side_boom_analytics_enabled
+			statsdCountingUrl.mockReturnValue( 'http://example.com/boom.gif' );
 
 			analytics.statsd.recordCounting( 'reader', 'page-count', 1 );
 
-			expect( statsdCountingUrl ).to.have.been.calledWith( 'reader', 'page-count', 1 );
-			expect( superagent.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
+			expect( statsdCountingUrl ).toHaveBeenCalledWith( 'reader', 'page-count', 1 );
+			expect( superagent.get ).toHaveBeenCalledWith( 'http://example.com/boom.gif' );
 		} );
 
 		test( 'does nothing if statsd analytics is not allowed', () => {
-			config.withArgs( 'server_side_boom_analytics_enabled' ).returns( false );
+			config.mockReturnValue( false ); // server_side_boom_analytics_enabled
 
 			analytics.statsd.recordCounting( 'reader', 'page-count', 1 );
 
-			expect( statsdCountingUrl ).not.to.have.been.called;
-			expect( superagent.get ).not.to.have.been.called;
+			expect( statsdCountingUrl ).not.toHaveBeenCalled();
+			expect( superagent.get ).not.toHaveBeenCalled();
 		} );
 	} );
 } );


### PR DESCRIPTION
Removes Lodash usages from the `client/server/analytics` module and fixes one little bug. There was a call that wants to omit undefined properties from an object:
```js
omit( eventProperties, ( prop ) => typeof prop === 'undefined' )
```
But this doesn't omit anything. `omit` accepts an array of string keys, not a function. It would have to be:
```js
omitBy( eventProperties, ( prop ) => typeof prop === 'undefined' )
```
which is what the [client-side implementation](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-analytics/src/tracks.ts#L232) does.

This PR fixes that by removing Lodash altogether and replacing the `omit` with a correct implementation with `Object.{entries,fromEntries}`. I also added a unit test that verifies the correct behavior, after refactoring the tests to use Jest asserts and mocks instead of `chai` and `sinon`.

I noticed this when reviewing #55732.