### PR TITLE
Design Picker: Increase size of thumbnails in design-setup-site step

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -715,6 +715,9 @@ export function generateSteps( {
 
 		'design-setup-site': {
 			stepName: 'design-setup-site',
+			props: {
+				largeThumbnails: true,
+			},
 			apiRequestFunction: setThemeOnSite,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,4 +1,5 @@
 import DesignPicker from '@automattic/design-picker';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -15,10 +16,12 @@ class DesignPickerStep extends Component {
 		stepName: PropTypes.string.isRequired,
 		locale: PropTypes.string.isRequired,
 		translate: PropTypes.func,
+		largeThumbnails: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		useHeadstart: true,
+		largeThumbnails: false,
 	};
 
 	pickDesign = ( selectedDesign ) => {
@@ -46,6 +49,9 @@ class DesignPickerStep extends Component {
 				theme={ this.props.isReskinned ? 'light' : 'dark' }
 				locale={ this.props.locale }
 				onSelect={ this.pickDesign }
+				className={ classnames( {
+					'design-picker-step__is-large-thumbnails': this.props.largeThumbnails,
+				} ) }
 			/>
 		);
 	}

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -1,7 +1,8 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-.signup__step.is-design {
+.signup__step.is-design,
+.signup__step.is-design-setup-site {
 	.step-wrapper {
 		padding-left: 24px;
 		padding-right: 24px;
@@ -42,6 +43,18 @@
 			font-size: inherit;
 			padding-top: 0;
 			padding-bottom: 0;
+		}
+	}
+
+	.design-picker.design-picker-step__is-large-thumbnails {
+		.design-picker__grid {
+			grid-template-columns: 1fr;
+
+			@include break-medium {
+				grid-template-columns: 1fr 1fr;
+				column-gap: 49px;
+				row-gap: 39px;
+			}
 		}
 	}
 }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -109,6 +109,7 @@ export interface DesignPickerProps {
 	premiumBadge?: React.ReactNode;
 	isGridMinimal?: boolean;
 	theme?: 'dark' | 'light';
+	className?: string;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -120,9 +121,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	premiumBadge,
 	isGridMinimal,
 	theme = 'light',
+	className,
 } ) => {
 	return (
-		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }` ) }>
+		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>
 			<div className={ isGridMinimal ? 'design-picker__grid-minimal' : 'design-picker__grid' }>
 				{ designs.map( ( design ) => (
 					<DesignButton


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<img width="751" alt="Screenshot 2021-09-09 at 5 52 46 PM" src="https://user-images.githubusercontent.com/1500769/132630629-fa067f56-5c87-4d74-aba8-e80f8fa3ee51.png">

* Updates thumbnail size so that 2 appear per row in the design picker
* Update gap between thumbnails to match design mockup

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/setup-site?siteSlug=yoursite.wordpress.com`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55604
