### PR TITLE
chore: Drop chai-enzyme dependency

### DIFF
--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -34,9 +34,9 @@ describe( 'AppPromo', () => {
 		test( 'should render the primary components', () => {
 			const wrapper = shallow( AppPromoComponent );
 
-			expect( wrapper ).to.have.descendants( '.app-promo' );
-			expect( wrapper ).to.have.descendants( '.app-promo__dismiss' );
-			expect( wrapper ).to.have.descendants( '.app-promo__icon' );
+			expect( wrapper.find( '.app-promo' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( '.app-promo__dismiss' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( '.app-promo__icon' ) ).to.have.lengthOf( 1 );
 		} );
 
 		test( 'should render the promo text', () => {
@@ -50,7 +50,7 @@ describe( 'AppPromo', () => {
 
 			const promoLink = wrapper.find( '.app-promo__link' );
 			expect( promoLink ).to.have.lengthOf( 1 );
-			expect( promoLink ).to.have.prop( 'href' ).equal( appPromoLink );
+			expect( promoLink.prop( 'href' ) ).to.equal( appPromoLink );
 		} );
 	} );
 

--- a/client/components/count/test/index.jsx
+++ b/client/components/count/test/index.jsx
@@ -7,7 +7,7 @@ import { Count } from '../';
 describe( 'Count', () => {
 	test( 'should use the correct class name', () => {
 		const count = shallow( <Count count={ 23 } numberFormat={ ( string ) => string } /> );
-		expect( count ).to.have.className( 'count' );
+		expect( count.hasClass( 'count' ) ).to.equal( true );
 	} );
 
 	test( 'should call provided as prop numberFormat function', () => {

--- a/client/components/forms/form-text-input/test/index.jsx
+++ b/client/components/forms/form-text-input/test/index.jsx
@@ -8,29 +8,29 @@ describe( '<FormTextInput />', () => {
 	test( 'should add the provided class names', () => {
 		const wrapper = shallow( <FormTextInput className="test" isError isValid /> );
 
-		expect( wrapper ).to.have.className( 'test' );
-		expect( wrapper ).to.have.className( 'is-error' );
-		expect( wrapper ).to.have.className( 'is-valid' );
+		expect( wrapper.hasClass( 'test' ) ).to.equal( true );
+		expect( wrapper.hasClass( 'is-error' ) ).to.equal( true );
+		expect( wrapper.hasClass( 'is-valid' ) ).to.equal( true );
 	} );
 
 	test( 'should have form-text-input class name', () => {
 		const wrapper = shallow( <FormTextInput /> );
 
-		expect( wrapper ).to.have.className( 'form-text-input' );
+		expect( wrapper.hasClass( 'form-text-input' ) ).to.equal( true );
 	} );
 
 	test( "should not pass component's own props down to the input", () => {
 		const wrapper = shallow( <FormTextInput isValid isError selectOnFocus /> );
 
-		expect( wrapper ).to.not.have.prop( 'isValid' );
-		expect( wrapper ).to.not.have.prop( 'isError' );
-		expect( wrapper ).to.not.have.prop( 'selectOnFocus' );
+		expect( wrapper.prop( 'isValid' ) ).to.equal( undefined );
+		expect( wrapper.prop( 'isError' ) ).to.equal( undefined );
+		expect( wrapper.prop( 'selectOnFocus' ) ).to.equal( undefined );
 	} );
 
 	test( "should pass props aside from component's own to the input", () => {
 		const wrapper = shallow( <FormTextInput placeholder="test placeholder" /> );
 
-		expect( wrapper ).to.have.prop( 'placeholder' );
+		expect( wrapper.prop( 'placeholder' ) ).to.equal( 'test placeholder' );
 	} );
 
 	test( 'should call select if selectOnFocus is true', () => {

--- a/client/components/sub-masterbar-nav/test/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/test/dropdown.jsx
@@ -19,8 +19,8 @@ describe( 'Dropdown', () => {
 		const select = wrapper.find( '.sub-masterbar-nav__select' );
 		const selected = select.find( Item );
 
-		expect( selected ).prop( 'label' ).to.equal( 'Select option' );
-		expect( selected ).prop( 'icon' ).to.equal( 'home' );
+		expect( selected.prop( 'label' ) ).to.equal( 'Select option' );
+		expect( selected.prop( 'icon' ) ).to.equal( 'home' );
 
 		const list = wrapper.find( '.sub-masterbar-nav__items' );
 		const items = list.find( Item );

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
 		"caniuse-lite": "^1.0.30001173",
 		"capture-website": "^1.0.0",
 		"chai": "^4.3.4",
-		"chai-enzyme": "^1.0.0-beta.1",
 		"chalk": "^4.0.0",
 		"check-node-version": "^4.0.2",
 		"cheerio": "^1.0.0-rc.3",

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -27,11 +27,6 @@ jest.mock( 'enzyme', () => {
 	if ( ! mockEnzymeSetup ) {
 		mockEnzymeSetup = true;
 
-		// configure custom enzyme matchers for chai
-		const chai = jest.requireActual( 'chai' );
-		const chaiEnzyme = jest.requireActual( 'chai-enzyme' );
-		chai.use( chaiEnzyme() );
-
 		// configure custom Enzyme matchers for Jest
 		jest.requireActual( 'jest-enzyme' );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12852,21 +12852,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai-enzyme@npm:^1.0.0-beta.1":
-  version: 1.0.0-beta.1
-  resolution: "chai-enzyme@npm:1.0.0-beta.1"
-  dependencies:
-    html: ^1.0.0
-  peerDependencies:
-    chai: ^3.0.0 || ^4.0.0
-    cheerio: 0.19.x || 0.20.x || 0.22.x || ^1.0.0-0
-    enzyme: ^2.7.0 || ^3.0.0
-    react: ^0.14.0 || ^15.0.0-0 || ^16.0.0-0
-    react-dom: ^0.14.0 || ^15.0.0-0 || ^16.0.0-0
-  checksum: c7d11e4444336b44d42c6cce4e9a7f7e08bb8a97fdbb8bd0a10e0bf2bf441af2dc601e03031ec13e4969191c125308e3be81703cb5b3129c275b0976b2e78c1a
-  languageName: node
-  linkType: hard
-
 "chai@npm:^4.3.4":
   version: 4.3.4
   resolution: "chai@npm:4.3.4"
@@ -21012,17 +20997,6 @@ fsevents@~2.1.2:
   peerDependencies:
     webpack: ^5.1.2
   checksum: f4fbf49f8449a0bf9bb4078640e9c0df503c9f28db3bc8f494ed70cc4a485d456f89f27a67d770825268fe595c58d5c09939688e504619979741903a3131b2d5
-  languageName: node
-  linkType: hard
-
-"html@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "html@npm:1.0.0"
-  dependencies:
-    concat-stream: ^1.4.7
-  bin:
-    html: ./bin/html.js
-  checksum: ae6e2e2f9c4de666c1b3133d96e33655327fc7d720480898bf5f486e8f2fd3398771ecf2a34491c2c486e603b7ae4009b9ab08f536ba60be7c8749fd6b8ce26a
   languageName: node
   linkType: hard
 
@@ -40064,7 +40038,6 @@ typescript@^4.3.5:
     caniuse-lite: ^1.0.30001173
     capture-website: ^1.0.0
     chai: ^4.3.4
-    chai-enzyme: ^1.0.0-beta.1
     chalk: ^4.0.0
     check-node-version: ^4.0.2
     cheerio: ^1.0.0-rc.3


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Drops `chai-enzyme`. This package is abandoned (last commit is from Jun 2018) and doesn't support React 17.

We were using it only in a few tests, I've manually converted them to regular enzyme + chai assertions
