### PR TITLE
Track legacy plan redirects in Jetpack pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -47,6 +47,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 	const viewTrackerPath = getViewTrackerPath( rootUrl, siteSlugProp );
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
+	const legacyPlan = planRecommendation ? planRecommendation[ 0 ] : null;
 
 	useEffect( () => {
 		dispatch(
@@ -57,6 +58,17 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 			} )
 		);
 	}, [ dispatch, rootUrl, siteSlug, viewTrackerPath ] );
+
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_pricing_legacy_redirect', {
+				site: siteSlug,
+				path: viewTrackerPath,
+				root_path: rootUrl,
+				legacy_plan: legacyPlan,
+			} )
+		);
+	}, [ legacyPlan, dispatch, rootUrl, siteSlug, viewTrackerPath ] );
 
 	const { unlinked, purchasetoken, purchaseNonce, site } = urlQueryArgs;
 	const canDoSiteOnlyCheckout = unlinked && !! site && !! ( purchasetoken || purchaseNonce );

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -60,14 +60,16 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	}, [ dispatch, rootUrl, siteSlug, viewTrackerPath ] );
 
 	useEffect( () => {
-		dispatch(
-			recordTracksEvent( 'calypso_jetpack_pricing_legacy_redirect', {
-				site: siteSlug,
-				path: viewTrackerPath,
-				root_path: rootUrl,
-				legacy_plan: legacyPlan,
-			} )
-		);
+		if ( legacyPlan ) {
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_pricing_legacy_redirect', {
+					site: siteSlug,
+					path: viewTrackerPath,
+					root_path: rootUrl,
+					legacy_plan: legacyPlan,
+				} )
+			);
+		}
 	}, [ legacyPlan, dispatch, rootUrl, siteSlug, viewTrackerPath ] );
 
 	const { unlinked, purchasetoken, purchaseNonce, site } = urlQueryArgs;


### PR DESCRIPTION
### Changes proposed in this Pull Request

In this PR, we dispatch a tracking event whenever a user tries to checkout with a Jetpack legacy plan, and is redirected to the pricing page.

### Testing instructions

- Download the PR and run Calypso
- Check that you can see tracking events in the console or the network panel
- Visit `/checkout/:site/:plan`, where `:site` is the slug of a Jetpack site, and `:plan` the slug of a legacy plan, e.g. `jetpack_personal`
- You should be redirected to the pricing page
- Check that the event `calypso_jetpack_pricing_legacy_redirect` was triggered, with the proper `legacy_plan` parameter
- Visit `/checkout/:site/:plan` with a current plan, e.g. `jetpack_backup_daily`
- Verify that the event wasn't dispatched
- Visit `/checkout/:site`
- Verify that the event wasn't dispatched