### PR TITLE
Emails: Update thank you page for check out when buying a professional email

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -391,7 +391,7 @@ export class CheckoutThankYou extends React.Component {
 		let wasDIFMProduct = false;
 		let delayedTransferPurchase = false;
 		let wasDomainMappingOrTransferProduct = false;
-		let wasTitanEmailPurchase = false;
+		let wasTitanEmailProductOnly = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
@@ -406,7 +406,7 @@ export class CheckoutThankYou extends React.Component {
 					( purchase ) => isDomainMapping( purchase ) || isDomainTransfer( purchase )
 				);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
-			wasTitanEmailPurchase = purchases.length === 1 && purchases.some( isTitanMail );
+			wasTitanEmailProductOnly = purchases.length === 1 && purchases.some( isTitanMail );
 		}
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
@@ -499,7 +499,7 @@ export class CheckoutThankYou extends React.Component {
 					selectedSiteSlug={ this.props.selectedSiteSlug }
 				/>
 			);
-		} else if ( wasTitanEmailPurchase ) {
+		} else if ( wasTitanEmailProductOnly ) {
 			return (
 				<TitanSetUpThankYou
 					domainName={ purchases[ 0 ].meta }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -391,7 +391,7 @@ export class CheckoutThankYou extends React.Component {
 		let wasDIFMProduct = false;
 		let delayedTransferPurchase = false;
 		let wasDomainMappingOrTransferProduct = false;
-		let wasTitanEmailProductOnly = false;
+		let wasTitanEmailOnlyProduct = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
@@ -406,7 +406,7 @@ export class CheckoutThankYou extends React.Component {
 					( purchase ) => isDomainMapping( purchase ) || isDomainTransfer( purchase )
 				);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
-			wasTitanEmailProductOnly = purchases.length === 1 && purchases.some( isTitanMail );
+			wasTitanEmailOnlyProduct = purchases.length === 1 && purchases.some( isTitanMail );
 		}
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
@@ -499,7 +499,7 @@ export class CheckoutThankYou extends React.Component {
 					selectedSiteSlug={ this.props.selectedSiteSlug }
 				/>
 			);
-		} else if ( wasTitanEmailProductOnly ) {
+		} else if ( wasTitanEmailOnlyProduct ) {
 			return (
 				<TitanSetUpThankYou
 					domainName={ purchases[ 0 ].meta }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -50,6 +50,7 @@ import {
 	domainManagementTransferInPrecheck,
 } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
+import TitanSetUpThankYou from 'calypso/my-sites/email/titan-set-up-thank-you';
 import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import {
@@ -390,6 +391,7 @@ export class CheckoutThankYou extends React.Component {
 		let wasDIFMProduct = false;
 		let delayedTransferPurchase = false;
 		let wasDomainMappingOrTransferProduct = false;
+		let wasTitanEmailPurchase = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
@@ -404,6 +406,7 @@ export class CheckoutThankYou extends React.Component {
 					( purchase ) => isDomainMapping( purchase ) || isDomainTransfer( purchase )
 				);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
+			wasTitanEmailPurchase = purchases.length === 1 && purchases.some( isTitanMail );
 		}
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
@@ -494,6 +497,14 @@ export class CheckoutThankYou extends React.Component {
 					type={ purchaseType }
 					domain={ domainName }
 					selectedSiteSlug={ this.props.selectedSiteSlug }
+				/>
+			);
+		} else if ( wasTitanEmailPurchase ) {
+			return (
+				<TitanSetUpThankYou
+					domainName={ purchases[ 0 ].meta }
+					subtitle={ translate( 'You will receive an email confirmation shortly.' ) }
+					title={ translate( 'Congratulations on your purchase!' ) }
 				/>
 			);
 		}

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -24,6 +24,8 @@ import './style.scss';
 type TitanSetUpThankYouProps = {
 	domainName: string;
 	emailAddress?: string;
+	title?: string;
+	subtitle?: string;
 };
 
 const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
@@ -31,7 +33,7 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
-	const { domainName, emailAddress } = props;
+	const { domainName, emailAddress, subtitle, title } = props;
 
 	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
 
@@ -96,7 +98,8 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 			sections={ [ titanThankYouSection ] }
 			showSupportSection={ true }
 			thankYouImage={ thankYouImage }
-			thankYouTitle={ translate( 'Your email is now ready to use' ) }
+			thankYouTitle={ title ?? translate( 'Your email is now ready to use' ) }
+			thankYouSubtitle={ subtitle }
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the workflow when the user buys a Professional Email subscription. Replaces the old check out thank you page with the new ThankYou component developed previously.

#### Testing instructions

1. Go to upgrades -> Emails
2. Click on Add email on on of your domains (buy a domain if you don't have available ones)
3. Fill data in Professional Email form
4. Pay with credits and check the resulting Thank you Page, comparing it with the below table
5. Check that each ones of the buttons behaves correctly

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/132212839-bb076a65-8250-4b44-8b25-7a0836434da4.png) | ![image](https://user-images.githubusercontent.com/5689927/132212950-49d77d8f-65cc-4fb3-af83-f11261f84071.png)

Related to {1200182182542585-as-1200802275826449}
