### PR TITLE
Move Reader filter buttons

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -100,9 +100,9 @@ class SearchStream extends React.Component {
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		const showFollowByUrl = resemblesUrl( query );
 		const queryWithoutProtocol = withoutHttp( query );
-		const segmentedControlStyle = ! wideDisplay
-			? { bottom: 15, right: 15 }
-			: { top: 41, right: 50 };
+		const segmentedControlClass = wideDisplay
+			? 'search-stream__sort-picker is-wide'
+			: 'search-stream__sort-picker';
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
@@ -180,11 +180,7 @@ class SearchStream extends React.Component {
 						</div>
 					) }
 					{ query && (
-						<SegmentedControl
-							compact
-							className="search-stream__sort-picker"
-							style={ segmentedControlStyle }
-						>
+						<SegmentedControl compact className={ segmentedControlClass }>
 							<SegmentedControl.Item
 								selected={ sortOrder !== 'date' }
 								onClick={ this.useRelevanceSort }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -100,6 +100,9 @@ class SearchStream extends React.Component {
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		const showFollowByUrl = resemblesUrl( query );
 		const queryWithoutProtocol = withoutHttp( query );
+		const segmentedControlStyle = ! wideDisplay
+			? { bottom: 15, right: 15 }
+			: { top: 41, right: 50 };
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
@@ -159,22 +162,6 @@ class SearchStream extends React.Component {
 							initialValue={ query || '' }
 							value={ query || '' }
 						/>
-						{ query && (
-							<SegmentedControl compact className="search-stream__sort-picker">
-								<SegmentedControl.Item
-									selected={ sortOrder !== 'date' }
-									onClick={ this.useRelevanceSort }
-								>
-									{ TEXT_RELEVANCE_SORT }
-								</SegmentedControl.Item>
-								<SegmentedControl.Item
-									selected={ sortOrder === 'date' }
-									onClick={ this.useDateSort }
-								>
-									{ TEXT_DATE_SORT }
-								</SegmentedControl.Item>
-							</SegmentedControl>
-						) }
 					</CompactCard>
 					{ showFollowByUrl && (
 						<div className="search-stream__url-follow">
@@ -191,6 +178,23 @@ class SearchStream extends React.Component {
 								followSource={ SEARCH_RESULTS_URL_INPUT }
 							/>
 						</div>
+					) }
+					{ query && (
+						<SegmentedControl
+							compact
+							className="search-stream__sort-picker"
+							style={ segmentedControlStyle }
+						>
+							<SegmentedControl.Item
+								selected={ sortOrder !== 'date' }
+								onClick={ this.useRelevanceSort }
+							>
+								{ TEXT_RELEVANCE_SORT }
+							</SegmentedControl.Item>
+							<SegmentedControl.Item selected={ sortOrder === 'date' } onClick={ this.useDateSort }>
+								{ TEXT_DATE_SORT }
+							</SegmentedControl.Item>
+						</SegmentedControl>
 					) }
 					{ query && (
 						<SearchStreamHeader

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -171,8 +171,6 @@
 // Date and Relevance sorter
 .search-stream__sort-picker {
 	position: absolute;
-	right: 50px;
-	top: 11px;
 	z-index: z-index( 'root', '.search-stream__sort-picker' );
 }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -172,6 +172,14 @@
 .search-stream__sort-picker {
 	position: absolute;
 	z-index: z-index( 'root', '.search-stream__sort-picker' );
+	bottom: 15px;
+	right: 15px;
+
+	&.is-wide {
+		bottom: unset;
+		right: 50px;
+		top: 41px;
+	}
 }
 
 // Posts and Sites results


### PR DESCRIPTION
### Changes proposed in this Pull Request
As mentioned in this [issue](https://github.com/Automattic/wp-calypso/issues/12821), long searches on mobile layout get hidden behind filter buttons. This PR moves the filter components outside the search bar and styles accordingly depending on screen width. This checks `wideDisplay` to determine what styling to use.

### Testing instructions
1. Open reader
2. Set screen width to 375px
3. Search for something really long.

### Screenshots
<img width="384" alt="Markup 2021-09-01 at 19 04 37" src="https://user-images.githubusercontent.com/33258733/131761963-93022ada-5ca2-45f0-8deb-72d3ca2ab662.png">

<img width="384" alt="Markup 2021-09-01 at 19 05 00" src="https://user-images.githubusercontent.com/33258733/131761980-0fee92af-7102-41b0-851c-36df7c0b5175.png">

<img width="1366" alt="Markup 2021-09-01 at 19 05 26" src="https://user-images.githubusercontent.com/33258733/131761988-4158396d-df2e-4514-ab13-37dcc2d179f7.png">


fixes #12821