### PR TITLE
[E2E/widgets-editor] Make sure the Welcome popup gets closed before the next step

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -645,7 +645,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-widgets__spec.ts; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -645,7 +645,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
+					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-widgets__spec.ts; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -462,7 +462,7 @@ fun seleniumBuildType( viewportName: String, buildUuid: String): BuildType  {
 				dockerImage = "%docker_image_e2e%"
 			}
 			bashNodeScript {
-				name = "Run e2e tests (desktop)"
+				name = "Run e2e tests ($viewportName)"
 				scriptContent = """
 					shopt -s globstar
 					set -x
@@ -615,7 +615,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 				dockerImage = "%docker_image_e2e%"
 			}
 			bashNodeScript {
-				name = "Run e2e tests (desktop)"
+				name = "Run e2e tests ($viewportName)"
 				scriptContent = """
 					shopt -s globstar
 					set -x

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -55,7 +55,7 @@ export class SidebarComponent {
 			// Click top-level item without waiting for navigation if targeting subitem.
 			await this.page.click( itemSelector );
 
-			const subitemSelector = `.is-toggle-open:not(.hovered) :text-is("${ subitem }"):visible`;
+			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible`;
 			await this.scrollItemIntoViewIfNeeded( subitemSelector );
 
 			await Promise.all( [ this.page.waitForNavigation(), this.page.click( subitemSelector ) ] );

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -55,7 +55,7 @@ export class SidebarComponent {
 			// Click top-level item without waiting for navigation if targeting subitem.
 			await this.page.click( itemSelector );
 
-			const subitemSelector = `:text-is("${ subitem }"):visible:below(${ itemSelector })`;
+			const subitemSelector = `.is-toggle-open:not(.hovered) :text-is("${ subitem }"):visible`;
 			await this.scrollItemIntoViewIfNeeded( subitemSelector );
 
 			await Promise.all( [ this.page.waitForNavigation(), this.page.click( subitemSelector ) ] );

--- a/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
@@ -20,29 +20,15 @@ describe( DataHelper.createSuiteTitle( 'Widgets' ), function () {
 	it( 'Navigate to the Block Widgets Editor', async function () {
 		sidebarComponent = new SidebarComponent( page );
 		await sidebarComponent.navigate( 'Appearance', 'Widgets' );
+		const widgetsMenu = await page.waitForSelector( '"Customising ▸ Widgets"' );
+		await widgetsMenu.waitForElementState( 'stable' );
 	} );
 
 	it( 'Dismiss the Welcome Guide Notice if displayed', async function () {
-		const buttonSelector = 'button:text("Got it")';
-		const hideWelcomePopup = async (): Promise< void > => {
-			try {
-				const button = await page.waitForSelector( buttonSelector );
-				await button.click();
-				// Retry if the button doesn't get hidden after 1 second. It can
-				// sometimes happen when clicked too early.
-				await button.waitForElementState( 'hidden', { timeout: 1000 } );
-			} catch {
-				return hideWelcomePopup();
-			}
-		};
-
-		// Hide the Welcome popup if it's present before the network gets idle.
-		await Promise.race( [ page.waitForLoadState( 'networkidle' ), hideWelcomePopup() ] );
-
-		// In case the network finished first, look for the button and click if found.
-		const button = await page.$( buttonSelector );
+		const button = await page.$( 'button:text("Got it")' );
 		if ( button ) {
-			await hideWelcomePopup();
+			await button.click();
+			await button.waitForElementState( 'hidden' );
 		}
 	} );
 
@@ -52,6 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Widgets' ), function () {
 			await page.fill( 'input[placeholder="Search"]', 'Top Posts and Pages' );
 			await page.click( 'button.editor-block-list-item-legacy-widget\\/top-posts' );
 		} );
+
 		it( 'Visibility options are shown for the Legacy Widget', async function () {
 			await page.click( 'a.button:text("Visibility")' );
 			await page.waitForSelector( 'div.widget-conditional' );


### PR DESCRIPTION
This PR ended up addressing 3 things:

1. **Widgets E2E suite flakiness**
  The flakiness was most probably caused by the fact that the Welcome guide's `Got it` button is initially _dead_ for a split second. To Playwright, that button is considered as clickable as it meets all the actionability conditions. But since the click was sometimes happening a bit _too early_, the "Welcome" banner sometimes wasn't disappearing and the test was getting stuck. It seems now to be resolved by waiting for the Widgets page to become stable instead of waiting for the `networkidle` event. [Here](https://github.com/Automattic/wp-calypso/pull/55760#issuecomment-907070093) are the stress test runs for the widgets suite.

2. **Sidebar flakiness on the `desktop` viewport**
  Sidebar flakiness on the desktop viewport was caused by the unstable appearance of the hovered item submenu. Playwright sometimes _notices_ that submenu and attempts to click it. This is a race condition because the submenu often disappears before the actual click action is performed, leaving the navigation in suspension. This seems now to be fixed by updating the submenu selector, which now explicitly targets the expanded submenu instead of targeting also the hovered one.

3. **Viewport name correction in the WebApp CI setup**
  Just [a small string correction](https://github.com/Automattic/wp-calypso/pull/55760/commits/4bfcbe1ed504a0cf756d8f2b3369d21b9599d971) - noticed that the viewport name is hardcoded in one spot.
