### PR TITLE
Composite Checkout: Clean up remaining JavaScript code

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -25,9 +25,7 @@ It's also possible to build an entirely custom form using the other components e
 
 ## How to use this package
 
-Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the following functions:
-
-- [createStripeMethod](#createStripeMethod)
+Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form.
 
 Any component which is a child of `CheckoutProvider` gets access to the following custom hooks:
 
@@ -367,18 +365,6 @@ An [@emotion/styled](https://emotion.sh/docs/styled) theme object that can be me
 ### createRegistry
 
 Creates a [data store](#data-stores) registry to be passed (optionally) to [CheckoutProvider](#checkoutprovider). See the `@wordpress/data` [docs for this function](https://developer.wordpress.org/block-editor/packages/packages-data/#createRegistry).
-
-### createStripeMethod
-
-Creates a [Payment Method](#payment-methods) object. Requires passing an object with the following properties:
-
-- `store: StripeStore`. The result of calling [createStripePaymentMethodStore](#createStripePaymentMethodStore).
-- `stripe: object`. The configured stripe object.
-- `stripeConfiguration: object`. The stripe configuration object.
-
-### createStripeMethodStore
-
-Creates a data store for use by [createStripeMethod](#createStripeMethod).
 
 ### defaultRegistry
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import {
 	Checkout,
 	CheckoutStepArea,
@@ -6,8 +7,6 @@ import {
 	CheckoutSteps,
 	CheckoutSummaryArea,
 	CheckoutProvider,
-	createStripeMethod,
-	createStripePaymentMethodStore,
 	defaultRegistry,
 	FormStatus,
 	getDefaultOrderSummary,
@@ -23,6 +22,10 @@ import {
 } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import React, { useState, useEffect, useMemo } from 'react';
+import {
+	createStripeMethod,
+	createStripePaymentMethodStore,
+} from '../src/lib/stripe-credit-card-fields-demo';
 import { StripeHookProvider, useStripe } from '../src/lib/stripe-demo';
 
 const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';
@@ -224,11 +227,7 @@ function MyCheckout() {
 		if ( isStripeLoading || stripeLoadingError || ! stripe || ! stripeConfiguration ) {
 			return null;
 		}
-		return createStripeMethod( {
-			store: stripeStore,
-			stripe,
-			stripeConfiguration,
-		} );
+		return createStripeMethod( { store: stripeStore } );
 	}, [ stripeStore, stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
 
 	const paymentMethods = [ stripeMethod ].filter( Boolean );

--- a/packages/composite-checkout/src/components/payment-logos.tsx
+++ b/packages/composite-checkout/src/components/payment-logos.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export function VisaLogo( { className }: { className?: string } ) {
+export function VisaLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }
@@ -29,7 +29,7 @@ VisaLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function MastercardLogo( { className }: { className?: string } ) {
+export function MastercardLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }
@@ -58,7 +58,7 @@ MastercardLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function AmexLogo( { className }: { className?: string } ) {
+export function AmexLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }
@@ -82,7 +82,7 @@ AmexLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function JcbLogo( { className }: { className?: string } ) {
+export function JcbLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }
@@ -118,7 +118,7 @@ JcbLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function DinersLogo( { className }: { className?: string } ) {
+export function DinersLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }
@@ -154,7 +154,7 @@ DinersLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function UnionpayLogo( { className }: { className?: string } ) {
+export function UnionpayLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }
@@ -186,7 +186,7 @@ UnionpayLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function DiscoverLogo( { className }: { className?: string } ) {
+export function DiscoverLogo( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }

--- a/packages/composite-checkout/src/lib/payment-methods/payment-logo.tsx
+++ b/packages/composite-checkout/src/lib/payment-methods/payment-logo.tsx
@@ -10,7 +10,15 @@ import {
 	DiscoverLogo,
 } from '../../components/payment-logos';
 
-export default function PaymentLogo( { brand, isSummary } ) {
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+export default function PaymentLogo( {
+	brand,
+	isSummary,
+}: {
+	brand: string;
+	isSummary?: boolean;
+} ): JSX.Element | null {
 	let cardFieldIcon = null;
 
 	switch ( brand ) {
@@ -70,16 +78,20 @@ export default function PaymentLogo( { brand, isSummary } ) {
 	return cardFieldIcon;
 }
 
+type BrandLogoProps = {
+	isSummary?: boolean;
+};
+
 const BrandLogo = styled.span`
-	display: ${ ( props ) => ( props.isSummary ? 'inline-block' : 'block' ) };
-	position: ${ ( props ) => ( props.isSummary ? 'relative' : 'absolute' ) };
-	top: ${ ( props ) => ( props.isSummary ? '0' : '15px' ) };
-	right: ${ ( props ) => ( props.isSummary ? '0' : '10px' ) };
+	display: ${ ( props: BrandLogoProps ) => ( props.isSummary ? 'inline-block' : 'block' ) };
+	position: ${ ( props: BrandLogoProps ) => ( props.isSummary ? 'relative' : 'absolute' ) };
+	top: ${ ( props: BrandLogoProps ) => ( props.isSummary ? '0' : '15px' ) };
+	right: ${ ( props: BrandLogoProps ) => ( props.isSummary ? '0' : '10px' ) };
 	transform: translateY( ${ ( props ) => ( props.isSummary ? '4px' : '0' ) } );
 
 	.rtl & {
 		right: auto;
-		left: ${ ( props ) => ( props.isSummary ? '0' : '10px' ) };
+		left: ${ ( props: BrandLogoProps ) => ( props.isSummary ? '0' : '10px' ) };
 	}
 `;
 
@@ -105,7 +117,7 @@ const SmallBrandLogo = styled( BrandLogo )`
 	}
 `;
 
-function LockIcon( { className } ) {
+function LockIcon( { className }: { className?: string } ): JSX.Element {
 	return (
 		<svg
 			className={ className }

--- a/packages/composite-checkout/src/lib/stripe-credit-card-fields-demo.js
+++ b/packages/composite-checkout/src/lib/stripe-credit-card-fields-demo.js
@@ -4,17 +4,17 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState } from 'react';
 import { CardCvcElement, CardExpiryElement, CardNumberElement } from 'react-stripe-elements';
-import Button from '../../components/button';
-import Field from '../../components/field';
-import GridRow from '../../components/grid-row';
-import { VisaLogo, MastercardLogo, AmexLogo } from '../../components/payment-logos';
-import Spinner from '../../components/spinner';
-import { registerStore, useSelect, useDispatch } from '../../lib/registry';
-import { FormStatus, useLineItems } from '../../public-api';
-import { useFormStatus } from '../form-status';
-import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
-import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
-import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import Button from '../components/button';
+import Field from '../components/field';
+import GridRow from '../components/grid-row';
+import { VisaLogo, MastercardLogo, AmexLogo } from '../components/payment-logos';
+import Spinner from '../components/spinner';
+import { registerStore, useSelect, useDispatch } from '../lib/registry';
+import { FormStatus, useLineItems } from '../public-api';
+import { useFormStatus } from './form-status';
+import { LeftColumn, RightColumn } from './styled-components/ie-fallback';
+import { PaymentMethodLogos } from './styled-components/payment-method-logos';
+import { SummaryLine, SummaryDetails } from './styled-components/summary-details';
 
 const actions = {
 	setCardDataError( type, message ) {

--- a/packages/composite-checkout/src/lib/stripe-credit-card-fields-demo.js
+++ b/packages/composite-checkout/src/lib/stripe-credit-card-fields-demo.js
@@ -15,12 +15,8 @@ import { useFormStatus } from '../form-status';
 import { LeftColumn, RightColumn } from '../styled-components/ie-fallback';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
-import PaymentLogo from './payment-logo';
 
 const actions = {
-	changeBrand( payload ) {
-		return { type: 'BRAND_SET', payload };
-	},
 	setCardDataError( type, message ) {
 		return { type: 'CARD_DATA_ERROR_SET', payload: { type, message } };
 	},
@@ -33,9 +29,6 @@ const actions = {
 };
 
 const selectors = {
-	getBrand( state ) {
-		return state.brand || '';
-	},
 	getCardholderName( state ) {
 		return state.cardholderName || '';
 	},
@@ -87,8 +80,6 @@ export function createStripePaymentMethodStore() {
 			switch ( action.type ) {
 				case 'CARDHOLDER_NAME_SET':
 					return { ...state, cardholderName: { value: action.payload, isTouched: true } };
-				case 'BRAND_SET':
-					return { ...state, brand: action.payload };
 				case 'CARD_DATA_COMPLETE_SET':
 					return {
 						...state,
@@ -123,21 +114,15 @@ function StripeCreditCardFields() {
 	const theme = useTheme();
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
 	const cardholderName = useSelect( ( select ) => select( 'stripe' ).getCardholderName() );
-	const brand = useSelect( ( select ) => select( 'stripe' ).getBrand() );
 	const {
 		cardNumber: cardNumberError,
 		cardCvc: cardCvcError,
 		cardExpiry: cardExpiryError,
 	} = useSelect( ( select ) => select( 'stripe' ).getCardDataErrors() );
-	const { changeCardholderName, changeBrand, setCardDataError, setCardDataComplete } = useDispatch(
-		'stripe'
-	);
+	const { changeCardholderName, setCardDataError, setCardDataComplete } = useDispatch( 'stripe' );
 
 	const handleStripeFieldChange = ( input ) => {
 		setCardDataComplete( input.elementType, input.complete );
-		if ( input.elementType === 'cardNumber' ) {
-			changeBrand( input.brand );
-		}
 
 		if ( input.error && input.error.message ) {
 			setCardDataError( input.elementType, input.error.message );
@@ -179,7 +164,6 @@ function StripeCreditCardFields() {
 								handleStripeFieldChange( input );
 							} }
 						/>
-						<PaymentLogo brand={ brand } />
 
 						{ cardNumberError && <StripeErrorMessage>{ cardNumberError }</StripeErrorMessage> }
 					</StripeFieldWrapper>
@@ -388,14 +372,11 @@ function ButtonContents( { formStatus, total } ) {
 
 function StripeSummary() {
 	const cardholderName = useSelect( ( select ) => select( 'stripe' ).getCardholderName() );
-	const brand = useSelect( ( select ) => select( 'stripe' ).getBrand() );
 
 	return (
 		<SummaryDetails>
 			<SummaryLine>{ cardholderName?.value }</SummaryLine>
-			<SummaryLine>
-				{ brand !== 'unknown' && '****' } <PaymentLogo brand={ brand } isSummary={ true } />
-			</SummaryLine>
+			<SummaryLine>{ '****' }</SummaryLine>
 		</SummaryDetails>
 	);
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -45,10 +45,6 @@ import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
 import PaymentLogo from './lib/payment-methods/payment-logo';
 import {
-	createStripeMethod,
-	createStripePaymentMethodStore,
-} from './lib/payment-methods/stripe-credit-card-fields';
-import {
 	usePaymentProcessor,
 	usePaymentProcessors,
 	makeManualResponse,
@@ -101,8 +97,6 @@ export {
 	SubmitButtonWrapper,
 	checkoutTheme,
 	createRegistry,
-	createStripeMethod,
-	createStripePaymentMethodStore,
 	defaultRegistry,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummary,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This converts the remaining JavaScript code in the `@automattic/composite-checkout` package to TypeScript except for the storybook demo. This also removes the package export for the stripe credit card payment method because that is now only used by the demo.

#### Testing instructions

- Verify that checkout in calypso still loads.
- Stop calypso, and run `yarn run composite-checkout:storybook:start`.
- Verify that you see the checkout demo appear in your browser.
- Verify that clicking through the demo brings you to the credit card payment method.