### PR TITLE
Run headstart after pick design

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -305,18 +305,24 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	} );
 }
 
-export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
-	if ( isEmpty( themeSlugWithRepo ) ) {
+export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, selectedDesign } ) {
+	let theme = '';
+
+	if ( themeSlugWithRepo ) {
+		theme = themeSlugWithRepo.split( '/' )[ 1 ];
+	} else if ( selectedDesign ) {
+		theme = selectedDesign.theme;
+	}
+
+	if ( ! theme ) {
 		defer( callback );
 
 		return;
 	}
 
-	wpcom
-		.undocumented()
-		.changeTheme( siteSlug, { theme: themeSlugWithRepo.split( '/' )[ 1 ] }, function ( errors ) {
-			callback( isEmpty( errors ) ? undefined : [ errors ] );
-		} );
+	wpcom.undocumented().changeTheme( siteSlug, { theme }, function ( errors ) {
+		callback( isEmpty( errors ) ? undefined : [ errors ] );
+	} );
 }
 
 export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxStore ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -414,11 +414,11 @@ export function generateFlows( {
 		},
 		{
 			name: 'setup-site',
-			steps: [ 'design' ],
+			steps: [ 'design-setup-site' ],
 			destination: getChecklistThemeDestination,
 			description:
 				'Sets up a site that has already been created and paid for (if purchases were made)',
-			lastModified: '2021-08-26',
+			lastModified: '2021-09-02',
 			providesDependenciesInQuery: [ 'siteSlug' ],
 			pageTitle: translate( 'Setup your site' ),
 		},

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -71,6 +71,7 @@ const stepNameToModuleName = {
 	'plans-personal-monthly': 'plans',
 	'plans-premium-monthly': 'plans',
 	design: 'design-picker',
+	'design-setup-site': 'design-picker',
 };
 
 export function getStepModuleName( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -707,6 +707,10 @@ export function generateSteps( {
 
 		design: {
 			stepName: 'design-picker',
+			apiRequestFunction:
+				currentPage && currentPage.toString().match( /\/start\/setup-site/ )
+					? setThemeOnSite
+					: null,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],
 			optionalDependencies: [ 'selectedDesign' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -707,10 +707,14 @@ export function generateSteps( {
 
 		design: {
 			stepName: 'design-picker',
-			apiRequestFunction:
-				currentPage && currentPage.toString().match( /\/start\/setup-site/ )
-					? setThemeOnSite
-					: null,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'selectedDesign' ],
+			optionalDependencies: [ 'selectedDesign' ],
+		},
+
+		'design-setup-site': {
+			stepName: 'design-setup-site',
+			apiRequestFunction: setThemeOnSite,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],
 			optionalDependencies: [ 'selectedDesign' ],

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import { has, keyBy, get, omit } from 'lodash';
-import stepsConfig from 'calypso/signup/config/steps-pure';
+import stepsConfig from 'calypso/signup/config/steps';
 import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_PROGRESS_COMPLETE_STEP,

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import { has, keyBy, get, omit } from 'lodash';
-import stepsConfig from 'calypso/signup/config/steps';
+import stepsConfig from 'calypso/signup/config/steps-pure';
 import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_PROGRESS_COMPLETE_STEP,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `setThemeOnSite` to run headstart on the site after picking the design.

https://user-images.githubusercontent.com/13596067/131617085-a0eb9c00-e1b6-4576-b087-30802f964605.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/start/setup-site?siteSlug=<your_site>
* Pick design
* Go to Appearance > Themes, check the theme is the same as your selection
* Go to the home page of your site, check home page is changed

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55782
