### PR TITLE
build: Add Webpack plugin to prevent cache writes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM ${base_image} as builder-cache-true
 
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
+ENV READONLY_CACHE=true
 
 ###################
 FROM builder-cache-${use_cache} as builder

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,6 +8,7 @@ ARG node_memory=8192
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
+ENV READONLY_CACHE=true
 ENV PROFILE=true
 ENV SKIP_TSC=true
 ENV NVM_DIR=/calypso/.nvm

--- a/build-tools/webpack/readonly-cache-plugin.js
+++ b/build-tools/webpack/readonly-cache-plugin.js
@@ -1,0 +1,17 @@
+module.exports = class ReadonlyCachePlugin {
+	apply( compiler ) {
+		compiler.cache.hooks.store.intercept( {
+			register: ( tapInfo ) => {
+				compiler
+					.getInfrastructureLogger( 'webpack.cache.ReadonlyCachePlugin' )
+					.info( `Cache is in read only mode. ${ tapInfo.name } won't be executed` );
+				return {
+					...tapInfo,
+					fn: function () {
+						//A no-op function prevent any hook to `compiler.cache.hooks.store` to do anything.
+					},
+				};
+			},
+		} );
+	}
+};

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -28,10 +28,10 @@ const cacheIdentifier = require( '../build-tools/babel/babel-loader-cache-identi
 const AssetsWriter = require( '../build-tools/webpack/assets-writer-plugin.js' );
 const getAliasesForExtensions = require( '../build-tools/webpack/extensions' );
 const GenerateChunksMapPlugin = require( '../build-tools/webpack/generate-chunks-map-plugin' );
+const ReadOnlyCachePlugin = require( '../build-tools/webpack/readonly-cache-plugin' );
 const RequireChunkCallbackPlugin = require( '../build-tools/webpack/require-chunk-callback-plugin' );
 const config = require( './server/config' );
 const { workerCount } = require( './webpack.common' );
-
 /**
  * Internal variables
  */
@@ -54,6 +54,7 @@ const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 const cachePath = path.resolve( '.cache', extraPath );
 const shouldUsePersistentCache = process.env.PERSISTENT_CACHE === 'true';
+const shouldUseReadonlyCache = process.env.READONLY_CACHE === 'true';
 const shouldProfile = process.env.PROFILE === 'true';
 
 function filterEntrypoints( entrypoints ) {
@@ -368,6 +369,8 @@ const webpackConfig = {
 
 		// Equivalent to the CLI flag --progress=profile
 		shouldProfile && new webpack.ProgressPlugin( { profile: true } ),
+
+		shouldUsePersistentCache && shouldUseReadonlyCache && new ReadOnlyCachePlugin(),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates a custom plugin to block any cache writes.

This is useful in CI. We run the builds in disposable containers, so writing the cache back to the filesystem provides no value at all. This should save up to 60 seconds in build time in some cases.

I raised a PR with webpack (https://github.com/webpack/webpack/pull/14090) with a cleaner solution. Meanwhile I'm using the custom plugin as a workaround (inspired by https://github.com/webpack/webpack/issues/13581)

#### Testing instructions

* Check the wepback logs in CI and verify there are no lines starting with (`[webpack.cache.PackFileCacheStrategy] Serialization of...`)

* Run `PROFILE=true PERSISTENT_CACHE=true yarn build-client-evergreen` locally and verify the cache is stored (look for `Serialization of` lines)