### PR TITLE
Updates copy of first step in the editor welcome guide

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -1,9 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { subscribeIsMobile, isMobile } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, hasTranslation } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classNames from 'classnames';
 import minimize from './icons/minimize';
@@ -86,9 +87,16 @@ function WelcomeTourCard( {
 }
 
 function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIndex } ) {
+	const localeSlug = useLocale();
+
 	// These are defined on their own lines because of a minification issue.
 	// __('translations') do not always work correctly when used inside of ternary statements.
-	const startTourLabel = __( 'Start Tour', 'full-site-editing' );
+	const startTourLabel =
+		localeSlug === 'en' ||
+		localeSlug === 'en-gb' ||
+		hasTranslation( 'Try it out!', 'full-site-editing' )
+			? __( 'Try it out!', 'full-site-editing' )
+			: __( 'Start Tour', 'full-site-editing' );
 	const nextLabel = __( 'Next', 'full-site-editing' );
 	return (
 		<>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, hasTranslation } from '@wordpress/i18n';
 
 const addBlock = 'https://s0.wp.com/i/editor-welcome-tour/slide-add-block.gif';
 const allBlocks = 'https://s0.wp.com/i/editor-welcome-tour/slide-all-blocks.gif';
@@ -22,10 +22,21 @@ function getTourContent( localeSlug ) {
 	return [
 		{
 			heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
-			description: __(
-				'Continue on with this short tour to learn the fundamentals of the WordPress editor.',
-				'full-site-editing'
-			),
+			description:
+				localeSlug === 'en' ||
+				localeSlug === 'en-gb' ||
+				hasTranslation(
+					'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+					'full-site-editing'
+				)
+					? __(
+							'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+							'full-site-editing'
+					  )
+					: __(
+							'Continue on with this short tour to learn the fundamentals of the WordPress editor.',
+							'full-site-editing'
+					  ),
 			imgSrc: welcome,
 			animation: null,
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the copy of the first step in the in-editor welcome guide/tour to emphasise that the user can follow along with each step as they go through.

Wording discussion: pdgK6S-6i-p2

<img width="431" alt="Screenshot 2021-09-08 at 10 11 39 AM" src="https://user-images.githubusercontent.com/1500769/132419320-46843971-1d8f-4971-9bfd-66e9c3e91c60.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a test site
* `install-plugin.sh etk update/etk-welcome-guide-1st-step`
* Open the guide from the hamburger menu in the editor
* Check that non-`en` locales aren't showing untranslated text

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55515