### PR TITLE
Subscriptions: Remove CSS rule that prevented displaying the image placeholder

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -122,7 +122,7 @@ class FeedHeader extends Component {
 									disabled={ feed.unseen_count === 0 }
 								>
 									<Gridicon icon="visible" size={ 18 } />
-									<span title={ translate( 'Mark all as seen' ) }>
+									<span className="reader-feed-header__visibility" title={ translate( 'Mark all as seen' ) }>
 										{ translate( 'Mark all as seen' ) }
 									</span>
 								</button>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -122,7 +122,10 @@ class FeedHeader extends Component {
 									disabled={ feed.unseen_count === 0 }
 								>
 									<Gridicon icon="visible" size={ 18 } />
-									<span className="reader-feed-header__visibility" title={ translate( 'Mark all as seen' ) }>
+									<span
+										className="reader-feed-header__visibility"
+										title={ translate( 'Mark all as seen' ) }
+									>
 										{ translate( 'Mark all as seen' ) }
 									</span>
 								</button>

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -11,7 +11,7 @@
 	svg {
 		display: inline-block;
 		top: 4px;
-		margin-right: 5px;
+		margin-right: 6px;
 		width: 18px;
 		position: relative;
 		color: var( --color-neutral-20 );
@@ -201,6 +201,13 @@
 	@include breakpoint-deprecated( '<660px' ) {
 		display: inline;
 	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		display: none;
+	}
+}
+
+.reader-feed-header__seen-button .reader-feed-header__visibility {
 
 	@include breakpoint-deprecated( '<480px' ) {
 		display: none;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -28,11 +28,6 @@
 	padding-bottom: 20px;
 }
 
-.reader-feed-header__site-icon .site-icon.is-blank {
-	height: 30px !important; // Prevents Settings from overlapping with Site Title
-	visibility: hidden;
-}
-
 .reader-feed-header .reader-feed-header__site-badge {
 	color: var( --color-text-subtle );
 	padding-right: 4px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/55135 by always displaying an image placeholder, it also hides the visibility icon label on mobile, as suggested by @bluefuton 

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/375980/131554375-d234d0b7-f744-48b9-8d4c-c802fb2c4135.png) | ![image](https://user-images.githubusercontent.com/375980/131671646-c4330a4d-f53e-4db7-abfa-3add32b4ec01.png)  |



#### Testing instructions
* Navigate to http://calypso.localhost:3000/read/ 
* Find a post without an image like this one:
![image](https://user-images.githubusercontent.com/375980/131554839-bb831b9a-a2a9-46a3-b70f-dd1a638b8807.png)
* Click on the User Name of that post
* Verify that the controls don't overlap the user name and the empty placeholder is visible

Related to https://github.com/Automattic/wp-calypso/issues/55135
