### PR TITLE
Add Back button to the domain suggestions screen

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import classnames from 'classnames';
@@ -13,7 +14,6 @@ import RegisterDomainStep from 'calypso/components/domains/register-domain-step'
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
-import Gridicon from 'calypso/components/gridicon';
 import Main from 'calypso/components/main';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -1,3 +1,4 @@
+import { BackButton } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -12,6 +13,7 @@ import RegisterDomainStep from 'calypso/components/domains/register-domain-step'
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import Gridicon from 'calypso/components/gridicon';
 import Main from 'calypso/components/main';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import {
@@ -24,7 +26,11 @@ import {
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
-import { domainAddEmailUpsell, domainMapping } from 'calypso/my-sites/domains/paths';
+import {
+	domainAddEmailUpsell,
+	domainMapping,
+	domainManagementList,
+} from 'calypso/my-sites/domains/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
@@ -211,6 +217,13 @@ class DomainSearch extends Component {
 			content = (
 				<span>
 					<div className="domain-search__content">
+						<BackButton
+							className={ 'domain-search__go-back' }
+							href={ domainManagementList( selectedSiteSlug ) }
+						>
+							<Gridicon icon="arrow-left" size={ 18 } />
+							{ translate( 'Back' ) }
+						</BackButton>
 						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 						<div className="domains__header">
 							<FormattedHeader

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -1,9 +1,18 @@
+@import '@automattic/onboarding/styles/mixins';
 // domain search
 
 .domain-search__content {
 	overflow: visible;
 	padding: 0 0 20px;
 	position: static;
+	.domain-search__go-back {
+		margin-bottom: 18px;
+		&.is-link {
+			@include onboarding-medium-text;
+			text-decoration: none;
+			color: var( --studio-gray-50 );
+		}
+	}
 }
 
 .domain-search-page-wrapper h2 {
@@ -17,6 +26,6 @@
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 17px;
+		font-size: 17px; /* stylelint-disable-line */
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Back button to the domain suggestions screen

Before:

<img width="1088" alt="Screenshot 2021-09-07 at 21 51 21" src="https://user-images.githubusercontent.com/1355045/132396352-b5928df5-8f11-4c1a-a54f-7df50326165a.png">

After:

<img width="1081" alt="Screenshot 2021-09-07 at 21 51 02" src="https://user-images.githubusercontent.com/1355045/132396360-d9ecf7d2-04ac-46be-8bcc-9af4cfe40860.png">

#### Testing instructions

* Go to Upgrades > Domains and click on "Add a domain to this site" and then "Search for a domain". Then you should see a Back button at the top - if you click it you should go back to the domain management list screen
