### PR TITLE
Reader: Fix Gallery block caption render

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -30,6 +30,11 @@
 	display: none;
 }
 
+// Gallery block fix
+.wp-block-gallery .blocks-gallery-item .blocks-gallery-item__caption {
+    box-sizing: border-box;
+}
+
 // gizmodo fixes
 .reader-full-post.feed-10080096 {
 	.align--bleed {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This commit addresses the issue https://github.com/Automattic/wp-calypso/issues/55548 where the Gallery caption background is longer than the image.

#### Testing instructions

1. Create a post with a two-column Gallery block in the Gutenberg editor.
2. View the post in the Reader: Captions should be nicely contained in the images without any overflow.

Before:
![Markup on 2021-09-02 at 11:29:53](https://user-images.githubusercontent.com/25105483/131997084-c407789a-80bb-4c24-aefc-2291a9f56d6f.png)

After:
![Markup on 2021-09-02 at 11:29:28](https://user-images.githubusercontent.com/25105483/131997128-84c92c48-1a01-4a98-b679-76e0cc5464c8.png)

Fixes #55548