### PR TITLE
Make masterbar in cloud pricing page wider

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -5,6 +5,7 @@ import { hideMasterbar } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
+import JetpackComMasterbar from './jpcom-masterbar';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
 	const urlQueryArgs = context.query;
@@ -22,6 +23,7 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 	}
 
 	context.store.dispatch( hideMasterbar() );
+	context.nav = <JetpackComMasterbar />;
 	context.header = <Header urlQueryArgs={ urlQueryArgs } />;
 	context.footer = <JetpackComFooter />;
 	next();

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import { preventWidows } from 'calypso/lib/formatting';
-import JetpackComMasterbar from '../jpcom-masterbar';
 import './style.scss';
 
 const Header: React.FC< Props > = () => {
@@ -11,8 +10,6 @@ const Header: React.FC< Props > = () => {
 
 	return (
 		<>
-			<JetpackComMasterbar />
-
 			<div className="header">
 				<FormattedHeader
 					className="header__main-title"

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -2,31 +2,45 @@
 @import '@wordpress/base-styles/mixins';
 
 .jpcom-masterbar {
+	display: flex;
+	align-items: center;
+
+	width: calc( 100% - 4rem );
+	height: 102px;
+	max-width: 1200px;
+	margin: -47px auto 0; // Undo the padding-top set by .layout__content
+	padding: 0 2rem;
+
 	background-color: var( --color-surface );
 
-	padding: 1em 16px;
-
-	// Undo the padding-top set by .layout__content for each
-	// screen size.
-	margin-top: -47px;
-
-	// We need to use this deprecated breakpoint because we need
-	// to match Calypso's layout breakpoint also.
-	@include breakpoint-deprecated( '>660px' ) {
-		padding: 20px 0 22px;
-
-		margin-top: -71px;
+	// Breakpoint taken from jetpack.com, not standard in Calypso
+	@media ( min-width: 661px ) {
+		width: 100%;
+		margin-top: -71px; // Undo the padding-top set by .layout__content
+		padding: 0;
 	}
 
-	@include break-large {
-		padding-bottom: 40px;
+	@media ( min-width: 783px ) {
+		width: 95vw;
+	}
 
-		margin-top: -79px;
+	@media ( min-width: 901px ) {
+		margin-top: -79px; // Undo the padding-top set by .layout__content
+	}
+
+	@media ( min-width: 1101px ) {
+		width: 90vw;
+	}
+
+	@media ( min-width: 1301px ) {
+		width: 85vw;
 	}
 }
 
 .jpcom-masterbar__inner {
 	position: relative;
+
+	width: 100%;
 
 	// Breakpoint taken from jetpack.com, not standard in Calypso
 	@media ( min-width: 375px ) {
@@ -40,10 +54,7 @@
 	@include break-large {
 		flex-wrap: nowrap;
 
-		max-width: 1040px;
-
 		margin: 0 auto;
-		padding: 0 32px;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -25,7 +25,6 @@ function stringToDuration( duration?: string ): Duration | undefined {
  * slug, otherwise, return null.
  *
  * @param {string} productSlug the slug of a Jetpack product
- *
  * @returns {[string, string] | null} the monthly and yearly slug of a supported Jetpack product
  */
 function getHighlightedProduct( productSlug?: string ): [ string, string ] | null {
@@ -66,6 +65,7 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 			siteSlug={ siteParam || context.query.site }
 			urlQueryArgs={ urlQueryArgs }
 			highlightedProducts={ highlightedProducts }
+			nav={ context.nav }
 			header={ context.header }
 			footer={ context.footer }
 			planRecommendation={ planRecommendation }

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -34,6 +34,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	siteSlug: siteSlugProp,
 	rootUrl,
 	urlQueryArgs,
+	nav,
 	header,
 	footer,
 	planRecommendation,
@@ -169,32 +170,36 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	);
 
 	return (
-		<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
-			<PageViewTracker
-				path={ viewTrackerPath }
-				properties={ viewTrackerProps }
-				title="Plans"
-				options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
-			/>
+		<>
+			{ nav }
 
-			{ header }
+			<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
+				<PageViewTracker
+					path={ viewTrackerPath }
+					properties={ viewTrackerProps }
+					title="Plans"
+					options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
+				/>
 
-			<ProductGrid
-				duration={ currentDuration }
-				urlQueryArgs={ urlQueryArgs }
-				planRecommendation={ planRecommendation }
-				onSelectProduct={ selectProduct }
-				onDurationChange={ trackDurationChange }
-				scrollCardIntoView={ scrollCardIntoView }
-				createButtonURL={ createProductURL }
-			/>
+				{ header }
 
-			{ siteId ? <QuerySiteProducts siteId={ siteId } /> : <QueryProductsList type="jetpack" /> }
-			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-			{ siteId && <QuerySites siteId={ siteId } /> }
+				<ProductGrid
+					duration={ currentDuration }
+					urlQueryArgs={ urlQueryArgs }
+					planRecommendation={ planRecommendation }
+					onSelectProduct={ selectProduct }
+					onDurationChange={ trackDurationChange }
+					scrollCardIntoView={ scrollCardIntoView }
+					createButtonURL={ createProductURL }
+				/>
 
-			{ footer }
-		</Main>
+				{ siteId ? <QuerySiteProducts siteId={ siteId } /> : <QueryProductsList type="jetpack" /> }
+				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+				{ siteId && <QuerySites siteId={ siteId } /> }
+
+				{ footer }
+			</Main>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -25,6 +25,7 @@ export type ScrollCardIntoViewCallback = ( arg0: HTMLDivElement, arg1: string ) 
 interface BasePageProps {
 	rootUrl: string;
 	urlQueryArgs: QueryArgs;
+	nav?: ReactNode;
 	header: ReactNode;
 	footer?: ReactNode;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes the masterbar in the cloud pricing page wider, in order to match the bar in Jetpack.com.

Fixes 1196108640073826-as-1200855424245096

### Implementation notes

I moved the masterbar out of the pricing page layout, to simplify CSS. Having the navigation outside of the `main` tag is also a better accessibility practice.

### Testing instructions

- Download the PR and run both cloud and Calypso
- Visit the pricing page
- Check that the masterbar is as wide as in http://jetpack.com/

### Screenshots

#### Jetpack.com

<img width="2032" alt="Screen Shot 2021-09-08 at 11 12 13 AM" src="https://user-images.githubusercontent.com/1620183/132537260-ffd05574-71d7-4ded-9338-4e624f97093a.png">


#### Cloud pricing page

_Before_

<img width="2032" alt="Screen Shot 2021-09-08 at 11 12 19 AM" src="https://user-images.githubusercontent.com/1620183/132537307-56421cae-d457-4d28-80c9-01330f8bf068.png">



_After_

<img width="2032" alt="Screen Shot 2021-09-08 at 11 12 17 AM" src="https://user-images.githubusercontent.com/1620183/132537344-fb361131-7798-431c-bd23-e4298453c496.png">
