### PR TITLE
Selenium: re-add canary back

### DIFF
--- a/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-gutenboarding__visit-spec.js
@@ -1,0 +1,19 @@
+import config from 'config';
+import * as driverManager from '../../lib/driver-manager.js';
+import LoginFlow from '../../lib/flows/login-flow.js';
+import NewPage from '../../lib/pages/gutenboarding/new-page.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+
+describe( `Gutenboarding - Visit Gutenboarding page as a logged in user: (${ screenSize }) @parallel @canary`, function () {
+	this.timeout( mochaTimeOut );
+
+	it( 'Can log in as user', async function () {
+		await new LoginFlow( this.driver ).login();
+	} );
+
+	it( 'Can visit Gutenboarding', async function () {
+		await NewPage.Visit( this.driver );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#55721 ended up removing the last `@canary` tagged spec, which causes magellan to fail.

Re-add the spec back.

#### Testing instructions


Related to #55721.
