### PR TITLE
Checkout: US 9 digit zip code validation/formatting

### DIFF
--- a/packages/wpcom-checkout/src/postal-code.ts
+++ b/packages/wpcom-checkout/src/postal-code.ts
@@ -79,13 +79,7 @@ const twoPartPostalCodes: Record<
 	US: {
 		length: [ 9 ],
 		delimiter: '-',
-		formatter: ( postalCodeInput: string, delimiter: string ) => {
-			return (
-				postalCodeInput.substring( 0, postalCodeInput.length - 4 ) +
-				delimiter +
-				postalCodeInput.substring( postalCodeInput.length - 4 )
-			);
-		},
+		partLength: 5,
 	},
 };
 
@@ -114,15 +108,15 @@ export function tryToGuessPostalCodeFormat(
 		return postalCode;
 	}
 
-	const postalCodeWithoutDelimeters = postalCode.replace( /[\s-]/g, '' );
+	const postalCodeWithoutDelimiters = postalCode.replace( /[\s-]/g, '' );
 
-	if ( countryCodeData.length.includes( postalCodeWithoutDelimeters.length ) ) {
+	if ( countryCodeData.length.includes( postalCodeWithoutDelimiters.length ) ) {
 		if ( isCountryCodeDataWithFormatter( countryCodeData ) ) {
-			return countryCodeData.formatter( postalCodeWithoutDelimeters, countryCodeData.delimiter );
+			return countryCodeData.formatter( postalCodeWithoutDelimiters, countryCodeData.delimiter );
 		}
 
 		return defaultFormatter(
-			postalCodeWithoutDelimeters,
+			postalCodeWithoutDelimiters,
 			countryCodeData.delimiter,
 			countryCodeData.partLength
 		);

--- a/packages/wpcom-checkout/src/postal-code.ts
+++ b/packages/wpcom-checkout/src/postal-code.ts
@@ -76,6 +76,17 @@ const twoPartPostalCodes: Record<
 		delimiter: ' ',
 		partLength: 3,
 	},
+	US: {
+		length: [ 9 ],
+		delimiter: '-',
+		formatter: ( postalCodeInput: string, delimiter: string ) => {
+			return (
+				postalCodeInput.substring( 0, postalCodeInput.length - 4 ) +
+				delimiter +
+				postalCodeInput.substring( postalCodeInput.length - 4 )
+			);
+		},
+	},
 };
 
 function isCountryCodeDataWithFormatter(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The changes in this PR add a formatter that correctly handles 9 digit US zip codes, removing the need to manually insert a hyphen, and will still fail incorrect zip codes (anything not 5 or 9 digits when US is the selected country).

#### Testing instructions

*Correct zip codes*
1. Add a plan or domain to the cart.
2. Enter a 9 digit US zip code without the hyphen (100195401 as an example); and click continue. It should auto-format to add the hyphen and accept the correctly formatted zip code.

*Incorrect zip codes*
1. Add a plan or domain to the cart.
2. Enter any non 5 or 9 digit US zip code ; and click continue. It should reject it when clicking continue.

Related to #56007
