### PR TITLE
Checkout: Reload cart when purchase completes

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -72,7 +72,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isJetpackCheckout?: boolean;
 	checkoutFlow?: string;
 } ): PaymentCompleteCallback {
-	const { responseCart } = useShoppingCart();
+	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart();
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -195,6 +195,7 @@ export default function useCreatePaymentCompleteCallback( {
 					fetchSitesAndUser(
 						domainName,
 						() => {
+							reloadCart();
 							performRedirect( url );
 						},
 						reduxStore
@@ -226,9 +227,11 @@ export default function useCreatePaymentCompleteCallback( {
 				return;
 			}
 
+			reloadCart();
 			performRedirect( url );
 		},
 		[
+			reloadCart,
 			siteSlug,
 			adminUrl,
 			redirectTo,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After https://github.com/Automattic/wp-calypso/pull/54667, the cached shopping cart data is now persisted in a singleton outside of the React render cycle. This means there are now situations where the shopping cart could get out-of-date. For example, if a purchase is completed (which clears the cart on the server) and the page is redirected using `page()` (which doesn't reload the page) to some other part of calypso that uses the shopping cart, the cart data will be out-of-date until some action is taken (or a refresh occurs because of a focus change).

This PR adds code that forces the cart to refresh whenever `onPaymentComplete` is called in checkout, just before the redirect.

Note that this will not work for redirect payment methods (eg: PayPal) since those never call `onPaymentComplete`; however, this should not be an issue because if a real redirect occurs, the cart will be refreshed anyway.

#### Testing instructions

- To do this you'll need a Personal or Premium plan already purchased, and you'll need to have at least one stored card.
- Visit /checkout/offer-quickstart-session/1234/example.com where example.com is your site (the number is a receipt ID but doesn't really matter).
- Click "Yes, I want a WordPress Expert by my side!" then click the "Pay" button in the modal.
- From this point on, do not refocus the window (eg: click outside the window and back again) because this could trigger a refetch!
- On the post-purchase page, click "My Sites" in the masterbar, then click "Upgrades" > "Plans" in the sidebar. None of these clicks should cause a real page redirect.
- Verify that the Popover cart icon in the header shows nothing in the cart.

Before:

<img width="548" alt="Screen Shot 2021-08-30 at 1 24 01 PM" src="https://user-images.githubusercontent.com/2036909/131379516-36d9b25a-403e-4c63-8979-a4f272e6f30c.png">

After:

<img width="550" alt="Screen Shot 2021-08-30 at 1 25 36 PM" src="https://user-images.githubusercontent.com/2036909/131379549-99372796-94cb-4223-8ecb-0096e3878dfd.png">
