### PR TITLE
Fix theme of DesignPicker

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -36,6 +36,7 @@ import {
 	getValidPath,
 	getFlowPageTitle,
 	shouldForceLogin,
+	isReskinnedFlow,
 } from './utils';
 
 const debug = debugModule( 'calypso:signup' );
@@ -94,10 +95,7 @@ export default {
 	redirectTests( context, next ) {
 		const isLoggedIn = isUserLoggedIn( context.store.getState() );
 		const currentFlowName = getFlowName( context.params, isLoggedIn );
-		if (
-			config( 'reskinned_flows' ).includes( currentFlowName ) &&
-			config.isEnabled( 'signup/reskin' )
-		) {
+		if ( isReskinnedFlow( currentFlowName ) ) {
 			next();
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -82,6 +82,7 @@ import {
 	getDestination,
 	getFirstInvalidStep,
 	getStepUrl,
+	isReskinnedFlow,
 } from './utils';
 import WpcomLoginForm from './wpcom-login-form';
 import './style.scss';
@@ -113,10 +114,6 @@ function removeLoadingScreenClassNamesFromBody() {
 
 function isWPForTeamsFlow( flowName ) {
 	return flowName === 'p2';
-}
-
-function isReskinnedFlow( flowName ) {
-	return config.isEnabled( 'signup/reskin' ) && config( 'reskinned_flows' ).includes( flowName );
 }
 
 class Signup extends React.Component {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -41,7 +41,13 @@ class DesignPickerStep extends Component {
 
 	renderDesignPicker() {
 		// props.locale obtained via `localize` HoC
-		return <DesignPicker theme="dark" locale={ this.props.locale } onSelect={ this.pickDesign } />;
+		return (
+			<DesignPicker
+				theme={ this.props.isReskinned ? 'light' : 'dark' }
+				locale={ this.props.locale }
+				onSelect={ this.pickDesign }
+			/>
+		);
 	}
 
 	headerText() {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -379,6 +379,14 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
+	.navigation-link.button.is-borderless {
+		color: var( --color-accent );
+
+		svg {
+			fill: var( --color-accent );
+		}
+	}
+
 	.navigation-link.button.back {
 		svg {
 			display: none;

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import flows from 'calypso/signup/config/flows';
@@ -208,4 +209,8 @@ export function canResumeFlow( flowName, progress, isUserLoggedIn ) {
 export const shouldForceLogin = ( flowName, userLoggedIn ) => {
 	const flow = flows.getFlow( flowName, userLoggedIn );
 	return !! flow && flow.forceLogin;
+};
+
+export const isReskinnedFlow = ( flowName ) => {
+	return config.isEnabled( 'signup/reskin' ) && config( 'reskinned_flows' ).includes( flowName );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently the theme prop of the design picker is `dark` so that we cannot see the theme name in new setup site flow introduced from https://github.com/Automattic/wp-calypso/pull/55741. The theme prop of the design picker depends on the background color and the white background depends on `isReskinnedFlow`. So, I use `isReskinnedFlow` to decide the theme should be `light` or `dark`.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/131323698-b5ad7d55-f58b-4f79-b67e-157cfd7643c2.png) | ![image](https://user-images.githubusercontent.com/13596067/131323746-e5390f66-fa74-4cdd-9f49-828724375146.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your test site>`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/55741
