### PR TITLE
Preview: remove Inline Help Popover interaction

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -13,7 +13,6 @@ import SpinnerLine from 'calypso/components/spinner-line';
 import { addQueryArgs } from 'calypso/lib/route';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isInlineHelpPopoverVisible from 'calypso/state/inline-help/selectors/is-inline-help-popover-visible';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -243,20 +242,16 @@ export class WebPreviewContent extends Component {
 		} else {
 			this.setState( { loaded: true, isLoadingSubpage: false } );
 		}
-		// Sometimes we force inline help open in the preview. In this case we don't want to hide it when the iframe loads
-		if ( ! this.props.isInlineHelpPopoverVisible ) {
-			this.focusIfNeeded();
-			// If the preview is loaded and the site is private atomic, there's a chance we ended up on
-			// "you need to login first" screen. These messages are handled by wpcomsh on the other end,
-			// and they make it possible to redirect to wp-login.php since it cannot be displayed in this
-			// iframe OR redirected to using <a href="" target="_top">.
-			if ( this.props.isPrivateAtomic ) {
-				const { protocol, host } = parseUrl( this.props.externalUrl );
-				this.iframe.contentWindow.postMessage(
-					{ connected: 'calypso' },
-					`${ protocol }//${ host }`
-				);
-			}
+
+		this.focusIfNeeded();
+
+		// If the preview is loaded and the site is private atomic, there's a chance we ended up on
+		// "you need to login first" screen. These messages are handled by wpcomsh on the other end,
+		// and they make it possible to redirect to wp-login.php since it cannot be displayed in this
+		// iframe OR redirected to using <a href="" target="_top">.
+		if ( this.props.isPrivateAtomic ) {
+			const { protocol, host } = parseUrl( this.props.externalUrl );
+			this.iframe.contentWindow.postMessage( { connected: 'calypso' }, `${ protocol }//${ host }` );
 		}
 	};
 
@@ -421,7 +416,6 @@ WebPreviewContent.defaultProps = {
 const mapState = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	return {
-		isInlineHelpPopoverVisible: isInlineHelpPopoverVisible( state ),
 		isPrivateAtomic: isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId ),
 		url: getSelectedSite( state )?.URL,
 	};

--- a/client/my-sites/preview/controller.js
+++ b/client/my-sites/preview/controller.js
@@ -2,12 +2,6 @@ import React from 'react';
 import PreviewMain from './main';
 
 export function preview( context, next ) {
-	context.primary = (
-		<PreviewMain
-			site={ context.params.site }
-			help={ typeof context.query.help !== 'undefined' }
-			checklist={ typeof context.query.checklist !== 'undefined' }
-		/>
-	);
+	context.primary = <PreviewMain site={ context.params.site } />;
 	next();
 }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -12,7 +12,6 @@ import Main from 'calypso/components/main';
 import WebPreview from 'calypso/components/web-preview';
 import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getSiteOption, isSitePreviewable } from 'calypso/state/sites/selectors';
@@ -24,8 +23,6 @@ import './style.scss';
 const debug = debugFactory( 'calypso:my-sites:preview' );
 
 class PreviewMain extends React.Component {
-	static displayName = 'Preview';
-
 	state = {
 		previewUrl: null,
 		editUrl: null,
@@ -55,10 +52,6 @@ class PreviewMain extends React.Component {
 	componentDidMount() {
 		if ( typeof window !== 'undefined' ) {
 			window.addEventListener( 'resize', this.debouncedUpdateLayout );
-		}
-
-		if ( this.props.help ) {
-			this.props.showInlineHelpPopover();
 		}
 	}
 
@@ -215,5 +208,4 @@ const mapState = ( state ) => {
 export default connect( mapState, {
 	recordTracksEvent,
 	setLayoutFocus,
-	showInlineHelpPopover,
 } )( localize( PreviewMain ) );


### PR DESCRIPTION
The preview component (displayed on the `/view/:site` route) has a check preventing focus-after-render if the Inline Help popover is displayed at the time of the navigation.

The `/view/:site` route also supports query parameters (`?help` and `?checklist`) that cause the Inline Help popover to open on navigation.

Both these features (added in PRs like #29068) were needed when Checklist was part of the Inline Help popup, but after the Checklist was removed from the popup (in #40415), they can be removed, too.

The patch removes several usages of the `state.inlineHelp.popover` Redux state, which we'd like to eventually remove completely.