### PR TITLE
Playwright: add WPCOM (desktop) Playwright build configuration.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -331,11 +331,21 @@ fun jetpackBuildType(screenSize: String): BuildType {
 	}
 }
 
-private object GutenbergPlaywrightE2E: BuildType ({
+private object GutenbergPlaywrightE2EDesktop: BuildType ({
 	name = "Playwright WPCOM E2E Tests (desktop)"
 	description = "Runs Gutenberg E2E tests in desktop size using Playwright"
 
-    name = "Hello world"
+    steps {
+        bashNodeScript {
+            scriptContent = "echo 'Hello world!'"
+        }
+    }
+})
+
+private object GutenbergPlaywrightE2EMobile: BuildType ({
+	name = "Playwright WPCOM E2E Tests (mobile)"
+	description = "Runs Gutenberg E2E tests in mobile size using Playwright"
+
     steps {
         bashNodeScript {
             scriptContent = "echo 'Hello world!'"

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -32,7 +32,8 @@ object WPComTests : Project({
 	// Keep the previous ID in order to preserve the historical data
 	buildType(gutenbergBuildType("desktop", "aee94c18-ee11-4c80-b6aa-245b967a97db"));
 	buildType(gutenbergBuildType("mobile","2af2eaed-87d5-41f4-ab1d-4ed589d5ae82"));
-	buildType(GutenbergPlaywrightE2E);
+	buildType(GutenbergPlaywrightE2EDesktop);
+	buildType(GutenbergPlaywrightE2EMobile);
 	buildType(jetpackBuildType("desktop"));
 	buildType(jetpackBuildType("mobile"));
 	buildType(VisualRegressionTests);

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -337,7 +337,7 @@ private object GutenbergPlaywrightE2E: BuildType ({
 
     name = "Hello world"
     steps {
-        script {
+        bashNodeScript {
             scriptContent = "echo 'Hello world!'"
         }
     }

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -32,7 +32,7 @@ object WPComTests : Project({
 	// Keep the previous ID in order to preserve the historical data
 	buildType(gutenbergBuildType("desktop", "aee94c18-ee11-4c80-b6aa-245b967a97db"));
 	buildType(gutenbergBuildType("mobile","2af2eaed-87d5-41f4-ab1d-4ed589d5ae82"));
-	buildType(gutenbergPlaywrightBuildType("mobile"));
+	buildType(GutenbergPlaywrightE2E);
 	buildType(jetpackBuildType("desktop"));
 	buildType(jetpackBuildType("mobile"));
 	buildType(VisualRegressionTests);
@@ -331,171 +331,168 @@ fun jetpackBuildType(screenSize: String): BuildType {
 	}
 }
 
-fun gutenbergPlaywrightBuildType( viewportName: String ): BuildType {
-	return BuildType {
-		id("WPComTests_gutenberg_Playwright_$viewportName")
-		name = "Playwright WPCOM E2E Tests ($viewportName)"
-		description = "Runs Gutenberg E2E tests in $viewportName size using Playwright"
+private object GutenbergPlaywrightE2E: BuildType {
+	name = "Playwright WPCOM E2E Tests (desktop)"
+	description = "Runs Gutenberg E2E tests in desktop size using Playwright"
 
-		artifactRules = """
-			reports => reports
-			logs.tgz => logs.tgz
-			screenshots => screenshots
-		""".trimIndent()
+	artifactRules = """
+		reports => reports
+		logs.tgz => logs.tgz
+		screenshots => screenshots
+	""".trimIndent()
 
-		vcs {
-			root(Settings.WpCalypso)
-			cleanCheckout = true
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	params {
+		text(
+			name = "URL",
+			value = "https://wordpress.com",
+			label = "Test URL",
+			description = "URL to test against",
+			allowEmpty = false
+		)
+		checkbox(
+			name = "GUTENBERG_EDGE",
+			value = "false",
+			label = "Use gutenberg-edge",
+			description = "Use a blog with gutenberg-edge sticker",
+			checked = "true",
+			unchecked = "false"
+		)
+		checkbox(
+			name = "COBLOCKS_EDGE",
+			value = "false",
+			label = "Use coblocks-edge",
+			description = "Use a blog with coblocks-edge sticker",
+			checked = "true",
+			unchecked = "false"
+		)
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Prepare environment"
+			scriptContent = """
+				export NODE_ENV="test"
+				export PLAYWRIGHT_BROWSERS_PATH=0
+
+				# Install modules
+				${_self.yarn_install_cmd}
+
+				# Build packages
+				yarn workspace @automattic/calypso-e2e build
+			"""
 		}
+		bashNodeScript {
+			name = "Run e2e tests (desktop)"
+			scriptContent = """
+				shopt -s globstar
+				set -x
 
-		params {
-			text(
-				name = "URL",
-				value = "https://wordpress.com",
-				label = "Test URL",
-				description = "URL to test against",
-				allowEmpty = false
-			)
-			checkbox(
-				name = "GUTENBERG_EDGE",
-				value = "false",
-				label = "Use gutenberg-edge",
-				description = "Use a blog with gutenberg-edge sticker",
-				checked = "true",
-				unchecked = "false"
-			)
-			checkbox(
-				name = "COBLOCKS_EDGE",
-				value = "false",
-				label = "Use coblocks-edge",
-				description = "Use a blog with coblocks-edge sticker",
-				checked = "true",
-				unchecked = "false"
-			)
+				chmod +x ./bin/get-calypso-live-url.sh
+				URL=${'$'}(./bin/get-calypso-live-url.sh ${BuildDockerImage.depParamRefs.buildNumber})
+				if [[ ${'$'}? -ne 0 ]]; then
+					// Command failed. URL contains stderr
+					echo ${'$'}URL
+					exit 1
+				fi
+
+				cd test/e2e
+				mkdir temp
+
+				export LIVEBRANCHES=true
+				export NODE_CONFIG_ENV=test
+				export PLAYWRIGHT_BROWSERS_PATH=0
+				export TEAMCITY_VERSION=2021
+
+				# Decrypt config
+				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
+
+				# Run the test
+				export VIEWPORT_NAME=desktop
+				export LOCALE=en
+				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
+				export DEBUG=pw:api
+
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright-wpcom
+			""".trimIndent()
+			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
 		}
+		bashNodeScript {
+			name = "Collect results"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -x
 
-		steps {
-			bashNodeScript {
-				name = "Prepare environment"
-				scriptContent = """
-					export NODE_ENV="test"
-					export PLAYWRIGHT_BROWSERS_PATH=0
+				mkdir -p screenshots
+				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
 
-					# Install modules
-					${_self.yarn_install_cmd}
-
-					# Build packages
-					yarn workspace @automattic/calypso-e2e build
-				"""
-			}
-			bashNodeScript {
-				name = "Run e2e tests ($viewportName)"
-				scriptContent = """
-					shopt -s globstar
-					set -x
-
-					chmod +x ./bin/get-calypso-live-url.sh
-					URL=${'$'}(./bin/get-calypso-live-url.sh ${BuildDockerImage.depParamRefs.buildNumber})
-					if [[ ${'$'}? -ne 0 ]]; then
-						// Command failed. URL contains stderr
-						echo ${'$'}URL
-						exit 1
-					fi
-
-					cd test/e2e
-					mkdir temp
-
-					export LIVEBRANCHES=true
-					export NODE_CONFIG_ENV=test
-					export PLAYWRIGHT_BROWSERS_PATH=0
-					export TEAMCITY_VERSION=2021
-
-					# Decrypt config
-					openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
-
-					# Run the test
-					export VIEWPORT_NAME=$viewportName
-					export LOCALE=en
-					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
-					export DEBUG=pw:api
-
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright-wpcom
-				""".trimIndent()
-				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
-			}
-			bashNodeScript {
-				name = "Collect results"
-				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-				scriptContent = """
-					set -x
-
-					mkdir -p screenshots
-					find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
-
-					mkdir -p logs
-					find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
-				""".trimIndent()
-			}
+				mkdir -p logs
+				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+			""".trimIndent()
 		}
+	}
 
-		features {
-			perfmon {
-			}
-			notifications {
-				notifierSettings = slackNotifier {
-					connection = "PROJECT_EXT_11"
-					sendTo = "#gutenberg-e2e"
-					messageFormat = verboseMessageFormat {
-						addBranch = true
-						addStatusText = true
-						maximumNumberOfChanges = 10
-					}
+	features {
+		perfmon {
+		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#gutenberg-e2e"
+				messageFormat = verboseMessageFormat {
+					addBranch = true
+					addStatusText = true
+					maximumNumberOfChanges = 10
 				}
-				branchFilter = "+:<default>"
-				buildFailed = true
-				buildFinishedSuccessfully = true
 			}
-			commitStatusPublisher {
-				vcsRootExtId = "${Settings.WpCalypso.id}"
-				publisher = github {
-					githubUrl = "https://api.github.com"
-					authType = personalToken {
-						token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-					}
+			branchFilter = "+:<default>"
+			buildFailed = true
+			buildFinishedSuccessfully = true
+		}
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
 				}
 			}
 		}
+	}
 
-		failureConditions {
-			executionTimeoutMin = 20
-			// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
-			// been muted previously.
-			nonZeroExitCode = false
+	failureConditions {
+		executionTimeoutMin = 20
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+		// been muted previously.
+		nonZeroExitCode = false
 
-			// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
-			// crashes and no tests are run.
-			failOnMetricChange {
-				metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
-				threshold = 50
-				units = BuildFailureOnMetric.MetricUnit.PERCENTS
-				comparison = BuildFailureOnMetric.MetricComparison.LESS
-				compareTo = build {
-					buildRule = lastSuccessful()
-				}
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+		// crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
 			}
 		}
+	}
 
-		triggers {
-			schedule {
-				schedulingPolicy = daily {
-					hour = 4
-				}
-				branchFilter = """
-					+:trunk
-				""".trimIndent()
-				triggerBuild = always()
-				withPendingChangesOnly = false
+	triggers {
+		schedule {
+			schedulingPolicy = daily {
+				hour = 4
 			}
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			triggerBuild = always()
+			withPendingChangesOnly = false
 		}
 	}
 }

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -331,171 +331,17 @@ fun jetpackBuildType(screenSize: String): BuildType {
 	}
 }
 
-private object GutenbergPlaywrightE2E: BuildType {
+private object GutenbergPlaywrightE2E: BuildType ({
 	name = "Playwright WPCOM E2E Tests (desktop)"
 	description = "Runs Gutenberg E2E tests in desktop size using Playwright"
 
-	artifactRules = """
-		reports => reports
-		logs.tgz => logs.tgz
-		screenshots => screenshots
-	""".trimIndent()
-
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
-
-	params {
-		text(
-			name = "URL",
-			value = "https://wordpress.com",
-			label = "Test URL",
-			description = "URL to test against",
-			allowEmpty = false
-		)
-		checkbox(
-			name = "GUTENBERG_EDGE",
-			value = "false",
-			label = "Use gutenberg-edge",
-			description = "Use a blog with gutenberg-edge sticker",
-			checked = "true",
-			unchecked = "false"
-		)
-		checkbox(
-			name = "COBLOCKS_EDGE",
-			value = "false",
-			label = "Use coblocks-edge",
-			description = "Use a blog with coblocks-edge sticker",
-			checked = "true",
-			unchecked = "false"
-		)
-	}
-
-	steps {
-		bashNodeScript {
-			name = "Prepare environment"
-			scriptContent = """
-				export NODE_ENV="test"
-				export PLAYWRIGHT_BROWSERS_PATH=0
-
-				# Install modules
-				${_self.yarn_install_cmd}
-
-				# Build packages
-				yarn workspace @automattic/calypso-e2e build
-			"""
-		}
-		bashNodeScript {
-			name = "Run e2e tests (desktop)"
-			scriptContent = """
-				shopt -s globstar
-				set -x
-
-				chmod +x ./bin/get-calypso-live-url.sh
-				URL=${'$'}(./bin/get-calypso-live-url.sh ${BuildDockerImage.depParamRefs.buildNumber})
-				if [[ ${'$'}? -ne 0 ]]; then
-					// Command failed. URL contains stderr
-					echo ${'$'}URL
-					exit 1
-				fi
-
-				cd test/e2e
-				mkdir temp
-
-				export LIVEBRANCHES=true
-				export NODE_CONFIG_ENV=test
-				export PLAYWRIGHT_BROWSERS_PATH=0
-				export TEAMCITY_VERSION=2021
-
-				# Decrypt config
-				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
-
-				# Run the test
-				export VIEWPORT_NAME=desktop
-				export LOCALE=en
-				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
-				export DEBUG=pw:api
-
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright-wpcom
-			""".trimIndent()
-			dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
-		}
-		bashNodeScript {
-			name = "Collect results"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				set -x
-
-				mkdir -p screenshots
-				find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
-
-				mkdir -p logs
-				find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
-			""".trimIndent()
-		}
-	}
-
-	features {
-		perfmon {
-		}
-		notifications {
-			notifierSettings = slackNotifier {
-				connection = "PROJECT_EXT_11"
-				sendTo = "#gutenberg-e2e"
-				messageFormat = verboseMessageFormat {
-					addBranch = true
-					addStatusText = true
-					maximumNumberOfChanges = 10
-				}
-			}
-			branchFilter = "+:<default>"
-			buildFailed = true
-			buildFinishedSuccessfully = true
-		}
-		commitStatusPublisher {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			publisher = github {
-				githubUrl = "https://api.github.com"
-				authType = personalToken {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-			}
-		}
-	}
-
-	failureConditions {
-		executionTimeoutMin = 20
-		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
-		// been muted previously.
-		nonZeroExitCode = false
-
-		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
-		// crashes and no tests are run.
-		failOnMetricChange {
-			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
-			threshold = 50
-			units = BuildFailureOnMetric.MetricUnit.PERCENTS
-			comparison = BuildFailureOnMetric.MetricComparison.LESS
-			compareTo = build {
-				buildRule = lastSuccessful()
-			}
-		}
-	}
-
-	triggers {
-		schedule {
-			schedulingPolicy = daily {
-				hour = 4
-			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
-			triggerBuild = always()
-			withPendingChangesOnly = false
-		}
-	}
-}
+    name = "Hello world"
+    steps {
+        script {
+            scriptContent = "echo 'Hello world!'"
+        }
+    }
+})
 
 private object VisualRegressionTests : BuildType({
 	name = "Visual Regression Tests"

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -32,6 +32,7 @@ object WPComTests : Project({
 	// Keep the previous ID in order to preserve the historical data
 	buildType(gutenbergBuildType("desktop", "aee94c18-ee11-4c80-b6aa-245b967a97db"));
 	buildType(gutenbergBuildType("mobile","2af2eaed-87d5-41f4-ab1d-4ed589d5ae82"));
+	buildType(gutenbergPlaywrightBuildType("mobile"));
 	buildType(jetpackBuildType("desktop"));
 	buildType(jetpackBuildType("mobile"));
 	buildType(VisualRegressionTests);
@@ -330,6 +331,175 @@ fun jetpackBuildType(screenSize: String): BuildType {
 	}
 }
 
+fun gutenbergPlaywrightBuildType( viewportName: String ): BuildType {
+	return BuildType {
+		id("WPComTests_gutenberg_Playwright_$viewportName")
+		name = "Playwright WPCOM E2E Tests ($viewportName)"
+		description = "Runs Gutenberg E2E tests in $viewportName size using Playwright"
+
+		artifactRules = """
+			reports => reports
+			logs.tgz => logs.tgz
+			screenshots => screenshots
+		""".trimIndent()
+
+		vcs {
+			root(Settings.WpCalypso)
+			cleanCheckout = true
+		}
+
+		params {
+			text(
+				name = "URL",
+				value = "https://wordpress.com",
+				label = "Test URL",
+				description = "URL to test against",
+				allowEmpty = false
+			)
+			checkbox(
+				name = "GUTENBERG_EDGE",
+				value = "false",
+				label = "Use gutenberg-edge",
+				description = "Use a blog with gutenberg-edge sticker",
+				checked = "true",
+				unchecked = "false"
+			)
+			checkbox(
+				name = "COBLOCKS_EDGE",
+				value = "false",
+				label = "Use coblocks-edge",
+				description = "Use a blog with coblocks-edge sticker",
+				checked = "true",
+				unchecked = "false"
+			)
+		}
+
+		steps {
+			bashNodeScript {
+				name = "Prepare environment"
+				scriptContent = """
+					export NODE_ENV="test"
+					export PLAYWRIGHT_BROWSERS_PATH=0
+
+					# Install modules
+					${_self.yarn_install_cmd}
+
+					# Build packages
+					yarn workspace @automattic/calypso-e2e build
+				"""
+			}
+			bashNodeScript {
+				name = "Run e2e tests ($viewportName)"
+				scriptContent = """
+					shopt -s globstar
+					set -x
+
+					chmod +x ./bin/get-calypso-live-url.sh
+					URL=${'$'}(./bin/get-calypso-live-url.sh ${BuildDockerImage.depParamRefs.buildNumber})
+					if [[ ${'$'}? -ne 0 ]]; then
+						// Command failed. URL contains stderr
+						echo ${'$'}URL
+						exit 1
+					fi
+
+					cd test/e2e
+					mkdir temp
+
+					export LIVEBRANCHES=true
+					export NODE_CONFIG_ENV=test
+					export PLAYWRIGHT_BROWSERS_PATH=0
+					export TEAMCITY_VERSION=2021
+
+					# Decrypt config
+					openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
+
+					# Run the test
+					export VIEWPORT_NAME=$viewportName
+					export LOCALE=en
+					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
+					export DEBUG=pw:api
+
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright-wpcom
+				""".trimIndent()
+				dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
+			}
+			bashNodeScript {
+				name = "Collect results"
+				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+				scriptContent = """
+					set -x
+
+					mkdir -p screenshots
+					find test/e2e -type f -path '*/screenshots/*' -print0 | xargs -r -0 mv -t screenshots
+
+					mkdir -p logs
+					find test/e2e -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+				""".trimIndent()
+			}
+		}
+
+		features {
+			perfmon {
+			}
+			notifications {
+				notifierSettings = slackNotifier {
+					connection = "PROJECT_EXT_11"
+					sendTo = "#gutenberg-e2e"
+					messageFormat = verboseMessageFormat {
+						addBranch = true
+						addStatusText = true
+						maximumNumberOfChanges = 10
+					}
+				}
+				branchFilter = "+:<default>"
+				buildFailed = true
+				buildFinishedSuccessfully = true
+			}
+			commitStatusPublisher {
+				vcsRootExtId = "${Settings.WpCalypso.id}"
+				publisher = github {
+					githubUrl = "https://api.github.com"
+					authType = personalToken {
+						token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+					}
+				}
+			}
+		}
+
+		failureConditions {
+			executionTimeoutMin = 20
+			// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have
+			// been muted previously.
+			nonZeroExitCode = false
+
+			// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner
+			// crashes and no tests are run.
+			failOnMetricChange {
+				metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+				threshold = 50
+				units = BuildFailureOnMetric.MetricUnit.PERCENTS
+				comparison = BuildFailureOnMetric.MetricComparison.LESS
+				compareTo = build {
+					buildRule = lastSuccessful()
+				}
+			}
+		}
+
+		triggers {
+			schedule {
+				schedulingPolicy = daily {
+					hour = 4
+				}
+				branchFilter = """
+					+:trunk
+				""".trimIndent()
+				triggerBuild = always()
+				withPendingChangesOnly = false
+			}
+		}
+	}
+}
+
 private object VisualRegressionTests : BuildType({
 	name = "Visual Regression Tests"
 	description = "Runs visual regression tests"
@@ -542,3 +712,4 @@ private object I18NTests : BuildType({
 		}
 	}
 })
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add a parallel Playwright (desktop) build configuration to the WPCOM project.

Key changes:
- new build configuration in `WPCOMTests.kt`.

Details:

As part of #55661 and #55715, the Quality Squad wants to set up a Playwright version of the WPCOM/Gutenberg tests on TeamCity. This would be similar to how the Calypso E2E project has been managed (parallel Selenium/Playwright build configurations during migration).

#### Testing instructions

Cannot test until this is merged.

Related to #55661
