### PR TITLE
Remove references to premium themes

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -115,7 +115,6 @@ import {
 	FEATURE_SPELLING_CORRECTION_V2,
 	FEATURE_STANDARD_SECURITY_TOOLS,
 	FEATURE_TRAFFIC_TOOLS,
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
 	FEATURE_UNLIMITED_PRODUCTS_SERVICES,
 	FEATURE_UNLIMITED_STORAGE,
 	FEATURE_UPLOAD_PLUGINS,
@@ -480,22 +479,6 @@ export const FEATURES_LIST = {
 					'to a previous point in time with just a click! While you’re at it, ' +
 					'improve your SEO with our Advanced SEO tools and automate social media sharing.'
 			),
-	},
-
-	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
-		getSlug: () => FEATURE_UNLIMITED_PREMIUM_THEMES,
-		getTitle: () =>
-			i18n.translate( '{{strong}}Unlimited{{/strong}} Premium themes', {
-				components: {
-					strong: <strong />,
-				},
-			} ),
-		getDescription: () =>
-			i18n.translate(
-				'Unlimited access to all of our advanced premium themes, ' +
-					'including designs specifically tailored for businesses.'
-			),
-		getStoreSlug: () => 'unlimited_themes',
 	},
 
 	[ FEATURE_VIDEO_UPLOADS ]: {

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -66,7 +66,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 				question={ translate( 'Can I install my own theme?' ) }
 				answer={ translate(
 					"Yes! With the WordPress.com Business or eCommerce plan you can install any theme you'd like." +
-						' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
+						' All plans give you access to our {{a}}directory of free themes{{/a}}.' +
 						' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
 					{
 						components: { a: <a href={ `/themes/${ siteSlug }` } /> },

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,10 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-	FEATURE_UPLOAD_THEMES,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-} from '@automattic/calypso-products';
+import { FEATURE_UPLOAD_THEMES, PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -649,7 +644,6 @@ class ThemeSheet extends React.Component {
 			isWpcomTheme,
 			isVip,
 			translate,
-			hasUnlimitedPremiumThemes,
 			canUserUploadThemes,
 			previousRoute,
 		} = this.props;
@@ -695,8 +689,7 @@ class ThemeSheet extends React.Component {
 
 		let pageUpsellBanner;
 		let previewUpsellBanner;
-		const hasWpComThemeUpsellBanner =
-			! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired;
+		const hasWpComThemeUpsellBanner = ! isJetpack && isPremium && ! isVip && ! retired;
 		const hasWpOrgThemeUpsellBanner =
 			! isWpcomTheme && ( ! siteId || ( ! isJetpack && ! canUserUploadThemes ) );
 		const hasUpsellBanner = hasWpComThemeUpsellBanner || hasWpOrgThemeUpsellBanner;
@@ -862,7 +855,6 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
-			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,7 +1,4 @@
-import {
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-	PLAN_JETPACK_SECURITY_REALTIME,
-} from '@automattic/calypso-products';
+import { PLAN_JETPACK_SECURITY_REALTIME } from '@automattic/calypso-products';
 import { pickBy } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -11,11 +8,7 @@ import { isPartnerPurchase } from 'calypso/lib/purchases';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
-import {
-	getCurrentPlan,
-	hasFeature,
-	isRequestingSitePlans,
-} from 'calypso/state/sites/plans/selectors';
+import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { getLastThemeQuery, getThemesFoundForQuery } from 'calypso/state/themes/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -52,7 +45,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		vertical,
 		tier,
 		translate,
-		hasUnlimitedPremiumThemes,
 		requestingSitePlans,
 		siteSlug,
 	} = props;
@@ -64,7 +56,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 			<SidebarNavigation />
 			<ThemesHeader />
 			<CurrentTheme siteId={ siteId } />
-			{ ! requestingSitePlans && currentPlan && ! hasUnlimitedPremiumThemes && ! isPartnerPlan && (
+			{ ! requestingSitePlans && currentPlan && ! isPartnerPlan && (
 				<UpsellNudge
 					forceDisplay
 					title={ translate( 'Get unlimited premium themes' ) }
@@ -140,7 +132,6 @@ export default connect( ( state, { siteId, tier } ) => {
 		showWpcomThemesList,
 		emptyContent,
 		isMultisite,
-		hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 		requestingSitePlans: isRequestingSitePlans( state, siteId ),
 		siteSlug,
 	};

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import React from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -6,24 +6,16 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { hasFeature, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
-	const {
-		hasUnlimitedPremiumThemes,
-		requestingSitePlans,
-		siteId,
-		isVip,
-		siteSlug,
-		translate,
-		isJetpack,
-	} = props;
+	const { requestingSitePlans, siteId, isVip, siteSlug, translate, isJetpack } = props;
 
-	const displayUpsellBanner = ! requestingSitePlans && ! hasUnlimitedPremiumThemes && ! isVip;
+	const displayUpsellBanner = ! requestingSitePlans && ! isVip;
 	const bannerLocationBelowSearch = ! isJetpack;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
@@ -78,6 +70,5 @@ export default connect( ( state, { siteId } ) => ( {
 	isJetpack: isJetpackSite( state, siteId ),
 	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
-	hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -291,7 +291,7 @@ class ThemeShowcase extends React.Component {
 			filterString,
 			locale,
 		} = this.props;
-		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
+		const tier = '';
 
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 

--- a/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
+++ b/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
@@ -1,8 +1,4 @@
-import {
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-	PLAN_JETPACK_SECURITY_REALTIME,
-} from '@automattic/calypso-products';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import { PLAN_JETPACK_SECURITY_REALTIME } from '@automattic/calypso-products';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
@@ -17,11 +13,7 @@ import 'calypso/state/themes/init';
  * @returns {?string}         Plan purchase URL
  */
 export function getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ) {
-	if (
-		isJetpackSite( state, siteId ) &&
-		isThemePremium( state, themeId ) &&
-		! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
-	) {
+	if ( isJetpackSite( state, siteId ) && isThemePremium( state, themeId ) ) {
 		return `/checkout/${ getSiteSlug( state, siteId ) }/${ PLAN_JETPACK_SECURITY_REALTIME }`;
 	}
 	return null;

--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,5 +1,3 @@
-import { FEATURE_UNLIMITED_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
 import 'calypso/state/themes/init';
@@ -13,8 +11,5 @@ import 'calypso/state/themes/init';
  * @returns {boolean}         True if the premium theme is available for the given site
  */
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
-	return (
-		isThemePurchased( state, themeId, siteId ) ||
-		hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
-	);
+	return isThemePurchased( state, themeId, siteId );
 }

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -20,7 +20,6 @@ export const FEATURE_SET_PRIMARY_CUSTOM_DOMAIN = 'set-primary-custom-domain';
 export const FEATURE_JETPACK_ESSENTIAL = 'jetpack-essential';
 export const FEATURE_JETPACK_ADVANCED = 'jetpack-advanced';
 export const FEATURE_FREE_THEMES = 'free-themes';
-export const FEATURE_UNLIMITED_PREMIUM_THEMES = 'premium-themes';
 export const FEATURE_3GB_STORAGE = '3gb-storage';
 export const FEATURE_6GB_STORAGE = '6gb-storage';
 export const FEATURE_13GB_STORAGE = '13gb-storage';

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -531,13 +531,13 @@ const getPlanBusinessDetails = () => ( {
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for small businesses:{{/strong}} Power your' +
-				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
+				' business website with custom plugins and themes,' +
 				' 200 GB storage, and the ability to remove WordPress.com branding.',
 			plansDescriptionHeadingComponent
 		),
 	getShortDescription: () =>
 		i18n.translate(
-			'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
+			'Power your business website with custom plugins and themes,' +
 				' 200 GB storage, and the ability to remove WordPress.com branding.'
 		),
 	getTagline: () =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Copy changes from https://github.com/Automattic/wp-calypso/pull/55889#pullrequestreview-743903591
* This also removes a lot of other code that relates to the `FEATURE_UNLIMITED_PREMIUM_THEMES` const.

#### Testing instructions

* Check that theme showcase and plans pages still load.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
