### PR TITLE
People: Differentiate between followers and viewers for private sites

### DIFF
--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -20,9 +20,9 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const { data: externalContributors } = useExternalContributorsQuery( siteId );
+	const isPrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
 
-	const GetRole = () => {
-		const isPrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
+	const getRole = () => {
 		const wpcomFollowerRole = getWpcomFollowerRole( isPrivate, translate );
 
 		if ( invite && invite.role ) {
@@ -44,7 +44,7 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 		return;
 	};
 
-	const getRoleBadgeText = ( role = GetRole() ) => {
+	const getRoleBadgeText = ( role = getRole() ) => {
 		let text;
 		switch ( role ) {
 			case 'super admin':
@@ -90,7 +90,7 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 		return text;
 	};
 
-	const getRoleBadgeClass = ( role = GetRole() ) => {
+	const getRoleBadgeClass = ( role = getRole() ) => {
 		return 'role-' + role;
 	};
 
@@ -192,7 +192,7 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 			);
 		}
 
-		if ( GetRole() ) {
+		if ( getRole() ) {
 			roleBadge = (
 				<div className={ classNames( 'people-profile__role-badge', getRoleBadgeClass() ) }>
 					{ getRoleBadgeText() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Related to #55259
* The label for invited Viewers (private sites only) was shown as Followers, which could be confusing. This is because Viewers and Followers are technically the same (their user object has the same role) but we label them differently on the front end.
* This adds a check before displaying the label to show "Viewer" instead of "Follower" when a site is private.

**Before**

<img width="767" alt="Screen Shot 2021-08-31 at 11 19 21 AM" src="https://user-images.githubusercontent.com/2124984/131531349-ff5b85b7-6c64-4fcd-9a51-691d809e601f.png">
<img width="766" alt="Screen Shot 2021-08-31 at 11 19 27 AM" src="https://user-images.githubusercontent.com/2124984/131531352-40698902-79c8-4712-a001-feaddadb6f4c.png">


**After**

<img width="776" alt="Screen Shot 2021-08-31 at 11 18 58 AM" src="https://user-images.githubusercontent.com/2124984/131531372-15abd13d-2e65-4ffa-8530-b025f5da1d48.png">
<img width="764" alt="Screen Shot 2021-08-31 at 11 19 07 AM" src="https://user-images.githubusercontent.com/2124984/131531376-b9f369ad-405a-44c6-8d35-1ab98f82ab99.png">

#### Testing instructions

* Switch to this PR and set your test site to private (Settings -> General) 
* Go to Users and invite a new user as a Viewer
* Under the pending invites tab, the badge under their username/email should say "Viewer" rather than "Follower"
* Make your site public again; the badge should now say "Follower"
* Make sure inviting other user types display the correct badge copy