### PR TITLE
Converts a few packages to ESM

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -92,7 +92,7 @@
 		"lint:php:fix": "../../vendor/bin/phpcbf --standard=../phpcs.xml ./ "
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
+		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",

--- a/client/components/has-site-purchases-switch/test/index.jsx
+++ b/client/components/has-site-purchases-switch/test/index.jsx
@@ -2,9 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { render as rtlRender, screen } from 'config/testing-library';
 import React from 'react';
 import { reducer as purchases } from 'calypso/state/purchases/reducer';
+import { render as rtlRender, screen } from 'calypso/test-helpers/config/testing-library';
 import HasSitePurchasesSwitch from '../index';
 
 import '@testing-library/jest-dom/extend-expect';

--- a/client/components/screen-options-tab/test/index.js
+++ b/client/components/screen-options-tab/test/index.js
@@ -3,10 +3,10 @@
  */
 
 import { fireEvent, screen } from '@testing-library/react';
-import { render as rtlRender } from 'config/testing-library';
 import React from 'react';
 import jetpack from 'calypso/state/jetpack/reducer';
 import { reducer as ui } from 'calypso/state/ui/reducer';
+import { render as rtlRender } from 'calypso/test-helpers/config/testing-library';
 import ScreenOptionsTab from '../index';
 
 jest.mock( 'react-redux', () => ( {

--- a/client/jetpack-cloud/sections/settings/loading/test/index.jsx
+++ b/client/jetpack-cloud/sections/settings/loading/test/index.jsx
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { render } from 'config/testing-library';
 import React from 'react';
+import { render } from 'calypso/test-helpers/config/testing-library';
 import '@testing-library/jest-dom/extend-expect';
 import AdvancedCredentialsLoadingPlaceholder from '../index';
 

--- a/client/jetpack-cloud/sections/settings/test/empty-content.jsx
+++ b/client/jetpack-cloud/sections/settings/test/empty-content.jsx
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 
-import { render } from 'config/testing-library';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { JETPACK_PRICING_PAGE } from 'calypso/lib/url/support';
+import { render } from 'calypso/test-helpers/config/testing-library';
 import NoSitePurchasesMessage from '../empty-content';
 
 describe( 'NoSitePurchasesMessage', () => {

--- a/client/package.json
+++ b/client/package.json
@@ -12,9 +12,9 @@
 	},
 	"main": "server/index.js",
 	"dependencies": {
-		"@automattic/accessible-focus": "^1.0.0-alpha.0",
-		"@automattic/browser-data-collector": "^0.0.1",
-		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
+		"@automattic/accessible-focus": "^1.0.0",
+		"@automattic/browser-data-collector": "^1.0.0",
+		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0-alpha.0",

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -129,6 +129,7 @@ const webpackConfig = {
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'calypso:src', 'module', 'main' ],
+		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 		alias: {
 			'@automattic/calypso-config': 'calypso/server/config',
 		},

--- a/packages/accessible-focus/CHANGELOG.md
+++ b/packages/accessible-focus/CHANGELOG.md
@@ -1,3 +1,9 @@
+# CHANGELOG
+
+## 1.0.0
+
+- Breaking: Module converted to ESM only. CJS build is not provided anymore.
+
 ## 1.0.0-alpha.0
 
 Extracted from `accessible-focus` and transformed to TypeScript and tests added.

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/accessible-focus",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0",
 	"description": "A package for detecting keyboard navigation.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -32,8 +32,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/browser-data-collector/CHANGELOG.md
+++ b/packages/browser-data-collector/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Breaking: Module converted to ESM only. CJS build is not provided anymore.

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -1,13 +1,18 @@
 {
 	"name": "@automattic/browser-data-collector",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"description": "A tool to collect data from different browser APIs",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
-	"main": "dist/cjs/index.js",
-	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.ts",
+	"type": "module",
+	"exports": {
+		"calypso:src": "./src/index.ts",
+		"import": "./dist/esm/index.js"
+	},
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
@@ -18,8 +23,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/browser-data-collector/tsconfig-cjs.json
+++ b/packages/browser-data-collector/tsconfig-cjs.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig",
-	"compilerOptions": {
-		"module": "commonjs",
-		"outDir": "dist/cjs"
-	}
-}

--- a/packages/calypso-analytics/jest.config.js
+++ b/packages/calypso-analytics/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
 	preset: '../../test/packages/jest-preset.js',
 };

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -1,14 +1,19 @@
 {
 	"name": "@automattic/calypso-analytics",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0",
 	"description": "Automattic Analytics",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
 	"sideEffects": true,
-	"main": "dist/cjs/index.js",
-	"module": "dist/esm/index.js",
-	"calypso:src": "src/index.ts",
+	"type": "module",
+	"exports": {
+		"calypso:src": "./src/index.ts",
+		"import": "./dist/esm/index.js"
+	},
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
@@ -26,8 +31,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/calypso-analytics/tsconfig-cjs.json
+++ b/packages/calypso-analytics/tsconfig-cjs.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig",
-	"compilerOptions": {
-		"module": "commonjs",
-		"outDir": "dist/cjs"
-	}
-}

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -122,6 +122,7 @@ function getWebpackConfig(
 		resolve: {
 			extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 			mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
+			conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 			modules: [ 'node_modules' ],
 		},
 		node: false,

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
+		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
+		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -36,7 +36,7 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
+		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@wordpress/components": "^13.0.3",
 		"@wordpress/react-i18n": "^1.0.3",

--- a/test/module-resolver.js
+++ b/test/module-resolver.js
@@ -1,45 +1,19 @@
+/* eslint-disable import/no-nodejs-modules */
+
+const enhancedResolve = require( 'enhanced-resolve' );
 const { packagesInMonorepo } = require( '../build-tools/lib/monorepo' );
 
 const packages = packagesInMonorepo().map( ( pkg ) => pkg.name );
-/**
- * Implements a custom resolver for Jest.
- *
- * If the package to be resolved is outside `./packages`, the resolver won't change anything (i.e. Jest will read the main file from `pkg.main`).
- * If the package is in `./packages` it will tell Jest to resolve from these fields in this order (if they are present):
- *
- *   1) `calypso:src`: For JavaScript packages this points to the _untranspiled_ source code (usually `./src/index.js`). This allows us to
- *      skip any package transpilation before it can be used by Webpack or Jest, saving some developer time.
- *   2) `module`: This points to the ESM transpilation of the package (usually `./dist/esm`). For TypeScript packages this is populated when
- *      running `yarn prepare`, which happens as a `postinstall` hook.
- *   3) `main`: This is the default, it points to a CJS transpilation (usually `./dist/cjs`). This is _not_ automatically populated and therefore
- *      not safe to use for Jest as it probably points to a file that doesn't exist. This is only populated when the package is packed when it is
- *      about to be published in the NPM repository.
- *
- * Doc: https://jestjs.io/docs/en/configuration#resolver-string
- *
- * How it works:
- *
- * Jest will call this method with the package to be resolved (`request`). We'll call back the default resolver (`options.defaultResolver`)
- * but passing an extra `packageFilter`. The default resolver is an instance of `resolve` (https://www.npmjs.com/package/resolve), which will
- * call `packageFilter` to pre-process `package.json` content before sending it back to Jest. We change `pkg.main` to point to `calypso:src`,
- * `module` or `main`, depending on which one is present.
- *
- * @param {string} request The package being requested
- * @param {*} options Options for the resolver
- */
-module.exports = ( request, options ) => {
-	return options.defaultResolver( request, {
-		...options,
-		packageFilter: ( pkg ) => {
-			//TODO: when Jest moves to resolver v2, this method will receive a second argument that points to the real package file (ie: no symlink)
-			//We can use it to determine if the package file is within the repo
-			if ( packages.includes( pkg.name ) ) {
-				return {
-					...pkg,
-					main: pkg[ 'calypso:src' ] || pkg.module || pkg.main,
-				};
-			}
-			return pkg;
-		},
-	} );
+const resolver = enhancedResolve.create.sync( {
+	extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+	mainFields: [ 'calypso:src', 'module', 'main' ],
+	conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
+} );
+
+module.exports = function ( request, options ) {
+	// Use enhanced-resolve only for packages in the monorepo, where we want to get `calypso:src`
+	if ( packages.includes( request ) ) {
+		return resolver( options.basedir, request );
+	}
+	return options.defaultResolver( request, options );
 };

--- a/test/module-resolver.js
+++ b/test/module-resolver.js
@@ -1,19 +1,24 @@
-/* eslint-disable import/no-nodejs-modules */
-
 const enhancedResolve = require( 'enhanced-resolve' );
-const { packagesInMonorepo } = require( '../build-tools/lib/monorepo' );
 
-const packages = packagesInMonorepo().map( ( pkg ) => pkg.name );
+/**
+ * Implements a custom resolver for Jest.
+ *
+ * We first try these fields in order (or their equivalent conditional export):
+ *
+ *   1) `calypso:src`: This is a sign that the package is in the monorepo. This property points to the _untranspiled_ source code
+ *      (usually `./src/index.js`). This allows us to skip any package transpilation before it can be used by Webpack or Jest,
+ *      saving some developer time.
+ *   3) `main`: This is the default, it points to a CJS module. If the package is in the monorepo this points to a file that usually
+ *      _does not_ exists, but it doesn't matter because all packages in the monorepo have `calypso:src`
+ *
+ * Once Jest supports ESM natively we can look for ESM packages (either using conditional export `import`, or the property `module` )
+ */
 const resolver = enhancedResolve.create.sync( {
 	extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
-	mainFields: [ 'calypso:src', 'module', 'main' ],
-	conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
+	mainFields: [ 'calypso:src', 'main' ],
+	conditionNames: [ 'calypso:src', 'node', 'require' ],
 } );
 
 module.exports = function ( request, options ) {
-	// Use enhanced-resolve only for packages in the monorepo, where we want to get `calypso:src`
-	if ( packages.includes( request ) ) {
-		return resolver( options.basedir, request );
-	}
-	return options.defaultResolver( request, options );
+	return resolver( options.basedir, request ).replace( /\0#/g, '#' );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/accessible-focus@^1.0.0-alpha.0, @automattic/accessible-focus@workspace:packages/accessible-focus":
+"@automattic/accessible-focus@^1.0.0, @automattic/accessible-focus@workspace:packages/accessible-focus":
   version: 0.0.0-use.local
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
   dependencies:
@@ -44,7 +44,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/browser-data-collector@^0.0.1, @automattic/browser-data-collector@workspace:packages/browser-data-collector":
+"@automattic/browser-data-collector@^1.0.0, @automattic/browser-data-collector@workspace:packages/browser-data-collector":
   version: 0.0.0-use.local
   resolution: "@automattic/browser-data-collector@workspace:packages/browser-data-collector"
   dependencies:
@@ -54,7 +54,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-analytics@^1.0.0-alpha.1, @automattic/calypso-analytics@workspace:packages/calypso-analytics":
+"@automattic/calypso-analytics@^1.0.0, @automattic/calypso-analytics@workspace:packages/calypso-analytics":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-analytics@workspace:packages/calypso-analytics"
   dependencies:
@@ -357,7 +357,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/domain-picker@workspace:packages/domain-picker"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0-alpha.1
+    "@automattic/calypso-analytics": ^1.0.0
     "@automattic/data-stores": ^2.0.0
     "@automattic/i18n-utils": ^1.0.0
     "@automattic/onboarding": ^1.0.0
@@ -571,7 +571,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/launch@workspace:packages/launch"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0-alpha.1
+    "@automattic/calypso-analytics": ^1.0.0
     "@automattic/data-stores": ^2.0.0
     "@automattic/domain-picker": ^1.0.0-alpha.0
     "@automattic/i18n-utils": ^1.0.0
@@ -1040,7 +1040,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/whats-new@workspace:packages/whats-new"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0-alpha.1
+    "@automattic/calypso-analytics": ^1.0.0
     "@automattic/i18n-utils": ^1.0.0
     "@wordpress/components": ^13.0.3
     "@wordpress/react-i18n": ^1.0.3
@@ -1149,7 +1149,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-editing-toolkit@workspace:apps/editing-toolkit"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0-alpha.1
+    "@automattic/calypso-analytics": ^1.0.0
     "@automattic/calypso-build": ^9.0.0
     "@automattic/composite-checkout": ^1.0.0
     "@automattic/data-stores": ^2.0.0
@@ -12337,9 +12337,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "calypso@workspace:client"
   dependencies:
-    "@automattic/accessible-focus": ^1.0.0-alpha.0
-    "@automattic/browser-data-collector": ^0.0.1
-    "@automattic/calypso-analytics": ^1.0.0-alpha.1
+    "@automattic/accessible-focus": ^1.0.0
+    "@automattic/browser-data-collector": ^1.0.0
+    "@automattic/calypso-analytics": ^1.0.0
     "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-config": ^1.0.0-alpha.0


### PR DESCRIPTION
#### Background

See #55855

#### Changes proposed in this Pull Request

Converts a few TypeScript packages to ESM:

* @automattic/accessible-focus
* @automattic/browser-data-collector
* @automattic/calypso-analytics

This includes refactoring our custom Jest resolver to use `enhanced-resolve` (Webpack's resolver). Inspired by comments in https://github.com/facebook/jest/issues/9771

#### Testing instructions

* Verify all builds are green