### PR TITLE
Checkout: Make state field not required in domainRequiredContactDetails

### DIFF
--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -852,7 +852,7 @@ export const domainRequiredContactDetails: ManagedContactDetailsRequiredMask = {
 	address1: true,
 	address2: false,
 	city: true,
-	state: true,
+	state: false,
 	postalCode: true,
 	countryCode: true,
 	fax: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `state` field is [marked as required](https://github.com/Automattic/wp-calypso/blob/46b2691975c9ac80db815b54b0ad8d5e3f01ec82/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts#L855) (on the frontend portion of the validation) for all countries when you have a domain in the cart, and since it is empty for non-US countries without a state value it will always be marked as incomplete. The user won't see the error, though, because there is no "State" field visible.

This has been the case for a long time, but the bug was only just discovered because it has been hidden due to a different bug. 

The logic to decide if we should require a bunch of fields, or just postal code and country, [happens when checkout loads](https://github.com/Automattic/wp-calypso/blob/46b2691975c9ac80db815b54b0ad8d5e3f01ec82/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L288-L295). The data it uses is [the current products in the cart](https://github.com/Automattic/wp-calypso/blob/46b2691975c9ac80db815b54b0ad8d5e3f01ec82/client/my-sites/checkout/composite-checkout/composite-checkout.tsx#L286), and it [only registers this choice once](https://github.com/Automattic/wp-calypso/blob/46b2691975c9ac80db815b54b0ad8d5e3f01ec82/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts#L45-L50). When checkout loads for the first time on a full page refresh, the cart is usually _still fetching_ and it does not yet have the domain visible in the cart data, so checkout uses the non-domain list of required fields. Thus the bug is concealed.

However, after [the cart was made into a singleton object](https://github.com/Automattic/wp-calypso/pull/54667), it's much easier for its products to already be loaded by the time checkout appears. If this is the case, then the correct mask is applied and the state field becomes required, triggering the bug. At this point, validation will fail for non-state countries forever until the checkout page is reloaded (and maybe not even then, depending on how quickly the cart endpoint loads).

This PR makes the `state` field not required. The bug where the store's required contact fields cannot be updated with cart changes will need to be fixed separately, but this should allow checkout to proceed for customers with a domain and without a State field.

#### Testing instructions

- Make sure you do not have a domain product in your cart.
- You'll need to make sure that your cached domain contact fields do not include a `state`. The simplest way to do this is probably to purchase a domain product with contact details for a country without a State field (eg: the UK). If you live outside the US, this may already be the case.
- Visit `/domains/add/` and add a domain to your cart.
- When you reach checkout, edit your contact details with valid data for a country without a State.
- Press "Continue" and verify that the form completes and that you see the final checkout step.