### PR TITLE
Use Fallback for Jetpack Module Check

### DIFF
--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -159,7 +159,7 @@ const mapStateToProps = ( state, { type } ) => {
 		services: getEligibleKeyringServices( state, siteId, type ),
 		expandedService: getExpandedService( state ),
 		isJetpack: isJetpackSite( state, siteId ),
-		isPublicizeActive: isJetpackModuleActive( state, siteId, 'publicize' ),
+		isPublicizeActive: isJetpackModuleActive( state, siteId, 'publicize', true ),
 	};
 };
 

--- a/client/state/selectors/is-jetpack-module-active.js
+++ b/client/state/selectors/is-jetpack-module-active.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isJetpackModuleActiveViaSiteOption from 'calypso/state/sites/selectors/is-jetpack-module-active';
 
 import 'calypso/state/jetpack/init';
 
@@ -11,9 +12,10 @@ import 'calypso/state/jetpack/init';
  * @param  {object}  state       Global state tree
  * @param  {number}  siteId      The ID of the site we're querying
  * @param  {string}  moduleSlug  Slug of the module
+ * @param  {boolean}  useFallback whether to also test the sites `active_modules`
  * @returns {?boolean}            Whether the module is active
  */
-export default function isJetpackModuleActive( state, siteId, moduleSlug ) {
+export default function isJetpackModuleActive( state, siteId, moduleSlug, useFallback = false ) {
 	if ( moduleSlug === 'photon' || moduleSlug === 'photon-cdn' || moduleSlug === 'videopress' ) {
 		// When site is atomic and private, we filter out certain modules from active modules list.
 		// This isn't actually changing any stored preferences, which means they are going to
@@ -24,5 +26,9 @@ export default function isJetpackModuleActive( state, siteId, moduleSlug ) {
 			return false;
 		}
 	}
-	return get( state.jetpack.modules.items, [ siteId, moduleSlug, 'active' ], null );
+	const moduleResult = get( state.jetpack.modules.items, [ siteId, moduleSlug, 'active' ], null );
+
+	return moduleResult || ! useFallback
+		? moduleResult
+		: isJetpackModuleActiveViaSiteOption( state, siteId, moduleSlug );
 }

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -71,7 +71,7 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 		if (
 			isJetpackSite( state, siteId ) &&
 			service.jetpack_module_required &&
-			! isJetpackModuleActive( state, siteId, service.jetpack_module_required )
+			! isJetpackModuleActive( state, siteId, service.jetpack_module_required, true )
 		) {
 			return false;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a fallback to site_options in cases where the jetpack modules request may have failed
* Use the fallback on the connection pages to determine if publicize is active

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
