### PR TITLE
Add background color to domain search card.

### DIFF
--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -76,6 +76,10 @@
 			background: var( --color-surface );
 		}
 	}
+
+	.card.register-domain-step__search-card {
+		background-color: var( --color-surface );
+	}
 }
 
 .register-domain-step__search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The domain search card has no background color, so anything scrolling behind it when it is stuck to the top of the page shows between the components. This PR just sets a background color so this doesn't happen.

#### Testing instructions

Go to the /domains/add page for a site and scroll so that one of the gray lines between the suggestions would show between the search input and the filter button. Make sure that it doesn't show up .

Before:

<img width="1042" alt="Screen Shot 2021-08-26 at 5 41 12 PM" src="https://user-images.githubusercontent.com/1379730/131039965-aceb8b59-f22a-4bcd-abc0-f7a30b59ebde.png">

After:

<img width="1042" alt="Screen Shot 2021-08-26 at 5 40 49 PM" src="https://user-images.githubusercontent.com/1379730/131039977-88196703-cea1-4590-a2d4-bc130195b7d5.png">
