### PR TITLE
re-apply "change add a menu link to point to the top level of customier"

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -16,10 +16,9 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/curren
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
-import getMenusUrl from 'calypso/state/selectors/get-menus-url';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
@@ -340,7 +339,7 @@ export default connect( ( state ) => {
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
 		isEmailUnverified: ! isCurrentUserEmailVerified( state ),
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
-		menusUrl: getMenusUrl( state, siteId ),
+		menusUrl: getCustomizerUrl( state, siteId, null, null, 'add-menu' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		tasks: taskList.getAll(),

--- a/client/state/sites/selectors/get-customizer-url.js
+++ b/client/state/sites/selectors/get-customizer-url.js
@@ -7,19 +7,22 @@ import isJetpackSite from './is-jetpack-site';
 /**
  * Returns the customizer URL for a site, or null if it cannot be determined.
  *
- * @param   {object}  state     Global state tree
- * @param   {?number} siteId    Site ID
- * @param   {string}  panel     Optional panel to autofocus
- * @param   {string}  returnUrl Optional return url for when the user closes the customizer
- * @returns {string}            Customizer URL
+ * @param   {object}  state        Global state tree
+ * @param   {?number} siteId       Site ID
+ * @param   {?string} panel        Optional panel to autofocus
+ * @param   {?string} returnUrl    Optional return url for when the user closes the customizer
+ * @param   {?string} guide        Optional parameter to show a help guide in the customizer. possible values:
+ *                                 'add-menu' and 'social-media' show custom guides, any other value shows the default guide
+ * @returns {string}               Customizer URL
  */
-export default function getCustomizerUrl( state, siteId, panel, returnUrl ) {
+export default function getCustomizerUrl( state, siteId, panel, returnUrl, guide ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		const url = [ '' ].concat( [ 'customize', panel, siteSlug ].filter( Boolean ) ).join( '/' );
 		return addQueryArgs(
 			{
 				return: returnUrl,
+				guide,
 			},
 			url
 		);
@@ -39,6 +42,7 @@ export default function getCustomizerUrl( state, siteId, panel, returnUrl ) {
 		{
 			return: returnUrl,
 			...getCustomizerFocus( panel ),
+			guide,
 		},
 		adminUrl
 	);

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3157,6 +3157,55 @@ describe( 'selectors', () => {
 			);
 		} );
 
+		test( 'should prepend guide parameter for WordPress.com site', () => {
+			const customizerUrl = getCustomizerUrl(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								jetpack: false,
+							},
+						},
+					},
+				},
+				77203199,
+				'identity',
+				null,
+				'test-guide'
+			);
+
+			chaiExpect( customizerUrl ).to.equal( '/customize/identity/example.com?guide=test-guide' );
+		} );
+
+		test( 'should prepend guide parameter for Jetpack site', () => {
+			const customizerUrl = getCustomizerUrl(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.com/wp-admin/',
+								},
+							},
+						},
+					},
+				},
+				77203199,
+				'identity',
+				null,
+				'test-guide'
+			);
+
+			chaiExpect( customizerUrl ).to.equal(
+				'https://example.com/wp-admin/customize.php?autofocus%5Bsection%5D=title_tagline&guide=test-guide'
+			);
+		} );
+
 		describe( 'browser', () => {
 			beforeAll( () => {
 				global.window = {


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/54583 was deployed and then[ reverted](https://github.com/Automattic/wp-calypso/pull/55602) when I found that the customizer [guides were broken](https://github.com/Automattic/wp-calypso/issues/55365#issuecomment-901541885). Now that [they are fixed](https://github.com/Automattic/wp-calypso/issues/55365#issuecomment-904602204), this diff re-applies the original change https://github.com/Automattic/wp-calypso/pull/54583 

![Sep-03-2021 19-44-56](https://user-images.githubusercontent.com/22446385/131986110-7147569b-e07b-45d6-9f34-46d08ac7c515.gif)

