### PR TITLE
wpcom editor e2e's - dismiss welcome tour card

### DIFF
--- a/test/e2e/lib/components/guide-component.js
+++ b/test/e2e/lib/components/guide-component.js
@@ -8,6 +8,7 @@ export default class GuideComponent extends AsyncBaseContainer {
 	}
 
 	async dismiss( waitOverride, selector = '.components-guide' ) {
+		// There are two versions of the guide.  Firse we check for the modal version.
 		if (
 			await driverHelper.isElementEventuallyLocatedAndVisible(
 				this.driver,
@@ -30,6 +31,20 @@ export default class GuideComponent extends AsyncBaseContainer {
 					By.css( '.components-guide__finish-button' )
 				);
 			}
+		}
+		// We must also check for the card based version of the welcome guide.
+		if (
+			await driverHelper.isElementEventuallyLocatedAndVisible(
+				this.driver,
+				By.css( '.wpcom-editor-welcome-tour-frame' ),
+				waitOverride
+			)
+		) {
+			const skipButtonLocator = driverHelper.createTextLocator(
+				By.css( '.wpcom-editor-welcome-tour-frame button' ),
+				'Skip'
+			);
+			await driverHelper.clickWhenClickable( this.driver, skipButtonLocator );
 		}
 	}
 }

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { By } from 'selenium-webdriver';
+import GuideComponent from '../../components/guide-component';
 import SiteEditorComponent from '../../components/site-editor-component';
 import * as driverHelper from '../../driver-helper';
 import GutenbergEditorComponent from '../gutenberg-editor-component';
@@ -19,6 +20,8 @@ export function createGeneralTests( { it, editorType, postType, baseContext = un
 			true,
 			'Tracking events stack missing from window._e2eEventsStack'
 		);
+		const editorWelcomeModal = new GuideComponent( this.driver );
+		await editorWelcomeModal.dismiss( 200 );
 	} );
 
 	it( 'Make sure required and custom properties are added to the events', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The welcome tour card has been intercepting clicks in the `specs/specs-wpcom/wp-calypso-gutenberg-page-editor-tracking-spec.js` test on mobile viewports (p1630533009067300-slack-C7YPUHBB2).  Here we update the guide component to handle the card version of the welcome tour as well.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify the welcome card is dismissed when running the above mentioned test suite.  (im currently having issues testing this locally, unable to get tests past login screen 🤔 )

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
