### PR TITLE
Themes Showcase: Add beta badge to current theme card

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -11,11 +11,11 @@ import InfoPopover from 'calypso/components/info-popover';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
+import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isFullSiteEditingTheme } from 'calypso/utils';
 import ThemeMoreButton from './more-button';
 
 import './style.scss';

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -13,6 +13,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
+import { isFullSiteEditingTheme } from 'calypso/utils';
 import ThemeMoreButton from './more-button';
 
 import './style.scss';
@@ -106,12 +107,6 @@ export class Theme extends Component {
 		const { theme } = this.props;
 		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
 		return some( skillLevels, { slug: 'beginner' } );
-	}
-
-	isFullSiteEditingTheme() {
-		const { theme } = this.props;
-		const features = get( theme, [ 'taxonomies', 'theme_feature' ] );
-		return some( features, { slug: 'block-templates' } );
 	}
 
 	renderPlaceholder() {
@@ -245,7 +240,7 @@ export class Theme extends Component {
 					<div className="theme__info">
 						<h2 className="theme__info-title">
 							{ name }
-							{ this.isFullSiteEditingTheme() && (
+							{ isFullSiteEditingTheme( this.props.theme ) && (
 								<Badge type="warning-clear" className="theme__badge-beta">
 									{ translate( 'Beta' ) }
 								</Badge>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -12,7 +12,9 @@ import PulsingDot from 'calypso/components/pulsing-dot';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isFullSiteEditingTheme } from 'calypso/utils';
 import ThemeMoreButton from './more-button';
 
@@ -70,6 +72,7 @@ export class Theme extends Component {
 			PropTypes.func,
 			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
+		isSiteUsingCoreSiteEditor: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -141,7 +144,7 @@ export class Theme extends Component {
 	};
 
 	render() {
-		const { active, price, theme, translate, upsellUrl } = this.props;
+		const { active, isSiteUsingCoreSiteEditor, price, theme, translate, upsellUrl } = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -202,6 +205,7 @@ export class Theme extends Component {
 		const e2eThemeName = name.toLowerCase().replace( /\s+/g, '-' );
 
 		const bookmarkRef = this.props.bookmarkRef ? { ref: this.props.bookmarkRef } : {};
+		const showBetaBadge = isFullSiteEditingTheme( this.props.theme ) && isSiteUsingCoreSiteEditor;
 
 		return (
 			<Card className={ themeClass } data-e2e-theme={ e2eThemeName } onClick={ this.setBookmark }>
@@ -240,7 +244,7 @@ export class Theme extends Component {
 					<div className="theme__info">
 						<h2 className="theme__info-title">
 							{ name }
-							{ isFullSiteEditingTheme( this.props.theme ) && (
+							{ showBetaBadge && (
 								<Badge type="warning-clear" className="theme__badge-beta">
 									{ translate( 'Beta' ) }
 								</Badge>
@@ -271,4 +275,12 @@ export class Theme extends Component {
 	}
 }
 
-export default connect( null, { recordTracksEvent, setThemesBookmark } )( localize( Theme ) );
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		return {
+			isSiteUsingCoreSiteEditor: isSiteUsingCoreSiteEditorSelector( state, siteId ),
+		};
+	},
+	{ recordTracksEvent, setThemesBookmark }
+)( localize( Theme ) );

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -10,6 +10,7 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { isFullSiteEditingTheme } from 'calypso/utils';
 import { trackClick } from '../helpers';
@@ -38,7 +39,13 @@ class CurrentTheme extends Component {
 	trackClick = ( event ) => trackClick( 'current theme', event );
 
 	render() {
-		const { currentTheme, currentThemeId, siteId, translate } = this.props;
+		const {
+			currentTheme,
+			currentThemeId,
+			isSiteUsingCoreSiteEditor,
+			siteId,
+			translate,
+		} = this.props;
 		const placeholderText = <span className="current-theme__placeholder">loading...</span>;
 		const text = currentTheme && currentTheme.name ? currentTheme.name : placeholderText;
 
@@ -51,6 +58,7 @@ class CurrentTheme extends Component {
 		const showScreenshot = currentTheme && currentTheme.screenshot;
 		// Some themes have no screenshot, so only show placeholder until details loaded
 		const showScreenshotPlaceholder = ! currentTheme;
+		const showBetaBadge = isFullSiteEditingTheme( currentTheme ) && isSiteUsingCoreSiteEditor;
 
 		return (
 			<Card className="current-theme">
@@ -69,7 +77,7 @@ class CurrentTheme extends Component {
 							) }
 							<div className="current-theme__description">
 								<div className="current-theme__title-wrapper">
-									{ isFullSiteEditingTheme( currentTheme ) && (
+									{ showBetaBadge && (
 										<Badge type="warning-clear" className="current-theme__badge-beta">
 											{ translate( 'Beta' ) }
 										</Badge>
@@ -119,10 +127,16 @@ class CurrentTheme extends Component {
 
 const ConnectedCurrentTheme = connectOptions( localize( CurrentTheme ) );
 
-const CurrentThemeWithOptions = ( { siteId, currentTheme, currentThemeId } ) => (
+const CurrentThemeWithOptions = ( {
+	siteId,
+	currentTheme,
+	currentThemeId,
+	isSiteUsingCoreSiteEditor,
+} ) => (
 	<ConnectedCurrentTheme
 		currentTheme={ currentTheme }
 		currentThemeId={ currentThemeId }
+		isSiteUsingCoreSiteEditor={ isSiteUsingCoreSiteEditor }
 		siteId={ siteId }
 		source="current theme"
 	/>
@@ -133,5 +147,6 @@ export default connect( ( state, { siteId } ) => {
 	return {
 		currentThemeId,
 		currentTheme: getCanonicalTheme( state, siteId, currentThemeId ),
+		isSiteUsingCoreSiteEditor: isSiteUsingCoreSiteEditorSelector( state, siteId ),
 	};
 } )( CurrentThemeWithOptions );

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -1,7 +1,7 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, map, pickBy, some } from 'lodash';
+import { map, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -11,6 +11,7 @@ import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { isFullSiteEditingTheme } from 'calypso/utils';
 import { trackClick } from '../helpers';
 import { connectOptions } from '../theme-options';
 
@@ -47,9 +48,6 @@ class CurrentTheme extends Component {
 				option.icon && ! ( option.hideForTheme && option.hideForTheme( currentThemeId, siteId ) )
 		);
 
-		// TODO: DRY with logic in client/components/theme/index.jsx
-		const features = get( currentTheme, [ 'taxonomies', 'theme_feature' ] );
-		const isFullSiteEditingTheme = some( features, { slug: 'block-templates' } );
 		const showScreenshot = currentTheme && currentTheme.screenshot;
 		// Some themes have no screenshot, so only show placeholder until details loaded
 		const showScreenshotPlaceholder = ! currentTheme;
@@ -71,7 +69,7 @@ class CurrentTheme extends Component {
 							) }
 							<div className="current-theme__description">
 								<div className="current-theme__title-wrapper">
-									{ isFullSiteEditingTheme && (
+									{ isFullSiteEditingTheme( currentTheme ) && (
 										<Badge type="warning-clear" className="current-theme__badge-beta">
 											{ translate( 'Beta' ) }
 										</Badge>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -10,9 +10,9 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import isSiteUsingCoreSiteEditorSelector from 'calypso/state/selectors/is-site-using-core-site-editor';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
-import { isFullSiteEditingTheme } from 'calypso/utils';
 import { trackClick } from '../helpers';
 import { connectOptions } from '../theme-options';
 

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -1,10 +1,11 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { map, pickBy } from 'lodash';
+import { get, map, pickBy, some } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import Badge from 'calypso/components/badge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -46,6 +47,9 @@ class CurrentTheme extends Component {
 				option.icon && ! ( option.hideForTheme && option.hideForTheme( currentThemeId, siteId ) )
 		);
 
+		// TODO: DRY with logic in client/components/theme/index.jsx
+		const features = get( currentTheme, [ 'taxonomies', 'theme_feature' ] );
+		const isFullSiteEditingTheme = some( features, { slug: 'block-templates' } );
 		const showScreenshot = currentTheme && currentTheme.screenshot;
 		// Some themes have no screenshot, so only show placeholder until details loaded
 		const showScreenshotPlaceholder = ! currentTheme;
@@ -67,6 +71,11 @@ class CurrentTheme extends Component {
 							) }
 							<div className="current-theme__description">
 								<div className="current-theme__title-wrapper">
+									{ isFullSiteEditingTheme && (
+										<Badge type="warning-clear" className="current-theme__badge-beta">
+											{ translate( 'Beta' ) }
+										</Badge>
+									) }
 									<span className="current-theme__label">
 										{ currentTheme && currentTheme.name && translate( 'Current Theme' ) }
 									</span>

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -52,12 +52,16 @@ $current-theme-border: 1px solid var( --color-border-subtle );
 	.current-theme__title-wrapper {
 		display: flex;
 		flex-direction: column;
-		align-items: flex-start;
+		align-items: center;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row-reverse;
 			justify-content: flex-end;
 		}
+	}
+
+	.current-theme__badge-beta {
+		margin-left: 6px;
 	}
 
 	.current-theme__label {

--- a/client/my-sites/themes/is-full-site-editing-theme.js
+++ b/client/my-sites/themes/is-full-site-editing-theme.js
@@ -1,0 +1,4 @@
+export function isFullSiteEditingTheme( theme ) {
+	const features = theme?.taxonomies?.theme_feature;
+	return features && features.some( ( feature ) => feature.slug === 'block-templates' );
+}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -85,8 +85,4 @@
 .section-nav__mobile-header-text .theme-showcase__badge-beta,
 .section-nav-tab__text .theme-showcase__badge-beta {
 	margin-left: 6px;
-	line-height: 12px;
-	height: 13px;
-	padding-left: 8px;
-	padding-right: 8px;
 }

--- a/client/utils.js
+++ b/client/utils.js
@@ -7,3 +7,8 @@ export function pathToRegExp( path ) {
 	}
 	return new RegExp( '^' + path + '(/.*)?$' );
 }
+
+export function isFullSiteEditingTheme( theme ) {
+	const features = theme?.taxonomies?.theme_feature;
+	return features && features.some( ( feature ) => feature.slug === 'block-templates' );
+}

--- a/client/utils.js
+++ b/client/utils.js
@@ -7,8 +7,3 @@ export function pathToRegExp( path ) {
 	}
 	return new RegExp( '^' + path + '(/.*)?$' );
 }
-
-export function isFullSiteEditingTheme( theme ) {
-	const features = theme?.taxonomies?.theme_feature;
-	return features && features.some( ( feature ) => feature.slug === 'block-templates' );
-}


### PR DESCRIPTION
### Changes proposed in this Pull Request
Add a Beta label to the current theme banner for block-based themes (tagged with block-templates) in the theme showcase. Also removes customized beta badge styling on the FSE tab to ensure consistent sizing between all beta badges.

### Screenshots
#### Before
<img width="1216" alt="Screen Shot 2021-09-08 at 5 25 19 PM" src="https://user-images.githubusercontent.com/5414230/132602759-05881c26-3885-4d7d-bdc8-833460114d53.png">

#### After
<img width="1278" alt="Screen Shot 2021-09-15 at 12 59 33 PM" src="https://user-images.githubusercontent.com/5414230/133501141-65350745-8683-4109-8bd7-7fb6a6ce568f.png">

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Appearance -> Themes
- Confirm current themes that support block-templates have a Beta badge

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/54508
