### PR TITLE
Redirect successfully canceled Subscriptions to the Purchase List

### DIFF
--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -51,7 +51,7 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 			// redirect back to Purchases list
 			dispatch(
 				successNotice(
-					translate( 'This subscription has been stopped. You will not be charged.' ),
+					translate( 'This subscription has been canceled. You will no longer be charged.' ),
 					{ displayOnNextPage: true }
 				)
 			);

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -12,6 +12,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import titles from 'calypso/me/purchases/titles';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { requestSubscriptionStop } from 'calypso/state/memberships/subscriptions/actions';
@@ -34,7 +35,18 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 		if ( stoppingStatus === 'fail' ) {
 			// run is-error notice to contact support
 			dispatch(
-				errorNotice( translate( 'There was a problem while stopping your subscription' ) )
+				errorNotice(
+					translate(
+						'There was a problem while stopping your subscription, please {{a}}{{strong}}contact support{{/strong}}{{/a}}.',
+						{
+							components: {
+								a: <a href={ CALYPSO_CONTACT } />,
+								br: <br />,
+								strong: <strong />,
+							},
+						}
+					)
+				)
 			);
 		} else if ( stoppingStatus === 'success' ) {
 			// redirect back to Purchases list

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -1,8 +1,9 @@
 import { Card, CompactCard } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
-import React from 'react';
-import { connect } from 'react-redux';
+import page from 'page';
+import React, { useEffect } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -18,107 +19,109 @@ import {
 	getSubscription,
 	getStoppingStatus,
 } from 'calypso/state/memberships/subscriptions/selectors';
+import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
 import { purchasesRoot } from '../purchases/paths';
 import MembershipSiteHeader from './header';
 
 import './subscription.scss';
 
-class Subscription extends React.Component {
-	stopSubscription = () => this.props.requestSubscriptionStop( this.props.subscription.ID );
+function Subscription( { translate, subscription, moment, stoppingStatus } ) {
+	const dispatch = useDispatch();
 
-	render() {
-		const { translate, subscription, moment, stoppingStatus } = this.props;
+	const stopSubscription = () => dispatch( requestSubscriptionStop( subscription.ID ) );
 
-		return (
-			<Main wideLayout className="memberships__subscription">
-				<DocumentHead title={ translate( 'Subscription Details' ) } />
-				<MeSidebarNavigation />
-				<QueryMembershipsSubscriptions />
-				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-				<HeaderCake backHref={ purchasesRoot }>{ translate( 'Subscription Details' ) }</HeaderCake>
-				{ stoppingStatus === 'start' && (
-					<Notice
-						status="is-info"
-						isLoading={ true }
-						text={ translate( 'Stopping this subscription' ) }
-					/>
-				) }
-				{ stoppingStatus === 'fail' && (
-					<Notice
-						status="is-error"
-						text={ translate( 'There was a problem while stopping your subscription' ) }
-					/>
-				) }
-				{ stoppingStatus === 'success' && (
-					<Notice
-						status="is-success"
-						text={ translate( 'This subscription has been stopped. You will not be charged.' ) }
-					/>
-				) }
+	useEffect( () => {
+		if ( stoppingStatus === 'fail' ) {
+			// run is-error notice to contact support
+			dispatch(
+				errorNotice( translate( 'There was a problem while stopping your subscription' ) )
+			);
+			return;
+		} else if ( stoppingStatus === 'success' ) {
+			// redirect back to Purchases list
+			dispatch(
+				successNotice(
+					translate( 'This subscription has been stopped. You will not be charged.' ),
+					{ displayOnNextPage: true }
+				)
+			);
 
-				{ subscription && (
-					<>
-						<Card className="memberships__subscription-meta">
-							<MembershipSiteHeader
-								name={ subscription.site_title }
-								domain={ subscription.site_url }
-							/>
-							<div className="memberships__subscription-header">
-								<div className="memberships__subscription-title">{ subscription.title }</div>
-								<div className="memberships__subscription-price">
-									{ formatCurrency( subscription.renewal_price, subscription.currency ) }
-								</div>
+			// TODO: refactor to work on site level subscriptions
+			page( purchasesRoot );
+		}
+	}, [ stoppingStatus, dispatch, translate ] );
+
+	return (
+		<Main wideLayout className="memberships__subscription">
+			<DocumentHead title={ translate( 'Subscription Details' ) } />
+			<MeSidebarNavigation />
+			<QueryMembershipsSubscriptions />
+			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+			<HeaderCake backHref={ purchasesRoot }>{ translate( 'Subscription Details' ) }</HeaderCake>
+			{ stoppingStatus === 'start' && (
+				<Notice
+					status="is-info"
+					isLoading={ true }
+					text={ translate( 'Stopping this subscription' ) }
+				/>
+			) }
+			{ subscription && (
+				<>
+					<Card className="memberships__subscription-meta">
+						<MembershipSiteHeader
+							name={ subscription.site_title }
+							domain={ subscription.site_url }
+						/>
+						<div className="memberships__subscription-header">
+							<div className="memberships__subscription-title">{ subscription.title }</div>
+							<div className="memberships__subscription-price">
+								{ formatCurrency( subscription.renewal_price, subscription.currency ) }
 							</div>
-							<ul className="memberships__subscription-inner-meta">
-								<li>
-									<em className="memberships__subscription-inner-detail-label">
-										{ translate( 'Renew interval' ) }
-									</em>
-									<span className="memberships__subscription-inner-detail">
-										{ subscription.renew_interval || '-' }
-									</span>
-								</li>
-								<li>
-									<em className="memberships__subscription-inner-detail-label">
-										{ translate( 'Subscribed On' ) }
-									</em>
-									<span className="memberships__subscription-inner-detail">
-										{ moment( subscription.start_date ).format( 'll' ) }
-									</span>
-								</li>
-								<li>
-									<em className="memberships__subscription-inner-detail-label">
-										{ translate( 'Renews on' ) }
-									</em>
-									<span className="memberships__subscription-inner-detail">
-										{ subscription.end_date
-											? moment( subscription.end_date ).format( 'll' )
-											: translate( 'Never Expires' ) }
-									</span>
-								</li>
-							</ul>
-						</Card>
-						<CompactCard
-							tagName="button"
-							className="memberships__subscription-remove"
-							onClick={ this.stopSubscription }
-						>
-							<Gridicon icon="trash" />
-							{ translate( 'Stop %s subscription.', { args: subscription.title } ) }
-						</CompactCard>
-					</>
-				) }
-			</Main>
-		);
-	}
+						</div>
+						<ul className="memberships__subscription-inner-meta">
+							<li>
+								<em className="memberships__subscription-inner-detail-label">
+									{ translate( 'Renew interval' ) }
+								</em>
+								<span className="memberships__subscription-inner-detail">
+									{ subscription.renew_interval || '-' }
+								</span>
+							</li>
+							<li>
+								<em className="memberships__subscription-inner-detail-label">
+									{ translate( 'Subscribed On' ) }
+								</em>
+								<span className="memberships__subscription-inner-detail">
+									{ moment( subscription.start_date ).format( 'll' ) }
+								</span>
+							</li>
+							<li>
+								<em className="memberships__subscription-inner-detail-label">
+									{ translate( 'Renews on' ) }
+								</em>
+								<span className="memberships__subscription-inner-detail">
+									{ subscription.end_date
+										? moment( subscription.end_date ).format( 'll' )
+										: translate( 'Never Expires' ) }
+								</span>
+							</li>
+						</ul>
+					</Card>
+					<CompactCard
+						tagName="button"
+						className="memberships__subscription-remove"
+						onClick={ stopSubscription }
+					>
+						<Gridicon icon="trash" />
+						{ translate( 'Stop %s subscription.', { args: subscription.title } ) }
+					</CompactCard>
+				</>
+			) }
+		</Main>
+	);
 }
 
-export default connect(
-	( state, props ) => ( {
-		subscription: getSubscription( state, props.subscriptionId ),
-		stoppingStatus: getStoppingStatus( state, props.subscriptionId ),
-	} ),
-	{
-		requestSubscriptionStop,
-	}
-)( localize( withLocalizedMoment( Subscription ) ) );
+export default connect( ( state, props ) => ( {
+	subscription: getSubscription( state, props.subscriptionId ),
+	stoppingStatus: getStoppingStatus( state, props.subscriptionId ),
+} ) )( localize( withLocalizedMoment( Subscription ) ) );

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -19,7 +19,7 @@ import {
 	getSubscription,
 	getStoppingStatus,
 } from 'calypso/state/memberships/subscriptions/selectors';
-import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { purchasesRoot } from '../purchases/paths';
 import MembershipSiteHeader from './header';
 
@@ -36,7 +36,6 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 			dispatch(
 				errorNotice( translate( 'There was a problem while stopping your subscription' ) )
 			);
-			return;
 		} else if ( stoppingStatus === 'success' ) {
 			// redirect back to Purchases list
 			dispatch(
@@ -45,8 +44,6 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 					{ displayOnNextPage: true }
 				)
 			);
-
-			// TODO: refactor to work on site level subscriptions
 			page( purchasesRoot );
 		}
 	}, [ stoppingStatus, dispatch, translate ] );

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -41,7 +41,6 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 						{
 							components: {
 								a: <a href={ CALYPSO_CONTACT } />,
-								br: <br />,
 								strong: <strong />,
 							},
 						}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a subscription is successfully canceled from the account purchases list the canceled subscription's page should redirect back to the Purchases list - **_BONUS_** - a green 'success' notice will appear in the upper right corner of the Purchases page to give a visual cue that the cancelation was successfully completed.

Alternatively, if the cancelation fails for some reason, the customer will remain on the Subscriptions purchase page and a red error notice will instruct them to Contact Support with a link to `https://wordpress.com/help/contact`

#### Testing instructions

**Testing set up:**

1. Properly sandbox the api, see PCYsg-lW4-p2 under Testing.
2. Go to P9LPZB-gd-p2 (edit page for password)
3. Sign up for a recurring payment, in this step you should see the sandbox Stripe cards on file as shown https://d.pr/i/NY5hww

**Test 1:**
* Now, go to https://wordpress.com/me/purchases and click on the new Subscription item, then cancel it.
* You should then be redirected back to the Purchases list with the following success notice

Success:

![image](https://user-images.githubusercontent.com/16580129/132564158-ea9a3a07-70f8-4015-b9d3-075db9de1a24.png)

**Test 2:**
* Add a new subscription following step 3 above
* Go to the subscription's purchase page where you see the option to cancel it - **don't cancel it**.
* To trigger the failure notice, open React component tools in your dev tools window and follow the diagram below
* TLDR - > Search for the Subscription[Localized] component -> change the value for the stoppingStatus prop from false to "fail" (quotes, this is a string) and then press enter to trigger the notice

![image](https://user-images.githubusercontent.com/16580129/132576688-1e51a805-f81d-4249-94d5-83fa7aadeb3d.png)


Fixes #49720