### PR TITLE
Shopping Cart: Prepare for 2.0 release

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,7 @@
 		"@automattic/popup-monitor": "^1.0.0",
 		"@automattic/react-virtualized": "^9.22.3",
 		"@automattic/request-external-access": "^1.0.0",
-		"@automattic/shopping-cart": "^1.0.0",
+		"@automattic/shopping-cart": "^2.0.0",
 		"@automattic/social-previews": "^1.0.1",
 		"@automattic/state-utils": "^1.0.0-alpha.4",
 		"@automattic/tree-select": "^1.0.3",

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -37,7 +37,7 @@
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
-		"@automattic/shopping-cart": "^1.0.0",
+		"@automattic/shopping-cart": "^2.0.0",
 		"@wordpress/components": "^13.0.3",
 		"@wordpress/icons": "^2.10.3",
 		"@wordpress/react-i18n": "^1.0.3",

--- a/packages/shopping-cart/CHANGELOG.md
+++ b/packages/shopping-cart/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.0
+
+- Refactor to use a singleton ShoppingCartManagerClient passed to each ShoppingCartProvider.
+- Require cart key to be passed to useShoppingCart and withShoppingCart.
+- Add `defaultCartKey` option.
+
 ## v1.1.0
 
 - Improve offline errors.

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/shopping-cart",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"description": "A library to use the WordPress.com shopping cart",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -40,7 +40,7 @@
 		"@automattic/calypso-products": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
-		"@automattic/shopping-cart": "^1.0.0",
+		"@automattic/shopping-cart": "^2.0.0",
 		"@emotion/styled": "^11.3.0",
 		"@wordpress/i18n": "^3.20.0",
 		"@wordpress/react-i18n": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,7 +571,7 @@ __metadata:
     "@automattic/i18n-utils": ^1.0.0
     "@automattic/onboarding": ^1.0.0
     "@automattic/plans-grid": ^1.0.0-alpha.0
-    "@automattic/shopping-cart": ^1.0.0
+    "@automattic/shopping-cart": ^2.0.0
     "@automattic/typography": ^1.0.0
     "@testing-library/react": ^12.0.0
     "@wordpress/base-styles": ^3.4.3
@@ -881,7 +881,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/shopping-cart@^1.0.0, @automattic/shopping-cart@workspace:packages/shopping-cart":
+"@automattic/shopping-cart@^2.0.0, @automattic/shopping-cart@workspace:packages/shopping-cart":
   version: 0.0.0-use.local
   resolution: "@automattic/shopping-cart@workspace:packages/shopping-cart"
   dependencies:
@@ -1121,7 +1121,7 @@ __metadata:
     "@automattic/calypso-products": ^1.0.0
     "@automattic/calypso-stripe": ^1.0.0
     "@automattic/composite-checkout": ^1.0.0
-    "@automattic/shopping-cart": ^1.0.0
+    "@automattic/shopping-cart": ^2.0.0
     "@emotion/styled": ^11.3.0
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.0.0
@@ -12624,7 +12624,7 @@ __metadata:
     "@automattic/popup-monitor": ^1.0.0
     "@automattic/react-virtualized": ^9.22.3
     "@automattic/request-external-access": ^1.0.0
-    "@automattic/shopping-cart": ^1.0.0
+    "@automattic/shopping-cart": ^2.0.0
     "@automattic/social-previews": ^1.0.1
     "@automattic/state-utils": ^1.0.0-alpha.4
     "@automattic/tree-select": ^1.0.3


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This bumps the shopping-cart package version to 2.0 and updates all package requirements.

Hopefully this won't cause any issues since it's a major version upgrade happening all at once. 😅  (The updates have already occurred, this is just the version number.)

#### Testing instructions

Verify that calypso builds.