### PR TITLE
Themes Showcase: nudge business plan instead of premium

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,4 +1,4 @@
-import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_THEMES } from '@automattic/calypso-products';
 import React from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -22,10 +22,11 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	if ( displayUpsellBanner ) {
 		upsellBanner = (
 			<UpsellNudge
-				plan={ PLAN_BUSINESS }
 				className="themes__showcase-banner"
-				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 				event="calypso_themes_list_install_themes"
+				feature={ FEATURE_UPLOAD_THEMES }
+				plan={ PLAN_BUSINESS }
+				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 				forceHref={ true }
 				showIcon={ true }
 			/>

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -24,7 +24,6 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 		upsellBanner = (
 			<UpsellNudge
 				plan={ PLAN_BUSINESS }
-				customerType="business"
 				className="themes__showcase-banner"
 				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 				event="calypso_themes_list_install_themes"

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,4 +1,4 @@
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
 import React from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -21,38 +21,24 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
-		if ( bannerLocationBelowSearch ) {
-			upsellBanner = (
-				<UpsellNudge
-					plan={ PLAN_PREMIUM }
-					customerType="business"
-					className="themes__showcase-banner"
-					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
-					event="themes_plans_free_personal"
-					forceHref={ true }
-					showIcon={ true }
-				/>
-			);
-		} else {
-			upsellBanner = (
-				<UpsellNudge
-					plan={ PLAN_PREMIUM }
-					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
-					description={ translate(
-						'Get advanced customization, more storage space, and video support along with the ability to upload any theme.'
-					) }
-					event="themes_plans_free_personal"
-					showIcon={ true }
-				/>
-			);
-		}
+		upsellBanner = (
+			<UpsellNudge
+				plan={ PLAN_BUSINESS }
+				customerType="business"
+				className="themes__showcase-banner"
+				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
+				event="calypso_themes_list_install_themes"
+				forceHref={ true }
+				showIcon={ true }
+			/>
+		);
 	}
+
 	return (
 		<Main fullWidthLayout className="themes">
 			<SidebarNavigation />
 			<ThemesHeader />
 			<CurrentTheme siteId={ siteId } />
-			{ bannerLocationBelowSearch ? null : upsellBanner }
 
 			<ThemeShowcase
 				{ ...props }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -7,16 +7,15 @@ import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
-	const { requestingSitePlans, siteId, isVip, siteSlug, translate, isJetpack } = props;
+	const { requestingSitePlans, siteId, isVip, siteSlug, translate } = props;
 
 	const displayUpsellBanner = ! requestingSitePlans && ! isVip;
-	const bannerLocationBelowSearch = ! isJetpack;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
@@ -42,7 +41,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 			<ThemeShowcase
 				{ ...props }
 				upsellUrl={ upsellUrl }
-				upsellBanner={ bannerLocationBelowSearch ? upsellBanner : null }
+				upsellBanner={ upsellBanner }
 				siteId={ siteId }
 			/>
 		</Main>
@@ -50,7 +49,6 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 } );
 
 export default connect( ( state, { siteId } ) => ( {
-	isJetpack: isJetpackSite( state, siteId ),
 	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -4,12 +4,17 @@ import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const { isJetpack, isAtomic, siteId, translate } = props;
+	const { activeTheme, isJetpack, isAtomic, siteId, translate } = props;
+
+	const getScreenshotOption = ( themeId ) => {
+		return activeTheme === themeId ? 'customize' : 'info';
+	};
 
 	// If we've only just switched from single to multi-site, there's a chance
 	// this component is still being rendered with site unset, so we need to guard
@@ -26,6 +31,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 				defaultOption="activate"
 				secondaryOption="tryandcustomize"
 				source="showcase"
+				getScreenshotOption={ getScreenshotOption }
 				listLabel={ translate( 'Uploaded themes' ) }
 				placeholderCount={ 5 }
 			/>
@@ -40,6 +46,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 			defaultOption="activate"
 			secondaryOption="tryandcustomize"
 			source="showcase"
+			getScreenshotOption={ getScreenshotOption }
 		/>
 	);
 };
@@ -50,5 +57,6 @@ export default connect( ( state ) => {
 		siteId: selectedSiteId,
 		isJetpack: isJetpackSite( state, selectedSiteId ),
 		isAtomic: isAtomicSite( state, selectedSiteId ),
+		activeTheme: getActiveTheme( state, selectedSiteId ),
 	};
 } )( localize( SingleSiteThemeShowcaseWithOptions ) );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -2,14 +2,14 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { isThemeActive } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const { isJetpack, siteId, translate } = props;
+	const { isJetpack, isAtomic, siteId, translate } = props;
 
 	// If we've only just switched from single to multi-site, there's a chance
 	// this component is still being rendered with site unset, so we need to guard
@@ -18,7 +18,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 		return <Main fullWidthLayout className="themes" />;
 	}
 
-	if ( isJetpack ) {
+	if ( isJetpack && ! isAtomic ) {
 		return (
 			<SingleSiteThemeShowcaseJetpack
 				{ ...props }
@@ -49,7 +49,6 @@ export default connect( ( state ) => {
 	return {
 		siteId: selectedSiteId,
 		isJetpack: isJetpackSite( state, selectedSiteId ),
-		getScreenshotOption: ( themeId ) =>
-			isThemeActive( state, themeId, selectedSiteId ) ? 'customize' : 'info',
+		isAtomic: isAtomicSite( state, selectedSiteId ),
 	};
 } )( localize( SingleSiteThemeShowcaseWithOptions ) );


### PR DESCRIPTION
In #55942, references to premium themes were removed from Calypso, and in #55989 the plans were correctly adjusted to reflect a plan that allows uploading themes, but the nudge itself still nudged the Premium plan.

This PR cleans up some of that logic by doing the following:
- removes the inaccessible above-search Jetpack `UpsellNudge` (handled by `../single-site-jetpack.jsx`)
- updates the plan constant to the Business plan
- updates the event name to reflect the plan upsell
- removes the deprecated "customerType" prop
- shows the upsell nudge to Premium plan users
- hides the upsell nudge from Atomic users

-----

**To test:**
Since the `customerType` prop was set to "business", the flow should remain largely unchanged.

- for a simple site with a free (existing behavior), Personal (existing behavior), or Premium plan (new behavior)
  - verify that the banner is shown beneath the showcase search
  - verify that clicking the banner takes you to the plans page with the Business plan marked "popular"
- for a Jetpack site (existing behavior)
  - verify that the Jetpack banner is shown above the search
  - verify that clicking the banner takes you to Checkout with the Jetpack Security Real-time plan in your cart
- for an Atomic Site with a business or e-commerce plan (new behavior)
  - verify that no banner is shown
- for an Atomic Site with a free, personal, or premium plan (new behavior)
  - verify that the banner is shown