### PR TITLE
Fix a bug in the amount of time that is shown remaining for a product during the Jetpack product cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
@@ -47,7 +47,7 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 			} );
 
 			return { timeRemainingNumber, unitOfTime };
-		} else if ( timeRemaining.weeks() >= 1 ) {
+		} else if ( timeRemaining.weeks() > 1 ) {
 			const timeRemainingNumber = timeRemaining.weeks();
 			const unitOfTime = translate( 'week', 'weeks', {
 				count: timeRemainingNumber,

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
@@ -5,12 +5,12 @@ import {
 	isJetpackScanSlug,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import JetpackBenefits from 'calypso/blocks/jetpack-benefits';
 import JetpackGeneralBenefits from 'calypso/blocks/jetpack-benefits/general-benefits';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { isPartnerPurchase } from 'calypso/lib/purchases';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -28,11 +28,12 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, productSlug )
 	) as ResponseCartProduct | null;
+	const moment = useLocalizedMoment();
 
 	const getTimeRemainingForSubscription = ( purchase: Purchase ) => {
-		const purchaseExpiryDate = moment( purchase.expiryDate );
+		const purchaseExpiryDate = moment.utc( purchase.expiryDate );
 
-		return moment.duration( purchaseExpiryDate.diff( moment( purchase.mostRecentRenewDate ) ) );
+		return moment.duration( purchaseExpiryDate.diff( moment.utc() ) );
 	};
 
 	const getTimeRemainingTranslatedPeriod = ( purchase: Purchase ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a bug in the Jetpack cancellation flow where the incorrect amount of time was shown remaining for a purchased plan or product.

#### Testing instructions

This change is best tested locally where you can temporarily edit the JS
You will need a site with a plan/ product that is purchased (using credits is fine). Plans or products that are provisioned by the host will not show amount of time remaining in the product cancellation flow. 

**Observe the incorrect behavior**
* Check out the `trunk` branch locally
*  Navigate to `/me/purchases` and select the plan/ product that you have purchased
* Click on the button to remove this purchase

* Observe the amount of time stated as remaining on the plan. If you are removing a monthly plan, the output should show "4 months" remaining. If you are removing a yearly plan, the output should show "11 months" remaining.
![Screen Shot 2021-09-07 at 3 07 43 PM](https://user-images.githubusercontent.com/18016357/132404382-18d3a847-1402-4db7-93f3-9dd1c1a49aa7.png)
* You can manually manipulate the the expiration date for the plan used by the script by editing the body of `getTimeRemainingForSubscription` in `jetpack-benefits-step.tsx`. Using code like this, the expiration date can be overridden:
```
const getTimeRemainingForSubscription = ( purchase: Purchase ) => {
    purchase.expiryDate = '2021-10-30T00:00:00+00:00';
    const purchaseExpiryDate = moment( purchase.expiryDate );

    return moment.duration( purchaseExpiryDate.diff( moment( purchase.mostRecentRenewDate ) ) );
};
```
* The amount of time that shows as remaining in the cancellation flow will be a difference between the last renewal date of the product and the product expiry date. Note that this is expressed in whole days, weeks or months.  If you purchased the product today - then today is the last renewal date. This will produce some confusing results that look correct, since the value of `purchase.mostRecentRenewDate` will be today's date. You can pretend you purchased this product in the past by temporarily setting the value of `purchase.mostRecentRenewDate` to a date one month ago inside the `getTimeRemainingForSubscription` function shown above.
* This behavior is incorrect - as the amount of time shown as remaining on the product/ plan should be the difference between the current date and the expiration date of the product/ plan.

**Observe the corrected behavior**
* Reset any changes you have made locally so far and check out this branch
* Repeat the same steps as above to open the Jetpack cancellation flow for your test product.
* Notice the amount of time stated as remaining on the product or plan. This amount of time should now vary based on today's date. (when a product has 2+ weeks left, time is shown as weeks or months)
* Try again to manipulate the time remaining on the plan manually by editing `jetpack-benefits-step.tsx`.
```
const getTimeRemainingForSubscription = ( purchase: Purchase ) => {
    purchase.expiryDate = '2021-10-30T00:00:00+00:00';    
    const purchaseExpiryDate = moment.utc( purchase.expiryDate );
 
    return moment.duration( purchaseExpiryDate.diff( moment.utc() ) );
};
```
*  Observe that the amount of time remaining in the cancellation modal now reflects the amount of time between the date you set and today. Note that this is expressed in whole days, weeks or months. For example, if today is September 7th at 3PM and I temporarily set `purchase.expiryDate = '2021-09-11T00:00:00+00:00';` - time remaining will show as 3 days because there will be 3 days and some hours remaining until the plan renews/ expires.
* Try setting `purchase.expiry` so that there is only one day remaining - the output for time remaining on the plan should not show
* Try setting `purchase.expiry` to a value that has more than 2 days and fewer than 2 weeks remaining - the amount of time remaining should show in days
* Try setting `purchase.expiry` to a value that has more than 2 weeks and fewer than 1 month remaining - the amount of time remaining should show in weeks
* Try setting `purchase.expiry` to a value that has more than 1 month remaining - the amount of time remaining should show in months.

