### PR TITLE
build: Reuse yarn cache between builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ references:
       CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_OPTIONS: --max-old-space-size=3072
       npm_config_cache: /home/circleci/.cache/yarn
-      YARN_CACHE_FOLDER: /home/circleci/.cache/yarn
       CHROME_VERSION: 84.0.4147.135-1
   desktop_defaults: &desktop_defaults
     working_directory: ~/wp-calypso

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -584,9 +584,6 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 		uuid = buildUuid
 		name = "Playwright E2E Tests ($viewportName)"
 		description = "Runs Calypso e2e tests in $viewportName size using Playwright"
-		params {
-			param("use_cached_node_modules", "false")
-		}
 
 		artifactRules = """
 			reports => reports

--- a/.teamcity/_self/yarnInstall.kt
+++ b/.teamcity/_self/yarnInstall.kt
@@ -4,14 +4,6 @@ package _self
  * Use variable in scripts to take advantage of node_module caching.
  */
 val yarn_install_cmd = """
-	# Load existing node_modules to reduce install time.
-	if [ -d /calypso/node_modules ] && [ "%use_cached_node_modules%" == "true" ] ; then
-		echo "Loading existing found node_modules..."
-		mv /calypso/node_modules ./node_modules
-	else
-		echo "No existing node_modules were found."
-	fi
-
 	# Do not type-check packages on postinstall, we already have a unit test for that
 	export SKIP_TSC=true
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -51,7 +51,6 @@ project {
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
-		param("use_cached_node_modules", "false")
 		text("E2E_WORKERS", "16", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
 		text("env.JEST_MAX_WORKERS", "16", label = "Jest max workers", description = "How many tests run in parallel", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ FROM node:${node_version}-buster as builder-cache-false
 # for yarn, terser, css-loader and babel.
 FROM ${base_image} as builder-cache-true
 
-ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,11 +1,11 @@
 #### cache image
 #### This image is not pushed to any repository and it shouldn't be used as base image for any other docker build.
 #### Its main goal is to create a `/calypso/.cache` that can be copied over other images that can benefit from a warm cache.
+#### Note that yarn v3 cache lives in `/calypso/.yarn`
 FROM node:16.7.0-buster as cache
 
 ARG node_memory=8192
 WORKDIR /calypso
-ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
 ENV PROFILE=true
@@ -43,7 +43,6 @@ ARG user=calypso
 ARG UID=1003
 
 WORKDIR /calypso
-ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV NVM_DIR=/calypso/.nvm
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
@@ -69,9 +68,7 @@ COPY --from=cache --chown=$UID /calypso/.nvm /calypso/.nvm
 # Copy all other caches (webpack, babel, yarn...)
 COPY --from=cache --chown=$UID /calypso/.cache /calypso/.cache
 COPY --from=cache --chown=$UID /calypso/.bashrc /calypso/.bashrc
-
-# Copy node_modules to reduce install time of future builds.
-COPY --from=cache --chown=$UID /calypso/node_modules /calypso/node_modules
+COPY --from=cache --chown=$UID /calypso/.yarn /calypso/.yarn
 
 ENTRYPOINT [ "/bin/bash" ]
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes the base cache image so it:

* Stores yarn's [offline cache](https://yarnpkg.com/features/offline-cache). This is stored in `/calypso/.yarn/`
* Remove usages of `YARN_CACHE_FOLDER`, it doesn't work in yarn v3
* Disables restoring `node_modules`. Yarn v3 is not happy if we only restore `./node_modules` and not `./packages/**/node_modules`, `./apps/**/node_modules`, etc. Plus we got a [suggestion from a yarn maintainer](https://github.com/Automattic/wp-calypso/pull/51719#pullrequestreview-721236130) to not cache it.

The result is a base cache image without `node_modules` and with a `yarn` cache, but nobody is using that `yarn` cache for now. Once this is merged and a new base image is produced, I'll change the builds to use it.

#### Testing instructions

* Check all builds pass.