### PR TITLE
Change ReskinnedProcessingScreen for setup-site flow

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -415,4 +415,10 @@ export default class SignupFlowController {
 		this._flowName = flowName;
 		this._flow = flows.getFlow( flowName, userLoggedIn );
 	}
+
+	getDestination() {
+		const dependencies = getSignupDependencyStore( this._reduxStore.getState() );
+
+		return this._destination( dependencies );
+	}
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -575,13 +575,15 @@ class Signup extends React.Component {
 		if ( isReskinned ) {
 			const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 			const hasPaidDomain = isDomainRegistration( domainItem );
-			const selectedDesign = get( this.props, 'signupDependencies.selectedDesign', false );
+			const destination = this.signupFlowController.getDestination();
 
 			return (
 				<ReskinnedProcessingScreen
 					flowName={ this.props.flowName }
 					hasPaidDomain={ hasPaidDomain }
-					hasSelectedDesign={ !! selectedDesign }
+					// If destination is not setup-site flow, we'll apply default design now
+					// because the user cannot choose design in current flow
+					hasAppliedDesign={ ! destination.startsWith( '/start/setup-site' ) }
 				/>
 			);
 		}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -575,11 +575,13 @@ class Signup extends React.Component {
 		if ( isReskinned ) {
 			const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 			const hasPaidDomain = isDomainRegistration( domainItem );
+			const selectedDesign = get( this.props, 'signupDependencies.selectedDesign', false );
 
 			return (
 				<ReskinnedProcessingScreen
 					flowName={ this.props.flowName }
 					hasPaidDomain={ hasPaidDomain }
+					hasSelectedDesign={ !! selectedDesign }
 				/>
 			);
 		}

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -7,20 +7,34 @@ import './style.scss';
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
 
+const useSteps = ( flowName, { hasPaidDomain } ) => {
+	const { __ } = useI18n();
+	let steps = [];
+
+	switch ( flowName ) {
+		case 'launch-site':
+			steps = [ __( 'Your site will be live shortly.' ) ]; // copy from 'packages/launch/src/focused-launch/success'
+			break;
+		case 'setup-site':
+			steps = [ __( 'Applying design' ) ];
+			break;
+		default:
+			steps = [
+				__( 'Building your site' ),
+				hasPaidDomain && __( 'Getting your domain' ),
+				__( 'Applying design' ),
+			].filter( Boolean );
+	}
+
+	return React.useRef( steps );
+};
+
 // This component is cloned from the CreateSite component of Gutenboarding flow
 // to work with the onboarding signup flow.
 export default function ReskinnedProcessingScreen( { flowName, hasPaidDomain } ) {
 	const { __ } = useI18n();
 
-	const steps = React.useRef(
-		flowName === 'launch-site'
-			? [ __( 'Your site will be live shortly.' ) ] // copy from 'packages/launch/src/focused-launch/success'
-			: [
-					__( 'Building your site' ),
-					hasPaidDomain && __( 'Getting your domain' ),
-					__( 'Applying design' ),
-			  ].filter( Boolean )
-	);
+	const steps = useSteps( flowName, { hasPaidDomain } );
 	const totalSteps = steps.current.length;
 
 	const [ currentStep, setCurrentStep ] = React.useState( 0 );

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -8,7 +8,7 @@ import './style.scss';
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
 
-const useSteps = ( { flowName, hasPaidDomain, hasSelectedDesign } ) => {
+const useSteps = ( { flowName, hasPaidDomain, hasAppliedDesign } ) => {
 	const { __ } = useI18n();
 	let steps = [];
 
@@ -17,13 +17,13 @@ const useSteps = ( { flowName, hasPaidDomain, hasSelectedDesign } ) => {
 			steps = [ __( 'Your site will be live shortly.' ) ]; // copy from 'packages/launch/src/focused-launch/success'
 			break;
 		case 'setup-site':
-			steps = [ hasSelectedDesign && __( 'Applying design' ) ];
+			steps = [ __( 'Applying design' ) ];
 			break;
 		default:
 			steps = [
 				__( 'Building your site' ),
 				hasPaidDomain && __( 'Getting your domain' ),
-				__( 'Applying design' ),
+				hasAppliedDesign && __( 'Applying design' ),
 			];
 	}
 
@@ -59,10 +59,6 @@ export default function ReskinnedProcessingScreen( props ) {
 		return () => clearTimeout( id );
 	}, [] );
 
-	if ( totalSteps === 0 ) {
-		return null;
-	}
-
 	return (
 		<div className="reskinned-processing-screen">
 			<h1 className="reskinned-processing-screen__progress-step">
@@ -90,5 +86,5 @@ export default function ReskinnedProcessingScreen( props ) {
 ReskinnedProcessingScreen.propTypes = {
 	flowName: PropTypes.string,
 	hasPaidDomain: PropTypes.bool,
-	hasSelectedDesign: PropTypes.bool,
+	hasAppliedDesign: PropTypes.bool,
 };

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,5 +1,6 @@
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import './style.scss';
@@ -7,7 +8,7 @@ import './style.scss';
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
 
-const useSteps = ( flowName, { hasPaidDomain } ) => {
+const useSteps = ( flowName, { hasPaidDomain, hasSelectedDesign } ) => {
 	const { __ } = useI18n();
 	let steps = [];
 
@@ -16,25 +17,29 @@ const useSteps = ( flowName, { hasPaidDomain } ) => {
 			steps = [ __( 'Your site will be live shortly.' ) ]; // copy from 'packages/launch/src/focused-launch/success'
 			break;
 		case 'setup-site':
-			steps = [ __( 'Applying design' ) ];
+			steps = [ hasSelectedDesign && __( 'Applying design' ) ];
 			break;
 		default:
 			steps = [
 				__( 'Building your site' ),
 				hasPaidDomain && __( 'Getting your domain' ),
 				__( 'Applying design' ),
-			].filter( Boolean );
+			];
 	}
 
-	return React.useRef( steps );
+	return React.useRef( steps.filter( Boolean ) );
 };
 
 // This component is cloned from the CreateSite component of Gutenboarding flow
 // to work with the onboarding signup flow.
-export default function ReskinnedProcessingScreen( { flowName, hasPaidDomain } ) {
+export default function ReskinnedProcessingScreen( {
+	flowName,
+	hasPaidDomain,
+	hasSelectedDesign,
+} ) {
 	const { __ } = useI18n();
 
-	const steps = useSteps( flowName, { hasPaidDomain } );
+	const steps = useSteps( flowName, { hasPaidDomain, hasSelectedDesign } );
 	const totalSteps = steps.current.length;
 
 	const [ currentStep, setCurrentStep ] = React.useState( 0 );
@@ -57,6 +62,10 @@ export default function ReskinnedProcessingScreen( { flowName, hasPaidDomain } )
 		const id = setTimeout( () => setHasStarted( true ), 750 );
 		return () => clearTimeout( id );
 	}, [] );
+
+	if ( totalSteps === 0 ) {
+		return null;
+	}
 
 	return (
 		<div className="reskinned-processing-screen">
@@ -81,3 +90,9 @@ export default function ReskinnedProcessingScreen( { flowName, hasPaidDomain } )
 		</div>
 	);
 }
+
+ReskinnedProcessingScreen.propTypes = {
+	flowName: PropTypes.string,
+	hasPaidDomain: PropTypes.bool,
+	hasSelectedDesign: PropTypes.bool,
+};

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -8,7 +8,7 @@ import './style.scss';
 // Total time to perform "loading"
 const DURATION_IN_MS = 6000;
 
-const useSteps = ( flowName, { hasPaidDomain, hasSelectedDesign } ) => {
+const useSteps = ( { flowName, hasPaidDomain, hasSelectedDesign } ) => {
 	const { __ } = useI18n();
 	let steps = [];
 
@@ -32,14 +32,10 @@ const useSteps = ( flowName, { hasPaidDomain, hasSelectedDesign } ) => {
 
 // This component is cloned from the CreateSite component of Gutenboarding flow
 // to work with the onboarding signup flow.
-export default function ReskinnedProcessingScreen( {
-	flowName,
-	hasPaidDomain,
-	hasSelectedDesign,
-} ) {
+export default function ReskinnedProcessingScreen( props ) {
 	const { __ } = useI18n();
 
-	const steps = useSteps( flowName, { hasPaidDomain, hasSelectedDesign } );
+	const steps = useSteps( props );
 	const totalSteps = steps.current.length;
 
 	const [ currentStep, setCurrentStep ] = React.useState( 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, it still shows `Building your site` and `Applying design` after design picker. It looks strange. So, update the process screen for it
  * Show `Applying design` if the user selects one of them
  * Show nothing if the user clicks `Skip for now`

https://user-images.githubusercontent.com/13596067/132621953-2231a2b0-8793-4975-b561-6b30b809518c.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/start/setup-site?siteSlug=<your_site>`
* Select the design
* Check process screen only shows `Applying design` step
* Reopen `/start/setup-site?siteSlug=<your_site>`
* Click `Skip for now`
* Check none of step will show

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/55883#issuecomment-911526896
