### PR TITLE
Wraps "Manage" in the translate function

### DIFF
--- a/client/my-sites/domains/domain-management/list/wpcom-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/wpcom-domain-item.jsx
@@ -56,7 +56,7 @@ export default function WpcomDomainItem( {
 					disabled={ disabled }
 					busy={ isBusy }
 				>
-					Manage
+					{ __( 'Manage' ) }
 					<Gridicon icon="chevron-down" />
 				</Button>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* One of our reviewers reported that on the domains management page in Calypso, the word "Manage" in the drop down menu at the bottom is not translated: 

![](https://user-images.githubusercontent.com/36699353/130931757-acfb0815-1edc-4d95-a9ba-83e21ce5f596.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Set your account language to one of our Mag-16 languages  (not English). 
* Navigate to `domains/manage` on the Calypso live website below and select one of your simple websites.
* Confirm that the manage text is showing translated:
<img width="887" alt="image" src="https://user-images.githubusercontent.com/23708351/132562365-7a6fcd8f-362d-4735-a18a-01c352326abc.png">

