### PR TITLE
build: Write webpack cache on cache image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,7 +8,7 @@ ARG node_memory=8192
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
-ENV READONLY_CACHE=true
+ENV READONLY_CACHE=false
 ENV PROFILE=true
 ENV SKIP_TSC=true
 ENV NVM_DIR=/calypso/.nvm


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables cache write in the base docker image. Without this, the base docker image doesn't have a cache that other builds can use.

#### Testing instructions

N/A