### PR TITLE
Improve unit tests for React 17 PR

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
@@ -6,6 +6,7 @@ const STORE_KEY = 'automattic/wpcom-welcome-guide';
 
 beforeAll( () => {
 	register();
+	jest.useFakeTimers(); // Required for wait-for-expect to work.
 } );
 
 let originalFetch;

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -17,7 +17,9 @@ describe( 'useTranslate()', () => {
 
 	beforeEach( () => {
 		// reset to default locale
-		i18n.setLocale();
+		act( () => {
+			i18n.setLocale();
+		} );
 
 		// create container
 		container = document.createElement( 'div' );
@@ -68,9 +70,11 @@ describe( 'useTranslate()', () => {
 
 	test( 'rerenders after update of current locale translations', () => {
 		// set some locale data
-		i18n.setLocale( {
-			'': { localeSlug: 'cs' },
-			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'cs' },
+				'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+			} );
 		} );
 
 		// render the Label component


### PR DESCRIPTION
#### Changes proposed in this Pull Request
There were two issues with unit tests in the React 17 PR (#54793).
1. With the latest wp monorepo updates, `i18n.setLocale` needs to be wrapped in `act`.
2. With the latest react/test environment, we need to set `jest.useFakeTimers()` in order for some ETK tests to pass. This is because the dependency `wait-for-expect` uses timeouts under the hood to wait for a fake network request to finish.

#### Testing instructions
- CI