### PR TITLE
Try jest-runner-groups as a way for e2e suites

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -297,7 +297,7 @@ fun gutenbergPlaywrightBuildType( viewportName: String, buildUuid: String ): Bui
                     export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
                     export DEBUG=pw:api
 
-                    xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright-wpcom
+                    xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=gutenberg
                 """.trimIndent()
                 dockerRunParameters = "-u %env.UID% --security-opt seccomp=.teamcity/docker-seccomp.json --shm-size=8gb"
             }

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --testNamePattern @parallel --maxWorkers=%E2E_WORKERS% specs/specs-playwright
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -27,6 +27,14 @@ module.exports = {
 				step: false,
 			},
 		},
+		{
+			files: [ 'specs/**/*' ],
+			rules: {
+				// We use jest-runner-groups to run spec suites, and these involve a custom doc header tag.
+				// Specs shouldn't have really any other jsdoc headers, so it should be safe to disable tag name checks.
+				'jsdoc/check-tag-names': 'off',
+			},
+		},
 	],
 	rules: {
 		'import/no-nodejs-modules': 'off',

--- a/test/e2e/docs/running-tests.md
+++ b/test/e2e/docs/running-tests.md
@@ -83,12 +83,14 @@ First, transpile TypeScript code:
 yarn workspace @automattic/calypso-e2e build --watch
 ```
 
-### All tests
+### A suite of specs
 
-Specify a directory to `Jest`:
+We use [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-groups) to group and run suites of specs.
+
+Use the `--group` arg to provide a suite to test `Jest`. For example, to run all the tests run on a Calypso PR, run...
 
 ```
-yarn jest specs/specs-playwright
+yarn jest --group=calypso-pr
 ```
 
 ### Individual spec file(s)

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -23,7 +23,7 @@ Refer to the [Playwright style guide](docs/style-guide-playwright.md) for more i
 
 Tests can be written in both TypeScript and JavaScript.
 
-1. create a spec file, following the structure:
+### 1. Create a spec file, following the structure:
 
 ```
 test/e2e/specs/specs-playwright/wp-<major feature>__<subfeature>.ts
@@ -34,7 +34,24 @@ This is for multiple reasons:
 - grouping of test specs by feature.
 - separation of subfeatures into separate files to take advantage of parallelization.
 
-2. import the basics:
+### 2. Assign the spec file to the appropriate suites
+
+Specs are grouped into suites using [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-groups). **Specs must be explicitly added to suites to be run as part of CI pipelines.**  
+To add your spec file to suites, add a jsdoc block at the top of the file, and use the `@group` tag for each suite.
+
+```typescript
+/**
+ * @group calypso-pr
+ * @group gutenberg
+ */
+```
+
+The current suites used are...
+- `calypso-pr` - tests run pre-merge on every Calypso PR.
+- `gutenberg` - WPCOM focused tests run as part of Gutenberg upgrades.
+
+
+### 3. Import the basics:
 
 ```typescript
 import { setupHooks, DataHelper, LoginFlow } from '@automattic/calypso-e2e';

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -23,7 +23,7 @@ Refer to the [Playwright style guide](docs/style-guide-playwright.md) for more i
 
 Tests can be written in both TypeScript and JavaScript.
 
-### 1. Create a spec file, following the structure:
+### 1. Create a spec file with the following structure
 
 ```
 test/e2e/specs/specs-playwright/wp-<major feature>__<subfeature>.ts
@@ -51,7 +51,7 @@ The current suites used are...
 - `gutenberg` - WPCOM focused tests run as part of Gutenberg upgrades.
 
 
-### 3. Import the basics:
+### 3. Import the basics
 
 ```typescript
 import { setupHooks, DataHelper, LoginFlow } from '@automattic/calypso-e2e';

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
 	transform: {
 		'\\.[jt]sx?$': [ 'babel-jest', { configFile: '../../babel.config.js' } ],
 	},
+	runner: 'groups', // This is for jest-runner-groups. It works with jest-circus below!
 	testRunner: 'jest-circus/runner',
 	testEnvironment: '<rootDir>/lib/jest/environment.js',
 };

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -51,8 +51,9 @@
 		"grunt-cli": "^1.2.0",
 		"grunt-concurrent": "^2.3.0",
 		"grunt-shell": "^1.1.2",
-		"jest": "^27.0.6",
+		"jest": "^26.6.3",
 		"jest-environment-node": "^26.6.2",
+		"jest-runner-groups": "^2.1.0",
 		"jest-teamcity": "^1.9.0",
 		"junit-viewer": "^4.9.6",
 		"lodash": "^4.17.20",
@@ -78,5 +79,9 @@
 		"xml2json-command": "^0.0.3",
 		"xmpp.js": "^0.3.0",
 		"xunit-viewer": "^5.1.8"
+	},
+	"peerDependencies": {
+		"jest-docblock": "*",
+		"jest-runner": "*"
 	}
 }

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -51,8 +51,10 @@
 		"grunt-cli": "^1.2.0",
 		"grunt-concurrent": "^2.3.0",
 		"grunt-shell": "^1.1.2",
-		"jest": "^26.6.3",
+		"jest": "^27.0.6",
+		"jest-docblock": "^27.0.6",
 		"jest-environment-node": "^26.6.2",
+		"jest-runner": "^27.0.6",
 		"jest-runner-groups": "^2.1.0",
 		"jest-teamcity": "^1.9.0",
 		"junit-viewer": "^4.9.6",
@@ -79,9 +81,5 @@
 		"xml2json-command": "^0.0.3",
 		"xmpp.js": "^0.3.0",
 		"xunit-viewer": "^5.1.8"
-	},
-	"peerDependencies": {
-		"jest-docblock": "*",
-		"jest-runner": "*"
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
@@ -1,3 +1,8 @@
+/**
+ * @group gutenberg
+ * @group coblocks
+ */
+
 import {
 	setupHooks,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
@@ -1,6 +1,5 @@
 /**
  * @group gutenberg
- * @group coblocks
  */
 
 import {

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -1,3 +1,8 @@
+/**
+ * @group gutenberg
+ * @group coblocks
+ */
+
 import path from 'path';
 import {
 	setupHooks,

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -1,6 +1,5 @@
 /**
  * @group gutenberg
- * @group coblocks
  */
 
 import path from 'path';

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -1,3 +1,8 @@
+/**
+ * @group calypso-pr
+ * @group gutenberg
+ */
+
 import path from 'path';
 import {
 	setupHooks,

--- a/test/e2e/specs/specs-playwright/wp-editor__tracks-events.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__tracks-events.ts
@@ -1,3 +1,7 @@
+/**
+ * @group gutenberg
+ */
+
 import {
 	DataHelper,
 	LoginFlow,

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	setupHooks,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	setupHooks,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
+++ b/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	EmailClient,

--- a/test/e2e/specs/specs-playwright/wp-likes__comment-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__comment-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group gutenberg
+ */
+
 import assert from 'assert';
 import {
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-likes__post-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group gutenberg
+ */
+
 import assert from 'assert';
 import {
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	MediaHelper,

--- a/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-media__upload-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import assert from 'assert';
 import {
 	setupHooks,

--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	setupHooks,
 	BrowserManager,

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	LoginFlow,

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	LoginFlow,

--- a/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-seo__preview-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	LoginFlow,

--- a/test/e2e/specs/specs-playwright/wp-site-import.ts
+++ b/test/e2e/specs/specs-playwright/wp-site-import.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	setupHooks,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-ssr_check.ts
+++ b/test/e2e/specs/specs-playwright/wp-ssr_check.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import { setupHooks, DataHelper } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 

--- a/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-stats__insights-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	setupHooks,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-support__home-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__home-spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import { DataHelper, LoginFlow, SupportComponent, setupHooks } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 

--- a/test/e2e/specs/specs-playwright/wp-support__popover-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-spec.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import assert from 'assert';
 import {
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__details-preview-activate.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	setupHooks,
 	DataHelper,

--- a/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
+++ b/test/e2e/specs/specs-playwright/wp-theme__popover-preview.js
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	LoginFlow,

--- a/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
@@ -1,3 +1,8 @@
+/**
+ * @group calypso-pr
+ * @group gutenberg
+ */
+
 import { DataHelper, LoginFlow, SidebarComponent, setupHooks } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40524,8 +40524,10 @@ typescript@^4.4.2:
     grunt-cli: ^1.2.0
     grunt-concurrent: ^2.3.0
     grunt-shell: ^1.1.2
-    jest: ^26.6.3
+    jest: ^27.0.6
+    jest-docblock: ^27.0.6
     jest-environment-node: ^26.6.2
+    jest-runner: ^27.0.6
     jest-runner-groups: ^2.1.0
     jest-teamcity: ^1.9.0
     junit-viewer: ^4.9.6
@@ -40552,9 +40554,6 @@ typescript@^4.4.2:
     xml2json-command: ^0.0.3
     xmpp.js: ^0.3.0
     xunit-viewer: ^5.1.8
-  peerDependencies:
-    jest-docblock: "*"
-    jest-runner: "*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23873,6 +23873,16 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"jest-runner-groups@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "jest-runner-groups@npm:2.1.0"
+  peerDependencies:
+    jest-docblock: ">= 24"
+    jest-runner: ">= 24"
+  checksum: 060316eab5df14a67acda32b007ba16097ace77605b1622c55c03e0b268b2c2d377d1942748b94467cc988c26d48ec0474a869826e6393f6984172de64f37c90
+  languageName: node
+  linkType: hard
+
 "jest-runner@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-runner@npm:26.6.3"
@@ -40514,8 +40524,9 @@ typescript@^4.4.2:
     grunt-cli: ^1.2.0
     grunt-concurrent: ^2.3.0
     grunt-shell: ^1.1.2
-    jest: ^27.0.6
+    jest: ^26.6.3
     jest-environment-node: ^26.6.2
+    jest-runner-groups: ^2.1.0
     jest-teamcity: ^1.9.0
     junit-viewer: ^4.9.6
     lodash: ^4.17.20
@@ -40541,6 +40552,9 @@ typescript@^4.4.2:
     xml2json-command: ^0.0.3
     xmpp.js: ^0.3.0
     xunit-viewer: ^5.1.8
+  peerDependencies:
+    jest-docblock: "*"
+    jest-runner: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Trying out e2e suites with jest-runner-groups. This allows you to create and run suites of tests with jsdoc file headers and a single CLI argument. See more at [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-groups).

### Testing instructions

Which approach do we want to do?

You can try out what this looks like with `yarn jest --group=coblocks`.

### Pro / Cons
This is an alternative to #56001. Here are the pro/cons as I see it comparing this approach to the naming/multi-config approach....

Pros:
- Don't have to do git renames to add suites
- Much less clutter in the file name
- Single jest config, just adding an even simpler CLI arg!

Cons:
- Not a widely-used repo (~25k downloads, which isn't small, but not massive). 
- We have to disable jsdoc tag checks for specs in eslint. This is pretty small though.

### To Do

- [x] Get it to work with Jest `v27`