### PR TITLE
Pw/editor post basic flow

### DIFF
--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -49,3 +49,12 @@ export function getViewportSize( target?: viewportName ): viewportSize {
 	}
 	return sizes[ target ];
 }
+
+/**
+ * Returns boolean indicating whether this test run should target a Gutenberg Edge user and site.
+ *
+ * @returns {boolean} True if should target Gutenberg edge. False otherwise.
+ */
+export function targetGutenbergEdge(): boolean {
+	return !! process.env.GUTENBERG_EDGE;
+}

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -70,7 +70,8 @@ export class EditorSettingsSidebarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickCategory( categoryName: string ): Promise< void > {
-		await this.frame.click( selectors.categoryCheckbox( categoryName ) );
+		//TODO: Categories can be slow because we never do any cleanup. Remove extended timeout once we start doing cleanup.
+		await this.frame.click( selectors.categoryCheckbox( categoryName ), { timeout: 60 * 1000 } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -41,7 +41,7 @@ export class EditorSettingsSidebarComponent {
 	}
 
 	/**
-	 * Clicks on one of the top tabs (e.g. 'Post' or 'Block') in the sidebar
+	 * Clicks on one of the top tabs (e.g. 'Post' or 'Block') in the sidebar. Ensures that tab becomes active.
 	 *
 	 * @param {EditorSidebarTab} tabName Name of tab to click.
 	 * @returns {Promise<void>} No return value.
@@ -68,9 +68,8 @@ export class EditorSettingsSidebarComponent {
 	 *
 	 * @param {string} categoryName The category name.
 	 * @returns {Promise<void>} No return value.
-	 * @throws If no category matching the name is found.
 	 */
-	async checkCategory( categoryName: string ): Promise< void > {
+	async clickCategory( categoryName: string ): Promise< void > {
 		await this.frame.click( selectors.categoryCheckbox( categoryName ) );
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -16,9 +16,10 @@ const selectors = {
 		`${ sidebarParentSelector } .is-opened .components-panel__body-toggle:has-text("${ sectionName }")`,
 	categoryCheckbox: ( categoryName: string ) =>
 		`${ sidebarParentSelector } [aria-label=Categories] :text("${ categoryName }")`,
-	tagInput: `${ sidebarParentSelector } >> .components-form-token-field:has-text("Add New Tag") >> input`,
+	tagInput: `${ sidebarParentSelector } .components-form-token-field:has-text("Add New Tag") input`,
 	addedTag: ( tagName: string ) =>
-		`${ sidebarParentSelector } >> .components-form-token-field:has-text("Add New Tag") >> .components-form-token-field__token:has-text("${ tagName }")`,
+		`${ sidebarParentSelector } .components-form-token-field:has-text("Add New Tag") .components-form-token-field__token:has-text("${ tagName }")`,
+	closeSidebarButton: `${ sidebarParentSelector } [aria-label="Close settings"]:visible`, // there's a hidden copy in there
 };
 
 /**
@@ -84,5 +85,14 @@ export class EditorSettingsSidebarComponent {
 		await this.frame.fill( selectors.tagInput, tagName );
 		await this.page.keyboard.press( 'Enter' );
 		await this.frame.waitForSelector( selectors.addedTag( tagName ) ); // make sure it got added!
+	}
+
+	/**
+	 * Closes this settings sidebar using close button within sidebar.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async closeSidebar(): Promise< void > {
+		await this.frame.click( selectors.closeSidebarButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -1,0 +1,88 @@
+import { Frame, Page } from 'playwright';
+
+export type EditorSidebarTab = 'Post' | 'Block';
+export type EditorSidebarSection = 'Categories' | 'Tags';
+
+const sidebarParentSelector = '[aria-label="Editor settings"]';
+
+const selectors = {
+	tabButton: ( tabName: EditorSidebarTab ) =>
+		`${ sidebarParentSelector } button:has-text("${ tabName }")`,
+	activeTabButton: ( tabName: EditorSidebarTab ) =>
+		`${ sidebarParentSelector } button.is-active:has-text("${ tabName }")`,
+	sectionToggle: ( sectionName: EditorSidebarSection ) =>
+		`${ sidebarParentSelector } .components-panel__body-toggle:has-text("${ sectionName }")`,
+	expandedSection: ( sectionName: EditorSidebarSection ) =>
+		`${ sidebarParentSelector } .is-opened .components-panel__body-toggle:has-text("${ sectionName }")`,
+	categoryCheckbox: ( categoryName: string ) =>
+		`${ sidebarParentSelector } [aria-label=Categories] :text("${ categoryName }")`,
+	tagInput: `${ sidebarParentSelector } >> .components-form-token-field:has-text("Add New Tag") >> input`,
+	addedTag: ( tagName: string ) =>
+		`${ sidebarParentSelector } >> .components-form-token-field:has-text("Add New Tag") >> .components-form-token-field__token:has-text("${ tagName }")`,
+};
+
+/**
+ * Component representing the settings sidebar in the editor.
+ */
+export class EditorSettingsSidebarComponent {
+	private frame: Frame;
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Frame} frame The editor iframe to use as the page for Playwright actions.
+	 * @param page The underlying Playwright page
+	 */
+	constructor( frame: Frame, page: Page ) {
+		this.frame = frame;
+		this.page = page;
+	}
+
+	/**
+	 * Clicks on one of the top tabs (e.g. 'Post' or 'Block') in the sidebar
+	 *
+	 * @param {EditorSidebarTab} tabName Name of tab to click.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async clickTab( tabName: EditorSidebarTab ): Promise< void > {
+		await this.frame.click( selectors.tabButton( tabName ) );
+		await this.frame.waitForSelector( selectors.activeTabButton( tabName ) );
+	}
+
+	/**
+	 * If the provided sidebar section is collapsed, toggles it to be expanded.
+	 *
+	 * @param {EditorSidebarSection} sectionName Name of section.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async expandSectionIfCollapsed( sectionName: EditorSidebarSection ): Promise< void > {
+		if ( ! ( await this.frame.isVisible( selectors.expandedSection( sectionName ) ) ) ) {
+			await this.frame.click( selectors.sectionToggle( sectionName ) );
+		}
+	}
+
+	/**
+	 * Check a category checkbox for a post in the sidebar.
+	 *
+	 * @param {string} categoryName The category name.
+	 * @returns {Promise<void>} No return value.
+	 * @throws If no category matching the name is found.
+	 */
+	async checkCategory( categoryName: string ): Promise< void > {
+		await this.frame.click( selectors.categoryCheckbox( categoryName ) );
+	}
+
+	/**
+	 * Enters a tag in the tag field, presses enter to submit it, and validates it shows up in field.
+	 * Does no partial matching, if a tag doesn't exist with the provided name, a new one is added.
+	 *
+	 * @param {string} tagName Tag name to enter.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async enterTag( tagName: string ): Promise< void > {
+		await this.frame.fill( selectors.tagInput, tagName );
+		await this.page.keyboard.press( 'Enter' );
+		await this.frame.waitForSelector( selectors.addedTag( tagName ) ); // make sure it got added!
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -6,3 +6,4 @@ export * from './preview-component';
 export * from './notifications-component';
 export * from './site-select-component';
 export * from './cookie-banner-component';
+export * from './editor-settings-sidebar-component';

--- a/packages/calypso-e2e/src/lib/components/preview-component.ts
+++ b/packages/calypso-e2e/src/lib/components/preview-component.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Frame, Page } from 'playwright';
 
 const selectors = {
 	previewPane: '.web-preview',
@@ -6,6 +6,7 @@ const selectors = {
 	// Actions on pane
 	closeButton: 'button[aria-label="Close preview"]',
 	activateButton: 'text=Activate',
+	iframe: '.web-preview__frame',
 };
 
 /**
@@ -39,5 +40,25 @@ export class PreviewComponent {
 	 */
 	async closePreview(): Promise< void > {
 		await this.page.click( selectors.closeButton );
+	}
+
+	/**
+	 * Validates that the provided text can be found in the preview content. Throws if it isn't.
+	 *
+	 * @param {string} text Text to search for in preview content
+	 */
+	async validateTextInPreviewContent( text: string ): Promise< void > {
+		const frame = await this.getPreviewFrame();
+		await frame.waitForSelector( `text=${ text }` );
+	}
+
+	/**
+	 * Get the Iframe element handle for the preview content.
+	 *
+	 * @returns {Frame} Handle for the preview content Iframe
+	 */
+	private async getPreviewFrame(): Promise< Frame > {
+		const elementHandle = await this.page.waitForSelector( selectors.iframe );
+		return ( await elementHandle.contentFrame() ) as Frame;
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/preview-component.ts
+++ b/packages/calypso-e2e/src/lib/components/preview-component.ts
@@ -2,15 +2,15 @@ import { Frame, Page } from 'playwright';
 
 const selectors = {
 	previewPane: '.web-preview',
+	iframe: '.web-preview__frame',
 
 	// Actions on pane
 	closeButton: 'button[aria-label="Close preview"]',
 	activateButton: 'text=Activate',
-	iframe: '.web-preview__frame',
 };
 
 /**
- * Component representing the site published preview component.
+ * Component representing the site published preview component. This same preview modal is used for themes and editor previewing.
  */
 export class PreviewComponent {
 	private page: Page;
@@ -34,7 +34,7 @@ export class PreviewComponent {
 	}
 
 	/**
-	 * Close the theme preview pane.
+	 * Close the preview pane.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */

--- a/packages/calypso-e2e/src/lib/components/preview-component.ts
+++ b/packages/calypso-e2e/src/lib/components/preview-component.ts
@@ -53,7 +53,7 @@ export class PreviewComponent {
 	}
 
 	/**
-	 * Get the Iframe element handle for the preview content.
+	 * Get the Iframe element handle for the preview content. This frame is the one located within the preview popup.
 	 *
 	 * @returns {Frame} Handle for the preview content Iframe
 	 */

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -23,7 +23,8 @@ const selectors = {
 	postToolbar: '.edit-post-header',
 	settingsToggle: '[aria-label="Settings"]',
 	saveDraftButton: '.editor-post-save-draft',
-	previewButton: '.edit-post-header a:has-text("Preview")', // there's a hidden button also with the Preview text
+	// there's a hidden button also with the "Preview" text, so using unique class name instead of text selector
+	previewButton: '.edit-post-header .editor-post-preview',
 	publishButton: ( parentSelector: string ) =>
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,
 

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -298,7 +298,7 @@ export class GutenbergEditorPage {
 	 *
 	 * @returns {Promise<void} No return value.
 	 */
-	async launchPreview(): Promise< void > {
+	async preview(): Promise< void > {
 		const frame = await this.getEditorFrame();
 		await frame.click( selectors.previewButton );
 	}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -67,7 +67,7 @@ export class GutenbergEditorPage {
 	 *
 	 * @returns {Promise<Frame>} iframe holding the editor.
 	 */
-	private async getEditorFrame(): Promise< Frame > {
+	async getEditorFrame(): Promise< Frame > {
 		const elementHandle = await this.page.waitForSelector( selectors.editorFrame );
 		return ( await elementHandle.contentFrame() ) as Frame;
 	}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -23,6 +23,7 @@ const selectors = {
 	postToolbar: '.edit-post-header',
 	settingsToggle: '[aria-label="Settings"]',
 	saveDraftButton: '.editor-post-save-draft',
+	previewButton: '.edit-post-header a:has-text("Preview")', // there's a hidden button also with the Preview text
 	publishButton: ( parentSelector: string ) =>
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,
 
@@ -289,6 +290,16 @@ export class GutenbergEditorPage {
 		// are disabled while the post is saved. Wait for the state of
 		// Publish button to return to 'enabled' before proceeding.
 		await frame.waitForSelector( selectors.publishButton( selectors.postToolbar ) );
+	}
+
+	/**
+	 * Launches editor preview by clicking toolbar preview button.
+	 *
+	 * @returns {Promise<void} No return value.
+	 */
+	async launchPreview(): Promise< void > {
+		const frame = await this.getEditorFrame();
+		await frame.click( selectors.previewButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -35,6 +35,9 @@ const selectors = {
 	publishPanel: '.editor-post-publish-panel',
 	viewButton: '.editor-post-publish-panel a:has-text("View")',
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
+
+	// Welcome tour
+	welcomeTourSkipButton: '.welcome-tour-card button:has-text("Skip")',
 };
 
 /**
@@ -180,6 +183,16 @@ export class GutenbergEditorPage {
 
 		// Strip out falsey values.
 		return lines.filter( Boolean ).join( '\n' );
+	}
+
+	/**
+	 * Dismisses the Welcome Tour (card) if it is present.
+	 */
+	async dismissWelcomeTourIfPresent(): Promise< void > {
+		const frame = await this.getEditorFrame();
+		if ( await frame.isVisible( selectors.welcomeTourSkipButton ) ) {
+			await frame.click( selectors.welcomeTourSkipButton );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -32,7 +32,7 @@ export class PublishedPostPage {
 	 *
 	 * @returns {Promise<Frame>} Frame holding the like widget on page.
 	 */
-	private async getFrame(): Promise< Frame > {
+	private async getLikeFrame(): Promise< Frame > {
 		// Obtain the ElementHandle for the widget containing the like/unlike button.
 		const elementHandle = await this.page.waitForSelector( selectors.likeWidget );
 		// Obtain the Frame object from the elementHandleHandle. This represents the widget iframe.
@@ -52,7 +52,7 @@ export class PublishedPostPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async likePost(): Promise< void > {
-		const frame = await this.getFrame();
+		const frame = await this.getLikeFrame();
 		await frame.click( selectors.likeButton );
 		await frame.waitForSelector( selectors.likedText, { state: 'visible' } );
 	}
@@ -66,8 +66,17 @@ export class PublishedPostPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async unlikePost(): Promise< void > {
-		const frame = await this.getFrame();
+		const frame = await this.getLikeFrame();
 		await frame.click( selectors.unlikeButton );
 		await frame.waitForSelector( selectors.notLikedText, { state: 'visible' } );
+	}
+
+	/**
+	 * Validates that the provided text can be found in the post page. Throws if it isn't.
+	 *
+	 * @param {string} text Text to search for in post page
+	 */
+	async validateTextInPost( text: string ): Promise< void > {
+		await this.page.waitForSelector( `text=${ text }` );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -5,6 +5,8 @@ import {
 	LoginFlow,
 	NewPostFlow,
 	setupHooks,
+	PreviewComponent,
+	PublishedPostPage,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
@@ -18,51 +20,94 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let page: Page;
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let settingsSidebar: EditorSettingsSidebarComponent;
+	let previewComponent: PreviewComponent;
+	let publishedPostPage: PublishedPostPage;
 	const user = 'gutenbergSimpleSiteUser';
 
 	setupHooks( ( args ) => {
 		page = args.page;
 	} );
 
-	it( 'Log in', async function () {
-		const loginFlow = new LoginFlow( page, user );
-		await loginFlow.logIn();
+	describe( 'Starting and populating post data', function () {
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( page, user );
+			await loginFlow.logIn();
+		} );
+
+		it( 'Start new post', async function () {
+			const newPostFlow = new NewPostFlow( page );
+			await newPostFlow.newPostFromNavbar();
+		} );
+
+		it( 'Enter post title', async function () {
+			gutenbergEditorPage = new GutenbergEditorPage( page );
+			await gutenbergEditorPage.enterTitle( title );
+		} );
+
+		it( 'Enter post text', async function () {
+			await gutenbergEditorPage.enterText( quote );
+		} );
+
+		it( 'Open editor settings sidebar for post', async function () {
+			await gutenbergEditorPage.openSettings();
+			const frame = await gutenbergEditorPage.getEditorFrame();
+			settingsSidebar = new EditorSettingsSidebarComponent( frame, page );
+			await settingsSidebar.clickTab( 'Post' );
+		} );
+
+		it( 'Add post category', async function () {
+			await settingsSidebar.expandSectionIfCollapsed( 'Categories' );
+			await settingsSidebar.checkCategory( category );
+		} );
+
+		it( 'Add post tag', async function () {
+			await settingsSidebar.expandSectionIfCollapsed( 'Tags' );
+			await settingsSidebar.enterTag( tag );
+		} );
 	} );
 
-	it( 'Start new post', async function () {
-		const newPostFlow = new NewPostFlow( page );
-		await newPostFlow.newPostFromNavbar();
+	describe( 'Preview post', function () {
+		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional
+		it( 'Close settings sidebar', async function () {
+			await settingsSidebar.closeSidebar();
+		} );
+
+		it( 'Launch preview', async function () {
+			await gutenbergEditorPage.launchPreview();
+			previewComponent = new PreviewComponent( page );
+			await previewComponent.previewReady();
+		} );
+
+		it( 'Post content is found in preview', async function () {
+			await previewComponent.validateTextInPreviewContent( title );
+			await previewComponent.validateTextInPreviewContent( quote );
+		} );
+
+		// We won't preview the metadata in the preview because of a race condition with tags.
+		// If you are really fast, like Playwright is, you can add a tag and launch a preview before
+		// the tag has been saved to the database, meaning it is not in the preview!
+		// It's sufficient to verify content in preview, and metadata in published post.
+
+		it( 'Close preview', async function () {
+			await previewComponent.closePreview();
+		} );
 	} );
 
-	it( 'Enter post title', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+	describe( 'Publish post', function () {
+		it( 'Publish and visit post', async function () {
+			const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
+			expect( publishedURL ).toBe( await page.url() );
+			publishedPostPage = new PublishedPostPage( page );
+		} );
 
-		await gutenbergEditorPage.enterTitle( title );
+		it( 'Post content is found in published post', async function () {
+			await publishedPostPage.validateTextInPost( title );
+			await publishedPostPage.validateTextInPost( quote );
+		} );
+
+		it( 'Post metadata is found in published post', async function () {
+			await publishedPostPage.validateTextInPost( category );
+			await publishedPostPage.validateTextInPost( tag );
+		} );
 	} );
-
-	it( 'Enter post text', async function () {
-		await gutenbergEditorPage.enterText( quote );
-	} );
-
-	it( 'Open editor settings sidebar for post', async function () {
-		await gutenbergEditorPage.openSettings();
-		const frame = await gutenbergEditorPage.getEditorFrame();
-		settingsSidebar = new EditorSettingsSidebarComponent( frame, page );
-		await settingsSidebar.clickTab( 'Post' );
-	} );
-
-	it( 'Add post category', async function () {
-		await settingsSidebar.expandSectionIfCollapsed( 'Categories' );
-		await settingsSidebar.checkCategory( category );
-	} );
-
-	it( 'Add post tag', async function () {
-		await settingsSidebar.expandSectionIfCollapsed( 'Tags' );
-		await settingsSidebar.enterTag( tag );
-	} );
-
-	// it( 'Publish and visit post', async function () {
-	// 	const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
-	// 	expect( publishedURL ).toBe( await page.url() );
-	// } );
 } );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -1,0 +1,68 @@
+import {
+	DataHelper,
+	GutenbergEditorPage,
+	EditorSettingsSidebarComponent,
+	LoginFlow,
+	NewPostFlow,
+	setupHooks,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+const quote =
+	'The problem with quotes on the Internet is that it is hard to verify their authenticity. \n— Abraham Lincoln';
+const title = DataHelper.getRandomPhrase();
+const category = 'Uncategorized';
+const tag = 'test-tag';
+
+describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
+	let page: Page;
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let settingsSidebar: EditorSettingsSidebarComponent;
+	const user = 'gutenbergSimpleSiteUser';
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginFlow = new LoginFlow( page, user );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+	} );
+
+	it( 'Enter post title', async function () {
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+
+		await gutenbergEditorPage.enterTitle( title );
+	} );
+
+	it( 'Enter post text', async function () {
+		await gutenbergEditorPage.enterText( quote );
+	} );
+
+	it( 'Open editor settings sidebar for post', async function () {
+		await gutenbergEditorPage.openSettings();
+		const frame = await gutenbergEditorPage.getEditorFrame();
+		settingsSidebar = new EditorSettingsSidebarComponent( frame, page );
+		await settingsSidebar.clickTab( 'Post' );
+	} );
+
+	it( 'Add post category', async function () {
+		await settingsSidebar.expandSectionIfCollapsed( 'Categories' );
+		await settingsSidebar.checkCategory( category );
+	} );
+
+	it( 'Add post tag', async function () {
+		await settingsSidebar.expandSectionIfCollapsed( 'Tags' );
+		await settingsSidebar.enterTag( tag );
+	} );
+
+	// it( 'Publish and visit post', async function () {
+	// 	const publishedURL = await gutenbergEditorPage.publish( { visit: true } );
+	// 	expect( publishedURL ).toBe( await page.url() );
+	// } );
+} );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -20,7 +20,7 @@ const tag = 'test-tag';
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
 	let gutenbergEditorPage: GutenbergEditorPage;
-	let settingsSidebar: EditorSettingsSidebarComponent;
+	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 	let previewComponent: PreviewComponent;
 	let publishedPostPage: PublishedPostPage;
 	const user = BrowserHelper.targetGutenbergEdge()
@@ -54,29 +54,29 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Open editor settings sidebar for post', async function () {
 			await gutenbergEditorPage.openSettings();
 			const frame = await gutenbergEditorPage.getEditorFrame();
-			settingsSidebar = new EditorSettingsSidebarComponent( frame, page );
-			await settingsSidebar.clickTab( 'Post' );
+			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+			await editorSettingsSidebarComponent.clickTab( 'Post' );
 		} );
 
 		it( 'Add post category', async function () {
-			await settingsSidebar.expandSectionIfCollapsed( 'Categories' );
-			await settingsSidebar.clickCategory( category );
+			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Categories' );
+			await editorSettingsSidebarComponent.clickCategory( category );
 		} );
 
 		it( 'Add post tag', async function () {
-			await settingsSidebar.expandSectionIfCollapsed( 'Tags' );
-			await settingsSidebar.enterTag( tag );
+			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Tags' );
+			await editorSettingsSidebarComponent.enterTag( tag );
 		} );
 	} );
 
 	describe( 'Preview post', function () {
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional
 		it( 'Close settings sidebar', async function () {
-			await settingsSidebar.closeSidebar();
+			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
 		it( 'Launch preview', async function () {
-			await gutenbergEditorPage.launchPreview();
+			await gutenbergEditorPage.preview();
 			previewComponent = new PreviewComponent( page );
 			await previewComponent.previewReady();
 		} );

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -1,4 +1,5 @@
 import {
+	BrowserHelper,
 	DataHelper,
 	GutenbergEditorPage,
 	EditorSettingsSidebarComponent,
@@ -22,7 +23,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let settingsSidebar: EditorSettingsSidebarComponent;
 	let previewComponent: PreviewComponent;
 	let publishedPostPage: PublishedPostPage;
-	const user = 'gutenbergSimpleSiteUser';
+	const user = BrowserHelper.targetGutenbergEdge()
+		? 'gutenbergSimpleSiteEdgeUser'
+		: 'gutenbergSimpleSiteUser';
 
 	setupHooks( ( args ) => {
 		page = args.page;
@@ -57,7 +60,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		it( 'Add post category', async function () {
 			await settingsSidebar.expandSectionIfCollapsed( 'Categories' );
-			await settingsSidebar.checkCategory( category );
+			await settingsSidebar.clickCategory( category );
 		} );
 
 		it( 'Add post tag', async function () {

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -1,3 +1,8 @@
+/**
+ * @group calypso-pr
+ * @group gutenberg
+ */
+
 import {
 	BrowserHelper,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -63,6 +63,11 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await editorSettingsSidebarComponent.clickTab( 'Post' );
 		} );
 
+		// Waiting to do this here as the Welcome Tour won't intefere with adding a title/content, and deferring gives it time to load in completely.
+		it( ' Dismiss Welcome Tour if it is present', async function () {
+			await gutenbergEditorPage.dismissWelcomeTourIfPresent();
+		} );
+
 		it( 'Add post category', async function () {
 			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Categories' );
 			await editorSettingsSidebarComponent.clickCategory( category );

--- a/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
@@ -3,11 +3,18 @@
  * @group gutenberg
  */
 
-import { DataHelper, LoginFlow, SidebarComponent, setupHooks } from '@automattic/calypso-e2e';
+import {
+	BrowserHelper,
+	DataHelper,
+	LoginFlow,
+	SidebarComponent,
+	setupHooks,
+} from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
-const user =
-	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+const user = BrowserHelper.targetGutenbergEdge()
+	? 'gutenbergSimpleSiteEdgeUser'
+	: 'gutenbergSimpleSiteUser';
 
 describe( DataHelper.createSuiteTitle( 'Widgets' ), function () {
 	let sidebarComponent: SidebarComponent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implements the Basic Post Flow from the editor/wpcom Playwright transition. See pciE2j-sq-p2.

Also adds a library method to check if we should be targeting Gutenberg Edge.

#### Testing instructions

- [ ] Mobile and desktop tests should pass

Fixes #55946 #55947