### PR TITLE
Add ownership verification steps to connection flow

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -13,6 +13,7 @@ export default function ConnectDomainStepLogin( {
 	className,
 	pageSlug,
 	domain,
+	isOwnershipVerificationFlow,
 	mode,
 	onNextStep,
 	progressStepList,
@@ -20,6 +21,11 @@ export default function ConnectDomainStepLogin( {
 	const { __ } = useI18n();
 	const stepContent = (
 		<div className={ className + '__login' }>
+			{ isOwnershipVerificationFlow && (
+				<p className={ className + '__text' }>
+					__( 'We need to confirm that you are authorized to connect this domain.' )
+				</p>
+			) }
 			<p className={ className + '__text' }>
 				{ createInterpolateElement(
 					__(
@@ -64,7 +70,12 @@ ConnectDomainStepLogin.propTypes = {
 	className: PropTypes.string.isRequired,
 	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
 	domain: PropTypes.string.isRequired,
+	isOwnershipVerificationFlow: PropTypes.bool,
 	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
 	onNextStep: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
+};
+
+ConnectDomainStepLogin.defaultProps = {
+	isOwnershipVerificationFlow: false,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -45,7 +45,7 @@ export default function ConnectDomainStepLogin( {
 		<div className={ className + '__login' }>
 			{ isOwnershipVerificationFlow && (
 				<p className={ className + '__text' }>
-					__( 'We need to confirm that you are authorized to connect this domain.' )
+					{ __( 'We need to confirm that you are authorized to connect this domain.' ) }
 				</p>
 			) }
 			<p className={ className + '__text' }>

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -3,9 +3,15 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepsHeadingAdvanced, stepsHeadingSuggested, stepSlug } from './constants';
+import {
+	modeType,
+	stepsHeadingAdvanced,
+	stepsHeadingOwnershipVerification,
+	stepsHeadingSuggested,
+	stepSlug,
+} from './constants';
 
 import './style.scss';
 
@@ -19,6 +25,22 @@ export default function ConnectDomainStepLogin( {
 	progressStepList,
 } ) {
 	const { __ } = useI18n();
+	const [ heading, setHeading ] = useState();
+
+	useEffect( () => {
+		switch ( mode ) {
+			case modeType.SUGGESTED:
+				setHeading( stepsHeadingSuggested );
+				return;
+			case modeType.ADVANCED:
+				setHeading( stepsHeadingAdvanced );
+				return;
+			case modeType.OWNERSHIP_VERIFICATION:
+				setHeading( stepsHeadingOwnershipVerification );
+				return;
+		}
+	}, [ mode ] );
+
 	const stepContent = (
 		<div className={ className + '__login' }>
 			{ isOwnershipVerificationFlow && (
@@ -51,8 +73,6 @@ export default function ConnectDomainStepLogin( {
 			</Button>
 		</div>
 	);
-
-	const heading = modeType.SUGGESTED === mode ? stepsHeadingSuggested : stepsHeadingAdvanced;
 
 	return (
 		<ConnectDomainStepWrapper

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -50,7 +50,7 @@ function ConnectDomainStepLogin( {
 				verificationData: getVerificationData(),
 			},
 			( error ) => {
-				if ( error ) {
+				if ( 'ownership_verification_failed' === error.error ) {
 					setAuthCodeError( error.message );
 				}
 				setConnectInProgress( false );

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -1,0 +1,141 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { connectDomainAction } from 'calypso/components/domains/use-my-domain/utilities';
+import wpcom from 'calypso/lib/wp';
+import { Input } from 'calypso/my-sites/domains/components/form';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
+import { modeType, stepsHeadingAdvanced, stepsHeadingSuggested, stepSlug } from './constants';
+
+import './style.scss';
+
+function ConnectDomainStepLogin( {
+	className,
+	defaultConnectHandler,
+	domain,
+	mode,
+	onConnect,
+	pageSlug,
+	progressStepList,
+	recordMappingButtonClickInUseYourDomain,
+	selectedSite,
+} ) {
+	const { __ } = useI18n();
+	const [ authCode, setAuthCode ] = useState( '' );
+	const [ authCodeCheckInProgress, setAuthCodeCheckInProgress ] = useState( false );
+	const [ connectInProgress, setConnectInProgress ] = useState( false );
+	const [ authCodeError, setAuthCodeError ] = useState( null );
+
+	const handleConnect = () => {
+		recordMappingButtonClickInUseYourDomain( domain );
+		setConnectInProgress( true );
+
+		const connectHandler = onConnect ?? defaultConnectHandler;
+		connectHandler( { domain, selectedSite }, () => setConnectInProgress( false ) );
+	};
+
+	const onAuthCodeChange = ( event ) => {
+		setAuthCode( event?.target?.value );
+		setAuthCodeError( null );
+	};
+
+	const checkAuthCode = () => {
+		if ( 0 === authCode.length ) {
+			setAuthCodeError( __( 'Please enter an authorization code.' ) );
+			return;
+		}
+
+		setAuthCodeCheckInProgress( true );
+		setAuthCodeError( null );
+
+		wpcom
+			.domains()
+			.authCodeCheck( domain, authCode )
+			.then( ( result ) => {
+				if ( true === result.success ) {
+					handleConnect();
+				} else {
+					setAuthCodeError(
+						__( 'Sorry, that authorization code is incorrect. Please try again.' )
+					);
+				}
+			} )
+			.catch( ( error ) => setAuthCodeError( error.message ) )
+			.finally( () => setAuthCodeCheckInProgress( false ) );
+	};
+
+	const stepContent = (
+		<div className={ className + '__login' }>
+			<p className={ className + '__text' }>
+				{ __(
+					'We will use your domain authorization code to verify that you are the domain owner.'
+				) }
+			</p>
+			<p className={ className + '__text' }>
+				{ __(
+					'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
+				) }
+			</p>
+			<div className={ className + '__authorization-code' }>
+				<Input
+					placeholder={ __( 'Enter your authorization code' ) }
+					onChange={ onAuthCodeChange }
+					value={ authCode }
+					isError={ !! authCodeError }
+					errorMessage={ authCodeError }
+				/>
+			</div>
+			<p className={ className + '__text' }>
+				{ __(
+					"Once you've entered the authorization code, click on the button below to proceed."
+				) }
+			</p>
+			<Button
+				busy={ authCodeCheckInProgress || connectInProgress }
+				disabled={ authCodeCheckInProgress || connectInProgress }
+				onClick={ checkAuthCode }
+				primary
+			>
+				{ __( 'Check authorization code' ) }
+			</Button>
+		</div>
+	);
+
+	const heading = modeType.SUGGESTED === mode ? stepsHeadingSuggested : stepsHeadingAdvanced;
+
+	return (
+		<ConnectDomainStepWrapper
+			className={ className }
+			heading={ heading }
+			mode={ mode }
+			progressStepList={ progressStepList }
+			pageSlug={ pageSlug }
+			stepContent={ stepContent }
+		/>
+	);
+}
+
+const recordMappingButtonClickInUseYourDomain = ( domain_name ) =>
+	recordTracksEvent( 'calypso_use_your_domain_mapping_click', { domain_name } );
+
+export default connect( ( state ) => ( { selectedSite: getSelectedSite( state ) } ), {
+	defaultConnectHandler: connectDomainAction,
+	recordMappingButtonClickInUseYourDomain,
+} )( localize( ConnectDomainStepLogin ) );
+
+ConnectDomainStepLogin.propTypes = {
+	className: PropTypes.string.isRequired,
+	defaultConnectHandler: PropTypes.func,
+	domain: PropTypes.string.isRequired,
+	mode: PropTypes.oneOf( Object.values( modeType ) ).isRequired,
+	onConnect: PropTypes.func,
+	pageSlug: PropTypes.oneOf( Object.values( stepSlug ) ).isRequired,
+	progressStepList: PropTypes.object.isRequired,
+	recordMappingButtonClickInUseYourDomain: PropTypes.func.isRequired,
+	selectedSite: PropTypes.object,
+};

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -83,7 +83,7 @@ function ConnectDomainStepLogin( {
 			</p>
 			<div className={ className + '__authorization-code' }>
 				<Input
-					placeholder={ __( 'Enter your authorization code' ) }
+					placeholder={ __( 'Enter authorization code' ) }
 					onChange={ onAuthCodeChange }
 					value={ authCode }
 					isError={ !! authCodeError }
@@ -101,7 +101,7 @@ function ConnectDomainStepLogin( {
 				onClick={ checkAuthCode }
 				primary
 			>
-				{ __( 'Check authorization code' ) }
+				{ __( 'Check my authorization code' ) }
 			</Button>
 		</div>
 	);

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -10,7 +10,7 @@ import { Input } from 'calypso/my-sites/domains/components/form';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
-import { modeType, stepsHeadingAdvanced, stepsHeadingSuggested, stepSlug } from './constants';
+import { modeType, stepsHeadingOwnershipVerification, stepSlug } from './constants';
 
 import './style.scss';
 
@@ -106,12 +106,10 @@ function ConnectDomainStepLogin( {
 		</div>
 	);
 
-	const heading = modeType.SUGGESTED === mode ? stepsHeadingSuggested : stepsHeadingAdvanced;
-
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ heading }
+			heading={ stepsHeadingOwnershipVerification }
 			mode={ mode }
 			progressStepList={ progressStepList }
 			pageSlug={ pageSlug }

--- a/client/components/domains/connect-domain-step/constants.jsx
+++ b/client/components/domains/connect-domain-step/constants.jsx
@@ -41,3 +41,4 @@ export const defaultDomainSetupInfo = {
 
 export const stepsHeadingSuggested = __( 'Suggested setup' );
 export const stepsHeadingAdvanced = __( 'Advanced setup' );
+export const stepsHeadingOwnershipVerification = __( 'Verify domain ownership' );

--- a/client/components/domains/connect-domain-step/constants.jsx
+++ b/client/components/domains/connect-domain-step/constants.jsx
@@ -4,6 +4,7 @@ export const modeType = {
 	SUGGESTED: 'suggested',
 	ADVANCED: 'advanced',
 	DONE: 'done',
+	OWNERSHIP_VERIFICATION: 'ownership_verification',
 };
 
 export const stepType = {
@@ -13,6 +14,7 @@ export const stepType = {
 	UPDATE_A_RECORDS: 'update_a_records',
 	CONNECTED: 'connected',
 	VERIFYING: 'verifying',
+	ENTER_AUTH_CODE: 'enter_auth_code',
 };
 
 export const stepSlug = {
@@ -26,6 +28,8 @@ export const stepSlug = {
 	ADVANCED_UPDATE: 'advanced_update',
 	ADVANCED_VERIFYING: 'advanced_verifying',
 	ADVANCED_CONNECTED: 'advanced_connected',
+	OWNERSHIP_VERIFICATION_LOGIN: 'ownership_verification_login',
+	OWNERSHIP_VERIFICATION_AUTH_CODE: 'ownership_verification_auth_code',
 };
 
 export const defaultDomainSetupInfo = {

--- a/client/components/domains/connect-domain-step/page-definitions.js
+++ b/client/components/domains/connect-domain-step/page-definitions.js
@@ -3,6 +3,7 @@ import ConnectDomainStepAdvancedRecords from './connect-domain-step-advanced-rec
 import ConnectDomainStepAdvancedStart from './connect-domain-step-advanced-start';
 import ConnectDomainStepDone from './connect-domain-step-done';
 import ConnectDomainStepLogin from './connect-domain-step-login';
+import ConnectDomainStepOwnershipAuthCode from './connect-domain-step-ownership-auth-code';
 import ConnectDomainStepSuggestedRecords from './connect-domain-step-suggested-records';
 import ConnectDomainStepSuggestedStart from './connect-domain-step-suggested-start';
 import { modeType, stepSlug, stepType } from './constants';
@@ -77,6 +78,28 @@ export const connectADomainStepsDefinition = {
 		step: stepType.VERIFYING,
 		component: ConnectDomainStepDone,
 		prev: stepSlug.ADVANCED_UPDATE,
+	},
+};
+
+export const connectADomainOwnershipVerificationStepsDefinition = {
+	[ 'unused start step' ]: {
+		mode: modeType.OWNERSHIP_VERIFICATION,
+		step: stepType.START,
+		next: stepSlug.OWNERSHIP_VERIFICATION_LOGIN,
+	},
+	[ stepSlug.OWNERSHIP_VERIFICATION_LOGIN ]: {
+		mode: modeType.OWNERSHIP_VERIFICATION,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: __( 'Log in to provider' ),
+		component: ConnectDomainStepLogin,
+		next: stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE,
+	},
+	[ stepSlug.OWNERSHIP_VERIFICATION_AUTH_CODE ]: {
+		mode: modeType.OWNERSHIP_VERIFICATION,
+		step: stepType.ENTER_AUTH_CODE,
+		name: __( 'Verify ownership' ),
+		component: ConnectDomainStepOwnershipAuthCode,
+		prev: stepSlug.OWNERSHIP_VERIFICATION_LOGIN,
 	},
 };
 

--- a/client/components/domains/connect-domain-step/style.scss
+++ b/client/components/domains/connect-domain-step/style.scss
@@ -367,6 +367,16 @@
 			}
 		}
 	}
+
+	&__authorization-code {
+		margin-bottom: 32px;
+
+		& input.form-text-input {
+			@include break-mobile {
+				width: 314px;
+			}
+		}
+	}
 }
 
 button.action_buttons__button.action-buttons__back.connect-domain-step__go-back {

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -159,6 +159,7 @@ function UseMyDomain( {
 				baseClassName={ 'connect-domain-step' }
 				domain={ domainName }
 				initialPageSlug={ ownershipVerificationFlowPageSlug }
+				isOwnershipVerificationFlow={ true }
 				onConnect={ onConnect }
 				onSetPage={ setOwnershipVerificationFlowPageSlug }
 				stepsDefinition={ connectADomainOwnershipVerificationStepsDefinition }

--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -5,10 +5,10 @@ import { domainManagementList, domainMappingSetup } from 'calypso/my-sites/domai
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 
-export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {} ) => (
-	dispatch,
-	getState
-) => {
+export const connectDomainAction = (
+	{ domain, selectedSite, verificationData },
+	onDone = () => {}
+) => ( dispatch, getState ) => {
 	const siteHasPaidPlan = isSiteOnPaidPlan( getState(), selectedSite.ID );
 
 	if ( selectedSite.is_vip ) {
@@ -23,7 +23,7 @@ export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {}
 	} else if ( siteHasPaidPlan ) {
 		wpcom
 			.site( selectedSite.ID )
-			.addDomainMapping( domain )
+			.addDomainMapping( domain, verificationData )
 			.then( () => {
 				dispatch(
 					successNotice(
@@ -38,7 +38,7 @@ export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {}
 			} )
 			.catch( ( error ) => {
 				dispatch( errorNotice( error.message ) );
-				onDone();
+				onDone( error );
 			} );
 	} else {
 		page( '/checkout/' + selectedSite.slug + '/domain-mapping:' + domain );

--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -37,7 +37,9 @@ export const connectDomainAction = (
 				page( domainMappingSetup( selectedSite.slug, domain ) );
 			} )
 			.catch( ( error ) => {
-				dispatch( errorNotice( error.message ) );
+				if ( 'ownership_verification_failed' !== error.error ) {
+					dispatch( errorNotice( error.message ) );
+				}
 				onDone( error );
 			} );
 	} else {

--- a/packages/wpcom.js/src/lib/domains.js
+++ b/packages/wpcom.js/src/lib/domains.js
@@ -63,19 +63,6 @@ class Domains {
 		const path = root + 'supported-states/' + countryCode;
 		return this.wpcom.req.get( path, query, fn );
 	}
-
-	/**
-	 * Get the results of an EPP code (auth-code) check for this domain.
-	 *
-	 * @param {string} domain - The domain name to check.
-	 * @param {string} authCode - The auth code for the given domain to check.
-	 * @param {Function} fn The callback function
-	 * @returns {Promise} A promise that resolves when the request completes
-	 */
-	authCodeCheck( domain, authCode, fn ) {
-		const path = root + encodeURIComponent( domain ) + '/inbound-transfer-check-auth-code';
-		return this.wpcom.req.get( path, { auth_code: authCode }, fn );
-	}
 }
 
 /**

--- a/packages/wpcom.js/src/lib/domains.js
+++ b/packages/wpcom.js/src/lib/domains.js
@@ -4,7 +4,7 @@ class Domains {
 	/**
 	 * `Domains` constructor.
 	 *
-	 * @param {WPCOM} wpcom - wpcom instance
+	 * @param wpcom - wpcom instance
 	 * @returns {undefined} undefined
 	 */
 	constructor( wpcom ) {
@@ -62,6 +62,19 @@ class Domains {
 	supportedStates( countryCode, query, fn ) {
 		const path = root + 'supported-states/' + countryCode;
 		return this.wpcom.req.get( path, query, fn );
+	}
+
+	/**
+	 * Get the results of an EPP code (auth-code) check for this domain.
+	 *
+	 * @param {string} domain - The domain name to check.
+	 * @param {string} authCode - The auth code for the given domain to check.
+	 * @param {Function} fn The callback function
+	 * @returns {Promise} A promise that resolves when the request completes
+	 */
+	authCodeCheck( domain, authCode, fn ) {
+		const path = root + encodeURIComponent( domain ) + '/inbound-transfer-check-auth-code';
+		return this.wpcom.req.get( path, { auth_code: authCode }, fn );
 	}
 }
 

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -404,12 +404,18 @@ class Site {
 	 * Add a domain mapping to a site.
 	 *
 	 * @param {string} domain - donain to map
+	 * @param {object} extraData - extra data passed to the endpoint
 	 * @param {object} [query] - query object parameter
 	 * @param {Function} fn - callback function
 	 * @returns {Function} request handler
 	 */
-	addDomainMapping( domain, query, fn ) {
-		return this.wpcom.req.post( `${ this.path }/add-domain-mapping`, query, { domain }, fn );
+	addDomainMapping( domain, extraData, query, fn ) {
+		return this.wpcom.req.post(
+			`${ this.path }/add-domain-mapping`,
+			query,
+			{ domain, ...extraData },
+			fn
+		);
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In certain cases, we may want to request that users verify ownership of domains they want to connect to their site. This PR adds a flow to allow this when connecting a domain to a site with a paid plan.

When you are on a site that requires ownership verification, you will first be prompted to log in to your provider:
<img width="1792" alt="Screen Shot 2021-09-09 at 10 07 33 AM" src="https://user-images.githubusercontent.com/1379730/132701784-bc10d557-e035-4240-b0a7-6659e668dc9b.png">


In the next step, you will be asked to enter the auth code for your domain:
<img width="1792" alt="Screen Shot 2021-09-09 at 10 07 39 AM" src="https://user-images.githubusercontent.com/1379730/132701828-7f477d5d-df0d-4e6b-a9de-5aea9c5c8cf1.png">


Leaving the auth code field blank or entering an incorrect value will cause errors to be shown below the auth code field:
<img width="1792" alt="Screen Shot 2021-09-09 at 10 07 44 AM" src="https://user-images.githubusercontent.com/1379730/132701932-cc09e66c-40d7-493f-af57-8fd413554a9a.png">


When the correct auth code is entered, the domain will be connected and the user will be directed to the "connect a domain flow" as usual. 

#### Testing instructions

Hack the back end to return `{ ownership_verification_type: 'auth_code' }` on the `is-available` endpoint.

Select a site that is on a paid plan and go through the "Use a domain I own" to connect a domain you already own that is not mapped to WordPress.com.

Try to verify the auth code without entering anything in the input field.
Try entering the incorrect auth code in the input field.
Make sure that your domain is properly connected when you enter the correct auth code.