### PR TITLE
Emails: Update positions for Titan button: add mail, mailboxes and remove

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -456,13 +456,7 @@ class EmailProvidersComparison extends React.Component {
 					comment:
 						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
 			  } )
-			: translate( 'Add %(titanProductName)s', {
-					args: {
-						titanProductName: getTitanProductName(),
-					},
-					comment:
-						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
-			  } );
+			: translate( 'Add Email' );
 
 		const formFields = (
 			<TitanNewMailboxList

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -456,7 +456,13 @@ class EmailProvidersComparison extends React.Component {
 					comment:
 						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
 			  } )
-			: translate( 'Add Email' );
+			: translate( 'Add %(titanProductName)s', {
+					args: {
+						titanProductName: getTitanProductName(),
+					},
+					comment:
+						'%(titanProductName) is the name of the product, which should be "Professional Email" translated',
+			  } );
 
 		const formFields = (
 			<TitanNewMailboxList

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -185,10 +185,7 @@
 			}
 
 			.email-providers-comparison__titan-mailbox-action-continue {
-				width: 100%;
-
 				@include break-mobile {
-					width: auto;
 					margin-left: auto;
 				}
 			}

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -183,6 +183,15 @@
 					margin-top: 0;
 				}
 			}
+
+			.email-providers-comparison__titan-mailbox-action-continue {
+				width: 100%;
+
+				@include break-mobile {
+					width: auto;
+					margin-left: auto;
+				}
+			}
 		}
 
 		.email-provider-features {

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -92,12 +92,6 @@ const TitanNewMailboxList = ( {
 					/>
 
 					<div className="titan-new-mailbox-list__actions">
-						{ showAddAnotherMailboxButton && index === lastMailboxIndex && (
-							<Button onClick={ () => onMailboxAdd() }>
-								<Gridicon icon="plus" />
-								<span>{ translate( 'Add another mailbox' ) }</span>
-							</Button>
-						) }
 						{ index > 0 && (
 							<Button
 								className="titan-new-mailbox-list__action-remove"
@@ -113,7 +107,15 @@ const TitanNewMailboxList = ( {
 				</React.Fragment>
 			) ) }
 
-			<div className="titan-new-mailbox-list__supplied-actions">{ children }</div>
+			<div className="titan-new-mailbox-list__supplied-actions">
+				{ showAddAnotherMailboxButton && (
+					<Button onClick={ () => onMailboxAdd() }>
+						<Gridicon icon="plus" />
+						<span>{ translate( 'Add another mailbox' ) }</span>
+					</Button>
+				) }
+				{ children }
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -63,8 +63,6 @@ const TitanNewMailboxList = ( {
 		onMailboxesChange( updatedMailboxes );
 	};
 
-	const lastMailboxIndex = mailboxes.length - 1;
-
 	return (
 		<div className="titan-new-mailbox-list__main">
 			{ mailboxes.map( ( mailbox, index ) => (

--- a/client/my-sites/email/titan-new-mailbox-list/style.scss
+++ b/client/my-sites/email/titan-new-mailbox-list/style.scss
@@ -54,9 +54,3 @@
 .titan-new-mailbox-list__separator {
 	margin-top: 1.5em;
 }
-
-.titan-new-mailbox-list__action-remove {
-	@include break-mobile {
-		margin-left: auto;
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change request is changing the layout of the 3 buttons in emails providers for Professional Email

1. Replaced "Add Professional Email" with "Add email"
2. Replaced the position of this button to be right aligned to the add mailbox one
3. Move "Add mailbox" below the form.
4. Move the "Remove mailbox" to the left side.

#### Testing instructions

1. Go to Upgrades -> Emails
2. Add an email provider to your domain (buy a domain if you don't have it)
3. Check that the Professional Email section is as per the below screenshot


BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/131148910-9b410d90-b57e-4b88-8e61-29e60b1789c2.png) | ![image](https://user-images.githubusercontent.com/5689927/131315900-b391e050-22c4-4d66-b40b-7860d5e167fd.png)


Responsive layout:
![titan provider resize](https://user-images.githubusercontent.com/5689927/131654325-f9684e42-8508-4ba7-870f-de7d219fc7d5.gif)


Related to {1200182182542585-as-1200861922411476}
