### PR TITLE
Checkout: Move Alipay payment method to wpcom-checkout package

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { createAlipayMethod, createAlipayPaymentMethodStore } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	createApplePayMethod,
@@ -17,6 +16,8 @@ import {
 	createIdealPaymentMethodStore,
 	createSofortMethod,
 	createSofortPaymentMethodStore,
+	createAlipayMethod,
+	createAlipayPaymentMethodStore,
 	isValueTruthy,
 } from '@automattic/wpcom-checkout';
 import { useMemo } from 'react';
@@ -95,13 +96,9 @@ export function useCreateCreditCard( {
 function useCreateAlipay( {
 	isStripeLoading,
 	stripeLoadingError,
-	stripeConfiguration,
-	stripe,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
-	stripeConfiguration: StripeConfiguration | null;
-	stripe: Stripe | null;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
 	const paymentMethodStore = useMemo( () => createAlipayPaymentMethodStore(), [] );
@@ -110,11 +107,9 @@ function useCreateAlipay( {
 			shouldLoad
 				? createAlipayMethod( {
 						store: paymentMethodStore,
-						stripe,
-						stripeConfiguration,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+		[ shouldLoad, paymentMethodStore ]
 	);
 }
 
@@ -389,8 +384,6 @@ export default function useCreatePaymentMethods( {
 	const alipayMethod = useCreateAlipay( {
 		isStripeLoading,
 		stripeLoadingError,
-		stripeConfiguration,
-		stripe,
 	} );
 
 	const p24Method = useCreateP24( {

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -43,7 +43,6 @@ import { useFormStatus } from './lib/form-status';
 import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processor-response-error';
 import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
-import { createAlipayPaymentMethodStore, createAlipayMethod } from './lib/payment-methods/alipay';
 import PaymentLogo from './lib/payment-methods/payment-logo';
 import {
 	createStripeMethod,
@@ -101,8 +100,6 @@ export {
 	RadioButton,
 	SubmitButtonWrapper,
 	checkoutTheme,
-	createAlipayMethod,
-	createAlipayPaymentMethodStore,
 	createRegistry,
 	createStripeMethod,
 	createStripePaymentMethodStore,

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -15,6 +15,7 @@ export * from './payment-methods/ideal';
 export * from './payment-methods/sofort';
 export * from './payment-methods/p24';
 export * from './payment-methods/eps';
+export * from './payment-methods/alipay';
 export * from './use-is-web-payment-available';
 export * from './payment-methods/google-pay';
 export * from './payment-methods/existing-credit-card';

--- a/packages/wpcom-checkout/src/payment-methods/alipay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/alipay.tsx
@@ -1,39 +1,64 @@
-import styled from '@emotion/styled';
+import {
+	Button,
+	FormStatus,
+	useLineItems,
+	useFormStatus,
+	registerStore,
+	useSelect,
+	useDispatch,
+} from '@automattic/composite-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import React from 'react';
-import Button from '../../components/button';
-import Field from '../../components/field';
-import { registerStore, useSelect, useDispatch } from '../../lib/registry';
-import { FormStatus, useLineItems } from '../../public-api';
-import { useFormStatus } from '../form-status';
-import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import Field from '../field';
+import { PaymentMethodLogos } from '../payment-method-logos';
+import styled from '../styled';
+import { SummaryLine, SummaryDetails } from '../summary-details';
+import type {
+	PaymentMethodStore,
+	StoreSelectors,
+	StoreSelectorsWithState,
+	StoreActions,
+	StoreState,
+} from '../payment-method-store';
+import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
 
-const debug = debugFactory( 'composite-checkout:alipay-payment-method' );
+const debug = debugFactory( 'wpcom-checkout:alipay-payment-method' );
 
-export function createAlipayPaymentMethodStore() {
+// Disabling this to make migration easier
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+type StoreKey = 'alipay';
+type NounsInStore = 'customerName';
+type AlipayStore = PaymentMethodStore< NounsInStore >;
+
+declare module '@wordpress/data' {
+	function select( key: StoreKey ): StoreSelectors< NounsInStore >;
+	function dispatch( key: StoreKey ): StoreActions< NounsInStore >;
+}
+
+const actions: StoreActions< NounsInStore > = {
+	changeCustomerName( payload ) {
+		return { type: 'CUSTOMER_NAME_SET', payload };
+	},
+};
+
+const selectors: StoreSelectorsWithState< NounsInStore > = {
+	getCustomerName( state ) {
+		return state.customerName || '';
+	},
+};
+
+export function createAlipayPaymentMethodStore(): AlipayStore {
 	debug( 'creating a new alipay payment method store' );
-	const actions = {
-		changeCustomerName( payload ) {
-			return { type: 'CUSTOMER_NAME_SET', payload };
-		},
-	};
-
-	const selectors = {
-		getCustomerName( state ) {
-			return state.customerName || '';
-		},
-	};
-
-	const store = registerStore( 'alipay', {
+	return registerStore( 'alipay', {
 		reducer(
-			state = {
+			state: StoreState< NounsInStore > = {
 				customerName: { value: '', isTouched: false },
 			},
 			action
-		) {
+		): StoreState< NounsInStore > {
 			switch ( action.type ) {
 				case 'CUSTOMER_NAME_SET':
 					return { ...state, customerName: { value: action.payload, isTouched: true } };
@@ -43,24 +68,16 @@ export function createAlipayPaymentMethodStore() {
 		actions,
 		selectors,
 	} );
-
-	return { ...store, actions, selectors };
 }
 
-export function createAlipayMethod( { store, stripe, stripeConfiguration } ) {
+export function createAlipayMethod( { store }: { store: AlipayStore } ): PaymentMethod {
 	return {
 		id: 'alipay',
 		label: <AlipayLabel />,
-		activeContent: <AlipayFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />,
+		activeContent: <AlipayFields />,
 		inactiveContent: <AlipaySummary />,
-		submitButton: (
-			<AlipayPayButton
-				store={ store }
-				stripe={ stripe }
-				stripeConfiguration={ stripeConfiguration }
-			/>
-		),
-		getAriaLabel: ( __ ) => __( 'Alipay' ),
+		submitButton: <AlipayPayButton store={ store } />,
+		getAriaLabel: () => 'Alipay',
 	};
 }
 
@@ -118,10 +135,27 @@ const AlipayField = styled( Field )`
 	}
 `;
 
-function AlipayPayButton( { disabled, onClick, store, stripe, stripeConfiguration } ) {
+function AlipayPayButton( {
+	disabled,
+	onClick,
+	store,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+	store: AlipayStore;
+} ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'alipay' ).getCustomerName() );
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; AlipayPayButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
 
 	return (
 		<Button
@@ -130,11 +164,9 @@ function AlipayPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 				if ( isFormValid( store ) ) {
 					debug( 'submitting alipay payment' );
 					onClick( 'alipay', {
-						stripe,
 						name: customerName?.value,
 						items,
 						total,
-						stripeConfiguration,
 					} );
 				}
 			} }
@@ -147,24 +179,24 @@ function AlipayPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 	);
 }
 
-function ButtonContents( { formStatus, total } ) {
+function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
-		return __( 'Processing…' );
+		return <>{ __( 'Processing…' ) }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		/* translators: %s is the total to be paid in localized currency */
-		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
+		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
 	}
-	return __( 'Please wait…' );
+	return <>{ __( 'Please wait…' ) }</>;
 }
 
-function isFormValid( store ) {
-	const customerName = store.selectors.getCustomerName( store.getState() );
+function isFormValid( store: AlipayStore ) {
+	const customerName = selectors.getCustomerName( store.getState() );
 
 	if ( ! customerName?.value.length ) {
 		// Touch the field so it displays a validation error
-		store.dispatch( store.actions.changeCustomerName( '' ) );
+		store.dispatch( actions.changeCustomerName( '' ) );
 		return false;
 	}
 	return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the Alipay payment method from the `@automattic/composite-checkout` package into the `@automattic/wpcom-checkout` package and converts it to TypeScript. This is similar to how Bancontact was moved in https://github.com/Automattic/wp-calypso/pull/51690, Giropay in https://github.com/Automattic/wp-calypso/pull/53346, iDEAL in https://github.com/Automattic/wp-calypso/pull/54940, Sofort in https://github.com/Automattic/wp-calypso/pull/55700, and p24 in https://github.com/Automattic/wp-calypso/pull/53510 This is related to the refactoring of https://github.com/Automattic/wp-calypso/issues/52215

#### Background

The `composite-checkout` package is intended to be a fairly generic checkout-building toolkit. As part of this we originally envisioned it containing various payment methods, but that quickly became a problem as it became clear that the payment methods we use on WordPress.com are pretty specific to our platform. To reduce leaky abstractions, we moved many of our payment methods over to calypso, but some have remained because the cost of moving them seemed too high for the benefit.

As we prepare to publish version 1.0.0 of the `@automattic/composite-checkout` package on npm, I think it's a good time to clean up extraneous parts of the package. The payment methods are the only part of the package that are not fully TypeScript and are also still pretty specific to our WordPress.com infrastructure. Eventually it would be nice to convert them all to TypeScript and put them in a package like `@automattic/wpcom-checkout` (which is intended to be WordPress.com specific). This PR converts one such payment method and moves it there.

#### Testing instructions

- Apply D45446-code to your sandbox and sandbox the API to force Alipay to be available.
- Set your user's currency to `EUR`.
- Visit checkout with a product in your cart.
- Verify that Alipay shows up as an available payment method.
- Select Alipay, fill in any string as the name.
- Click to submit the purchase.
- Verify that you're redirected to the Stripe test page.
- Verify that the information in the Stripe test page shows the correct total, name, and bank. (No need to confirm the payment.)