### PR TITLE
Revert "Add GDPR location refresh to avoid missing GA page view (#55667)"

### DIFF
--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -4,7 +4,7 @@ import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytic
 import { retarget as retargetAdTrackers } from 'calypso/lib/analytics/ad-tracking';
 import { retargetFullStory } from 'calypso/lib/analytics/fullstory';
 import { updateQueryParamsTracking } from 'calypso/lib/analytics/sem';
-import { saveCouponQueryArgument, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
+import { saveCouponQueryArgument } from 'calypso/lib/analytics/utils';
 import { gaRecordPageView } from './ga';
 import { processQueue } from './queue';
 import { referRecordPageView } from './refer';
@@ -12,8 +12,7 @@ import { referRecordPageView } from './refer';
 export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) {
 	// Add delay to avoid stale `_dl` in recorded calypso_page_view event details.
 	// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript.
-	setTimeout( async function () {
-		await refreshCountryCodeCookieGdpr();
+	setTimeout( () => {
 		// Tracks, Google Analytics, Refer platform.
 		recordTracksPageViewWithPageParams( urlPath, params );
 		gaRecordPageView( urlPath, pageTitle, options?.useJetpackGoogleAnalytics );
@@ -22,7 +21,7 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 		// Retargeting.
 		saveCouponQueryArgument();
 		updateQueryParamsTracking();
-		await retargetAdTrackers( urlPath );
+		retargetAdTrackers( urlPath );
 
 		// FullStory.
 		retargetFullStory();

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -29,7 +29,6 @@
 	"features": {
 		"activity-log/display-rules": false,
 		"activity-log/v2": true,
-		"ad-tracking": false,
 		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,


### PR DESCRIPTION
This reverts commit 46b2691975c9ac80db815b54b0ad8d5e3f01ec82.

See discussion at p1631024862050300-slack-CVD3SUW1L
