### PR TITLE
Change tags education link to support doc for users in different langs

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/tags-education/src/add-tags-education-link.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tags-education/src/add-tags-education-link.js
@@ -21,7 +21,7 @@ const addTagsEducationLink = createHigherOrderComponent( ( PostTaxonomyType ) =>
 				<PostTaxonomyType { ...props } />
 				<ExternalLink
 					href={ localizeUrl(
-						'https://wordpress.com/blog/2014/04/21/better-tagging/',
+						'https://wordpress.com/support/posts/tags/',
 						// TODO: remove tagsEducationLocale after fixing useLocalizeUrl.
 						// See https://github.com/Automattic/wp-calypso/pull/55527.
 						// `useLocalizeUrl` will try to get the current locale slug from the @wordpress/i18n locale data if missing `LocaleProvider`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* According to pdgK6S-14-p2#comment-169, the blog post is not suitable for non-English speaking users, so change the link to support docs that are translated into 16 languages.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your API
* Open another terminal and run cd apps/wpcom-block-editor && yarn dev --sync
* Open your local calypso
* Create or edit the post
* Click "Build your audience with tags" in the Tags section
* It should open the link to support doc

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55300