### PR TITLE
Editor Welcome: enable the new welcome tour on mobile

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -78,10 +78,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		$should_open_patterns_panel = (bool) get_option( 'was_created_with_blank_canvas_design' );
 
-		if ( wp_is_mobile() ) {
-			// Designs for welcome tour on mobile are in progress, until then do not show on mobile.
-			$variant = 'modal';
-		} elseif ( $should_open_patterns_panel ) {
+		if ( $should_open_patterns_panel ) {
 			$variant = 'blank-canvas-tour';
 		} else {
 			$variant = 'tour';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -60,6 +60,7 @@ registerPlugin( 'wpcom-block-editor-nux', {
 			);
 		}
 
+		// This case is redundant now and it will be cleaned up in a follow-up PR
 		if ( variant === 'modal' && Guide && GuidePage ) {
 			return <WpcomNux />;
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -108,7 +108,9 @@ const selectors = {
 	isWelcomeGuideShown: ( state ) => !! state.showWelcomeGuide,
 	isWelcomeGuideStatusLoaded: ( state ) => typeof state.showWelcomeGuide !== 'undefined',
 	getTourRating: ( state ) => state.tourRating,
-	getWelcomeGuideVariant: ( state ) => state.welcomeGuideVariant,
+	// the 'modal' variant previously used for mobile has been removed but its slug may still be persisted in local storage
+	getWelcomeGuideVariant: ( state ) =>
+		state.welcomeGuideVariant === 'modal' ? DEFAULT_VARIANT : state.welcomeGuideVariant,
 };
 
 export function register() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Stop using old NUX on mobile and use the Editor Welcome currently used on desktop

#### Testing instructions

* Sync ETK PCYsg-ly5-p2
* Sandbox a site
* Open _Welcome Guide_ on mobile
* The same version used on desktop should be displayed

### Demo
* Before

https://user-images.githubusercontent.com/14192054/131114480-0c236801-1c93-4b70-bf90-dc6478365ee0.mov

* After

https://user-images.githubusercontent.com/14192054/131114491-a167ff66-9212-4f08-9e74-2717c96dbac7.mov


Related to #52280
Fixes the broken UI illustrated in https://github.com/Automattic/wp-calypso/issues/52280#issuecomment-906195184