### PR TITLE
Add hasTranslation to strings added to inlineSupportLinks in Calypso sections 

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
-import { localize, useTranslate } from 'i18n-calypso';
+import i18nCalypso, { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
@@ -46,14 +46,22 @@ function BillingHistory(): JSX.Element {
 			<FormattedHeader
 				brandFont
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
-						},
-					}
-				) }
+				subHeaderText={
+					i18nCalypso.hasTranslation(
+						'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+					)
+						? translate(
+								'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="billing" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate( 'View, print, and email your receipts.' )
+				}
 				align="left"
 			/>
 			<QueryBillingTransactions />
@@ -66,4 +74,4 @@ function BillingHistory(): JSX.Element {
 		</Main>
 	);
 }
-export default localize( BillingHistory );
+export default BillingHistory;

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -1,4 +1,4 @@
-import { localize, useTranslate } from 'i18n-calypso';
+import i18nCalypso, { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -24,16 +24,22 @@ function PaymentMethods(): JSX.Element {
 			<FormattedHeader
 				brandFont
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: (
-								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
-							),
-						},
-					}
-				) }
+				subHeaderText={
+					i18nCalypso.hasTranslation(
+						'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+					)
+						? translate(
+								'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate( 'Add or delete payment methods for your account.' )
+				}
 				align="left"
 			/>
 			<PurchasesNavigation section="paymentMethods" />
@@ -42,4 +48,4 @@ function PaymentMethods(): JSX.Element {
 	);
 }
 
-export default localize( PaymentMethods );
+export default PaymentMethods;

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import i18nCalypso, { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -72,14 +72,22 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 				brandFont
 				className="billing-history__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
-						},
-					}
-				) }
+				subHeaderText={
+					i18nCalypso.hasTranslation(
+						'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+					)
+						? translate(
+								'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="billing" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate( 'View, print, and email your receipts for this site.' )
+				}
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Billing History' } siteSlug={ siteSlug } />

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { useTranslate } from 'i18n-calypso';
+import i18nCalypso, { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -62,14 +62,22 @@ export function Purchases(): JSX.Element {
 				brandFont
 				className="purchases__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
-						},
-					}
-				) }
+				subHeaderText={
+					i18nCalypso.hasTranslation(
+						'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+					)
+						? translate(
+								'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="purchases" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate( 'View, manage, or cancel your plan and other purchases for this site.' )
+				}
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Active Upgrades' } siteSlug={ siteSlug } />

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -26,7 +26,6 @@ import {
 } from './paths';
 import Subscriptions from './subscriptions';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
-
 function useLogPurchasesError( message: string ) {
 	const reduxDispatch = useDispatch();
 

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -26,6 +26,7 @@ import {
 } from './paths';
 import Subscriptions from './subscriptions';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
+
 function useLogPurchasesError( message: string ) {
 	const reduxDispatch = useDispatch();
 

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
-import { useTranslate } from 'i18n-calypso';
+import i18nCalypso, { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React, { useCallback, useMemo, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -66,16 +66,22 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 				brandFont
 				className="payment-methods__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
-					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: (
-								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
-							),
-						},
-					}
-				) }
+				subHeaderText={
+					i18nCalypso.hasTranslation(
+						'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+					)
+						? translate(
+								'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate( 'Add or delete payment methods for your account.' )
+				}
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Payment Methods' } siteSlug={ siteSlug } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

InlineSupportLinks added in https://github.com/Automattic/wp-calypso/pull/55766 were merged before translations could finish.

This change will add a fallback translation using the hasTranslation method.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch Calypso interface language to a non-English language from https://wordpress.com/me/account
* Load Calypso locally and navigate to https://wordpress.com/me/purchases
* Purchase/Billing/Payment Methods tabs should show strings in the localized language

![image](https://user-images.githubusercontent.com/16580129/131587017-51734a2b-1e36-44d1-9ba4-a24e0a484b78.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55766
