### PR TITLE
`InlineHelp`: remove usage of `support_type`

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -442,7 +442,5 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 		}
 	} );
 
-	return [ ...exactMatches, ...partialMatches, ...synonymMatches ]
-		.map( ( item ) => ( { ...item, key: item.title } ) )
-		.slice( 0, limit );
+	return [ ...exactMatches, ...partialMatches, ...synonymMatches ].slice( 0, limit );
 }

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -4,7 +4,6 @@ import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import { getCustomizerUrl } from 'calypso/state/sites/selectors';
-import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
 
 /**
  * Returns admin section items with site-based urls.
@@ -444,6 +443,6 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 	} );
 
 	return [ ...exactMatches, ...partialMatches, ...synonymMatches ]
-		.map( ( item ) => ( { ...item, support_type: SUPPORT_TYPE_ADMIN_SECTION, key: item.title } ) )
+		.map( ( item ) => ( { ...item, key: item.title } ) )
 		.slice( 0, limit );
 }

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -106,7 +106,7 @@ function HelpSearchResults( {
 	};
 
 	const renderHelpLink = ( result, type ) => {
-		const { link, title, icon = 'domains', post_id } = result;
+		const { link, title, icon, post_id } = result;
 
 		const external = externalLinks && type !== SUPPORT_TYPE_ADMIN_SECTION;
 
@@ -140,7 +140,7 @@ function HelpSearchResults( {
 								rel: 'noreferrer',
 							} ) }
 						>
-							{ type === SUPPORT_TYPE_ADMIN_SECTION && <Gridicon icon={ icon } size={ 18 } /> }
+							{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 							<span>{ preventWidows( decodeEntities( title ) ) }</span>
 						</a>
 					</div>

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -80,10 +80,10 @@ function HelpSearchResults( {
 		}
 	}, [ isSearching, hasAPIResults, searchQuery ] );
 
-	const onLinkClickHandler = ( event, result ) => {
-		const { support_type: supportType, link } = result;
+	const onLinkClickHandler = ( event, result, type ) => {
+		const { link } = result;
 		// check and catch admin section links.
-		if ( supportType === SUPPORT_TYPE_ADMIN_SECTION && link ) {
+		if ( type === SUPPORT_TYPE_ADMIN_SECTION && link ) {
 			// record track-event.
 			dispatch(
 				recordTracksEvent( 'calypso_inlinehelp_admin_section_visit', {
@@ -105,17 +105,10 @@ function HelpSearchResults( {
 		onSelect( event, result );
 	};
 
-	const renderHelpLink = ( result ) => {
-		const {
-			link,
-			key,
-			title,
-			support_type = SUPPORT_TYPE_API_HELP,
-			icon = 'domains',
-			post_id,
-		} = result;
+	const renderHelpLink = ( result, type ) => {
+		const { link, key, title, icon = 'domains', post_id } = result;
 
-		const external = externalLinks && support_type !== SUPPORT_TYPE_ADMIN_SECTION;
+		const external = externalLinks && type !== SUPPORT_TYPE_ADMIN_SECTION;
 
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
@@ -140,16 +133,14 @@ function HelpSearchResults( {
 								if ( ! external ) {
 									event.preventDefault();
 								}
-								onLinkClickHandler( event, result );
+								onLinkClickHandler( event, result, type );
 							} }
 							{ ...( external && {
 								target: '_blank',
 								rel: 'noreferrer',
 							} ) }
 						>
-							{ support_type === SUPPORT_TYPE_ADMIN_SECTION && (
-								<Gridicon icon={ icon } size={ 18 } />
-							) }
+							{ type === SUPPORT_TYPE_ADMIN_SECTION && <Gridicon icon={ icon } size={ 18 } /> }
 							<span>{ preventWidows( decodeEntities( title ) ) }</span>
 						</a>
 					</div>
@@ -169,7 +160,7 @@ function HelpSearchResults( {
 					</h3>
 				) : null }
 				<ul className="inline-help__results-list" aria-labelledby={ title ? id : undefined }>
-					{ results.map( renderHelpLink ) }
+					{ results.map( ( result ) => renderHelpLink( result, type ) ) }
 				</ul>
 			</Fragment>
 		) : null;

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -106,7 +106,7 @@ function HelpSearchResults( {
 	};
 
 	const renderHelpLink = ( result, type ) => {
-		const { link, key, title, icon = 'domains', post_id } = result;
+		const { link, title, icon = 'domains', post_id } = result;
 
 		const external = externalLinks && type !== SUPPORT_TYPE_ADMIN_SECTION;
 
@@ -124,7 +124,7 @@ function HelpSearchResults( {
 		}
 
 		return (
-			<Fragment key={ link ?? key }>
+			<Fragment key={ link ?? title }>
 				<li className="inline-help__results-item">
 					<div className="inline-help__results-cell">
 						<a

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -35,7 +35,6 @@ describe( 'filterListBySearchTerm()', () => {
 			{
 				description: 'Better than that other section.',
 				icon: 'beta',
-				key: 'The best section',
 				link: '/best/section/eva',
 				synonyms: [ 'yolo', 'gud' ],
 				title: 'The best section',
@@ -49,7 +48,6 @@ describe( 'filterListBySearchTerm()', () => {
 			{
 				description: 'Better than that other section.',
 				icon: 'beta',
-				key: 'The best section',
 				link: '/best/section/eva',
 				synonyms: [ 'yolo', 'gud' ],
 				title: 'The best section',
@@ -63,7 +61,6 @@ describe( 'filterListBySearchTerm()', () => {
 			{
 				description: 'Better than that other section.',
 				icon: 'beta',
-				key: 'The best section',
 				link: '/best/section/eva',
 				synonyms: [ 'yolo', 'gud' ],
 				title: 'The best section',

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -39,7 +39,6 @@ describe( 'filterListBySearchTerm()', () => {
 				link: '/best/section/eva',
 				synonyms: [ 'yolo', 'gud' ],
 				title: 'The best section',
-				support_type: 'admin_section',
 			},
 		] );
 	} );
@@ -54,7 +53,6 @@ describe( 'filterListBySearchTerm()', () => {
 				link: '/best/section/eva',
 				synonyms: [ 'yolo', 'gud' ],
 				title: 'The best section',
-				support_type: 'admin_section',
 			},
 		] );
 	} );
@@ -69,7 +67,6 @@ describe( 'filterListBySearchTerm()', () => {
 				link: '/best/section/eva',
 				synonyms: [ 'yolo', 'gud' ],
 				title: 'The best section',
-				support_type: 'admin_section',
 			},
 		] );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove usage of `support_type` property for Inline Help result sections

#### Testing instructions

* Open the Inline Help widget (blue FAB button on the bottom right)
* Make sure contextual results are shown as on prod
* Perform a search and verify search results and admin results are shown as on prod

Follow up to #55753
