### PR TITLE
inline-help: decouple filtering `contextualResults` for _Managing Purchases_ from other results

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -9,12 +9,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { getSectionName } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getAdminHelpResults from 'calypso/state/inline-help/selectors/get-admin-help-results';
 import getContextualHelpResults from 'calypso/state/inline-help/selectors/get-contextual-help-results';
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import { getSectionName } from 'calypso/state/ui/selectors';
 import {
 	SUPPORT_TYPE_ADMIN_SECTION,
 	SUPPORT_TYPE_API_HELP,

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -37,15 +37,11 @@ const resultsSpeak = debounceSpeak( { message: 'Search results loaded.' } );
 
 const errorSpeak = debounceSpeak( { message: 'No search results found.' } );
 
-const filterManagePurchaseLink = ( hasPurchases, section ) => ( { post_id } ) => {
-	if (
-		post_id === 111349 &&
-		! hasPurchases &&
-		! [ 'purchases', 'site-purchases' ].includes( section )
-	) {
-		return false;
+const filterManagePurchaseLink = ( hasPurchases, isPurchasesSection ) => {
+	if ( hasPurchases || isPurchasesSection ) {
+		return () => true;
 	}
-	return true;
+	return ( { post_id } ) => post_id !== 111349;
 };
 
 function HelpSearchResults( {
@@ -59,9 +55,11 @@ function HelpSearchResults( {
 	const dispatch = useDispatch();
 
 	const currentUserId = useSelector( getCurrentUserId );
-	const sectionName = useSelector( getSectionName );
 	const hasPurchases = useSelector( ( state ) =>
 		hasCancelableUserPurchases( state, currentUserId )
+	);
+	const isPurchasesSection = useSelector( ( state ) =>
+		[ 'purchases', 'site-purchases' ].includes( getSectionName( state ) )
 	);
 	const rawContextualResults = useSelector( getContextualHelpResults );
 	const adminResults = useSelector( ( state ) => getAdminHelpResults( state, searchQuery, 3 ) );
@@ -69,7 +67,7 @@ function HelpSearchResults( {
 	const contextualResults = rawContextualResults.filter(
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
-		filterManagePurchaseLink( hasPurchases, sectionName )
+		filterManagePurchaseLink( hasPurchases, isPurchasesSection )
 	);
 	const { data: searchResults = [], isLoading: isSearching } = useInlineHelpSearchQuery(
 		searchQuery

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -13,8 +13,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getAdminHelpResults from 'calypso/state/inline-help/selectors/get-admin-help-results';
 import getContextualHelpResults from 'calypso/state/inline-help/selectors/get-contextual-help-results';
-import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
-import { getSectionName } from 'calypso/state/ui/selectors';
 import {
 	SUPPORT_TYPE_ADMIN_SECTION,
 	SUPPORT_TYPE_API_HELP,
@@ -48,10 +46,6 @@ function HelpSearchResults( {
 	const dispatch = useDispatch();
 
 	const currentUserId = useSelector( getCurrentUserId );
-	const hasPurchases = useSelector( ( state ) =>
-		hasCancelableUserPurchases( state, currentUserId )
-	);
-	const sectionName = useSelector( getSectionName );
 	const contextualResults = useSelector( getContextualHelpResults );
 	const adminResults = useSelector( ( state ) => getAdminHelpResults( state, searchQuery, 3 ) );
 
@@ -106,22 +100,9 @@ function HelpSearchResults( {
 	};
 
 	const renderHelpLink = ( result, type ) => {
-		const { link, title, icon, post_id } = result;
+		const { link, title, icon } = result;
 
 		const external = externalLinks && type !== SUPPORT_TYPE_ADMIN_SECTION;
-
-		// Unless searching with Inline Help or on the Purchases section, hide the
-		// "Managing Purchases" documentation link for users who have not made a purchase.
-		if (
-			post_id === 111349 &&
-			! isSearching &&
-			! hasAPIResults &&
-			! hasPurchases &&
-			sectionName !== 'purchases' &&
-			sectionName !== 'site-purchases'
-		) {
-			return null;
-		}
 
 		return (
 			<Fragment key={ link ?? title }>

--- a/client/state/inline-help/selectors/get-contextual-help-results.js
+++ b/client/state/inline-help/selectors/get-contextual-help-results.js
@@ -1,4 +1,6 @@
 import { getContextResults } from 'calypso/blocks/inline-help/contextual-help';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 import 'calypso/state/inline-help/init';
@@ -9,4 +11,25 @@ import 'calypso/state/inline-help/init';
  * @param  {object}  state  Global state tree
  * @returns {Array}         List of contextual results based on route
  */
-export default ( state ) => getContextResults( getSectionName( state ) );
+export default ( state ) => {
+	const currentUserId = getCurrentUserId( state );
+	const hasPurchases = hasCancelableUserPurchases( state, currentUserId );
+
+	const sectionName = getSectionName( state );
+	const contextualResults = getContextResults( sectionName );
+
+	const results = contextualResults.filter( ( { post_id } ) => {
+		// Unless searching with Inline Help or on the Purchases section, hide the
+		// "Managing Purchases" documentation link for users who have not made a purchase.
+		if (
+			post_id === 111349 &&
+			! hasPurchases &&
+			! [ 'purchases', 'site-purchases' ].includes( sectionName )
+		) {
+			return false;
+		}
+		return true;
+	} );
+
+	return results;
+};

--- a/client/state/inline-help/selectors/get-contextual-help-results.js
+++ b/client/state/inline-help/selectors/get-contextual-help-results.js
@@ -1,6 +1,4 @@
 import { getContextResults } from 'calypso/blocks/inline-help/contextual-help';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 import 'calypso/state/inline-help/init';
@@ -11,25 +9,4 @@ import 'calypso/state/inline-help/init';
  * @param  {object}  state  Global state tree
  * @returns {Array}         List of contextual results based on route
  */
-export default ( state ) => {
-	const currentUserId = getCurrentUserId( state );
-	const hasPurchases = hasCancelableUserPurchases( state, currentUserId );
-
-	const sectionName = getSectionName( state );
-	const contextualResults = getContextResults( sectionName );
-
-	const results = contextualResults.filter( ( { post_id } ) => {
-		// Unless searching with Inline Help or on the Purchases section, hide the
-		// "Managing Purchases" documentation link for users who have not made a purchase.
-		if (
-			post_id === 111349 &&
-			! hasPurchases &&
-			! [ 'purchases', 'site-purchases' ].includes( sectionName )
-		) {
-			return false;
-		}
-		return true;
-	} );
-
-	return results;
-};
+export default ( state ) => getContextResults( getSectionName( state ) );


### PR DESCRIPTION
Decouple the logic for hiding the _Managing Purchases_ link on certain sections from other result types (api results and admin sections).

Background: https://github.com/Automattic/wp-calypso/pull/45408#discussion_r699947788

### Testing instructions

- With an account which hasn't made a purchase, go to e..g the `home` section and make sure the _Managing Purchases_ link isn't listed there. You can test more sections by looking at [`getContextLinksForSection()`](https://github.com/Automattic/wp-calypso/blob/648a610583d9bc0936ca5cc10337dcafaef40f79/client/blocks/inline-help/contextual-help.js#L56) and see which contains a link for `post_id === 111349` 
- Verify vice versa with an account which has made a purchase it shows up on `home`

<img width="352" alt="Screenshot 2021-09-03 at 09 50 26" src="https://user-images.githubusercontent.com/9202899/131970192-9ac2c6df-7781-441e-8e8f-e82bff3970db.png">
