### PR TITLE
Theme Showcase: Fix copy on upsell

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -27,7 +27,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 					plan={ PLAN_PREMIUM }
 					customerType="business"
 					className="themes__showcase-banner"
-					title={ translate( 'Upload your own themes with our Premium and Business plans!' ) }
+					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 					event="themes_plans_free_personal"
 					forceHref={ true }
 					showIcon={ true }
@@ -37,7 +37,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 			upsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_PREMIUM }
-					title={ translate( 'Upload your own themes with our Premium and Business plans!' ) }
+					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 					description={ translate(
 						'Get advanced customization, more storage space, and video support along with the ability to upload any theme.'
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update wording on Theme Showcase upsell to reflect the correct upgrade path for uploading themes (Business and eCommerce, not Premium and Business)

**Before**

<img width="1376" alt="Screen Shot 2021-09-03 at 10 02 25 AM" src="https://user-images.githubusercontent.com/2124984/132018303-14d37422-3b7c-4dfb-b425-bd7f3162ba89.png">


**After**

<img width="1354" alt="Screen Shot 2021-09-03 at 10 02 11 AM" src="https://user-images.githubusercontent.com/2124984/132018317-8dedf24d-1ccf-466e-8772-46139dddfcd5.png">


#### Testing instructions

* Switch to this PR on a free simple site
* Go to `/themes/[site]`
* You should see the upsell underneath the search area

Fixes #55988