### PR TITLE
inline-help: some cleanups (`i18n-calypso`, `lodash`)

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -1,12 +1,6 @@
-export const RESULT_TYPE = 'type';
-export const RESULT_TITLE = 'title';
-export const RESULT_DESCRIPTION = 'description';
-export const RESULT_LINK = 'link';
 export const RESULT_ARTICLE = 'article';
 export const RESULT_TOUR = 'tour';
 export const RESULT_VIDEO = 'video';
-export const RESULT_POST_ID = 'post_id';
-export const RESULT_BLOG_ID = 'blog_id';
 export const VIEW_CONTACT = 'contact';
 export const VIEW_RICH_RESULT = 'richresult';
 export const VIEW_FORUM = 'forums';

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1,5 +1,4 @@
 import i18n, { translate } from 'i18n-calypso';
-import { compact, get } from 'lodash';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 
@@ -1460,15 +1459,15 @@ export function getContextResults( section ) {
 
 	// make sure editorially to show at most one tour and one video at once
 	// `first` is a safe-guard in case that fails
-	const video = get( videosForSection, section )?.[ 0 ];
-	const tour = get( toursForSection, section )?.[ 0 ];
-	const links = get( contextLinksForSection, section, fallbackLinks );
+	const video = videosForSection[ section ]?.[ 0 ];
+	const tour = toursForSection[ section ]?.[ 0 ];
+	const links = contextLinksForSection[ section ] ?? fallbackLinks;
 
 	// If true, still display fallback links in addition (as opposed to instead
 	// of) the other context links.
 	if ( section === 'home' ) {
-		return compact( [ tour, video, ...getFallbackLinks(), ...links ] );
+		return [ tour, video, ...getFallbackLinks(), ...links ].filter( Boolean );
 	}
 
-	return compact( [ tour, video, ...links ] );
+	return [ tour, video, ...links ].filter( Boolean );
 }

--- a/client/blocks/inline-help/dialog.jsx
+++ b/client/blocks/inline-help/dialog.jsx
@@ -1,12 +1,14 @@
 import { Button, Dialog } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import ResizableIframe from 'calypso/components/resizable-iframe';
 
 import './dialog.scss';
 
-function InlineHelpDialog( { dialogType, videoLink, onClose, translate } ) {
+function InlineHelpDialog( { dialogType, videoLink, onClose } ) {
+	const translate = useTranslate();
+
 	/* @TODO: This class is not valid and this tricks the linter
 	 * fix this class and fix the linter to catch similar instances.
 	 */
@@ -46,4 +48,4 @@ function InlineHelpDialog( { dialogType, videoLink, onClose, translate } ) {
 	);
 }
 
-export default localize( InlineHelpDialog );
+export default InlineHelpDialog;

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -10,35 +10,39 @@ const trackForumOpen = () =>
 		location: 'inline-help-popover',
 	} );
 
-const InlineHelpForumView = ( { translate } ) => (
-	<div className="inline-help__forum-view">
-		<h2 className="inline-help__view-heading">
-			{ preventWidows( translate( 'Ask the Community for Help' ) ) }
-		</h2>
-		<p>
-			{ preventWidows(
-				translate(
-					'Use this link to post a question in our {{strong}}public forums{{/strong}}, ' +
-						'where thousands of WordPress.com members around the world ' +
-						'can offer their expertise and advice.',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				)
-			) }
-		</p>
-		<Button
-			href={ localizeUrl( 'https://en.forums.wordpress.com/' ) }
-			target="_blank"
-			rel="noopener noreferrer"
-			primary
-			onClick={ trackForumOpen }
-		>
-			{ translate( 'Go to the Support Forums' ) }
-		</Button>
-	</div>
-);
+const InlineHelpForumView = () => {
+	const translate = useTranslate();
 
-export default localize( InlineHelpForumView );
+	return (
+		<div className="inline-help__forum-view">
+			<h2 className="inline-help__view-heading">
+				{ preventWidows( translate( 'Ask the Community for Help' ) ) }
+			</h2>
+			<p>
+				{ preventWidows(
+					translate(
+						'Use this link to post a question in our {{strong}}public forums{{/strong}}, ' +
+							'where thousands of WordPress.com members around the world ' +
+							'can offer their expertise and advice.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					)
+				) }
+			</p>
+			<Button
+				href={ localizeUrl( 'https://en.forums.wordpress.com/' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+				primary
+				onClick={ trackForumOpen }
+			>
+				{ translate( 'Go to the Support Forums' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default InlineHelpForumView;

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -1,7 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { get, omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -10,15 +9,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
 import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
-import {
-	RESULT_ARTICLE,
-	RESULT_DESCRIPTION,
-	RESULT_LINK,
-	RESULT_TITLE,
-	RESULT_TOUR,
-	RESULT_TYPE,
-	RESULT_VIDEO,
-} from './constants';
+import { RESULT_ARTICLE, RESULT_TOUR, RESULT_VIDEO } from './constants';
 
 class InlineHelpRichResult extends Component {
 	static propTypes = {
@@ -49,15 +40,12 @@ class InlineHelpRichResult extends Component {
 		const isLocaleEnglish = 'en' === getLocaleSlug();
 		const { type, tour, link, searchQuery, postId } = this.props;
 
-		const tracksData = omitBy(
-			{
-				search_query: searchQuery,
-				tour,
-				result_url: link,
-				location: 'inline-help-popover',
-			},
-			( data ) => typeof data === 'undefined'
-		);
+		const tracksData = {
+			search_query: searchQuery,
+			location: 'inline-help-popover',
+			...( link && { result_url: link } ),
+			...( tour && { tour } ),
+		};
 
 		this.props.recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData );
 		this.props.closePopover();
@@ -82,8 +70,8 @@ class InlineHelpRichResult extends Component {
 
 	render() {
 		const { type, title, description, link } = this.props;
-		const buttonLabel = get( this.buttonLabels, type, '' );
-		const buttonIcon = get( this.buttonIcons, type );
+		const buttonLabel = this.buttonLabels[ type ] ?? '';
+		const buttonIcon = this.buttonIcons[ type ];
 		const classes = classNames( 'inline-help__richresult__title' );
 
 		return (
@@ -102,14 +90,8 @@ class InlineHelpRichResult extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { result } ) => ( {
+const mapStateToProps = ( state ) => ( {
 	searchQuery: getSearchQuery( state ),
-	type: get( result, RESULT_TYPE, RESULT_ARTICLE ),
-	title: get( result, RESULT_TITLE ),
-	link: get( result, RESULT_LINK ),
-	description: get( result, RESULT_DESCRIPTION ),
-	tour: get( result, RESULT_TOUR ),
-	postId: get( result, 'post_id' ),
 } );
 
 const mapDispatchToProps = {

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -43,8 +43,8 @@ class InlineHelpRichResult extends Component {
 		const tracksData = {
 			search_query: searchQuery,
 			location: 'inline-help-popover',
-			...( link && { result_url: link } ),
-			...( tour && { tour } ),
+			result_url: link,
+			tour,
 		};
 
 		this.props.recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData );

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -24,10 +24,16 @@ class InlineHelpRichResult extends Component {
 		tour: PropTypes.string,
 	};
 
-	buttonLabels = {
-		article: this.props.translate( 'Read more' ),
-		video: this.props.translate( 'Watch a video' ),
-		tour: this.props.translate( 'Start Tour' ),
+	getButtonLabel = ( type ) => {
+		const { translate } = this.props;
+
+		const labels = {
+			article: translate( 'Read more' ),
+			video: translate( 'Watch a video' ),
+			tour: translate( 'Start Tour' ),
+		};
+
+		return labels[ type ];
 	};
 
 	buttonIcons = {
@@ -70,7 +76,7 @@ class InlineHelpRichResult extends Component {
 
 	render() {
 		const { type, title, description, link } = this.props;
-		const buttonLabel = this.buttonLabels[ type ] ?? '';
+		const buttonLabel = this.getButtonLabel( type );
 		const buttonIcon = this.buttonIcons[ type ];
 		const classes = classNames( 'inline-help__richresult__title' );
 

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -24,7 +24,7 @@ class InlineHelpRichResult extends Component {
 		tour: PropTypes.string,
 	};
 
-	getButtonLabel = ( type ) => {
+	getButtonLabel = ( type = 'article' ) => {
 		const { translate } = this.props;
 
 		const labels = {
@@ -44,7 +44,8 @@ class InlineHelpRichResult extends Component {
 
 	handleClick = ( event ) => {
 		const isLocaleEnglish = 'en' === getLocaleSlug();
-		const { type, tour, link, searchQuery, postId } = this.props;
+		const { searchQuery, result } = this.props;
+		const { type, tour, link, post_id: postId } = result;
 
 		const tracksData = {
 			search_query: searchQuery,
@@ -66,7 +67,7 @@ class InlineHelpRichResult extends Component {
 				dialogType: 'video',
 				videoLink: link,
 			} );
-		} else if ( type === RESULT_ARTICLE && postId && isLocaleEnglish ) {
+		} else if ( ( ! type || type === RESULT_ARTICLE ) && postId && isLocaleEnglish ) {
 			// Until we can deliver localized inline support article content, we send the
 			// the user to the localized support blog, if one exists.
 			event.preventDefault();
@@ -75,7 +76,7 @@ class InlineHelpRichResult extends Component {
 	};
 
 	render() {
-		const { type, title, description, link } = this.props;
+		const { type, title, description, link } = this.props.result;
 		const buttonLabel = this.getButtonLabel( type );
 		const buttonIcon = this.buttonIcons[ type ];
 		const classes = classNames( 'inline-help__richresult__title' );

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -24,28 +24,28 @@ class InlineHelpRichResult extends Component {
 		tour: PropTypes.string,
 	};
 
-	getButtonLabel = ( type = 'article' ) => {
+	getButtonLabel = ( type = RESULT_ARTICLE ) => {
 		const { translate } = this.props;
 
 		const labels = {
-			article: translate( 'Read more' ),
-			video: translate( 'Watch a video' ),
-			tour: translate( 'Start Tour' ),
+			[ RESULT_ARTICLE ]: translate( 'Read more' ),
+			[ RESULT_VIDEO ]: translate( 'Watch a video' ),
+			[ RESULT_TOUR ]: translate( 'Start Tour' ),
 		};
 
 		return labels[ type ];
 	};
 
 	buttonIcons = {
-		tour: 'list-ordered',
-		video: 'video',
-		article: 'reader',
+		[ RESULT_TOUR ]: 'list-ordered',
+		[ RESULT_VIDEO ]: 'video',
+		[ RESULT_ARTICLE ]: 'reader',
 	};
 
 	handleClick = ( event ) => {
 		const isLocaleEnglish = 'en' === getLocaleSlug();
 		const { searchQuery, result } = this.props;
-		const { type, tour, link, post_id: postId } = result;
+		const { type = RESULT_ARTICLE, tour, link, post_id: postId } = result;
 
 		const tracksData = {
 			search_query: searchQuery,
@@ -60,19 +60,26 @@ class InlineHelpRichResult extends Component {
 		if ( type === RESULT_TOUR ) {
 			event.preventDefault();
 			this.props.requestGuidedTour( tour );
-		} else if ( type === RESULT_VIDEO ) {
+			return;
+		}
+
+		if ( type === RESULT_VIDEO ) {
 			event.preventDefault();
 			this.props.setDialogState( {
 				showDialog: true,
 				dialogType: 'video',
 				videoLink: link,
 			} );
-		} else if ( ( ! type || type === RESULT_ARTICLE ) && postId && isLocaleEnglish ) {
+			return;
+		}
+
+		if ( postId && isLocaleEnglish ) {
 			// Until we can deliver localized inline support article content, we send the
 			// the user to the localized support blog, if one exists.
 			event.preventDefault();
 			this.props.openSupportArticleDialog( { postId, postUrl: link } );
-		} // else falls back on href
+		}
+		// falls back on href
 	};
 
 	render() {

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { speak } from '@wordpress/a11y';
 import { useTranslate } from 'i18n-calypso';
-import { debounce, isEmpty } from 'lodash';
+import { debounce } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Fragment, useEffect } from 'react';
@@ -81,7 +81,7 @@ function HelpSearchResults( {
 		errorSpeak.cancel();
 
 		// If there's no query, then we don't need to announce anything.
-		if ( isEmpty( searchQuery ) ) {
+		if ( ! searchQuery ) {
 			return;
 		}
 

--- a/client/blocks/inline-help/placeholder-lines.jsx
+++ b/client/blocks/inline-help/placeholder-lines.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default ( { lines = 4 } ) => (
 	<div className="inline-help__results-placeholder">
 		{ Array.from( { length: lines }, ( _, n ) => (
-			<div key={ `line-${ n }` } className="inline-help__results-placeholder-item" />
+			<div key={ n } className="inline-help__results-placeholder-item" />
 		) ) }
 	</div>
 );

--- a/client/blocks/inline-help/placeholder-lines.jsx
+++ b/client/blocks/inline-help/placeholder-lines.jsx
@@ -1,9 +1,8 @@
-import { times } from 'lodash';
 import React from 'react';
 
 export default ( { lines = 4 } ) => (
 	<div className="inline-help__results-placeholder">
-		{ times( lines, ( n ) => (
+		{ Array.from( { length: lines }, ( _, n ) => (
 			<div key={ `line-${ n }` } className="inline-help__results-placeholder-item" />
 		) ) }
 	</div>

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -11,7 +11,16 @@ import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-supp
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
+import {
+	VIEW_CONTACT,
+	VIEW_RICH_RESULT,
+	RESULT_ARTICLE,
+	RESULT_DESCRIPTION,
+	RESULT_LINK,
+	RESULT_TITLE,
+	RESULT_TOUR,
+	RESULT_TYPE,
+} from './constants';
 import InlineHelpRichResult from './inline-help-rich-result';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpSearchResults from './inline-help-search-results';
@@ -139,6 +148,7 @@ class InlineHelpPopover extends Component {
 
 	renderSecondaryView = () => {
 		const { onClose, setDialogState } = this.props;
+		const { selectedResult } = this.state;
 		const classes = classNames(
 			'inline-help__secondary-view',
 			`inline-help__${ this.state.activeSecondaryView }`
@@ -158,9 +168,14 @@ class InlineHelpPopover extends Component {
 						),
 						[ VIEW_RICH_RESULT ]: (
 							<InlineHelpRichResult
-								result={ this.state.selectedResult }
 								setDialogState={ setDialogState }
 								closePopover={ onClose }
+								type={ selectedResult?.[ RESULT_TYPE ] ?? RESULT_ARTICLE }
+								title={ selectedResult?.[ RESULT_TITLE ] }
+								link={ selectedResult?.[ RESULT_LINK ] }
+								description={ selectedResult?.[ RESULT_DESCRIPTION ] }
+								tour={ selectedResult?.[ RESULT_TOUR ] }
+								postId={ selectedResult?.post_id }
 							/>
 						),
 					}[ this.state.activeSecondaryView ]

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -11,16 +11,7 @@ import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-supp
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetInlineHelpContactForm } from 'calypso/state/inline-help/actions';
 import getSearchQuery from 'calypso/state/inline-help/selectors/get-search-query';
-import {
-	VIEW_CONTACT,
-	VIEW_RICH_RESULT,
-	RESULT_ARTICLE,
-	RESULT_DESCRIPTION,
-	RESULT_LINK,
-	RESULT_TITLE,
-	RESULT_TOUR,
-	RESULT_TYPE,
-} from './constants';
+import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
 import InlineHelpRichResult from './inline-help-rich-result';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpSearchResults from './inline-help-search-results';
@@ -170,12 +161,7 @@ class InlineHelpPopover extends Component {
 							<InlineHelpRichResult
 								setDialogState={ setDialogState }
 								closePopover={ onClose }
-								type={ selectedResult?.[ RESULT_TYPE ] ?? RESULT_ARTICLE }
-								title={ selectedResult?.[ RESULT_TITLE ] }
-								link={ selectedResult?.[ RESULT_LINK ] }
-								description={ selectedResult?.[ RESULT_DESCRIPTION ] }
-								tour={ selectedResult?.[ RESULT_TOUR ] }
-								postId={ selectedResult?.post_id }
+								result={ selectedResult }
 							/>
 						),
 					}[ this.state.activeSecondaryView ]

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -28,8 +28,7 @@ const HelpSearch = ( { searchQuery, track } ) => {
 		}
 
 		const resultLink = getResultLink( result );
-		const type = result.type ?? RESULT_ARTICLE;
-		const tour = result.tour;
+		const { type = RESULT_ARTICLE, tour } = result;
 
 		const tracksData = Object.fromEntries(
 			Object.entries( {

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -2,12 +2,7 @@ import { Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
-import {
-	RESULT_ARTICLE,
-	RESULT_LINK,
-	RESULT_TOUR,
-	RESULT_TYPE,
-} from 'calypso/blocks/inline-help/constants';
+import { RESULT_ARTICLE } from 'calypso/blocks/inline-help/constants';
 import HelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import HelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
 import CardHeading from 'calypso/components/card-heading';
@@ -21,7 +16,7 @@ const HELP_COMPONENT_LOCATION = 'customer-home';
 const amendYouTubeLink = ( link = '' ) =>
 	link.replace( 'youtube.com/embed/', 'youtube.com/watch?v=' );
 
-const getResultLink = ( result ) => amendYouTubeLink( result[ RESULT_LINK ] );
+const getResultLink = ( result ) => amendYouTubeLink( result.link );
 
 const HelpSearch = ( { searchQuery, track } ) => {
 	const translate = useTranslate();
@@ -33,8 +28,8 @@ const HelpSearch = ( { searchQuery, track } ) => {
 		}
 
 		const resultLink = getResultLink( result );
-		const type = result[ RESULT_TYPE ] ?? RESULT_ARTICLE;
-		const tour = result[ RESULT_TOUR ];
+		const type = result.type ?? RESULT_ARTICLE;
+		const tour = result.tour;
 
 		const tracksData = Object.fromEntries(
 			Object.entries( {


### PR DESCRIPTION
Based on #55978, needs rebase after that PR got merged.

#### Changes proposed in this Pull Request

Some code cleanups in `client/blocks/inline-help`

- remove some usages of lodash 
- use `useTranslate` instead of `localize` HOC where applicable

Found while working on inline help widget.

#### Testing instructions

Smoke test the Inline Help widget. Otherwise I think a code review should be sufficient.
