### PR TITLE
Update domains menu item to 'Make primary address'

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -178,7 +178,7 @@ class DomainItem extends PureComponent {
 				>
 					{ this.canSetAsPrimary() && (
 						<PopoverMenuItem icon="domains" onClick={ this.makePrimary }>
-							{ translate( 'Make primary domain' ) }
+							{ translate( 'Make primary address' ) }
 						</PopoverMenuItem>
 					) }
 					{ this.canRenewDomain() && (

--- a/client/my-sites/domains/domain-management/list/wpcom-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/wpcom-domain-item.jsx
@@ -69,7 +69,7 @@ export default function WpcomDomainItem( {
 			>
 				{ canMakePrimary && (
 					<PopoverMenuItem icon="domains" onClick={ handleMakePrimary }>
-						{ __( 'Make primary domain' ) }
+						{ __( 'Make primary address' ) }
 					</PopoverMenuItem>
 				) }
 				{ ! isAtomicSite && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For consistency, we want to update the wording of domain item menu from "Make primary domain" to "Make primary address".

Before:

<img width="1124" alt="Screen Shot 2021-08-27 at 2 52 17 PM" src="https://user-images.githubusercontent.com/1379730/131175495-5477a962-7284-4536-85a1-388d25d009ee.png">

<img width="1070" alt="Screen Shot 2021-08-27 at 2 52 44 PM" src="https://user-images.githubusercontent.com/1379730/131175505-80d55e76-adb5-4307-82e8-290f2e338eae.png">


After:

<img width="1108" alt="Screen Shot 2021-08-27 at 2 47 48 PM" src="https://user-images.githubusercontent.com/1379730/131175522-eebef379-c0fa-4a59-a14a-86df4689eba4.png">

<img width="1140" alt="Screen Shot 2021-08-27 at 2 48 14 PM" src="https://user-images.githubusercontent.com/1379730/131175529-cba2ac82-c761-44a5-b515-85edaa44cfd1.png">


#### Testing instructions

Visit the `/domains/manage/` path for a site.  Make sure that the menu items for both custom domains and the wordpress.com subdomain reads "Make primary address"