### PR TITLE
Experiment: Emphasize the refund policy v2

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -194,6 +194,7 @@ export class PlansStep extends Component {
 	getSubHeaderTextForExperiment() {
 		const { hideFreePlan, flowName, translate } = this.props;
 		const defaultSubHeaderText = this.getSubHeaderText();
+		const refundWindow = 'yearly' === this.getIntervalType() ? 14 : 7;
 
 		if ( ! isDesktop() || 'onboarding' !== flowName ) {
 			return defaultSubHeaderText;
@@ -202,14 +203,22 @@ export class PlansStep extends Component {
 		let emphasizedRefundPolicyText = '';
 		if ( hideFreePlan ) {
 			emphasizedRefundPolicyText = translate(
-				'Try risk-free with a 14-day money back guarantee on all plans.'
+				'Try risk-free with a %(days)s-day money back guarantee on all plans.',
+				{
+					args: {
+						days: refundWindow,
+					},
+				}
 			);
 		} else {
 			emphasizedRefundPolicyText = translate(
-				'Try risk-free with a 14-day money back guarantee on all plans. Or {{link}}start with a free site{{/link}}.',
+				'Try risk-free with a %(days)s-day money back guarantee on all plans. Or {{link}}start with a free site{{/link}}.',
 				{
 					components: {
 						link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+					},
+					args: {
+						days: refundWindow,
 					},
 				}
 			);
@@ -217,7 +226,7 @@ export class PlansStep extends Component {
 
 		return (
 			<Experiment
-				name="emphasizing_refund_policy"
+				name="emphasizing_refund_policy_v2"
 				defaultExperience={ defaultSubHeaderText }
 				treatmentExperience={ emphasizedRefundPolicyText }
 				loadingExperience={ '\u00A0' } // &nbsp;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up PR of #55657 that shows an incorrect refund window for monthly plans. The old experiment is closed in favor of the new experiment this PR runs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a website as a logged user or a logged-out user.
* You should be able to see the new copy emphasizing the 14-day money-back guarantee if you're assigned to the treatment of the `emphasizing_refund_policy_v2` experiment. 
  <img width="1254" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/130585002-a214f9ab-fc2a-47bc-a91f-d0c7e38ed8c0.png">
* The refund window should be _"7-day"_ instead of _"14-day"_ when the _Pay monthly_ is selected.

cc @paulbonahora @southp @olaolusoga
