### PR TITLE
Jetpack Search: Change customizer links to Customberg

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -34,7 +34,7 @@ import { downloadTrafficGuide } from 'calypso/my-sites/marketing/ultimate-traffi
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getJetpackSearchCustomizeUrl } from 'calypso/state/sites/selectors';
 import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgrade-intent';
 
 import './style.scss';
@@ -42,7 +42,6 @@ import './style.scss';
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
 		isAtomic: PropTypes.bool,
-		siteAdminUrl: PropTypes.string,
 		displayMode: PropTypes.string,
 		upgradeIntent: PropTypes.string,
 		selectedSite: PropTypes.object,
@@ -382,21 +381,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		page( domainManagementTransferInPrecheck( selectedSite.slug, primaryPurchase.meta ) );
 	};
 
-	goToCustomizer = ( event ) => {
-		event.preventDefault();
-		const { siteAdminUrl } = this.props;
-
-		if ( ! siteAdminUrl ) {
-			return;
-		}
-
+	recordThankYouClick = () => {
 		this.props.recordTracksEvent( 'calypso_jetpack_product_thankyou', {
 			product_name: 'search',
 			value: 'Customizer',
 			site: 'wpcom',
 		} );
-
-		window.location.href = siteAdminUrl + 'admin.php?page=jetpack-search-configure';
 	};
 
 	getButtonText = () => {
@@ -497,6 +487,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 	getButtons() {
 		const {
 			hasFailedPurchases,
+			jetpackSearchCustomizeUrl,
 			translate,
 			primaryPurchase,
 			purchases,
@@ -512,9 +503,14 @@ export class CheckoutThankYouHeader extends PureComponent {
 		if ( isSearch ) {
 			return (
 				<div className="checkout-thank-you__header-button">
-					<button className={ headerButtonClassName } onClick={ this.goToCustomizer }>
-						{ translate( 'Try Search and customize it now' ) }
-					</button>
+					<Button
+						className={ headerButtonClassName }
+						primary
+						href={ jetpackSearchCustomizeUrl }
+						onClick={ this.recordThankYouClick }
+					>
+						{ translate( 'Customize Search' ) }
+					</Button>
 				</div>
 			);
 		}
@@ -645,7 +641,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
 		isAtomic: isAtomicSite( state, ownProps.selectedSite?.ID ),
-		siteAdminUrl: getSiteAdminUrl( state, ownProps.selectedSite?.ID ),
+		jetpackSearchCustomizeUrl: getJetpackSearchCustomizeUrl( state, ownProps.selectedSite?.ID ),
 	} ),
 	{
 		recordStartTransferClickInThankYou,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -396,7 +396,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			site: 'wpcom',
 		} );
 
-		window.location.href = siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search';
+		window.location.href = siteAdminUrl + 'admin.php?page=jetpack-search-configure';
 	};
 
 	getButtonText = () => {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
@@ -1,32 +1,22 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactElement, useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import versionCompare from 'calypso/lib/version-compare';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import React, { ReactElement } from 'react';
 import ThankYou, { ThankYouCtaType } from './thank-you';
 
 const ThankYouCta: ThankYouCtaType = ( {
 	dismissUrl,
-	jetpackVersion,
+	jetpackSearchCustomizeUrl,
 	recordThankYouClick,
-	siteAdminUrl,
 } ) => {
 	const translate = useTranslate();
 	return (
 		<>
 			<Button
 				primary
-				href={
-					jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
-						? siteAdminUrl + 'plugins.php'
-						: siteAdminUrl + 'admin.php?page=jetpack-search-configure'
-				}
+				href={ jetpackSearchCustomizeUrl }
 				onClick={ () => recordThankYouClick( 'search', 'customizer' ) }
 			>
-				{ jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
-					? translate( 'Update Jetpack' )
-					: translate( 'Try Search and customize it now' ) }
+				{ translate( 'Try Search and customize it now' ) }
 			</Button>
 			<Button href={ dismissUrl }>{ translate( 'Skip for now' ) }</Button>
 		</>
@@ -35,10 +25,6 @@ const ThankYouCta: ThankYouCtaType = ( {
 
 const SearchProductThankYou = (): ReactElement => {
 	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
-	const jetpackVersion = useMemo( () => selectedSite?.options?.jetpack_version || 0, [
-		selectedSite,
-	] );
 	return (
 		<ThankYou
 			illustration="/calypso/images/illustrations/thankYou.svg"
@@ -48,16 +34,10 @@ const SearchProductThankYou = (): ReactElement => {
 			<>
 				<p>{ translate( 'We are currently indexing your site.' ) }</p>
 				<p>
-					{ jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
-						? translate(
-								"In the meantime you'll need to update Jetpack to version 8.4 or higher in order " +
-									"to get the most out of Jetpack Search. Once you've updated Jetpack, " +
-									"we'll configure Search for you. You can try search and customize it to your liking."
-						  )
-						: translate(
-								'In the meantime, we have configured Jetpack Search on your site — ' +
-									'you should try customizing it in your traditional WordPress dashboard.'
-						  ) }
+					{ translate(
+						'In the meantime, we have configured Jetpack Search on your site — ' +
+							'you should try customizing it in your traditional WordPress dashboard.'
+					) }
 				</p>
 			</>
 		</ThankYou>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
@@ -20,7 +20,7 @@ const ThankYouCta: ThankYouCtaType = ( {
 				href={
 					jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
 						? siteAdminUrl + 'plugins.php'
-						: siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search'
+						: siteAdminUrl + 'admin.php?page=jetpack-search-configure'
 				}
 				onClick={ () => recordThankYouClick( 'search', 'customizer' ) }
 			>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.tsx
@@ -16,7 +16,7 @@ const ThankYouCta: ThankYouCtaType = ( {
 				href={ jetpackSearchCustomizeUrl }
 				onClick={ () => recordThankYouClick( 'search', 'customizer' ) }
 			>
-				{ translate( 'Try Search and customize it now' ) }
+				{ translate( 'Customize Search' ) }
 			</Button>
 			<Button href={ dismissUrl }>{ translate( 'Skip for now' ) }</Button>
 		</>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.tsx
@@ -35,7 +35,8 @@ const mapDispatchToProps = { recordTracksEvent, requestGuidedTour };
 
 export type ThankYouCtaType = React.FC< {
 	dismissUrl: string;
-	jetpackVersion: string;
+	jetpackSearchCustomizeUrl?: string;
+	jetpackVersion?: string;
 	recordThankYouClick: ( productName: string, value?: string ) => void;
 	siteAdminUrl: string;
 	startChecklistTour: () => void;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -45,7 +45,7 @@ import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedu
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getJetpackSearchCustomizeUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AntiSpamProductThankYou from './current-plan-thank-you/anti-spam-thank-you';
 import BackupProductThankYou from './current-plan-thank-you/backup-thank-you';
@@ -104,7 +104,7 @@ class CurrentPlan extends Component {
 	};
 
 	renderThankYou() {
-		const { currentPlan, product, selectedSite } = this.props;
+		const { currentPlan, jetpackSearchCustomizeUrl, product } = this.props;
 
 		if ( JETPACK_BACKUP_PRODUCTS.includes( product ) ) {
 			return <BackupProductThankYou />;
@@ -119,8 +119,7 @@ class CurrentPlan extends Component {
 		}
 
 		if ( JETPACK_SEARCH_PRODUCTS.includes( product ) ) {
-			const jetpackVersion = selectedSite?.options?.jetpack_version ?? 0;
-			return <SearchProductThankYou { ...{ jetpackVersion } } />;
+			return <SearchProductThankYou { ...{ jetpackSearchCustomizeUrl } } />;
 		}
 
 		if (
@@ -287,6 +286,7 @@ export default connect( ( state, { requestThankYou } ) => {
 		purchases,
 		hasDomainsLoaded: !! domains,
 		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+		jetpackSearchCustomizeUrl: getJetpackSearchCustomizeUrl( state, selectedSiteId ),
 		selectedSite,
 		selectedSiteId,
 		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -25,7 +25,7 @@ import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchas
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isDeactivatingJetpackModule from 'calypso/state/selectors/is-deactivating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getJetpackSearchCustomizeUrl } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -286,7 +286,7 @@ class Search extends Component {
 				</CompactCard>
 				{ hasSearchProduct && fields.instant_search_enabled && (
 					<CompactCard
-						href={ `${ this.props.siteAdminUrl }admin.php?page=jetpack-search-configure` }
+						href={ this.props.jetpackSearchCustomizeUrl }
 						target={ siteIsJetpack ? 'external' : null }
 					>
 						{ translate( 'Customize Search' ) }
@@ -340,8 +340,8 @@ export default connect( ( state, { isRequestingSettings } ) => {
 		hasSearchProduct,
 		isSearchEligible,
 		isLoading: isRequestingSettings || isFetchingSitePurchases( state ),
+		jetpackSearchCustomizeUrl: getJetpackSearchCustomizeUrl( state, siteId ),
 		site: getSelectedSite( state ),
-		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		siteIsJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import Banner from 'calypso/components/banner';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -54,6 +55,16 @@ class Search extends Component {
 		submitForm: PropTypes.func.isRequired,
 		updateFields: PropTypes.func.isRequired,
 	};
+
+	renderLoadingPlaceholder() {
+		return (
+			<Banner
+				jetpack={ this.props.siteIsJetpack }
+				disableHref
+				description={ this.props.translate( 'Loading your purchases…' ) }
+			/>
+		);
+	}
 
 	renderInfoLink( link ) {
 		return (
@@ -308,9 +319,15 @@ class Search extends Component {
 							: this.props.upgradeLink
 					) }
 				</SettingsSectionHeader>
-				{ ( this.props.hasSearchProduct || this.props.isSearchEligible ) &&
-					this.renderSettingsCard() }
-				{ ! this.props.hasSearchProduct && this.renderUpgradeNotice() }
+				{ this.props.isLoading ? (
+					this.renderLoadingPlaceholder()
+				) : (
+					<>
+						{ ( this.props.hasSearchProduct || this.props.isSearchEligible ) &&
+							this.renderSettingsCard() }
+						{ ! this.props.hasSearchProduct && this.renderUpgradeNotice() }
+					</>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -25,7 +25,7 @@ import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchas
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isDeactivatingJetpackModule from 'calypso/state/selectors/is-deactivating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import { isJetpackSite, getCustomizerUrl } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -286,7 +286,7 @@ class Search extends Component {
 				</CompactCard>
 				{ hasSearchProduct && fields.instant_search_enabled && (
 					<CompactCard
-						href={ this.props.customizerUrl }
+						href={ `${ this.props.siteAdminUrl }admin.php?page=jetpack-search-configure` }
 						target={ siteIsJetpack ? 'external' : null }
 					>
 						{ translate( 'Customize Search' ) }
@@ -337,11 +337,11 @@ export default connect( ( state, { isRequestingSettings } ) => {
 
 	return {
 		activatingSearchModule: activating || deactivating,
-		customizerUrl: getCustomizerUrl( state, siteId, 'jetpack_search' ),
 		hasSearchProduct,
 		isSearchEligible,
 		isLoading: isRequestingSettings || isFetchingSitePurchases( state ),
 		site: getSelectedSite( state ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		siteIsJetpack: isJetpackSite( state, siteId ),

--- a/client/state/sites/selectors/get-jetpack-search-customize-url.js
+++ b/client/state/sites/selectors/get-jetpack-search-customize-url.js
@@ -1,0 +1,30 @@
+import versionCompare from 'calypso/lib/version-compare';
+import { getSiteAdminUrl, getJetpackVersion, isJetpackSite } from 'calypso/state/sites/selectors';
+
+/**
+ * Returns the appropriate URL for customizing the Jetpack Search experience.
+ * This function supports both Jetpack and WordPress.com sites.
+ *
+ * @param  {object}    state  Global state tree
+ * @param  {?number}   siteId Site ID
+ * @returns {?string}         URL for customizing Jetpack Search.
+ *                            Can be the the Customizer or Customberg.
+ */
+export default function getJetpackSearchCustomizeUrl( state, siteId ) {
+	const adminUrl = getSiteAdminUrl( state, siteId );
+	if ( ! adminUrl ) {
+		return null;
+	}
+
+	if ( isJetpackSite( state, siteId ) ) {
+		const jetpackVersion = getJetpackVersion( state, siteId );
+		let url = adminUrl + 'customize.php?autofocus[section]=jetpack_search';
+		if ( jetpackVersion && versionCompare( jetpackVersion, '10.1', '>=' ) ) {
+			url = adminUrl + 'admin.php?page=jetpack-search-configure';
+		}
+		return url;
+	}
+
+	// All WPCOM sites, both Simple and Atomic, support Customberg.
+	return adminUrl + 'admin.php?page=jetpack-search-configure';
+}

--- a/client/state/sites/selectors/get-jetpack-version.js
+++ b/client/state/sites/selectors/get-jetpack-version.js
@@ -1,0 +1,16 @@
+import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+
+/**
+ * Returns the Jetpack version for the given site.
+ *
+ * @param  {object}    state  Global state tree
+ * @param  {?number}   siteId Site ID
+ * @returns {?string}         Jetpack version
+ */
+export default function getJetpackVersion( state, siteId ) {
+	if ( isJetpackSite( state, siteId ) ) {
+		return getSite( state, siteId )?.options?.jetpack_version ?? null;
+	}
+
+	return null;
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -63,3 +63,5 @@ export { default as getSelectedSiteWithFallback } from './get-site-with-fallback
 export { default as getSiteWooCommerceUrl } from './get-site-woocommerce-url';
 export { default as getSiteWooCommerceWizardUrl } from './get-site-woocommerce-wizard-url';
 export { default as getSiteWordPressSeoWizardUrl } from './get-site-wordpress-seo-wizard-url';
+export { default as getJetpackSearchCustomizeUrl } from './get-jetpack-search-customize-url';
+export { default as getJetpackVersion } from './get-jetpack-version';

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -16,5 +16,6 @@ export interface SiteData {
 export interface SiteDataOptions {
 	admin_url: string | undefined;
 	is_mapped_domain: boolean;
+	jetpack_version: string | undefined;
 	// TODO: fill out the rest of this
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes custom handling for customers running Jetpack versions below 8.4.
- For customers running Jetpack versions >= 10.1, change search customization links to Customberg the new configuration experience ("Customberg") at `wp-admin/admin.php?page=jetpack-search-configure`.
- For customers running Jetpack versions < 10.1, continue linking to the Jetpack Search section in the WordPress Customizer.
- Added a loading message for the search section of Performance settings: <img width="736" alt="Screen Shot 2021-09-24 at 5 40 55 PM" src="https://user-images.githubusercontent.com/4044428/134749812-97096784-03c3-44c8-985b-5f9644e62b00.png">
 

Note: Please ship this change after landing D66714-code and D66856-code. Shipping this change is equivalent to launching Customberg to WordPress.com.

#### Testing instructions

Testing the Performance settings page:
* Navigate to `/settings/performance/<site>` for a site with a Jetpack Search subscription.
* Ensure that the `Customize Search` link points to the new Search configuration page if appropriate.

Testing the purchase flow:
* Navigate to `/checkout/<site>/jetpack_search_monthly` for a site without a Jetpack Search subscription.
* Complete the purchase. On the Thank You page, ensure that clicking on `Customize Search` takes you to the new Search configuration page if appropriate.