### PR TITLE
/plans: Append ref param if it exists

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -623,13 +623,12 @@ export default function pages() {
 					res.redirect(
 						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
 					);
+				} else {
+					const pricingPageUrl = ref
+						? `https://wordpress.com/pricing/?ref=${ ref }`
+						: 'https://wordpress.com/pricing';
+					res.redirect( pricingPageUrl );
 				}
-
-				if ( ref ) {
-					res.redirect( `https://wordpress.com/pricing/?ref=${ ref }` );
-				}
-
-				res.redirect( 'https://wordpress.com/pricing' );
 			} else {
 				next();
 			}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -617,14 +617,19 @@ export default function pages() {
 		app.get( '/plans', function ( req, res, next ) {
 			if ( ! req.context.isLoggedIn ) {
 				const queryFor = req.query?.for;
+				const ref = req.query?.ref;
 
 				if ( queryFor && 'jetpack' === queryFor ) {
 					res.redirect(
 						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
 					);
-				} else {
-					res.redirect( 'https://wordpress.com/pricing' );
 				}
+
+				if ( ref ) {
+					res.redirect( `https://wordpress.com/pricing/?ref=${ ref }` );
+				}
+
+				res.redirect( 'https://wordpress.com/pricing' );
 			} else {
 				next();
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When /plans is accessed in a logged out context, then we redirect to wordpress.com/pricing. This PR will carry over a `ref` param if it exists from the /plans URL to the /pricing URL. 

Context - pxWta-10d#comment-5146

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally and edit the following line locally to allow for execution in development environment:
https://github.com/Automattic/wp-calypso/blob/e377bbdbf9d0e4b90ab04938b8535486ba1bc131/client/server/pages/index.js#L599

In the above line, locally edit the `if` condition to:
```
if ( process.env.NODE_ENV === 'development' ) {
```

* Now run `yarn start` (hot update won't work, so you need. to run yarn start)
* While logged out of WP.com, visit `http://calypso.localhost:3000/plans` and verify that you are redirected to `https://wordpress.com/pricing`.
* While logged out of WP.com, visit `http://calypso.localhost:3000/plans/?ref=something` and verify that you are redirected to `https://wordpress.com/pricing/?ref=something`.
* While logged out of WP.com, visit `http://calypso.localhost:3000/plans/?for=jetpack` and verify that you redirected to the login page.
* While logged in, visit  `http://calypso.localhost:3000/plans/?ref=something` and you should be taken to Calypso's plans page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


