### PR TITLE
Welcome Tour: Show overlay controls when the focus is within

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -152,16 +152,19 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 		opacity: 0;
 		transition: opacity 200ms;
 	}
-}
 
-.wpcom-editor-welcome-tour-frame:hover .welcome-tour-card__overlay-controls .components-button,
-.welcome-tour-card__overlay-controls-visible .components-button {
-	opacity: 0.7;
-}
+	.wpcom-editor-welcome-tour-frame:hover &,
+	.wpcom-editor-welcome-tour-frame:focus-within &,
+	&-controls-visible {
+		.components-button {
+			opacity: 0.7;
 
-.wpcom-editor-welcome-tour-frame .welcome-tour-card__overlay-controls .components-button:hover,
-.welcome-tour-card__overlay-controls-visible .components-button:hover {
-	opacity: 0.9;
+			&:hover,
+			&:focus {
+				opacity: 0.9;
+			}
+		}
+	}
 }
 
 .welcome-tour-card__next-btn {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -155,7 +155,7 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 
 	.wpcom-editor-welcome-tour-frame:hover &,
 	.wpcom-editor-welcome-tour-frame:focus-within &,
-	&-controls-visible {
+	&.welcome-tour-card__overlay-controls-visible {
 		.components-button {
 			opacity: 0.7;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
* show overlay controls when the focus is within
* darken the overlay control buttons when focused
* (dev) reduce repetition in SCSS

### Before
<img width="424" alt="Screenshot 2021-09-03 at 15 52 37" src="https://user-images.githubusercontent.com/14192054/132011693-a83e5396-6d87-4796-a678-323e1ef2b7ab.png">

### After
<img width="426" alt="Screenshot 2021-09-03 at 16 08 22" src="https://user-images.githubusercontent.com/14192054/132011680-f249d098-bf86-426a-9624-8097ffeacb2b.png">

Related to https://github.com/Automattic/wp-calypso/pull/55936
Closes #56030

