### PR TITLE
Google Analytics: Update Support Link

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -9,6 +9,7 @@ import React, { useEffect } from 'react';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextValidation from 'calypso/components/forms/form-input-validation';
@@ -135,14 +136,12 @@ const GoogleAnalyticsJetpackForm = ( {
 										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
 									/>
 								) }
-								<ExternalLink
-									icon
-									href="https://support.google.com/analytics/answer/1032385?hl=en"
-									target="_blank"
-									rel="noopener noreferrer"
+								<InlineSupportLink
+									supportPostId={ 98905 }
+									supportLink="https://wordpress.com/support/google-analytics/#get-your-measurement-id"
 								>
 									{ translate( 'Where can I find my Measurement ID?' ) }
-								</ExternalLink>
+								</InlineSupportLink>
 							</FormFieldset>
 							<FormFieldset>
 								<ToggleControl

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -8,7 +8,7 @@ import { ToggleControl } from '@wordpress/components';
 import React, { useEffect } from 'react';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import ExternalLink from 'calypso/components/external-link';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -138,14 +138,12 @@ const GoogleAnalyticsSimpleForm = ( {
 										text={ translate( 'Invalid Google Analytics Measurement ID.' ) }
 									/>
 								) }
-								<ExternalLink
-									icon
-									href="https://support.google.com/analytics/answer/1032385?hl=en"
-									target="_blank"
-									rel="noopener noreferrer"
+								<InlineSupportLink
+									supportPostId={ 98905 }
+									supportLink="https://wordpress.com/support/google-analytics/#get-your-measurement-id"
 								>
 									{ translate( 'Where can I find my Measurement ID?' ) }
-								</ExternalLink>
+								</InlineSupportLink>
 							</FormFieldset>
 							<p>
 								{ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates the support document link to the WordPress.com one, as that contains the relevant information referenced on the page. It probably also brings i18n benefits.

#### Testing instructions

Click the "Where can I find my measurement ID?" link under the Google Analytics section, which can be found at `/marketing/traffic/SITE` - you will need a Premium plan or Jetpack site to try this. You should now see the WP.com support document instead of being redirected to the Google one.

<img width="1077" alt="Screenshot 2021-09-03 at 09 02 40" src="https://user-images.githubusercontent.com/43215253/131972294-a8d48cd9-479d-4849-92d5-a5a6d2991250.png">

cc @blackjackkent, @sixhours 

Fixes #55923