### PR TITLE
Theme Showcase: Remove segmented control for theme tiers

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -289,7 +289,6 @@ class ThemeShowcase extends React.Component {
 			pathName,
 			title,
 			filterString,
-			isMultisite,
 			locale,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
@@ -385,7 +384,6 @@ class ThemeShowcase extends React.Component {
 						onSearch={ this.doSearch }
 						search={ filterString + search }
 						tier={ tier }
-						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect }
 					/>
 					{ isLoggedIn && (

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Popover } from '@automattic/components';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
@@ -11,7 +10,6 @@ import { connect } from 'react-redux';
 import Gridicon from 'calypso/components/gridicon';
 import KeyedSuggestions from 'calypso/components/keyed-suggestions';
 import Search from 'calypso/components/search';
-import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { getThemeFilters, getThemeFilterToTermTable } from 'calypso/state/themes/selectors';
 import MagicSearchWelcome from './welcome';
@@ -23,19 +21,11 @@ const preferredOrderOfTaxonomies = [ 'feature', 'layout', 'column', 'subject', '
 
 class ThemesMagicSearchCard extends React.Component {
 	static propTypes = {
-		tier: PropTypes.string,
-		select: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		onSearch: PropTypes.func.isRequired,
 		search: PropTypes.string,
 		translate: PropTypes.func.isRequired,
-		showTierThemesControl: PropTypes.bool,
 		isBreakpointActive: PropTypes.bool, // comes from withMobileBreakpoint HOC
-	};
-
-	static defaultProps = {
-		tier: 'all',
-		showTierThemesControl: true,
 	};
 
 	constructor( props ) {
@@ -279,15 +269,8 @@ class ThemesMagicSearchCard extends React.Component {
 	};
 
 	render() {
-		const { translate, filters, showTierThemesControl } = this.props;
+		const { translate, filters } = this.props;
 		const { isPopoverVisible } = this.state;
-		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
-
-		const tiers = [
-			{ value: 'all', label: translate( 'All' ) },
-			{ value: 'free', label: translate( 'Free' ) },
-			{ value: 'premium', label: translate( 'Premium' ) },
-		];
 
 		const filtersKeys = [
 			...intersection( preferredOrderOfTaxonomies, Object.keys( filters ) ),
@@ -381,14 +364,6 @@ class ThemesMagicSearchCard extends React.Component {
 						onClick={ this.handleClickInside }
 					>
 						{ searchField }
-						{ isPremiumThemesEnabled && showTierThemesControl && (
-							<SimplifiedSegmentedControl
-								key={ this.props.tier }
-								initialSelected={ this.props.tier ? this.props.tier : 'all' }
-								options={ tiers }
-								onSelect={ this.props.select }
-							/>
-						) }
 					</div>
 				</StickyPanel>
 			</div>

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -11,6 +11,7 @@
 	background: white;
 	border: 1px solid var( --color-border-subtle );
 	border-bottom: 0;
+	padding: 11px;
 	transition: all 0.15s ease-in-out;
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -26,7 +27,6 @@
 	.search {
 		position: relative;
 		flex: 0 1 auto;
-		margin: 0 5px 0 10px;
 		height: 36px;
 		border: solid 1px var( --color-neutral-10 );
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -11,7 +11,6 @@
 	background: white;
 	border: 1px solid var( --color-border-subtle );
 	border-bottom: 0;
-	padding: 11px;
 	transition: all 0.15s ease-in-out;
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -29,6 +28,7 @@
 		flex: 0 1 auto;
 		height: 36px;
 		border: solid 1px var( --color-neutral-10 );
+		margin: 10px;
 
 		&.has-focus,
 		&.has-focus:hover {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -207,7 +207,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: 'free',
+			tier: '',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { compact, isEqual, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -190,16 +189,7 @@ function bindGetPremiumThemePrice( state, siteId ) {
 export const ConnectedThemesSelection = connect(
 	(
 		state,
-		{
-			filter,
-			page,
-			search,
-			tier,
-			vertical,
-			siteId,
-			source,
-			isLoading: isCustomizedThemeListLoading,
-		}
+		{ filter, page, search, vertical, siteId, source, isLoading: isCustomizedThemeListLoading }
 	) => {
 		const isJetpack = isJetpackSite( state, siteId );
 		let sourceSiteId;
@@ -217,7 +207,7 @@ export const ConnectedThemesSelection = connect(
 		const query = {
 			search,
 			page,
-			tier: config.isEnabled( 'upgrades/premium-themes' ) ? tier : 'free',
+			tier: 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number,
 		};

--- a/config/development.json
+++ b/config/development.json
@@ -156,7 +156,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -105,7 +105,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -114,7 +114,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -114,7 +114,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/premium-themes": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,7 +123,6 @@
 		"upgrades/checkout": true,
 		"upgrades/domain-search": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -47,24 +47,6 @@ export class ThemesPage {
 	}
 
 	/**
-	 * Filters the themes on page according to the pricing structure.
-	 *
-	 * @param {string} type Pre-defined types of themes.
-	 * @returns {Promise<void>} No return value.
-	 */
-	async filterThemes( type: 'All' | 'Free' | 'Premium' ): Promise< void > {
-		await this.pageSettled();
-
-		const selector = `a[role="radio"]:has-text("${ type }")`;
-		await this.page.click( selector );
-		const button = await this.page.waitForSelector( selector );
-
-		// Wait for placeholder to disappear (indicating load is completed).
-		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
-		await this.page.waitForFunction( ( element: any ) => element.ariaChecked === 'true', button );
-	}
-
-	/**
 	 * Given a keyword, perform a search in the Themes toolbar.
 	 *
 	 * @param {string} keyword Theme name to search for. Can be a partial match.

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -45,7 +45,6 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {
 		themesPage = new ThemesPage( page );
-		await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -42,7 +42,6 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), () => {
 
 	it( `Search for free theme with keyword ${ themeName }`, async function () {
 		themesPage = new ThemesPage( page );
-		await themesPage.filterThemes( 'Free' );
 		await themesPage.search( themeName );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of retiring our premium theme program (pNEWy-e9X-p2) we need to remove the toggle for premium themes from the showcase filters.

#### Testing instructions
* Go to http://calypso.localhost:3000/themes/[site] to see the Theme Showcase and confirm that you can't see the Segmented Control:

<img width="1440" alt="Screenshot 2021-08-31 at 13 19 48" src="https://user-images.githubusercontent.com/275961/131502166-81fb0776-4b34-4bbe-b7b2-7dff2487f376.png">

