### PR TITLE
build: Drop lerna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ test-results*.xml
 /client/style.json
 spec-xunit-reporter-0.0.1.tgz
 *xunit_*.xml
-lerna-debug.log
 /vendor
 
 # added during build

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,6 +1,6 @@
 # Dependency management
 
-This project uses [yarn v3](https://yarnpkg.com/) to manage its dependencies. It uses workspaces[https://yarnpkg.com/features/workspaces] functionallity to manage the monorepo.
+This project uses [yarn v3](https://yarnpkg.com/) to manage its dependencies. It uses workspaces[https://yarnpkg.com/features/workspaces] functionality to manage the monorepo.
 
 ## Working with sub-packages
 

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,6 +1,6 @@
 # Dependency management
 
-This project uses [yarn v1](https://classic.yarnpkg.com/lang/en/) to manage its dependencies. It uses `yarn workspaces` functionallity and [lerna](https://github.com/lerna/lerna) to manage the monorepo.
+This project uses [yarn v3](https://yarnpkg.com/) to manage its dependencies. It uses workspaces[https://yarnpkg.com/features/workspaces] functionallity to manage the monorepo.
 
 ## Working with sub-packages
 
@@ -114,10 +114,10 @@ Note that the output includes which sub-package has the dependency. It is possib
 Run
 
 ```
-npx yarn-deduplicate --list
+yarn dedupe --check
 ```
 
-It is recommended to run this command after adding a new dependency and fix potential duplications with `npx yarn-deduplicate --package <duplicated-package>`
+It is recommended to run this command after adding a new dependency and fix potential duplications with `yarn dedupe`
 
 ## Differences with `npm`
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -1,20 +1,20 @@
 # Working with the Monorepo
 
-Calypso is a monorepo. In addition to the Calypso application, it also hosts a number of independent packages that are published to NPM.
+Calypso is a monorepo. In addition to the Calypso application, it also hosts a number of independent packages that are published to NPM, apps that are built and deployed as WordPress.com plugins, and other supporting packages.
 
 ## Module Layout
 
 These packages live under the `packages` and `apps` directories, one folder per module.
 
-Two different directories with packages are:
+Directories with packages are:
 
 `/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso. See "Publishing" below.
 `/apps` — WPCOM plugins
-`/desktop` - WP Desktop app. Currently this is not part of the monorepo in the sense that it has its own dependency tree (its own `yarn.lock`)
+`/desktop` - WP Desktop app. Currently this is not part of the monorepo in the sense that it has its own dependency tree (its own `yarn.lock`). The reason is we want a lean `node_modules` because it will be bundled with the WP Desktop app.
 `/client` - Calypso app.
 `/test/e2e` - Package to run e2e tests
 
-Except `/packages/*`, packages are typically not published to NPM.
+Except those inside `/packages/*`, packages are not published to NPM.
 
 Modules should follow our convention for layout:
 
@@ -161,9 +161,9 @@ Note that if you're building with Webpack, you may need to turn off [`resolve.sy
 
 ## Publishing
 
-We use the regular NPM publish flow to publish packages.
+### Preparation
 
-### Make sure changelogs and `package.json` versions are up to date
+#### Make sure changelogs and `package.json` versions are up to date
 
 For all packages that you want to publish, make sure that their `package.json` versions are bumped. Decide carefully whether you want to publish a patch, a minor or a major update of the package. Be mindful about [semantic versioning](https://semver.org/).
 
@@ -171,15 +171,15 @@ Make sure that the `CHANGELOG.md` document contains up-to-date information, with
 
 Create PRs with the necessary changes and merge them to `trunk` before publishing.
 
-### Checkout the latest trunk locally and build the packages
+#### Checkout the latest trunk
 
 Always publish from the latest `trunk` branch, so that the package contents come from a verified source that everyone has access to. It's too easy to publish a NPM package from a local branch, or even uncommitted local modifications that are invisible to anyone but you.
 
-### Getting NPM permissions to publish in the `@automattic` scope
+#### Getting NPM permissions to publish in the `@automattic` scope
 
 To publish packages in the `@automattic` scope, and to update packages owned by the `automattic` organization, you need to be a member of this organization on npmjs.com. If you're an Automattician, you can add yourself to the organization, using the credentials found in the secret store.
 
-### Tagging a package
+#### Tagging a package
 
 It is recommended you create a git tag with the package and version you are about to publish. This will help us track where a specific version comes from. For example:
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -1,15 +1,20 @@
 # Working with the Monorepo
 
-Calypso is a monorepo. In addition to the Calypso application, it also hosts a number of independent modules that are published to NPM.
+Calypso is a monorepo. In addition to the Calypso application, it also hosts a number of independent packages that are published to NPM.
 
 ## Module Layout
 
-These modules live under the `packages` and `apps` directories, one folder per module.
+These packages live under the `packages` and `apps` directories, one folder per module.
 
-Two different directories for modules are:
+Two different directories with packages are:
 
-`/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `yarn start`. See "Publishing" below.
-`/apps` — projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `yarn start`.
+`/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso. See "Publishing" below.
+`/apps` — WPCOM plugins
+`/desktop` - WP Desktop app. Currently this is not part of the monorepo in the sense that it has its own dependency tree (its own `yarn.lock`)
+`/client` - Calypso app.
+`/test/e2e` - Package to run e2e tests
+
+Except `/packages/*`, packages are typically not published to NPM.
 
 Modules should follow our convention for layout:
 
@@ -19,6 +24,9 @@ package.json
 
 # a readme for your module
 README.md
+
+# a changelog for your module
+CHANGELOG.md
 
 # source code lives here
 src/
@@ -36,17 +44,11 @@ test/
 	module-b.js
 ```
 
-Your `package.json` can have any of the [normal properties](https://docs.npmjs.com/files/package.json) but at a minimum should contain `main`, `module`, and `sideEffects`.
+Your `package.json` can have any of the [normal properties](https://docs.npmjs.com/files/package.json) but at a minimum should contain `main`, `module`, `calypso:src` and `sideEffects`.
 
 ### devDependencies
 
 It used to be that `devDependencies` needed to be added to the root `package.json` but since we moved to `yarn` workspaces we're able to add them as regular `devDependencies` within the package that uses them.
-
-### dependencies
-
-Running the following in your `wp-calypso` root
-`yarn workspace @automattic/{{your-package}} run prepare && npx @yarnpkg/doctor packages/{{your-package}}`
-will output all the unmet dependencies.
 
 ### sideEffects
 
@@ -69,6 +71,7 @@ failing to do so, will make your package work correctly in the dev build but tre
 	"name": "@automattic/your-package",
 	"version": "1.0.0",
 	"description": "My new package",
+	"calypso:src": "src/index.js",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"sideEffects": false,
@@ -97,10 +100,10 @@ failing to do so, will make your package work correctly in the dev build but tre
 }
 ```
 
-If your package requires compilation, the `package.json` `prepare` script should compile the package:
+If your package requires compilation, the `package.json` `build` script should compile the package:
 
 - If it contains ES6+ code that needs to be transpiled, use `transpile` (from `@automattic/calypso-build`) which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds. Also, make sure to add `@automattic/calypso-build` in `devDependencies`.
-- If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg `.scss`) then after `transpile` append `&& copy-assets` ie `"prepare": "transpile && copy-assets"`.
+- If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg `.scss`) then after `transpile` append `&& copy-assets` ie `"build": "transpile && copy-assets"`.
 
 Running `yarn run lint:package-json` will lint all `package.json`'s under `./packages|apps/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
 
@@ -136,7 +139,7 @@ Or specific apps:
 yarn workspace @automattic/wpcom-block-editor run build
 ```
 
-All `prepare` scripts found in all `package.json`s of apps and packages are always run on Calypso's `yarn`. Therefore independent apps in `/apps` directory can use `build` instead of `prepare` so avoid unnecessary builds.
+All `prepare` scripts found in all `package.json`s of apps and packages are always run on Calypso's `yarn`. Therefore packages can use `build` instead of `prepare` so avoid unnecessary builds. Please only add a `prepare` script if your package really needs to be built for the rest of the repo to work.
 
 You can also run other custom `package.json` scripts only for your app or package:
 
@@ -158,7 +161,7 @@ Note that if you're building with Webpack, you may need to turn off [`resolve.sy
 
 ## Publishing
 
-We use [Lerna](https://lerna.js.org/) and its `publish` command to publish the monorepo packages to NPM registry. Please do not use regular [`yarn publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.
+We use the regular NPM publish flow to publish packages.
 
 ### Make sure changelogs and `package.json` versions are up to date
 
@@ -166,93 +169,31 @@ For all packages that you want to publish, make sure that their `package.json` v
 
 Make sure that the `CHANGELOG.md` document contains up-to-date information, with the `next` heading replaced with the version number that you are about to publish.
 
-Create PRs with the necessary changes and merge them to `trunk` before publishing. Lerna will add a `gitHead` field to each published package's `package.json`. That field contains the hash of the Git commit that the package was published from. It's better if this commit hash is a permanent one from the `trunk` branch, rather than an ephemeral commit from a local branch.
+Create PRs with the necessary changes and merge them to `trunk` before publishing.
 
 ### Checkout the latest trunk locally and build the packages
 
 Always publish from the latest `trunk` branch, so that the package contents come from a verified source that everyone has access to. It's too easy to publish a NPM package from a local branch, or even uncommitted local modifications that are invisible to anyone but you.
 
-Build the `dist/` directories (the transpiled package content that will be published) from scratch.
-
-```
-git checkout trunk
-git pull
-git status (should be clean!)
-yarn run distclean
-yarn install --frozen-lockfile
-yarn run build-packages
-```
-
 ### Getting NPM permissions to publish in the `@automattic` scope
 
 To publish packages in the `@automattic` scope, and to update packages owned by the `automattic` organization, you need to be a member of this organization on npmjs.com. If you're an Automattician, you can add yourself to the organization, using the credentials found in the secret store.
 
-### Publishing all outdated packages
+### Tagging a package
 
-It's good to start un-authenticated, since Lerna doesn't have `--dry-run` option like NPM does: `npm logout`.
-
-Now run: `npx lerna publish from-package`
-
-Lerna will show a list of packages that have versions higher than the latest one published in the NPM registry. Verify that this is indeed the list of packages that you want to publish. If something looks off, abort!
-
-If you say "yes" to the Lerna prompt, and are not authenticated, the publishing will fail with authentication error. Better to say "no".
-
-Now make sure you're logged in at this point, we're going to publish 🚀: `npm whoami`, `npm login`. Enter your username, password, and the OTP code.
-
-Before publishing, keep your OTP (one time password) authenticator app around, as NPM will ask for another OTP code when publishing, even though you already entered one code when logging in. We recommend to set your NPM account to the highest security level, which requires two-factor authentication for both authentication and publishing.
-
-The following command will publish the packages:
-
-```
-npx lerna publish from-package
-```
-
-Lerna will ask you to confirm the publish action, and will also ask for an OTP code.
-
-Pat yourself on the back, you published!
-
-#### Publishing unstable (beta) versions of packages
-
-If you publish a package the default way, the new version will be tagged in the NPM registry with the `latest` tag. NPM clients will install the `latest` version by default, if no other version is specified.
-
-To publish unstable (alpha, beta) versions of packages, and to keep the `latest` tag pointing to a stable version, you can add a `--dist-tag next` option:
-
-```
-npx lerna publish --dist-tag next from-package
-```
-
-The published packages will be tagged as `next`, and installed only when the `next` tag is specified explicitly:
-
-```
-yarn install i18n-calypso@next
-```
-
-#### Running `lerna publish` in non-interactive mode
-
-If you don't want Lerna to ask you any questions when publishing, specify the `--yes` option to skip the confirmation prompt.
-
-The OTP code can be specified as the `NPM_CONFIG_OTP` environment variable, again avoiding Lerna/NPM asking for it interactively. For example:
-
-```
-NPM_CONFIG_OTP=[YOUR_OTP_CODE] npx lerna publish from-package --yes
-```
-
-### Publishing a single package
-
-What if you want to publish just one updated package? `lerna publish from-package` either publishes all eligible packages, or nothing. It doesn't give you a choice. That's where you need `lerna publish from-git`.
-
-To publish only selected packages, you need to create Git tags in form `name@version`. For example:
+It is recommended you create a git tag with the package and version you are about to publish. This will help us track where a specific version comes from. For example:
 
 ```
 git tag "@automattic/calypso-build@6.1.0"
+git push --tags
 ```
 
-or
+### Publishing a package
 
-```
-git tag "@automattic/components@1.0.0"
-```
+Once the above steps (checkout `trunk`, get `@automattic` permissions and package tagging) are done, you are ready to publish the package:
 
-Now `npx lerna publish from-git` will offer to publish only the packages that have a matching Git tag on the current `HEAD` revision.
+First you need to authenticate with the registry: `yarn npm login --scope automattic`. To verify it worked you can use `yarn npm whoami --scope automattic`
 
-The rest of the workflow is exactly the same as in the `from-package` case.
+Then you are ready to publish it: `cd packages/<your-package> && yarn npm publish`.
+
+Done!

--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
 		"jest-environment-jsdom": "^27.0.6",
 		"jest-enzyme": "^7.1.2",
 		"jest-junit": "^9.0.0",
-		"lerna": "^4.0.0",
 		"loader-utils": "^1.2.3",
 		"lodash": "^4.17.21",
 		"lunr": "^2.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4139,795 +4139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna/add@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/add@npm:4.0.0"
-  dependencies:
-    "@lerna/bootstrap": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/filter-options": 4.0.0
-    "@lerna/npm-conf": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    dedent: ^0.7.0
-    npm-package-arg: ^8.1.0
-    p-map: ^4.0.0
-    pacote: ^11.2.6
-    semver: ^7.3.4
-  checksum: b20eb2d32408ab787ad99fe6357f113475d4d8c34187dfac9e71226277dd6fc3490150c9120d07f74c02d1c59414e42df010e9343a1765000faef5ab23f77562
-  languageName: node
-  linkType: hard
-
-"@lerna/bootstrap@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/bootstrap@npm:4.0.0"
-  dependencies:
-    "@lerna/command": 4.0.0
-    "@lerna/filter-options": 4.0.0
-    "@lerna/has-npm-version": 4.0.0
-    "@lerna/npm-install": 4.0.0
-    "@lerna/package-graph": 4.0.0
-    "@lerna/pulse-till-done": 4.0.0
-    "@lerna/rimraf-dir": 4.0.0
-    "@lerna/run-lifecycle": 4.0.0
-    "@lerna/run-topologically": 4.0.0
-    "@lerna/symlink-binary": 4.0.0
-    "@lerna/symlink-dependencies": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    dedent: ^0.7.0
-    get-port: ^5.1.1
-    multimatch: ^5.0.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-    p-waterfall: ^2.1.1
-    read-package-tree: ^5.3.1
-    semver: ^7.3.4
-  checksum: 16da64bf541045250fc1c9ac385e1837af62b6d5a08dc64ca2c502afd7a97feba8039496e93cc6f8b679d648daa035ffbf76f86c90c7158df68259f78cf77e50
-  languageName: node
-  linkType: hard
-
-"@lerna/changed@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/changed@npm:4.0.0"
-  dependencies:
-    "@lerna/collect-updates": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/listable": 4.0.0
-    "@lerna/output": 4.0.0
-  checksum: 9442f0f9d40fb1cce344ddef07f7d04377712f1926eaefba212fe04d7213605b69c7a4b0a7abe286bbc9c079e766166a9994d6c42c6e9a2460332ae0e351502f
-  languageName: node
-  linkType: hard
-
-"@lerna/check-working-tree@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/check-working-tree@npm:4.0.0"
-  dependencies:
-    "@lerna/collect-uncommitted": 4.0.0
-    "@lerna/describe-ref": 4.0.0
-    "@lerna/validation-error": 4.0.0
-  checksum: 415a681069b9bffd2f68628a68b4710ccd7e394d70437e592f515c590972a378b99ee1984c6137b9170ef796571e3f7568c45dc3e3fe8d2e527dcf6be89f946b
-  languageName: node
-  linkType: hard
-
-"@lerna/child-process@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/child-process@npm:4.0.0"
-  dependencies:
-    chalk: ^4.1.0
-    execa: ^5.0.0
-    strong-log-transformer: ^2.1.0
-  checksum: 85a9d2302691e9348b5b7fd848dcf93101188859257bfc0315dabf96f6b385ee269d1d127f3c44dfd3f64c39247b3e4995f03ca0b70d2bcd44da8acc904c0cab
-  languageName: node
-  linkType: hard
-
-"@lerna/clean@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/clean@npm:4.0.0"
-  dependencies:
-    "@lerna/command": 4.0.0
-    "@lerna/filter-options": 4.0.0
-    "@lerna/prompt": 4.0.0
-    "@lerna/pulse-till-done": 4.0.0
-    "@lerna/rimraf-dir": 4.0.0
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-    p-waterfall: ^2.1.1
-  checksum: 83e4b1945fff7c10a03780eae1348d956f2c318e158374d5dce995d549a3ebbb87e4e36b81e4383a2748e9ca3285e87202c0c1af3480f308ce16c152041e08f9
-  languageName: node
-  linkType: hard
-
-"@lerna/cli@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/cli@npm:4.0.0"
-  dependencies:
-    "@lerna/global-options": 4.0.0
-    dedent: ^0.7.0
-    npmlog: ^4.1.2
-    yargs: ^16.2.0
-  checksum: bb6638381543bc99c77acd6d0c6169c0f8072a34b0830f0a082aeabe5968aa605501676aa1ad663a480d91a115b218098ec6da48da2e6e0cf64f2750acd97ca2
-  languageName: node
-  linkType: hard
-
-"@lerna/collect-uncommitted@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/collect-uncommitted@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    chalk: ^4.1.0
-    npmlog: ^4.1.2
-  checksum: b35b82312c9f68b16ee8447790c5a1998794772fe3592ae606fd227243693e54e5892d1884e01ea91a0288561881ca80b06507ccb15897557ef9818bfd27b634
-  languageName: node
-  linkType: hard
-
-"@lerna/collect-updates@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/collect-updates@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/describe-ref": 4.0.0
-    minimatch: ^3.0.4
-    npmlog: ^4.1.2
-    slash: ^3.0.0
-  checksum: d4fcdf35f9f8590e9247013710b30e5931af78c98a802d701d7991edf5e6f6ced4bed96e99b70bc3e926e125a16b9a2a0f9f0b4692dacd9751ddc0db96ed9484
-  languageName: node
-  linkType: hard
-
-"@lerna/command@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/command@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/package-graph": 4.0.0
-    "@lerna/project": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    "@lerna/write-log-file": 4.0.0
-    clone-deep: ^4.0.1
-    dedent: ^0.7.0
-    execa: ^5.0.0
-    is-ci: ^2.0.0
-    npmlog: ^4.1.2
-  checksum: 6c901035f028103b317d17617956e9b1a7d5af2a33ff5d88dc533a5d00b5c6c99aa2842f0ef3043cb393133f49f66622392dc937105d50276f543f8e90a73101
-  languageName: node
-  linkType: hard
-
-"@lerna/conventional-commits@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/conventional-commits@npm:4.0.0"
-  dependencies:
-    "@lerna/validation-error": 4.0.0
-    conventional-changelog-angular: ^5.0.12
-    conventional-changelog-core: ^4.2.2
-    conventional-recommended-bump: ^6.1.0
-    fs-extra: ^9.1.0
-    get-stream: ^6.0.0
-    lodash.template: ^4.5.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    pify: ^5.0.0
-    semver: ^7.3.4
-  checksum: b33764f891faa5b193a605a9320583641aab6098311052185f3d47bc75cc1e2f0397be09b2101b5f9406ab6cced554d1d9397c20b45871c2bc62ba61be043756
-  languageName: node
-  linkType: hard
-
-"@lerna/create-symlink@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/create-symlink@npm:4.0.0"
-  dependencies:
-    cmd-shim: ^4.1.0
-    fs-extra: ^9.1.0
-    npmlog: ^4.1.2
-  checksum: e28aa42bccd4c14e2466624d533d7e4bd66eb67c3c0f5fb8ac0f4c39e66b461e6599145a7d2bfd7e2ccb5f0fa105516de94fd74ccb571fe7c508910c5dbc97e7
-  languageName: node
-  linkType: hard
-
-"@lerna/create@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/create@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/npm-conf": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    dedent: ^0.7.0
-    fs-extra: ^9.1.0
-    globby: ^11.0.2
-    init-package-json: ^2.0.2
-    npm-package-arg: ^8.1.0
-    p-reduce: ^2.1.0
-    pacote: ^11.2.6
-    pify: ^5.0.0
-    semver: ^7.3.4
-    slash: ^3.0.0
-    validate-npm-package-license: ^3.0.4
-    validate-npm-package-name: ^3.0.0
-    whatwg-url: ^8.4.0
-    yargs-parser: 20.2.4
-  checksum: dcf362c5779dd53e4220ffa8f10117e5a3a5b9505ceddd31f379f3a9bc9c75de82c7aec24e08b77ea124c8d433d62fdb199de96d6a4e017da25d538c52a319bb
-  languageName: node
-  linkType: hard
-
-"@lerna/describe-ref@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/describe-ref@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    npmlog: ^4.1.2
-  checksum: 8f25619c6d12424c0239f9839782315c020869985f89b02b2f5b78e0eeed70dfa4445eb6ca2e0cd4fa709f88eaac48e86a3091d4647283111157f67e810ffc5e
-  languageName: node
-  linkType: hard
-
-"@lerna/diff@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/diff@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    npmlog: ^4.1.2
-  checksum: e7a6798c6840c608cf5436826b280df69a6925ab01e7062651ae954aefe6e9b2f7f64a03b5fca1224a0ad823a6e9db8d15529826f5401a943c14aa95dcc4c1b8
-  languageName: node
-  linkType: hard
-
-"@lerna/exec@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/exec@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/filter-options": 4.0.0
-    "@lerna/profiler": 4.0.0
-    "@lerna/run-topologically": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    p-map: ^4.0.0
-  checksum: 8a416a8b702de8f209aea4b0bf0fc8b414b5cee677d0f4c1e5c582e5ffbe6371f652d912df8f14d8ce720a2e63ba7aacba4ef3cbe588df3ed2d4ff1916a73dc3
-  languageName: node
-  linkType: hard
-
-"@lerna/filter-options@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/filter-options@npm:4.0.0"
-  dependencies:
-    "@lerna/collect-updates": 4.0.0
-    "@lerna/filter-packages": 4.0.0
-    dedent: ^0.7.0
-    npmlog: ^4.1.2
-  checksum: be84a7ed5fc0b04c2dacc6d863ba5a1ae5a52745c7a70864e3bb401668af84280bfd8fe0dcb52b3a1e48b6a8e9cb9359cd6ca1d043917d667f38cd48d262cf92
-  languageName: node
-  linkType: hard
-
-"@lerna/filter-packages@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/filter-packages@npm:4.0.0"
-  dependencies:
-    "@lerna/validation-error": 4.0.0
-    multimatch: ^5.0.0
-    npmlog: ^4.1.2
-  checksum: 01e1829f0f6dcbfbfea091421ce030d83ea8db36ca4e556f6005467f5b874a0d2b85b91ccea2265e22a3752b80cf49df27d0735fbdb66b2772a032fa08e50eeb
-  languageName: node
-  linkType: hard
-
-"@lerna/get-npm-exec-opts@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/get-npm-exec-opts@npm:4.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 8b09bdcffc9da36b9194dba27619d888c1556482dc38598dd243f645cd7d2a404b60f4153322f05e9b7a8105d641ecc23e13fef7d86ac4f8a4818592dbeb5e55
-  languageName: node
-  linkType: hard
-
-"@lerna/get-packed@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/get-packed@npm:4.0.0"
-  dependencies:
-    fs-extra: ^9.1.0
-    ssri: ^8.0.1
-    tar: ^6.1.0
-  checksum: 9d98709c49d7a0e28bbba9de02660ca9a5befec313850cb1e138ccd9a2d2fb0c35b1d2cd79f8d54afaebd7779b54974921c452ecee9d9dadf1d72cbec162440e
-  languageName: node
-  linkType: hard
-
-"@lerna/github-client@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/github-client@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@octokit/plugin-enterprise-rest": ^6.0.1
-    "@octokit/rest": ^18.1.0
-    git-url-parse: ^11.4.4
-    npmlog: ^4.1.2
-  checksum: ff9657b023da3993be73aae0e937d8b069b7736ca2ac3ccd5c47281609f974bb4eaf2ec63985980cd4bd3668bfa5c4fe6f97897a01a1a921c1b1b86200088003
-  languageName: node
-  linkType: hard
-
-"@lerna/gitlab-client@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/gitlab-client@npm:4.0.0"
-  dependencies:
-    node-fetch: ^2.6.1
-    npmlog: ^4.1.2
-    whatwg-url: ^8.4.0
-  checksum: a8ee3f87eda96c3044feed866909e8d6402030bbb7d9f7a56e188fbb5483f61e5a880540a0d6c42a0954619d3f53c431fcdf7f2499b640874b6a4546489c857a
-  languageName: node
-  linkType: hard
-
-"@lerna/global-options@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/global-options@npm:4.0.0"
-  checksum: eb7989d23c39a3fc475d42e74ebb073ef355c1a297c05e353113f103d1d5fa1d40a0b4f72f687bf6408c9946f99959711535f789d75fbbae10a12138a217729e
-  languageName: node
-  linkType: hard
-
-"@lerna/has-npm-version@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/has-npm-version@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    semver: ^7.3.4
-  checksum: 21230b49ccf5de1c27eca3a9c41cf8f144da3b5b49aa208b66aebf03f950092c1d146ab2cdc6390a815fa0f28db798c240a60c6ecfab3540a1f073470f525257
-  languageName: node
-  linkType: hard
-
-"@lerna/import@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/import@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/prompt": 4.0.0
-    "@lerna/pulse-till-done": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    dedent: ^0.7.0
-    fs-extra: ^9.1.0
-    p-map-series: ^2.1.0
-  checksum: af62e1d10e0dfbfb5e7cdb8fe370c87538d4344d2b2d3b9616abbd7503db81bb903a2368baf8fc1edc91acc12c1282f7943e84d347080608f77d20b30354a0e7
-  languageName: node
-  linkType: hard
-
-"@lerna/info@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/info@npm:4.0.0"
-  dependencies:
-    "@lerna/command": 4.0.0
-    "@lerna/output": 4.0.0
-    envinfo: ^7.7.4
-  checksum: 1eeceb8dd19c8998ad574917960428e466da36f7196fad5fcaabf82eb3c393f6d4b9664803af0a5ded7ed2631d31a1e5467e9f4ce80eec929cc31b39225610b4
-  languageName: node
-  linkType: hard
-
-"@lerna/init@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/init@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/command": 4.0.0
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-    write-json-file: ^4.3.0
-  checksum: 2380deda57c7aeea47dba02ff296aa70385e86cb39868451613c65e418984b9701436788af0194357f2548765ebefbcd8d7d7fd6f669ea1aedbcbc22d8ef3a4d
-  languageName: node
-  linkType: hard
-
-"@lerna/link@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/link@npm:4.0.0"
-  dependencies:
-    "@lerna/command": 4.0.0
-    "@lerna/package-graph": 4.0.0
-    "@lerna/symlink-dependencies": 4.0.0
-    p-map: ^4.0.0
-    slash: ^3.0.0
-  checksum: 4889dbe490e8813284abf349c948a56cd88735537ffe10102b5aa42d1994247af7c4286a6e23ccc9854f976809e1293663410aba3968ec69b2968b242b2a1968
-  languageName: node
-  linkType: hard
-
-"@lerna/list@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/list@npm:4.0.0"
-  dependencies:
-    "@lerna/command": 4.0.0
-    "@lerna/filter-options": 4.0.0
-    "@lerna/listable": 4.0.0
-    "@lerna/output": 4.0.0
-  checksum: bee3827862639a86b133fafe5918b2086085af8afb0e13e8e9fd30aefd562a7f75600bb9ce4c4a5914c3c3d5cfbede417d82f2ff323956cfa8d605750c459d89
-  languageName: node
-  linkType: hard
-
-"@lerna/listable@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/listable@npm:4.0.0"
-  dependencies:
-    "@lerna/query-graph": 4.0.0
-    chalk: ^4.1.0
-    columnify: ^1.5.4
-  checksum: 5ec85ec247ecda00cf76d327b5fd5b4449be3061a0f2a3dc72f1c42dc6f1559a13f56024051e594b597fa9d90f62a2fc0818aa153b949b1a36d7650153af7cfb
-  languageName: node
-  linkType: hard
-
-"@lerna/log-packed@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/log-packed@npm:4.0.0"
-  dependencies:
-    byte-size: ^7.0.0
-    columnify: ^1.5.4
-    has-unicode: ^2.0.1
-    npmlog: ^4.1.2
-  checksum: 2eba7081f69fca830ae3db5d7bbade03f497bcb653560ca520dd0658edc90b3e3145869c7cdbc9753417550521438367c3d9353b11d19475afe35d695b802a66
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-conf@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/npm-conf@npm:4.0.0"
-  dependencies:
-    config-chain: ^1.1.12
-    pify: ^5.0.0
-  checksum: 5f14e9926ff8ff537125099dce6fca9e53ec5ec77040226647787ddfb7ac92350007935c533b2c30b31860cf8acc51f268b4ef153f90d8032794ba4db8be8ffd
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-dist-tag@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/npm-dist-tag@npm:4.0.0"
-  dependencies:
-    "@lerna/otplease": 4.0.0
-    npm-package-arg: ^8.1.0
-    npm-registry-fetch: ^9.0.0
-    npmlog: ^4.1.2
-  checksum: f445b40687d83e64b3c5d251d8117bf75ab52a99d22817d94a36d3c3556248976d656805e6dceb2c709a17cde95027e839bc90bf8063fa143af85b146910ff54
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-install@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/npm-install@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/get-npm-exec-opts": 4.0.0
-    fs-extra: ^9.1.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    signal-exit: ^3.0.3
-    write-pkg: ^4.0.0
-  checksum: 167c4c0800fdfcfa1e3463cae35a45455ae6c2c0b49d9fb482859a1801d5106015d68f324c33c06bd026ad8b316a3a309a6108c532f8b5542482176378af1fcf
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-publish@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/npm-publish@npm:4.0.0"
-  dependencies:
-    "@lerna/otplease": 4.0.0
-    "@lerna/run-lifecycle": 4.0.0
-    fs-extra: ^9.1.0
-    libnpmpublish: ^4.0.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    pify: ^5.0.0
-    read-package-json: ^3.0.0
-  checksum: 950ddf11e5b31409ff14c8cd817a5336d3f1594fc4f4f25808ee2383bdeefeedc4ff875d3050a49c2a47cd20ce56b2a4d2af50d11d373d74ae992c7d1b0097ad
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-run-script@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/npm-run-script@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    "@lerna/get-npm-exec-opts": 4.0.0
-    npmlog: ^4.1.2
-  checksum: cddacbb2ad51d5139aa1af05eb05469b9e40b81a353c100a8780be2595165e44a52d2408aacd9f8eea6a41d198ecf37c4e0331802e317ab9e823a632308213ab
-  languageName: node
-  linkType: hard
-
-"@lerna/otplease@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/otplease@npm:4.0.0"
-  dependencies:
-    "@lerna/prompt": 4.0.0
-  checksum: e6063e4ba17948e897e1ed3925ab51396a62c5feb74b8039c20765bfdf550b97d1cad686a5d1ac97da96e52b78869498b90b8980b8960f2ce56c444564739984
-  languageName: node
-  linkType: hard
-
-"@lerna/output@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/output@npm:4.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 9cb4efdd3fcfdd1a7a849d0faaf3db36b6bf562fa6e7e0e669ac5cb224b30a3aa326daa77c969a297252a295b0f2172843624cd92f3293e9f87d5751d37d5e41
-  languageName: node
-  linkType: hard
-
-"@lerna/pack-directory@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/pack-directory@npm:4.0.0"
-  dependencies:
-    "@lerna/get-packed": 4.0.0
-    "@lerna/package": 4.0.0
-    "@lerna/run-lifecycle": 4.0.0
-    npm-packlist: ^2.1.4
-    npmlog: ^4.1.2
-    tar: ^6.1.0
-    temp-write: ^4.0.0
-  checksum: e9cf85ed4a2cc766ede2dbd1f131ca5441aab05f0af710b3eaa59af48f334932fb5bf17e3845cf2c4830aff01e4dc97ef4bcd70caf2a4cc9c246555f2c49a4c3
-  languageName: node
-  linkType: hard
-
-"@lerna/package-graph@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/package-graph@npm:4.0.0"
-  dependencies:
-    "@lerna/prerelease-id-from-version": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    semver: ^7.3.4
-  checksum: 833d44ddab8eb32162ca12e7640c1366ec5d80069422246f3f96a4790fa226d7c54261ceb8d6d9cfcc703d968a74c8c3b7e1ef2389c5ef06a828acb537eca0f1
-  languageName: node
-  linkType: hard
-
-"@lerna/package@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/package@npm:4.0.0"
-  dependencies:
-    load-json-file: ^6.2.0
-    npm-package-arg: ^8.1.0
-    write-pkg: ^4.0.0
-  checksum: 8b6b0a771a86f993af22fe1435db6c2953e7e39112557b5256bdfaf834daa2f8f5819fa062e6a8d3af95a061a034d84355cac79c355ce1c51076920f4a5ad426
-  languageName: node
-  linkType: hard
-
-"@lerna/prerelease-id-from-version@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/prerelease-id-from-version@npm:4.0.0"
-  dependencies:
-    semver: ^7.3.4
-  checksum: b4870215b94eacc50b917555998f36f4f2b1ab534f10f483a3210173c110e1c00b87daee8ebceabd2f393b9e1b1c57c3235f0a6765d8ba29749ddcfb7ddc33ca
-  languageName: node
-  linkType: hard
-
-"@lerna/profiler@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/profiler@npm:4.0.0"
-  dependencies:
-    fs-extra: ^9.1.0
-    npmlog: ^4.1.2
-    upath: ^2.0.1
-  checksum: a66325db14014391c271cc6fcf34de060a90cfa6f96e07b29279881cc4d40cc50021a02617747a9af122d9bb06a0c80c49d176ac470f9de1e5a327e62236af91
-  languageName: node
-  linkType: hard
-
-"@lerna/project@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/project@npm:4.0.0"
-  dependencies:
-    "@lerna/package": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    cosmiconfig: ^7.0.0
-    dedent: ^0.7.0
-    dot-prop: ^6.0.1
-    glob-parent: ^5.1.1
-    globby: ^11.0.2
-    load-json-file: ^6.2.0
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    resolve-from: ^5.0.0
-    write-json-file: ^4.3.0
-  checksum: d789dcd905974da1476a25c0a8186f535c70d421b10a105e4bb78ec6396e82eca1c72232a867f7c8478443dd5006df657809474ad36028838a777ae78c69757d
-  languageName: node
-  linkType: hard
-
-"@lerna/prompt@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/prompt@npm:4.0.0"
-  dependencies:
-    inquirer: ^7.3.3
-    npmlog: ^4.1.2
-  checksum: 22ea4c663940645fd08d8db13cc58f5ba3e0c2e8d733262461f17a63a8bfb03a567c488cc11b924350697ef8f9e2abc7302d5c8752f5dd1cb5fa47f48558a041
-  languageName: node
-  linkType: hard
-
-"@lerna/publish@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/publish@npm:4.0.0"
-  dependencies:
-    "@lerna/check-working-tree": 4.0.0
-    "@lerna/child-process": 4.0.0
-    "@lerna/collect-updates": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/describe-ref": 4.0.0
-    "@lerna/log-packed": 4.0.0
-    "@lerna/npm-conf": 4.0.0
-    "@lerna/npm-dist-tag": 4.0.0
-    "@lerna/npm-publish": 4.0.0
-    "@lerna/otplease": 4.0.0
-    "@lerna/output": 4.0.0
-    "@lerna/pack-directory": 4.0.0
-    "@lerna/prerelease-id-from-version": 4.0.0
-    "@lerna/prompt": 4.0.0
-    "@lerna/pulse-till-done": 4.0.0
-    "@lerna/run-lifecycle": 4.0.0
-    "@lerna/run-topologically": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    "@lerna/version": 4.0.0
-    fs-extra: ^9.1.0
-    libnpmaccess: ^4.0.1
-    npm-package-arg: ^8.1.0
-    npm-registry-fetch: ^9.0.0
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    p-pipe: ^3.1.0
-    pacote: ^11.2.6
-    semver: ^7.3.4
-  checksum: cf23f07071e505af5e88fa9df4595632a3a0cc22a862d634831a89d87daaf75720b43025e043241e33a0de58e3aa2324a3ee182d65dcd76a61ff9359575fb0ac
-  languageName: node
-  linkType: hard
-
-"@lerna/pulse-till-done@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/pulse-till-done@npm:4.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 6a1fd372cdccb97b15ada1495cfce8cf124e67d0265803dffd47541d343d909cf47edad8d18513c911aabac8fdb0726d48c5841e8aea1bec820e2b475a29717d
-  languageName: node
-  linkType: hard
-
-"@lerna/query-graph@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/query-graph@npm:4.0.0"
-  dependencies:
-    "@lerna/package-graph": 4.0.0
-  checksum: 028daea415e14b8d4b3e63780269be76a6a7b1731747ec24e4125d66ff45bceebc2855db7962516adc056887d2c52153e38f646185651554287c1bf3975e642c
-  languageName: node
-  linkType: hard
-
-"@lerna/resolve-symlink@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/resolve-symlink@npm:4.0.0"
-  dependencies:
-    fs-extra: ^9.1.0
-    npmlog: ^4.1.2
-    read-cmd-shim: ^2.0.0
-  checksum: 5819360d83da2e358e964c51a55c32a3e8cbde128b3cd3bb1b3fcf8873d52f292fe1c831c720b1c5c69de57fe308ec46a6f035c303f9a07327d95f106ce135c1
-  languageName: node
-  linkType: hard
-
-"@lerna/rimraf-dir@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/rimraf-dir@npm:4.0.0"
-  dependencies:
-    "@lerna/child-process": 4.0.0
-    npmlog: ^4.1.2
-    path-exists: ^4.0.0
-    rimraf: ^3.0.2
-  checksum: a31f783f14811f87d5a2e03adb5d6d0fbc131bc31cfe6e9d0602abe7bc0472b7a4f1dd137bcc719a6a19f435fb6a11237d16d4704b9925affcc1a7ff74502821
-  languageName: node
-  linkType: hard
-
-"@lerna/run-lifecycle@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/run-lifecycle@npm:4.0.0"
-  dependencies:
-    "@lerna/npm-conf": 4.0.0
-    npm-lifecycle: ^3.1.5
-    npmlog: ^4.1.2
-  checksum: b826c16a219cfd398193701e613b0a21478802eed18df540a5d397873e42db2acbbf9d075ce5ecf01d301a644b4dcbc0bb24d2c217ebfc38fc2b22a07f4c9162
-  languageName: node
-  linkType: hard
-
-"@lerna/run-topologically@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/run-topologically@npm:4.0.0"
-  dependencies:
-    "@lerna/query-graph": 4.0.0
-    p-queue: ^6.6.2
-  checksum: 3ef4a5dacb5b768b1c68c530b7e73af90fddefaf2c2d5427420ade01e10ac8662e7d330dcaf9ec0c94714223a6698752b7edb3c4807826a7c868b338f8fcad95
-  languageName: node
-  linkType: hard
-
-"@lerna/run@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/run@npm:4.0.0"
-  dependencies:
-    "@lerna/command": 4.0.0
-    "@lerna/filter-options": 4.0.0
-    "@lerna/npm-run-script": 4.0.0
-    "@lerna/output": 4.0.0
-    "@lerna/profiler": 4.0.0
-    "@lerna/run-topologically": 4.0.0
-    "@lerna/timer": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    p-map: ^4.0.0
-  checksum: 908014083ce9f3000bb83103b9b307ec6eb2651f76a2cd34d0c6c0ff226d359f5608fc36de9fc7dc8d1ce0732ce055875f97e33ae0923c66817494c32c8093e0
-  languageName: node
-  linkType: hard
-
-"@lerna/symlink-binary@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/symlink-binary@npm:4.0.0"
-  dependencies:
-    "@lerna/create-symlink": 4.0.0
-    "@lerna/package": 4.0.0
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-  checksum: d457a8ef53da014815ffe70379a0375f1a005c12e369e861a5850fe7d679e017b2a2f029c256c3fbc0903c6978d2652eb6f3561bc06ce49bc71986fc0261d395
-  languageName: node
-  linkType: hard
-
-"@lerna/symlink-dependencies@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/symlink-dependencies@npm:4.0.0"
-  dependencies:
-    "@lerna/create-symlink": 4.0.0
-    "@lerna/resolve-symlink": 4.0.0
-    "@lerna/symlink-binary": 4.0.0
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-  checksum: c6abc8de621c6d651e728bdfdeed7f8a6ef98297598cd142e654014be6c570a5fc770126fdf04c80704d190ed6ecad659dd955174293643b303afd62d4c5232c
-  languageName: node
-  linkType: hard
-
-"@lerna/timer@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/timer@npm:4.0.0"
-  checksum: 3cb861b2314eaa2f5a094ed6444f7736cdd16eb172c84ec0794136f2532178eaab9e414ba653dec6e0243fc50ba51c5b1f4ade26706b3bece6ec453640db4fff
-  languageName: node
-  linkType: hard
-
-"@lerna/validation-error@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/validation-error@npm:4.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 721d13055364bd45006fd1804fc8ffbafa780aaff44517c38b2c078bf6350b6d1c34c9ed7e2ed5b3b9c59ffd743ba40bd3bda55945ee030286455de5524198c8
-  languageName: node
-  linkType: hard
-
-"@lerna/version@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/version@npm:4.0.0"
-  dependencies:
-    "@lerna/check-working-tree": 4.0.0
-    "@lerna/child-process": 4.0.0
-    "@lerna/collect-updates": 4.0.0
-    "@lerna/command": 4.0.0
-    "@lerna/conventional-commits": 4.0.0
-    "@lerna/github-client": 4.0.0
-    "@lerna/gitlab-client": 4.0.0
-    "@lerna/output": 4.0.0
-    "@lerna/prerelease-id-from-version": 4.0.0
-    "@lerna/prompt": 4.0.0
-    "@lerna/run-lifecycle": 4.0.0
-    "@lerna/run-topologically": 4.0.0
-    "@lerna/validation-error": 4.0.0
-    chalk: ^4.1.0
-    dedent: ^0.7.0
-    load-json-file: ^6.2.0
-    minimatch: ^3.0.4
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    p-pipe: ^3.1.0
-    p-reduce: ^2.1.0
-    p-waterfall: ^2.1.1
-    semver: ^7.3.4
-    slash: ^3.0.0
-    temp-write: ^4.0.0
-    write-json-file: ^4.3.0
-  checksum: fa0de0b3cec2f152664789fec2f055a3c60e3c2d617d8f3fc80839877d2aa999825ad9b78fcfa0859b9abedd0a3084e7eedfdd4d55f1efeeb7b126eb2745cd65
-  languageName: node
-  linkType: hard
-
-"@lerna/write-log-file@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@lerna/write-log-file@npm:4.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-    write-file-atomic: ^3.0.3
-  checksum: 3f90fb5eff8aa9bf6bbe4ecabfe6213d796a2c9eeae40aec408443cbe648124985bde381535117b7a56b91deeb7349153126fc1ca8ddc91635226f02adad0112
-  languageName: node
-  linkType: hard
-
 "@mdx-js/mdx@npm:^1.6.22":
   version: 1.6.22
   resolution: "@mdx-js/mdx@npm:1.6.22"
@@ -5025,226 +4236,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/ci-detect@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "@npmcli/ci-detect@npm:1.3.0"
-  checksum: 4f5646ba67823d0723a4fcf35d3626269be9929bde7df95cfbfb39233c16ea37a508705f503d9bbd31d4c315b413f552f40e74dc36754d195daba8d21d6fdaf5
-  languageName: node
-  linkType: hard
-
-"@npmcli/git@npm:^2.0.1":
-  version: 2.0.6
-  resolution: "@npmcli/git@npm:2.0.6"
-  dependencies:
-    "@npmcli/promise-spawn": ^1.1.0
-    lru-cache: ^6.0.0
-    mkdirp: ^1.0.3
-    npm-pick-manifest: ^6.0.0
-    promise-inflight: ^1.0.1
-    promise-retry: ^2.0.1
-    semver: ^7.3.2
-    unique-filename: ^1.1.1
-    which: ^2.0.2
-  checksum: 4fd89e7a2e0c088bf3a289fd7592dd33e79478d703cdb943ed17a3da7d5dfba94a4bd877c16a9d65260b2f83d4e2bbc532518c6392fddc330a93e4e76d380581
-  languageName: node
-  linkType: hard
-
-"@npmcli/installed-package-contents@npm:^1.0.6":
-  version: 1.0.7
-  resolution: "@npmcli/installed-package-contents@npm:1.0.7"
-  dependencies:
-    npm-bundled: ^1.1.1
-    npm-normalize-package-bin: ^1.0.1
-  bin:
-    installed-package-contents: index.js
-  checksum: 69c23b489ebfc90a28f6ee5293256bf6dae656292c8e13d52cd770fee2db2c9ecbeb7586387cd9006bc1968439edd5c75aeeb7d39ba0c8eb58905c3073bee067
-  languageName: node
-  linkType: hard
-
 "@npmcli/move-file@npm:^1.0.1":
   version: 1.0.1
   resolution: "@npmcli/move-file@npm:1.0.1"
   dependencies:
     mkdirp: ^1.0.4
   checksum: 7621f261f28606227ee4338b896058049a943b7691f86a2ac757df899799d84a0269b8105f82d6206cdbb5effde8bb3b8d2c39dbd3cf14aa21a7ae04a17f51bc
-  languageName: node
-  linkType: hard
-
-"@npmcli/node-gyp@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@npmcli/node-gyp@npm:1.0.2"
-  checksum: 3a29bbd7f2cc919c8c702d6f2af15198a1f54c7f6bfd5909b6178467359c917f8afae60bb399e937a0e3945225bf1776d591bd44839a553610a6e2d070b4facc
-  languageName: node
-  linkType: hard
-
-"@npmcli/promise-spawn@npm:^1.1.0, @npmcli/promise-spawn@npm:^1.2.0, @npmcli/promise-spawn@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@npmcli/promise-spawn@npm:1.3.2"
-  dependencies:
-    infer-owner: ^1.0.4
-  checksum: 2ef7231c978c237e5475a51390d2416e30c0362cf1b0a75fe56dbca07c693d6eac80b4be7b668c001a79ceeafed7896617463b88f20ded47f3201ce1528d85ee
-  languageName: node
-  linkType: hard
-
-"@npmcli/run-script@npm:^1.8.2":
-  version: 1.8.3
-  resolution: "@npmcli/run-script@npm:1.8.3"
-  dependencies:
-    "@npmcli/node-gyp": ^1.0.2
-    "@npmcli/promise-spawn": ^1.3.2
-    infer-owner: ^1.0.4
-    node-gyp: ^7.1.0
-    puka: ^1.0.1
-    read-package-json-fast: ^2.0.1
-  checksum: 6d68a2b9f4d8e8afd15cb7886cb7979314ddd2ea4dc3fd6fd41ab60aec67d34aa8f955acc5b7bc7221e5ec8607ec7ba722ab8f6ad432e50b136efff824283fdf
-  languageName: node
-  linkType: hard
-
-"@octokit/auth-token@npm:^2.4.4":
-  version: 2.4.5
-  resolution: "@octokit/auth-token@npm:2.4.5"
-  dependencies:
-    "@octokit/types": ^6.0.3
-  checksum: f3b97f97d2605ba075d19c565cf8b1439f55f6319dd3722e495dac59141a56ecd4db4dc5ce168389bb66913194cc7d4c93c237f6d63e5ab3ce394777d296a239
-  languageName: node
-  linkType: hard
-
-"@octokit/core@npm:^3.2.3":
-  version: 3.2.5
-  resolution: "@octokit/core@npm:3.2.5"
-  dependencies:
-    "@octokit/auth-token": ^2.4.4
-    "@octokit/graphql": ^4.5.8
-    "@octokit/request": ^5.4.12
-    "@octokit/types": ^6.0.3
-    before-after-hook: ^2.1.0
-    universal-user-agent: ^6.0.0
-  checksum: 354d3bf12b724941443a1c1db40068c0114491daed1e8e54694450f09a5e892d90d968275701f01a3d9002d96c21909fd4ce577a6224019119488e1f377f9fb3
-  languageName: node
-  linkType: hard
-
-"@octokit/endpoint@npm:^6.0.1":
-  version: 6.0.5
-  resolution: "@octokit/endpoint@npm:6.0.5"
-  dependencies:
-    "@octokit/types": ^5.0.0
-    is-plain-object: ^4.0.0
-    universal-user-agent: ^6.0.0
-  checksum: 0a8bfeed9c5abe6f31b5a505d5a6435df6ee329d0b6b37bb424661e17d34f1f887064b34c16bd378f3301b859c050ac45b3b6313d7480054cdbbd791f01f8158
-  languageName: node
-  linkType: hard
-
-"@octokit/graphql@npm:^4.5.8":
-  version: 4.6.0
-  resolution: "@octokit/graphql@npm:4.6.0"
-  dependencies:
-    "@octokit/request": ^5.3.0
-    "@octokit/types": ^6.0.3
-    universal-user-agent: ^6.0.0
-  checksum: fe5aa44983ad7f6ea1faefd2935e5ded2b2815ea62f72d3282d54bc8705f2afb0ceab432a8f5225ffd1562a6838360ccdf72e737755ab7140dd7fcdfc9d549a6
-  languageName: node
-  linkType: hard
-
-"@octokit/openapi-types@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "@octokit/openapi-types@npm:5.3.2"
-  checksum: edb8d37e78a82ba00fce1f14115372f7ef4244e0d0be35c95d633d37ff90ceb689c3eb2f9c3a45e6247b01fdaaa439e75bd9a7e0506b042f8c3a53ccc4c21ab4
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-enterprise-rest@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "@octokit/plugin-enterprise-rest@npm:6.0.1"
-  checksum: 26bd0a30582954efcd29b41e16698db79e9d20e3f88c4069b43b183223cee69862621f18b6a7a1c9257b1cd07c24477e403b75c74688660ecf31d467b9d8fd9e
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-paginate-rest@npm:^2.6.2":
-  version: 2.11.0
-  resolution: "@octokit/plugin-paginate-rest@npm:2.11.0"
-  dependencies:
-    "@octokit/types": ^6.11.0
-  peerDependencies:
-    "@octokit/core": ">=2"
-  checksum: 135af213652059e0da8f1171f9e307afe579ba2a160a4f967f6bf0a17d3e2c269ba53af8ab349e3d51d143a0558e6814da54b7c33ecd24710a37b7fc52dc6062
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-request-log@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "@octokit/plugin-request-log@npm:1.0.3"
-  peerDependencies:
-    "@octokit/core": ">=3"
-  checksum: 37d1de1abdbc0081daa6b173ceb91b7c0f51710294c3fe61baae8bb7810bf6c35d4cf0e587f7071c5a9ce91ac7392defcf7e584301959aead4dd3e3044cf6184
-  languageName: node
-  linkType: hard
-
-"@octokit/plugin-rest-endpoint-methods@npm:4.13.5":
-  version: 4.13.5
-  resolution: "@octokit/plugin-rest-endpoint-methods@npm:4.13.5"
-  dependencies:
-    "@octokit/types": ^6.12.2
-    deprecation: ^2.3.1
-  peerDependencies:
-    "@octokit/core": ">=3"
-  checksum: e730dddcce64ede13350d2ba25193b2991d07e366da27eeef6bcc45cfcd0071f032865458ecbd48c5942bbb968aee1cbc666b1b938ceb8ce13df5727700f87ac
-  languageName: node
-  linkType: hard
-
-"@octokit/request-error@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@octokit/request-error@npm:2.0.2"
-  dependencies:
-    "@octokit/types": ^5.0.1
-    deprecation: ^2.0.0
-    once: ^1.4.0
-  checksum: 5c1f7c5c150cacc6bb8c8b46d03ad6efb186e518bba2747ad415a7b184140ef701a25f94b7f83553895d17ae5aa1569a12a2625f327779391d6331bbb86d6a88
-  languageName: node
-  linkType: hard
-
-"@octokit/request@npm:^5.3.0, @octokit/request@npm:^5.4.12":
-  version: 5.4.14
-  resolution: "@octokit/request@npm:5.4.14"
-  dependencies:
-    "@octokit/endpoint": ^6.0.1
-    "@octokit/request-error": ^2.0.0
-    "@octokit/types": ^6.7.1
-    deprecation: ^2.0.0
-    is-plain-object: ^5.0.0
-    node-fetch: ^2.6.1
-    once: ^1.4.0
-    universal-user-agent: ^6.0.0
-  checksum: 05482a85b5167a0de7d2a55d1885798ea9c4db95592ac71c67c02fe8258b9491140148e2d2af62faf80588a5bd10ed92c6f200916ff4cae285c9a015d8ced49f
-  languageName: node
-  linkType: hard
-
-"@octokit/rest@npm:^18.1.0":
-  version: 18.3.5
-  resolution: "@octokit/rest@npm:18.3.5"
-  dependencies:
-    "@octokit/core": ^3.2.3
-    "@octokit/plugin-paginate-rest": ^2.6.2
-    "@octokit/plugin-request-log": ^1.0.2
-    "@octokit/plugin-rest-endpoint-methods": 4.13.5
-  checksum: 58e00663b7d7d40ac64f44c9c4e58eb072852b544a6e75d071ec0d2887843d218de4871c7084812816c05469f945b0b5403b74014d7aec28cc7e048365c0189d
-  languageName: node
-  linkType: hard
-
-"@octokit/types@npm:^5.0.0, @octokit/types@npm:^5.0.1":
-  version: 5.4.1
-  resolution: "@octokit/types@npm:5.4.1"
-  dependencies:
-    "@types/node": ">= 8"
-  checksum: 4108addce79926aababab50f14e942f533b86f2d76e034312a54a03fbafb30ddc0923e41a6e37733bc718805c4829b0067f2415c24a144fd468342bbf7a3d566
-  languageName: node
-  linkType: hard
-
-"@octokit/types@npm:^6.0.3, @octokit/types@npm:^6.11.0, @octokit/types@npm:^6.12.2, @octokit/types@npm:^6.7.1":
-  version: 6.12.2
-  resolution: "@octokit/types@npm:6.12.2"
-  dependencies:
-    "@octokit/openapi-types": ^5.3.2
-  checksum: 4d743bdd022582383ab4cec13b28f3667726c32b5bbfdeb84a6b2ce7e2de0384710925750bcbd394d4e29b5d4827ee1b750d1d4403444932cf3b4e8a7bf0c189
   languageName: node
   linkType: hard
 
@@ -7128,7 +6125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:*, @types/minimatch@npm:^3.0.3":
+"@types/minimatch@npm:*":
   version: 3.0.4
   resolution: "@types/minimatch@npm:3.0.4"
   checksum: 6a61ad8ed703f7e81ff58cdb9721cc009cfb0ebc5151c7eaa490bfc373c387be7070d09943e0b4e3df6c572977ed1798959ce990693889670a564e7f7d5a7b59
@@ -7166,7 +6163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:^15.0.2":
+"@types/node@npm:*, @types/node@npm:^15.0.2":
   version: 15.0.3
   resolution: "@types/node@npm:15.0.3"
   checksum: 8d49a4832d8132e50fc2df8c593bbe5998c7a72af51ceeb618ef942b8f92cdb74ffc51a94992a3db2593ee156e0c623a99f987fce499600cd75e972b2e4e15c3
@@ -9858,7 +8855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"JSONStream@npm:^1.0.3, JSONStream@npm:^1.0.4":
+"JSONStream@npm:^1.0.3":
   version: 1.3.5
   resolution: "JSONStream@npm:1.3.5"
   dependencies:
@@ -10013,13 +9010,6 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: ecff67f32fe07569188d407ef09e29237a4349a4fbf1ecf2bb2c6a615d7cb4e3e079b1015a2a0775dac509c7fd2877849a04a05e75978d1154e0dc7331f70dde
-  languageName: node
-  linkType: hard
-
-"add-stream@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "add-stream@npm:1.0.0"
-  checksum: 985014a14e76ca4cb24e0fc58bb1556794cf38c5c8937de335a10584f50a371dc48e1c34a59391c7eb9c1fc908b4b86764df5d2756f701df6ba95d1ca2f63ddc
   languageName: node
   linkType: hard
 
@@ -10416,13 +9406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "aproba@npm:2.0.0"
-  checksum: d06e26384a8f6245d8c8896e138c0388824e259a329e0c9f196b4fa533c82502a6fd449586e3604950a0c42921832a458bb3aa0aa9f0ba449cfd4f50fd0d09b5
-  languageName: node
-  linkType: hard
-
 "archiver-utils@npm:^2.1.0":
   version: 2.1.0
   resolution: "archiver-utils@npm:2.1.0"
@@ -10530,13 +9513,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-differ@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "array-differ@npm:3.0.0"
-  checksum: c0d924cc2b7e3f5a0e6ae932e8941c5fddc0412bcecf8d5152641910e60f5e1c1e87da2b32083dec2f92f9a8f78e916ea68c22a0579794ba49886951ae783123
-  languageName: node
-  linkType: hard
-
 "array-each@npm:^1.0.1":
   version: 1.0.1
   resolution: "array-each@npm:1.0.1"
@@ -10590,13 +9566,6 @@ __metadata:
   version: 2.1.2
   resolution: "array-flatten@npm:2.1.2"
   checksum: bdc1cee68e41bec9cfc1161408734e2269428ef371445606bce4e6241001e138a94b9a617cc9a5b4b7fe6a3a51e3d5a942646975ce82a2e202ccf3e9b478c82f
-  languageName: node
-  linkType: hard
-
-"array-ify@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "array-ify@npm:1.0.0"
-  checksum: 75c9c072faac47bd61779c0c595e912fe660d338504ac70d10e39e1b8a4a0c9c87658703d619b9d1b70d324177ae29dc8d07dda0d0a15d005597bc4c5a59c70c
   languageName: node
   linkType: hard
 
@@ -10744,7 +9713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.0, asap@npm:~2.0.3, asap@npm:~2.0.6":
+"asap@npm:~2.0.3, asap@npm:~2.0.6":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
@@ -11730,13 +10699,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"before-after-hook@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "before-after-hook@npm:2.1.0"
-  checksum: aedf3e711d83a261bcabbecd42c51096ad337e657e18ca299cf5847c11997e13f8c3718496f6ba7fe51fc62169dbf629790f19aed278b8065babbf838b3788c0
-  languageName: node
-  linkType: hard
-
 "better-assert@npm:~1.0.0":
   version: 1.0.2
   resolution: "better-assert@npm:1.0.2"
@@ -12345,13 +11307,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builtins@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "builtins@npm:1.0.3"
-  checksum: 493afcc1db0a56d174cc85bebe5ca69144f6fdd0007d6cbe6b2434185314c79d83cb867e492b56aa5cf421b4b8a8135bf96ba4c3ce71994cf3da154d1ea59747
-  languageName: node
-  linkType: hard
-
 "bulma@npm:^0.8.0":
   version: 0.8.2
   resolution: "bulma@npm:0.8.2"
@@ -12379,20 +11334,6 @@ __metadata:
   bin:
     bunyan: bin/bunyan
   checksum: c7b3adc07a4db3256f857dcba42b97dd6c35ab054cb26766643aae2b90e1b614795cdf231774ddaf374572d952f52ef4f4205047e15414e155e478aa0672e041
-  languageName: node
-  linkType: hard
-
-"byline@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "byline@npm:5.0.0"
-  checksum: 33fb64cd84440b3652a99a68d732c56ef18a748ded495ba38e7756a242fab0d4654b9b8ce269fd0ac14c5f97aa4e3c369613672b280a1f60b559b34223105c85
-  languageName: node
-  linkType: hard
-
-"byte-size@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "byte-size@npm:7.0.1"
-  checksum: 3edcd515b61e9c43a90aa33fdca37a2d11faa0d24e87d3a55f738398d247cd632efc0b346c026bd70f8a57a20bb8469e24136aeaef6f2e72e716e093d6b3b031
   languageName: node
   linkType: hard
 
@@ -13676,15 +12617,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cmd-shim@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "cmd-shim@npm:4.1.0"
-  dependencies:
-    mkdirp-infer-owner: ^2.0.0
-  checksum: 9cb911c768a5894473e72d87e682fdfb9bc8f8097cc21bbbf1120a69f8c2edda3f72135beb41cbc75ec3fe113a96c3d6b37c652df800208e6fe71ed97a0cc602
-  languageName: node
-  linkType: hard
-
 "co@npm:3.1.0":
   version: 3.1.0
   resolution: "co@npm:3.1.0"
@@ -13863,16 +12795,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"columnify@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "columnify@npm:1.5.4"
-  dependencies:
-    strip-ansi: ^3.0.0
-    wcwidth: ^1.0.0
-  checksum: bed7041413afab966f6c478730a1617764065c6cee598b6ba8d7400fb95974b857682a721b7edd7358e10ab3e47512930208903707f7f806fa887f9ee6ca5946
-  languageName: node
-  linkType: hard
-
 "combine-source-map@npm:^0.8.0, combine-source-map@npm:~0.8.0":
   version: 0.8.0
   resolution: "combine-source-map@npm:0.8.0"
@@ -14023,16 +12945,6 @@ __metadata:
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
   checksum: 33a124960e471c25ee19280c9ce31ccc19574b566dc514fe4f4ca4c34fa8b0b57cf437671f5de380e11353ea9426213fca17687dd2ef03134fea2dbc53809fd6
-  languageName: node
-  linkType: hard
-
-"compare-func@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "compare-func@npm:2.0.0"
-  dependencies:
-    array-ify: ^1.0.0
-    dot-prop: ^5.1.0
-  checksum: 78bd4dd4ed311a79bd264c9e13c36ed564cde657f1390e699e0f04b8eee1fc06ffb8698ce2dfb5fbe7342d509579c82d4e248f08915b708f77f7b72234086cc3
   languageName: node
   linkType: hard
 
@@ -14196,18 +13108,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concat-stream@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "concat-stream@npm:2.0.0"
-  dependencies:
-    buffer-from: ^1.0.0
-    inherits: ^2.0.3
-    readable-stream: ^3.0.2
-    typedarray: ^0.0.6
-  checksum: 29565dd9198fe1d8cf57f6cc71527dbc6ad67e12e4ac9401feb389c53042b2dceedf47034cbe702dfc4fd8df3ae7e6bfeeebe732cc4fa2674e484c13f04c219a
-  languageName: node
-  linkType: hard
-
 "concurrently@npm:^3.6.1":
   version: 3.6.1
   resolution: "concurrently@npm:3.6.1"
@@ -14244,16 +13144,6 @@ __metadata:
   bin:
     concurrently: ./bin/concurrently.js
   checksum: 639066704d197a919929522abf4372fb8a31bccfa5a8174231c9306b27f430c9994ad5022b26c2deeddd2630ed9e7593f374bb14f0a77e11b10bc7d7a0ab2d4e
-  languageName: node
-  linkType: hard
-
-"config-chain@npm:^1.1.12":
-  version: 1.1.12
-  resolution: "config-chain@npm:1.1.12"
-  dependencies:
-    ini: ^1.3.4
-    proto-list: ~1.2.1
-  checksum: fd07fb8ca4d06d540ee64824ca4778065eefaaed59e1ad157b6a7d764370581dfb44f2dda7cf65589a9199e27f7afe73c271b2e45abe3d766a915ad926150361
   languageName: node
   linkType: hard
 
@@ -14343,111 +13233,6 @@ __metadata:
   version: 0.3.1
   resolution: "continuable-cache@npm:0.3.1"
   checksum: 389bfe22b6dee87849a0d65d9e474129c8a59b2fe5d31335d357163b47e0af000f557fd86c37ee1704f43ed54526e8582da3ced00a69c643b9400bad352de3fc
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-angular@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "conventional-changelog-angular@npm:5.0.12"
-  dependencies:
-    compare-func: ^2.0.0
-    q: ^1.5.1
-  checksum: fc0d5ba4478cd0058778000f0939a5c8f7da1c469f4d4d8ee36519cac8f41a85299ef6ea8733cc232f4ad0904a0f7c392073ade3a9b700c18ef6237c9ba69c03
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-core@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "conventional-changelog-core@npm:4.2.2"
-  dependencies:
-    add-stream: ^1.0.0
-    conventional-changelog-writer: ^4.0.18
-    conventional-commits-parser: ^3.2.0
-    dateformat: ^3.0.0
-    get-pkg-repo: ^1.0.0
-    git-raw-commits: ^2.0.8
-    git-remote-origin-url: ^2.0.0
-    git-semver-tags: ^4.1.1
-    lodash: ^4.17.15
-    normalize-package-data: ^3.0.0
-    q: ^1.5.1
-    read-pkg: ^3.0.0
-    read-pkg-up: ^3.0.0
-    shelljs: ^0.8.3
-    through2: ^4.0.0
-  checksum: b9a6f1bca491fe63f70428860a2617c56b80d38a0c4c7f1b67adca4b686d5edd79b8755cf9933107c5991310556a51902a0ee2ef9d72ac3fa35c4ada37cb50c2
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-preset-loader@npm:^2.3.4":
-  version: 2.3.4
-  resolution: "conventional-changelog-preset-loader@npm:2.3.4"
-  checksum: a978bcd5fc2eb12b56bc03ec59705af32e521fd27b98a209a26767c2078d423e7d8e30c09d45547371631790f0387453434c73c4541521a7473dce14d5360c7d
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-writer@npm:^4.0.18":
-  version: 4.1.0
-  resolution: "conventional-changelog-writer@npm:4.1.0"
-  dependencies:
-    compare-func: ^2.0.0
-    conventional-commits-filter: ^2.0.7
-    dateformat: ^3.0.0
-    handlebars: ^4.7.6
-    json-stringify-safe: ^5.0.1
-    lodash: ^4.17.15
-    meow: ^8.0.0
-    semver: ^6.0.0
-    split: ^1.0.0
-    through2: ^4.0.0
-  bin:
-    conventional-changelog-writer: cli.js
-  checksum: 6917eef68be4cfd18136a99ad83d7b29b4146d824ef8a74bf5ac3ff05bc4af6d8b4db51dca08beb336b09b9256ac67e7efce0198ecf150ed2d311e91659fe7b1
-  languageName: node
-  linkType: hard
-
-"conventional-commits-filter@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "conventional-commits-filter@npm:2.0.7"
-  dependencies:
-    lodash.ismatch: ^4.4.0
-    modify-values: ^1.0.0
-  checksum: df06fb29285b473614f5094e983d26fcc14cd0f64b2cbb2f65493fc8bd47c077c2310791d26f4b2b719e9585aaade95370e73230bff6647163164a18b9dfaa07
-  languageName: node
-  linkType: hard
-
-"conventional-commits-parser@npm:^3.2.0":
-  version: 3.2.1
-  resolution: "conventional-commits-parser@npm:3.2.1"
-  dependencies:
-    JSONStream: ^1.0.4
-    is-text-path: ^1.0.1
-    lodash: ^4.17.15
-    meow: ^8.0.0
-    split2: ^3.0.0
-    through2: ^4.0.0
-    trim-off-newlines: ^1.0.0
-  bin:
-    conventional-commits-parser: cli.js
-  checksum: 281625407a639cacd499591ebd3c3c53b9b367b2d81cfc002b461e22119875bfb4f66df35fc00a876fedbff04dc31856cce3c5dd8caa582c980985fafcb2be20
-  languageName: node
-  linkType: hard
-
-"conventional-recommended-bump@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "conventional-recommended-bump@npm:6.1.0"
-  dependencies:
-    concat-stream: ^2.0.0
-    conventional-changelog-preset-loader: ^2.3.4
-    conventional-commits-filter: ^2.0.7
-    conventional-commits-parser: ^3.2.0
-    git-raw-commits: ^2.0.8
-    git-semver-tags: ^4.1.1
-    meow: ^8.0.0
-    q: ^1.5.1
-  bin:
-    conventional-recommended-bump: cli.js
-  checksum: 649e6230be7e96e057a542a2695710aeaee356297d307691b3398e0f18d596b4a5b3ba56307755e779d8687a13b2466844300c649eb23f44fe5f1db9f923f3f4
   languageName: node
   linkType: hard
 
@@ -15498,13 +14283,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dargs@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "dargs@npm:7.0.0"
-  checksum: ec7f6a8315a8fa2f8b12d39207615bdf62b4d01f631b96fbe536c8ad5469ab9ed710d55811e564d0d5c1d548fc8cb6cc70bf0939f2415790159f5a75e0f96c92
-  languageName: node
-  linkType: hard
-
 "dash-ast@npm:^1.0.0":
   version: 1.0.0
   resolution: "dash-ast@npm:1.0.0"
@@ -15561,13 +14339,6 @@ __metadata:
   version: 0.0.2
   resolution: "date-format@npm:0.0.2"
   checksum: ef6117bd0ca7b646c022909b15396a8492e8e3ef5bfcd560420faac0a0c45292a13a2f541da56f78dd79035ffb04eeb7a219edfbb6c7b98ac3b091666dc69e55
-  languageName: node
-  linkType: hard
-
-"dateformat@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "dateformat@npm:3.0.3"
-  checksum: 2effb8bef52ff912f87a05e4adbeacff46353e91313ad1ea9ed31412db26849f5a0fcc7e3ce36dbfb84fc6c881a986d5694f84838ad0da7000d5150693e78678
   languageName: node
   linkType: hard
 
@@ -15644,13 +14415,6 @@ __metadata:
   dependencies:
     ms: ^2.1.1
   checksum: 37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
-  languageName: node
-  linkType: hard
-
-"debuglog@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "debuglog@npm:1.0.1"
-  checksum: d98ac9abe6a528fcbb4d843b1caf5a9116998c76e1263d8ff4db2c086aa96fa7ea4c752a81050fa2e4304129ef330e6e4dc9dd4d47141afd7db80bf699f08219
   languageName: node
   linkType: hard
 
@@ -15974,13 +14738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "deprecation@npm:2.3.1"
-  checksum: 23d688ba66b74d09b908c40a76179418acbeeb0bfdf218c8075c58ad8d0c315130cb91aa3dffb623aa3a411a3569ce56c6460de6c8d69071c17fe6dd2442f032
-  languageName: node
-  linkType: hard
-
 "deps-sort@npm:^2.0.0":
   version: 2.0.1
   resolution: "deps-sort@npm:2.0.1"
@@ -16034,20 +14791,6 @@ __metadata:
   dependencies:
     repeating: ^2.0.0
   checksum: 066a0d13eadebb1e7d2ba395fdf9f3956f31f8383a6db263320108c283e2230250a102f4871f54926cc8a77c6323ac7103f30550a4ac3d6518aa1b934c041295
-  languageName: node
-  linkType: hard
-
-"detect-indent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "detect-indent@npm:5.0.0"
-  checksum: 58d985dd5b4d5e5aad6fe7d8ecc74538fa92c807c894794b8505569e45651bf01a38755b65d9d3d17e512239a26d3131837cbef43cf4226968d5abf175bbcc9d
-  languageName: node
-  linkType: hard
-
-"detect-indent@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "detect-indent@npm:6.0.0"
-  checksum: 6ca3511e6189d63d22e80ee81d847d81b800dc6a23dd23b10e3d39ca8407b5cf763e8dbef25ac18b3b75dd14c4ab00ad39316656eec5ae3932abf745967d9bf4
   languageName: node
   linkType: hard
 
@@ -16117,16 +14860,6 @@ __metadata:
   version: 0.0.818844
   resolution: "devtools-protocol@npm:0.0.818844"
   checksum: 5426f922699cb456b61ba8a951b753d2e250b1f7b3aed41bcddad40df5b7dda1dcdcf6d0d776314da53ec8fdeb961b31edadf20e3a5cb1bac50b5b9ec8b6cf51
-  languageName: node
-  linkType: hard
-
-"dezalgo@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "dezalgo@npm:1.0.3"
-  dependencies:
-    asap: ^2.0.0
-    wrappy: 1
-  checksum: 6e59d007653be156b2d9da758cc86f5f3efbe7c97a84262ae3562a308145cde11e4152fd3c4b527632cd7c499abd2dabb1cf3d5ef84d8f3e23e9cb149408a45b
   languageName: node
   linkType: hard
 
@@ -16486,21 +15219,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^5.1.0, dot-prop@npm:^5.2.0":
+"dot-prop@npm:^5.2.0":
   version: 5.3.0
   resolution: "dot-prop@npm:5.3.0"
   dependencies:
     is-obj: ^2.0.0
   checksum: 93f0d343ef87fe8869320e62f2459f7e70f49c6098d948cc47e060f4a3f827d0ad61e83cb82f2bd90cd5b9571b8d334289978a43c0f98fea4f0e99ee8faa0599
-  languageName: node
-  linkType: hard
-
-"dot-prop@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "dot-prop@npm:6.0.1"
-  dependencies:
-    is-obj: ^2.0.0
-  checksum: 30e51ec6408978a6951b21e7bc4938aad01a86f2fdf779efe52330205c6bb8a8ea12f35925c2029d6dc9d1df22f916f32f828ce1e9b259b1371c580541c22b5a
   languageName: node
   linkType: hard
 
@@ -16977,7 +15701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:^7.7.2, envinfo@npm:^7.7.3, envinfo@npm:^7.7.4":
+"envinfo@npm:^7.7.2, envinfo@npm:^7.7.3":
   version: 7.7.4
   resolution: "envinfo@npm:7.7.4"
   bin:
@@ -18063,7 +16787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.4":
+"eventemitter3@npm:^4.0.0":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
@@ -19539,7 +18263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1, fs-extra@npm:^9.1.0":
+"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
   dependencies:
@@ -19551,16 +18275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-minipass@npm:^1.2.5":
-  version: 1.2.7
-  resolution: "fs-minipass@npm:1.2.7"
-  dependencies:
-    minipass: ^2.6.0
-  checksum: c8259ce8caab360f16b8c3774fd09dd1d5240d6f3f78fd8efa0a215b5f40edfa90e7b5b5ddc2335a4c50885e29d5983f9fe6ac3ac19320e6917a21dbb9f05c64
-  languageName: node
-  linkType: hard
-
-"fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
+"fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
@@ -19785,32 +18500,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"get-pkg-repo@npm:^1.0.0":
-  version: 1.4.0
-  resolution: "get-pkg-repo@npm:1.4.0"
-  dependencies:
-    hosted-git-info: ^2.1.4
-    meow: ^3.3.0
-    normalize-package-data: ^2.3.0
-    parse-github-repo-url: ^1.3.0
-    through2: ^2.0.0
-  bin:
-    get-pkg-repo: cli.js
-  checksum: b1b6c3a4bdc91033a517e42c18b2da710d0c667e32785b8c7ea3a54cde1a252d72e376f1dc14d00c85952396090bb322d9995162358ed5ddccc088a6d4435292
-  languageName: node
-  linkType: hard
-
 "get-port@npm:^3.1.0":
   version: 3.2.0
   resolution: "get-port@npm:3.2.0"
   checksum: 1b6c3fe89074be3753d9ddf3d67126ea351ab9890537fe53fefebc2912d1d66fdc112451bbc76d33ae5ceb6ca70be2a91017944e3ee8fb0814ac9b295bf2a5b8
-  languageName: node
-  linkType: hard
-
-"get-port@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "get-port@npm:5.1.1"
-  checksum: 2873877a469b24e6d5e0be490724a17edb39fafc795d1d662e7bea951ca649713b4a50117a473f9d162312cb0e946597bd0e049ed2f866e79e576e8e213d3d1c
   languageName: node
   linkType: hard
 
@@ -19928,71 +18621,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"git-raw-commits@npm:^2.0.8":
-  version: 2.0.10
-  resolution: "git-raw-commits@npm:2.0.10"
-  dependencies:
-    dargs: ^7.0.0
-    lodash: ^4.17.15
-    meow: ^8.0.0
-    split2: ^3.0.0
-    through2: ^4.0.0
-  bin:
-    git-raw-commits: cli.js
-  checksum: 52ede7507ef5a1ee78318e3f74f7f254f7a0534a5858da892fae7a9184793b979d0761a55d989b7a1e255e57cf29f39b4dfba2a2027fa561114a43c5599166ad
-  languageName: node
-  linkType: hard
-
-"git-remote-origin-url@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "git-remote-origin-url@npm:2.0.0"
-  dependencies:
-    gitconfiglocal: ^1.0.0
-    pify: ^2.3.0
-  checksum: 3a846ce98ed36b2d0b801e8ec1ab299a236cfc6fa264bfdf9f42301abfdfd8715c946507fd83a10b9db449eb609ac6f8a2a341daf52e3af0000367487f486355
-  languageName: node
-  linkType: hard
-
-"git-semver-tags@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "git-semver-tags@npm:4.1.1"
-  dependencies:
-    meow: ^8.0.0
-    semver: ^6.0.0
-  bin:
-    git-semver-tags: cli.js
-  checksum: cd8c91c666901f8dd6381f4cef2aec32aa3f39e517bd8d8491f9133adf956dde9e0487d510fa0f12042fa474f21a8a88b4aa56db8b473979c7491109c57b7016
-  languageName: node
-  linkType: hard
-
-"git-up@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "git-up@npm:4.0.1"
-  dependencies:
-    is-ssh: ^1.3.0
-    parse-url: ^5.0.0
-  checksum: f3e25537123995d1d0c6ad46e8b14f44b20706b95ca05aa4e877e0cb8a3151dfec41bf4e09c570e12375a199d3abe92c171cc388de645846b8804dc058220939
-  languageName: node
-  linkType: hard
-
-"git-url-parse@npm:^11.4.4":
-  version: 11.4.4
-  resolution: "git-url-parse@npm:11.4.4"
-  dependencies:
-    git-up: ^4.0.0
-  checksum: fa7f4c6f1b8fce043271878c297428897ddee1ddb65fbe0892116dc0f4095c4a2e65b9c8e29d5f2243764cd49585637b80edfa7ed83a7ab11293d28b86eaf04e
-  languageName: node
-  linkType: hard
-
-"gitconfiglocal@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gitconfiglocal@npm:1.0.0"
-  dependencies:
-    ini: ^1.3.2
-  checksum: cfcb16344834113199f209f2758ced778dc30e075ddb49b5dde659b4dd2deadee824db0a1b77e1303cb594d9e8b2240da18c67705f657aa76affb444aa349005
-  languageName: node
-  linkType: hard
-
 "github-from-package@npm:0.0.0":
   version: 0.0.0
   resolution: "github-from-package@npm:0.0.0"
@@ -20029,7 +18657,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.0.0, glob-parent@npm:^5.1.0, glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.0, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.0.0, glob-parent@npm:^5.1.0, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.0, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -20388,7 +19016,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.4, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.4, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.6
   resolution: "graceful-fs@npm:4.2.6"
   checksum: f24a75a9ca057c3d482148242878c7fe9e25ce73a46c7480a58b53f1915c93d9ddf27c2d22d8b99182447e8d7f37ae6b29a74b246bbcc8c0d0b36b0d0648cea5
@@ -20594,24 +19222,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.6":
-  version: 4.7.7
-  resolution: "handlebars@npm:4.7.7"
-  dependencies:
-    minimist: ^1.2.5
-    neo-async: ^2.6.0
-    source-map: ^0.6.1
-    uglify-js: ^3.1.4
-    wordwrap: ^1.0.0
-  dependenciesMeta:
-    uglify-js:
-      optional: true
-  bin:
-    handlebars: bin/handlebars
-  checksum: 4c0913fc0018a2a2e358ee94e4fe83f071762b8bec51a473d187e6642e94e569843adcf550ffe329554c63ad450c062f3a05447bd2e3fff5ebfe698e214225c6
-  languageName: node
-  linkType: hard
-
 "har-schema@npm:^2.0.0":
   version: 2.0.0
   resolution: "har-schema@npm:2.0.0"
@@ -20714,7 +19324,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
+"has-unicode@npm:^2.0.0":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
@@ -21588,15 +20198,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"ignore-walk@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "ignore-walk@npm:3.0.3"
-  dependencies:
-    minimatch: ^3.0.4
-  checksum: 80d8a223fa82609188033581212b0e3906ddb996c35e2a8693a17f2f03f5f2e411bc877db3dca3aaf407b4220fa83cab33f5d5cb91c4a42cda8dc7cf3eb63915
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^4.0.3, ignore@npm:^4.0.6":
   version: 4.0.6
   resolution: "ignore@npm:4.0.6"
@@ -21818,26 +20419,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.2, ini@npm:^1.3.4, ini@npm:^1.3.5, ini@npm:~1.3.0":
+"ini@npm:^1.3.4, ini@npm:^1.3.5, ini@npm:~1.3.0":
   version: 1.3.5
   resolution: "ini@npm:1.3.5"
   checksum: 8ac1bed81d502b6a5ae349a02e052564fa46983e552ee34caca48c23a48d83e89a3b64278204e05003c2762659c81b5f5d351db96815e10e2f2b33a33998c683
-  languageName: node
-  linkType: hard
-
-"init-package-json@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "init-package-json@npm:2.0.2"
-  dependencies:
-    glob: ^7.1.1
-    npm-package-arg: ^8.1.0
-    promzard: ^0.3.0
-    read: ~1.0.1
-    read-package-json: ^3.0.0
-    semver: ^7.3.2
-    validate-npm-package-license: ^3.0.4
-    validate-npm-package-name: ^3.0.0
-  checksum: a60a8520cd0c5bd178d3b741ee17e082a9d88fecfa409ca10c7d71220d1f04b3f53a8f843908dbc5a891d6e9fb81ebd7edd5f3a4d6b9f42c382f52bdd0a73980
   languageName: node
   linkType: hard
 
@@ -21901,7 +20486,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"inquirer@npm:^7.0.0, inquirer@npm:^7.1.0, inquirer@npm:^7.3.3":
+"inquirer@npm:^7.0.0, inquirer@npm:^7.1.0":
   version: 7.3.3
   resolution: "inquirer@npm:7.3.3"
   dependencies:
@@ -21974,7 +20559,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"interpret@npm:1.2.0, interpret@npm:^1.0.0":
+"interpret@npm:1.2.0":
   version: 1.2.0
   resolution: "interpret@npm:1.2.0"
   checksum: 1482626650a5ba3cfdbe42a43c8feb939ef51cfd6b056686e40943ea215ac2055f9ed7c632ed2521180de2c01197d8b8a02961324e21f89339379cd76ec56a51
@@ -22632,7 +21217,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^1.0.0, is-plain-obj@npm:^1.1.0":
+"is-plain-obj@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-plain-obj@npm:1.1.0"
   checksum: daaee1805add26f781b413fdf192fc91d52409583be30ace35c82607d440da63cc4cac0ac55136716688d6c0a2c6ef3edb2254fecbd1fe06056d6bd15975ee8c
@@ -22661,20 +21246,6 @@ fsevents@~2.1.2:
   dependencies:
     isobject: ^3.0.1
   checksum: f050fdd5203d9c81e8c4df1b3ff461c4bc64e8b5ca383bcdde46131361d0a678e80bcf00b5257646f6c636197629644d53bd8e2375aea633de09a82d57e942f4
-  languageName: node
-  linkType: hard
-
-"is-plain-object@npm:^4.0.0":
-  version: 4.1.1
-  resolution: "is-plain-object@npm:4.1.1"
-  checksum: 6a3a4a5a6c74416c46c51692e936fd81a91d28a9b46e791c08627f53b691855fe1be70b869ccd42c3ef404a4defe14c3babf5472c1d41d8150b421759c2ce436
-  languageName: node
-  linkType: hard
-
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: 893e42bad832aae3511c71fd61c0bf61aa3a6d853061c62a307261842727d0d25f761ce9379f7ba7226d6179db2a3157efa918e7fe26360f3bf0842d9f28942c
   languageName: node
   linkType: hard
 
@@ -22753,15 +21324,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"is-ssh@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "is-ssh@npm:1.3.1"
-  dependencies:
-    protocols: ^1.1.0
-  checksum: 761c5acdd8f071f90e6be4ed99f8f010f59009ac6acf2df35f886f717b1315a11fcbc2665ada8938e4688dc9e0c92b59d971c9b380b63d2511c72317fbf43264
-  languageName: node
-  linkType: hard
-
 "is-stream@npm:^1.0.1, is-stream@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-stream@npm:1.1.0"
@@ -22796,15 +21358,6 @@ fsevents@~2.1.2:
   dependencies:
     has-symbols: ^1.0.1
   checksum: 9eebf119a46c7f4e787340d5663f99a5b85afb310891b332dc1c4f4f9be9922a0e5b1483664963fb9ed6cd53481fc15452a1339b8183ee2b9e2646696fdf2d52
-  languageName: node
-  linkType: hard
-
-"is-text-path@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "is-text-path@npm:1.0.1"
-  dependencies:
-    text-extensions: ^1.0.0
-  checksum: 61c8650c29548febb6bf69e9541fc11abbbb087a0568df7bc471ba264e95fb254def4e610631cbab4ddb0a1a07949d06416f4ebeaf37875023fb184cdb87ee84
   languageName: node
   linkType: hard
 
@@ -24616,13 +23169,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"json-parse-even-better-errors@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "json-parse-even-better-errors@npm:2.3.1"
-  checksum: 140932564c8f0b88455432e0f33c4cb4086b8868e37524e07e723f4eaedb9425bdc2bafd71bd1d9765bd15fd1e2d126972bc83990f55c467168c228c24d665f3
-  languageName: node
-  linkType: hard
-
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -24803,7 +23349,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"jsonparse@npm:^1.2.0, jsonparse@npm:^1.3.1":
+"jsonparse@npm:^1.2.0":
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 89bc68080cd0a0e276d4b5ab1b79cacd68f562467008d176dc23e16e97d4efec9e21741d92ba5087a8433526a45a7e6a9d5ef25408696c402ca1cfbc01a90bf0
@@ -25124,34 +23670,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"lerna@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "lerna@npm:4.0.0"
-  dependencies:
-    "@lerna/add": 4.0.0
-    "@lerna/bootstrap": 4.0.0
-    "@lerna/changed": 4.0.0
-    "@lerna/clean": 4.0.0
-    "@lerna/cli": 4.0.0
-    "@lerna/create": 4.0.0
-    "@lerna/diff": 4.0.0
-    "@lerna/exec": 4.0.0
-    "@lerna/import": 4.0.0
-    "@lerna/info": 4.0.0
-    "@lerna/init": 4.0.0
-    "@lerna/link": 4.0.0
-    "@lerna/list": 4.0.0
-    "@lerna/publish": 4.0.0
-    "@lerna/run": 4.0.0
-    "@lerna/version": 4.0.0
-    import-local: ^3.0.2
-    npmlog: ^4.1.2
-  bin:
-    lerna: cli.js
-  checksum: d184d202f83e47338196bee42c712f7367409432749bfa4f152b0edc576b5f844f0df3d08bc3841c8982792772e4061d111e9760aebe741f98ae575382f98cea
-  languageName: node
-  linkType: hard
-
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -25185,31 +23703,6 @@ fsevents@~2.1.2:
     prelude-ls: ^1.2.1
     type-check: ~0.4.0
   checksum: effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
-  languageName: node
-  linkType: hard
-
-"libnpmaccess@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "libnpmaccess@npm:4.0.1"
-  dependencies:
-    aproba: ^2.0.0
-    minipass: ^3.1.1
-    npm-package-arg: ^8.0.0
-    npm-registry-fetch: ^9.0.0
-  checksum: 903870898dc45c4b415dd2c616de9eda65fa1a7518ce54f3ad55af9bce6671c2a53ff441ebcb07dae7efd7f2634d0dcc38cb69aaf7f90e5a7740f1770926603c
-  languageName: node
-  linkType: hard
-
-"libnpmpublish@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "libnpmpublish@npm:4.0.0"
-  dependencies:
-    normalize-package-data: ^3.0.0
-    npm-package-arg: ^8.1.0
-    npm-registry-fetch: ^9.0.0
-    semver: ^7.1.3
-    ssri: ^8.0.0
-  checksum: 78a07d3781aeb84e9dfbcf5e6aa92fc5e25daa06adf1c613efa7fc432663c461cb1e71abf77a125fb85ab81c21c65f05599e189366ec4c5eba400f2bea92cc82
   languageName: node
   linkType: hard
 
@@ -25308,18 +23801,6 @@ fsevents@~2.1.2:
     pify: ^3.0.0
     strip-bom: ^3.0.0
   checksum: 6b48f6a0256bdfcc8970be2c57f68f10acb2ee7e63709b386b2febb6ad3c86198f840889cdbe71d28f741cbaa2f23a7771206b138cd1bdd159564511ca37c1d5
-  languageName: node
-  linkType: hard
-
-"load-json-file@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "load-json-file@npm:6.2.0"
-  dependencies:
-    graceful-fs: ^4.1.15
-    parse-json: ^5.0.0
-    strip-bom: ^4.0.0
-    type-fest: ^0.6.0
-  checksum: fcb46ef75bab917f37170ba76781a1690bf67144bb53931cb0ed8e4aa20ca439e9c354fcf3594aed531f47dbeb4a49800acab7fdffd553c402ac40c987706d7b
   languageName: node
   linkType: hard
 
@@ -25594,13 +24075,6 @@ fsevents@~2.1.2:
   version: 3.3.2
   resolution: "lodash.isfinite@npm:3.3.2"
   checksum: 997f5f2e96daf3f9f7e27a46cf5b409097d6426e137357f95b1aa357b3abfdf6c61225d451aab40be58941a87df5d5ca85617e85960f6fe50ee09aba41a974de
-  languageName: node
-  linkType: hard
-
-"lodash.ismatch@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.ismatch@npm:4.4.0"
-  checksum: 8f96a5dc4b8d3fc5a033dcb259d0c3148a1044fa4d02b4a0e8dce0fa1f2ef3ec4ac131e20b5cb2c985a4e9bcb1c37c0aa5af2cef70094959389617347b8fc645
   languageName: node
   linkType: hard
 
@@ -26030,7 +24504,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^8.0.14, make-fetch-happen@npm:^8.0.9":
+"make-fetch-happen@npm:^8.0.14":
   version: 8.0.14
   resolution: "make-fetch-happen@npm:8.0.14"
   dependencies:
@@ -26573,25 +25047,6 @@ fsevents@~2.1.2:
     type-fest: ^0.8.1
     yargs-parser: ^18.1.1
   checksum: d88cb8a34229b30981a720c4b1caaf391888d8df1ee0a02782ff24bee8486c54bc95ce84a815c8d152a96201d2cf9c544da55c3880b7b1efe90df0a5dc1cfc8f
-  languageName: node
-  linkType: hard
-
-"meow@npm:^8.0.0":
-  version: 8.1.2
-  resolution: "meow@npm:8.1.2"
-  dependencies:
-    "@types/minimist": ^1.2.0
-    camelcase-keys: ^6.2.2
-    decamelize-keys: ^1.1.0
-    hard-rejection: ^2.1.0
-    minimist-options: 4.1.0
-    normalize-package-data: ^3.0.0
-    read-pkg-up: ^7.0.1
-    redent: ^3.0.0
-    trim-newlines: ^3.0.0
-    type-fest: ^0.18.0
-    yargs-parser: ^20.2.3
-  checksum: 9a8d90e616f783650728a90f4ea1e5f763c1c5260369e6596b52430f877f4af8ecbaa8c9d952c93bbefd6d5bda4caed6a96a20ba7d27b511d2971909b01922a2
   languageName: node
   linkType: hard
 
@@ -27181,7 +25636,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^1.3.0, minipass-fetch@npm:^1.3.2":
+"minipass-fetch@npm:^1.3.2":
   version: 1.3.3
   resolution: "minipass-fetch@npm:1.3.3"
   dependencies:
@@ -27205,16 +25660,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"minipass-json-stream@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "minipass-json-stream@npm:1.0.1"
-  dependencies:
-    jsonparse: ^1.3.1
-    minipass: ^3.0.0
-  checksum: 9285cbbea801e7bd6a923e7fb66d9c47c8bad880e70b29f0b8ba220c283d065f47bfa887ef87fd1b735d39393ecd53bb13d40c260354e8fcf93d47cf4bf64e9c
-  languageName: node
-  linkType: hard
-
 "minipass-pipeline@npm:^1.2.2, minipass-pipeline@npm:^1.2.4":
   version: 1.2.4
   resolution: "minipass-pipeline@npm:1.2.4"
@@ -27233,31 +25678,12 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"minipass@npm:^2.6.0, minipass@npm:^2.8.6, minipass@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "minipass@npm:2.9.0"
-  dependencies:
-    safe-buffer: ^5.1.2
-    yallist: ^3.0.0
-  checksum: 307d8765ac3db9fcd6b486367e6f6c3e460f3a3e198d95d6c0005a2d95804c40c72959261cdebde3c8237cda0b03d4c01975e4581fe11abcf201f5005caafd2a
-  languageName: node
-  linkType: hard
-
 "minipass@npm:^3.0.0, minipass@npm:^3.1.0, minipass@npm:^3.1.1, minipass@npm:^3.1.3":
   version: 3.1.3
   resolution: "minipass@npm:3.1.3"
   dependencies:
     yallist: ^4.0.0
   checksum: 5dbbf1afd68aa686f0b587f2104c96c22b517da2db35787329ff460128efe583ba363e9cd4572895cdf0f0633fa3ad1b65283a953d889a76f11bdfbb19567bc6
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^1.2.1":
-  version: 1.3.3
-  resolution: "minizlib@npm:1.3.3"
-  dependencies:
-    minipass: ^2.9.0
-  checksum: 79798032bbaa6594fa517e5b7ff9977951984fc9548a421b28d3fb0add8ed7e98a33e41e262af53b944f9d860c1e00fc778b477ef692e7b38b1ba12b390ffb17
   languageName: node
   linkType: hard
 
@@ -27332,17 +25758,6 @@ fsevents@~2.1.2:
   version: 0.5.3
   resolution: "mkdirp-classic@npm:0.5.3"
   checksum: 95371d831d196960ddc3833cc6907e6b8f67ac5501a6582f47dfae5eb0f092e9f8ce88e0d83afcae95d6e2b61a01741ba03714eeafb6f7a6e9dcc158ac85b168
-  languageName: node
-  linkType: hard
-
-"mkdirp-infer-owner@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "mkdirp-infer-owner@npm:2.0.0"
-  dependencies:
-    chownr: ^2.0.0
-    infer-owner: ^1.0.4
-    mkdirp: ^1.0.3
-  checksum: 548356a586b92a16fc90eb62b953e5a23d594b56084ecdf72446f4164bbaa6a3bacd8c140672ad24f10c5f561e16c35ac3d97a5ab422832c5ed5449c72501a03
   languageName: node
   linkType: hard
 
@@ -27449,13 +25864,6 @@ fsevents@~2.1.2:
   version: 2.0.5
   resolution: "mockdate@npm:2.0.5"
   checksum: c90418b86c070b33ddefc757861f12bdd7c4b1e465ef9645a0ef17dd4d426f3b06e4d6d2f4489421907e50b54f5f6193d5891d0098dc10395b6a203615dd6c59
-  languageName: node
-  linkType: hard
-
-"modify-values@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "modify-values@npm:1.0.1"
-  checksum: 6acb1b82aaf7a02f9f7b554b20cbfc159f223a79c66b0a257511c5933d50b85e12ea1220b0a90a2af6f80bc29ff784f929a52a51881867a93ae6a12ce87a729a
   languageName: node
   linkType: hard
 
@@ -27602,19 +26010,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"multimatch@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "multimatch@npm:5.0.0"
-  dependencies:
-    "@types/minimatch": ^3.0.3
-    array-differ: ^3.0.0
-    array-union: ^2.1.0
-    arrify: ^2.0.1
-    minimatch: ^3.0.4
-  checksum: 252ffae6d19491c169c22fc30cf8a99f6031f94a3495f187d3430b06200e9f05a7efae90ab9d834f090834e0d9c979ab55e7ad21f61a37995d807b4b0ccdcbd1
-  languageName: node
-  linkType: hard
-
 "mustache@npm:^2.2.0":
   version: 2.3.2
   resolution: "mustache@npm:2.3.2"
@@ -27640,7 +26035,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:0.0.8, mute-stream@npm:~0.0.4":
+"mute-stream@npm:0.0.8":
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: 18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
@@ -27777,7 +26172,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.5.0, neo-async@npm:^2.6.0, neo-async@npm:^2.6.1, neo-async@npm:^2.6.2":
+"neo-async@npm:^2.5.0, neo-async@npm:^2.6.1, neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
@@ -27938,47 +26333,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^5.0.2":
-  version: 5.1.0
-  resolution: "node-gyp@npm:5.1.0"
-  dependencies:
-    env-paths: ^2.2.0
-    glob: ^7.1.4
-    graceful-fs: ^4.2.2
-    mkdirp: ^0.5.1
-    nopt: ^4.0.1
-    npmlog: ^4.1.2
-    request: ^2.88.0
-    rimraf: ^2.6.3
-    semver: ^5.7.1
-    tar: ^4.4.12
-    which: ^1.3.1
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 6580242608028b9c1328748c793cd521af8e99b2209b912ef7be7bb840e26b84d4d5c68e3cf0a5ba1a5d5d51d2d06b917dd854489b32673aaed0f67585b768c7
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:^7.1.0":
-  version: 7.1.2
-  resolution: "node-gyp@npm:7.1.2"
-  dependencies:
-    env-paths: ^2.2.0
-    glob: ^7.1.4
-    graceful-fs: ^4.2.3
-    nopt: ^5.0.0
-    npmlog: ^4.1.2
-    request: ^2.88.2
-    rimraf: ^3.0.2
-    semver: ^7.3.2
-    tar: ^6.0.2
-    which: ^2.0.2
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 2fe78d02fb152c8f5a59c9b0a558cbc5beb7f574c25646d4cfdbb62eaa36f3b43ebc585d7b53df84ef4eff5c5b4ad0a2b5a37c09816ac11f61a3bdcedd82df04
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:latest":
   version: 8.2.0
   resolution: "node-gyp@npm:8.2.0"
@@ -28119,18 +26473,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"nopt@npm:^4.0.1, nopt@npm:~4.0.1":
-  version: 4.0.3
-  resolution: "nopt@npm:4.0.3"
-  dependencies:
-    abbrev: 1
-    osenv: ^0.1.4
-  bin:
-    nopt: bin/nopt.js
-  checksum: 03e54cdf8c9b46924cfadf333b2b86fc180410d74d51f9c72fec5ef9c6f1a19ec533f647c05e40d49ef7491af59664c5d0baace808d6ccfe3ff064ae630a61b4
-  languageName: node
-  linkType: hard
-
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -28153,7 +26495,19 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.0.0, normalize-package-data@npm:^2.3.0, normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.3.4, normalize-package-data@npm:^2.5.0":
+"nopt@npm:~4.0.1":
+  version: 4.0.3
+  resolution: "nopt@npm:4.0.3"
+  dependencies:
+    abbrev: 1
+    osenv: ^0.1.4
+  bin:
+    nopt: bin/nopt.js
+  checksum: 03e54cdf8c9b46924cfadf333b2b86fc180410d74d51f9c72fec5ef9c6f1a19ec533f647c05e40d49ef7491af59664c5d0baace808d6ccfe3ff064ae630a61b4
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.3.4, normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -28207,7 +26561,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^3.0.0, normalize-url@npm:^3.3.0":
+"normalize-url@npm:^3.0.0":
   version: 3.3.0
   resolution: "normalize-url@npm:3.3.0"
   checksum: 07c2fdcfac898d97eee256d7f62108034224588263fadc45caba0cc402b2bd59b9bd9e66e0c54ac9ee902fcb27af80cacd36375f641409f46749b4eb10f47352
@@ -28228,40 +26582,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"npm-bundled@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "npm-bundled@npm:1.1.1"
-  dependencies:
-    npm-normalize-package-bin: ^1.0.1
-  checksum: 9f1e3f3b786b2a1e765cf8b1b4890c71974c7aa0333729b7d719993a52b7c560ffd00ce5bcfb3f27d5fd40e2efc4111dcafd7e88e58cf932caf931de2a5c60f2
-  languageName: node
-  linkType: hard
-
-"npm-install-checks@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "npm-install-checks@npm:4.0.0"
-  dependencies:
-    semver: ^7.1.1
-  checksum: 86f50aad609bb51833c0a9dcddf25ecc011f9f786f04c1d591e94982a35cf6f5325e3499729e2792a99d1438043405cf350ace8e30665131eae43be566e104ae
-  languageName: node
-  linkType: hard
-
-"npm-lifecycle@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "npm-lifecycle@npm:3.1.5"
-  dependencies:
-    byline: ^5.0.0
-    graceful-fs: ^4.1.15
-    node-gyp: ^5.0.2
-    resolve-from: ^4.0.0
-    slide: ^1.1.6
-    uid-number: 0.0.6
-    umask: ^1.1.0
-    which: ^1.3.1
-  checksum: 73ac1a606298b68994ee45415065f7248358018ff03009a0b43709d9adda126e1bbd1f76e92a39fda14fb20b45cd146f4f67ab9a07dba973cf831f2fea035783
-  languageName: node
-  linkType: hard
-
 "npm-merge-driver@npm:^2.3.5":
   version: 2.3.5
   resolution: "npm-merge-driver@npm:2.3.5"
@@ -28271,24 +26591,6 @@ fsevents@~2.1.2:
   bin:
     npm-merge-driver: index.js
   checksum: 946b298b25ae1d12a4e4aa81e0fbf0647c295a2f66bc2a9900faa65c565b69ba286e1e3d1a65befd7364c44a85d1b9d44a14536616e41a56eed1f08a59a03ea3
-  languageName: node
-  linkType: hard
-
-"npm-normalize-package-bin@npm:^1.0.0, npm-normalize-package-bin@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "npm-normalize-package-bin@npm:1.0.1"
-  checksum: b0c8c05fe419a122e0ff970ccbe7874ae24b4b4b08941a24d18097fe6e1f4b93e3f6abfb5512f9c5488827a5592f2fb3ce2431c41d338802aed24b9a0c160551
-  languageName: node
-  linkType: hard
-
-"npm-package-arg@npm:^8.0.0, npm-package-arg@npm:^8.0.1, npm-package-arg@npm:^8.1.0":
-  version: 8.1.1
-  resolution: "npm-package-arg@npm:8.1.1"
-  dependencies:
-    hosted-git-info: ^3.0.6
-    semver: ^7.0.0
-    validate-npm-package-name: ^3.0.0
-  checksum: 833f1f6b730649a4f19b5a8491f4e640f31940aa907ec86ed58d7b3ebe48bf528ad4d3f6151199944cb5a60c24e810d75e0e0ee3226af80026f91d34619b49f8
   languageName: node
   linkType: hard
 
@@ -28314,47 +26616,6 @@ fsevents@~2.1.2:
   bin:
     npmPkgJsonLint: src/cli.js
   checksum: 7d0a9373905106713cb55c866294445b8e0bad0497b7ebe1f048b8b00ad5c346cc7933ca30536cf3538126787070e45a743153bba28cd9515483bc9216dd4d57
-  languageName: node
-  linkType: hard
-
-"npm-packlist@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "npm-packlist@npm:2.1.4"
-  dependencies:
-    glob: ^7.1.6
-    ignore-walk: ^3.0.3
-    npm-bundled: ^1.1.1
-    npm-normalize-package-bin: ^1.0.1
-  bin:
-    npm-packlist: bin/index.js
-  checksum: e316cc6232d4561f4ccc2a95fb23781f26488e0c2aa4fbe9d079141b2f83a4d23e8afdeaa015b26de3d902c71d217cbd75bc0a3c1fe2a39dfc8aee88d5c51693
-  languageName: node
-  linkType: hard
-
-"npm-pick-manifest@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "npm-pick-manifest@npm:6.1.0"
-  dependencies:
-    npm-install-checks: ^4.0.0
-    npm-package-arg: ^8.0.0
-    semver: ^7.0.0
-  checksum: 641b1b6fca8a0cd9d949fd6434464e68f510d5561b14a48dee169d621ae81c545c01f929e5473ae427a581c73807fbc1ee74a1c19f6910890df254e52d3e18f8
-  languageName: node
-  linkType: hard
-
-"npm-registry-fetch@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "npm-registry-fetch@npm:9.0.0"
-  dependencies:
-    "@npmcli/ci-detect": ^1.0.0
-    lru-cache: ^6.0.0
-    make-fetch-happen: ^8.0.9
-    minipass: ^3.1.3
-    minipass-fetch: ^1.3.0
-    minipass-json-stream: ^1.0.1
-    minizlib: ^2.0.0
-    npm-package-arg: ^8.0.0
-  checksum: f0c00cb98f217f4f2137316bccdeae29b4efbd4842bde9bf6a4912865e14b76dbac43ba1674a83feb095fb3eb13c1702fc256013492856db4a0412c59eb439d2
   languageName: node
   linkType: hard
 
@@ -29077,13 +27338,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"p-map-series@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-map-series@npm:2.1.0"
-  checksum: 302ca686a61c498b227fc45d4e2b2e5bfd20a03f4156a976d94c4ff7decf9cd5a815fa6846b43b37d587ffa8d4671ff2bd596fa83fe8b9113b5102da94940e2a
-  languageName: node
-  linkType: hard
-
 "p-map@npm:^1.1.1":
   version: 1.2.0
   resolution: "p-map@npm:1.2.0"
@@ -29116,30 +27370,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"p-pipe@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "p-pipe@npm:3.1.0"
-  checksum: 9b3076828ea7e9469c0f92c78fa44096726208d547efdb2d6148cbe135d1a70bd449de5be13e234dd669d9515343bd68527b316bf9d5639cee639e2fdde20aaf
-  languageName: node
-  linkType: hard
-
-"p-queue@npm:^6.6.2":
-  version: 6.6.2
-  resolution: "p-queue@npm:6.6.2"
-  dependencies:
-    eventemitter3: ^4.0.4
-    p-timeout: ^3.2.0
-  checksum: 5739ecf5806bbeadf8e463793d5e3004d08bb3f6177bd1a44a005da8fd81bb90f80e4633e1fb6f1dfd35ee663a5c0229abe26aebb36f547ad5a858347c7b0d3e
-  languageName: node
-  linkType: hard
-
-"p-reduce@npm:^2.0.0, p-reduce@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-reduce@npm:2.1.0"
-  checksum: 27b8ff0fb044995507a06cd6357dffba0f2b98862864745972562a21885d7906ce5c794036d2aaa63ef6303158e41e19aed9f19651dfdafb38548ecec7d0de15
-  languageName: node
-  linkType: hard
-
 "p-retry@npm:^3.0.1":
   version: 3.0.1
   resolution: "p-retry@npm:3.0.1"
@@ -29149,7 +27379,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"p-timeout@npm:^3.1.0, p-timeout@npm:^3.2.0":
+"p-timeout@npm:^3.1.0":
   version: 3.2.0
   resolution: "p-timeout@npm:3.2.0"
   dependencies:
@@ -29162,44 +27392,6 @@ fsevents@~2.1.2:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
-  languageName: node
-  linkType: hard
-
-"p-waterfall@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "p-waterfall@npm:2.1.1"
-  dependencies:
-    p-reduce: ^2.0.0
-  checksum: ccae582b75a3597018a375f8eac32b93e8bfb9fc22a8e5037787ef4ebf5958d7465c2d3cbe26443971fbbfda2bcb7b645f694b91f928fc9a71fa5031e6e33f85
-  languageName: node
-  linkType: hard
-
-"pacote@npm:^11.2.6":
-  version: 11.3.0
-  resolution: "pacote@npm:11.3.0"
-  dependencies:
-    "@npmcli/git": ^2.0.1
-    "@npmcli/installed-package-contents": ^1.0.6
-    "@npmcli/promise-spawn": ^1.2.0
-    "@npmcli/run-script": ^1.8.2
-    cacache: ^15.0.5
-    chownr: ^2.0.0
-    fs-minipass: ^2.1.0
-    infer-owner: ^1.0.4
-    minipass: ^3.1.3
-    mkdirp: ^1.0.3
-    npm-package-arg: ^8.0.1
-    npm-packlist: ^2.1.4
-    npm-pick-manifest: ^6.0.0
-    npm-registry-fetch: ^9.0.0
-    promise-retry: ^2.0.1
-    read-package-json-fast: ^2.0.1
-    rimraf: ^3.0.2
-    ssri: ^8.0.1
-    tar: ^6.1.0
-  bin:
-    pacote: lib/bin.js
-  checksum: c74d8783b447165e2aa3f81c85e2dff6dcec56a6f43d83e80b74a212c68d88108330e596ea123876a0e9c9c5d262a5251a0eefbeb3403b2df25bb851ef6e89b1
   languageName: node
   linkType: hard
 
@@ -29374,13 +27566,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"parse-github-repo-url@npm:^1.3.0":
-  version: 1.4.1
-  resolution: "parse-github-repo-url@npm:1.4.1"
-  checksum: 9170f591cd21f0ada9651c7525ed1e3cb8279cd14d2a588582294408c3db0a231ed9b76e8c2a2529ba9a80ab418ee06909c3aa07aa3380f3a09664f06e6f8806
-  languageName: node
-  linkType: hard
-
 "parse-headers@npm:^2.0.0":
   version: 2.0.3
   resolution: "parse-headers@npm:2.0.3"
@@ -29446,28 +27631,6 @@ fsevents@~2.1.2:
   version: 1.0.0
   resolution: "parse-passwd@npm:1.0.0"
   checksum: 1c05c05f95f184ab9ca604841d78e4fe3294d46b8e3641d305dcc28e930da0e14e602dbda9f3811cd48df5b0e2e27dbef7357bf0d7c40e41b18c11c3a8b8d17b
-  languageName: node
-  linkType: hard
-
-"parse-path@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "parse-path@npm:4.0.1"
-  dependencies:
-    is-ssh: ^1.3.0
-    protocols: ^1.4.0
-  checksum: e1fd31bfff434101d5bf3d04698c0fb558053b41cc55e10d40a49c04d617e0823d9d08ec2a7dd0156f126c35bdc3b9af5dc35dc48665c9fced660eee91967518
-  languageName: node
-  linkType: hard
-
-"parse-url@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "parse-url@npm:5.0.1"
-  dependencies:
-    is-ssh: ^1.3.0
-    normalize-url: ^3.3.0
-    parse-path: ^4.0.0
-    protocols: ^1.4.0
-  checksum: 90a7b5a660c224813f8eff9bf27d13317b85b386eaf202445250b9cc79240e89937144f42d5a727af11a916e47477ae40346841459c3a1b1f2deb550cfe528a7
   languageName: node
   linkType: hard
 
@@ -29842,13 +28005,6 @@ fsevents@~2.1.2:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
-  languageName: node
-  linkType: hard
-
-"pify@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "pify@npm:5.0.0"
-  checksum: 9f6f3cd1f159652692f514383efe401a06473af35a699962230ad1c4c9796df5999961461fc1a3b81eed8e3e74adb8bd032474fb3f93eb6bdbd9f33328da1ed2
   languageName: node
   linkType: hard
 
@@ -31429,15 +29585,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"promzard@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "promzard@npm:0.3.0"
-  dependencies:
-    read: 1
-  checksum: 7fd8dbcd9764b35092da65867cc60fdcf2ea85d77e8ed1ae348ec0af1a22616f74053ccf8dad7d8de01e1e3aafe349d77ef56653c2db3791589ac2a8ef485149
-  languageName: node
-  linkType: hard
-
 "prop-types-exact@npm:^1.2.0":
   version: 1.2.0
   resolution: "prop-types-exact@npm:1.2.0"
@@ -31487,13 +29634,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"proto-list@npm:~1.2.1":
-  version: 1.2.4
-  resolution: "proto-list@npm:1.2.4"
-  checksum: b9179f99394ec8a68b8afc817690185f3b03933f7b46ce2e22c1930dc84b60d09f5ad222beab4e59e58c6c039c7f7fcf620397235ef441a356f31f9744010e12
-  languageName: node
-  linkType: hard
-
 "protobufjs@npm:^6.8.0":
   version: 6.9.0
   resolution: "protobufjs@npm:6.9.0"
@@ -31515,13 +29655,6 @@ fsevents@~2.1.2:
     pbjs: bin/pbjs
     pbts: bin/pbts
   checksum: c30077d8cfc12a59ea03ecdd747fad827d58778d5b10e32e1aee2c5ba295768aaa5790746603ba86160634e1774849decdea427b3bbb9f0cec83e8ad75275860
-  languageName: node
-  linkType: hard
-
-"protocols@npm:^1.1.0, protocols@npm:^1.4.0":
-  version: 1.4.7
-  resolution: "protocols@npm:1.4.7"
-  checksum: f2a1e62d6679155d0ceb7b474334510f62501b90187cb90f1ab0dd70fd33a8998bb2c6f7e76e404bb78d5fa9f6d09fbef4890351cceecba875f7beb8766e6fc5
   languageName: node
   linkType: hard
 
@@ -31574,13 +29707,6 @@ fsevents@~2.1.2:
     randombytes: ^2.0.1
     safe-buffer: ^5.1.2
   checksum: 6c2cc19fbb554449e47f2175065d6b32f828f9b3badbee4c76585ac28ae8641aafb9bb107afc430c33c5edd6b05dbe318df4f7d6d7712b1093407b11c4280700
-  languageName: node
-  linkType: hard
-
-"puka@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "puka@npm:1.0.1"
-  checksum: 246f6c840fdb7f037093e8a9068d0baf6f64a14d2246232a30f1b11421349ccf30425ff1bcd74674cf2585c78f4e73495260ebef02c17c1c7f061954a67b9744
   languageName: node
   linkType: hard
 
@@ -31708,7 +29834,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"q@npm:^1.1.2, q@npm:^1.5.1":
+"q@npm:^1.1.2":
   version: 1.5.1
   resolution: "q@npm:1.5.1"
   checksum: 7855fbdba126cb7e92ef3a16b47ba998c0786ec7fface236e3eb0135b65df36429d91a86b1fff3ab0927b4ac4ee88a2c44527c7c3b8e2a37efbec9fe34803df4
@@ -32714,68 +30840,12 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"read-cmd-shim@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "read-cmd-shim@npm:2.0.0"
-  checksum: 482a80d1e7a907e436060b5fce296cc12dd368318a5dcf5efb304911da642a69fb78853a684fb4ebc10e75b0b320d084a4d6c0ce5d5a55442898b8d747b466a7
-  languageName: node
-  linkType: hard
-
 "read-only-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "read-only-stream@npm:2.0.0"
   dependencies:
     readable-stream: ^2.0.2
   checksum: eafd8029bf5a4854fbdee815f6f9d915eb38b590e6daf17ba0fdc3ef929fe8a425b40b67e021a29b4e576519e48aafafbe82e8cd21284a7f18f17f207f2d9581
-  languageName: node
-  linkType: hard
-
-"read-package-json-fast@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "read-package-json-fast@npm:2.0.2"
-  dependencies:
-    json-parse-even-better-errors: ^2.3.0
-    npm-normalize-package-bin: ^1.0.1
-  checksum: 7e2b8b0cd69966c2c378ba50a6afb9f84b1b678e1612a259ebce933c286e965570663ffa3db92ae7676959a31956aaefe09279f0b1282a70e52c5bff68f0baa0
-  languageName: node
-  linkType: hard
-
-"read-package-json@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "read-package-json@npm:2.1.1"
-  dependencies:
-    glob: ^7.1.1
-    graceful-fs: ^4.1.2
-    json-parse-better-errors: ^1.0.1
-    normalize-package-data: ^2.0.0
-    npm-normalize-package-bin: ^1.0.0
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 10b726bf49ab6a8105c78fc1c5b59f675e1cfe606048ff2fe596e60c7f368551cd1ea0e4e71cc95697123cce04c07f9f5b1ebfccc91b83745af9abb5d5113bef
-  languageName: node
-  linkType: hard
-
-"read-package-json@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "read-package-json@npm:3.0.1"
-  dependencies:
-    glob: ^7.1.1
-    json-parse-even-better-errors: ^2.3.0
-    normalize-package-data: ^3.0.0
-    npm-normalize-package-bin: ^1.0.0
-  checksum: 8893852ace05ee7bae8461198762643e6cdf261d5786de592954461f21daec5812c5adc485b8565f0a1f36d90d1fe51fa19616c7dce7893bef78ea66821dab1f
-  languageName: node
-  linkType: hard
-
-"read-package-tree@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "read-package-tree@npm:5.3.1"
-  dependencies:
-    read-package-json: ^2.0.0
-    readdir-scoped-modules: ^1.0.0
-    util-promisify: ^2.1.0
-  checksum: d74a62fef914c408e893b7f8cf28ff81f2d2d175e2d3fba3b832ec1cf8b6d61d31bab15b55092d0acad0132175bdfe84297f1c07d7b90aa618f0ec165d496fdf
   languageName: node
   linkType: hard
 
@@ -32865,15 +30935,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"read@npm:1, read@npm:~1.0.1":
-  version: 1.0.7
-  resolution: "read@npm:1.0.7"
-  dependencies:
-    mute-stream: ~0.0.4
-  checksum: 443533f05d5bb11b36ef1c6d625aae4e2ced8967e93cf546f35aa77b4eb6bd157f4256619e446bae43467f8f6619c7bc5c76983348dffaf36afedf4224f46216
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:1 || 2, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.0.6, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:^2.3.7, readable-stream@npm:~2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
@@ -32889,17 +30950,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "readable-stream@npm:3.6.0"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: 937bedd29ac8a68331666291922bea892fa2be1a33269e582de9f844a2002f146cf831e39cd49fe6a378d3f0c27358f259ed0e20d20f0bdc6a3f8fc21fce42dc
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:>=1.0.33-1 <1.1.0-0, readable-stream@npm:~1.0.31":
   version: 1.0.34
   resolution: "readable-stream@npm:1.0.34"
@@ -32912,15 +30962,14 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"readdir-scoped-modules@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "readdir-scoped-modules@npm:1.1.0"
+"readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "readable-stream@npm:3.6.0"
   dependencies:
-    debuglog: ^1.0.1
-    dezalgo: ^1.0.0
-    graceful-fs: ^4.1.2
-    once: ^1.3.0
-  checksum: 21a53741c488775cbf78b0b51f1b897e9c523b1bcf54567fc2c8ed09b12d9027741f45fcb720f388c0c3088021b54dc3f616c07af1531417678cc7962fc15e5c
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: 937bedd29ac8a68331666291922bea892fa2be1a33269e582de9f844a2002f146cf831e39cd49fe6a378d3f0c27358f259ed0e20d20f0bdc6a3f8fc21fce42dc
   languageName: node
   linkType: hard
 
@@ -35237,7 +33286,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.3, semver@npm:^7.2.1, semver@npm:^7.2.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:^7.0.0, semver@npm:^7.1.3, semver@npm:^7.2.1, semver@npm:^7.2.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -35524,19 +33573,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shelljs@npm:^0.8.3":
-  version: 0.8.4
-  resolution: "shelljs@npm:0.8.4"
-  dependencies:
-    glob: ^7.0.0
-    interpret: ^1.0.0
-    rechoir: ^0.6.2
-  bin:
-    shjs: bin/shjs
-  checksum: 28f0157ac1b60ff786faa96237d9c2bea659bfa3daa5e207960af8dbc93e3a3f81c3bbd39e1d105b5a0182f40b3239c27adc73a9e8a42a08ec78459692d66c16
-  languageName: node
-  linkType: hard
-
 "shellwords@npm:^0.1.1":
   version: 0.1.1
   resolution: "shellwords@npm:0.1.1"
@@ -35731,13 +33767,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"slide@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "slide@npm:1.1.6"
-  checksum: f3bde70fd4c0a2ba6c23c674f010849865ddfacbc0ae3a57522d7ce88e4cc6c186d627943c34004d4f009a3fb477c03307b247ab69a266de4b3c72b271a6a03a
-  languageName: node
-  linkType: hard
-
 "slugify@npm:^1.0.2":
   version: 1.4.0
   resolution: "slugify@npm:1.4.0"
@@ -35916,24 +33945,6 @@ resolve@^2.0.0-next.3:
     ip: ^1.1.5
     smart-buffer: ^4.1.0
   checksum: db7bb7072196b2233a80a706d0cb247341bc592f354073a3224a2d813b5dab0d73d3327247a094ccf61aa77ccf2186bec73d3b71ffb9f672563b726300156d39
-  languageName: node
-  linkType: hard
-
-"sort-keys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "sort-keys@npm:2.0.0"
-  dependencies:
-    is-plain-obj: ^1.0.0
-  checksum: c11a6313995cb67ccf35fed4b1f6734176cc1d1e350ee311c061a2340ada4f7e23b046db064d518b63adba98c0f763739920c59fb4659a0b8482ec7a1f255081
-  languageName: node
-  linkType: hard
-
-"sort-keys@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "sort-keys@npm:4.2.0"
-  dependencies:
-    is-plain-obj: ^2.0.0
-  checksum: a63304c7ba55ad3640198fbbd105a1f5a78c1d2c3eb4a7f27857b0c5aeb22983b2b16297265c3c9624d0b03955993e61b92b4601107c4886adc0875d8322f0dd
   languageName: node
   linkType: hard
 
@@ -36196,24 +34207,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"split2@npm:^3.0.0":
-  version: 3.2.2
-  resolution: "split2@npm:3.2.2"
-  dependencies:
-    readable-stream: ^3.0.0
-  checksum: 2dad5603c52b353939befa3e2f108f6e3aff42b204ad0f5f16dd12fd7c2beab48d117184ce6f7c8854f9ee5ffec6faae70d243711dd7d143a9f635b4a285de4e
-  languageName: node
-  linkType: hard
-
-"split@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "split@npm:1.0.1"
-  dependencies:
-    through: 2
-  checksum: 7f489e7ed5ff8a2e43295f30a5197ffcb2d6202c9cf99357f9690d645b19c812bccf0be3ff336fea5054cda17ac96b91d67147d95dbfc31fbb5804c61962af85
-  languageName: node
-  linkType: hard
-
 "sprintf-js@npm:^1.0.3, sprintf-js@npm:^1.1.1":
   version: 1.1.2
   resolution: "sprintf-js@npm:1.1.2"
@@ -36265,7 +34258,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ssri@npm:^8.0.0, ssri@npm:^8.0.1":
+"ssri@npm:^8.0.0":
   version: 8.0.1
   resolution: "ssri@npm:8.0.1"
   dependencies:
@@ -36766,19 +34759,6 @@ resolve@^2.0.0-next.3:
   version: 3.1.1
   resolution: "striptags@npm:3.1.1"
   checksum: 695a6f885c41bedf41eef39ae30de8b5fe097e06e2874726cd9c05c3a6a15b72bb567e50b8e18b7ce87ef8822f0d5e9fed5f467c344858163682d51451c58835
-  languageName: node
-  linkType: hard
-
-"strong-log-transformer@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "strong-log-transformer@npm:2.1.0"
-  dependencies:
-    duplexer: ^0.1.1
-    minimist: ^1.2.0
-    through: ^2.3.4
-  bin:
-    sl-log-transformer: bin/sl-log-transformer.js
-  checksum: 3c3b8aa8f34d661910563ff996412e2f527fc814e699a376854b554d4a4294ab7e285b4e2c08a080a7b19c5600a9b93a98798d3ac600fe3de545ca6605c07829
   languageName: node
   linkType: hard
 
@@ -37299,22 +35279,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"tar@npm:^4.4.12":
-  version: 4.4.13
-  resolution: "tar@npm:4.4.13"
-  dependencies:
-    chownr: ^1.1.1
-    fs-minipass: ^1.2.5
-    minipass: ^2.8.6
-    minizlib: ^1.2.1
-    mkdirp: ^0.5.0
-    safe-buffer: ^5.1.2
-    yallist: ^3.0.3
-  checksum: 30d053ef489c41e3ef41ec9d26abd403309a50f17d2c916a0432009fd8cbc819a200106f632db1674b230b2b91020befe68c3e19b828f78f10ed826375ac879f
-  languageName: node
-  linkType: hard
-
-"tar@npm:^6.0.2, tar@npm:^6.1.0, tar@npm:^6.1.2":
+"tar@npm:^6.0.2, tar@npm:^6.1.2":
   version: 6.1.10
   resolution: "tar@npm:6.1.10"
   dependencies:
@@ -37351,26 +35316,6 @@ swiper@4.5.1:
     lodash: ^4.17.21
     memoizerific: ^1.11.3
   checksum: 14be7bf39634c253181eceabe10c6fe1768ba2baf7a1aad8b0289b9ca7fff976d4ecd9445628ef1e9faf382e2c46e3a7db7da2e3b0bd8a540917d20ff18cd182
-  languageName: node
-  linkType: hard
-
-"temp-dir@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "temp-dir@npm:1.0.0"
-  checksum: 648669d5e154d1961217784c786acadccf0156519c19e0aceda7edc76f5bdfa32a40dd7f88ebea9238ed6e3dedf08b846161916c8947058c384761351be90a8e
-  languageName: node
-  linkType: hard
-
-"temp-write@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "temp-write@npm:4.0.0"
-  dependencies:
-    graceful-fs: ^4.1.15
-    is-stream: ^2.0.0
-    make-dir: ^3.0.0
-    temp-dir: ^1.0.0
-    uuid: ^3.3.2
-  checksum: 91a6b0dd85a5d606db3e1326b23830c2c14b7a249a26a1e42a023af597edeedef338a3b37a38b6bbd22cceee4fff2108545cfb65fca1ab8289927cf9501d6c9e
   languageName: node
   linkType: hard
 
@@ -37620,13 +35565,6 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"text-extensions@npm:^1.0.0":
-  version: 1.9.0
-  resolution: "text-extensions@npm:1.9.0"
-  checksum: 9ad5a9f723a871e2d884e132d7e93f281c60b5759c95f3f6b04704856548715d93a36c10dbaf5f12b91bf405f0cf3893bf169d4d143c0f5509563b992d385443
-  languageName: node
-  linkType: hard
-
 "text-hex@npm:1.0.x":
   version: 1.0.0
   resolution: "text-hex@npm:1.0.0"
@@ -37743,16 +35681,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"through2@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "through2@npm:4.0.2"
-  dependencies:
-    readable-stream: 3
-  checksum: 3741564ae99990a4a79097fe7a4152c22348adc4faf2df9199a07a66c81ed2011da39f631e479fdc56483996a9d34a037ad64e76d79f18c782ab178ea9b6778c
-  languageName: node
-  linkType: hard
-
-"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3.6":
+"through@npm:>=2.2.7 <3, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
@@ -38130,13 +36059,6 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"trim-off-newlines@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "trim-off-newlines@npm:1.0.1"
-  checksum: d24cee003b4509d743e40ff5de70a9abf7a144d0ea25c68aaefc85e8870ee18b24c459e1429a194a57ea743947da63d840f7ce94969e7ac3de0fa49932f130d6
-  languageName: node
-  linkType: hard
-
 "trim-repeated@npm:^1.0.0":
   version: 1.0.0
   resolution: "trim-repeated@npm:1.0.0"
@@ -38367,13 +36289,6 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "type-fest@npm:0.4.1"
-  checksum: 2e65f43209492638244842f70d86e7325361c92dd1cc8e3bf5728c96b980305087fa5ba60652e9053d56c302ef4f1beb9652a91b72a50da0ea66c6b851f3b9cb
-  languageName: node
-  linkType: hard
-
 "type-fest@npm:^0.6.0":
   version: 0.6.0
   resolution: "type-fest@npm:0.6.0"
@@ -38539,7 +36454,7 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"uglify-js@npm:^3.1.4, uglify-js@npm:^3.6.1":
+"uglify-js@npm:^3.6.1":
   version: 3.9.2
   resolution: "uglify-js@npm:3.9.2"
   dependencies:
@@ -38580,13 +36495,6 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"uid-number@npm:0.0.6":
-  version: 0.0.6
-  resolution: "uid-number@npm:0.0.6"
-  checksum: 0b9922962d24df7a67d05b60e9b8647c217f2bcb8880da24132945715abe4b2b0cf16089f8f11ac4e60d6db0da6ca0af24d3f8bae7df53ca098ac00954841235
-  languageName: node
-  linkType: hard
-
 "ultron@npm:1.0.x":
   version: 1.0.2
   resolution: "ultron@npm:1.0.2"
@@ -38598,13 +36506,6 @@ typescript@^4.4.2:
   version: 1.1.1
   resolution: "ultron@npm:1.1.1"
   checksum: 527d7f687012898e3af8d646936ecba776a7099ef8d3d983f9b3ccd5e84e266af0f714d859be15090b55b93f331bb95e5798bce555d9bb08e2f4bf2faac16517
-  languageName: node
-  linkType: hard
-
-"umask@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "umask@npm:1.1.0"
-  checksum: 22f308853eb94f919c18d5be155ad5182416841e9e95921d8f056d70df023fa02ec861dd23687243eeaf16bb5aea09a4690539fe50ed9562bb818432f554c638
   languageName: node
   linkType: hard
 
@@ -38971,13 +36872,6 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"universal-user-agent@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "universal-user-agent@npm:6.0.0"
-  checksum: ebeb0206963666c13bcf9ebc86d0577c7daed5870c05cd34d4972ee7a43b9ef20679baf2a8c83bf1b71d899bae67243ac4982d84ddaf9ba0355ff76595819961
-  languageName: node
-  linkType: hard
-
 "universalify@npm:^0.1.0, universalify@npm:^0.1.2":
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
@@ -39034,13 +36928,6 @@ typescript@^4.4.2:
   version: 1.2.0
   resolution: "upath@npm:1.2.0"
   checksum: 3746f24099bf69dbf8234cecb671e1016e1f6b26bd306de4ff8966fb0bc463fa1014ffc48646b375de1ab573660e3a0256f6f2a87218b2dfa1779a84ef6992fa
-  languageName: node
-  linkType: hard
-
-"upath@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "upath@npm:2.0.1"
-  checksum: 79e8e1296b00e24a093b077cfd7a238712d09290c850ce59a7a01458ec78c8d26dcc2ab50b1b9d6a84dabf6511fb4969afeb8a5c9a001aa7272b9cc74c34670f
   languageName: node
   linkType: hard
 
@@ -39238,15 +37125,6 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"util-promisify@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "util-promisify@npm:2.1.0"
-  dependencies:
-    object.getownpropertydescriptors: ^2.0.3
-  checksum: 00783d459e83b64943eecccf3dedc9a704b929032d65c4d835acd1f9ba81a2c3da0bda28b03635b6f10406f7a4febbe9a3be305bad67e53c6108fa3e48877e3f
-  languageName: node
-  linkType: hard
-
 "util.promisify@npm:1.0.0":
   version: 1.0.0
   resolution: "util.promisify@npm:1.0.0"
@@ -39417,22 +37295,13 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.4":
+"validate-npm-package-license@npm:^3.0.1":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
     spdx-correct: ^3.0.0
     spdx-expression-parse: ^3.0.0
   checksum: 7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
-  languageName: node
-  linkType: hard
-
-"validate-npm-package-name@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "validate-npm-package-name@npm:3.0.0"
-  dependencies:
-    builtins: ^1.0.3
-  checksum: 064f21f59aefae6cc286dd4a50b15d14adb0227e0facab4316197dfb8d06801669e997af5081966c15f7828a5e6ff1957bd20886aeb6b9d0fa430e4cb5db9c4a
   languageName: node
   linkType: hard
 
@@ -39663,7 +37532,7 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"wcwidth@npm:^1.0.0, wcwidth@npm:^1.0.1":
+"wcwidth@npm:^1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
   dependencies:
@@ -40096,7 +37965,7 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^8.0.0, whatwg-url@npm:^8.4.0, whatwg-url@npm:^8.5.0":
+"whatwg-url@npm:^8.0.0, whatwg-url@npm:^8.5.0":
   version: 8.7.0
   resolution: "whatwg-url@npm:8.7.0"
   dependencies:
@@ -40443,7 +38312,6 @@ typescript@^4.4.2:
     jest-environment-jsdom: ^27.0.6
     jest-enzyme: ^7.1.2
     jest-junit: ^9.0.0
-    lerna: ^4.0.0
     loader-utils: ^1.2.3
     lodash: ^4.17.21
     lunr: ^2.3.8
@@ -40695,7 +38563,7 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^2.3.0, write-file-atomic@npm:^2.4.2":
+"write-file-atomic@npm:^2.3.0":
   version: 2.4.3
   resolution: "write-file-atomic@npm:2.4.3"
   dependencies:
@@ -40715,45 +38583,6 @@ typescript@^4.4.2:
     signal-exit: ^3.0.2
     typedarray-to-buffer: ^3.1.5
   checksum: 7fb67affd811c7a1221bed0c905c26e28f0041e138fb19ccf02db57a0ef93ea69220959af3906b920f9b0411d1914474cdd90b93a96e5cd9e8368d9777caac0e
-  languageName: node
-  linkType: hard
-
-"write-json-file@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "write-json-file@npm:3.2.0"
-  dependencies:
-    detect-indent: ^5.0.0
-    graceful-fs: ^4.1.15
-    make-dir: ^2.1.0
-    pify: ^4.0.1
-    sort-keys: ^2.0.0
-    write-file-atomic: ^2.4.2
-  checksum: 3eadcb6e832ac34dbba37d4eea8871d9fef0e0d77c486b13ed5f81d84a8fcecd9e1a04277e2691eb803c2bed39c2a315e98b96f492c271acee2836acc6276043
-  languageName: node
-  linkType: hard
-
-"write-json-file@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "write-json-file@npm:4.3.0"
-  dependencies:
-    detect-indent: ^6.0.0
-    graceful-fs: ^4.1.15
-    is-plain-obj: ^2.0.0
-    make-dir: ^3.0.0
-    sort-keys: ^4.0.0
-    write-file-atomic: ^3.0.0
-  checksum: 042a93096437fddac5125e66e412bb9e091b9cd5eb8357c8c6bc64e9021af2c4f1ec37915fc29519d71e140baba6890a93fd21019ad4930d4bb6a5aed9129ac7
-  languageName: node
-  linkType: hard
-
-"write-pkg@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "write-pkg@npm:4.0.0"
-  dependencies:
-    sort-keys: ^2.0.0
-    type-fest: ^0.4.1
-    write-json-file: ^3.2.0
-  checksum: 8e20db5fa444dad04e3703c18d8e0f89679caa60accbee5da9ea3aa076430b3f32d99f50d8860d29044245775795455c62d12d16a7856d407e30df7b79f39505
   languageName: node
   linkType: hard
 
@@ -41078,7 +38907,7 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"yallist@npm:^3.0.0, yallist@npm:^3.0.2, yallist@npm:^3.0.3":
+"yallist@npm:^3.0.2":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
   checksum: c66a5c46bc89af1625476f7f0f2ec3653c1a1791d2f9407cfb4c2ba812a1e1c9941416d71ba9719876530e3340a99925f697142989371b72d93b9ee628afd8c1
@@ -41113,13 +38942,6 @@ typescript@^4.4.2:
     camelcase: ^5.0.0
     decamelize: ^1.2.0
   checksum: aeded49d2285c5e284e48b7c69eab4a6cf1c94decfdba073125cc4054ff49da7128a3c7c840edb6b497a075e455be304e89ba4b9228be35f1ed22f4a7bba62cc
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:20.2.4":
-  version: 20.2.4
-  resolution: "yargs-parser@npm:20.2.4"
-  checksum: 08dc341f0b9f940c2fffc1d1decf3be00e28cabd2b578a694901eccc7dcd10577f10c6aa1b040fdd9a68b2042515a60f18476543bccacf9f3ce2c8534cd87435
   languageName: node
   linkType: hard
 
@@ -41346,7 +39168,7 @@ typescript@^4.4.2:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.0.0, yargs@npm:^16.0.3, yargs@npm:^16.1.0, yargs@npm:^16.2.0":
+"yargs@npm:^16.0.0, yargs@npm:^16.0.3, yargs@npm:^16.1.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove lerna dependency
* Document how to publish packages without lerna

Note that we haven't used `lerna` to build packages for a while, the only usage left was in the documentation to release packages (which doesn't seem to work anymore, see p1630964304090300-slack-C02DQP0FP)