### PR TITLE
Remove wpcom.undocumented() methods for retrieving and removing purchases

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -40,10 +40,6 @@ UndocumentedMe.prototype.getReceipt = function ( receiptId, queryOrCallback ) {
 	);
 };
 
-UndocumentedMe.prototype.purchases = function ( callback ) {
-	return this.wpcom.req.get( '/me/purchases', callback );
-};
-
 UndocumentedMe.prototype.sendSMSValidationCode = function ( callback ) {
 	const args = {
 		apiVersion: '1.1',
@@ -249,17 +245,6 @@ UndocumentedMe.prototype.newValidationAccountRecoveryEmail = function ( callback
 	};
 
 	return this.wpcom.req.post( args, callback );
-};
-
-UndocumentedMe.prototype.deletePurchase = function ( purchaseId, fn ) {
-	debug( '/me/purchases/{purchaseId}/delete' );
-
-	return this.wpcom.req.post(
-		{
-			path: `/me/purchases/${ purchaseId }/delete`,
-		},
-		fn
-	);
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1832,11 +1832,6 @@ Undocumented.prototype.changeTheme = function ( siteSlug, data, fn ) {
 	);
 };
 
-Undocumented.prototype.sitePurchases = function ( siteId, fn ) {
-	debug( '/site/:site_id/purchases' );
-	return this.wpcom.req.get( { path: '/sites/' + siteId + '/purchases' }, fn );
-};
-
 Undocumented.prototype.resetPasswordForMailbox = function ( domainName, mailbox, fn ) {
 	debug( '/domains/:domainName/google-apps/:mailbox/get-new-password' );
 	return this.wpcom.req.post(

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -22,6 +22,9 @@ jest.mock( 'calypso/lib/wp', () => ( {
 		getSitePlans: () => {},
 		getSiteFeatures: () => {},
 	} ),
+	req: {
+		get: () => Promise.reject( new Error( '.get() not implemented in mock' ) ),
+	},
 } ) );
 
 const emptyResponseCart = getEmptyResponseCart();

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -1,5 +1,5 @@
 import i18n from 'i18n-calypso';
-import wp from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import {
 	PURCHASES_REMOVE,
 	PURCHASES_SITE_FETCH,
@@ -16,8 +16,6 @@ import { requestHappychatEligibility } from 'calypso/state/happychat/user/action
 
 import 'calypso/state/purchases/init';
 
-const wpcom = wp.undocumented();
-
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );
 const PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
 
@@ -32,11 +30,8 @@ export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
 		siteId,
 	} );
 
-	return new Promise( ( resolve, reject ) => {
-		wpcom.sitePurchases( siteId, ( error, data ) => {
-			error ? reject( error ) : resolve( data );
-		} );
-	} )
+	return wpcom.req
+		.get( `/sites/${ siteId }/purchases` )
 		.then( ( data ) => {
 			dispatch( {
 				type: PURCHASES_SITE_FETCH_COMPLETED,
@@ -57,11 +52,8 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 		type: PURCHASES_USER_FETCH,
 	} );
 
-	return new Promise( ( resolve, reject ) => {
-		wpcom.me().purchases( ( error, data ) => {
-			error ? reject( error ) : resolve( data );
-		} );
-	} )
+	return wpcom.req
+		.get( '/me/purchases' )
 		.then( ( data ) => {
 			dispatch( {
 				type: PURCHASES_USER_FETCH_COMPLETED,
@@ -78,11 +70,8 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 };
 
 export const removePurchase = ( purchaseId, userId ) => ( dispatch ) => {
-	return new Promise( ( resolve, reject ) => {
-		wpcom.me().deletePurchase( purchaseId, ( error, data ) => {
-			error ? reject( error ) : resolve( data );
-		} );
-	} )
+	return wpcom.req
+		.post( `/me/purchases/${ purchaseId }/delete` )
 		.then( ( data ) => {
 			dispatch( {
 				type: PURCHASE_REMOVE_COMPLETED,


### PR DESCRIPTION
Removes the `wpcom.undocumented()` `.sitePurchases()`, `.me().purchases()` and `.me().deletePurchase()` methods and replaces their usages with direct `wpcom.req` calls.

**How to test:**
Verify that fetching and deleting purchases still works, and that these three methods were used only at one place: the `purchases/actions` thunks.