### PR TITLE
Jetpack site-less Checkout: add new UI for automatic provisioning

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -78,7 +78,7 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 						productName,
 					},
 			  } );
-	}, [ productName ] );
+	}, [ automaticTransferSucceeded, productName, translate ] );
 
 	return (
 		<Main wideLayout className="jetpack-checkout-siteless-thank-you-completed">

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -142,7 +142,7 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 								{ productName &&
 									rawSite?.name &&
 									translate(
-										"We successfully activated %(productName)s on {{strong}}%(siteName)s{{/strong}}. Next, we'll recommend features based on your goals",
+										"We successfully activated %(productName)s on {{strong}}%(siteName)s{{/strong}}. Next, we'll recommend features based on your goals.",
 										{
 											args: { productName, siteName: rawSite.name },
 											components: {
@@ -153,14 +153,14 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 								{ productName &&
 									! rawSite &&
 									translate(
-										"We successfully activated %(productName)s. Next, we'll recommend features based on your goals",
+										"We successfully activated %(productName)s. Next, we'll recommend features based on your goals.",
 										{
 											args: { productName },
 										}
 									) }
 								{ ! productName &&
 									translate(
-										"We successfully activated your subscription. Next, we'll recommend features based on your goals"
+										"We successfully activated your subscription. Next, we'll recommend features based on your goals."
 									) }
 							</p>
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -146,7 +146,9 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 										{
 											args: { productName, siteName: rawSite.name },
 											components: {
-												strong: <strong />,
+												strong: (
+													<strong className="jetpack-checkout-siteless-thank-you-completed__site-name" />
+												),
 											},
 										}
 									) }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -675,6 +675,28 @@
 	}
 }
 
+@mixin jetpack-primary-button() {
+	// button colors imported from packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+	background-color: var( --studio-jetpack-green-50 );
+	border-color: var( --studio-jetpack-green-50 );
+	color: var( --color-text-inverted );
+
+	&:hover,
+	&:focus {
+		background-color: var( --studio-jetpack-green-60 );
+		border-color: var( --studio-jetpack-green-60 );
+		color: var( --color-text-inverted );
+	}
+
+	&[disabled],
+	&:disabled,
+	&.disabled {
+		color: var( --color-neutral-20 );
+		background-color: var( --color-surface );
+		border-color: var( --color-neutral-5 );
+	}
+}
+
 .jetpack-checkout-siteless-thank-you-completed {
 	&.main.is-wide-layout {
 		max-width: 660px;
@@ -708,6 +730,11 @@
 				font-size: 18px; /* stylelint-disable-line */
 				line-height: 1.75rem;
 			}
+		}
+		.jetpack-checkout-siteless-thank-you-completed__button,
+		.jetpack-checkout-siteless-thank-you-completed__button:visited {
+			border-radius: 2px;
+			@include jetpack-primary-button;
 		}
 
 		a.jetpack-checkout-siteless-thank-you-completed__link,
@@ -953,25 +980,7 @@
 		.jetpack-checkout-thank-you__button,
 		.jetpack-checkout-thank-you__button:visited {
 			border-radius: calc( 2px * 2 );
-			// button colors imported from packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
-			background-color: var( --studio-jetpack-green-50 );
-			border-color: var( --studio-jetpack-green-50 );
-			color: var( --color-text-inverted );
-
-			&:hover,
-			&:focus {
-				background-color: var( --studio-jetpack-green-60 );
-				border-color: var( --studio-jetpack-green-60 );
-				color: var( --color-text-inverted );
-			}
-
-			&[disabled],
-			&:disabled,
-			&.disabled {
-				color: var( --color-neutral-20 );
-				background-color: var( --color-surface );
-				border-color: var( --color-neutral-5 );
-			}
+			@include jetpack-primary-button;
 		}
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -762,6 +762,10 @@
 	}
 }
 
+.jetpack-checkout-siteless-thank-you-completed__site-name {
+	white-space: nowrap;
+}
+
 .jetpack-checkout-siteless-thank-you {
 	.jetpack-checkout-siteless-thank-you__card {
 		display: flex;

--- a/client/my-sites/checkout/checkout-thank-you/test/utils.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/utils.js
@@ -1,0 +1,50 @@
+import { getActivationCompletedLink } from '../utils';
+
+describe( 'getActivationCompletedLink', () => {
+	it( 'return link to /landing section in cloud when there is no valid site or product slug', () => {
+		const validProductInvalidSite = getActivationCompletedLink( 'jetpack_scan', null, null );
+		expect( validProductInvalidSite ).toBe( 'https://cloud.jetpack.com/landing' );
+
+		const validSiteInvalidProduct = getActivationCompletedLink(
+			null,
+			'mysite.wordpress.com',
+			null
+		);
+		expect( validSiteInvalidProduct ).toBe(
+			'https://cloud.jetpack.com/landing/mysite.wordpress.com'
+		);
+	} );
+
+	it( 'return link to /backup if a Backup product and a valid site are given', () => {
+		const response = getActivationCompletedLink(
+			'jetpack_backup_daily',
+			'mysite.wordpress.com',
+			null
+		);
+		expect( response ).toBe( 'https://cloud.jetpack.com/backup/mysite.wordpress.com' );
+	} );
+
+	it( 'return link to /scan if a Scan product and a valid site are given', () => {
+		const response = getActivationCompletedLink( 'jetpack_scan', 'mysite.wordpress.com', null );
+		expect( response ).toBe( 'https://cloud.jetpack.com/scan/mysite.wordpress.com' );
+	} );
+
+	it( 'return link to /search if a Search product and a valid site are given', () => {
+		const response = getActivationCompletedLink( 'jetpack_search', 'mysite.wordpress.com', null );
+		expect( response ).toBe( 'https://cloud.jetpack.com/jetpack-search/mysite.wordpress.com' );
+	} );
+
+	it( 'return link to WP Admin for any other product than scan, backup, or search', () => {
+		const response = getActivationCompletedLink(
+			'jetpack_security_daily',
+			'mysite.wordpress.com',
+			'https://mysite.jurassic.ninja/wp-admin'
+		);
+		expect( response ).toBe( 'https://mysite.jurassic.ninja/wp-admin' );
+	} );
+
+	it( 'return link to /landing for any other product than scan, backup, or search when WP Admin URL is not valid', () => {
+		const response = getActivationCompletedLink( 'jetpack_complete', 'mysite.wordpress.com', null );
+		expect( response ).toBe( 'https://cloud.jetpack.com/landing/mysite.wordpress.com' );
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/utils.js
+++ b/client/my-sites/checkout/checkout-thank-you/utils.js
@@ -1,3 +1,8 @@
+import {
+	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_SCAN_PRODUCTS,
+	JETPACK_SEARCH_PRODUCTS,
+} from '@automattic/calypso-products';
 import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -21,4 +26,34 @@ export async function addOnboardingCallInternalNote( receiptId, jetpackTemporary
 		),
 		apiNamespace: 'wpcom/v2',
 	} );
+}
+
+/*
+ * Compute link to send a user after a site-less subscription has been successfully transferred
+ * to the user site.
+ *
+ * @param productSlug string – The slug of a Jetpack product.
+ * @param siteSlug string|null – The slug of a site.
+ * @param wpAdminUrl string|null – The URL of a site's WP Admin.
+ */
+export function getActivationCompletedLink( productSlug, siteSlug, wpAdminUrl ) {
+	const baseJetpackCloudUrl = 'https://cloud.jetpack.com';
+
+	if ( ! siteSlug ) {
+		return `${ baseJetpackCloudUrl }/landing`;
+	}
+
+	if ( productSlug && JETPACK_BACKUP_PRODUCTS.includes( productSlug ) ) {
+		return `${ baseJetpackCloudUrl }/backup/${ siteSlug }`;
+	}
+
+	if ( productSlug && JETPACK_SEARCH_PRODUCTS.includes( productSlug ) ) {
+		return `${ baseJetpackCloudUrl }/jetpack-search/${ siteSlug }`;
+	}
+
+	if ( productSlug && JETPACK_SCAN_PRODUCTS.includes( productSlug ) ) {
+		return `${ baseJetpackCloudUrl }/scan/${ siteSlug }`;
+	}
+
+	return wpAdminUrl || `${ baseJetpackCloudUrl }/landing/${ siteSlug }`;
 }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -310,12 +310,13 @@ export function jetpackCheckoutThankYou( context, next ) {
 }
 
 export function jetpackCheckoutThankYouCompleted( context, next ) {
-	const { siteId, receiptId } = context.query;
+	const { siteId, receiptId, activated } = context.query;
 	context.primary = (
 		<JetpackCheckoutSitelessThankYouCompleted
 			productSlug={ context.params.product }
 			jetpackTemporarySiteId={ siteId }
 			receiptId={ receiptId }
+			activated={ !! activated }
 		/>
 	);
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -310,13 +310,12 @@ export function jetpackCheckoutThankYou( context, next ) {
 }
 
 export function jetpackCheckoutThankYouCompleted( context, next ) {
-	const { siteId, receiptId, activated } = context.query;
+	const { siteId, receiptId } = context.query;
 	context.primary = (
 		<JetpackCheckoutSitelessThankYouCompleted
 			productSlug={ context.params.product }
 			jetpackTemporarySiteId={ siteId }
 			receiptId={ receiptId }
-			activated={ !! activated }
 		/>
 	);
 

--- a/client/state/data-layer/wpcom/jetpack-checkout/support-ticket/index.js
+++ b/client/state/data-layer/wpcom/jetpack-checkout/support-ticket/index.js
@@ -31,11 +31,13 @@ const onUpdateSuccess = ( action, response ) => {
 		{
 			type: JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_REQUEST_SUCCESS,
 			receiptId: action.receiptId,
+			jetpackTemporarySiteId: action.jetpackTemporarySiteId,
 		},
 		{
 			type: JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE,
 			receiptId: action.receiptId,
 			payload: response,
+			jetpackTemporarySiteId: action.jetpackTemporarySiteId,
 		},
 	];
 };

--- a/client/state/jetpack-checkout/reducer.ts
+++ b/client/state/jetpack-checkout/reducer.ts
@@ -21,14 +21,17 @@ export const requestStatus = keyedReducer( 'receiptId', ( state, { type } ) => {
 	return state;
 } );
 
-export const submittedSiteUrl = keyedReducer( 'receiptId', ( state, { type, payload } ) => {
-	switch ( type ) {
-		case JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE:
-			return payload;
-	}
+export const submittedSiteUrl = keyedReducer(
+	'jetpackTemporarySiteId',
+	( state, { type, payload } ) => {
+		switch ( type ) {
+			case JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE:
+				return payload;
+		}
 
-	return state;
-} );
+		return state;
+	}
+);
 
 export default combineReducers( {
 	requestStatus,

--- a/client/state/selectors/get-jetpack-checkout-support-ticket-destination-site-id.ts
+++ b/client/state/selectors/get-jetpack-checkout-support-ticket-destination-site-id.ts
@@ -1,0 +1,18 @@
+import 'calypso/state/data-layer/wpcom/jetpack-checkout/support-ticket';
+
+import type { AppState } from 'calypso/types';
+
+/**
+ * Return the site ID of the site that the subscription was transferred to, or 0 if
+ * the subscription could not be transferred.
+ *
+ * @param  {object}    state     Global state tree
+ * @param  {number}    siteId    The ID of the temporary site
+ * @returns {number} The response body containing the destination site ID
+ */
+export default function getJetpackCheckoutSupportTicketDestinationSiteId(
+	state: AppState,
+	siteId: number
+): number {
+	return state.jetpackCheckout?.submittedSiteUrl?.[ siteId ]?.transferred_to || 0;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new UI for the incoming automatic provisioning feature that's being worked on the backend. This new UI will be shown in case the automatic provisioning succeeds.

**Note 1**: ~~the accompanying endpoint changes are not ready yet, so this new UI is not reachable in the current state of the app. For that reason, I added support for a query parameter that can make the UI appear.~~ D64912-code is in a state where we can use the endpoint and test the whole flow (automatic provisioning).

**Note 2**: the CTA in the new UI leads users to different places according to the purchased subscription. Jetpack Scan, Jetpack Backup, and Jetpack Search products should lead users to `https://cloud.jetpack.com/:product/:site`, while any other product should lead users to their WP Admin dashboard page.

#### Testing instructions

Prerequisite: the ID of a connected Jetpack site owned by you (in the instructions I'll use `197185040` but you need to replace it with your own site ID).

**Current success UI**
* Download this PR.
* Start Calypso with `yarn start`.
* Visit `/checkout/jetpack/thank-you-completed/no-site/jetpack_scan?siteId=10&receiptId=20` (do not replace the query parameters values).
* Verify you see the current UI that users see when they submit a website address. 
<img src="https://user-images.githubusercontent.com/3418513/131678265-3c5d359f-2b5f-41e2-a5b4-2ab1c37bbd11.png" width="500" />

---

**New UI: Jetpack Scan**
* Visit `/checkout/jetpack/thank-you-completed/no-site/jetpack_scan?siteId=10&receiptId=20` (do not replace the query parameters values).
* Open the JS Console and execute the following (replacing `197185040` with the site ID of the site you selected at the beginning):
```
dispatch( {
    type: 'JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE',
    receiptId: 20,
    payload: { transferred_to: 197185040 },
    jetpackTemporarySiteId: 10,
} );
```
* Verify you see the new UI that users will see after they get their subscription provisioned. The UI should include the name of the product and the name of the site (that's why you need to use the site ID of a connected site).
<img src="https://user-images.githubusercontent.com/3418513/131679117-2a7175c0-5e85-4ee5-b385-cd0fdef5b60e.png" width="500" />
* Verify that the `Let's go!` button leads you to `https://cloud.jetpack.com/scan/:site-slug`.

---

**New UI: Jetpack Backup**
* Visit `/checkout/jetpack/thank-you-completed/no-site/jetpack_backup_daily?siteId=10&receiptId=20` (do not replace the query parameters values).
* Open the JS Console and execute the following (replacing `197185040` with the site ID of the site you selected at the beginning):
```
dispatch( {
    type: 'JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE',
    receiptId: 20,
    payload: { transferred_to: 197185040 },
    jetpackTemporarySiteId: 10,
} );
```
* Verify you see the new UI that users will see after they get their subscription provisioned. The UI should include the name of the product and the name of the site (that's why you need to use the site ID of a connected site).
<img src="https://user-images.githubusercontent.com/3418513/131680123-9fc3e6f2-0d71-447e-8e01-b2937174bc21.png" width="500" />
* Verify that the `Let's go!` button leads you to `https://cloud.jetpack.com/backup/:site-slug`.

---

**New UI: Jetpack Search**
* Visit `/checkout/jetpack/thank-you-completed/no-site/jetpack_search?siteId=10&receiptId=20` (do not replace the query parameters values).
* Open the JS Console and execute the following (replacing `197185040` with the site ID of the site you selected at the beginning):
```
dispatch( {
    type: 'JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE',
    receiptId: 20,
    payload: { transferred_to: 197185040 },
    jetpackTemporarySiteId: 10,
} );
```
* Verify you see the new UI that users will see after they get their subscription provisioned. The UI should include the name of the product and the name of the site (that's why you need to use the site ID of a connected site).
<img src="https://user-images.githubusercontent.com/3418513/131680204-c4018938-e055-44d3-a2d9-8753930e1af1.png" width="500" />
* Verify that the `Let's go!` button leads you to `https://cloud.jetpack.com/jetpack-search/:site-slug`.

---

**New UI: any other Jetpack product/plan**
* Visit `/checkout/jetpack/thank-you-completed/no-site/jetpack_security_daily?siteId=10&receiptId=20` (do not replace the query parameters values).
* Open the JS Console and execute the following (replacing `197185040` with the site ID of the site you selected at the beginning):
```
dispatch( {
    type: 'JETPACK_CHECKOUT_UPDATE_SUPPORT_TICKET_RECEIVE',
    receiptId: 20,
    payload: { transferred_to: 197185040 },
    jetpackTemporarySiteId: 10,
} );
```
* Verify you see the new UI that users will see after they get their subscription provisioned. The UI should include the name of the product and the name of the site (that's why you need to use the site ID of a connected site).
<img src="https://user-images.githubusercontent.com/3418513/131680270-cafd0eb6-e92e-440b-ab7b-6155584d1c2c.png" width="500" />
* Verify that the `Let's go!` button leads you to the WP Admin dashboard of your site.

---

**Full test: complete a site-less purchase**
* Patch your sandbox with D64912-code.
* Sandbox `public-api.wordpress.com`.
* Complete a site-less purchase.
* Enter the address of a connected site you own.
* Verify that you're redirected to the new success UI.
* Verify that the button leads to the purchased product section in the cloud.

https://user-images.githubusercontent.com/3418513/131752872-3b7a61dc-b931-4678-b7eb-f3c2ae443db0.mp4

---

**Unit tests suite**

* Execute `yarn test-client client/my-sites/checkout/checkout-thank-you/test/utils.js`.
* Verify all tests pass.


```
 PASS  client/my-sites/checkout/checkout-thank-you/test/utils.js

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.78 s, estimated 1 s
Ran all test suites matching /client\/my-sites\/checkout\/checkout-thank-you\/test\/utils.js/i.
```

---


Related to 1200738571375997-as-1200794056860704