### PR TITLE
Fix/domain suggestion price layout issue

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -31,7 +31,7 @@
 	.is-section-signup &:not( .domain-product-price__domain-step-signup-flow ) {
 		@include breakpoint-deprecated( '>660px' ) {
 			padding-left: 1em;
-			padding-right: 2em;
+			padding-right: 1em;
 		}
 	}
 

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -30,7 +30,7 @@
 
 	.is-section-signup &:not( .domain-product-price__domain-step-signup-flow ) {
 		@include breakpoint-deprecated( '>660px' ) {
-			padding-left: 1em;
+			//padding-left: 1em;
 			padding-right: 1em;
 		}
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -30,7 +30,6 @@
 
 	.is-section-signup &:not( .domain-product-price__domain-step-signup-flow ) {
 		@include breakpoint-deprecated( '>660px' ) {
-			//padding-left: 1em;
 			padding-right: 1em;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The prices in the domain suggestions on `/start/add-domain/select-domain` were misaligned.
This PR makes sure that all of the prices are aligned.

Before:
<img width="1109" alt="Screen Shot 2021-08-26 at 9 03 45 AM" src="https://user-images.githubusercontent.com/1379730/130968078-255b5cf8-dfcc-4364-9466-9b10007c0c5d.png">

After:
<img width="1024" alt="Screen Shot 2021-08-26 at 9 03 01 AM" src="https://user-images.githubusercontent.com/1379730/130968092-1e4f0d7f-a82b-48e7-a667-803a4c8dd9da.png">
<img width="1024" alt="Screen Shot 2021-08-26 at 9 02 53 AM" src="https://user-images.githubusercontent.com/1379730/130968105-8a2f40ce-0ba9-4bd9-a309-67911812e188.png">
<img width="1109" alt="Screen Shot 2021-08-26 at 9 03 26 AM" src="https://user-images.githubusercontent.com/1379730/130968109-c632fe05-7c71-4858-ac37-5cc17a8ebee6.png">


#### Testing instructions

Check the domain suggestions on the following pages. Make sure the prices are all aligned with each other.

http://calypso.localhost:3000/start/add-domain/select-domain
http://calypso.localhost:3000/start/domains
http://calypso.localhost:3000/domains/add/a8ctest.com
