### PR TITLE
Playwright: add step to accept cookies when viewing published post

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -695,7 +695,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 		}
 
 		failureConditions {
-			executionTimeoutMin = 20
+			executionTimeoutMin = 60
 		}
 
 		dependencies {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
+					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-likes__post-spec.js specs/specs-playwright/wp-notifications__trash-spec.js; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-likes__post-spec.js specs/specs-playwright/wp-notifications__trash-spec.js; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}
@@ -695,7 +695,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 		}
 
 		failureConditions {
-			executionTimeoutMin = 60
+			executionTimeoutMin = 20
 		}
 
 		dependencies {

--- a/packages/calypso-e2e/src/lib/components/cookie-banner-component.ts
+++ b/packages/calypso-e2e/src/lib/components/cookie-banner-component.ts
@@ -1,0 +1,28 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	acceptCookie: 'input[value="Close and accept"]',
+};
+
+/**
+ * Represents the cookie banner shown on pages when not logged in.
+ */
+export class CookieBannerComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Accept and clear the cookie notice.
+	 */
+	async acceptCookie(): Promise< void > {
+		await this.page.click( selectors.acceptCookie );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -5,3 +5,4 @@ export * from './support-component';
 export * from './preview-component';
 export * from './notifications-component';
 export * from './site-select-component';
+export * from './cookie-banner-component';

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -7,6 +7,7 @@ import {
 	CommentsComponent,
 	NavbarComponent,
 	NotificationsComponent,
+	CookieBannerComponent,
 } from '@automattic/calypso-e2e';
 
 describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
@@ -45,6 +46,8 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 
 	it( 'Clear cookies', async function () {
 		await BrowserManager.clearAuthenticationState( page );
+		const cookieBannerComponent = new CookieBannerComponent( page );
+		await cookieBannerComponent.acceptCookie();
 	} );
 
 	it( `Log in as ${ notificationsUser }`, async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add a step to accept and close the cookie banner for tests that view a published post while logged out.

Key changes:
- addition of new component representing the cookie notice banner.
- addition of step to accept and close the banner after clearing cookies.

Details:

The `Clear Cookies` step in `Notifications` spec intermittently fails at the `page.goto` step.

My first suspicion is that this has to do with the cookie banner that appears when viewing a published post while logged out. This hypothesis is supported by the fact that the only other `Clear Cookies` step in the Playwright suite present in `Likes: Posts` spec has not failed intermittently. 

The key difference: `Likes: Posts` test site does not display a cookie banner whereas `Notifications` test site does.

#### Testing instructions

I've stress tested this change and it appears to be reliable 100% on both desktop and mobile.

- First run: timed out at 20min [here](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_desktop/6631813)
- Second run: completed 100 iterations [here](https://teamcity.a8c.com/buildConfiguration/calypso_Calypso_E2E_Playwright_desktop/6631990)

Fixes #55845