### PR TITLE
Add readme files to images folders

### DIFF
--- a/client/assets/images/README.md
+++ b/client/assets/images/README.md
@@ -1,0 +1,8 @@
+# Images
+
+Images from this folder are managed by Webpack, and can be imported like this:
+
+```javascript
+import mediaPostImage from 'assets/images/upgrades/media-post.svg';
+```
+Note this creates an immutable name with a hash suffix for the image asset: the url  will change if the source image changes.

--- a/client/assets/images/README.md
+++ b/client/assets/images/README.md
@@ -1,8 +1,15 @@
 # Images
 
-Images from this folder are managed by Webpack, and can be imported like this:
+Images from this folder are managed by webpack, and can be imported like this:
 
 ```javascript
-import mediaPostImage from 'assets/images/upgrades/media-post.svg';
+import mediaPostImageURL from 'assets/images/upgrades/media-post.svg';
 ```
-Note this creates an immutable name with a hash suffix for the image asset: the url  will change if the source image changes.
+
+You can then use such image that way:
+
+```javascript
+<img src={ mediaPostImageURL } alt="Illustration" />
+```
+
+Technically speaking, webpack will copy that image to the `public/images` output folder automatically, with an immutable hashed name (so this name will change if the source image changes).

--- a/static/images/README.md
+++ b/static/images/README.md
@@ -1,0 +1,3 @@
+# Images
+
+The `static/images` folder is being phased out, as this approach had some issues with caching. Please add new images to the `client/assets/images` folder instead (see [documentation](../../client/assets/images/README.md)).


### PR DESCRIPTION
This pull request adds two readme files to the following images folders:

* `client/assets/images`
* `static/images`

The goal here is to document which folder should actually be used for new images. Note this topic was discussed internally at 
p1591988253070000-slack-calypso.