### PR TITLE
Jetpack: update copy styling on Site Search popover

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -158,7 +158,7 @@
 .jetpack-product-card__get-started {
 	display: inline-block;
 	margin-block-start: 24px;
-	border-radius: 4px;
+	border-radius: 4px; /* stylelint-disable-line scales/radii */
 	padding: 4px 24px 4px 8px;
 
 	font-size: $font-body-small;
@@ -202,7 +202,7 @@
 
 	&::before {
 		border-top: 3px solid var( --studio-pink-50 );
-		border-radius: 3px;
+		border-radius: 3px; /* stylelint-disable-line scales/radii */
 		transform: initial;
 	}
 }
@@ -252,6 +252,11 @@
 }
 .jetpack-product-card__price-tooltip p {
 	margin-bottom: 1rem;
+	font-size: inherit;
+
+	&:first-of-type {
+		margin-bottom: 0.5rem;
+	}
 }
 
 .jetpack-product-card__expiration-date {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy styling on Site Search popover.

#### Testing instructions

* Fire up this PR by running `yarn start-jetpack-cloud`.
* Head to http://jetpack.cloud.localhost:3000/pricing/
* Make sure the popover under the Site Search card looks good.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/132524576-2aa8c71c-81ae-4f28-b85c-1941c5983765.png) | ![image](https://user-images.githubusercontent.com/390760/132524624-4fcf0902-4312-4faf-9c2f-9ce1d4c38f90.png)

