### PR TITLE
Fixes Auto-renew label not being translated

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -146,12 +146,9 @@ class DomainItem extends PureComponent {
 			return;
 		}
 
-		const autoRenewLabel = translate( 'Auto-renew: %(autoRenewValue)s', {
-			args: {
-				autoRenewValue: domainDetails?.isAutoRenewing ? 'on' : 'off',
-			},
-			comment: 'Auto-renew a domain registration. %(autoRenewValue)s can be "on" or "off"',
-		} );
+		const autoRenewLabel = domainDetails?.isAutoRenewing
+			? translate( 'Auto-renew (on)' )
+			: translate( 'Auto-renew (off)' );
 		return <span className="domain-item__meta-item">{ autoRenewLabel }</span>;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the domains management page in Calypso, the on/off text after "Auto-renew" is not translated:

![](https://user-images.githubusercontent.com/36699353/132260312-10673905-ac58-45f7-b0db-e484c43009fa.png)

This diff refactors the "Auto-renew" label to make it easier to properly translate. 
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your account language to one of our Mag-16 languages (not English).
* Navigate to `domains/manage` on the Calypso live website below and select a website which has a domain registered with WordPress.com
* Confirm that Auto-renew on / off is translated:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/23708351/132697792-7e59e035-d4a1-43f5-a982-7999ff75f9d9.png">


