### PR TITLE
Domains: Add skip button in professional email mailbox list form in upsell page

### DIFF
--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -35,6 +35,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 					comment,
 				} ) }
 				selectedDomainName={ domain }
+				skipButtonLabel={ translate( 'Not interested' ) }
 			/>
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -417,7 +417,9 @@ class EmailProvidersComparison extends React.Component {
 			currencyCode,
 			domain,
 			hasCartDomain,
+			onSkipClick,
 			selectedDomainName,
+			showSkipButton,
 			titanMailProduct,
 			translate,
 		} = this.props;
@@ -477,6 +479,10 @@ class EmailProvidersComparison extends React.Component {
 				>
 					{ buttonLabel }
 				</Button>
+
+				{ showSkipButton && (
+					<Button onClick={ onSkipClick }>{ translate( 'Not interested' ) }</Button>
+				) }
 			</TitanNewMailboxList>
 		);
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -537,7 +537,7 @@ class EmailProvidersComparison extends React.Component {
 
 		const headerContent = skipHeaderElement ? null : (
 			<HeaderCake
-				actionButton={ this.renderSkipButton() }
+				actionButton={ this.renderHeaderSkipButton() }
 				alwaysShowActionText
 				onClick={ this.handleBack }
 			>
@@ -580,7 +580,7 @@ class EmailProvidersComparison extends React.Component {
 		);
 	}
 
-	renderSkipButton() {
+	renderHeaderSkipButton() {
 		const { showSkipButton, onSkipClick, translate } = this.props;
 
 		return showSkipButton ? (

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -83,6 +83,7 @@ class EmailProvidersComparison extends React.Component {
 		promoHeaderTitle: PropTypes.string,
 		selectedDomainName: PropTypes.string.isRequired,
 		showSkipButton: PropTypes.bool,
+		skipButtonLabel: PropTypes.string,
 
 		// Props injected via connect()
 		currencyCode: PropTypes.string,
@@ -420,6 +421,7 @@ class EmailProvidersComparison extends React.Component {
 			onSkipClick,
 			selectedDomainName,
 			showSkipButton,
+			skipButtonLabel,
 			titanMailProduct,
 			translate,
 		} = this.props;
@@ -480,9 +482,7 @@ class EmailProvidersComparison extends React.Component {
 					{ buttonLabel }
 				</Button>
 
-				{ showSkipButton && (
-					<Button onClick={ onSkipClick }>{ translate( 'Not interested' ) }</Button>
-				) }
+				{ showSkipButton && <Button onClick={ onSkipClick }>{ skipButtonLabel }</Button> }
 			</TitanNewMailboxList>
 		);
 

--- a/client/my-sites/email/titan-new-mailbox-list/style.scss
+++ b/client/my-sites/email/titan-new-mailbox-list/style.scss
@@ -6,13 +6,13 @@
 		margin-bottom: 0;
 	}
 
-	.titan-new-mailbox-list__actions,
-	.titan-new-mailbox-list__supplied-actions {
+	.titan-new-mailbox-list__actions {
 		display: flex;
 		flex-direction: column-reverse;
 
 		@include break-mobile {
 			flex-direction: row;
+			justify-content: space-between;
 		}
 
 		> button:not( :last-child ) {
@@ -25,9 +25,21 @@
 		}
 	}
 
-	.titan-new-mailbox-list__actions {
+	.titan-new-mailbox-list__supplied-actions {
+		display: flex;
+		flex-direction: column;
+
 		@include break-mobile {
-			justify-content: space-between;
+			flex-direction: row;
+		}
+
+		> button:not( :first-child ) {
+			margin-top: 1em;
+
+			@include break-mobile {
+				margin-top: 0;
+				margin-left: 1.5em;
+			}
 		}
 	}
 }

--- a/client/my-sites/email/titan-new-mailbox-list/style.scss
+++ b/client/my-sites/email/titan-new-mailbox-list/style.scss
@@ -15,7 +15,7 @@
 			justify-content: space-between;
 		}
 
-		> button:not( :last-child ) {
+		> .button:not( :last-child ) {
 			margin-top: 1em;
 
 			@include break-mobile {
@@ -33,7 +33,7 @@
 			flex-direction: row;
 		}
 
-		> button:not( :first-child ) {
+		> .button:not( :first-child ) {
 			margin-top: 1em;
 
 			@include break-mobile {


### PR DESCRIPTION
~~⚠️ Depends on merge of #55529~~

Related to #55529, #55183

#### Changes proposed in this Pull Request

This PR adds an additional skip button inside the titan mailbox list form, in `EmailProvidersComparison` component. The present skip button in header could be missed by the user and adding this button in the form could help users with smaller viewports, if they scroll down far enough.

#### Testing instructions

1. Visit `http://calypso.localhost:3000/domains/manage/:siteSlug`
2. Click _Just search for a domain_
3. Select a domain
4. Change URL as follows in the address bar and press enter:
  
   ```diff
   - http://calypso.localhost:3000/domains/add/:domain/google-workspace/:siteSlug
   + http://calypso.localhost:3000/domains/add/:domain/email/:siteSlug
   ```
5. Test in different viewport sizes
6. Click _Not interested_

#### Screenshots

<details>
<summary>Click/tap on this section to see screenshots</summary>

##### Mobile

| Before | After |
|-------|-------|
| ![before_mobile](https://user-images.githubusercontent.com/2759499/131003616-7ae1e941-7900-42a7-b5d5-d6cfbe072a4d.jpeg) | ![skip_mobile](https://user-images.githubusercontent.com/2759499/131003647-6bf31f60-2b09-41ac-912b-aa5f1f7bb8c9.jpeg) |

##### Desktop

| Before | After |
|-------|-------|
| ![before_desktop](https://user-images.githubusercontent.com/2759499/131003689-de82f7d2-e0d6-40ac-b744-0b0b826da968.jpeg) | ![skip_desktop](https://user-images.githubusercontent.com/2759499/131003710-f130ca38-5ffb-42cb-b6d1-a42c7b4419e5.jpeg) |

</details>

cc @daledupreez 