### PR TITLE
Checkout: Remove text for logged-in email contact field

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -249,9 +249,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		return (
 			<>
 				<div className="contact-details-form-fields__row">
-					{ this.createEmailField(
-						translate( "You'll use this email address to access your account later" )
-					) }
+					{ this.createEmailField() }
 
 					{ this.createField(
 						'phone',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The email field in the checkout domain contact form displays the help text "You'll use this email address to access your account later" when you're visiting logged-out checkout because in that case the email address is used for more than just the registrar records. However, as of https://github.com/Automattic/wp-calypso/pull/53481 that same text was added to the logged-in email field by mistake. This PR removes the text from the logged-in field.

Before:

<img width="319" alt="Screen Shot 2021-08-31 at 5 21 18 PM" src="https://user-images.githubusercontent.com/2036909/131763504-7772a58a-3040-4051-b255-ee8920d70612.png">

After:

<img width="311" alt="Screen Shot 2021-09-01 at 8 44 11 PM" src="https://user-images.githubusercontent.com/2036909/131763729-2212a7d3-4192-4679-9cdd-78768eca817d.png">


#### Testing instructions

- Visit `/domains/add/` to add a domain to your cart and visit checkout.
- Edit the contact details step of checkout and verify that you do not see any help text below the email field.