### PR TITLE
Add support links to additional Calypso sections

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -43,9 +43,9 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/publicize/',
 		post_id: 4789,
 	},
-	ads: {
-		link: 'https://wordpress.com/support/wordads-and-earn/',
-		post_id: 154292,
+	earn: {
+		link: 'https://wordpress.com/support/monetize-your-site/',
+		post_id: 120172,
 	},
 	import: {
 		link: 'https://wordpress.com/support/import/',

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -76,11 +76,11 @@ export const getContextLinks = () => ( {
 		post_id: 111349,
 	},
 	billing: {
-		link: localizeUrl( 'https://wordpress.com/support/billing-history/' ),
+		link: 'https://wordpress.com/support/billing-history/',
 		post_id: 40792,
 	},
 	payment_methods: {
-		link: localizeUrl( 'https://wordpress.com/support/payment/' ),
+		link: 'https://wordpress.com/support/payment/',
 		post_id: 76237,
 	},
 } );

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -75,4 +75,12 @@ export const getContextLinks = () => ( {
 		link: 'https://wordpress.com/support/manage-purchases/',
 		post_id: 111349,
 	},
+	billing: {
+		link: localizeUrl( 'https://wordpress.com/support/billing-history/' ),
+		post_id: 40792,
+	},
+	payment_methods: {
+		link: localizeUrl( 'https://wordpress.com/support/payment/' ),
+		post_id: 76237,
+	},
 } );

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingHistoryList from 'calypso/me/purchases/billing-history/billing-history-list';
@@ -45,7 +46,14 @@ function BillingHistory(): JSX.Element {
 			<FormattedHeader
 				brandFont
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate( 'View, print, and email your receipts.' ) }
+				subHeaderText={ translate(
+					'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
+						},
+					}
+				) }
 				align="left"
 			/>
 			<QueryBillingTransactions />

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -2,6 +2,7 @@ import { localize, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
@@ -23,7 +24,16 @@ function PaymentMethods(): JSX.Element {
 			<FormattedHeader
 				brandFont
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate( 'Add or delete payment methods for your account.' ) }
+				subHeaderText={ translate(
+					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+							),
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation section="paymentMethods" />

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -199,7 +199,7 @@ class EarningsMain extends Component {
 						'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
-								learnMoreLink: <InlineSupportLink supportContext="ads" showIcon={ false } />,
+								learnMoreLink: <InlineSupportLink supportContext="earn" showIcon={ false } />,
 							},
 						}
 					) }

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -7,6 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { BillingHistoryContent } from 'calypso/me/purchases/billing-history/main';
@@ -69,7 +70,14 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 				brandFont
 				className="billing-history__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate( 'View, print, and email your receipts for this site.' ) }
+				subHeaderText={ translate(
+					'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Billing History' } siteSlug={ siteSlug } />

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CancelPurchase from 'calypso/me/purchases/cancel-purchase';
@@ -25,7 +26,6 @@ import {
 } from './paths';
 import Subscriptions from './subscriptions';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
-
 function useLogPurchasesError( message: string ) {
 	const reduxDispatch = useDispatch();
 
@@ -62,7 +62,12 @@ export function Purchases(): JSX.Element {
 				className="purchases__page-heading"
 				headerText={ titles.sectionTitle }
 				subHeaderText={ translate(
-					'View, manage, or cancel your plan and other purchases for this site.'
+					'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
+						},
+					}
 				) }
 				align="left"
 			/>

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -26,6 +26,7 @@ import {
 } from './paths';
 import Subscriptions from './subscriptions';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
+
 function useLogPurchasesError( message: string ) {
 	const reduxDispatch = useDispatch();
 

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
@@ -65,7 +66,16 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 				brandFont
 				className="payment-methods__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate( 'Add or delete payment methods for your account.' ) }
+				subHeaderText={ translate(
+					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+							),
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Payment Methods' } siteSlug={ siteSlug } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update 'Learn More' link on Tools > Earn section to https://wordpress.com/support/monetize-your-site/
- Add purchase supportContext to My Site > Upgrades > Purchases
- Add support links to Billing History and Payment methods sections, both account and site level.

#### Testing instructions

- Go to Tools > Earn and click on Learn More link at top of page, this should open a modal containing the Monetize Your Site support page
- Go to http://calypso.localhost:3000/purchases/subscriptions/[siteUrl] and click on Learn More, should open a modal containing https://wordpress.com/support/manage-purchases/
- From the page in step two, click on the Billing and Payment Methods tabs, should have respective Learn More links opening documentation for Billing and Payment Methods
- Go to https://wordpress.com/me/purchases and check that the Learn More links also work as they do in steps 2 and 3.

**Context:**
- https://wp.me/p7DVsv-cyS#comment-37359
