### PR TITLE
Fix the add a domain component to not make unnecessary domain suggestions API requests

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -331,8 +331,6 @@ class RegisterDomainStep extends React.Component {
 		const query = this.state.lastQuery || storedQuery;
 
 		if ( query && ! this.state.searchResults && ! this.state.subdomainSearchResults ) {
-			this.onSearch( query );
-
 			// Delete the stored query once it is consumed.
 			globalThis?.sessionStorage?.removeItem( SESSION_STORAGE_QUERY_KEY );
 		} else {
@@ -406,8 +404,7 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	render() {
-		const queryObject = getQueryObject( this.props );
-		const { isSignupStep, showAlreadyOwnADomain } = this.props;
+		const { suggestion, isSignupStep, showAlreadyOwnADomain } = this.props;
 
 		const {
 			availabilityError,
@@ -421,6 +418,8 @@ class RegisterDomainStep extends React.Component {
 			trademarkClaimsNoticeInfo,
 			isQueryInvalid,
 		} = this.state;
+
+		const queryObject = ! suggestion && getQueryObject( this.props );
 
 		if ( trademarkClaimsNoticeInfo ) {
 			return this.renderTrademarkClaimsNotice();

--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
 		"@automattic/popup-monitor": "^1.0.0",
 		"@automattic/react-virtualized": "^9.21.2",
 		"@automattic/request-external-access": "^1.0.0",
+		"@automattic/search": "^1.0.0",
 		"@automattic/shopping-cart": "^1.0.0",
 		"@automattic/social-previews": "^1.0.1",
 		"@automattic/state-utils": "^1.0.0-alpha.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12313,6 +12313,7 @@ __metadata:
     "@automattic/popup-monitor": ^1.0.0
     "@automattic/react-virtualized": ^9.21.2
     "@automattic/request-external-access": ^1.0.0
+    "@automattic/search": ^1.0.0
     "@automattic/shopping-cart": ^1.0.0
     "@automattic/social-previews": ^1.0.1
     "@automattic/state-utils": ^1.0.0-alpha.4


### PR DESCRIPTION
The `RegisterDomainStep` component is making 2 extra domain suggestions API calls (one of those is not even having the correct parameters). 

#### Changes proposed in this Pull Request

* Stop calling onSearch in the `RegisterDomainStep` component as this happens in the `Search` component
* Don't render the `QueryDomainsSuggestions` component if there is a search term preset

#### Testing instructions

* Spin up this branch of Calypso and open `/domains/add/{site_name}` with network inspector opened. Check how many calls to the suggestion endpoint are there - we should only have one. Check the same in production to see the extra API calls.

