### PR TITLE
 Update plugins upsell nudges to suggest paid plans

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -45,7 +45,12 @@ import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-s
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getSitePlan, isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import {
+	getSitePlan,
+	isJetpackSite,
+	isRequestingSites,
+	isCurrentPlanPaid,
+} from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -441,6 +446,32 @@ export class PluginsBrowser extends Component {
 		);
 	}
 
+	renderPaidPlanUpgradeNudge() {
+		if (
+			! this.props.selectedSiteId ||
+			! this.props.sitePlan ||
+			this.props.isVipSite ||
+			this.props.jetpackNonAtomic ||
+			this.props.isPaidPlan
+		) {
+			return null;
+		}
+
+		const { translate, siteSlug } = this.props;
+		const bannerURL = `/plans/my-plan/${ siteSlug }`;
+		const title = translate( 'Upgrade to a paid plan to install plugins.' );
+
+		return (
+			<UpsellNudge
+				event="calypso_plugins_browser_upgrade_nudge"
+				showIcon={ true }
+				href={ bannerURL }
+				feature={ FEATURE_UPLOAD_PLUGINS }
+				title={ title }
+			/>
+		);
+	}
+
 	renderPageViewTracker() {
 		const { category, selectedSiteId, trackPageViews } = this.props;
 
@@ -506,7 +537,8 @@ export class PluginsBrowser extends Component {
 						</div>
 					</div>
 				) }
-				{ this.renderUpgradeNudge() }
+				{ ! isEnabled( 'woop' ) && this.renderUpgradeNudge() }
+				{ isEnabled( 'woop' ) && this.renderPaidPlanUpgradeNudge() }
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }
 				<InfiniteScroll nextPageMethod={ this.fetchNextPagePlugins } />
@@ -534,6 +566,7 @@ export default flow(
 				sitePlan,
 				hasPremiumPlan,
 				hasBusinessPlan,
+				isPaidPlan: isCurrentPlanPaid( state, selectedSiteId ),
 				isJetpackSite: isJetpackSite( state, selectedSiteId ),
 				jetpackNonAtomic:
 					isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),

--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,7 @@
 		"upsell/troubleshooting": true,
 		"woocommerce/extension-referrers": true,
 		"woocommerce/store-on-non-atomic-sites": true,
+		"woop": true,
 		"wpcom-user-bootstrap": false,
 		"wordpress-action-search": false,
 		"redirect-fallback-browsers": true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [x] Changes wording to suggest any paid plan
* [x] Points at the plan selection screen instead of checkout with a business plan

#### Testing instructions

This banner appears in two places with similar but different code. 

* Testing on a free site, the banners should both now point at the new link and suggest any paid plan.
* Testing on a premium plan, the banner should be hidden with the flag enabled.
* An individual plugin page
* ^ With flag http://calypso.localhost:3000/plugins/woocommerce/wooptest1.wordpress.com?flags=woop
* ^ Without flag http://calypso.localhost:3000/plugins/woocommerce/wooptest1.wordpress.com?flags=-woop
* The plugins home page 
* ^ With flag http://calypso.localhost:3000/plugins/manage/wooptest1.wordpress.com?flags=woop
* ^ Without flag http://calypso.localhost:3000/plugins/manage/wooptest1.wordpress.com?flags=-woop

Before
![Screenshot 2021-09-02 at 12-15-11 WooCommerce Plugin ‹ Woop Test 1 — WordPress com](https://user-images.githubusercontent.com/811776/131770513-9ad8428f-29f1-4830-95db-a8f13c2afb1e.png)

After
![Screenshot 2021-09-02 at 12-23-28 WooCommerce Plugin ‹ Free - Simple Site — WordPress com](https://user-images.githubusercontent.com/811776/131771206-0935a9fb-017a-4dac-8722-44c154038550.png)

Related to #55917