### PR TITLE
Checkout: Pass cartKey to useShoppingCart in many checkout display components

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { ResponseCartMessage } from '@automattic/shopping-cart';
@@ -21,7 +22,8 @@ function CartMessage( { message }: { message: ResponseCartMessage } ): JSX.Eleme
 }
 
 export default function CartMessages(): null {
-	const { responseCart: cart, isLoading: isLoadingCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart: cart, isLoading: isLoadingCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 
 	const showErrorMessages = useCallback(

--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -9,6 +9,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { Field, styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
@@ -42,7 +43,8 @@ export default function ContactDetailsContainer( {
 	isLoggedOutCart: boolean;
 } ): JSX.Element {
 	const translate = useTranslate();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const domainNames: string[] = responseCart.products
 		.filter( ( product ) => isDomainProduct( product ) || isDomainTransfer( product ) )
 		.filter( ( product ) => ! isDomainMapping( product ) )

--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -9,6 +9,7 @@ import {
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import { getTopLevelOfTld } from 'calypso/lib/domains';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
 import type {
 	DomainContactDetailsErrors,
@@ -45,7 +46,8 @@ export default function DomainContactDetails( {
 	emailOnly?: boolean;
 } ): JSX.Element {
 	const translate = useTranslate();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const needsOnlyGoogleAppsDetails =
 		hasGoogleApps( responseCart ) &&
 		! hasDomainRegistration( responseCart ) &&

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import React from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
 import { NonProductLineItem } from './wp-line-item';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
@@ -65,7 +66,8 @@ export default function PaymentMethodStep( {
 }: {
 	activeStepContent: React.ReactNode;
 } ): JSX.Element {
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -8,6 +8,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	isPlanIncludingSiteBackup,
 	isBackupProductIncludedInSitePlan,
@@ -33,7 +34,8 @@ const PrePurchaseNotices = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
 
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const cartItemSlugs = responseCart.products.map( ( item ) => item.product_slug );
 
 	const currentSitePlan = useSelector( ( state ) => {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -17,6 +17,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -29,7 +30,8 @@ export default function WPCheckoutOrderSummary( {
 } = {} ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
@@ -236,7 +238,8 @@ function CheckoutSummaryFeaturesListDomainItem( { domain, hasMonthlyPlan, nextDo
 
 function CheckoutSummaryPlanFeatures( { siteId } ) {
 	const translate = useTranslate();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const hasDomainsInCart = responseCart.products.some(
 		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
 	);

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -31,6 +31,7 @@ import {
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
 import { validateContactDetails } from '../lib/contact-validation';
@@ -59,7 +60,8 @@ const ContactFormTitle = (): JSX.Element => {
 	const translate = useTranslate();
 	const isActive = useIsStepActive();
 	const isComplete = useIsStepComplete();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const contactDetailsType = getContactDetailsType( responseCart );
 
 	if ( contactDetailsType === 'domain' ) {
@@ -135,12 +137,13 @@ export default function WPCheckout( {
 	infoMessage?: JSX.Element;
 	createUserAndSiteBeforeTransaction: boolean;
 } ): JSX.Element {
+	const cartKey = useCartKey();
 	const {
 		responseCart,
 		applyCoupon,
 		updateLocation,
 		isPendingUpdate: isCartPendingUpdate,
-	} = useShoppingCart();
+	} = useShoppingCart( cartKey );
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const total = useTotal();
@@ -525,7 +528,8 @@ function SubmitButtonHeader() {
 }
 
 const SubmitButtonFooter = () => {
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const translate = useTranslate();
 
 	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.js
@@ -3,6 +3,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
 import React from 'react';
 import { hasOnlyRenewalItems } from 'calypso/lib/cart-values/cart-items';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { SummaryLine, SummaryDetails } from './summary-details';
 
 export default function WPContactFormSummary( {
@@ -11,7 +12,8 @@ export default function WPContactFormSummary( {
 	isLoggedOutCart,
 } ) {
 	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
-	const { responseCart: cart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart: cart } = useShoppingCart( cartKey );
 	const isRenewal = cart && hasOnlyRenewalItems( cart );
 
 	// Check if paymentData is empty

--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -26,6 +26,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import getPriceTierForUnits from 'calypso/my-sites/plans/jetpack-plans/get-price-tier-for-units';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -706,7 +707,8 @@ function WPLineItem( {
 } ): JSX.Element {
 	const id = product.uuid;
 	const translate = useTranslate();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const hasDomainsInCart = responseCart.products.some(
 		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
 	);

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -3,6 +3,7 @@ import { getCouponLineItemFromCart, getCreditsLineItemFromCart } from '@automatt
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import joinClasses from './join-classes';
 import { NonProductLineItem, LineItem } from './wp-line-item';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -54,7 +55,8 @@ export function WPOrderReviewLineItems( {
 	onChangePlanLength?: OnChangeItemVariant;
 	createUserAndSiteBeforeTransaction?: boolean;
 } ): JSX.Element {
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -25,6 +25,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import wp from 'calypso/lib/wp';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -191,6 +192,7 @@ export default function CompositeCheckout( {
 		jetpackPurchaseToken,
 	} );
 
+	const cartKey = useCartKey();
 	const {
 		couponStatus,
 		applyCoupon,
@@ -203,7 +205,7 @@ export default function CompositeCheckout( {
 		loadingError: cartLoadingError,
 		loadingErrorType: cartLoadingErrorType,
 		addProductsToCart,
-	} = useShoppingCart();
+	} = useShoppingCart( cartKey );
 
 	const maybeJetpackIntroCouponCode = useMaybeJetpackIntroCouponCode(
 		productsForCart,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -17,6 +17,7 @@ import page from 'page';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -46,6 +47,7 @@ import {
 jest.mock( 'calypso/state/sites/selectors' );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
+jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
 
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
@@ -98,6 +100,7 @@ describe( 'CompositeCheckout', () => {
 				setCart: mockSetCartEndpoint,
 			} );
 			const mainCartKey = 'foo.com';
+			useCartKey.mockImplementation( () => ( useUndefinedCartKey ? undefined : mainCartKey ) );
 			return (
 				<ReduxProvider store={ store }>
 					<ShoppingCartProvider


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After https://github.com/Automattic/wp-calypso/pull/54667, we need to pass the cart key as an argument to `useShoppingCart` (although there's currently a fallback in place while we migrate). You can read more about the reason behind the change in that PR.

This PR provides the cart key argument to most display components in checkout. There's more to be migrated, but this is enough for one PR.

#### Testing instructions

- Add both a domain and a plan to your cart and visit checkout.
- Verify that the products you added to your cart are displayed correctly.
- Verify that the total and taxes are displayed correctly in both the sidebar (which is a header on mobile) and the last checkout step.
- Edit your contact information and enter an invalid address (eg: mismatched country and postal code) and try to save the contact information step.
- Verify that you see an error message displayed about invalid contact information.
- Correct the contact information and try to save the contact information step.
- Verify that the validation is successful.
