### PR TITLE
Allow all jetpack plans to enable VideoPress

### DIFF
--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -21,7 +21,7 @@ import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-t
 import getMediaStorageLimit from 'calypso/state/selectors/get-media-storage-limit';
 import getMediaStorageUsed from 'calypso/state/selectors/get-media-storage-used';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class MediaSettingsPerformance extends Component {
@@ -154,6 +154,7 @@ export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 	const isVideoPressAvailable =
+		isJetpackSite( state, selectedSiteId ) ||
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) ||
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -178,7 +178,10 @@ export default connect( ( state ) => {
 			isJetpackSite( state, selectedSiteId ) &&
 			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
 			! getSitePurchases( state, selectedSiteId ).find( checkForJetpackVideoPressProduct ) &&
-			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ), // Jetpack Pro is the feature used in current plans that include VP
+			// These features are used in current plans that include VP
+			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) &&
+			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) &&
+			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ),
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
 		sitePlanSlug,

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -1,5 +1,6 @@
 import {
 	planHasFeature,
+	FEATURE_JETPACK_VIDEOPRESS,
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
@@ -16,7 +17,6 @@ import QueryMediaStorage from 'calypso/components/data/query-media-storage';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SupportInfo from 'calypso/components/support-info';
-import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import getMediaStorageLimit from 'calypso/state/selectors/get-media-storage-limit';
 import getMediaStorageUsed from 'calypso/state/selectors/get-media-storage-used';
@@ -73,6 +73,7 @@ class MediaSettingsPerformance extends Component {
 
 	renderVideoStorageIndicator() {
 		const {
+			isVideoPressFreeTier,
 			mediaStorageLimit,
 			mediaStorageUsed,
 			siteId,
@@ -88,6 +89,7 @@ class MediaSettingsPerformance extends Component {
 
 		const renderedStorageInfo =
 			isStorageDataValid &&
+			! isVideoPressFreeTier &&
 			( isStorageUnlimited ? (
 				<FormSettingExplanation className="site-settings__videopress-storage-used">
 					{ translate( '%(size)s uploaded, unlimited storage available', {
@@ -116,19 +118,24 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	renderVideoUpgradeNudge() {
-		const { isVideoPressAvailable, siteSlug, translate } = this.props;
+		const { isVideoPressFreeTier, mediaStorageUsed, siteSlug, translate } = this.props;
 
+		const upsellMessage =
+			0 === mediaStorageUsed
+				? translate(
+						'1 free video available. Upgrade now to unlock more videos and 1TB of storage.'
+				  )
+				: translate(
+						'You have used your free video. Upgrade now to unlock more videos and 1TB of storage.'
+				  );
 		return (
-			! isVideoPressAvailable && (
+			isVideoPressFreeTier && (
 				<UpsellNudge
-					title={ translate( 'Get unlimited video hosting' ) }
-					description={ translate(
-						'Tired of ads in your videos? Get high-speed video right on your site'
-					) }
+					title={ upsellMessage }
 					event={ 'jetpack_video_settings' }
-					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PRO }
+					feature={ FEATURE_JETPACK_VIDEOPRESS }
 					showIcon={ true }
-					href={ `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_VIDEO_UPLOADS_JETPACK_PRO ] }` }
+					href={ `/checkout/${ siteSlug }/${ FEATURE_JETPACK_VIDEOPRESS }` }
 				/>
 			)
 		);
@@ -162,6 +169,7 @@ export default connect( ( state ) => {
 	return {
 		isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 		isVideoPressAvailable,
+		isVideoPressFreeTier: isJetpackSite( state, selectedSiteId ) && ( true || true ), // ! VP product or ! Security
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
 		sitePlanSlug,

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -177,9 +177,8 @@ export default connect( ( state ) => {
 		isVideoPressFreeTier:
 			isJetpackSite( state, selectedSiteId ) &&
 			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
-			( ! getSitePurchases( state, selectedSiteId ).find( checkForJetpackVideoPressProduct ) ||
-				false ||
-				false ), // ! VP product or ! Security or ! Complete // todo: remove Security once that is a fact
+			! getSitePurchases( state, selectedSiteId ).find( checkForJetpackVideoPressProduct ) &&
+			! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ), // Jetpack Pro is the feature used in current plans that include VP
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
 		sitePlanSlug,

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -21,6 +21,7 @@ import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-t
 import getMediaStorageLimit from 'calypso/state/selectors/get-media-storage-limit';
 import getMediaStorageUsed from 'calypso/state/selectors/get-media-storage-used';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -169,7 +170,10 @@ export default connect( ( state ) => {
 	return {
 		isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 		isVideoPressAvailable,
-		isVideoPressFreeTier: isJetpackSite( state, selectedSiteId ) && ( true || true ), // ! VP product or ! Security
+		isVideoPressFreeTier:
+			isJetpackSite( state, selectedSiteId ) &&
+			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
+			( true || true ), // ! VP product or ! Security
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
 		sitePlanSlug,

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -1,4 +1,5 @@
 import {
+	isJetpackVideoPress,
 	planHasFeature,
 	FEATURE_JETPACK_VIDEOPRESS,
 	FEATURE_VIDEO_UPLOADS,
@@ -18,6 +19,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getMediaStorageLimit from 'calypso/state/selectors/get-media-storage-limit';
 import getMediaStorageUsed from 'calypso/state/selectors/get-media-storage-used';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -157,6 +159,8 @@ class MediaSettingsPerformance extends Component {
 		);
 	}
 }
+const checkForJetpackVideoPressProduct = ( purchase ) =>
+	purchase.active && isJetpackVideoPress( purchase );
 
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
@@ -173,7 +177,9 @@ export default connect( ( state ) => {
 		isVideoPressFreeTier:
 			isJetpackSite( state, selectedSiteId ) &&
 			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
-			( true || true ), // ! VP product or ! Security
+			( ! getSitePurchases( state, selectedSiteId ).find( checkForJetpackVideoPressProduct ) ||
+				false ||
+				false ), // ! VP product or ! Security or ! Complete // todo: remove Security once that is a fact
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
 		sitePlanSlug,

--- a/packages/calypso-products/src/is-jetpack-videopress.js
+++ b/packages/calypso-products/src/is-jetpack-videopress.js
@@ -1,0 +1,8 @@
+import { JETPACK_VIDEOPRESS_PRODUCTS } from './constants';
+import { formatProduct } from './format-product';
+
+export function isJetpackVideoPress( product ) {
+	product = formatProduct( product );
+
+	return JETPACK_VIDEOPRESS_PRODUCTS.includes( product.product_slug );
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -62,6 +62,7 @@ export { isJetpackProductSlug } from './is-jetpack-product-slug';
 export { isJetpackScan } from './is-jetpack-scan';
 export { isJetpackScanSlug } from './is-jetpack-scan-slug';
 export { isJetpackSearch } from './is-jetpack-search';
+export { isJetpackVideoPress } from './is-jetpack-videopress';
 export { isJpphpBundle } from './is-jpphp-bundle';
 export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';
 export { default as isJetpackPurchasableItem } from './is-jetpack-purchasable-item';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow any JetPack site to see and enable the `Enable fast, ad-free video hosting` setting under Settings > Performance > Media
* This should only be possible once the new Jetpack VideoPress products (and free tier) are released - we may need to detect this based on _something_ or just wait to deploy until after they are available.

NOTE: This PR is based off of https://github.com/Automattic/wp-calypso/pull/56103

**Before**
<img width="748" alt="Screen Shot 2021-09-27 at 4 15 06 PM" src="https://user-images.githubusercontent.com/4081020/134978698-752c8ae5-cbdd-47ff-8095-58e2499069f5.png">

**After**
<img width="740" alt="Screen Shot 2021-09-27 at 4 16 17 PM" src="https://user-images.githubusercontent.com/4081020/134978794-2f59047b-7aa3-4b09-9f86-0757d561d2c4.png">

<img width="748" alt="Screen Shot 2021-09-27 at 4 15 19 PM" src="https://user-images.githubusercontent.com/4081020/134978685-aa8e61da-a90f-47c1-bfb7-cc0e0ae2b0d5.png">


### Open Question
Should we change the name of the section to be more Jetpack VideoPress specific?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* apply D67397-code to sandbox and sandbox `public-api.wordpress.com`
* View a free Jetpack site in Calypso (`yarn start` or using the live link in the bot comments below)
* Open the `Settings -> Performance` menu
* VideoPress setting should be available to be toggled on
* When in free plan, the messaging should change depending on if you've uploaded a video or not yet
* When in a paid plan, the storage "progress bar" should be visible
* You should now be able to upload a video in the Media library
* When in a simple site (non-Jetpack), the Video toggle should not be visible (seems this is a Jetpack only feature)
* When in an Atomic site, the video toggle should be visible and should show the storage available to the site (not the Jetpack plan's available storage - because they won't have it) and should **NOT** show the upsell

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  956-gh-Automattic/greenhouse