### PR TITLE
Use flags to control the destination of onboarding flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -11,7 +11,6 @@ export function generateFlows( {
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 	getImportDestination = noop,
-	getSetupSiteDestination = noop,
 } = {} ) {
 	const flows = [
 		{
@@ -114,9 +113,7 @@ export function generateFlows( {
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ 'user', 'domains', 'emails', 'plans' ]
 				: [ 'user', 'domains', 'plans' ],
-			destination: isEnabled( 'signup/setup-site-after-checkout' )
-				? getSetupSiteDestination
-				: getSignupDestination,
+			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
 			showRecaptcha: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -11,6 +11,7 @@ export function generateFlows( {
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 	getImportDestination = noop,
+	getSetupSiteDestination = noop,
 } = {} ) {
 	const flows = [
 		{
@@ -113,7 +114,9 @@ export function generateFlows( {
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ 'user', 'domains', 'emails', 'plans' ]
 				: [ 'user', 'domains', 'plans' ],
-			destination: getSignupDestination,
+			destination: isEnabled( 'signup/setup-site-after-checkout' )
+				? getSetupSiteDestination
+				: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
 			showRecaptcha: true,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -89,6 +89,14 @@ function getImportDestination( { importSiteEngine, importSiteUrl, siteSlug } ) {
 	);
 }
 
+function getSetupSiteDestination( { siteSlug } ) {
+	if ( 'no-site' === siteSlug ) {
+		return '/home';
+	}
+
+	return addQueryArgs( { siteSlug }, '/start/setup-site' );
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -98,6 +106,7 @@ const flows = generateFlows( {
 	getChecklistThemeDestination,
 	getEditorDestination,
 	getImportDestination,
+	getSetupSiteDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { get, includes, reject } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
@@ -54,12 +55,16 @@ function getRedirectDestination( dependencies ) {
 	return '/';
 }
 
-function getSignupDestination( dependencies ) {
-	if ( 'no-site' === dependencies.siteSlug ) {
+function getSignupDestination( { siteSlug } ) {
+	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
 
-	return `/home/${ dependencies.siteSlug }`;
+	if ( isEnabled( 'signup/setup-site-after-checkout' ) ) {
+		return addQueryArgs( { siteSlug }, '/start/setup-site' );
+	}
+
+	return `/home/${ siteSlug }`;
 }
 
 function getLaunchDestination( dependencies ) {
@@ -89,14 +94,6 @@ function getImportDestination( { importSiteEngine, importSiteUrl, siteSlug } ) {
 	);
 }
 
-function getSetupSiteDestination( { siteSlug } ) {
-	if ( 'no-site' === siteSlug ) {
-		return '/home';
-	}
-
-	return addQueryArgs( { siteSlug }, '/start/setup-site' );
-}
-
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -106,7 +103,6 @@ const flows = generateFlows( {
 	getChecklistThemeDestination,
 	getEditorDestination,
 	getImportDestination,
-	getSetupSiteDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/config/development.json
+++ b/config/development.json
@@ -151,6 +151,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
+		"signup/setup-site-after-checkout": false,
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,6 +102,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
+		"signup/setup-site-after-checkout": false,
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -110,6 +110,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
+		"signup/setup-site-after-checkout": false,
 		"site-indicator": true,
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,6 +111,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
+		"signup/setup-site-after-checkout": false,
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,6 +120,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
+		"signup/setup-site-after-checkout": false,
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use flag `signup/setup-site-after-checkout` to decide final destination of onboarding flow. Then, we can let the user go to the design picker after checkout.
* The function `getSignupDestination` is used by lots of flow and it cannot get the flow name from arguments. So, I don't check the flag at that time and use the current approach. I'm not sure it's easy or not if we want to do the experiment by `loadExperimentAssignment` in the future.
* As discussed in p1630579029091000/1630576003.088500-slack-C029SB8JT8S, keep the current flow to stay on the plans page if the user hasn’t completed their purchase (maybe close the checkout page or remove paid plan from cart)

https://user-images.githubusercontent.com/13596067/131818138-62f92e65-4f0a-434d-a380-7aea9132a789.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=signup/setup-site-after-checkout`
* Complete the onboarding flow with free/paid plan
* Check final destination is `Choose a design` or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55784