### PR TITLE
Webpack: Reqire process.js for polyfills

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -251,6 +251,7 @@
 		"component-query": "^0.0.3",
 		"pkg-dir": "^5.0.0",
 		"postcss-custom-properties": "^11.0.0",
+		"process": "^0.11.10",
 		"react-test-renderer": "^16.12.0",
 		"redux-mock-store": "^1.5.4"
 	}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -257,8 +257,6 @@ const webpackConfig = {
 			// importing `./client/file.js` is the same thing than importing `calypso/file.js`
 			calypso: __dirname,
 
-			// Node polyfills
-			process: 'process/browser',
 			util: findPackage( 'util/' ), //Trailing `/` stops node from resolving it to the built-in module
 		} ),
 	},
@@ -275,8 +273,9 @@ const webpackConfig = {
 			__i18n_text_domain__: JSON.stringify( 'default' ),
 			global: 'window',
 		} ),
+		// Node polyfills
 		new webpack.ProvidePlugin( {
-			process: 'process/browser',
+			process: 'process/browser.js',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12758,6 +12758,7 @@ __metadata:
     postcss: ^8.2.6
     postcss-custom-properties: ^11.0.0
     prismjs: ^1.17.1
+    process: ^0.11.10
     prop-types: ^15.7.2
     qrcode.react: ^1.0.0
     qs: ^6.9.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In #54793, a dependency is introduced on `lib0`. This causes our webpack build to fail with the following error:

```
ERROR in ../node_modules/lib0/environment.js 14:29-36
Module not found: Error: Can't resolve 'process/browser' in '/home/nt/source/wp-calypso/node_modules/lib0'
Did you mean 'browser.js'?
BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve 'process/browser' in '/home/nt/source/wp-calypso/node_modules/lib0'
  Parsed request is a module
  using description file: /home/nt/source/wp-calypso/node_modules/lib0/package.json (relative path: .)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /home/nt/source/wp-calypso/node_modules/lib0/node_modules doesn't exist or is not a directory
      /home/nt/source/wp-calypso/node_modules/node_modules doesn't exist or is not a directory
      looking for modules in /home/nt/source/wp-calypso/node_modules
        existing directory /home/nt/source/wp-calypso/node_modules/process
          using description file: /home/nt/source/wp-calypso/node_modules/process/package.json (relative path: .)
            using description file: /home/nt/source/wp-calypso/node_modules/process/package.json (relative path: ./browser)
              Field 'browser' doesn't contain a valid alias configuration
              /home/nt/source/wp-calypso/node_modules/process/browser doesn't exist
      /home/nt/source/node_modules doesn't exist or is not a directory
      looking for modules in /home/nt/node_modules
        /home/nt/node_modules/process doesn't exist
      /home/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
 @ ../node_modules/lib0/buffer.js 8:0-39 77:24-37 80:26-39
 @ ../node_modules/yjs/dist/yjs.mjs 8:0-38 715:11-32
 @ ../node_modules/@automattic/isolated-block-editor/build-module/components/block-editor-contents/use-yjs/yjs-doc.js 1:0-27 13:18-25 38:24-45 101:32-55 116:10-25 121:10-25
```

Based on some investigation, this happens when `webpack` tries to alias the `process` variable in `lib0/environment.js`. Based on the error `The extension in the request is mandatory for it to be fully specified`, I changed `process/browser` polyfill to `process/browser.js` in our webpack config. This fixed the error in the React 17 PR.

Also, according to https://stackoverflow.com/a/65018686, it's helpful to add a dependency on `process` (though I'm not sure if this is needed), and we don't have to add the alias if we use `ProvidePlugin`.

### Testing instructions
CI should pass. Also try `yarn start` locally.
