### PR TITLE
Domains: Fix bug when switching sites while on the domain search page

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -87,7 +87,6 @@ import {
 import { hideSitePreview, showSitePreview } from 'calypso/state/signup/preview/actions';
 import { isSitePreviewVisible } from 'calypso/state/signup/preview/selectors';
 import AlreadyOwnADomain from './already-own-a-domain';
-import SearchWithTyper from './search';
 import tip from './tip';
 
 import './style.scss';
@@ -516,7 +515,6 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderSearchBar() {
-		const { isSignupStep } = this.props;
 		const componentProps = {
 			className: this.state.clickedExampleSuggestion ? 'is-refocused' : undefined,
 			autoFocus: true,
@@ -536,18 +534,9 @@ class RegisterDomainStep extends React.Component {
 			isReskinned: this.props.isReskinned,
 		};
 
-		if ( isSignupStep ) {
-			return (
-				<>
-					<Search { ...componentProps }></Search>
-					{ this.renderSearchFilters() }
-				</>
-			);
-		}
-
 		return (
 			<>
-				<SearchWithTyper { ...componentProps }></SearchWithTyper>
+				<Search { ...componentProps }></Search>
 				{ this.renderSearchFilters() }
 			</>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When you were on the domain search page and switched to another site, the navigation would break. It seems there are some reference issues with the `SearchWithTyper` component, so we'll fix this for now by removing it temporarily.

Video showing the bug:

https://user-images.githubusercontent.com/5324818/131029125-d0af440c-eb04-46dc-a3f1-7fdd08886a9d.mp4

#### Testing instructions

Open the live Calypso link and navigate to the domain search page on a site. Switch to another site and ensure nothing breaks and that no reference warnings appear on the dev console of your browser.

