### PR TITLE
[E2E][GB] Fix non-awaited argument to `getInputText`

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -91,7 +91,7 @@ export default class GutenbergEditorComponent extends AbstractEditorComponent {
 
 	async getTitle() {
 		return await driverHelper.getInputText(
-			this.driver.findElement( By.css( '.editor-post-title__input' ) )
+			await this.driver.findElement( By.css( '.editor-post-title__input' ) )
 		);
 	}
 


### PR DESCRIPTION
Interestingly enough, `findElement` doesn't need to be awaited/resolved, see: https://github.com/Automattic/wp-calypso/pull/55878#discussion_r704507474. It was a mistake though, and we shouldn't pass a thenable like this when expecting something else. The fact it still worked was pure luck!

#### Changes proposed in this Pull Request

* `await` for unwanted `IThenable`. More information here: https://github.com/Automattic/wp-calypso/pull/55878#discussion_r704507474.

#### Testing instructions

* Tests should pass.

Related to https://github.com/Automattic/wp-calypso/pull/55878.
