### PR TITLE
Add comparison context to EmailProvidersComparison tracking

### DIFF
--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -18,6 +18,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 			<EmailProvidersComparison
 				backPath={ domainAddNew( selectedSiteSlug ) }
 				cartDomainName={ domain }
+				comparisonContext="domain-upsell"
 				headerTitle={ translate( 'Register %(domainName)s', {
 					args: { domainName: domain },
 					comment,

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -72,7 +72,10 @@ export default {
 	emailManagementPurchaseNewEmailAccount( pageContext, next ) {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
-				<EmailProvidersComparison selectedDomainName={ pageContext.params.domain } />
+				<EmailProvidersComparison
+					comparisonContext="email-purchase"
+					selectedDomainName={ pageContext.params.domain }
+				/>
 			</CalypsoShoppingCartProvider>
 		);
 

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -76,8 +76,9 @@ class EmailManagementHome extends React.Component {
 			if ( ! domainHasEmail( selectedDomain ) ) {
 				return (
 					<EmailProvidersComparison
-						selectedDomainName={ selectedDomainName }
 						backPath={ domainManagementList( selectedSite.slug, null ) }
+						comparisonContext="email-home-selected-domain"
+						selectedDomainName={ selectedDomainName }
 					/>
 				);
 			}
@@ -99,6 +100,7 @@ class EmailManagementHome extends React.Component {
 		if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
 			return (
 				<EmailProvidersComparison
+					comparisonContext="email-home-single-domain"
 					selectedDomainName={ domainsWithNoEmail[ 0 ].name }
 					skipHeaderElement={ true }
 				/>

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -98,6 +98,10 @@ class EmailProvidersComparison extends React.Component {
 		titanMailProduct: PropTypes.object,
 	};
 
+	static defaultProps = {
+		comparisonContext: 'email-purchase',
+	};
+
 	isMounted = false;
 
 	constructor( props ) {
@@ -122,12 +126,6 @@ class EmailProvidersComparison extends React.Component {
 
 	componentWillUnmount() {
 		this.isMounted = false;
-	}
-
-	getComparisonContext() {
-		const { comparisonContext = 'email-purchase' } = this.props;
-
-		return comparisonContext;
 	}
 
 	onExpandedStateChange = ( providerKey, isExpanded ) => {
@@ -173,7 +171,7 @@ class EmailProvidersComparison extends React.Component {
 	};
 
 	onTitanConfirmNewMailboxes = () => {
-		const { domain, domainName, hasCartDomain } = this.props;
+		const { comparisonContext, domain, domainName, hasCartDomain } = this.props;
 		const { titanMailboxes } = this.state;
 
 		const validatedTitanMailboxes = validateTitanMailboxes( titanMailboxes );
@@ -185,7 +183,7 @@ class EmailProvidersComparison extends React.Component {
 			: getCurrentUserCannotAddEmailReason( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
-			context: this.getComparisonContext(),
+			context: comparisonContext,
 			mailbox_count: validatedTitanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: 'titan',
@@ -244,14 +242,14 @@ class EmailProvidersComparison extends React.Component {
 	};
 
 	onGoogleConfirmNewUsers = () => {
-		const { domain, gSuiteProduct, hasCartDomain } = this.props;
+		const { comparisonContext, domain, gSuiteProduct, hasCartDomain } = this.props;
 		const { googleUsers } = this.state;
 
 		const usersAreValid = areAllUsersValid( googleUsers );
 		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
-			context: this.getComparisonContext(),
+			context: comparisonContext,
 			mailbox_count: googleUsers.length,
 			mailboxes_valid: usersAreValid ? 1 : 0,
 			provider: 'google',
@@ -644,7 +642,7 @@ class EmailProvidersComparison extends React.Component {
 	}
 
 	renderDomainEligibilityNotice() {
-		const { domain, domainName } = this.props;
+		const { comparisonContext, domain, domainName } = this.props;
 
 		if ( this.isDomainEligibleForEmail( domain ) ) {
 			return null;
@@ -660,7 +658,7 @@ class EmailProvidersComparison extends React.Component {
 				<TrackComponentView
 					eventName="calypso_email_providers_comparison_page_domain_not_eligible_error_impression"
 					eventProperties={ {
-						context: this.getComparisonContext(),
+						context: comparisonContext,
 						domain: domainName,
 						error_code: cannotAddEmailReason.code,
 					} }
@@ -674,6 +672,7 @@ class EmailProvidersComparison extends React.Component {
 
 	render() {
 		const {
+			comparisonContext,
 			domainsWithForwards,
 			hideEmailForwardingCard,
 			isGSuiteSupported,
@@ -707,7 +706,7 @@ class EmailProvidersComparison extends React.Component {
 				<TrackComponentView
 					eventName="calypso_email_providers_comparison_page_view"
 					eventProperties={ {
-						context: this.getComparisonContext(),
+						context: comparisonContext,
 						is_gsuite_supported: isGSuiteSupported,
 						layout: 'stacked',
 					} }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -75,6 +75,7 @@ class EmailProvidersComparison extends React.Component {
 	static propTypes = {
 		// Props passed to this component
 		cartDomainName: PropTypes.string,
+		comparisonContext: PropTypes.string,
 		headerTitle: PropTypes.string,
 		hideEmailForwardingCard: PropTypes.bool,
 		hideEmailHeader: PropTypes.bool,
@@ -121,6 +122,12 @@ class EmailProvidersComparison extends React.Component {
 
 	componentWillUnmount() {
 		this.isMounted = false;
+	}
+
+	getComparisonContext() {
+		const { comparisonContext = 'email-purchase' } = this.props;
+
+		return comparisonContext;
 	}
 
 	onExpandedStateChange = ( providerKey, isExpanded ) => {
@@ -178,6 +185,7 @@ class EmailProvidersComparison extends React.Component {
 			: getCurrentUserCannotAddEmailReason( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
+			context: this.getComparisonContext(),
 			mailbox_count: validatedTitanMailboxes.length,
 			mailboxes_valid: mailboxesAreValid ? 1 : 0,
 			provider: 'titan',
@@ -243,6 +251,7 @@ class EmailProvidersComparison extends React.Component {
 		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
 
 		recordTracksEvent( 'calypso_email_providers_add_click', {
+			context: this.getComparisonContext(),
 			mailbox_count: googleUsers.length,
 			mailboxes_valid: usersAreValid ? 1 : 0,
 			provider: 'google',
@@ -651,6 +660,7 @@ class EmailProvidersComparison extends React.Component {
 				<TrackComponentView
 					eventName="calypso_email_providers_comparison_page_domain_not_eligible_error_impression"
 					eventProperties={ {
+						context: this.getComparisonContext(),
 						domain: domainName,
 						error_code: cannotAddEmailReason.code,
 					} }
@@ -697,6 +707,7 @@ class EmailProvidersComparison extends React.Component {
 				<TrackComponentView
 					eventName="calypso_email_providers_comparison_page_view"
 					eventProperties={ {
+						context: this.getComparisonContext(),
 						is_gsuite_supported: isGSuiteSupported,
 						layout: 'stacked',
 					} }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new `context` value to the tracking events for the `EmailProvidersComparison` component that is specified by the `comparisonContext` prop (which defaults to `email-purchase`).
* The change is needed so we can clearly distinguish between the different contexts in which the component may appear.

#### Testing instructions

The testing instructions here are the same for four different situations where we can show the `EmailProvidersComparison` component (the expected context value is noted):
* When purchasing a new domain via `/domains/add/:domainName/email/:siteSlug` - `domain-upsell`
* When exploring email options for an existing domain via `/email/:domainName/purchase/:siteSlug` - `email-purchase`
* When navigating to the email management page for an existing domain that doesn't have email via `/email/:domainName/manage/:siteSlug` - `email-home-selected-domain`
* When navigating to the email home page for a site that has only one domain without email via `/email/:siteSlug` - `email-home-single-domain`

For each of the pages identified above:
* Ensure that you're logged into the site and have your browser network tools open to show Tracks events (which are handled via requests to `t.gif`).
* Navigate to the page/URL identified above
* Verify that you see a `calypso_email_providers_comparison_page_view` event sent to the server with the appropriate `context` value
* Fill out most of the form for Professional Email, but leave out one of the required fields (like the password) and then click on "Add"
* Verify that you see a `calypso_email_providers_add_click` event logged with the expected `context` value
* Expand the Google Workspace section and fill out most of the form for Google Workspace, but leave a required field (like password) blank, and then click on "Add"
* Verify that you see a `calypso_email_providers_add_click` event logged with the expected `context` value
