### PR TITLE
Update fine print copy in Cloud pricing page

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,5 +1,3 @@
-
-
 .author-compact-profile {
 	font-size: $font-body-small;
 	display: flex;

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,3 +1,5 @@
+
+
 .author-compact-profile {
 	font-size: $font-body-small;
 	display: flex;

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -139,17 +139,17 @@ const DisplayPrice = ( {
 	);
 	const discountElt =
 		billingTerm === TERM_ANNUALLY
-			? translate( '* Save %(percent)d%% for the first year', {
+			? translate( 'Save %(percent)d%% for the first year ✢', {
 					args: {
 						percent: ( ( originalPrice - couponDiscountedPrice ) / originalPrice ) * 100,
 					},
-					comment: 'Asterisk clause describing the displayed price adjustment',
+					comment: '✢ clause describing the displayed price adjustment',
 			  } )
-			: translate( '* You Save %(percent)d%%', {
+			: translate( 'You Save %(percent)d%% ✢', {
 					args: {
 						percent: INTRO_PRICING_DISCOUNT_PERCENTAGE,
 					},
-					comment: 'Asterisk clause describing the displayed price adjustment',
+					comment: '✢ clause describing the displayed price adjustment',
 			  } );
 
 	return (

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -16,9 +16,10 @@ const Banner: React.FC = () => {
 				</p>
 				<p className="intro-pricing-banner__call-to-action">
 					{ translate(
-						'Get the perfect Jetpack for your site with %(percent)d%% off the first term. *Try it risk free with our %(days)d-day money-back guarantee.',
+						'Get the perfect Jetpack for your site with %(percent)d%% off the first term. Try it risk free with our %(days)d-day money-back guarantee.*',
 						{
 							args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE, days: 14 },
+							comment: '* clause describing the money back guarantee',
 						}
 					) }
 				</p>

--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -37,7 +37,20 @@ const JetpackFAQ: React.FC = () => {
 				<h2 className="jetpack-faq__heading">{ translate( 'Frequently Asked Questions' ) }</h2>
 
 				<FoldableFAQ
-					id="faq-1"
+					id="priority-support"
+					question={ translate( 'Is priority support included in all plans?' ) }
+					onToggle={ onFaqToggle }
+				>
+					{ translate(
+						'Yes, our expert Happiness Engineers provide priority support to all customers with paid plans and services! Have a question or a problem? Just {{helpLink}}contact support{{/helpLink}} and we’ll get back to you in no time.',
+						{
+							components: { helpLink: getHelpLink( 'more_questions' ) },
+						}
+					) }
+				</FoldableFAQ>
+
+				<FoldableFAQ
+					id="cancellation-policy"
 					question={ translate( 'What is your cancellation policy?' ) }
 					onToggle={ onFaqToggle }
 				>
@@ -51,7 +64,7 @@ const JetpackFAQ: React.FC = () => {
 				</FoldableFAQ>
 
 				<FoldableFAQ
-					id="faq-2"
+					id="wpcom-account"
 					question={ translate( 'Why do I need a WordPress.com account?' ) }
 					onToggle={ onFaqToggle }
 				>
@@ -63,7 +76,7 @@ const JetpackFAQ: React.FC = () => {
 				</FoldableFAQ>
 
 				<FoldableFAQ
-					id="faq-3"
+					id="hosting-requirements"
 					question={ translate( 'What are the hosting requirements?' ) }
 					onToggle={ onFaqToggle }
 				>
@@ -73,7 +86,7 @@ const JetpackFAQ: React.FC = () => {
 				</FoldableFAQ>
 
 				<FoldableFAQ
-					id="faq-4"
+					id="multisite-network"
 					question={ translate( 'Does this work with a multisite network?' ) }
 					onToggle={ onFaqToggle }
 				>
@@ -85,7 +98,7 @@ const JetpackFAQ: React.FC = () => {
 				</FoldableFAQ>
 
 				<FoldableFAQ
-					id="faq-5"
+					id="more-questions"
 					question={ translate( 'Have more questions?' ) }
 					onToggle={ onFaqToggle }
 				>

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -236,17 +236,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 						onButtonClick={ scrollToComparison }
 					/>
 				</div>
-				<ul className="product-grid__asterisk-list">
-					<li className="product-grid__asterisk-item">
-						{ translate( 'Special introductory pricing, all renewals are at full price.' ) }
-					</li>
-					<li className="product-grid__asterisk-item">
-						{ translate( 'Monthly plans are 7-day money back guarantee.' ) }
-					</li>
-					<li className="product-grid__asterisk-item">
-						{ translate( 'All paid products and plans include priority support.' ) }
-					</li>
-				</ul>
 			</ProductGridSection>
 			<ProductGridSection title={ translate( 'More Products' ) }>
 				<ul className="product-grid__product-grid">
@@ -282,6 +271,17 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				</div>
 			</ProductGridSection>
 			<StoreFooter />
+			<ul className="product-grid__asterisk-list">
+				<li className="product-grid__asterisk-item">
+					{ translate( '* Monthly plans are 7-day money back guarantee.' ) }
+				</li>
+				<li className="product-grid__asterisk-item">
+					{ translate( '✢ Discount is for first term only, all renewals are at full price.' ) }
+				</li>
+				<li className="product-grid__asterisk-item">
+					{ translate( 'All paid products and plans include priority support.' ) }
+				</li>
+			</ul>
 		</>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -278,9 +278,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				<li className="product-grid__asterisk-item">
 					{ translate( '✢ Discount is for first term only, all renewals are at full price.' ) }
 				</li>
-				<li className="product-grid__asterisk-item">
-					{ translate( 'All paid products and plans include priority support.' ) }
-				</li>
 			</ul>
 		</>
 	);

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -112,10 +112,6 @@
 }
 
 .product-grid__asterisk-item {
-	&::before {
-		content: '*';
-	}
-
 	color: var( --color-neutral-light );
 
 	font-size: $font-body;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the fine prints in the cloud pricing page.

Fixes 1196108640073826-as-1200844075034058

### Testing instructions

- Download the PR and run cloud
- Visit the pricing page
- Check that you can see the updates mentioned in the captures below

### Screenshots

1. Asterisk in the banner is now at the end of the line.
<img width="594" alt="Screen Shot 2021-09-07 at 4 45 53 PM" src="https://user-images.githubusercontent.com/1620183/132408805-a98ad319-cbaa-492e-8fb6-fed7324f3af8.png">


2. Asterisk in the discount label has been replaced by another symbol, and is now at the end of the string.
<img width="321" alt="Screen Shot 2021-09-07 at 4 46 02 PM" src="https://user-images.githubusercontent.com/1620183/132408807-ebc52118-435d-4d81-b7c6-3b3e29342134.png">


3. Fine prints have been moved at the bottom of the page, and reordered.
4. Copy for the pricing item has been updated as well.
5. Priority support small print has been removed.
<img width="833" alt="Screen Shot 2021-09-14 at 3 24 36 PM" src="https://user-images.githubusercontent.com/1620183/133321620-7961953e-2e0f-4f8c-a45b-f9f45b55a9bb.png">


6.New FAQ item has been added on top.
<img width="785" alt="Screen Shot 2021-09-14 at 3 25 58 PM" src="https://user-images.githubusercontent.com/1620183/133321577-ddd5d123-76c3-42cb-9050-c2b309658286.png">


