### PR TITLE
Remove TS no-use-before-define rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,10 +122,6 @@ module.exports = {
 					'@typescript-eslint/explicit-function-return-type': 'off',
 					'@typescript-eslint/explicit-member-accessibility': 'off',
 					'@typescript-eslint/no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
-					'@typescript-eslint/no-use-before-define': [
-						'error',
-						{ functions: false, typedefs: false },
-					],
 					'@typescript-eslint/no-var-requires': 'off',
 					// REST API objects include underscores
 					'@typescript-eslint/camelcase': 'off',

--- a/client/my-sites/checkout/composite-checkout/components/coupon.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/coupon.tsx
@@ -8,8 +8,6 @@ import joinClasses from './join-classes';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { CouponStatus } from '@automattic/shopping-cart';
 
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 export default function Coupon( {
 	id,
 	className,

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -63,9 +63,6 @@ import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
-// This will make converting to TS less noisy. The order of components can be reorganized later
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 const ContactFormTitle = (): JSX.Element => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 import {
 	getYearlyPlanByMonthly,
 	isWpComPlan,
@@ -72,7 +70,6 @@ type PopupMessageProps = {
 	isVisible: boolean;
 };
 
-// eslint-disable @typescript-eslint/no-use-before-define
 export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	context,
 	children,

--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -6,8 +6,6 @@ import joinClasses from '../lib/join-classes';
 import styled from '../lib/styled';
 import Button from './button';
 
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 export default function CheckoutModal( {
 	className,
 	title,

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -4,9 +4,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from './styled';
 
-// Disabling this to make migrating files easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 export default function Field( {
 	type,
 	id,

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -2,9 +2,6 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 export const PaymentMethodLogos = styled.span`
 	text-align: right;
 	transform: translateY( 3px );

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -26,9 +26,6 @@ import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/compos
 
 const debug = debugFactory( 'wpcom-checkout:bancontact-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 type StoreKey = 'bancontact';
 type NounsInStore = 'customerName';
 type BancontactStore = PaymentMethodStore< NounsInStore >;

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -26,9 +26,6 @@ import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/compos
 
 const debug = debugFactory( 'wpcom-checkout:eps-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 type StoreKey = 'eps';
 type NounsInStore = 'customerName';
 type EpsStore = PaymentMethodStore< NounsInStore >;

--- a/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/existing-credit-card.tsx
@@ -16,9 +16,6 @@ import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/compos
 
 const debug = debugFactory( 'wpcom-checkout:existing-card-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 export function createExistingCardMethod( {
 	id,
 	cardholderName,

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -26,9 +26,6 @@ import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/compos
 
 const debug = debugFactory( 'wpcom-checkout:giropay-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 type StoreKey = 'giropay';
 type NounsInStore = 'customerName';
 type GiropayStore = PaymentMethodStore< NounsInStore >;

--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -26,9 +26,6 @@ import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/compos
 
 const debug = debugFactory( 'wpcom-checkout:ideal-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 type StoreKey = 'ideal';
 type NounsInStore = 'customerName' | 'customerBank';
 type IdealStore = PaymentMethodStore< NounsInStore >;

--- a/packages/wpcom-checkout/src/payment-methods/p24.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/p24.tsx
@@ -24,9 +24,6 @@ import type {
 } from '../payment-method-store';
 import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 const debug = debugFactory( 'wpcom-checkout:p24-payment-method' );
 
 type StoreKey = 'p24';

--- a/packages/wpcom-checkout/src/payment-methods/paypal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/paypal.tsx
@@ -15,9 +15,6 @@ import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checko
 
 const debug = debugFactory( 'wpcom-checkout:paypal' );
 
-// Disabling this rule to make migrating this easier with fewer changes
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 export function createPayPalMethod( {
 	labelText = null,
 }: {

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -26,9 +26,6 @@ import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/compos
 
 const debug = debugFactory( 'wpcom-checkout:sofort-payment-method' );
 
-// Disabling this to make migration easier
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 type StoreKey = 'sofort';
 type NounsInStore = 'customerName';
 type SofortStore = PaymentMethodStore< NounsInStore >;

--- a/packages/wpcom-checkout/src/payment-request-button.tsx
+++ b/packages/wpcom-checkout/src/payment-request-button.tsx
@@ -6,9 +6,6 @@ import { GooglePayMark } from './google-pay-mark';
 import styled from './styled';
 import type { StripePaymentRequest } from '@automattic/calypso-stripe';
 
-// Disabling this rule to make migrating this to calypso easier with fewer changes
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 // The react-stripe-elements PaymentRequestButtonElement cannot have its
 // paymentRequest updated once it has been rendered, so this is a custom one.
 // See: https://github.com/stripe/react-stripe-elements/issues/284


### PR DESCRIPTION
### Changes proposed in this Pull Request
While working on some TypeScript files in #32930, I noticed that I was unable to commit due to the "no-use-before-define" typescript-eslint rule. I propose we remove this rule, as I don't see a benefit to it.

It prevents this sort of pattern, where a helper component is defined after the main component:

```ts
export default function ErrorMessage( { children }: { children?: React.ReactNode } ) {
	return <Error>{ children }</Error>;
}

const Error = styled.div< React.HTMLAttributes< HTMLDivElement > >``
```

In my opinion, that is a bit too picky. :) Plus, in TypeScript, if a definition for a variable isn't found, compilation should fail. I think that is a better way to handle problems with variables not existing.

I also found this, but I think it is for a different rule (no use before _declare_)

> Since most modern TypeScript doesn’t use var, [no use before declare] is generally discouraged and is kept around for legacy purposes. It is slow to compute, is not enabled in the built-in configuration presets, and should not be used to inform TSLint design decisions.
>
> https://palantir.github.io/tslint/rules/no-use-before-declare/

### Testing instructions
CI should pass.