### PR TITLE
build: Import RootChild using relative paths

### DIFF
--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -1,10 +1,10 @@
-import { RootChild } from '@automattic/components';
 import classNames from 'classnames';
 import { useRtl } from 'i18n-calypso';
 import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
+import RootChild from '../root-child';
 import {
 	bindWindowListeners,
 	unbindWindowListeners,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Imports `RootChild` using relative paths (`../root-child`) instead of self-referencing package (`@automattic/components`).

This was causing a bug because `tsc` thinks `dist/types/button/index.d.ts` (and a few more files like that one) is an _input_ file:

```
$ yarn tsc --build ./tsconfig.json               
error TS5055: Cannot write file '/Users/sergio/src/automattic/wp-calypso/packages/components/dist/types/button/index.d.ts' because it would overwrite input file.
...
```

Using `--explainFiles` we can see `dist/types/button/index.d.ts` is in fact an input file, and it is "Imported via '@automattic/components'":

```
$ yarn tsc --build ./tsconfig.json --explainFiles 
...
dist/types/button/index.d.ts
  Imported via "./button" from file 'dist/types/index.d.ts'

dist/types/index.d.ts
  Imported via '@automattic/components' from file 'src/popover/index.jsx' with packageId '@automattic/components/dist/types/index.d.ts@1.0.0-alpha.3'
...
```


#### Testing instructions

Check out this branch and do `cd packages/components && yarn tsc --build ./tsconfig.json`. Verify you don't get the error anymore.