### PR TITLE
ci: Install desktop deps directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,7 @@ jobs:
           environment:
             CSC_LINK: resource/certificates/mac.p12
             CSC_FOR_PULL_REQUEST: true
+            USE_HARD_LINKS: "false"
           command: |
             set +e
             source $HOME/.nvm/nvm.sh
@@ -389,6 +390,7 @@ jobs:
           name: Build Desktop Linux
           environment:
             CSC_LINK: resource/certificates/win.p12
+            USE_HARD_LINKS: "false"
           command: |
             set +e
             source $HOME/.nvm/nvm.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,8 @@ references:
       nvm use
       npm install -g yarn@1.22.10
       yarn
-      yarn run build-desktop:install-app-deps
+      cd desktop
+      yarn
   desktop-cache-paths: &desktop-cache-paths
     - desktop/resource/certificates/win.p12
     - desktop/resource/certificates/mac.p12
@@ -397,7 +398,8 @@ jobs:
             # Otherwise only build application executable required for end-to-end testing.
             ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|desktop/yarn.lock' && ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 
-            ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS yarn run build-desktop
+            cd desktop
+            ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS yarn run build
       - run:
           name: e2e Tests
           command: |
@@ -461,7 +463,8 @@ jobs:
           name: Install Desktop Dependencies
           command: |
             yarn
-            yarn run build-desktop:install-app-deps
+            cd desktop
+            yarn
       - when:
           condition: << pipeline.git.tag >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ references:
     command: |
       source "$HOME/.nvm/nvm.sh"
       nvm use
-      npm install -g yarn
+      npm install -g yarn@1.22.10
       yarn
       yarn run build-desktop:install-app-deps
   desktop-cache-paths: &desktop-cache-paths
@@ -453,7 +453,7 @@ jobs:
             nvm use $NODE_VERSION
       - run:
           name: Install Yarn
-          command: npm install -g yarn
+          command: npm install -g yarn@1.22.10
       - run:
           name: Install Make
           command: cinst make


### PR DESCRIPTION
#### Background

Since the migration to Yarn v3, desktop builds in `trunk` have been failing.

One of the reasons is Yarn v3 doesn't play nice when calling `yarn` inside an npm scripts _and_ that `yarn` is v1. Which is the case for Desktop. More details in https://github.com/Automattic/wp-calypso/pull/51719#discussion_r683114682

Note that another cause of broken builds was addressed in a different PR (#55759), which is the target of this PR.

#### Changes proposed in this Pull Request

* "Un-nest" yarn scripts that call yarn again
* Ensure we start with Yarn v1, as it can install both `package.json` and `desktop/package.json`
* Set USE_HARD_LINKS = false. I don't know why we need this now to be honest, but we are already using it in TeamCity (https://github.com/Automattic/wp-calypso/blob/trunk/.teamcity/_self/projects/DesktopApp.kt#L66). I got the suggestion from https://github.com/electron-userland/electron-builder/issues/3179

