### PR TITLE
Playwright: re-add wait for spinner when waiting for search query to complete.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-support; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
+					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-support; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -8,6 +8,7 @@ const selectors = {
 	searchInput: '[aria-label="Search"]',
 	clearSearch: '[aria-label="Close Search"]',
 	supportCard: '.card.help-search',
+	spinner: '.spinner',
 
 	// Results
 	resultsPlaceholder: '.inline-help__results-placeholder-item',
@@ -250,6 +251,7 @@ export class SupportComponent {
 					{ timeout: 60000 }
 				),
 				this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'detached' } ),
+				this.page.waitForSelector( selectors.spinner, { state: 'detached' } ),
 				this.page.fill( selectors.searchInput, text ),
 			] );
 		} else {

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -251,7 +251,7 @@ export class SupportComponent {
 					{ timeout: 60000 }
 				),
 				this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'detached' } ),
-				this.page.waitForSelector( selectors.spinner, { state: 'detached' } ),
+				this.page.waitForSelector( selectors.spinner, { state: 'hidden', timeout: 60000 } ),
 				this.page.fill( selectors.searchInput, text ),
 			] );
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to re-add the wait for `.spinner` element to the list of promises to resolve when running a search query.

Background details:

In a previous PR #55253, the wait for elements `.spinner` and `.placeholder` were replaced with a singular call to wait for the query response. At the time this looked to be sufficient, but as it turns out there can be slight delays between the promise for query response resolving and the actual result items being rendered on the screen fully.

PRs #55620 and #55339 were previously merged in an attempt to make the results wait for the placeholders to disappear, but it turns out the original solution I had - waiting for both `.spinner` and `.placeholder` - was the correct solution all along.

#### Testing instructions

Stress test was conducted on both [desktop](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_desktop/6620655) and [mobile](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_mobile/6620992) viewports and passed without issue.

Another stress test has been run approximately a day later - [desktop](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_desktop/6623838) and [mobile](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_mobile/6623840).

Related to #
