### PR TITLE
Billing History: Print Receipt hides reminder text

### DIFF
--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -33,6 +33,8 @@ import {
 	renderTransactionQuantitySummary,
 } from './utils';
 
+import './style.scss';
+
 class BillingReceipt extends React.Component {
 	componentDidMount() {
 		this.redirectIfInvalidTransaction();

--- a/client/me/purchases/billing-history/receipt.jsx
+++ b/client/me/purchases/billing-history/receipt.jsx
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
+import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
@@ -351,14 +352,29 @@ function ReceiptDetails( { transaction } ) {
 }
 
 function EmptyReceiptDetails() {
+	// When the content of the text area is empty, hide the "Billing Details" label for printing.
+	const [ hideDetailsLabelOnPrint, setHideDetailsLabelOnPrint ] = useState( true );
+	const onChange = useCallback(
+		( e ) => {
+			const value = e.target.value.trim();
+			if ( hideDetailsLabelOnPrint && value.length > 0 ) {
+				setHideDetailsLabelOnPrint( false );
+			} else if ( ! hideDetailsLabelOnPrint && value.length === 0 ) {
+				setHideDetailsLabelOnPrint( true );
+			}
+		},
+		[ hideDetailsLabelOnPrint, setHideDetailsLabelOnPrint ]
+	);
+
 	return (
 		<li className="billing-history__billing-details">
-			<ReceiptLabels />
+			<ReceiptLabels hideDetailsLabelOnPrint={ hideDetailsLabelOnPrint } />
 			<TextareaAutosize
 				className="billing-history__billing-details-editable"
 				aria-labelledby="billing-history__billing-details-description"
 				id="billing-history__billing-details-textarea"
 				rows="1"
+				onChange={ onChange }
 			/>
 		</li>
 	);
@@ -380,7 +396,7 @@ export function ReceiptPlaceholder() {
 	);
 }
 
-function ReceiptLabels() {
+function ReceiptLabels( { hideDetailsLabelOnPrint } ) {
 	const translate = useTranslate();
 
 	let labelContent = translate(
@@ -393,7 +409,10 @@ function ReceiptLabels() {
 	}
 	return (
 		<div>
-			<FormLabel htmlFor="billing-history__billing-details-textarea">
+			<FormLabel
+				htmlFor="billing-history__billing-details-textarea"
+				className={ classNames( { 'receipt__no-print': hideDetailsLabelOnPrint } ) }
+			>
 				{ translate( 'Billing Details' ) }
 			</FormLabel>
 			<div

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -460,7 +460,7 @@ textarea.billing-history__billing-details-editable {
 	}
 
 	body {
-		font-family: -apple-system, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+		font-family: $sans;
 	}
 }
 

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -437,6 +437,7 @@ textarea.billing-history__billing-details-editable {
 }
 
 @media print {
+	.is-section-me,
 	.is-section-billing,
 	.is-section-purchases {
 		// stylelint-disable-next-line selector-max-id
@@ -447,7 +448,7 @@ textarea.billing-history__billing-details-editable {
 		.inline-help,
 		.billing-history__billing-details-description,
 		.receipt__no-print {
-			display: none;
+			display: none !important;
 		}
 	}
 

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -28,6 +28,8 @@ import { getReceiptUrlFor, getBillingHistoryUrlFor } from '../paths';
 import useRedirectToHistoryPageOnInvalidTransaction from './use-redirect-to-history-page-on-invalid-transaction';
 import useRedirectToHistoryPageOnWrongSiteForTransaction from './use-redirect-to-history-page-on-wrong-site-for-transaction';
 
+import './style.scss';
+
 function useLogBillingHistoryError( message: string ) {
 	const reduxDispatch = useDispatch();
 

--- a/client/my-sites/purchases/billing-history/style.scss
+++ b/client/my-sites/purchases/billing-history/style.scss
@@ -29,6 +29,6 @@
 	}
 
 	body {
-		font-family: -apple-system, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+		font-family: $sans;
 	}
 }

--- a/client/my-sites/purchases/billing-history/style.scss
+++ b/client/my-sites/purchases/billing-history/style.scss
@@ -1,0 +1,34 @@
+@media print {
+	.billing-history {
+		// stylelint-disable-next-line selector-max-id
+		#secondary,
+		.masterbar,
+		.billing-history__receipt-links,
+		.header-cake.card,
+		.inline-help,
+		.billing-history__billing-details-description,
+		.receipt__no-print {
+			// Some specificity rules are overriding this;
+			// we want the "don't display on print" to have top priority
+			display: none !important;
+		}
+	}
+
+	.billing-history__billing-details-description {
+		background: transparent;
+		border: 0;
+		padding: 0;
+		margin: 0;
+	}
+
+	.billing-history__billing-details-editable {
+		background: transparent;
+		border: 0;
+		padding: 0;
+		margin: 0;
+	}
+
+	body {
+		font-family: -apple-system, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Receipts have an optional field that can be typed into. This has some helper text that remains while printing.
  * Fix in this PR: Hide helper text while printing.
![2021-08-31_10-54](https://user-images.githubusercontent.com/937354/131535813-d1908575-d477-4dea-851b-09056173caaa.png)
![2021-08-31_10-55](https://user-images.githubusercontent.com/937354/131535821-bb2479f6-bc1f-491d-9464-46fa03cc71e0.png)
* There exists CSS to hide this text, but it's not being loaded in this context. I believe after some reorganization (Possibly: (#46224)), the CSS isn't being loaded. 
  * Previous location of CSS: [`client/me/purchases/billing-history/style.scss`](https://github.com/Automattic/wp-calypso/blob/909eeed6981df80b96d39c7c9b7e1be0cae1d4ee/client/me/purchases/billing-history/style.scss#L439-L464
)
    * I don't know enough about other contexts receipts can be displayed in to have the confidence to remove this CSS, so I left it alone.
  * New location of CSS: `client/my-sites/purchases/billing-history/style.scss` (added in this PR)
    * I had to change `.is-section-billing` to `.billing-history`, add an `!important` to the display none, and add additional rules to hide the border of the textarea shown in my screenshot above.
* Bonus new feature: The "Billing Details" header is hidden while printing if the user has not typed into the optional field.

![2021-08-31_11-02](https://user-images.githubusercontent.com/937354/131537003-f017bc65-1621-4841-ba28-7681f648d8bd.png)
^ Has typed, pre-print
![2021-08-31_11-02_1](https://user-images.githubusercontent.com/937354/131537041-f128acbe-e5fa-4464-81d6-725cce62a864.png)
^ Has typed, print

vs.

![2021-08-31_11-09](https://user-images.githubusercontent.com/937354/131538065-b65c048a-bb9b-4360-90d5-83cb4a63da01.png)
^ Has not typed, pre-print
![2021-08-31_11-11](https://user-images.githubusercontent.com/937354/131538350-8f93ed6b-a4e7-413d-8d13-97ce1febd620.png)
^ Has not typed, print - "Billing Details" is now hidden as to not display an empty section

* This was initally reported in the "Site" context, but I discovered the same problem happens in the "Me" context and fixed it there, too.




#### Testing instructions

* Context 1: Site.
  * Start at My Home
  * Hover Upgrades
  * Click on Purchases
  * Click Billing History
  * Click View Receipt on any purchase listed.
    * URL should be in the form of `/purchases/billing-history/<url: string>/<id: number>`
    * Try both cases: Leaving the optional "Billing Details" field blank, and adding text to it  
  * Click Print Receipt at the bottom of the purchase details screen.
    * The reminder text "Use this field to add your billing information (eg. business address) before printing." should not display   while printing
    * The border around the textinput should not display while printing
    * If you left the optional field blank, the header "Billing Details" should not display while printing
* Context 2: Me
  * Visit `/me/purchases/billing`
  * Click View Receipt on any purchase listed.
  * Click Print Receipt at the bottom of the purchase details screen.
    * The reminder text "Use this field to add your billing information (eg. business address) before printing." should not display   while printing
    * The border around the textinput should not display while printing
    * If you left the optional field blank, the header "Billing Details" should not display while printing



Related to https://github.com/Automattic/wp-calypso/issues/55757
