### PR TITLE
Show Jetpack Plans page for Jetpack Product Sites

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -4,14 +4,16 @@ import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
+import { default as getIsJetpackProductSite } from 'calypso/state/sites/selectors/is-jetpack-product-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import Plans from './plans';
 
 function showJetpackPlans( context ) {
 	const getState = context.store.getState();
 	const siteId = getSelectedSiteId( getState );
+	const isJetpackProductSite = getIsJetpackProductSite( getState, siteId );
 	const isWpcom = isSiteWpcom( getState, siteId );
-	return ! isWpcom;
+	return ! isWpcom || isJetpackProductSite;
 }
 
 export function plans( context, next ) {

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -46,7 +46,7 @@ export { default as isBackupPluginActive } from './is-backup-plugin-active';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';
 export { default as isCurrentSitePlan } from './is-current-site-plan';
 export { default as isJetpackMinimumVersion } from './is-jetpack-minimum-version';
-export { default as isJetpackModuleActive } from './is-jetpack-mod
+export { default as isJetpackModuleActive } from './is-jetpack-module-active';
 export { default as isJetpackSite } from './is-jetpack-site';
 export { default as isJetpackProductSite } from './is-jetpack-product-site';
 export { default as isJetpackSiteMainNetworkSite } from './is-jetpack-site-main-network-site';

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -46,8 +46,9 @@ export { default as isBackupPluginActive } from './is-backup-plugin-active';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';
 export { default as isCurrentSitePlan } from './is-current-site-plan';
 export { default as isJetpackMinimumVersion } from './is-jetpack-minimum-version';
-export { default as isJetpackModuleActive } from './is-jetpack-module-active';
+export { default as isJetpackModuleActive } from './is-jetpack-mod
 export { default as isJetpackSite } from './is-jetpack-site';
+export { default as isJetpackProductSite } from './is-jetpack-product-site';
 export { default as isJetpackSiteMainNetworkSite } from './is-jetpack-site-main-network-site';
 export { default as isJetpackSiteMultiSite } from './is-jetpack-site-multi-site';
 export { default as isJetpackSiteSecondaryNetworkSite } from './is-jetpack-site-secondary-network-site';

--- a/client/state/sites/selectors/is-jetpack-product-site.js
+++ b/client/state/sites/selectors/is-jetpack-product-site.js
@@ -1,0 +1,22 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+
+/**
+ * Returns true if site is a Jetpack site with a product plugin installed ( i.e. Jetpack Backup )
+ * false if the site has the full Jetpack plugin or is hosted on WordPress.com, or null if the site is unknown.
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {?number}   siteId Site ID
+ * @returns {?boolean}        Whether site is a Jetpack site
+ */
+export default function isJetpackProductSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return (
+		( site?.options?.jetpack_connection_active_plugins || [] ).filter(
+			( plugin ) => plugin !== 'jetpack'
+		).length > 0
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show Jetpack plans page for Jetpack Product Sites ( i.e. Jetpack Backup ) in Calypso Blue

#### Testing instructions

1. connect a test site with only Jetpack Backup ( do not connect the full plugin )
2. boot branch
3. navigate to `/plans/:testSiteSlug:`
4. verify that the Jetpack plans page is shown
