### PR TITLE
Simplify the domain mapping verification screen

### DIFF
--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -5,10 +5,10 @@ import { domainManagementList, domainMappingSetup } from 'calypso/my-sites/domai
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 
-export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {} ) => (
-	dispatch,
-	getState
-) => {
+export const connectDomainAction = (
+	{ domain, selectedSite, verificationData },
+	onDone = () => {}
+) => ( dispatch, getState ) => {
 	const siteHasPaidPlan = isSiteOnPaidPlan( getState(), selectedSite.ID );
 
 	if ( selectedSite.is_vip ) {
@@ -23,7 +23,7 @@ export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {}
 	} else if ( siteHasPaidPlan ) {
 		wpcom
 			.site( selectedSite.ID )
-			.addDomainMapping( domain )
+			.addDomainMapping( domain, verificationData )
 			.then( () => {
 				dispatch(
 					successNotice(
@@ -38,7 +38,7 @@ export const connectDomainAction = ( { domain, selectedSite }, onDone = () => {}
 			} )
 			.catch( ( error ) => {
 				dispatch( errorNotice( error.message ) );
-				onDone();
+				onDone( error );
 			} );
 	} else {
 		page( '/checkout/' + selectedSite.slug + '/domain-mapping:' + domain );

--- a/packages/wpcom.js/src/lib/domains.js
+++ b/packages/wpcom.js/src/lib/domains.js
@@ -63,19 +63,6 @@ class Domains {
 		const path = root + 'supported-states/' + countryCode;
 		return this.wpcom.req.get( path, query, fn );
 	}
-
-	/**
-	 * Get the results of an EPP code (auth-code) check for this domain.
-	 *
-	 * @param {string} domain - The domain name to check.
-	 * @param {string} authCode - The auth code for the given domain to check.
-	 * @param {Function} fn The callback function
-	 * @returns {Promise} A promise that resolves when the request completes
-	 */
-	authCodeCheck( domain, authCode, fn ) {
-		const path = root + encodeURIComponent( domain ) + '/inbound-transfer-check-auth-code';
-		return this.wpcom.req.get( path, { auth_code: authCode }, fn );
-	}
 }
 
 /**

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -404,12 +404,18 @@ class Site {
 	 * Add a domain mapping to a site.
 	 *
 	 * @param {string} domain - donain to map
+	 * @param {object} extraData - extra data passed to the endpoint
 	 * @param {object} [query] - query object parameter
 	 * @param {Function} fn - callback function
 	 * @returns {Function} request handler
 	 */
-	addDomainMapping( domain, query, fn ) {
-		return this.wpcom.req.post( `${ this.path }/add-domain-mapping`, query, { domain }, fn );
+	addDomainMapping( domain, extraData, query, fn ) {
+		return this.wpcom.req.post(
+			`${ this.path }/add-domain-mapping`,
+			query,
+			{ domain, ...extraData },
+			fn
+		);
 	}
 
 	/**


### PR DESCRIPTION
This is a proposal for an update to #56011

In order to simplify the domain mapping verification I believe we should call only the add domain mapping endpoint with all the data provided. That way we won't check the auth code more than once and also this'll probably simplify future ownership verification types.

#### Changes proposed in this Pull Request

* Update the domain mapping verification screen to only call the add mapping endpoint and show the error returned from it (if any)

#### Testing instructions

* On the backend make the add domain endpoint throw an error
* Then follow the instructons in #56011
