### PR TITLE
Refactor connect domain steps

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
@@ -1,18 +1,18 @@
 import { Button } from '@automattic/components';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectDomainStepClipboardButton from './connect-domain-step-clipboard-button';
 import ConnectDomainStepVerificationNotice from './connect-domain-step-verification-error-notice';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug } from './constants';
+import { modeType, stepSlug, stepsHeadingAdvanced } from './constants';
 
 import './style.scss';
 
 export default function ConnectDomainStepAdvancedRecords( {
 	className,
-	currentPageSlug,
+	pageSlug,
 	domain,
 	domainSetupInfo,
 	mode,
@@ -22,6 +22,7 @@ export default function ConnectDomainStepAdvancedRecords( {
 	verificationInProgress,
 	verificationStatus,
 } ) {
+	const { __ } = useI18n();
 	const { data } = domainSetupInfo;
 	const { default_ip_addresses: ipAddresses } = data;
 	const recordLabels = {
@@ -147,8 +148,8 @@ export default function ConnectDomainStepAdvancedRecords( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			currentPageSlug={ currentPageSlug }
-			mode={ mode }
+			heading={ stepsHeadingAdvanced }
+			pageSlug={ pageSlug }
 			progressStepList={ progressStepList }
 			stepContent={ stepContent }
 		/>
@@ -157,7 +158,7 @@ export default function ConnectDomainStepAdvancedRecords( {
 
 ConnectDomainStepAdvancedRecords.propTypes = {
 	className: PropTypes.string.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	domain: PropTypes.string.isRequired,
 	domainSetupInfo: PropTypes.object.isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,

--- a/client/components/domains/connect-domain-step/connect-domain-step-advanced-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-advanced-start.jsx
@@ -17,7 +17,6 @@ export default function ConnectDomainStepAdvancedStart( {
 	pageSlug,
 	mode,
 	onNextStep,
-	// onSwitchToSuggestedSetup,
 	progressStepList,
 	setPage,
 } ) {
@@ -85,7 +84,6 @@ ConnectDomainStepAdvancedStart.propTypes = {
 	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,
-	// onSwitchToSuggestedSetup: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
 	setPage: PropTypes.func.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-advanced-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-advanced-start.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -8,18 +8,22 @@ import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug } from './constants';
+import { modeType, stepSlug, stepsHeadingAdvanced } from './constants';
 
 import './style.scss';
 
 export default function ConnectDomainStepAdvancedStart( {
 	className,
-	currentPageSlug,
+	pageSlug,
 	mode,
 	onNextStep,
-	onSwitchToSuggestedSetup,
+	// onSwitchToSuggestedSetup,
 	progressStepList,
+	setPage,
 } ) {
+	const { __ } = useI18n();
+	const switchToSuggestedSetup = () => setPage( stepSlug.SUGGESTED_START );
+
 	const stepContent = (
 		<>
 			<Notice
@@ -30,7 +34,7 @@ export default function ConnectDomainStepAdvancedStart( {
 				{ __(
 					'We advise using our recommended setup instead, with WordPress.com name servers. Our advanced setup requires manually managing DNS records for any added services such as Professional Email yourself.'
 				) }
-				<NoticeAction onClick={ onSwitchToSuggestedSetup }>
+				<NoticeAction onClick={ switchToSuggestedSetup }>
 					{ __( 'Back to recommended setup' ) }
 				</NoticeAction>
 			</Notice>
@@ -43,7 +47,7 @@ export default function ConnectDomainStepAdvancedStart( {
 						{
 							a: createElement( 'a', {
 								className: 'connect-domain-step__change_mode_link',
-								onClick: onSwitchToSuggestedSetup,
+								onClick: switchToSuggestedSetup,
 							} ),
 						}
 					) }
@@ -67,9 +71,10 @@ export default function ConnectDomainStepAdvancedStart( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
+			heading={ stepsHeadingAdvanced }
 			mode={ mode }
 			progressStepList={ progressStepList }
-			currentPageSlug={ currentPageSlug }
+			pageSlug={ pageSlug }
 			stepContent={ stepContent }
 		/>
 	);
@@ -77,9 +82,10 @@ export default function ConnectDomainStepAdvancedStart( {
 
 ConnectDomainStepAdvancedStart.propTypes = {
 	className: PropTypes.string.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,
-	onSwitchToSuggestedSetup: PropTypes.func.isRequired,
+	// onSwitchToSuggestedSetup: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
+	setPage: PropTypes.func.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-clipboard-button.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-clipboard-button.jsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
@@ -8,6 +8,7 @@ import Gridicon from 'calypso/components/gridicon';
 import './style.scss';
 
 export default function ConnectDomainStepClipboardButton( { baseClassName, classes, text } ) {
+	const { __ } = useI18n();
 	const [ copiedText, setCopiedText ] = useState( false );
 	const copied = () => setCopiedText( true );
 	const buttonClasses = classNames( baseClassName + '__clipboard-button', ...classes );

--- a/client/components/domains/connect-domain-step/connect-domain-step-done.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-done.jsx
@@ -1,6 +1,7 @@
 import { Button, Card } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -13,7 +14,8 @@ import { stepType } from './constants';
 
 import './style.scss';
 
-function ConnectDomainStepDone( { className, domain, step, selectedSiteSlug } ) {
+const ConnectDomainStepDone = ( { className, domain, step, selectedSiteSlug } ) => {
+	const { __ } = useI18n();
 	const siteDomainsUrl = domainManagementList( selectedSiteSlug );
 
 	const illustration = domainConnectedIllustration && (
@@ -77,7 +79,7 @@ function ConnectDomainStepDone( { className, domain, step, selectedSiteSlug } ) 
 			</div>
 		</Card>
 	);
-}
+};
 
 ConnectDomainStepDone.propTypes = {
 	className: PropTypes.string,

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -1,21 +1,23 @@
 import { Button } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug } from './constants';
+import { modeType, stepsHeadingAdvanced, stepsHeadingSuggested, stepSlug } from './constants';
 
 import './style.scss';
 
 export default function ConnectDomainStepLogin( {
 	className,
-	currentPageSlug,
+	pageSlug,
 	domain,
 	mode,
 	onNextStep,
 	progressStepList,
 } ) {
+	const { __ } = useI18n();
 	const stepContent = (
 		<div className={ className + '__login' }>
 			<p className={ className + '__text' }>
@@ -44,12 +46,15 @@ export default function ConnectDomainStepLogin( {
 		</div>
 	);
 
+	const heading = modeType.SUGGESTED === mode ? stepsHeadingSuggested : stepsHeadingAdvanced;
+
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
+			heading={ heading }
 			mode={ mode }
 			progressStepList={ progressStepList }
-			currentPageSlug={ currentPageSlug }
+			pageSlug={ pageSlug }
 			stepContent={ stepContent }
 		/>
 	);
@@ -57,7 +62,7 @@ export default function ConnectDomainStepLogin( {
 
 ConnectDomainStepLogin.propTypes = {
 	className: PropTypes.string.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	domain: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,

--- a/client/components/domains/connect-domain-step/connect-domain-step-progress.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-progress.jsx
@@ -6,7 +6,7 @@ import Gridicon from 'calypso/components/gridicon';
 
 import './style.scss';
 
-export default function ConnectDomainStepProgress( { baseClassName, steps, currentPageSlug } ) {
+export default function ConnectDomainStepProgress( { baseClassName, steps, pageSlug } ) {
 	let currentStepNumber = 0;
 
 	return (
@@ -14,7 +14,7 @@ export default function ConnectDomainStepProgress( { baseClassName, steps, curre
 			{ Object.values( steps )
 				.map( ( stepName, index ) => {
 					const stepNumber = index + 1;
-					if ( stepName === steps[ currentPageSlug ] ) {
+					if ( stepName === steps[ pageSlug ] ) {
 						currentStepNumber = stepNumber;
 					}
 
@@ -67,5 +67,5 @@ export default function ConnectDomainStepProgress( { baseClassName, steps, curre
 ConnectDomainStepProgress.propTypes = {
 	baseClassName: PropTypes.string.isRequired,
 	steps: PropTypes.object.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-records.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-records.jsx
@@ -1,17 +1,17 @@
 import { Button } from '@automattic/components';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectDomainStepClipboardButton from './connect-domain-step-clipboard-button';
 import ConnectDomainStepVerificationNotice from './connect-domain-step-verification-error-notice';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepSlug } from './constants';
+import { modeType, stepSlug, stepsHeadingSuggested } from './constants';
 
 import './style.scss';
 
 export default function ConnectDomainStepSuggestedRecords( {
 	className,
-	currentPageSlug,
+	pageSlug,
 	domainSetupInfo,
 	mode,
 	onVerifyConnection,
@@ -20,6 +20,7 @@ export default function ConnectDomainStepSuggestedRecords( {
 	verificationInProgress,
 	verificationStatus,
 } ) {
+	const { __ } = useI18n();
 	const { data } = domainSetupInfo;
 	const { wpcom_name_servers: nameServers } = data;
 
@@ -66,9 +67,10 @@ export default function ConnectDomainStepSuggestedRecords( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
+			heading={ stepsHeadingSuggested }
 			mode={ mode }
 			progressStepList={ progressStepList }
-			currentPageSlug={ currentPageSlug }
+			pageSlug={ pageSlug }
 			stepContent={ stepContent }
 		/>
 	);
@@ -76,7 +78,7 @@ export default function ConnectDomainStepSuggestedRecords( {
 
 ConnectDomainStepSuggestedRecords.propTypes = {
 	className: PropTypes.string.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	domainSetupInfo: PropTypes.object.isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onVerifyConnection: PropTypes.func.isRequired,

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -1,10 +1,14 @@
 import { Button } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import CardHeading from 'calypso/components/card-heading';
-import { modeType, stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
+import {
+	modeType,
+	stepsHeadingSuggested,
+	stepSlug,
+} from 'calypso/components/domains/connect-domain-step/constants';
 import MaterialIcon from 'calypso/components/material-icon';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
 
@@ -12,12 +16,16 @@ import './style.scss';
 
 export default function ConnectDomainStepSuggestedStart( {
 	className,
-	currentPageSlug,
+	pageSlug,
 	mode,
 	onNextStep,
-	onSwitchToAdvancedSetup,
+	// onSwitchToAdvancedSetup,
 	progressStepList,
+	setPage,
 } ) {
+	const { __ } = useI18n();
+	const switchToAdvancedSetup = () => setPage( stepSlug.ADVANCED_START );
+
 	const stepContent = (
 		<div className={ className + '__suggested-start' }>
 			<p className={ className + '__text' }>
@@ -28,7 +36,7 @@ export default function ConnectDomainStepSuggestedStart( {
 					{
 						a: createElement( 'a', {
 							className: 'connect-domain-step__change_mode_link',
-							onClick: onSwitchToAdvancedSetup,
+							onClick: switchToAdvancedSetup,
 						} ),
 					}
 				) }
@@ -51,9 +59,10 @@ export default function ConnectDomainStepSuggestedStart( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
+			heading={ stepsHeadingSuggested }
 			mode={ mode }
 			progressStepList={ progressStepList }
-			currentPageSlug={ currentPageSlug }
+			pageSlug={ pageSlug }
 			stepContent={ stepContent }
 		/>
 	);
@@ -61,9 +70,10 @@ export default function ConnectDomainStepSuggestedStart( {
 
 ConnectDomainStepSuggestedStart.propTypes = {
 	className: PropTypes.string.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,
-	onSwitchToAdvancedSetup: PropTypes.func.isRequired,
+	// onSwitchToAdvancedSetup: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
+	setPage: PropTypes.func.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -19,7 +19,6 @@ export default function ConnectDomainStepSuggestedStart( {
 	pageSlug,
 	mode,
 	onNextStep,
-	// onSwitchToAdvancedSetup,
 	progressStepList,
 	setPage,
 } ) {
@@ -73,7 +72,6 @@ ConnectDomainStepSuggestedStart.propTypes = {
 	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,
-	// onSwitchToAdvancedSetup: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
 	setPage: PropTypes.func.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-support-info-link.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-support-info-link.jsx
@@ -1,5 +1,5 @@
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,6 +13,7 @@ import { modeType } from './constants';
 import './style.scss';
 
 export default function ConnectDomainStepSupportInfoLink( { baseClassName, mode } ) {
+	const { __ } = useI18n();
 	const supportLink = {
 		[ modeType.SUGGESTED ]: MAP_DOMAIN_CHANGE_NAME_SERVERS,
 		[ modeType.ADVANCED ]: MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS,

--- a/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
@@ -13,8 +13,6 @@ export default function ConnectDomainStepSwitchSetupInfoLink( {
 	currentStep,
 	currentMode,
 	setPage,
-	// onSwitchToAdvancedSetup,
-	// onSwitchToSuggestedSetup,
 } ) {
 	const { __ } = useI18n();
 
@@ -59,6 +57,4 @@ ConnectDomainStepSwitchSetupInfoLink.propTypes = {
 	currentMode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	currentStep: PropTypes.oneOf( Object.values( stepType ) ).isRequired,
 	setPage: PropTypes.func.isRequired,
-	// onSwitchToAdvancedSetup: PropTypes.func.isRequired,
-	// onSwitchToSuggestedSetup: PropTypes.func.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
@@ -1,10 +1,10 @@
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'calypso/components/gridicon';
-import { stepType, modeType } from './constants';
+import { stepType, modeType, stepSlug } from './constants';
 
 import './style.scss';
 
@@ -12,24 +12,30 @@ export default function ConnectDomainStepSwitchSetupInfoLink( {
 	baseClassName,
 	currentStep,
 	currentMode,
-	onSwitchToAdvancedSetup,
-	onSwitchToSuggestedSetup,
+	setPage,
+	// onSwitchToAdvancedSetup,
+	// onSwitchToSuggestedSetup,
 } ) {
+	const { __ } = useI18n();
+
 	if ( [ stepType.CONNECTED, stepType.VERIFYING ].includes( currentStep ) ) {
 		return null;
 	}
+
+	const switchToAdvancedSetup = () => setPage( stepSlug.ADVANCED_START );
+	const switchToSuggestedSetup = () => setPage( stepSlug.SUGGESTED_START );
 
 	const message =
 		modeType.ADVANCED === currentMode ? (
 			<span className={ baseClassName + '__text' }>
 				{ createInterpolateElement( __( 'Switch to our <a>suggested setup</a>.' ), {
-					a: createElement( 'a', { onClick: onSwitchToSuggestedSetup } ),
+					a: createElement( 'a', { onClick: switchToSuggestedSetup } ),
 				} ) }
 			</span>
 		) : (
 			<span className={ baseClassName + '__text' }>
 				{ createInterpolateElement( __( 'Switch to our <a>advanced setup</a>.' ), {
-					a: createElement( 'a', { onClick: onSwitchToAdvancedSetup } ),
+					a: createElement( 'a', { onClick: switchToAdvancedSetup } ),
 				} ) }
 			</span>
 		);
@@ -52,6 +58,7 @@ ConnectDomainStepSwitchSetupInfoLink.propTypes = {
 	baseClassName: PropTypes.string.isRequired,
 	currentMode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	currentStep: PropTypes.oneOf( Object.values( stepType ) ).isRequired,
-	onSwitchToAdvancedSetup: PropTypes.func.isRequired,
-	onSwitchToSuggestedSetup: PropTypes.func.isRequired,
+	setPage: PropTypes.func.isRequired,
+	// onSwitchToAdvancedSetup: PropTypes.func.isRequired,
+	// onSwitchToSuggestedSetup: PropTypes.func.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-wrapper.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-wrapper.jsx
@@ -1,30 +1,27 @@
 import { Card } from '@automattic/components';
-import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import ConnectDomainStepProgress from './connect-domain-step-progress';
-import { modeType, stepSlug } from './constants';
+import { stepSlug } from './constants';
 
 import './style.scss';
 
 export default function ConnectDomainStepWrapper( {
 	className,
-	mode,
+	heading,
 	progressStepList,
-	currentPageSlug,
+	pageSlug,
 	stepContent,
 } ) {
-	const heading = modeType.SUGGESTED === mode ? __( 'Suggested setup' ) : __( 'Advanced setup' );
-
 	const StepsProgress = (
 		<ConnectDomainStepProgress
 			baseClassName={ className }
 			steps={ progressStepList }
-			currentPageSlug={ currentPageSlug }
+			pageSlug={ pageSlug }
 		/>
 	);
-	const showProgress = Object.keys( progressStepList ).includes( currentPageSlug );
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
 
 	return (
 		<Card className={ className }>
@@ -37,8 +34,8 @@ export default function ConnectDomainStepWrapper( {
 
 ConnectDomainStepWrapper.propTypes = {
 	className: PropTypes.string,
-	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
+	heading: PropTypes.string,
 	progressStepList: PropTypes.object.isRequired,
-	currentPageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	stepContent: PropTypes.element,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-steps.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-steps.jsx
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types';
+import React, { useState, useEffect, useCallback } from 'react';
+import './style.scss';
+import { connect } from 'react-redux';
+import {
+	getPageSlug,
+	getProgressStepList,
+} from 'calypso/components/domains/connect-domain-step/page-definitions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+function ConnectDomainSteps( {
+	baseClassName,
+	domain,
+	initialPageSlug,
+	onSetPage,
+	stepsDefinition,
+	selectedSite,
+	...stepProps
+} ) {
+	const [ mode, setMode ] = useState( stepsDefinition[ initialPageSlug ].mode );
+	const [ step, setStep ] = useState( stepsDefinition[ initialPageSlug ].step );
+	const [ pageSlug, setPageSlug ] = useState( initialPageSlug );
+	const [ progressStepList, setProgressStepList ] = useState( {} );
+
+	const StepsComponent = stepsDefinition?.[ pageSlug ].component;
+
+	const setPage = useCallback(
+		( pageStepSlug ) => {
+			setPageSlug( pageStepSlug );
+			onSetPage && onSetPage( pageStepSlug );
+			setStep( stepsDefinition[ pageStepSlug ].step );
+			setMode( stepsDefinition[ pageStepSlug ].mode );
+		},
+		[ onSetPage, stepsDefinition ]
+	);
+
+	const setNextStep = () => {
+		const next = stepsDefinition[ pageSlug ]?.next;
+		next && setPage( next );
+	};
+
+	useEffect( () => {
+		setPage( initialPageSlug );
+	}, [ initialPageSlug, setPage ] );
+
+	useEffect( () => {
+		setPageSlug( getPageSlug( mode, step, stepsDefinition ) );
+	}, [ mode, step, stepsDefinition ] );
+
+	useEffect( () => {
+		setProgressStepList( getProgressStepList( mode, stepsDefinition ) );
+	}, [ mode, stepsDefinition ] );
+
+	return (
+		<StepsComponent
+			className={ baseClassName }
+			domain={ domain }
+			step={ step }
+			mode={ mode }
+			onNextStep={ setNextStep }
+			progressStepList={ progressStepList }
+			pageSlug={ pageSlug }
+			setPage={ setPage }
+			{ ...stepProps }
+		/>
+	);
+}
+
+ConnectDomainSteps.propTypes = {
+	baseClassName: PropTypes.string.isRequired,
+	domain: PropTypes.string.isRequired,
+	initialPageSlug: PropTypes.string.isRequired,
+	onSetPage: PropTypes.func,
+	stepsDefinition: PropTypes.object.isRequired,
+	selectedSite: PropTypes.object,
+};
+
+export default connect( ( state ) => ( { selectedSite: getSelectedSite( state ) } ) )(
+	ConnectDomainSteps
+);

--- a/client/components/domains/connect-domain-step/constants.jsx
+++ b/client/components/domains/connect-domain-step/constants.jsx
@@ -1,6 +1,9 @@
+import { __ } from '@wordpress/i18n';
+
 export const modeType = {
 	SUGGESTED: 'suggested',
 	ADVANCED: 'advanced',
+	DONE: 'done',
 };
 
 export const stepType = {
@@ -31,3 +34,6 @@ export const defaultDomainSetupInfo = {
 		wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 	},
 };
+
+export const stepsHeadingSuggested = __( 'Suggested setup' );
+export const stepsHeadingAdvanced = __( 'Advanced setup' );

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -1,5 +1,6 @@
 import { BackButton } from '@automattic/onboarding';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
@@ -13,78 +14,44 @@ import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepSwitchSetupInfoLink from './connect-domain-step-switch-setup-info-link';
 import { isMappingVerificationSuccess } from './connect-domain-step-verification-status-parsing.js';
+import ConnectDomainSteps from './connect-domain-steps';
 import { modeType, stepType, stepSlug, defaultDomainSetupInfo } from './constants';
-import {
-	defaultStepsDefinition,
-	getPageSlug,
-	getProgressStepList,
-	getStepsDefinition,
-} from './page-definitions';
+import { connectADomainStepsDefinition } from './page-definitions.js';
 
 import './style.scss';
 
 function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialStep, showErrors } ) {
-	const [ mode, setMode ] = useState( modeType.SUGGESTED );
-	const [ step, setStep ] = useState( stepType.START );
-	const [ currentPageSlug, setCurrentPageSlug ] = useState( stepSlug.SUGGESTED_START );
-	const [ progressStepList, setProgressStepList ] = useState( {} );
+	const { __ } = useI18n();
+	const [ pageSlug, setPageSlug ] = useState( stepSlug.SUGGESTED_START );
 	const [ verificationStatus, setVerificationStatus ] = useState( {} );
 	const [ verificationInProgress, setVerificationInProgress ] = useState( false );
 	const [ domainSetupInfo, setDomainSetupInfo ] = useState( defaultDomainSetupInfo );
 	const [ domainSetupInfoError, setDomainSetupInfoError ] = useState( {} );
 	const [ loadingDomainSetupInfo, setLoadingDomainSetupInfo ] = useState( false );
-	const [ stepsDefinition, setStepsDefinition ] = useState( defaultStepsDefinition );
 
 	const baseClassName = 'connect-domain-step';
-	const StepsComponent = stepsDefinition?.[ currentPageSlug ].component;
-	const isStepStart = stepType.START === step;
+	const isStepStart = stepType.START === connectADomainStepsDefinition[ pageSlug ].step;
+	const mode = connectADomainStepsDefinition[ pageSlug ].mode;
+	const step = connectADomainStepsDefinition[ pageSlug ].step;
 
 	const statusRef = useRef( {} );
 
-	const setPage = useCallback(
-		( pageStepSlug ) => {
-			setCurrentPageSlug( pageStepSlug );
-			setStep( stepsDefinition[ pageStepSlug ].step );
-			setMode( stepsDefinition[ pageStepSlug ].mode );
-		},
-		[ stepsDefinition ]
-	);
-
-	const setNextStep = () => {
-		const next = stepsDefinition[ currentPageSlug ]?.next;
-		next && setPage( next );
-	};
-
-	const switchToSuggestedSetup = () => {
-		setPage( stepSlug.SUGGESTED_START );
-	};
-
-	const switchToAdvancedSetup = () => {
-		setPage( stepSlug.ADVANCED_START );
-	};
-
-	useEffect( () => {
-		setStepsDefinition( getStepsDefinition( selectedSite, domain, domainSetupInfo ) );
-	}, [ domain, domainSetupInfo, selectedSite ] );
-
-	useEffect( () => {
-		setCurrentPageSlug( getPageSlug( mode, step, stepsDefinition ) );
-	}, [ mode, step, stepsDefinition ] );
-
 	useEffect( () => {
 		if ( initialStep && Object.values( stepSlug ).includes( initialStep ) ) {
-			setPage( initialStep );
+			setPageSlug( initialStep );
 		}
-	}, [ initialStep, setPage ] );
-
-	useEffect( () => {
-		setProgressStepList( getProgressStepList( mode, stepsDefinition ) );
-	}, [ mode, stepsDefinition ] );
+	}, [ initialStep, setPageSlug ] );
 
 	const verifyConnection = useCallback(
 		( setStepAfterVerify = true ) => {
 			setVerificationStatus( {} );
 			setVerificationInProgress( true );
+
+			const connectedSlug =
+				modeType.SUGGESTED === mode ? stepSlug.SUGGESTED_CONNECTED : stepSlug.ADVANCED_CONNECTED;
+			const verifyingSlug =
+				modeType.SUGGESTED === mode ? stepSlug.SUGGESTED_VERIFYING : stepSlug.ADVANCED_VERIFYING;
+
 			wpcom
 				.domain( domain )
 				.updateConnectionModeAndGetMappingStatus( mode )
@@ -92,21 +59,21 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 					setVerificationStatus( { data } );
 					if ( setStepAfterVerify ) {
 						if ( isMappingVerificationSuccess( mode, data ) ) {
-							setStep( stepType.CONNECTED );
+							setPageSlug( connectedSlug );
 						} else {
-							setStep( stepType.VERIFYING );
+							setPageSlug( verifyingSlug );
 						}
 					}
 				} )
 				.catch( ( error ) => {
 					setVerificationStatus( { error } );
 					if ( setStepAfterVerify ) {
-						setStep( stepType.VERIFYING );
+						setPageSlug( verifyingSlug );
 					}
 				} )
 				.finally( () => setVerificationInProgress( false ) );
 		},
-		[ mode, domain ]
+		[ domain, mode ]
 	);
 
 	useEffect( () => {
@@ -139,10 +106,10 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 	}, [ showErrors, verifyConnection ] );
 
 	const goBack = () => {
-		const prevPageSlug = stepsDefinition[ currentPageSlug ]?.prev;
+		const prevPageSlug = connectADomainStepsDefinition[ pageSlug ]?.prev;
 
 		if ( prevPageSlug ) {
-			setPage( prevPageSlug );
+			setPageSlug( prevPageSlug );
 		} else {
 			page( domainManagementList( selectedSite.slug ) );
 		}
@@ -166,21 +133,17 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 				headerText={ headerText }
 				align="left"
 			/>
-			<StepsComponent
-				className={ baseClassName }
+			<ConnectDomainSteps
+				baseClassName={ baseClassName }
 				domain={ domain }
-				step={ step }
-				mode={ mode }
-				onNextStep={ setNextStep }
+				initialPageSlug={ pageSlug }
+				stepsDefinition={ connectADomainStepsDefinition }
+				onSetPage={ setPageSlug }
 				onVerifyConnection={ verifyConnection }
 				verificationInProgress={ verificationInProgress }
 				verificationStatus={ verificationStatus || {} }
 				domainSetupInfo={ domainSetupInfo }
 				domainSetupInfoError={ domainSetupInfoError }
-				onSwitchToAdvancedSetup={ switchToAdvancedSetup }
-				onSwitchToSuggestedSetup={ switchToSuggestedSetup }
-				progressStepList={ progressStepList }
-				currentPageSlug={ currentPageSlug }
 				showErrors={ showErrors }
 			/>
 			{ isStepStart && <DomainTransferRecommendation /> }
@@ -189,9 +152,7 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 				baseClassName={ baseClassName }
 				currentMode={ mode }
 				currentStep={ step }
-				setPage={ setPage }
-				onSwitchToAdvancedSetup={ switchToAdvancedSetup }
-				onSwitchToSuggestedSetup={ switchToSuggestedSetup }
+				setPage={ setPageSlug }
 			/>
 		</>
 	);

--- a/client/components/domains/connect-domain-step/page-definitions.js
+++ b/client/components/domains/connect-domain-step/page-definitions.js
@@ -7,7 +7,7 @@ import ConnectDomainStepSuggestedRecords from './connect-domain-step-suggested-r
 import ConnectDomainStepSuggestedStart from './connect-domain-step-suggested-start';
 import { modeType, stepSlug, stepType } from './constants';
 
-export const defaultStepsDefinition = {
+export const connectADomainStepsDefinition = {
 	// Suggested flow
 	[ stepSlug.SUGGESTED_START ]: {
 		mode: modeType.SUGGESTED,
@@ -78,12 +78,6 @@ export const defaultStepsDefinition = {
 		component: ConnectDomainStepDone,
 		prev: stepSlug.ADVANCED_UPDATE,
 	},
-};
-
-// eslint-disable-next-line no-unused-vars
-export const getStepsDefinition = ( selectedSite, domain, domainSetupInfo ) => {
-	// This can be used to determine which steps definition to use based on the inputs.
-	return defaultStepsDefinition;
 };
 
 export const getPageSlug = ( mode, step, stepsDefinition ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Refactor the connect domain steps so that the controls to move to the next/previous step is handled in an independent component (ConnectDomainSteps). This will simplify adding an upcoming connect domain flow on a different page without the header from the ConnectDomainStep file.

Basically, the logic that manages which step is shown is moved from `ConnectDomainStep` to  `ConnectDomainSteps` which can be used independently.

This PR also fixes the way that the `__` function is imported.

#### Testing instructions

Visit `/domains/mapping/[site slug]/setup/[domain name]` and make sure that both the suggested and advanced flows all work correctly.

Also add the query string `?step=suggested_update` or `?step=advanced_update` and make sure that the correct step is loaded.
Then add `&showErrors=true` to the query string and make sure that any connection errors for the given domain are shown in a notice on the page.