### PR TITLE
Playwright: update viewports and associated modules/specs.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -207,12 +207,12 @@ fun gutenbergBuildType(screenSize: String, buildUuid: String): BuildType {
 	}
 }
 
-fun gutenbergPlaywrightBuildType( viewportName: String, buildUuid: String ): BuildType {
-	return BuildType {
-		id("WPComTests_gutenberg_Playwright_$viewportName")
+fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): BuildType {
+    return BuildType {
+		id("WPComTests_gutenberg_Playwright_$targetDevice")
 		uuid=buildUuid
-		name = "Playwright E2E Tests ($viewportName)"
-		description = "Runs Gutenberg E2E tests in $viewportName size using Playwright"
+		name = "Playwright E2E Tests ($targetDevice)"
+		description = "Runs Gutenberg E2E tests as $targetDevice using Playwright"
 
 
 		artifactRules = """
@@ -267,7 +267,7 @@ fun gutenbergPlaywrightBuildType( viewportName: String, buildUuid: String ): Bui
 				"""
 			}
 			bashNodeScript {
-				name = "Run e2e tests ($viewportName)"
+				name = "Run e2e tests ($targetDevice)"
 				scriptContent = """
 					shopt -s globstar
 					set -x
@@ -281,7 +281,7 @@ fun gutenbergPlaywrightBuildType( viewportName: String, buildUuid: String ): Bui
 					export GUTENBERG_EDGE=%GUTENBERG_EDGE%
 					export COBLOCKS_EDGE=%COBLOCKS_EDGE%
 					export URL=%URL%
-					export VIEWPORT_NAME=$viewportName
+					export VIEWPORT_NAME=$targetDevice
 					export LOCALE=en
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -578,12 +578,12 @@ fun seleniumBuildType( viewportName: String, buildUuid: String): BuildType  {
 	}
 }
 
-fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
+fun playwrightBuildType( targetDevice: String, buildUuid: String ): BuildType {
 	return BuildType {
-		id("Calypso_E2E_Playwright_$viewportName")
+		id("Calypso_E2E_Playwright_$targetDevice")
 		uuid = buildUuid
-		name = "Playwright E2E Tests ($viewportName)"
-		description = "Runs Calypso e2e tests in $viewportName size using Playwright"
+		name = "Playwright E2E Tests ($targetDevice)"
+		description = "Runs Calypso e2e tests as $targetDevice using Playwright"
 
 		artifactRules = """
 			reports => reports
@@ -612,7 +612,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 				dockerImage = "%docker_image_e2e%"
 			}
 			bashNodeScript {
-				name = "Run e2e tests ($viewportName)"
+				name = "Run e2e tests ($targetDevice)"
 				scriptContent = """
 					shopt -s globstar
 					set -x
@@ -637,7 +637,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
 					# Run the test
-					export VIEWPORT_NAME=$viewportName
+					export TARGET_DEVICE=$targetDevice
 					export LOCALE=en
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api

--- a/packages/calypso-e2e/__mocks__/config.js
+++ b/packages/calypso-e2e/__mocks__/config.js
@@ -10,24 +10,6 @@ const values = {
 	},
 	viewportName: 'desktop',
 	locale: 'en',
-	viewportSize: {
-		mobile: {
-			width: 400,
-			height: 1000,
-		},
-		tablet: {
-			width: 1024,
-			height: 1000,
-		},
-		desktop: {
-			width: 1440,
-			height: 1000,
-		},
-		laptop: {
-			width: 1440,
-			height: 790,
-		},
-	},
 	calypsoBaseURL: 'https://wordpress.com',
 	testAccounts: {
 		basicUser: [ 'wpcomuser', 'hunter2', 'wpcomuser.wordpress.com' ],

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -1,6 +1,6 @@
 import phrase from 'asana-phrase';
 import config from 'config';
-import { getViewportName } from './browser-helper';
+import { getTargetDeviceName } from './browser-helper';
 
 export type DateFormat = 'ISO';
 export { config };
@@ -198,7 +198,7 @@ export function createSuiteTitle( title: string ): string {
 	const parts = [
 		`[${ getJetpackHost() }]`,
 		`${ toTitleCase( title ) }:`,
-		`(${ getViewportName() })`,
+		`(${ getTargetDeviceName() })`,
 		'@parallel',
 	];
 

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -1,4 +1,12 @@
 import { Page } from 'playwright';
+import { getTargetDeviceName } from './browser-helper';
+
+const selectors = {
+	// clickNavTab
+	navTab: ( tab: string ) => `.section-nav-tab:has-text("${ tab }")`,
+	selectedNavTab: ( tab: string ) => `li.section-nav-tab.is-selected:has-text("${ tab }")`,
+	mobileNavTabsToggle: 'button.section-nav__mobile-header',
+};
 
 /**
  * Waits for the element specified by the selector to become enabled.
@@ -18,7 +26,6 @@ import { Page } from 'playwright';
  * @param {string} selector Selector of the target element.
  * @param {{[key: string]: number}} options Object parameter.
  * @param {number} options.timeout Timeout to override the default value.
- *
  */
 export async function waitForElementEnabled(
 	page: Page,
@@ -30,4 +37,39 @@ export async function waitForElementEnabled(
 		elementHandle.waitForElementState( 'enabled', options ),
 		page.waitForFunction( ( element: any ) => element.ariaDisabled !== 'true', elementHandle ),
 	] );
+}
+
+/**
+ * Locates and clicks on a specified tab on the NavTab.
+ *
+ * NavTabs are used throughout calypso to contain multiple related but separate pages within the same
+ * overall page. For instance, on the Media gallery page a NavTab is used to filter the gallery to
+ * show a specific category of gallery items.
+ *
+ * @param {Page} page Underlying page on which interactions take place.
+ * @param {string} name Name of the tab to be clicked.
+ */
+export async function clickNavTab( page: Page, name: string ): Promise< void > {
+	const targetDevice = getTargetDeviceName();
+
+	if ( targetDevice === 'mobile' ) {
+		// Mobile view - navtabs become a dropdown.
+		await page.click( selectors.mobileNavTabsToggle );
+		await page.click( selectors.navTab( name ) );
+	} else {
+		// Desktop view - navtabs are constantly visible tabs.
+		await page.click( selectors.navTab( name ) );
+	}
+
+	// Check that intended tab is now selected.
+	// Instead of using `waitForSelector`, this appraoch of manually checking
+	// the attribute in classList is preferable as it works across all scenarios.
+	// See https://github.com/Automattic/wp-calypso/issues/56038.
+	const elementHandle = await page.$( selectors.selectedNavTab( name ) );
+	const isSelected = await elementHandle
+		?.getAttribute( 'class' )
+		.then( ( classes ) => classes?.includes( 'is-selected' ) );
+	if ( ! isSelected ) {
+		throw new Error( `Failed to select tab ${ name }.` );
+	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	// Buttons on navbar
-	mySiteButton: 'text=My Site',
+	mySiteButton: 'button[data-tip-target="my-sites"]',
 	writeButton: '*css=a >> text=Write',
 	notificationsButton: 'a[href="/notifications"]',
 };

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -1,5 +1,5 @@
 import { ElementHandle, Page } from 'playwright';
-import { getViewportName } from '../../browser-helper';
+import { getTargetDeviceName } from '../../browser-helper';
 import { NavbarComponent } from './navbar-component';
 
 const selectors = {
@@ -44,7 +44,7 @@ export class SidebarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async navigate( item: string, subitem?: string, retries = 3 ): Promise< void > {
-		if ( getViewportName() === 'mobile' ) {
+		if ( getTargetDeviceName() === 'mobile' ) {
 			await this.openMobileSidebar();
 		}
 
@@ -124,11 +124,11 @@ export class SidebarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async switchSite(): Promise< void > {
-		const viewportName = getViewportName();
+		const device = getTargetDeviceName();
 
 		await this.waitForSidebarInitialization();
 
-		if ( viewportName === 'mobile' ) {
+		if ( device === 'mobile' ) {
 			await this.openMobileSidebar();
 		}
 

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright';
-import { getViewportName } from '../../browser-helper';
+import { getTargetDeviceName } from '../../browser-helper';
 
 export type Plans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
 export type Features =
@@ -150,7 +150,7 @@ export class GutenboardingFlow {
 	 */
 	async selectFont( name: string ): Promise< void > {
 		// Font selector depends on the viewport name but lumps non-mobile into desktop.
-		const viewportName = getViewportName() === 'mobile' ? 'mobile' : 'desktop';
+		const viewportName = getTargetDeviceName() === 'mobile' ? 'mobile' : 'desktop';
 
 		// Mobile viewport puts the buttons behind a dropdown.
 		if ( viewportName === 'mobile' ) {

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -30,5 +30,6 @@ export class NewPostFlow {
 		await navbarComponent.clickNewPost();
 		const gutenbergEditorPage = new GutenbergEditorPage( this.page );
 		await gutenbergEditorPage.waitUntilLoaded();
+		await gutenbergEditorPage.dismissWelcomeTourIfPresent();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -37,7 +37,7 @@ const selectors = {
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 
 	// Welcome tour
-	welcomeTourSkipButton: '.welcome-tour-card button:has-text("Skip")',
+	welcomeTourCloseButton: 'button[aria-label="Close Tour"]',
 };
 
 /**
@@ -190,8 +190,8 @@ export class GutenbergEditorPage {
 	 */
 	async dismissWelcomeTourIfPresent(): Promise< void > {
 		const frame = await this.getEditorFrame();
-		if ( await frame.isVisible( selectors.welcomeTourSkipButton ) ) {
-			await frame.click( selectors.welcomeTourSkipButton );
+		if ( await frame.isVisible( selectors.welcomeTourCloseButton ) ) {
+			await frame.click( selectors.welcomeTourCloseButton );
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -1,11 +1,7 @@
 import { Page } from 'playwright';
-import { toTitleCase } from '../../data-helper';
+import { clickNavTab } from '../../element-helper';
 
 const selectors = {
-	content: '#primary',
-	navTabs: 'div.section-nav-tabs',
-	navTabsDropdownOption: '.select-dropdown__option',
-
 	// Traffic tab
 	websiteMetaTextArea: '#advanced_seo_front_page_description',
 	seoPreviewButton: '.seo-settings__preview-button',
@@ -34,21 +30,8 @@ export class MarketingPage {
 	 * @param {string} name Name of the tab to click on the top of the page.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async clickTabItem( name: string ): Promise< void > {
-		const navTabs = await this.page.waitForSelector( selectors.navTabs );
-
-		// When in mobile viewport, the tab items are changed to a pseudo-dropdown.
-		const isDropdown = await navTabs
-			.getAttribute( 'class' )
-			.then( ( value ) => value?.includes( 'is-dropdown' ) );
-		const sanitizedName = toTitleCase( [ name ] );
-
-		if ( isDropdown ) {
-			await navTabs.click();
-			await this.page.click( `${ selectors.navTabsDropdownOption } >> text=${ sanitizedName }` );
-		} else {
-			await this.page.click( `text=${ sanitizedName }` );
-		}
+	async clickTab( name: string ): Promise< void > {
+		await clickNavTab( this.page, name );
 	}
 
 	/* SEO Preview Methods */

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { clickNavTab } from '../../element-helper';
 
 export type PeoplePageTabs = 'Team' | 'Followers' | 'Email Followers' | 'Invites';
 
@@ -12,6 +13,9 @@ const selectors = {
 	deletedUserContentAction: ( action: 'reassign' | 'delete' ) => `input[value="${ action }"]`,
 	deleteUserButton: `button:text("Delete user")`,
 	deleteConfirmBanner: ':text("Successfully deleted")',
+
+	// Header
+	invitePeopleButton: '.people-list-section-header__add-button',
 
 	// Invites
 	invitedUser: ( email: string ) => `[title="${ email }"]`,
@@ -28,7 +32,7 @@ export class PeoplePage {
 	/**
 	 * Constructs an instance of the component.
 	 *
-	 * @param {Page} page The underlying page.
+	 * @param {Page} page The underlying page
 	 */
 	constructor( page: Page ) {
 		this.page = page;
@@ -41,20 +45,7 @@ export class PeoplePage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: PeoplePageTabs ): Promise< void > {
-		const navTabs = await this.page.waitForSelector( selectors.navTabs );
-
-		const isDropdown = await navTabs
-			.getAttribute( 'class' )
-			.then( ( value ) => value?.includes( 'is-dropdown' ) );
-
-		if ( isDropdown ) {
-			// Mobile view - navtabs become a dropdown.
-			await navTabs.click();
-			await this.page.click( `${ selectors.navTabsDropdownOptions } >> text=${ name }` );
-		} else {
-			// Desktop view - navtabs are constantly visible tabs.
-			await this.page.click( `${ selectors.navTabs } >> text=${ name }` );
-		}
+		await clickNavTab( this.page, name );
 	}
 
 	/* Team People */
@@ -103,7 +94,7 @@ export class PeoplePage {
 	async clickInviteUser(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForNavigation(),
-			this.page.click( 'span:text-is("Invite")' ),
+			this.page.click( selectors.invitePeopleButton ),
 		] );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright';
-import { getViewportName } from '../../browser-helper';
-import { viewportName } from '../../types';
+import { getTargetDeviceName } from '../../browser-helper';
+import { TargetDevice } from '../../types';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
 export type Plan = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
@@ -17,7 +17,7 @@ const selectors = {
 		plan,
 		buttonText,
 	}: {
-		viewport: viewportName;
+		viewport: TargetDevice;
 		plan: Plan;
 		buttonText: PlanActionButton;
 	} ) => {
@@ -87,7 +87,7 @@ export class PlansPage {
 		buttonText: PlanActionButton;
 	} ): Promise< void > {
 		const selector = selectors.actionButton( {
-			viewport: getViewportName(),
+			viewport: getTargetDeviceName(),
 			plan: plan,
 			buttonText: buttonText,
 		} );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -81,13 +81,8 @@ export class PlansPage {
 	 *
 	 * @param {PlansPageTab} targetTab Name of the navigation tab to click on
 	 */
-	async clickNavigationTab( targetTab: PlansPageTab ): Promise< void > {
+	async clickTab( targetTab: PlansPageTab ): Promise< void > {
 		await clickNavTab( this.page, targetTab );
-
-		// Close the dropdown manually due to https://github.com/Automattic/wp-calypso/issues/56038.
-		if ( getTargetDeviceName() === 'mobile' ) {
-			await this.page.click( selectors.mobileNavTabsToggle );
-		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -35,6 +35,8 @@ export class PublishedPostPage {
 	private async getLikeFrame(): Promise< Frame > {
 		// Obtain the ElementHandle for the widget containing the like/unlike button.
 		const elementHandle = await this.page.waitForSelector( selectors.likeWidget );
+		// Without the next line, headless viewports fail to locate the Like widget.
+		await elementHandle.scrollIntoViewIfNeeded();
 		// Obtain the Frame object from the elementHandleHandle. This represents the widget iframe.
 		const frame = ( await elementHandle.contentFrame() ) as Frame;
 		// Wait until the widget element is stable in the DOM.

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -1,10 +1,7 @@
 import { Page } from 'playwright';
+import { clickNavTab } from '../../element-helper';
 
 export type StatsTabs = 'Traffic' | 'Insights' | 'Store';
-
-const selectors = {
-	tabItems: ( name: StatsTabs ) => `a:has-text("${ name }")`,
-};
 
 /**
  * Represents the Statistics page.
@@ -27,10 +24,7 @@ export class StatsPage {
 	 * @param {StatsTabs} name Name of the tab to click.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async clickTabItem( name: StatsTabs ): Promise< void > {
-		await this.page.click( selectors.tabItems( name ) );
-
-		// Confirm the tab is now selected.
-		await this.page.waitForSelector( `*css=li.is-selected >> ${ selectors.tabItems( name ) }` );
+	async clickTab( name: StatsTabs ): Promise< void > {
+		await clickNavTab( this.page, name );
 	}
 }

--- a/packages/calypso-e2e/src/types.d.ts
+++ b/packages/calypso-e2e/src/types.d.ts
@@ -1,8 +1,1 @@
-// Browser Manager
-export type viewportName = 'desktop' | 'mobile' | 'laptop' | 'tablet';
-export type localeCode = string;
-
-export type viewportSize = {
-	width: number;
-	height: number;
-};
+export type TargetDevice = 'desktop' | 'mobile' | 'laptop' | 'tablet';

--- a/packages/calypso-e2e/test/browser-helper.test.ts
+++ b/packages/calypso-e2e/test/browser-helper.test.ts
@@ -35,7 +35,7 @@ describe( 'BrowserHelper Tests', function () {
 		);
 
 		test( 'Returns default value found in config if environment variable not set', function () {
-			delete process.env.VIEWPORT_NAME;
+			delete process.env.TARGET_DEVICE;
 			expect( getTargetDeviceName() ).toBe( 'desktop' );
 		} );
 	} );

--- a/packages/calypso-e2e/test/data-helper.test.ts
+++ b/packages/calypso-e2e/test/data-helper.test.ts
@@ -107,7 +107,7 @@ describe( 'DataHelper Tests', function () {
 		`(
 			'Returns $expected if toTitleCase is called with $words',
 			function ( { suite, viewport, expected } ) {
-				process.env.VIEWPORT_NAME = viewport;
+				process.env.TARGET_DEVICE = viewport;
 				expect( createSuiteTitle( suite ) ).toStrictEqual( expected );
 			}
 		);

--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -24,24 +24,6 @@
 		"log": "."
 	},
 	"viewportName": "desktop",
-	"viewportSize": {
-		"mobile": {
-			"width": 400,
-			"height": 1000
-		},
-		"tablet": {
-			"width": 1024,
-			"height": 1000
-		},
-		"desktop": {
-			"width": 1440,
-			"height": 1000
-		},
-		"laptop": {
-			"width": 1440,
-			"height": 790
-		}
-	},
 	"locale": "en",
 	"sauceConfigurations": {
 		"osx-chrome": {

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -35,7 +35,7 @@ Environment Variables are values that are defined at the system level to serve a
 | SCREENSHOTDIR   | Override the default path for screenshots to be written.      | /tmp/screenshots | No       | **NO**         |
 | TEMP_ASSET_PATH | Override the base artifacts path.                             | /tmp/artifacts   | No       | **NO**         |
 | VIDEODIR        | Override the default path for video recordings to be written. | /tmp/recordings  | No       | **NO**         |
-| TARGET_DEVICE   | Specify the device type to be used.                         | desktop          | No       | **NO**         |
+| TARGET_DEVICE   | Specify the device type to be used.                           | desktop          | No       | **NO**         |
 
 <!-- When adding new rows, run the following command to sort the resulting sub-table in alphabetical order:
 

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -35,7 +35,7 @@ Environment Variables are values that are defined at the system level to serve a
 | SCREENSHOTDIR   | Override the default path for screenshots to be written.      | /tmp/screenshots | No       | **NO**         |
 | TEMP_ASSET_PATH | Override the base artifacts path.                             | /tmp/artifacts   | No       | **NO**         |
 | VIDEODIR        | Override the default path for video recordings to be written. | /tmp/recordings  | No       | **NO**         |
-| VIEWPORT_NAME   | Specify the viewport size to be used.                         | desktop          | No       | **NO**         |
+| TARGET_DEVICE   | Specify the device type to be used.                         | desktop          | No       | **NO**         |
 
 <!-- When adding new rows, run the following command to sort the resulting sub-table in alphabetical order:
 

--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -63,11 +63,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await editorSettingsSidebarComponent.clickTab( 'Post' );
 		} );
 
-		// Waiting to do this here as the Welcome Tour won't intefere with adding a title/content, and deferring gives it time to load in completely.
-		it( ' Dismiss Welcome Tour if it is present', async function () {
-			await gutenbergEditorPage.dismissWelcomeTourIfPresent();
-		} );
-
 		it( 'Add post category', async function () {
 			await editorSettingsSidebarComponent.expandSectionIfCollapsed( 'Categories' );
 			await editorSettingsSidebarComponent.clickCategory( category );

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
@@ -35,7 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Language' ), function () 
 	describe.each( [
 		{ language: 'Spanish', target: 'es', labelText: 'Mi página web se llama' },
 		{ language: 'Japanese', target: 'ja', labelText: '私のサイトの名前は' },
-		{ language: 'Arabic', target: 'ar', labelText: 'سيكون اسم موقعي' },
+		// { language: 'Arabic', target: 'ar', labelText: 'سيكون اسم موقعي' }, // https://github.com/Automattic/wp-calypso/issues/56006
 		{ language: 'Hebrew', target: 'he', labelText: 'האתר שלי נקרא' },
 		{ language: 'Russian', target: 'ru', labelText: 'Мой сайт называется' },
 	] )( 'Change Language', function ( { language, target, labelText } ) {

--- a/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
+++ b/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
@@ -67,13 +67,13 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 			emailAddress: testEmailAddress,
 		} );
 		const links = await emailClient.getLinksFromMessage( message );
-		const acceptInviteLink = links.find( ( link: string ) => link.includes( 'accept-invite' ) );
-		if ( ! acceptInviteLink ) {
-			throw new Error( 'Invite link was not found.' );
-		}
-		adjustedInviteLink = DataHelper.adjustInviteLink( acceptInviteLink );
+		const acceptInviteLink = links.find( ( link: string ) =>
+			link.includes( 'accept-invite' )
+		) as string;
 
 		expect( acceptInviteLink ).toBeDefined();
+
+		adjustedInviteLink = DataHelper.adjustInviteLink( acceptInviteLink );
 	} );
 
 	it( `Ensure invite link is no longer valid`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
@@ -43,11 +43,8 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 			await sidebarComponent.navigate( 'Media' );
 		} );
 
-		it( 'See media gallery', async function () {
-			mediaPage = new MediaPage( page );
-		} );
-
 		it( 'Show only images', async function () {
+			mediaPage = new MediaPage( page );
 			await mediaPage.clickTab( 'Images' );
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -38,7 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 
 		it( 'Click on the "My Plan" tab', async function () {
 			plansPage = new PlansPage( page );
-			await plansPage.clickNavigationTab( 'My Plan' );
+			await plansPage.clickTab( 'My Plan' );
 		} );
 
 		it( 'The Premium plan is listed as current plan on "My Plan" tab', async function () {
@@ -46,7 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 		} );
 
 		it( 'Click on the "Plans" navigation tab', async function () {
-			await plansPage.clickNavigationTab( 'Plans' );
+			await plansPage.clickTab( 'Plans' );
 		} );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'SEO Preview Page' ), function () {
 
 	it( 'Click on Traffic tab', async function () {
 		marketingPage = new MarketingPage( page );
-		await marketingPage.clickTabItem( 'Traffic' );
+		await marketingPage.clickTab( 'Traffic' );
 	} );
 
 	it( 'Enter SEO meta description', async function () {

--- a/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
@@ -35,7 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 
 		it( 'Click on Insights tab', async function () {
 			const statsPage = new StatsPage( page );
-			await statsPage.clickTabItem( 'Insights' );
+			await statsPage.clickTab( 'Insights' );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes the update of the viewport size used for desktop and mobile and refactors precipitated as a result of the viewport change.

Key changes:
- environment variable renamed from `VIEWPORT_NAME` to `TARGET_DEVICE`.
- mobile viewport changed to mimic Pixel 4a (5G) @ 412px x 765px viewport.
- desktop viewport changed to mimic Desktop Chrome (HiDPI).
- adjustments to selectors and methods caused by use of smaller horizontal viewport for mobile.
- extraction of `clickNavTab` methods into a method in `ElementHelper`.

Background details:

As noted in the [P2](pciE2j-sj-p2), viewports used in calypso e2e tests were not wholly reflective of trends.
In addition, the framework was set up in such a way that mobile viewport had been tested at 500px width instead of the expected 400px.

As the breakpoint for calypso is at 480px, this meant the `mobile` layout being tested was in fact a layout between [`mobile` and `desktop` breakpoints](https://github.com/Automattic/wp-calypso/blob/38c37bbfe35b8c741c4e346637987ddc0fb3ab59/packages/viewport/src/index.js).

#### Testing instructions

- [ ] desktop tests pass.
- [ ] mobile tests pass.
- [ ] unit tests pass.

Related to #55718.