### PR TITLE
Update icon used for typography:global styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/global-styles-sidebar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/global-styles-sidebar.js
@@ -3,11 +3,11 @@ import { dispatch } from '@wordpress/data';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { typography } from '@wordpress/icons';
 import { getQueryArg } from '@wordpress/url';
 import { FONT_BASE, FONT_HEADINGS } from './constants';
 import FontPairingsPanel from './font-pairings-panel';
 import FontSelectionPanel from './font-selection-panel';
-import { GlobalStylesIcon } from './icon';
 
 const ANY_PROPERTY = 'ANY_PROPERTY';
 
@@ -77,11 +77,11 @@ export default ( {
 		} );
 	return (
 		<>
-			<PluginSidebarMoreMenuItem icon={ <GlobalStylesIcon /> } target="global-styles">
+			<PluginSidebarMoreMenuItem icon={ typography } target="global-styles">
 				{ __( 'Global Styles', 'full-site-editing' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
-				icon={ <GlobalStylesIcon /> }
+				icon={ typography }
 				name={ 'global-styles' }
 				title={ __( 'Global Styles', 'full-site-editing' ) }
 				className="global-styles-sidebar"

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/icon.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/icon.js
@@ -1,9 +1,0 @@
-import { Path, SVG } from '@wordpress/components';
-
-// For now, this icon shows a font style picker. Once we add colors, we'll want colors.
-
-export const GlobalStylesIcon = () => (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M9.93 13.5h4.14L12 7.98zM20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-4.05 16.5l-1.14-3H9.17l-1.12 3H5.96l5.11-13h1.86l5.11 13h-2.09z" />
-	</SVG>
-);


### PR DESCRIPTION
Updates the current icon used for the typography panel with the latest from `wordpress/icon` which should be a lot more clear.

**Before:**
![image](https://user-images.githubusercontent.com/548849/132487662-8ea081f9-c2f4-4aec-9aa6-4065f5661954.png)

**After:**
![image](https://user-images.githubusercontent.com/548849/132487507-74cf7b4b-aa83-45a0-9741-6522c29dc52c.png)
