### PR TITLE
Domains: Add atomic site verification for "change site address"

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -305,7 +305,7 @@ export class SiteAddressChanger extends Component {
 			return (
 				<div className="site-address-changer site-address-changer__only-owner-info">
 					<Gridicon icon="info-outline" />
-					{ translate( 'You cannot change the free site address for atomic sites.' ) }
+					{ translate( 'You cannot change the free WordPress.com address for atomic sites.' ) }
 				</div>
 			);
 		}

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -13,6 +13,7 @@ import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-w
 import Gridicon from 'calypso/components/gridicon';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	requestSiteAddressChange,
 	requestSiteAddressAvailability,
@@ -268,6 +269,7 @@ export class SiteAddressChanger extends Component {
 			siteId,
 			selectedSiteSlug,
 			translate,
+			isAtomicSite,
 		} = this.props;
 
 		const { domainFieldValue, newDomainSuffix } = this.state;
@@ -295,6 +297,15 @@ export class SiteAddressChanger extends Component {
 									components: { strong: <strong /> },
 								}
 						  ) }
+				</div>
+			);
+		}
+
+		if ( isAtomicSite ) {
+			return (
+				<div className="site-address-changer site-address-changer__only-owner-info">
+					<Gridicon icon="info-outline" />
+					{ translate( 'You cannot change the free site address for atomic sites.' ) }
 				</div>
 			);
 		}
@@ -367,6 +378,7 @@ export default connect(
 		return {
 			siteId,
 			selectedSiteSlug: getSiteSlug( state, siteId ),
+			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 			isAvailable: isSiteAddressValidationAvailable( state, siteId ),
 			isSiteAddressChangeRequesting: isRequestingSiteAddressChange( state, siteId ),
 			isAvailabilityPending: getSiteAddressAvailabilityPending( state, siteId ),

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -99,7 +99,7 @@ export class List extends React.Component {
 	}
 
 	renderNewDesign() {
-		const { selectedSite, domains, currentRoute, translate } = this.props;
+		const { selectedSite, domains, currentRoute, translate, isAtomicSite } = this.props;
 		const { settingPrimaryDomain } = this.state;
 		const disabled = settingPrimaryDomain;
 
@@ -160,6 +160,7 @@ export class List extends React.Component {
 				{ wpcomDomain && (
 					<WpcomDomainItem
 						key="wpcom-domain-item"
+						isAtomicSite={ isAtomicSite }
 						currentRoute={ currentRoute }
 						domain={ wpcomDomain }
 						disabled={ disabled }

--- a/client/my-sites/domains/domain-management/list/wpcom-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/wpcom-domain-item.jsx
@@ -18,10 +18,12 @@ export default function WpcomDomainItem( {
 	isBusy,
 	onMakePrimary,
 	site,
+	isAtomicSite,
 } ) {
 	const [ menuVisibility, setMenuVisibility ] = useState( false );
 	const buttonRef = useRef( null );
 	const canMakePrimary = domain.canSetAsPrimary && ! domain.isPrimary;
+	const shouldShowManageButton = canMakePrimary || ! isAtomicSite;
 	const handleMakePrimary = ( event ) => {
 		event.stopPropagation();
 		onMakePrimary( domain.domain );
@@ -46,17 +48,19 @@ export default function WpcomDomainItem( {
 					{ __( 'Primary site address' ) }
 				</Badge>
 			) }
-			<Button
-				className="wpcom-domain-item__manage-button"
-				compact
-				ref={ buttonRef }
-				onClick={ handleToggleMenu }
-				disabled={ disabled }
-				busy={ isBusy }
-			>
-				Manage
-				<Gridicon icon="chevron-down" />
-			</Button>
+			{ shouldShowManageButton && (
+				<Button
+					className="wpcom-domain-item__manage-button"
+					compact
+					ref={ buttonRef }
+					onClick={ handleToggleMenu }
+					disabled={ disabled }
+					busy={ isBusy }
+				>
+					Manage
+					<Gridicon icon="chevron-down" />
+				</Button>
+			) }
 			<PopoverMenu
 				isVisible={ menuVisibility }
 				onClose={ handleMenuClose }
@@ -68,12 +72,14 @@ export default function WpcomDomainItem( {
 						{ __( 'Make primary domain' ) }
 					</PopoverMenuItem>
 				) }
-				<PopoverMenuItem
-					icon="reblog"
-					href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
-				>
-					{ __( 'Change site address' ) }
-				</PopoverMenuItem>
+				{ ! isAtomicSite && (
+					<PopoverMenuItem
+						icon="reblog"
+						href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
+					>
+						{ __( 'Change site address' ) }
+					</PopoverMenuItem>
+				) }
 			</PopoverMenu>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the site is not Atomic, then the option for changing the site's free address will be listed/enabled. Otherwise, the option is not listed.
Also, the "manage" button for the free site now is **only** visible if there's a least one option enabled on it - either changing the free address or setting the free domain as primary. If both conditions are not met, then the button will not be visible.
 
#### Preview
 
##### Non-atomic site

<img width="997" alt="non-atomic-with-plan" src="https://user-images.githubusercontent.com/18705930/131027654-b73a9aa0-8689-482c-971d-dbc98163f230.png">

##### Atomic site (with a custom domain)
<img width="1001" alt="atomic-with-custom-domain" src="https://user-images.githubusercontent.com/18705930/131027716-01b2549e-6703-455c-aa36-53206e9dbd19.png">

##### Atomic site (without a custom domain)
<img width="1004" alt="atomic-without-custom-domain" src="https://user-images.githubusercontent.com/18705930/131038652-18dcfaae-93a9-4db8-8623-74082ffebdec.png">

##### Manually browsing to the change free site address page on atomic site
![image](https://user-images.githubusercontent.com/18705930/131045282-e32c4a12-da9e-4e35-9972-f3cd0e547e1c.png)


#### Testing instructions
- Go to the domain management page;
- Check the "manage" button visibility:
  - Check that the button is not visible for atomic sites with no custom domain;
  - Check that the button is visible for atomic sites with a custom domain and without the free domain marked as primary;
  - Check that the button is visible for non-atomic sites;
- Check that it is not possible to change the free site address when manually browsing to the page on an atomic site (`/domains/manage/:site-slug/change-site-address/:primary-domain`)
- Make sure that tests won't break. 😛 

Fixes https://github.com/Automattic/wp-calypso/issues/55764.
