### PR TITLE
Welcome tour: Make the close/minimise buttons visible in mobile resolution

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { subscribeIsMobile } from '@automattic/viewport';
+import { subscribeIsMobile, isMobile } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -121,10 +121,10 @@ function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIn
 }
 
 function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
-	const [ isMobile, setIsMobile ] = useState( false );
+	const [ isMobileView, setIsMobileView ] = useState( isMobile() );
 
 	useEffectOnlyOnce( () => {
-		const unsubscribe = subscribeIsMobile( ( isNarrow ) => setIsMobile( isNarrow ) );
+		const unsubscribe = subscribeIsMobile( ( isNarrow ) => setIsMobileView( isNarrow ) );
 		return function cleanup() {
 			unsubscribe();
 		};
@@ -138,7 +138,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 		} );
 	};
 	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls', {
-		'welcome-tour-card__overlay-controls-visible': isMobile,
+		'welcome-tour-card__overlay-controls-visible': isMobileView,
 	} );
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Makes the close/minimise buttons in the Welcome Tour always visible in a mobile resolution (<480px).

Initialises the respective state of the card component to the value of `isMobile` from @a8c/viewport. Originally this was set to `false` to be updated by the subscriber when the resolution changes. This tunes a little the mobile behavior of the current tour but does not address or modifies what the actual view is on mobile (currently a different welcome modal).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the website in a **desktop** browser. I've checked this with Chrome.
2. Open WordPress.com > My Sites > Pages > Add New Page (and select blank layout) or a Post.
3. Click on the three dots on top-right corner and open Welcome guide.
4. Use the dev tools to switch to a **mobile** resolution (<480px -> does not include tablets e.g. iPad). 
5. The buttons to minimize/close should always be visible.

![Kapture 2021-08-26 at 15 15 25](https://user-images.githubusercontent.com/1705499/130961118-cb8c8dfb-a89b-4a11-934b-f7670b1b3d2e.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55587, #55131