### PR TITLE
Composite Checkout: Remove border and background from disabled text buttons

### DIFF
--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -10,7 +10,9 @@ const CallToAction = styled( 'button' )< CallToActionProps >`
 	border-radius: ${ ( props ) => ( props.buttonType === 'paypal' ? '50px' : '2px' ) };
 	padding: ${ ( props ) => ( props.buttonType === 'text-button' ? '0' : '10px 15px' ) };
 	border: ${ ( props ) =>
-		! props.buttonType || props.disabled ? '1px solid ' + props.theme.colors.borderColor : '0' };
+		! props.buttonType || ( props.disabled && props.buttonType !== 'text-button' )
+			? '1px solid ' + props.theme.colors.borderColor
+			: '0' };
 	background: ${ getBackgroundColor };
 	color: ${ getTextColor };
 	font-weight: ${ ( props ) => props.theme.weights.normal };
@@ -175,7 +177,7 @@ function getBackgroundColor( {
 	theme: Theme;
 } ) {
 	const { colors } = theme;
-	if ( disabled ) {
+	if ( disabled && buttonType !== 'text-button' ) {
 		return colors.disabledPaymentButtons;
 	}
 	switch ( buttonType ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `Button` component from the `@automattic/composite-checkout` package has a "text-only" type, which displays the button as a link. In this mode, the button should never have a border or a background color applied.

This PR removes the border and background color from the "text-only" button when it is disabled.

Before:
![before-remove-bg-and-border](https://user-images.githubusercontent.com/2036909/132398979-d8028ea9-7464-4502-bf2b-66abf990037e.png)

After:
![delete-text-button-normal](https://user-images.githubusercontent.com/2036909/132398991-0939d05e-331b-485f-99d5-43238651acee.png)


#### Testing instructions

Apply https://github.com/Automattic/wp-calypso/pull/56045 and verify that the cart item delete buttons do not have a border or background when the the cart is updating.