### PR TITLE
Yarn: Discard incompatible platform warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,7 +5,7 @@ enableGlobalCache: true
 logFilters:
   - code: YN0013
     level: discard
-  - code: YN0062 # Incompatible platform warnings. (e.g. fsevents)
+  - pattern: "fsevents@*/* The platform * is incompatible with this module, link skipped."
     level: discard
 
 nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,6 +5,8 @@ enableGlobalCache: true
 logFilters:
   - code: YN0013
     level: discard
+  - code: YN0062 # Incompatible platform warnings. (e.g. fsevents)
+    level: discard
 
 nodeLinker: node-modules
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
If you've ever developed JS on non-macOS platforms, you'll constantly see messages about "fsevents" being unsupported by the platform. This applies whether you're using yarn1, npm, or yarn3. I first remember seeing it when I was learning react on a windows machine 6 years ago! It seems we finally have a way to avoid that noise in the install log.

This PR discards the warning code `YN0062` via `.yarnrc.yml`, as it is not actionable. I don't know if this warning would ever be helpful -- I've never seen it for any high-level packages, just for os-level ones we don't really control.

Before:

```sh
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 456ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 1s 579ms
➤ YN0000: ┌ Link step
➤ YN0062: │ fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=1cc4b2 The platform linux is incompatible with this module, link skipped.
➤ YN0062: │ fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=1cc4b2 The platform linux is incompatible with this module, link skipped.
➤ YN0062: │ fsevents@patch:fsevents@npm%3A2.1.2#~builtin<compat/fsevents>::version=2.1.2&hash=1cc4b2 The platform linux is incompatible with this module, link skipped.
➤ YN0000: └ Completed in 2s 217ms
➤ YN0000: Done with warnings in 4s 425ms
```

After:

```
➜  wp-calypso git:(trunk) yarn
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 426ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 1s 621ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 2s 200ms
➤ YN0000: Done in 4s 422ms
```
 

### Testing instructions
- Run `yarn` on a non-mac platform, like linux or windows. 
- You should not see a warning about fsevents.
