### PR TITLE
Stats: Update Parse.ly link, tweaks to mobile styles

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -314,7 +314,12 @@ class StatsSite extends Component {
 							) }
 						</p>
 					</div>
-					<Button primary href="https://parse.ly" onClick={ this.parselyClick } target="_blank">
+					<Button
+						primary
+						href="https://www.parse.ly/wordpress-demo?utm_source=wpstats&utm_medium=jitm&utm_campaign=parselywpstatsdemo"
+						onClick={ this.parselyClick }
+						target="_blank"
+					>
 						{ translate( 'Learn more' ) }
 					</Button>
 				</Card>

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -143,6 +143,7 @@
 
 	& > div {
 		flex: 1;
+		margin-right: 30px;
 	}
 
 	img {
@@ -152,12 +153,10 @@
 	}
 
 	p {
-		margin: 0;
 		color: var( --color-text-subtle );
 	}
 
 	.button {
-		margin-top: 16px;
 		margin-left: auto;
 		justify-self: flex-end;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Parse.ly link to include specific route and referrer
* Tweaks to mobile styles

**Before**

<img width="684" alt="Screen Shot 2021-09-08 at 9 57 55 AM" src="https://user-images.githubusercontent.com/2124984/132523277-e7b838c4-084d-4f9c-9d34-8a74037a27bb.png">

**After**

<img width="682" alt="Screen Shot 2021-09-08 at 9 57 33 AM" src="https://user-images.githubusercontent.com/2124984/132523320-3a107378-b5c0-43ed-9020-98341d74811b.png">


#### Testing instructions

* Switch to this PR, navigate to `/stats`
* On the Parse.ly banner at the bottom of the screen, "Learn more" should now link to `https://www.parse.ly/wordpress-demo?utm_source=wpstats&utm_medium=jitm&utm_campaign=parselywpstatsdemo` instead of `https://parse.ly`
* Things should look a little cleaner on small screens as an added bonus
