### PR TITLE
Emails: Change wording on cancelation survey for Google Workspace

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -58,7 +58,7 @@ class GSuiteCancellationFeatures extends Component {
 				comment:
 					'%(domainName) is the name of the domain (e.g. example.com) ' +
 					'%(googleMailService)s can be either "G Suite" or "Google Workspace" ' +
-					"and %(days)s is a number of days (usually '30')",
+					"and %(days)d is a number of days (usually '30')",
 				components: {
 					strong: <strong />,
 				},

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -54,7 +54,8 @@ class GSuiteCancellationFeatures extends Component {
 							},
 							comment:
 								'%(domainName) is the name of the domain, e.g. example.com; ' +
-								'%(googleMailService)s can be either "G Suite" or "Google Workspace" ',
+								'%(googleMailService)s can be either "G Suite" or "Google Workspace" ' +
+								'and %(days)s is a number of days which will generally be 30, and will always be at least 10',
 							components: {
 								strong: <strong />,
 							},

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -38,7 +38,7 @@ class GSuiteCancellationFeatures extends Component {
 					{ translate(
 						'If you cancel your subscription now, you will lose access to all of ' +
 							'your %(googleMailService)s features %(days)s. After that time, ' +
-							'you will need to start a new subscription with Google or another reseller.',
+							'you will need to purchase a new subscription with Google.',
 						{
 							args: {
 								googleMailService: getGoogleMailServiceFamily( productSlug ),

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -17,6 +17,13 @@ class GSuiteCancellationFeatures extends Component {
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_learn_more_click' );
 	};
 
+	getTimePeriod = () => {
+		const { status, translate } = this.props;
+		return status === 'suspended'
+			? translate( 'immediately' )
+			: translate( 'in %(days)s days', { args: { days: '30' }, comment: 'Number of days' } );
+	};
+
 	render() {
 		const { purchase, translate } = this.props;
 		const { meta: domainName, productSlug } = purchase;
@@ -30,14 +37,15 @@ class GSuiteCancellationFeatures extends Component {
 				<p>
 					{ translate(
 						'If you cancel your subscription now, you will lose access to all of ' +
-							'your features immediately. After that time, you will need to start a new ' +
-							'subscription with Google or another reseller.',
+							'your %(googleMailService)s features %(days)s. After that time, ' +
+							'you will need to start a new subscription with Google or another reseller.',
 						{
 							args: {
 								googleMailService: getGoogleMailServiceFamily( productSlug ),
+								days: this.getTimePeriod(),
 							},
-							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-							components: { siteName: <em>{ domainName }</em> },
+							comment:
+								'%(googleMailService)s can be either "G Suite" or "Google Workspace" and %(days)s might be "immediately" or "after 30 days"',
 						}
 					) }
 				</p>

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -24,14 +24,14 @@ class GSuiteCancellationFeatures extends Component {
 		return (
 			<div className="gsuite-cancel-purchase-dialog__features">
 				<CardHeading tagName="h3" size={ 24 }>
-					{ translate( "Are you sure? Here's what you'll be missing:" ) }
+					{ translate( 'Are you sure?' ) }
 				</CardHeading>
 
 				<p>
 					{ translate(
-						'If you cancel your subscription now, you will lose access to all of your ' +
-							'%(googleMailService)s features immediately. After that time, you will need to ' +
-							'start a new subscription with Google or another reseller.',
+						'If you cancel your subscription now, you will lose access to all of ' +
+							'your features immediately. After that time, you will need to start a new ' +
+							'subscription with Google or another reseller.',
 						{
 							args: {
 								googleMailService: getGoogleMailServiceFamily( productSlug ),
@@ -41,6 +41,10 @@ class GSuiteCancellationFeatures extends Component {
 						}
 					) }
 				</p>
+
+				<CardHeading tagName="h3" size={ 24 }>
+					{ translate( "Here’s what you'll be missing" ) }
+				</CardHeading>
 
 				<GSuiteFeatures productSlug={ productSlug } domainName={ domainName } type={ 'list' } />
 

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -23,7 +23,7 @@ class GSuiteCancellationFeatures extends Component {
 
 		const googleMailService = getGoogleMailServiceFamily( productSlug );
 
-		if ( googleSubscriptionStatus === 'suspended' ) {
+		if ( [ 'suspended', '' ].includes( googleSubscriptionStatus ) ) {
 			return translate(
 				'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
 					'your %(googleMailService)s features immediately{{/strong}}, and you will ' +

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -18,7 +18,7 @@ class GSuiteCancellationFeatures extends Component {
 	};
 
 	getAccessMessage = () => {
-		const { googleSubscriptionStatus, translate, purchase } = this.props;
+		const { googleSubscriptionStatus, purchase, translate } = this.props;
 		const { meta: domainName, productSlug } = purchase;
 
 		const googleMailService = getGoogleMailServiceFamily( productSlug );

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -17,11 +17,51 @@ class GSuiteCancellationFeatures extends Component {
 		this.props.recordTracksEvent( 'calypso_purchases_gsuite_remove_purchase_learn_more_click' );
 	};
 
-	getTimePeriod = () => {
-		const { status, translate } = this.props;
-		return status === 'suspended'
-			? translate( 'immediately' )
-			: translate( 'in %(days)s days', { args: { days: '30' }, comment: 'Number of days' } );
+	getAccessMessage = () => {
+		const { googleSubscriptionStatus, translate, purchase } = this.props;
+		const { meta: domainName, productSlug } = purchase;
+
+		const googleMailService = getGoogleMailServiceFamily( productSlug );
+
+		const accessMessage =
+			googleSubscriptionStatus === 'suspended'
+				? translate(
+						'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
+							'your %(googleMailService)s features immediately{{/strong}}, and you will ' +
+							'need to purchase a new subscription with Google if you wish to regain access to the features.',
+						{
+							args: {
+								domainName,
+								googleMailService,
+							},
+							comment:
+								'%(domainName) is the name of the domain, e.g. example.com; ' +
+								'%(googleMailService)s can be either "G Suite" or "Google Workspace" ',
+							components: {
+								strong: <strong />,
+							},
+						}
+				  )
+				: translate(
+						'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
+							'your %(googleMailService)s features in %(days)s days{{/strong}}. After that time, ' +
+							'you will need to purchase a new subscription with Google.',
+						{
+							args: {
+								domainName,
+								googleMailService,
+								days: '30',
+							},
+							comment:
+								'%(domainName) is the name of the domain, e.g. example.com; ' +
+								'%(googleMailService)s can be either "G Suite" or "Google Workspace" ',
+							components: {
+								strong: <strong />,
+							},
+						}
+				  );
+
+		return accessMessage;
 	};
 
 	render() {
@@ -34,24 +74,10 @@ class GSuiteCancellationFeatures extends Component {
 					{ translate( 'Are you sure?' ) }
 				</CardHeading>
 
-				<p>
-					{ translate(
-						'If you cancel your subscription now, you will lose access to all of ' +
-							'your %(googleMailService)s features %(days)s. After that time, ' +
-							'you will need to purchase a new subscription with Google.',
-						{
-							args: {
-								googleMailService: getGoogleMailServiceFamily( productSlug ),
-								days: this.getTimePeriod(),
-							},
-							comment:
-								'%(googleMailService)s can be either "G Suite" or "Google Workspace" and %(days)s might be "immediately" or "after 30 days"',
-						}
-					) }
-				</p>
+				<p>{ this.getAccessMessage() }</p>
 
 				<CardHeading tagName="h3" size={ 24 }>
-					{ translate( "Here’s what you'll be missing" ) }
+					{ translate( "Here’s what you'll be missing:" ) }
 				</CardHeading>
 
 				<GSuiteFeatures productSlug={ productSlug } domainName={ domainName } type={ 'list' } />
@@ -66,6 +92,7 @@ GSuiteCancellationFeatures.propTypes = {
 	purchase: PropTypes.object.isRequired,
 	recordTracksEvent: PropTypes.func.isRequired,
 	translate: PropTypes.func.isRequired,
+	googleSubscriptionStatus: PropTypes.string,
 };
 
 export default connect( null, {

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -36,7 +36,7 @@ class GSuiteCancellationFeatures extends Component {
 						googleMailService,
 					},
 					comment:
-						'%(domainName) is the name of the domain, e.g. example.com; ' +
+						'%(domainName) is the name of the domain (e.g. example.com) ' +
 						'%(googleMailService)s can be either "G Suite" or "Google Workspace" ',
 					components: {
 						strong: <strong />,

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -23,46 +23,45 @@ class GSuiteCancellationFeatures extends Component {
 
 		const googleMailService = getGoogleMailServiceFamily( productSlug );
 
-		const accessMessage =
-			googleSubscriptionStatus === 'suspended'
-				? translate(
-						'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
-							'your %(googleMailService)s features immediately{{/strong}}, and you will ' +
-							'need to purchase a new subscription with Google if you wish to regain access to the features.',
-						{
-							args: {
-								domainName,
-								googleMailService,
-							},
-							comment:
-								'%(domainName) is the name of the domain, e.g. example.com; ' +
-								'%(googleMailService)s can be either "G Suite" or "Google Workspace" ',
-							components: {
-								strong: <strong />,
-							},
-						}
-				  )
-				: translate(
-						'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
-							'your %(googleMailService)s features in %(days)s days{{/strong}}. After that time, ' +
-							'you will need to purchase a new subscription with Google.',
-						{
-							args: {
-								domainName,
-								googleMailService,
-								days: '30',
-							},
-							comment:
-								'%(domainName) is the name of the domain, e.g. example.com; ' +
-								'%(googleMailService)s can be either "G Suite" or "Google Workspace" ' +
-								'and %(days)s is a number of days which will generally be 30, and will always be at least 10',
-							components: {
-								strong: <strong />,
-							},
-						}
-				  );
+		if ( googleSubscriptionStatus === 'suspended' ) {
+			return translate(
+				'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
+					'your %(googleMailService)s features immediately{{/strong}}, and you will ' +
+					'need to purchase a new subscription with Google if you wish to regain access to the features.',
+				{
+					args: {
+						domainName,
+						googleMailService,
+					},
+					comment:
+						'%(domainName) is the name of the domain, e.g. example.com; ' +
+						'%(googleMailService)s can be either "G Suite" or "Google Workspace" ',
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
 
-		return accessMessage;
+		return translate(
+			'If you cancel your subscription for %(domainName)s now, {{strong}}you will lose access to all of ' +
+				'your %(googleMailService)s features in %(days)s days{{/strong}}. After that time, ' +
+				'you will need to purchase a new subscription with Google.',
+			{
+				args: {
+					domainName,
+					googleMailService,
+					days: '30',
+				},
+				comment:
+					'%(domainName) is the name of the domain, e.g. example.com; ' +
+					'%(googleMailService)s can be either "G Suite" or "Google Workspace" ' +
+					'and %(days)s is a number of days which will generally be 30, and will always be at least 10',
+				components: {
+					strong: <strong />,
+				},
+			}
+		);
 	};
 
 	render() {

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -65,7 +66,7 @@ class GSuiteCancellationFeatures extends Component {
 	};
 
 	render() {
-		const { purchase, translate } = this.props;
+		const { googleSubscriptionStatus, purchase, translate } = this.props;
 		const { meta: domainName, productSlug } = purchase;
 
 		return (
@@ -74,7 +75,9 @@ class GSuiteCancellationFeatures extends Component {
 					{ translate( 'Are you sure?' ) }
 				</CardHeading>
 
-				<p>{ this.getAccessMessage() }</p>
+				<p className={ classNames( { placeholder: googleSubscriptionStatus === '' } ) }>
+					{ this.getAccessMessage() }
+				</p>
 
 				<CardHeading tagName="h3" size={ 24 }>
 					{ translate( "Here’s what you'll be missing:" ) }

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -89,10 +89,10 @@ class GSuiteCancellationFeatures extends Component {
 }
 
 GSuiteCancellationFeatures.propTypes = {
+	googleSubscriptionStatus: PropTypes.string,
 	purchase: PropTypes.object.isRequired,
 	recordTracksEvent: PropTypes.func.isRequired,
 	translate: PropTypes.func.isRequired,
-	googleSubscriptionStatus: PropTypes.string,
 };
 
 export default connect( null, {

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-features.jsx
@@ -29,7 +29,9 @@ class GSuiteCancellationFeatures extends Component {
 
 				<p>
 					{ translate(
-						'If you cancel and remove %(googleMailService)s from {{siteName/}} you will lose access to the following: ',
+						'If you cancel your subscription now, you will lose access to all of your ' +
+							'%(googleMailService)s features immediately. After that time, you will need to ' +
+							'start a new subscription with Google or another reseller.',
 						{
 							args: {
 								googleMailService: getGoogleMailServiceFamily( productSlug ),

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import { getSelectedDomain } from 'calypso/lib/domains';
+import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
 import { getName } from 'calypso/lib/purchases';
 import wpcom from 'calypso/lib/wp';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
@@ -196,9 +197,8 @@ class GSuiteCancelPurchaseDialog extends Component {
 	};
 
 	render() {
-		const { isVisible, onClose, purchase, domains, domain } = this.props;
+		const { isVisible, onClose, purchase, selectedDomain } = this.props;
 		const { surveyAnswerId, surveyAnswerText, isRemoving } = this.state;
-		const selectedDomain = getSelectedDomain( { domains, selectedDomainName: domain } );
 		return (
 			// By checking isVisible here we prevent rendering a "reset" dialog state before it closes
 			isVisible && (
@@ -211,7 +211,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 					{ steps.GSUITE_INITIAL_STEP === this.state.step ? (
 						<GSuiteCancellationFeatures
 							purchase={ purchase }
-							status={ selectedDomain?.googleAppsSubscription?.status }
+							googleSubscriptionStatus={ getGSuiteSubscriptionStatus( selectedDomain ) }
 						/>
 					) : (
 						<GSuiteCancellationSurvey
@@ -240,13 +240,16 @@ GSuiteCancelPurchaseDialog.propTypes = {
 };
 
 export default connect(
-	( state, { purchase, site } ) => {
+	( state, { purchase, site, domain } ) => {
 		return {
 			productName: getName( purchase ),
 			domain: purchase.meta,
 			purchasesError: getPurchasesError( state ),
+			selectedDomain: getSelectedDomain( {
+				domains: getDomainsBySiteId( state, site.ID ),
+				selectedDomainName: domain,
+			} ),
 			userId: getCurrentUserId( state ),
-			domains: getDomainsBySiteId( state, site.ID ),
 		};
 	},
 	{

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -210,8 +210,8 @@ class GSuiteCancelPurchaseDialog extends Component {
 				>
 					{ steps.GSUITE_INITIAL_STEP === this.state.step ? (
 						<GSuiteCancellationFeatures
-							purchase={ purchase }
 							googleSubscriptionStatus={ getGSuiteSubscriptionStatus( selectedDomain ) }
+							purchase={ purchase }
 						/>
 					) : (
 						<GSuiteCancellationSurvey

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import { getName } from 'calypso/lib/purchases';
 import wpcom from 'calypso/lib/wp';
-import { getSelectedDomain } from 'calypso/lib/domains';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -209,7 +209,8 @@ class GSuiteCancelPurchaseDialog extends Component {
 					onClose={ onClose }
 				>
 					{ steps.GSUITE_INITIAL_STEP === this.state.step ? (
-						<GSuiteCancellationFeatures purchase={ purchase }
+						<GSuiteCancellationFeatures
+							purchase={ purchase }
 							status={ selectedDomain?.googleAppsSubscription?.status }
 						/>
 					) : (

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -7,12 +7,14 @@ import { connect } from 'react-redux';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import { getName } from 'calypso/lib/purchases';
 import wpcom from 'calypso/lib/wp';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { removePurchase } from 'calypso/state/purchases/actions';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import GSuiteCancellationFeatures from './gsuite-cancellation-features';
 import GSuiteCancellationSurvey from './gsuite-cancellation-survey';
 import * as steps from './steps';
@@ -194,9 +196,9 @@ class GSuiteCancelPurchaseDialog extends Component {
 	};
 
 	render() {
-		const { isVisible, onClose, purchase } = this.props;
+		const { isVisible, onClose, purchase, domains, domain } = this.props;
 		const { surveyAnswerId, surveyAnswerText, isRemoving } = this.state;
-
+		const selectedDomain = getSelectedDomain( { domains, selectedDomainName: domain } );
 		return (
 			// By checking isVisible here we prevent rendering a "reset" dialog state before it closes
 			isVisible && (
@@ -207,7 +209,9 @@ class GSuiteCancelPurchaseDialog extends Component {
 					onClose={ onClose }
 				>
 					{ steps.GSUITE_INITIAL_STEP === this.state.step ? (
-						<GSuiteCancellationFeatures purchase={ purchase } />
+						<GSuiteCancellationFeatures purchase={ purchase }
+							status={ selectedDomain?.googleAppsSubscription?.status }
+						/>
 					) : (
 						<GSuiteCancellationSurvey
 							disabled={ isRemoving }
@@ -235,12 +239,13 @@ GSuiteCancelPurchaseDialog.propTypes = {
 };
 
 export default connect(
-	( state, { purchase } ) => {
+	( state, { purchase, site } ) => {
 		return {
 			productName: getName( purchase ),
 			domain: purchase.meta,
 			purchasesError: getPurchasesError( state ),
 			userId: getCurrentUserId( state ),
+			domains: getDomainsBySiteId( state, site.ID ),
 		};
 	},
 	{

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -240,14 +240,14 @@ GSuiteCancelPurchaseDialog.propTypes = {
 };
 
 export default connect(
-	( state, { purchase, site, domain } ) => {
+	( state, { purchase, site } ) => {
 		return {
 			domain: purchase.meta,
 			productName: getName( purchase ),
 			purchasesError: getPurchasesError( state ),
 			selectedDomain: getSelectedDomain( {
 				domains: getDomainsBySiteId( state, site.ID ),
-				selectedDomainName: domain,
+				selectedDomainName: purchase.meta,
 			} ),
 			userId: getCurrentUserId( state ),
 		};

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
-import { getSelectedDomain } from 'calypso/lib/domains';
-import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
 import { getName } from 'calypso/lib/purchases';
 import wpcom from 'calypso/lib/wp';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
@@ -15,7 +13,6 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { removePurchase } from 'calypso/state/purchases/actions';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import GSuiteCancellationFeatures from './gsuite-cancellation-features';
 import GSuiteCancellationSurvey from './gsuite-cancellation-survey';
 import * as steps from './steps';
@@ -197,7 +194,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	};
 
 	render() {
-		const { isVisible, onClose, purchase, selectedDomain } = this.props;
+		const { isVisible, onClose, purchase } = this.props;
 		const { surveyAnswerId, surveyAnswerText, isRemoving } = this.state;
 		return (
 			// By checking isVisible here we prevent rendering a "reset" dialog state before it closes
@@ -209,10 +206,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 					onClose={ onClose }
 				>
 					{ steps.GSUITE_INITIAL_STEP === this.state.step ? (
-						<GSuiteCancellationFeatures
-							googleSubscriptionStatus={ getGSuiteSubscriptionStatus( selectedDomain ) }
-							purchase={ purchase }
-						/>
+						<GSuiteCancellationFeatures purchase={ purchase } />
 					) : (
 						<GSuiteCancellationSurvey
 							disabled={ isRemoving }
@@ -240,15 +234,11 @@ GSuiteCancelPurchaseDialog.propTypes = {
 };
 
 export default connect(
-	( state, { purchase, site } ) => {
+	( state, { purchase } ) => {
 		return {
 			domain: purchase.meta,
 			productName: getName( purchase ),
 			purchasesError: getPurchasesError( state ),
-			selectedDomain: getSelectedDomain( {
-				domains: getDomainsBySiteId( state, site.ID ),
-				selectedDomainName: purchase.meta,
-			} ),
 			userId: getCurrentUserId( state ),
 		};
 	},

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -242,8 +242,8 @@ GSuiteCancelPurchaseDialog.propTypes = {
 export default connect(
 	( state, { purchase, site, domain } ) => {
 		return {
-			productName: getName( purchase ),
 			domain: purchase.meta,
+			productName: getName( purchase ),
 			purchasesError: getPurchasesError( state ),
 			selectedDomain: getSelectedDomain( {
 				domains: getDomainsBySiteId( state, site.ID ),

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -196,6 +196,7 @@ class GSuiteCancelPurchaseDialog extends Component {
 	render() {
 		const { isVisible, onClose, purchase } = this.props;
 		const { surveyAnswerId, surveyAnswerText, isRemoving } = this.state;
+
 		return (
 			// By checking isVisible here we prevent rendering a "reset" dialog state before it closes
 			isVisible && (

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/style.scss
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/style.scss
@@ -12,3 +12,7 @@
 		content: none;
 	}
 }
+
+.gsuite-cancel-purchase-dialog__dialog > div > p.placeholder {
+	@include placeholder();
+}

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/style.scss
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/style.scss
@@ -12,7 +12,3 @@
 		content: none;
 	}
 }
-
-.gsuite-cancel-purchase-dialog__dialog > div > p.placeholder {
-	@include placeholder();
-}

--- a/client/lib/gsuite/get-gsuite-subscription-status.js
+++ b/client/lib/gsuite/get-gsuite-subscription-status.js
@@ -1,6 +1,5 @@
 /**
- * Gets Google Workspace subscription status for a given domain object,
- * If resulting status is null or undefined, it returns empty string.
+ * Gets Google Workspace subscription status for a given domain object
  *
  * @param {object} domain - Domain object
  * @returns {string} - Subscription status or empty string for null/undefined values

--- a/client/lib/gsuite/get-gsuite-subscription-status.js
+++ b/client/lib/gsuite/get-gsuite-subscription-status.js
@@ -1,0 +1,3 @@
+export function getGSuiteSubscriptionStatus( domain ) {
+	return domain?.googleAppsSubscription?.status;
+}

--- a/client/lib/gsuite/get-gsuite-subscription-status.js
+++ b/client/lib/gsuite/get-gsuite-subscription-status.js
@@ -1,5 +1,5 @@
 /**
- * Gets Google Workspace subscription status for a given domain object
+ * Gets Google Workspace subscription status for a given domain object.
  *
  * @param {object} domain - Domain object
  * @returns {string} - Subscription status or empty string for null/undefined values

--- a/client/lib/gsuite/get-gsuite-subscription-status.js
+++ b/client/lib/gsuite/get-gsuite-subscription-status.js
@@ -1,3 +1,10 @@
+/**
+ * Gets Google Workspace subscription status for a given domain object,
+ * If resulting status is null or undefined, it returns empty string.
+ *
+ * @param {object} domain - Domain object
+ * @returns {string} - Subscription status or empty string for null/undefined values
+ */
 export function getGSuiteSubscriptionStatus( domain ) {
-	return domain?.googleAppsSubscription?.status;
+	return domain?.googleAppsSubscription?.status ?? '';
 }

--- a/client/lib/gsuite/has-gsuite-with-another-provider.js
+++ b/client/lib/gsuite/has-gsuite-with-another-provider.js
@@ -7,7 +7,7 @@ import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subsc
  * @returns {boolean} - true if the domain is with another provider, false otherwise
  */
 export function hasGSuiteWithAnotherProvider( domain ) {
-	const domainStatus = getGSuiteSubscriptionStatus( domain );
+	const status = getGSuiteSubscriptionStatus( domain );
 
-	return 'other_provider' === domainStatus;
+	return 'other_provider' === status;
 }

--- a/client/lib/gsuite/has-gsuite-with-another-provider.js
+++ b/client/lib/gsuite/has-gsuite-with-another-provider.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subscription-status';
 
 /**
  * Given a domain object, does that domain have G Suite with another provider.
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * @returns {boolean} - true if the domain is with another provider, false otherwise
  */
 export function hasGSuiteWithAnotherProvider( domain ) {
-	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
+	const domainStatus = getGSuiteSubscriptionStatus( domain );
 
 	return 'other_provider' === domainStatus;
 }

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subscription-status';
 
 /**
  * Given a domain object, does that domain have G Suite with us.
@@ -8,6 +8,6 @@ import { get } from 'lodash';
  */
 export function hasGSuiteWithUs( domain ) {
 	const defaultValue = '';
-	const domainStatus = get( domain, 'googleAppsSubscription.status', defaultValue );
+	const domainStatus = getGSuiteSubscriptionStatus( domain );
 	return ! [ defaultValue, 'no_subscription', 'other_provider' ].includes( domainStatus );
 }

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -7,6 +7,6 @@ import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subsc
  * @returns {boolean} - true if the domain is under our management, false otherwise
  */
 export function hasGSuiteWithUs( domain ) {
-	const domainStatus = getGSuiteSubscriptionStatus( domain );
-	return ! [ '', 'no_subscription', 'other_provider' ].includes( domainStatus );
+	const status = getGSuiteSubscriptionStatus( domain );
+	return ! [ '', 'no_subscription', 'other_provider' ].includes( status );
 }

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -8,5 +8,6 @@ import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subsc
  */
 export function hasGSuiteWithUs( domain ) {
 	const status = getGSuiteSubscriptionStatus( domain );
+
 	return ! [ '', 'no_subscription', 'other_provider' ].includes( status );
 }

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -7,7 +7,6 @@ import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subsc
  * @returns {boolean} - true if the domain is under our management, false otherwise
  */
 export function hasGSuiteWithUs( domain ) {
-	const defaultValue = '';
 	const domainStatus = getGSuiteSubscriptionStatus( domain );
-	return ! [ defaultValue, 'no_subscription', 'other_provider' ].includes( domainStatus );
+	return ! [ '', 'no_subscription', 'other_provider' ].includes( domainStatus );
 }

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -14,6 +14,7 @@ export {
 export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
 export { getGSuiteProductSlug } from './get-gsuite-product-slug';
 export { getGSuiteSubscriptionId } from './get-gsuite-subscription-id';
+export { getGSuiteSubscriptionStatus } from './get-gsuite-subscription-status';
 export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { getMonthlyPrice } from './get-monthly-price';
 export {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Pull Request just changes the wording in the cancelation survey for Google Workspace / G Suite to clearly communicate to the user what will happen after cancelation. The wording message will change depending on the product and subscription status. It also adds a new function to resolve Google Workspace status and make use of it in some other places.

#### Testing instructions

Test with not suspended Google Workspace Subscription

1. Have a Google WorkSpace account on your preferred site (not suspended subscription)
2. Go to Emails -> Click on the Google Workspace
3. Click on View billing and payment settings
4. Click on Remove Google Workspace Business Starter
5. Visual inspection for the following images

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/131639852-fe4002a1-ce6f-4ac8-a60e-1ed451d8db11.png) | ![image](https://user-images.githubusercontent.com/5689927/132247487-3b12b706-9d17-4200-bd6e-27ed1da933ec.png)


Test with suspended Google Workspace Subscription

1. Have a Google WorkSpace account on your preferred site (suspended subscription)
2. Go to Emails -> Click on the Google Workspace
3. Click on View billing and payment settings
4. Click on Remove Google Workspace Business Starter
5. Visual inspection for the following images

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/131639852-fe4002a1-ce6f-4ac8-a60e-1ed451d8db11.png) | ![image](https://user-images.githubusercontent.com/5689927/132247555-5548a50c-fbf5-4572-a6cf-e30386f27602.png)



**REMARKS:**
The difference in the tests are subtle. The only change in the wording is "in 30 days" when a subscription is not suspended, meanwhile when the subscription is "suspended" it should say "immediately"

In case that some data is still loading (selectedDomain), we will show the "immediately" variant until it loads
![image](https://user-images.githubusercontent.com/5689927/132247555-5548a50c-fbf5-4572-a6cf-e30386f27602.png)

Related to {1200182182542585-as-1200713434691255}
