### PR TITLE
Jetpack Cancellation Form: Fix selected site id

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -23,7 +23,6 @@ import './style.scss';
 interface Props {
 	disableButtons?: boolean;
 	purchase: Purchase;
-	selectedSite: { slug: string; ID: number };
 	isVisible: boolean;
 	onClose: () => void;
 	onClickFinalConfirm: () => void;
@@ -32,14 +31,14 @@ interface Props {
 	recordTracksEvent: ( name: string, data: Record< string, unknown > ) => void;
 }
 
-const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, selectedSite, ...props } ) => {
+const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ...props } ) => {
 	const translate = useTranslate();
 	const [ cancellationStep, setCancellationStep ] = useState( steps.FEATURES_LOST_STEP ); // set initial state
 	const [ surveyAnswerId, setSurveyAnswerId ] = useState< string | null >( null );
 	const [ surveyAnswerText, setSurveyAnswerText ] = useState< TranslateResult | string >( '' );
 
 	const isAtomicSite = useSelector( ( state ) =>
-		isSiteAutomatedTransfer( state, selectedSite.ID )
+		isSiteAutomatedTransfer( state, purchase.siteId )
 	);
 
 	/**
@@ -54,7 +53,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, selectedSite
 
 	// Record an event for Tracks
 	const recordEvent = ( name: string, properties = {} ) => {
-		const { purchase, flowType } = props;
+		const { flowType } = props;
 
 		recordTracksEvent( name, {
 			cancellation_flow: flowType,
@@ -116,7 +115,6 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, selectedSite
 
 	const onSubmit = () => {
 		if ( surveyAnswerId ) {
-			const { purchase } = props;
 			const surveyData = {
 				'why-cancel': {
 					response: surveyAnswerId,
@@ -127,7 +125,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, selectedSite
 
 			submitSurvey(
 				'calypso-cancel-jetpack',
-				selectedSite.ID,
+				purchase.siteId,
 				enrichedSurveyData( surveyData, purchase )
 			);
 		}
@@ -222,7 +220,6 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, selectedSite
 	 * @returns current step {string|null}
 	 */
 	const renderCurrentStep = () => {
-		const { purchase } = props;
 		const productName = getName( purchase );
 
 		// Step 1: what will be lost by cancelling
@@ -231,7 +228,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, selectedSite
 			// this differs a bit depending on the product/ what JP modules are active
 			return (
 				<JetpackBenefitsStep
-					siteId={ selectedSite.ID }
+					siteId={ purchase.siteId }
 					purchase={ purchase }
 					productSlug={ purchase.productSlug }
 				/>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -302,13 +302,12 @@ class RemovePurchase extends Component {
 	}
 
 	renderJetpackDialog() {
-		const { purchase, site } = this.props;
+		const { purchase } = this.props;
 
 		return (
 			<CancelJetpackForm
 				disableButtons={ this.state.isRemoving }
 				purchase={ purchase }
-				selectedSite={ site }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 				onClickFinalConfirm={ this.removePurchase }


### PR DESCRIPTION
Before this commit, thet CancelJetpackForm was using the selectedSite.ID to handle all logic related to the site id, but this is not super reliable since the selectedSite doesn't get changed just by clicking on the product from /me/purchases. In this case, the ideal is to rely on the purchase.siteId.

#### Changes proposed in this Pull Request

* Refactor `CancelJetpackForm` to use `purchase.siteId` instead of `selectedSite.ID`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WordPress.com (make sure to be proxied)
* Select a site test site from the site selector sidebar
* Open /me/purchases and start to cancel any of the products you see there that are not related to the site you selected in the step above
* It will show the cancellation pop up, but for the site you selected via the site selector (this is the wrong behavior)
* Check out this branch and run `yarn start`
* Go to the calypso.localhost:3000 and repeat the steps above
* Make sure this time whenever you try to cancel a product it will show the information to that specific product, and not the one you initially selected via the site selector

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
