### PR TITLE
Run `build-client` instead of `build-client-both`

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -31,7 +31,7 @@ RUN cd / \
 	# Prime yarn cache
 	&& yarn \
 	# Prime webpack caches
-	&& NODE_ENV=production yarn build-client-both
+	&& NODE_ENV=production yarn build-client
 
 ENTRYPOINT [ "/bin/bash" ]
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Cleanup after #53366

Use `build-client` instead of `build-client-both`
