### PR TITLE
Composite Checkout: Prepare for 1.0 release

### DIFF
--- a/packages/composite-checkout/CHANGELOG.md
+++ b/packages/composite-checkout/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0.0
+
+- Initial release.

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/composite-checkout",
 	"version": "1.0.0",
-	"description": "A checkout component for Automattic brands",
+	"description": "A set of React components and helpers that can be used to create a checkout flow.",
 	"main": "dist/cjs/public-api.js",
 	"module": "dist/esm/public-api.js",
 	"types": "dist/types/public-api.d.ts",
@@ -67,6 +67,5 @@
 	"peerDependencies": {
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `@automattic/composite-checkout` package for its initial public release.

#### Testing instructions

Make sure that calypso builds.