### PR TITLE
Enable the Install button on premium and personal plans

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import {
 	findFirstSimilarPlanKey,
 	FEATURE_UPLOAD_PLUGINS,
@@ -123,8 +123,9 @@ export class PluginMeta extends Component {
 			return false;
 		}
 		return (
-			isPersonal( this.props.selectedSite.plan ) ||
-			isPremium( this.props.selectedSite.plan ) ||
+			( isEnabled( 'woop' ) &&
+				( isPersonal( this.props.selectedSite.plan ) ||
+					isPremium( this.props.selectedSite.plan ) ) ) ||
 			isBusiness( this.props.selectedSite.plan ) ||
 			isEnterprise( this.props.selectedSite.plan ) ||
 			isEcommerce( this.props.selectedSite.plan )

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -6,6 +6,8 @@ import {
 	isBusiness,
 	isEcommerce,
 	isEnterprise,
+	isPremium,
+	isPersonal,
 } from '@automattic/calypso-products';
 import { Button, Card, CompactCard } from '@automattic/components';
 import classNames from 'classnames';
@@ -121,6 +123,8 @@ export class PluginMeta extends Component {
 			return false;
 		}
 		return (
+			isPersonal( this.props.selectedSite.plan ) ||
+			isPremium( this.props.selectedSite.plan ) ||
 			isBusiness( this.props.selectedSite.plan ) ||
 			isEnterprise( this.props.selectedSite.plan ) ||
 			isEcommerce( this.props.selectedSite.plan )


### PR DESCRIPTION
This likely won't be merged, simply needed something to test out D66270-code easily / explore the AT process a bit.

#### Changes proposed in this Pull Request

* [x] Enable the Install button on any paid plan.

#### Testing instructions

* Test the Install button is enabled on a test site with a premium plan.
* With flag http://calypso.localhost:3000/plugins/woocommerce/wooptest1.wordpress.com?flags=woop
* Without flag http://calypso.localhost:3000/plugins/woocommerce/wooptest1.wordpress.com?flags=-woop

Clicking the button should stall out the first time and rest quickly after a page reset. (The request fails on the backend, this is expected.)

Before
![Screenshot 2021-09-02 at 12-44-06 WooCommerce Plugin ‹ Woop Test 1 — WordPress com](https://user-images.githubusercontent.com/811776/131773370-3360bb6e-ee05-4e77-a1d9-93dfd95f0838.png)

After
![Screenshot 2021-09-02 at 12-43-54 WooCommerce Plugin ‹ Woop Test 1 — WordPress com](https://user-images.githubusercontent.com/811776/131773378-3887a192-231e-4129-9805-1552b347ce36.png)


Related to #
