### PR TITLE
ci: Do not install Chrome on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ references:
       CIRCLE_ARTIFACTS: /tmp/artifacts
       CIRCLE_TEST_REPORTS: /tmp/test_results
       PUPPETEER_SKIP_DOWNLOAD: 'true'
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'true'
+      SKIP_TSC: 'true'
       NODE_OPTIONS: --max-old-space-size=3072
       npm_config_cache: /home/circleci/.cache/yarn
   desktop_defaults: &desktop_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,8 @@ references:
       CIRCLE_ARTIFACTS: /tmp/artifacts
       CIRCLE_TEST_REPORTS: /tmp/test_results
       PUPPETEER_SKIP_DOWNLOAD: 'true'
-      DETECT_CHROMEDRIVER_VERSION: 'false'
-      CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_OPTIONS: --max-old-space-size=3072
       npm_config_cache: /home/circleci/.cache/yarn
-      CHROME_VERSION: 84.0.4147.135-1
   desktop_defaults: &desktop_defaults
     working_directory: ~/wp-calypso
 
@@ -169,23 +166,6 @@ references:
     fail_only: true
     mentions: '$CIRCLE_USERNAME'
     failure_message: ':red_circle: wp-desktop tests for $CIRCLE_BRANCH have failed.\n\nCalypso PR: $CIRCLE_PULL_REQUEST'
-  install-specific-chrome-browser: &install-specific-chrome-browser
-    name: Install Chrome
-    command: |
-      sudo apt-get update
-      cd /tmp
-      wget --no-check-certificate https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb
-      sudo dpkg -i google-chrome-stable_${CHROME_VERSION}_amd64.deb || sudo apt-get -y -f install
-      rm google-chrome-stable_${CHROME_VERSION}_amd64.deb;
-      sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
-      CHROME_VERSION="$(google-chrome --version)"
-      CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')"
-      CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*}
-      CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE})
-      curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip"
-      cd /tmp && unzip chromedriver_linux64.zip && rm -rf chromedriver_linux64.zip && sudo mv chromedriver /usr/local/bin/chromedriver && sudo chmod +x /usr/local/bin/chromedriver
-      google-chrome --version
-      chromedriver --version
 
 commands:
   prepare:
@@ -216,7 +196,6 @@ jobs:
       - run: *update-git
       - save_cache: *save-git-cache
       - run: *update-node
-      - run: *install-specific-chrome-browser
       # npm dependencies
       - restore_cache: *restore-yarn-cache
       - run: *yarn-install


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Do not install Chrome on CircleCI jobs.

The only job we run in CircleCI is to extract translations. It doesn't need a browser at all.

#### Testing instructions

Verify all tests are green