### PR TITLE
Colour Scheme Picker: Display Success Notice on Change

### DIFF
--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -1,10 +1,11 @@
-import { translate } from 'i18n-calypso';
+import { translate, localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
+import { successNotice } from 'calypso/state/notices/actions';
 import { savePreference, setPreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getColorSchemesData from './constants';
@@ -23,12 +24,25 @@ class ColorSchemePicker extends PureComponent {
 	};
 
 	handleColorSchemeSelection = ( event ) => {
-		const { temporarySelection, onSelection, saveColorSchemePreference } = this.props;
+		const {
+			temporarySelection,
+			translate,
+			onSelection,
+			saveColorSchemePreference,
+			successNotice,
+		} = this.props;
 		const { value } = event.currentTarget;
+		const noticeSettings = {
+			id: 'color-scheme-picker-save',
+			duration: 10000,
+		};
+
 		if ( temporarySelection ) {
 			onSelection( value );
 		}
 		saveColorSchemePreference( value, temporarySelection );
+
+		successNotice( translate( 'Settings saved successfully!' ), noticeSettings );
 	};
 
 	render() {
@@ -66,5 +80,5 @@ export default connect(
 			colorSchemePreference: getPreference( state, 'colorScheme' ),
 		};
 	},
-	{ saveColorSchemePreference }
-)( ColorSchemePicker );
+	{ saveColorSchemePreference, successNotice }
+)( localize( ColorSchemePicker ) );

--- a/client/components/global-notices/README.md
+++ b/client/components/global-notices/README.md
@@ -11,7 +11,7 @@ Notices should be added by dispatching a notice action. See [notice actions](../
 Dispatching a notice from a component might look like this:
 
 ```js
-import { successNotices } from 'calypso/state/notices/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 
 function MyComponent() {
 	return <button onClick={ this.props.successNotice( 'Objective achieved!' ) }>Click me!</button>;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Colour Scheme Picker is the only option on Account Settings which doesn't display a global notice upon change, which feels a little odd - although the user can see that their interface has changed, there's no way to know whether this is permanent or will be removed upon refresh.

I'm pretty sure not including this global notice was an oversight, but feel free to close if it was intentional.

#### Testing instructions

Change your colour scheme and verify a success notice is displayed.

<img width="1444" alt="Screenshot 2021-09-03 at 18 20 05" src="https://user-images.githubusercontent.com/43215253/132043824-8c113bb6-05a5-45fa-a2b7-25530b34b5c9.png">

cc @sixhours