### PR TITLE
Prototype of a tabbed plans page in the signup flow

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -129,17 +129,18 @@ export class PlansStep extends Component {
 
 		const treatmentPlanDisplay = (
 			<TabbedPlans
-				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+				customerType={ this.getCustomerType() }
+				domainName={ this.getDomainName() }
+				flowName={ flowName }
 				hideFreePlan={ hideFreePlan }
-				onUpgradeClick={ this.onSelectPlan }
+				intervalType={ this.getIntervalType() }
+				isAllPaidPlansShown={ true }
 				isInSignup={ true }
 				isLaunchPage={ isLaunchPage }
-				intervalType={ this.getIntervalType() }
-				domainName={ this.getDomainName() }
-				customerType={ this.getCustomerType() }
+				onUpgradeClick={ this.onSelectPlan }
+				plans={ [ 'personal-bundle', 'value_bundle', 'business-bundle', 'ecommerce-bundle' ] }
 				planTypes={ planTypes }
-				flowName={ flowName }
-				isAllPaidPlansShown={ true }
+				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
 				shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
 			/>
 		);

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -12,15 +12,17 @@ import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
+import { Experiment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import TabbedPlans from 'calypso/signup/steps/plans/tabbed-plans';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
+import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSiteGoals } from 'calypso/state/signup/steps/site-goals/selectors';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
-import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
 
@@ -113,40 +115,66 @@ export class PlansStep extends Component {
 			planTypes,
 			flowName,
 			showTreatmentPlansReorderTest,
+			// eslint-disable-next-line no-unused-vars
 			isLoadingExperiment,
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 		} = this.props;
 
+		const loadingPlanDisplay = (
+			<div className="plans__loading-container">
+				<PulsingDot delay={ 400 } active />
+			</div>
+		);
+
+		const treatmentPlanDisplay = (
+			<TabbedPlans
+				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+				hideFreePlan={ hideFreePlan }
+				onUpgradeClick={ this.onSelectPlan }
+				isInSignup={ true }
+				isLaunchPage={ isLaunchPage }
+				intervalType={ this.getIntervalType() }
+				domainName={ this.getDomainName() }
+				customerType={ this.getCustomerType() }
+				planTypes={ planTypes }
+				flowName={ flowName }
+				isAllPaidPlansShown={ true }
+				shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
+			/>
+		);
+		const defaultPlanDisplay = (
+			<PlansFeaturesMain
+				site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+				hideFreePlan={ hideFreePlan }
+				isInSignup={ true }
+				isLaunchPage={ isLaunchPage }
+				intervalType={ this.getIntervalType() }
+				onUpgradeClick={ this.onSelectPlan }
+				showFAQ={ false }
+				domainName={ this.getDomainName() }
+				customerType={ this.getCustomerType() }
+				disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+				plansWithScroll={ isDesktop() }
+				planTypes={ planTypes }
+				flowName={ flowName }
+				showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+				isAllPaidPlansShown={ true }
+				isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+				shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
+				isReskinned={ isReskinned }
+			/>
+		);
+
 		return (
 			<div>
 				<QueryPlans />
-				{ isLoadingExperiment ? (
-					<div className="plans__loading-container">
-						<PulsingDot delay={ 400 } active />
-					</div>
-				) : (
-					<PlansFeaturesMain
-						site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-						hideFreePlan={ hideFreePlan }
-						isInSignup={ true }
-						isLaunchPage={ isLaunchPage }
-						intervalType={ this.getIntervalType() }
-						onUpgradeClick={ this.onSelectPlan }
-						showFAQ={ false }
-						domainName={ this.getDomainName() }
-						customerType={ this.getCustomerType() }
-						disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-						plansWithScroll={ isDesktop() }
-						planTypes={ planTypes }
-						flowName={ flowName }
-						showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-						isAllPaidPlansShown={ true }
-						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-						shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
-						isReskinned={ isReskinned }
-					/>
-				) }
+				<Experiment
+					name="tabbed_plans_poc"
+					defaultExperience={ defaultPlanDisplay }
+					treatmentExperience={ treatmentPlanDisplay }
+					loadingExperience={ loadingPlanDisplay }
+				/>
 			</div>
 		);
 	}

--- a/client/signup/steps/plans/tabbed-plans-style.scss
+++ b/client/signup/steps/plans/tabbed-plans-style.scss
@@ -3,7 +3,6 @@
 	grid-template-columns: 0.8fr 1fr 1fr 1.25fr;
 	grid-template-rows: auto;
 	grid-template-areas:
-		'tabs	tabs				tabs				tabs'
 		'.		plan-header-1		plan-header-2	both-plans'
 		'. 		price-1 			price-2 		both-plans'
 		'ft-1 	feature-1-1 		feature-2-1 	both-plans'

--- a/client/signup/steps/plans/tabbed-plans-style.scss
+++ b/client/signup/steps/plans/tabbed-plans-style.scss
@@ -1,0 +1,108 @@
+.tabbed-plans__grid-container {
+	display: grid;
+	grid-template-columns: 0.8fr 1fr 1fr 1.25fr;
+	grid-template-rows: auto;
+	grid-template-areas:
+		'tabs	tabs				tabs				tabs'
+		'.		plan-header-1		plan-header-2	both-plans'
+		'. 		price-1 			price-2 		both-plans'
+		'ft-1 	feature-1-1 		feature-2-1 	both-plans'
+		'ft-2	feature-1-2 		feature-2-2		both-plans'
+		'ft-3	feature-1-3 		feature-2-3		both-plans'
+		'ft-4	feature-1-4 		feature-2-4		both-plans'
+		'ft-5	feature-1-5 		feature-2-5		both-plans'
+		'. 		button-1 			button-2 		.';
+}
+
+.tabbed-plans__tab-1 {
+	order: 1;
+}
+
+.tabbed-plans__tab-2 {
+	order: 2;
+}
+
+.tabbed-plans__header-1 {
+	grid-area: plan-header-1;
+}
+
+.tabbed-plans__header-2 {
+	grid-area: plan-header-2;
+}
+
+.tabbed-plans__price-1 {
+	grid-area: price-1;
+}
+
+.tabbed-plans__price-2 {
+	grid-area: price-2;
+}
+
+.tabbed-plans__button-1 {
+	grid-area: button-1;
+}
+
+.tabbed-plans__button-2 {
+	grid-area: button-2;
+}
+
+.tabbed-plans__feature-title-1 {
+	grid-area: ft-1;
+}
+
+.tabbed-plans__feature-title-2 {
+	grid-area: ft-2;
+}
+
+.tabbed-plans__feature-title-3 {
+	grid-area: ft-3;
+}
+
+.tabbed-plans__feature-title-4 {
+	grid-area: ft-4;
+}
+
+.tabbed-plans__feature-title-5 {
+	grid-area: ft-5;
+}
+
+.tabbed-plans__feature-1-1 {
+	grid-area: feature-1-1;
+}
+
+.tabbed-plans__feature-2-1 {
+	grid-area: feature-2-1;
+}
+
+.tabbed-plans__feature-1-2 {
+	grid-area: feature-1-2;
+}
+
+.tabbed-plans__feature-2-2 {
+	grid-area: feature-2-2;
+}
+
+.tabbed-plans__feature-1-3 {
+	grid-area: feature-1-3;
+}
+
+.tabbed-plans__feature-2-3 {
+	grid-area: feature-2-3;
+}
+
+.tabbed-plans__feature-1-4 {
+	grid-area: feature-1-4;
+}
+
+.tabbed-plans__feature-2-4 {
+	grid-area: feature-2-4;
+}
+
+.tabbed-plans__feature-1-5 {
+	grid-area: feature-1-5;
+}
+
+.tabbed-plans__feature-2-5 {
+	grid-area: feature-2-5;
+}
+

--- a/client/signup/steps/plans/tabbed-plans.js
+++ b/client/signup/steps/plans/tabbed-plans.js
@@ -1,181 +1,229 @@
 /**
  * External dependencies
  */
+import {
+	applyTestFiltersToPlansList,
+	findPlansKeys,
+	getPlan as getPlanFromKey,
+	getYearlyPlanByMonthly,
+	isMonthly,
+	TERM_MONTHLY,
+	TERM_ANNUALLY,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getPlan, getPlanBySlug, getPlanRawPrice } from 'calypso/state/plans/selectors';
 
 /**
  * Internal dependencies
  */
 import './tabbed-plans-style.scss';
 
-function TabbedPlans( { onUpgradeClick } ) {
+function TabbedPlans( { currencyCode, onUpgradeClick, planProperties } ) {
+	const translate = useTranslate();
 	const tabList = [ 'Limited', 'Professional' ];
-	const bothPlansProfessional = [
-		'Unlimited posts/pages/products',
-		'World class 24/7 support',
-		'Custom domain (free for first year)',
-		'WordPress.com ads removed',
-		'Ability to sell products/services',
-		'Earn ad revenue',
-		'Video hosting',
-		'Google Analytics',
-		'MailChimp integration',
-	];
-	const bothPlansLimited = [
-		'Both plans feature 1',
-		'Both plans feature 2',
-		'Both plans feature 3',
-		'Both plans feature 4',
-		'Both plans feature 5',
-	];
-	const featureComparisonProfessional = [
-		{ featureName: 'Install plugins', planOne: 'None', planTwo: '58,000+ Available' },
-		{ featureName: 'Themes available', planOne: '25', planTwo: '8,000 to choose from' },
-		{ featureName: 'SEO', planOne: 'Simple', planTwo: 'Advanced for better ranking' },
-		{ featureName: 'Storage', planOne: '100GB (for images and video)', planTwo: '200GB' },
-		{ featureName: 'WooCommerce fees', planOne: '5.5% + 30c', planTwo: '3.9% + 30c' },
-	];
-	const featureComparisonLimited = [
-		{ featureName: 'Install plugins', planOne: 'None', planTwo: 'None' },
-		{ featureName: 'Themes available', planOne: '5', planTwo: '10' },
-		{ featureName: 'SEO', planOne: 'Simple', planTwo: 'Simple' },
-		{ featureName: 'Storage', planOne: '3GB (for images and video)', planTwo: '10GB' },
-		{ featureName: 'WooCommerce fees', planOne: '10% + 30c', planTwo: '8% + 30c' },
-	];
-	const planDetailsProfessional = [
-		{
-			planName: 'WordPress Premium',
-			price: 12,
-			cta: 'Start with Premium',
-			productId: 1003,
-			productSlug: 'value-bundle',
-		},
-		{
-			planName: 'WordPress Plus',
-			price: 48,
-			cta: 'Start with Plus',
-			productId: 1008,
-			productSlug: 'business-bundle',
-		},
-	];
-	const planDetailsLimited = [
-		{
-			planName: 'WordPress Limited',
-			price: 0,
-			cta: 'Start with Limited',
-			productSlug: null,
-			productId: null,
-		},
-		{
-			planName: 'WordPress Personal',
-			price: 4,
-			cta: 'Start with Personal',
-			productId: 1009,
-			productSlug: 'personal-bundle',
-		},
-	];
 
-	const [ bothPlansItems, setBothPlansItems ] = useState( bothPlansProfessional );
-	const [ featureComparison, setFeatureComparison ] = useState( featureComparisonProfessional );
-	const [ planDetails, setPlanDetails ] = useState( planDetailsProfessional );
+	const bothPlansData = {
+		Professional: [
+			translate( 'Unlimited posts/pages/products' ),
+			translate( 'World class 24/7 support' ),
+			translate( 'Custom domain (free for first year)' ),
+			translate( 'WordPress.com ads removed' ),
+			translate( 'Ability to sell products/services' ),
+			translate( 'Earn ad revenue' ),
+			translate( 'Video hosting' ),
+			translate( 'Google Analytics' ),
+			translate( 'MailChimp integration' ),
+		],
+		Limited: [
+			translate( 'Both plans feature 1' ),
+			translate( 'Both plans feature 2' ),
+			translate( 'Both plans feature 3' ),
+			translate( 'Both plans feature 4' ),
+			translate( 'Both plans feature 5' ),
+		],
+	};
+
+	const featureComparisonData = {
+		Professional: [
+			{
+				featureName: translate( 'Install plugins' ),
+				planOne: translate( 'None' ),
+				planTwo: translate( '58,000+ Available' ),
+			},
+			{
+				featureName: translate( 'Themes available' ),
+				planOne: translate( '25' ),
+				planTwo: translate( '8,000 to choose from' ),
+			},
+			{
+				featureName: translate( 'SEO' ),
+				planOne: translate( 'Simple' ),
+				planTwo: translate( 'Advanced for better ranking' ),
+			},
+			{
+				featureName: translate( 'Storage' ),
+				planOne: translate( '100GB (for images and video)' ),
+				planTwo: translate( '200GB' ),
+			},
+			{
+				featureName: translate( 'WooCommerce fees' ),
+				planOne: translate( '5.5% + 30c' ),
+				planTwo: translate( '3.9% + 30c' ),
+			},
+		],
+		Limited: [
+			{
+				featureName: translate( 'Install plugins' ),
+				planOne: translate( 'None' ),
+				planTwo: translate( 'None' ),
+			},
+			{
+				featureName: translate( 'Themes available' ),
+				planOne: translate( '5' ),
+				planTwo: translate( '10' ),
+			},
+			{
+				featureName: translate( 'SEO' ),
+				planOne: translate( 'Simple' ),
+				planTwo: translate( 'Simple' ),
+			},
+			{
+				featureName: translate( 'Storage' ),
+				planOne: translate( '3GB (for images and video)' ),
+				planTwo: translate( '10GB' ),
+			},
+			{
+				featureName: translate( 'WooCommerce fees' ),
+				planOne: translate( '10% + 30c' ),
+				planTwo: translate( '8% + 30c' ),
+			},
+		],
+	};
+
+	const [ bothPlansItems, setBothPlansItems ] = useState( bothPlansData.Professional );
+	const [ featureComparison, setFeatureComparison ] = useState(
+		featureComparisonData.Professional
+	);
+	const [ planDetails, setPlanDetails ] = useState();
 	const [ selectedTab, setSelectedTab ] = useState( 'Professional' );
+	const [ termLength, setTermLength ] = useState( 'annual' );
 
 	const toggleTab = () =>
-		selectedTab === 'Professional' ? setSelectedTab( 'Limited' ) : setSelectedTab( 'Professional' );
+		selectedTab === tabList[ 0 ] ? setSelectedTab( tabList[ 1 ] ) : setSelectedTab( tabList[ 0 ] );
 
 	const handleUpgradeButtonClick = ( productSlug, productId ) => {
-		if ( productSlug === null ) {
-			onUpgradeClick( null );
-		} else {
-			onUpgradeClick( { product_slug: productSlug, product_id: productId } );
-		}
+		const args = productSlug === null ? null : { product_slug: productSlug, product_id: productId };
+		onUpgradeClick( args );
 	};
 
 	useEffect( () => {
-		if ( selectedTab === 'Professional' ) {
-			setBothPlansItems( bothPlansProfessional );
-			setPlanDetails( planDetailsProfessional );
-			setFeatureComparison( featureComparisonProfessional );
-		} else {
-			setBothPlansItems( bothPlansLimited );
-			setPlanDetails( planDetailsLimited );
-			setFeatureComparison( featureComparisonLimited );
-		}
+		const planFilter =
+			selectedTab === 'Professional' ? [ 'Business', 'eCommerce' ] : [ 'Personal', 'Premium' ];
+
+		const displayedPlans = planProperties.filter( ( plan ) =>
+			planFilter.includes( plan.planName )
+		);
+
+		setBothPlansItems( bothPlansData[ selectedTab ] );
+		setFeatureComparison( featureComparisonData[ selectedTab ] );
+		setPlanDetails( displayedPlans );
 	}, [ selectedTab ] );
 
-	// ** Things to handle:
-	// * 	- whether the user added a domain in the prior step
-	// * 	- Handle Monthly / Annually toggles
-
 	return (
-		<Grid className="tabbed-plans__grid-container">
+		<>
 			<TabContainer>
 				{ tabList.map( ( item, index ) =>
 					item === selectedTab ? (
-						<SelectedTab className={ `tabbed-plans__tab-${ index + 1 }` } onClick={ toggleTab }>
+						<SelectedTab
+							key={ `tab${ index }` }
+							className={ `tabbed-plans__tab-${ index + 1 }` }
+							onClick={ toggleTab }
+						>
 							{ item }
 						</SelectedTab>
 					) : (
-						<Tab className={ `tabbed-plans__tab-${ index + 1 }` } onClick={ toggleTab }>
+						<Tab
+							key={ `tab${ index }` }
+							className={ `tabbed-plans__tab-${ index + 1 }` }
+							onClick={ toggleTab }
+						>
 							{ item }
 						</Tab>
 					)
 				) }
 			</TabContainer>
-			{ planDetails.map( ( item, index ) => (
-				<React.Fragment key={ `planDetails${ index }` }>
-					<PlanHeader
-						key={ `planHeader${ index }` }
-						className={ `tabbed-plans__header-${ index + 1 }` }
-					>
-						{ item.planName }
-					</PlanHeader>
-					<Price key={ `planPrice${ index }` } className={ `tabbed-plans__price-${ index + 1 }` }>
-						${ item.price } /mo
-					</Price>
-					<CtaButton
-						key={ `planCta${ index }` }
-						className={ `tabbed-plans__button-${ index + 1 }` }
-						onClick={ () => handleUpgradeButtonClick( item.productSlug, item.productId ) }
-					>
-						{ item.cta }
-					</CtaButton>
-				</React.Fragment>
-			) ) }
+			<Grid className="tabbed-plans__grid-container">
+				{ planDetails &&
+					planDetails.map( ( item, index ) => (
+						<React.Fragment key={ `planDetails${ index }` }>
+							<PlanHeader
+								key={ `planHeader${ index }` }
+								className={ `tabbed-plans__header-${ index + 1 }` }
+							>
+								{ translate( 'WordPress %(planName)s', {
+									args: { planName: item.planName },
+									comment: 'For example, WordPress Business',
+								} ) }
+							</PlanHeader>
+							<PlanPrice
+								key={ `planPrice${ index }` }
+								className={ `tabbed-plans__price-${ index + 1 }` }
+								currencyCode={ currencyCode }
+								rawPrice={ termLength === 'annual' ? item.rawPrice : item.rawPriceForMonthlyPlan }
+								displayPerMonthNotation={ true }
+							/>
 
-			{ featureComparison.map( ( item, index ) => (
-				<React.Fragment key={ `feature${ index }` }>
-					<FeatureTitle
-						key={ `featureTitle${ index }` }
-						className={ `tabbed-plans__feature-title-${ index + 1 }` }
-					>
-						{ item.featureName }
-					</FeatureTitle>
-					<Feature
-						key={ `featureItemOne${ index }` }
-						className={ `tabbed-plans__feature-1-${ index + 1 }` }
-					>
-						{ item.planOne }
-					</Feature>
-					<Feature
-						key={ `featureItemTwo${ index }` }
-						className={ `tabbed-plans__feature-2-${ index + 1 }` }
-					>
-						{ item.planTwo }
-					</Feature>
-				</React.Fragment>
-			) ) }
+							<CtaButton
+								key={ `planCta${ index }` }
+								className={ `tabbed-plans__button-${ index + 1 }` }
+								onClick={ () => handleUpgradeButtonClick( item.planSlug, item.planProductId ) }
+							>
+								{ translate( 'Start with %(planName)s', {
+									args: { planName: item.planName },
+									comment: 'For example, Start with Business',
+								} ) }
+							</CtaButton>
+						</React.Fragment>
+					) ) }
 
-			<BothPlans>
-				<BothPlansHeader>Included with both plans:</BothPlansHeader>
-				{ bothPlansItems.map( ( item, index ) => (
-					<BothPlansItem key={ `bothItems${ index }` }>{ item }</BothPlansItem>
+				{ featureComparison.map( ( item, index ) => (
+					<React.Fragment key={ `feature${ index }` }>
+						<FeatureTitle
+							key={ `featureTitle${ index }` }
+							className={ `tabbed-plans__feature-title-${ index + 1 }` }
+						>
+							{ item.featureName }
+						</FeatureTitle>
+						<Feature
+							key={ `featureItemOne${ index }` }
+							className={ `tabbed-plans__feature-1-${ index + 1 }` }
+						>
+							{ item.planOne }
+						</Feature>
+						<Feature
+							key={ `featureItemTwo${ index }` }
+							className={ `tabbed-plans__feature-2-${ index + 1 }` }
+						>
+							{ item.planTwo }
+						</Feature>
+					</React.Fragment>
 				) ) }
-			</BothPlans>
-		</Grid>
+
+				<BothPlans>
+					<BothPlansHeader>{ translate( 'Included with both plans:' ) }</BothPlansHeader>
+					{ bothPlansItems.map( ( item, index ) => (
+						<BothPlansItem key={ `bothItems${ index }` }>{ item }</BothPlansItem>
+					) ) }
+				</BothPlans>
+			</Grid>
+		</>
 	);
 }
 
@@ -183,7 +231,49 @@ TabbedPlans.propTypes = {
 	onUpgradeClick: PropTypes.func,
 };
 
-export default TabbedPlans;
+const mapStateToProps = ( state, ownProps ) => {
+	const { plans } = ownProps;
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+	const planProperties = plans.map( ( plan ) => {
+		const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
+		const planProductId = planConstantObj.getProductId();
+		const planObject = getPlan( state, planProductId );
+		const rawPrice = getPlanRawPrice( state, planProductId, true );
+		const isMonthlyPlan = isMonthly( plan );
+		let annualPricePerMonth = rawPrice;
+		if ( isMonthlyPlan ) {
+			// Get annual price per month for comparison
+			const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
+			if ( yearlyPlan ) {
+				annualPricePerMonth = getPlanRawPrice( state, yearlyPlan.product_id, true );
+			}
+		}
+		const monthlyPlanKey = findPlansKeys( {
+			group: planConstantObj.group,
+			term: TERM_MONTHLY,
+			type: planConstantObj.type,
+		} )[ 0 ];
+		const monthlyPlanProductId = getPlanFromKey( monthlyPlanKey )?.getProductId();
+		// This is the per month price of a monthly plan. E.g. $14 for Premium monthly.
+		const rawPriceForMonthlyPlan = getPlanRawPrice( state, monthlyPlanProductId, true );
+
+		return {
+			annualPricePerMonth,
+			currencyCode: getCurrentUserCurrencyCode( state ),
+			planName: planObject?.product_name_short,
+			planObject,
+			planProductId,
+			planSlug: planObject?.product_slug,
+			rawPrice,
+			rawPriceForMonthlyPlan,
+		};
+	} );
+	return {
+		planProperties,
+	};
+};
+
+export default connect( mapStateToProps )( TabbedPlans );
 
 const CtaButton = styled( Button )`
 	border: 1px solid black;
@@ -212,12 +302,6 @@ const PlanHeader = styled.div`
 	font-size: 25px;
 `;
 
-const Price = styled.div`
-	font-size: 36px;
-	padding: 36px 0;
-	font-weight: 600;
-`;
-
 const BothPlans = styled.div`
 	grid-area: both-plans;
 	border-left: 1px solid #ddd;
@@ -236,7 +320,6 @@ const BothPlansItem = styled.p`
 `;
 
 const TabContainer = styled.ul`
-	grid-area: tabs;
 	display: flex;
 	flex-flow: row nowrap;
 	justify-content: flex-start;

--- a/client/signup/steps/plans/tabbed-plans.js
+++ b/client/signup/steps/plans/tabbed-plans.js
@@ -1,0 +1,263 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './tabbed-plans-style.scss';
+
+function TabbedPlans( { onUpgradeClick } ) {
+	const tabList = [ 'Limited', 'Professional' ];
+	const bothPlansProfessional = [
+		'Unlimited posts/pages/products',
+		'World class 24/7 support',
+		'Custom domain (free for first year)',
+		'WordPress.com ads removed',
+		'Ability to sell products/services',
+		'Earn ad revenue',
+		'Video hosting',
+		'Google Analytics',
+		'MailChimp integration',
+	];
+	const bothPlansLimited = [
+		'Both plans feature 1',
+		'Both plans feature 2',
+		'Both plans feature 3',
+		'Both plans feature 4',
+		'Both plans feature 5',
+	];
+	const featureComparisonProfessional = [
+		{ featureName: 'Install plugins', planOne: 'None', planTwo: '58,000+ Available' },
+		{ featureName: 'Themes available', planOne: '25', planTwo: '8,000 to choose from' },
+		{ featureName: 'SEO', planOne: 'Simple', planTwo: 'Advanced for better ranking' },
+		{ featureName: 'Storage', planOne: '100GB (for images and video)', planTwo: '200GB' },
+		{ featureName: 'WooCommerce fees', planOne: '5.5% + 30c', planTwo: '3.9% + 30c' },
+	];
+	const featureComparisonLimited = [
+		{ featureName: 'Install plugins', planOne: 'None', planTwo: 'None' },
+		{ featureName: 'Themes available', planOne: '5', planTwo: '10' },
+		{ featureName: 'SEO', planOne: 'Simple', planTwo: 'Simple' },
+		{ featureName: 'Storage', planOne: '3GB (for images and video)', planTwo: '10GB' },
+		{ featureName: 'WooCommerce fees', planOne: '10% + 30c', planTwo: '8% + 30c' },
+	];
+	const planDetailsProfessional = [
+		{
+			planName: 'WordPress Premium',
+			price: 12,
+			cta: 'Start with Premium',
+			productId: 1003,
+			productSlug: 'value-bundle',
+		},
+		{
+			planName: 'WordPress Plus',
+			price: 48,
+			cta: 'Start with Plus',
+			productId: 1008,
+			productSlug: 'business-bundle',
+		},
+	];
+	const planDetailsLimited = [
+		{
+			planName: 'WordPress Limited',
+			price: 0,
+			cta: 'Start with Limited',
+			productSlug: null,
+			productId: null,
+		},
+		{
+			planName: 'WordPress Personal',
+			price: 4,
+			cta: 'Start with Personal',
+			productId: 1009,
+			productSlug: 'personal-bundle',
+		},
+	];
+
+	const [ bothPlansItems, setBothPlansItems ] = useState( bothPlansProfessional );
+	const [ featureComparison, setFeatureComparison ] = useState( featureComparisonProfessional );
+	const [ planDetails, setPlanDetails ] = useState( planDetailsProfessional );
+	const [ selectedTab, setSelectedTab ] = useState( 'Professional' );
+
+	const toggleTab = () =>
+		selectedTab === 'Professional' ? setSelectedTab( 'Limited' ) : setSelectedTab( 'Professional' );
+
+	const handleUpgradeButtonClick = ( productSlug, productId ) => {
+		if ( productSlug === null ) {
+			onUpgradeClick( null );
+		} else {
+			onUpgradeClick( { product_slug: productSlug, product_id: productId } );
+		}
+	};
+
+	useEffect( () => {
+		if ( selectedTab === 'Professional' ) {
+			setBothPlansItems( bothPlansProfessional );
+			setPlanDetails( planDetailsProfessional );
+			setFeatureComparison( featureComparisonProfessional );
+		} else {
+			setBothPlansItems( bothPlansLimited );
+			setPlanDetails( planDetailsLimited );
+			setFeatureComparison( featureComparisonLimited );
+		}
+	}, [ selectedTab ] );
+
+	// ** Things to handle:
+	// * 	- whether the user added a domain in the prior step
+	// * 	- Handle Monthly / Annually toggles
+
+	return (
+		<Grid className="tabbed-plans__grid-container">
+			<TabContainer>
+				{ tabList.map( ( item, index ) =>
+					item === selectedTab ? (
+						<SelectedTab className={ `tabbed-plans__tab-${ index + 1 }` } onClick={ toggleTab }>
+							{ item }
+						</SelectedTab>
+					) : (
+						<Tab className={ `tabbed-plans__tab-${ index + 1 }` } onClick={ toggleTab }>
+							{ item }
+						</Tab>
+					)
+				) }
+			</TabContainer>
+			{ planDetails.map( ( item, index ) => (
+				<React.Fragment key={ `planDetails${ index }` }>
+					<PlanHeader
+						key={ `planHeader${ index }` }
+						className={ `tabbed-plans__header-${ index + 1 }` }
+					>
+						{ item.planName }
+					</PlanHeader>
+					<Price key={ `planPrice${ index }` } className={ `tabbed-plans__price-${ index + 1 }` }>
+						${ item.price } /mo
+					</Price>
+					<CtaButton
+						key={ `planCta${ index }` }
+						className={ `tabbed-plans__button-${ index + 1 }` }
+						onClick={ () => handleUpgradeButtonClick( item.productSlug, item.productId ) }
+					>
+						{ item.cta }
+					</CtaButton>
+				</React.Fragment>
+			) ) }
+
+			{ featureComparison.map( ( item, index ) => (
+				<React.Fragment key={ `feature${ index }` }>
+					<FeatureTitle
+						key={ `featureTitle${ index }` }
+						className={ `tabbed-plans__feature-title-${ index + 1 }` }
+					>
+						{ item.featureName }
+					</FeatureTitle>
+					<Feature
+						key={ `featureItemOne${ index }` }
+						className={ `tabbed-plans__feature-1-${ index + 1 }` }
+					>
+						{ item.planOne }
+					</Feature>
+					<Feature
+						key={ `featureItemTwo${ index }` }
+						className={ `tabbed-plans__feature-2-${ index + 1 }` }
+					>
+						{ item.planTwo }
+					</Feature>
+				</React.Fragment>
+			) ) }
+
+			<BothPlans>
+				<BothPlansHeader>Included with both plans:</BothPlansHeader>
+				{ bothPlansItems.map( ( item, index ) => (
+					<BothPlansItem key={ `bothItems${ index }` }>{ item }</BothPlansItem>
+				) ) }
+			</BothPlans>
+		</Grid>
+	);
+}
+
+TabbedPlans.propTypes = {
+	onUpgradeClick: PropTypes.func,
+};
+
+export default TabbedPlans;
+
+const CtaButton = styled( Button )`
+	border: 1px solid black;
+	margin: 30px 30px 0 0;
+	padding: 10px 36px;
+	font-weight: 600;
+`;
+
+const Feature = styled.div`
+	margin-bottom: 10px;
+`;
+
+const FeatureTitle = styled.h2`
+	margin-left: 36px;
+	font-weight: 600;
+`;
+
+const Grid = styled.div`
+	border-bottom: 1px solid black;
+	border-left: 1px solid black;
+	border-right: 1px solid black;
+	padding: 0 0 36px 0;
+`;
+const PlanHeader = styled.div`
+	margin-top: 20px;
+	font-size: 25px;
+`;
+
+const Price = styled.div`
+	font-size: 36px;
+	padding: 36px 0;
+	font-weight: 600;
+`;
+
+const BothPlans = styled.div`
+	grid-area: both-plans;
+	border-left: 1px solid #ddd;
+	margin: 20px;
+	padding-left: 20px;
+`;
+
+const BothPlansHeader = styled.h2`
+	font-size: 20px;
+	margin-bottom: 20px;
+`;
+
+const BothPlansItem = styled.p`
+	font-size: 1rem;
+	margin: 0 0 5px 0;
+`;
+
+const TabContainer = styled.ul`
+	grid-area: tabs;
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: flex-start;
+	align-items: flex-end;
+	border-bottom: 1px solid black;
+	margin: 0 -2px -1px -1px;
+	border-left: 1px solid white;
+	border-right: 1px solid white;
+	padding-left: 20px;
+`;
+
+const Tab = styled.li`
+	padding: 6px 36px;
+	list-style: none;
+	background-color: #dddddd;
+	border: 1px solid black;
+	margin: 0 -1px -1px -1px;
+`;
+
+const SelectedTab = styled( Tab )`
+	background-color: #fff;
+	border-bottom: 1px solid white;
+	margin: 0 -1px -1px -1px;
+`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Proof of concept for a tabbed version of the plans page in the signup flow.

![CleanShot 2021-08-26 at 13 54 17](https://user-images.githubusercontent.com/35781181/131013954-4c5e0ab1-2090-456b-9385-7e6ce32d7f20.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Checkout this PR.
* Add yourself to the treatment variation of the `tabbed_plans_poc`Explat test.
* Navigate to the `/start/new/` signup flow and proceed to the Plans page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
