### PR TITLE
Fix cmd + click not work on link in post publish panel or toast notification

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -679,6 +679,11 @@ async function openLinksInParentFrame( calypsoPort ) {
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
 	].join( ',' );
 	$( '#editor' ).on( 'click', viewPostLinkSelectors, ( e ) => {
+		// Ignore if the click has modifier
+		if ( e.shiftKey || e.ctrlKey || e.metaKey ) {
+			return;
+		}
+
 		e.preventDefault();
 		calypsoPort.postMessage( {
 			action: 'viewPost',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We can also change the `target` attribute to `_top` to ensure the links open in the top frame. But as those buttons are shown after publishing, it's not easy to catch the publish event. So I just ignore the behavior to fix the cmd + click not work if the click has a modifier. 

https://user-images.githubusercontent.com/13596067/132156984-45f152e5-bb54-42a6-a095-863a1b7c0e45.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create or edit a post
* Publish the post
* Check `cmd + click in macOS`, `ctrl + click in windows` and `shift + click` work correctly or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55785