### PR TITLE
Increase ICFY node memory

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -5,9 +5,9 @@ on: [push]
 jobs:
   build:
     name: Build ICFY stats
-
     runs-on: ubuntu-latest
-
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - name: Set up Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Set node memory for ICFY. Previously, this value was not set. I observed several "heap out of memory" errors over the past few days in the ICFY github action, so I think this should fix it. Resolves #55770.

#### Testing instructions
- ICFY should pass
