### PR TITLE
Fix site selector style in inline help

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -261,9 +261,6 @@
 	}
 
 	.sites-dropdown {
-		.site-selector .search {
-			top: 51px;
-		}
 		.site-selector__sites {
 			max-height: 20vh;
 		}


### PR DESCRIPTION
Fixes broken style that offsets the search box in Inline Help:

<img width="325" alt="Screenshot 2021-09-02 at 11 22 03" src="https://user-images.githubusercontent.com/664258/131826533-1d929f50-4f36-47d7-8abd-3cec0f9ee8b5.png">

After the patch, the search box is at the right place:

<img width="326" alt="Screenshot 2021-09-02 at 12 03 55" src="https://user-images.githubusercontent.com/664258/131826597-8f1e80c5-971c-4826-b8fc-256c4732f89c.png">
