### PR TITLE
Implement JP pricing page without monthly experiment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -68,12 +68,30 @@
 	}
 }
 
-.product-grid__filter-bar {
+.product-grid__filter-bar,
+.product-grid__filter-bar-placeholder {
 	height: 63px;
 	margin-bottom: 70px;
 
 	@include break-small {
 		margin-bottom: 50px;
+	}
+}
+
+.product-grid__filter-bar-placeholder {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	width: 250px;
+	margin-left: auto;
+	margin-right: auto;
+
+	> :first-child {
+		@include placeholder();
+
+		width: 100%;
+		height: 24px;
 	}
 }
 
@@ -108,7 +126,6 @@
 .product-grid__more.is-detached {
 	margin-top: 48px;
 }
-
 
 /*
  * From this point, rules only apply:


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements an experiment in which we remove the monthly products from the Jetpack pricing page.

Fixes 1196108640073826-as-1200717945837676

### Implementation notes

Concretely, we've just removed the term toggle, since yearly products are shown by default.

### Testing instructions

1. Download the PR and run Calypso or Jetpack cloud
2. Visit the pricing page
3. Check that you see the term toggle, that it behaves as expected, and that the PR didn't raise any error in the console
4. Assign yourself to the `treatment` variation, either via Abacus (link in task) or by manually updating the value of `variationName` in the `explat-experiment--calypso_jetpack_pricing_page_without_monthly` local storage item
5. Refresh the page
6. Check that you don't see the term toggle anymore, and that there's no error in the console
<img width="967" alt="Screen Shot 2021-09-01 at 3 59 47 PM" src="https://user-images.githubusercontent.com/1620183/131735954-981ef6e2-576e-4e5f-81ad-d83b496f095d.png">

### Screenshots

#### Control

<img width="950" alt="Screen Shot 2021-09-01 at 3 55 09 PM" src="https://user-images.githubusercontent.com/1620183/131735399-c77608ad-2997-4c28-b9f9-0d73e5114161.png">


#### Treatment

<img width="960" alt="Screen Shot 2021-09-01 at 3 55 19 PM" src="https://user-images.githubusercontent.com/1620183/131735413-2203eb8b-11ca-4364-8a0b-f583e43539c7.png">
