### PR TITLE
Purchases: Run experiment for redesigned pre-cancellation survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -34,6 +34,7 @@ import FormLegend from 'calypso/components/forms/form-legend';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import HappychatButton from 'calypso/components/happychat/button';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getName, isRefundable } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { DOWNGRADEABLE_PLANS_FROM_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
@@ -168,6 +169,7 @@ class CancelPurchaseForm extends React.Component {
 			importQuestionText: '',
 			isSubmitting: false,
 			upsell: '',
+			fullscreen: false,
 		};
 	}
 
@@ -1141,11 +1143,18 @@ class CancelPurchaseForm extends React.Component {
 	}
 
 	componentDidMount() {
-		this.initSurveyState();
+		loadExperimentAssignment( 'fullscreen_precancellation_survey' ).then(
+			( experimentAssignment ) => {
+				if ( 'treatment' === experimentAssignment?.variationName ) {
+					this.setState( { fullscreen: true } );
+				}
+				this.initSurveyState();
+			}
+		);
 	}
 
 	render() {
-		const { surveyStep } = this.state;
+		const { fullscreen, surveyStep } = this.state;
 		if ( ! surveyStep ) {
 			return null;
 		}
@@ -1160,7 +1169,7 @@ class CancelPurchaseForm extends React.Component {
 			translate,
 		} = this.props;
 
-		if ( config.isEnabled( 'purchases/cancel-plan-fullscreen-form' ) && isPlan( purchase ) ) {
+		if ( fullscreen && isPlan( purchase ) ) {
 			return (
 				<>
 					<QueryPlans />

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1148,7 +1148,7 @@ class CancelPurchaseForm extends React.Component {
 			return;
 		}
 
-		loadExperimentAssignment( 'fullscreen_precancellation_survey' ).then(
+		loadExperimentAssignment( 'fullscreen_precancellation_survey_v2' ).then(
 			( experimentAssignment ) => {
 				if ( 'treatment' === experimentAssignment?.variationName ) {
 					this.setState( { fullscreen: true } );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1143,6 +1143,11 @@ class CancelPurchaseForm extends React.Component {
 	}
 
 	componentDidMount() {
+		if ( ! isPlan( this.props.purchase ) ) {
+			this.initSurveyState();
+			return;
+		}
+
 		loadExperimentAssignment( 'fullscreen_precancellation_survey' ).then(
 			( experimentAssignment ) => {
 				if ( 'treatment' === experimentAssignment?.variationName ) {

--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -28,7 +28,7 @@ export default function stepsForProductAndSurvey(
 	precancellationChatAvailable,
 	downgradePossible
 ) {
-	if ( survey.fullscreen && isPlan( product ) ) {
+	if ( survey?.fullscreen && isPlan( product ) ) {
 		return [ steps.FEEDBACK_STEP ];
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	GROUP_WPCOM,
 	GROUP_JETPACK,
@@ -29,7 +28,7 @@ export default function stepsForProductAndSurvey(
 	precancellationChatAvailable,
 	downgradePossible
 ) {
-	if ( config.isEnabled( 'purchases/cancel-plan-fullscreen-form' ) && isPlan( product ) ) {
+	if ( survey.fullscreen && isPlan( product ) ) {
 		return [ steps.FEEDBACK_STEP ];
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/56020

#### Changes proposed in this Pull Request

Add an experiment check which determines whether the new redesigned pre-cancellation survey should should up, effectively removing the feature flag support introduced in https://github.com/Automattic/wp-calypso/pull/55891.

#### Testing instructions

- Use the Calypso live link below.
- Switch to a site with a paid plan.
- Go to Upgrades > Purchases.
- Try cancelling/removing the plan.
- Make sure you get the current small dialog with multiple steps.
- Go to the experiment page in Abacus (see pbxNRc-Ue-p2#comment-2276) and add yourself to the `treatment` variation using the bookmarklets.
- Wait a bit for the cache to be updated.
- Reload Calypso and try cancelling/removing the plan again.
- Make sure you get the new fullscreen dialog with one single step.