### PR TITLE
Domains: Update "change site address" verification message

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -305,7 +305,7 @@ export class SiteAddressChanger extends Component {
 			return (
 				<div className="site-address-changer site-address-changer__only-owner-info">
 					<Gridicon icon="info-outline" />
-					{ translate( 'You cannot change the free WordPress.com address for atomic sites.' ) }
+					{ translate( 'wpcomstaging.com addresses cannot be changed.' ) }
 				</div>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Replaces the message for the AT site verification introduced in #55773.

#### Preview
![image](https://user-images.githubusercontent.com/18705930/131176211-82539def-14e5-4b26-8d7a-96946f87d5af.png)

#### Testing instructions
- Check that the new message (`"wpcomstaging.com addresses cannot be changed."`) is displayed.