### PR TITLE
Jetpack site-less checkout: disable site-less purchases of Search products

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -416,7 +416,10 @@ export function redirectToSiteLessCheckout( context, next ) {
 
 	const urlQueryArgs = context.query;
 
-	if ( config.isEnabled( 'jetpack/siteless-checkout' ) ) {
+	if (
+		config.isEnabled( 'jetpack/siteless-checkout' ) &&
+		! [ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( planSlug )
+	) {
 		if ( ! urlQueryArgs?.checkoutBackUrl ) {
 			urlQueryArgs.checkoutBackUrl = 'https://jetpack.com';
 		}

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -418,7 +418,7 @@ export function redirectToSiteLessCheckout( context, next ) {
 
 	if (
 		config.isEnabled( 'jetpack/siteless-checkout' ) &&
-		! [ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( planSlug )
+		! JETPACK_SEARCH_PRODUCTS.includes( planSlug )
 	) {
 		if ( ! urlQueryArgs?.checkoutBackUrl ) {
 			urlQueryArgs.checkoutBackUrl = 'https://jetpack.com';

--- a/client/my-sites/plans/jetpack-plans/build-checkout-url.ts
+++ b/client/my-sites/plans/jetpack-plans/build-checkout-url.ts
@@ -1,4 +1,8 @@
 import config from '@automattic/calypso-config';
+import {
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+} from '@automattic/calypso-products';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/route';
 import { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -39,7 +43,11 @@ export default function buildCheckoutURL(
 			? 'http://calypso.localhost:3000'
 			: 'https://wordpress.com';
 
-	if ( ! siteSlug && config.isEnabled( 'jetpack/siteless-checkout' ) ) {
+	if (
+		! siteSlug &&
+		config.isEnabled( 'jetpack/siteless-checkout' ) &&
+		! [ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( productsString )
+	) {
 		return addQueryArgs( urlQueryArgs, host + `/checkout/jetpack/${ productsString }` );
 	}
 

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -11,7 +11,6 @@ import page from 'page';
 import React from 'react';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { login } from 'calypso/lib/paths';
-import { addQueryArgs } from 'calypso/lib/route';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { ALLOWED_MOBILE_APP_REDIRECT_URL_LIST } from '../../jetpack-connect/constants';
@@ -100,21 +99,5 @@ export function purchase( context, next ) {
 			url={ query.url }
 		/>
 	);
-	next();
-}
-
-export function redirectToSitelessCheckout( context, next ) {
-	const { type, interval } = context.params;
-
-	const planSlug = getPlanSlugFromFlowType( type, interval );
-
-	if (
-		config.isEnabled( 'jetpack/siteless-checkout' ) &&
-		! [ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( planSlug )
-	) {
-		page( addQueryArgs( context.query, `/checkout/jetpack/${ planSlug }` ) );
-		return;
-	}
-
 	next();
 }

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -110,7 +110,7 @@ export function redirectToSitelessCheckout( context, next ) {
 
 	if (
 		config.isEnabled( 'jetpack/siteless-checkout' ) &&
-		[ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( planSlug )
+		! [ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ].includes( planSlug )
 	) {
 		page( addQueryArgs( context.query, `/checkout/jetpack/${ planSlug }` ) );
 		return;

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -7,7 +7,6 @@ import '../../jetpack-connect/style.scss';
 export default function () {
 	page(
 		'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
-		controller.redirectToSitelessCheckout,
 		controller.redirectToLogin,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We realized there are unsolved issues regarding site-less purchases of Search products (read pbtFFM-142-p2). This PR removes all Search products from the site-less checkout flow to make it work as it worked before we launched the mentioned flow, meaning users need to go through Jetpack Connect to check out the product.

#### Testing instructions

##### Testing changes on Calypso Green

* Start Calypso Green with `yarn start-jetpack-cloud`.
* Visit `http://jetpack.cloud.localhost:3000/pricing`.
* Verify that Jetpack Search (monthly and yearly) product card points to `https://wordpress.com/jetpack/connect/jetpack_search` (I removed some parts of the URL for readability's sake).
* Verify that all other paid product cards point to `https://wordpress.com/checkout/jetpack/:product` (I removed some parts of the URL for readability's sake).

##### Testing changes on Calypso Blue

* Start Calypso Blue with `yarn start`.
* Visit the following list of URLs, and verify that in each case you land on Jetpack Connect and the page's header reads `Get Search` (bonus point if you enter a connect Jetpack site address to verify that you're redirected to checkout):
  * http://calypso.localhost:3000/jetpack/connect/jetpack_search
  * http://calypso.localhost:3000/jetpack/connect/jetpack_search_monthly
  * http://calypso.localhost:3000/purchase-product/jetpack_search
  * http://calypso.localhost:3000/purchase-product/jetpack_search/yearly
  * http://calypso.localhost:3000/purchase-product/jetpack_search/monthly
  * http://calypso.localhost:3000/purchase-product/wpcom_search
  * http://calypso.localhost:3000/purchase-product/wpcom_search/yearly
  * http://calypso.localhost:3000/purchase-product/wpcom_search/monthly
* Verify that if you visit `http://calypso.localhost:3000/jetpack/connect/:product` with any other product than Search, you're redirected to checkout.

Related to 1164141197617539-as-1200925841937155