### PR TITLE
build: Enable aggregated cache info

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: 0
 
 enableGlobalCache: true
 
+preferAggregateCacheInfo: true
+
 logFilters:
   - pattern: "fsevents@*/* The platform * is incompatible with this module, link skipped."
     level: discard

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,294 +3,292 @@ compressionLevel: 0
 enableGlobalCache: true
 
 logFilters:
-  - code: YN0013
-    level: discard
   - pattern: "fsevents@*/* The platform * is incompatible with this module, link skipped."
     level: discard
 
 nodeLinker: node-modules
 
 packageExtensions:
-  "@emotion/native@10.0.27":
+  '@emotion/native@10.0.27':
     peerDependencies:
-      "@emotion/core": "*"
-      react: "*"
-  "@storybook/core@6.1.10":
+      '@emotion/core': '*'
+      react: '*'
+  '@storybook/core@6.1.10':
     peerDependencies:
-      typescript: "*"
-  "@storybook/react@6.1.10":
+      typescript: '*'
+  '@storybook/react@6.1.10':
     peerDependencies:
-      typescript: "*"
-  "@types/wordpress__block-editor@2.2.9":
+      typescript: '*'
+  '@types/wordpress__block-editor@2.2.9':
     peerDependencies:
-      react: "*"
-      react-dom: "*"
-  "@types/wordpress__blocks@6.4.12":
+      react: '*'
+      react-dom: '*'
+  '@types/wordpress__blocks@6.4.12':
     peerDependencies:
-      react: "*"
-  "@types/wordpress__components@9.8.6":
+      react: '*'
+  '@types/wordpress__components@9.8.6':
     peerDependencies:
-      react: "*"
-  "@types/wordpress__data-controls@1.0.5":
+      react: '*'
+  '@types/wordpress__data-controls@1.0.5':
     peerDependencies:
-      react-native: "*"
-  "@types/wordpress__editor@9.4.6":
+      react-native: '*'
+  '@types/wordpress__editor@9.4.6':
     peerDependencies:
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-  "@types/wordpress__media-utils@0.2.4":
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+  '@types/wordpress__media-utils@0.2.4':
     peerDependencies:
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-  "@types/wordpress__plugins@2.3.7":
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+  '@types/wordpress__plugins@2.3.7':
     peerDependencies:
-      react: "*"
-  "@wordpress/annotations@1.24.8":
+      react: '*'
+  '@wordpress/annotations@1.24.8':
     peerDependencies:
-      react: "*"
-  "@wordpress/api-fetch@3.23.1":
+      react: '*'
+  '@wordpress/api-fetch@3.23.1':
     peerDependencies:
-      react-native: "*"
-  "@wordpress/api-fetch@4.0.0":
+      react-native: '*'
+  '@wordpress/api-fetch@4.0.0':
     peerDependencies:
-      react-native: "*"
-  "@wordpress/block-editor@5.3.3":
+      react-native: '*'
+  '@wordpress/block-editor@5.3.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/block-library@2.29.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/block-library@2.29.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/blocks@7.0.6":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/blocks@7.0.6':
     peerDependencies:
-      react: "*"
-  "@wordpress/blocks@8.0.3":
+      react: '*'
+  '@wordpress/blocks@8.0.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/components@12.0.8":
+      react: '*'
+  '@wordpress/components@12.0.8':
     peerDependencies:
-      "@wordpress/data": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-  "@wordpress/components@13.0.3":
+      '@wordpress/data': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+  '@wordpress/components@13.0.3':
     peerDependencies:
-      "@wordpress/data": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-  "@wordpress/compose@3.25.3":
+      '@wordpress/data': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+  '@wordpress/compose@3.25.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/core-data@2.26.3":
+      react: '*'
+  '@wordpress/core-data@2.26.3':
     peerDependencies:
-      react: "*"
-      react-native: "*"
-  "@wordpress/data-controls@1.21.3":
+      react: '*'
+      react-native: '*'
+  '@wordpress/data-controls@1.21.3':
     peerDependencies:
-      react: "*"
-      react-native: "*"
-  "@wordpress/data@4.27.3":
+      react: '*'
+      react-native: '*'
+  '@wordpress/data@4.27.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/edit-post@3.27.3":
+      react: '*'
+  '@wordpress/edit-post@3.27.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/edit-site@1.17.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/edit-site@1.17.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/editor@9.26.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/editor@9.26.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/format-library@1.27.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/format-library@1.27.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/interface@1.0.6":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/interface@1.0.6':
     peerDependencies:
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-  "@wordpress/interface@2.0.2":
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+  '@wordpress/interface@2.0.2':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/jest-preset-default@7.0.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/jest-preset-default@7.0.3':
     peerDependencies:
-      "@babel/core": "*"
-      react: "*"
-      react-dom: "*"
-  "@wordpress/keyboard-shortcuts@1.14.3":
+      '@babel/core': '*'
+      react: '*'
+      react-dom: '*'
+  '@wordpress/keyboard-shortcuts@1.14.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/list-reusable-blocks@1.25.8":
+      react: '*'
+  '@wordpress/list-reusable-blocks@1.25.8':
     peerDependencies:
-      "@wordpress/data": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-  "@wordpress/media-utils@1.20.3":
+      '@wordpress/data': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+  '@wordpress/media-utils@1.20.3':
     peerDependencies:
-      react-native: "*"
-  "@wordpress/notices@2.13.3":
+      react-native: '*'
+  '@wordpress/notices@2.13.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/nux@3.25.3":
+      react: '*'
+  '@wordpress/nux@3.25.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/plugins@2.25.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/plugins@2.25.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/postcss-plugins-preset@3.0.0":
+      react: '*'
+  '@wordpress/postcss-plugins-preset@3.0.0':
     peerDependencies:
-      postcss: "*"
-  "@wordpress/reusable-blocks@1.2.3":
+      postcss: '*'
+  '@wordpress/reusable-blocks@1.2.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/rich-text@3.25.3":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/rich-text@3.25.3':
     peerDependencies:
-      react: "*"
-  "@wordpress/scripts@15.0.1":
+      react: '*'
+  '@wordpress/scripts@15.0.1':
     peerDependencies:
-      "@babel/core": "*"
-      react: "*"
-      react-dom: "*"
-  "@wordpress/server-side-render@1.21.3":
+      '@babel/core': '*'
+      react: '*'
+      react-dom: '*'
+  '@wordpress/server-side-render@1.21.3':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
-  "@wordpress/url@2.22.2":
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
+  '@wordpress/url@2.22.2':
     peerDependencies:
-      react-native: "*"
-  "@wordpress/viewport@2.26.3":
+      react-native: '*'
+  '@wordpress/viewport@2.26.3':
     peerDependencies:
-      react: "*"
-  "@wp-g2/components@0.0.140":
+      react: '*'
+  '@wp-g2/components@0.0.140':
     peerDependencies:
-      "@wordpress/data": "*"
-      "@wordpress/is-shallow-equal": "*"
-  "@wp-g2/components@0.0.160":
+      '@wordpress/data': '*'
+      '@wordpress/is-shallow-equal': '*'
+  '@wp-g2/components@0.0.160':
     peerDependencies:
-      "@wordpress/data": "*"
-      "@wordpress/is-shallow-equal": "*"
-  "@wp-g2/context@0.0.140":
+      '@wordpress/data': '*'
+      '@wordpress/is-shallow-equal': '*'
+  '@wp-g2/context@0.0.140':
     peerDependencies:
-      "@wordpress/data": "*"
-      "@wordpress/is-shallow-equal": "*"
-  "@wp-g2/context@0.0.160":
+      '@wordpress/data': '*'
+      '@wordpress/is-shallow-equal': '*'
+  '@wp-g2/context@0.0.160':
     peerDependencies:
-      "@wordpress/data": "*"
-      "@wordpress/is-shallow-equal": "*"
-  "@wp-g2/styles@0.0.140":
+      '@wordpress/data': '*'
+      '@wordpress/is-shallow-equal': '*'
+  '@wp-g2/styles@0.0.140':
     peerDependencies:
-      "@wordpress/data": "*"
-      "@wordpress/is-shallow-equal": "*"
-  "@wp-g2/styles@0.0.160":
+      '@wordpress/data': '*'
+      '@wordpress/is-shallow-equal': '*'
+  '@wp-g2/styles@0.0.160':
     peerDependencies:
-      "@wordpress/data": "*"
-      "@wordpress/is-shallow-equal": "*"
+      '@wordpress/data': '*'
+      '@wordpress/is-shallow-equal': '*'
   fake-indexeddb@3.1.3:
     peerDependencies:
-      core-js-bundle: "*"
-      regenerator-runtime: "*"
+      core-js-bundle: '*'
+      regenerator-runtime: '*'
   file-loader@*:
     peerDependenciesMeta:
       webpack:
         optional: true
-  "@automattic/isolated-block-editor@1.0.2":
+  '@automattic/isolated-block-editor@1.0.2':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
   jest-enzyme@7.1.2:
     peerDependencies:
-      react: "*"
-  "@automattic/newspack-blocks@*":
+      react: '*'
+  '@automattic/newspack-blocks@*':
     peerDependencies:
-      "@wp-g2/create-styles": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
-      reakit-utils: "*"
+      '@wp-g2/create-styles': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+      reakit-utils: '*'
   newspack-components@*:
     peerDependencies:
-      "@wordpress/data": "*"
-      react: "*"
-      react-dom: "*"
-      react-native: "*"
+      '@wordpress/data': '*'
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
   react-dev-utils@10.2.1:
     peerDependencies:
-      typescript: "*"
-      webpack: "*"
+      typescript: '*'
+      webpack: '*'
   react-live@1.12.0:
     peerDependencies:
-      react: "*"
+      react: '*'
   react-with-styles@3.2.3:
     peerDependencies:
-      react-dom: "*"
+      react-dom: '*'
   reakit-warning@0.4.0:
     peerDependencies:
-      react-dom: "*"
+      react-dom: '*'
   reakit-warning@0.5.5:
     peerDependencies:
-      react-dom: "*"
+      react-dom: '*'
   reakit-warning@0.6.1:
     peerDependencies:
-      react-dom: "*"
+      react-dom: '*'
   realistic-structured-clone@2.0.2:
     peerDependencies:
-      core-js-bundle: "*"
-      regenerator-runtime: "*"
+      core-js-bundle: '*'
+      regenerator-runtime: '*'
   typeson-registry@1.0.0-alpha.35:
     peerDependencies:
-      core-js-bundle: "*"
-      regenerator-runtime: "*"
+      core-js-bundle: '*'
+      regenerator-runtime: '*'
   xunit-viewer@5.2.0:
     peerDependencies:
-      "@babel/core": "*"
+      '@babel/core': '*'
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
+    spec: '@yarnpkg/plugin-workspace-tools'
 
 yarnPath: .yarn/releases/yarn-3.0.0.cjs


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use aggregated logs instead of hiding them.

#### Testing instructions

Check CI logs and see the cache info is aggregated:

```
07:20:12   ➤ YN0000: ┌ Fetch step
07:20:15   ➤ YN0013: │ 3747 packages were already cached
07:20:15   ➤ YN0000: └ Completed in 2s 430ms
```