### PR TITLE
Reorder the domain transfer bullets so that the one year renewal one is the first one

### DIFF
--- a/client/components/domains/use-my-domain/utilities/option-info.js
+++ b/client/components/domains/use-my-domain/utilities/option-info.js
@@ -22,8 +22,8 @@ export const optionInfo = {
 		recommended: true,
 		learnMoreLink: INCOMING_DOMAIN_TRANSFER,
 		benefits: [
-			__( 'Manage everything you need in one place' ),
 			__( "We'll renew your domain for another year" ),
+			__( 'Manage everything you need in one place' ),
 			__( 'Private domain registration and SSL certificate included for free' ),
 		],
 	},


### PR DESCRIPTION
That's pretty much it - just reordering the features of the incoming transfer

#### Changes proposed in this Pull Request

* Reorder the domain transfer bullets so that the one year renewal one is the first one

Before:

<img width="474" alt="Screenshot 2021-08-26 at 14 12 55" src="https://user-images.githubusercontent.com/1355045/130953041-f0f84eb2-6f0a-4b60-b9dd-bb99cc182763.png">

After:

<img width="508" alt="Screenshot 2021-08-26 at 14 12 36" src="https://user-images.githubusercontent.com/1355045/130953055-7b36f356-6c71-4cd7-8218-0dfa2a9b7b58.png">

#### Testing instructions

* Spin up the Calypso branch and navigate to `/domains/add/use-my-domain/{your-site-address}`. Verify that the first bullet in the transfer options box is "We'll renew your domain for another year"
