### PR TITLE
Remove Calendly Scheduling URL From Non-Production Environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"difm_typeform_id": "lU7xT1zM",
 	"features": {
 		"activity-log/display-rules": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"difm_typeform_id": "",
 	"features": {
 		"automated-transfer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/jetpack-onboarding-call-test",
 	"difm_typeform_id": "lU7xT1zM",
 	"features": {
 		"ad-tracking": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Remove Calendly from non-production environments

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Boot branch
2. Navigate to `/checkout/jetpack/thank-you/no-site/jetpack_backup_daily`
3. Verify the Scheduling Widget does not appear to right
<img width="1190" alt="Screen Shot 2021-09-02 at 10 21 45 AM" src="https://user-images.githubusercontent.com/2810519/131889029-195d422c-e8ae-48eb-854b-0c2a3cffbfa2.png">
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

