### PR TITLE
Remove spacing above inline help search field

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -261,9 +261,7 @@
 	}
 
 	.sites-dropdown {
-		.site-selector .search {
-			top: 51px;
-		}
+
 		.site-selector__sites {
 			max-height: 20vh;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A position of `top: 51px` pushed the search input field down which caused the search field to overlap the site list. 
* Removed CSS declaration `.inline-help__contact .sites-dropdown .site-selector .search { top: 51px; }` as it didn't appear to be used anywhere but the inline-help component. Not sure why it was originally added. 
* Removing the declaration doesn't appear to cause any issues with the functionality of component.  

**Before:**
<img width="293" alt="before-" src="https://user-images.githubusercontent.com/35543432/131442044-7ca2cbf5-dc6f-4c17-ab34-b4d043eb858f.png">

**After:**
<img width="293" alt="after-" src="https://user-images.githubusercontent.com/35543432/131442047-b31aea95-1a3d-4427-afef-8babf69f1e2a.png">




#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on help FAB and then on 'Contact Us'
* Click on default site to select new site
* Now there shouldn't be a space above the search field and the search field shouldn't overlap the site selection 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55608
