### PR TITLE
Allow buttons to track if link has context.

### DIFF
--- a/apps/notifications/src/panel/indices-to-html/index.js
+++ b/apps/notifications/src/panel/indices-to-html/index.js
@@ -138,12 +138,15 @@ function render_range( new_sub_text, new_sub_range, range_info, range_data, opti
 					new_container.setAttribute( 'rel', 'noopener noreferrer' );
 				}
 
-				if ( 'post' === range_info.type ) {
+				if ( 'post' === range_info_type ) {
 					new_container.setAttribute( 'data-post-id', range_info.id );
 					new_container.setAttribute( 'data-site-id', range_info.site_id );
 					new_container.setAttribute( 'data-link-type', 'post' );
 					new_container.setAttribute( 'target', '_self' );
-				} else if ( 'tracks' === range_info.type && range_info.context ) {
+				} else if (
+					( 'tracks' === range_info_type || 'button' === range_info_type ) &&
+					range_info.context
+				) {
 					new_container.setAttribute( 'data-link-type', 'tracks' );
 					new_container.setAttribute( 'data-tracks-event', range_info.context );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to make the actions in a masterbar notification body more obvious by using buttons, but these are tracked links. This PR uses the existing button type with a context as per the 'tracks' type to allow the button links to be tracked. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- apply D66606-code and send yourself a Renewal Failure email by clicking 'post note to me' from the dev-mc notification previewer (ping me for a link)
- visit calypso.localhost:3000 for your A11n account
- verify that the new notification has a button labelled 'Renew now'
- inspect that button and verify that it has attributes `data-link-type="tracks" data-tracks-event="open_link_to_manage_purchase"`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

