### PR TITLE
Remove unused getCart/setCart undocumented functions

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -877,44 +877,6 @@ Undocumented.prototype.getSiteFeatures = function ( siteDomain, fn ) {
 };
 
 /**
- * Get cart.
- *
- * @param {string} cartKey The cart's key.
- * @param {Function} fn The callback function.
- */
-Undocumented.prototype.getCart = function ( cartKey, fn ) {
-	debug( 'GET: /me/shopping-cart/:cart-key' );
-
-	return this._sendRequest(
-		{
-			path: '/me/shopping-cart/' + cartKey,
-			method: 'GET',
-		},
-		fn
-	);
-};
-
-/**
- * Set cart.
- *
- * @param {string} cartKey The cart's key.
- * @param {object} data The POST data.
- * @param {Function} fn The callback function.
- */
-Undocumented.prototype.setCart = function ( cartKey, data, fn ) {
-	debug( 'POST: /me/shopping-cart/:cart-key', data );
-
-	return this._sendRequest(
-		{
-			path: '/me/shopping-cart/' + cartKey,
-			method: 'POST',
-			body: data,
-		},
-		fn
-	);
-};
-
-/**
  * Get a list of the user's stored cards
  *
  * @param {Function} [fn] The callback function.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As all shopping cart API calls now use `wp.req` directly for calls to the `/me/shopping-cart` endpoint, this PR removes the `wp.undocumented` functions `getCart` and `setCart` which are otherwise unused.

This is part of an effort to remove uses of `wp.undocumented` as it is deprecated and will be removed.

#### Testing instructions

Just make sure that `getCart` and `setCart` are not used anywhere. (I used the command `rg --type js --type ts -w --color=always .etCart client` but feel free to use your own method of searching.)