### PR TITLE
Only show recommended badge for transfers when it makes sense

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -131,6 +131,10 @@ export function getOptionInfo( {
 		}
 	}
 
+	if ( transferContent.onSelect && connectContent.onSelect ) {
+		transferContent.recommended = true;
+	}
+
 	connectContent.primary = ! transferContent?.primary;
 
 	if ( transferContent?.primary ) {

--- a/client/components/domains/use-my-domain/utilities/option-info.js
+++ b/client/components/domains/use-my-domain/utilities/option-info.js
@@ -19,7 +19,6 @@ export const optionInfo = {
 		illustration: transferIllustration,
 		titleText: optionTitleText.transfer,
 		topText: __( 'Manage your domain directly on WordPress.com' ),
-		recommended: true,
 		learnMoreLink: INCOMING_DOMAIN_TRANSFER,
 		benefits: [
 			__( 'Manage everything you need in one place' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when you go to the `/domains/add/use-my-domain/[site slug here]` page and select a domain that is already connected to your site, transfer is the only option. But since this is the only option, it doesn't make sense to show that this is recommended.

So, if transfer is the only option, we should not show the "Recommended" badge.

Before:
<img width="1071" alt="Screen Shot 2021-08-26 at 11 47 10 AM" src="https://user-images.githubusercontent.com/1379730/130994377-308c4bed-6d6a-465d-be0f-80d6bbb33af2.png">

After:
<img width="1071" alt="Screen Shot 2021-08-26 at 11 47 15 AM" src="https://user-images.githubusercontent.com/1379730/130994397-9e99549b-f40c-492d-950e-ac0cefa44cd0.png">


#### Testing instructions

Visit `/domains/add/use-my-domain/[site slug here]` using a site that has a domain already connected (FKA mapped) to it. Select that already connected domain and you should see that the only option is to transfer the domain without the badge.