### PR TITLE
Theme Showcase: Replace QueryTheme with QueryCanonicalTheme for ThemePreview

### DIFF
--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import QueryTheme from 'calypso/components/data/query-theme';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import WebPreview from 'calypso/components/web-preview';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideThemePreview } from 'calypso/state/themes/actions';
 import {
@@ -94,7 +95,7 @@ class ThemePreview extends React.Component {
 	};
 
 	render() {
-		const { themeId } = this.props;
+		const { themeId, isJetpack, isAtomic, demoUrl, children } = this.props;
 		const { showActionIndicator } = this.state;
 		if ( ! themeId ) {
 			return null;
@@ -102,9 +103,10 @@ class ThemePreview extends React.Component {
 
 		return (
 			<div>
-				{ this.props.isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-				{ this.props.children }
-				{ this.props.demoUrl && (
+				{ isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
+				{ isAtomic && <QueryTheme themeId={ themeId } siteId="wpcom" /> }
+				{ children }
+				{ demoUrl && (
 					<WebPreview
 						showPreview={ true }
 						showExternal={ false }
@@ -137,9 +139,11 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
 		const themeOptions = getThemePreviewThemeOptions( state );
+		const isAtomic = isSiteWpcomAtomic( state, siteId );
 		return {
 			themeId,
 			isJetpack,
+			isAtomic,
 			themeOptions,
 			isInstalling: isInstallingTheme( state, themeId, siteId ),
 			isActive: isThemeActive( state, themeId, siteId ),

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -3,10 +3,9 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import QueryTheme from 'calypso/components/data/query-theme';
+import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import WebPreview from 'calypso/components/web-preview';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideThemePreview } from 'calypso/state/themes/actions';
 import {
@@ -95,7 +94,7 @@ class ThemePreview extends React.Component {
 	};
 
 	render() {
-		const { themeId, isJetpack, isAtomic, demoUrl, children } = this.props;
+		const { themeId, siteId, demoUrl, children } = this.props;
 		const { showActionIndicator } = this.state;
 		if ( ! themeId ) {
 			return null;
@@ -103,8 +102,7 @@ class ThemePreview extends React.Component {
 
 		return (
 			<div>
-				{ isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-				{ isAtomic && <QueryTheme themeId={ themeId } siteId="wpcom" /> }
+				{ <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }
 				{ children }
 				{ demoUrl && (
 					<WebPreview
@@ -139,11 +137,10 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
 		const themeOptions = getThemePreviewThemeOptions( state );
-		const isAtomic = isSiteWpcomAtomic( state, siteId );
 		return {
 			themeId,
+			siteId,
 			isJetpack,
-			isAtomic,
 			themeOptions,
 			isInstalling: isInstallingTheme( state, themeId, siteId ),
 			isActive: isThemeActive( state, themeId, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* At some point during the course of working on the Showcase in #54361, we broke live demo links on Atomic sites for many WordPress.com themes that were not available in the WordPress.org showcase. I still don't know what we broke, specifically, or why we were able to use `QueryTheme` before without problems. :-/ 
* But I noticed that this line sets the query source for Jetpack sites (and therefore Atomic sites, in most cases) to WP.org rather than WP.com, causing empty `demoUrl` properties for themes that don't exist on WP.org:
https://github.com/Automattic/wp-calypso/blob/0b1198ce5237a2540aaeeff024da4d5532a84acb/client/my-sites/themes/theme-preview.jsx#L105
* Using `QueryCanonicalTheme` rather than `QueryTheme` lets us handle the logic as to which source to look at (wpcom or wporg) and fixes the broken demo links (and probably other features of the Showcase) for Atomic sites
* This also prevents many themes from opening demo site previews in a new window, since they're looking at `*.wordpress.com` demo sites instead of `*.wp-themes.com` demo sites and can therefore use `WebPreview`

**Before**

Clicking "Live Demo" for a theme like Rivington does nothing. Clicking "Live Demo" for a theme like Seedlet opens the WP.org demo in a new tab.

https://user-images.githubusercontent.com/2124984/131889007-b030a13f-bc7c-44a9-b5a0-c8d5a224c0fb.mov

**After**

Clicking "Live Demo" for Rivington opens a theme demo in `WebPreview`. Clicking "Live Demo" for Seedlet or Spearhead open their respective theme demos in a `WebPreview` component.

https://user-images.githubusercontent.com/2124984/131889075-adb6d410-ec69-4674-98bc-9156b92fcdb6.mov


#### Testing instructions

* Switch to this PR, navigate to `/themes/[site]` on an Atomic site
* Click on lots of themes, checking their "Live Demo" links. Most should open in a `WebPreview` rather than a new tab; check the behavior under multiple tabs (Recommended, My Themes, etc.)
* Themes like Rivington or Jones that have not been added to WordPress.org, should still show a demo site in a `WebPreview` component.
* Themes like Twenty Twenty One or Ryu that have been added to WordPress.org should still show the WP.com demo site in a `WebPreview` component rather than the WP.org demo site in a new tab.
* Make sure you can still activate the themes as expected, and perform all other theme actions.
* Switch to a Simple site. Repeat the tests, checking that all links for themes work as expected.

Related to #55497