### PR TITLE
Remove Lodash from Layout components (layout + masterbar)

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
-import { startsWith, flowRight as compose, some } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -170,8 +169,8 @@ class Layout extends Component {
 		return (
 			! exemptedSections.includes( this.props.sectionName ) &&
 			! exemptedRoutes.includes( this.props.currentRoute ) &&
-			! some( exemptedRoutesStartingWith, ( startsWithString ) =>
-				this.props.currentRoute?.startsWith( startsWithString )
+			! exemptedRoutesStartingWith.some( ( startsWithString ) =>
+				this.props.currentRoute.startsWith( startsWithString )
 			)
 		);
 	}
@@ -196,8 +195,8 @@ class Layout extends Component {
 		return (
 			! exemptedSections.includes( this.props.sectionName ) &&
 			! exemptedRoutes.includes( this.props.currentRoute ) &&
-			! some( exemptedRoutesStartingWith, ( startsWithString ) =>
-				this.props.currentRoute?.startsWith( startsWithString )
+			! exemptedRoutesStartingWith.some( ( startsWithString ) =>
+				this.props.currentRoute.startsWith( startsWithString )
 			)
 		);
 	}
@@ -356,18 +355,17 @@ class Layout extends Component {
 	}
 }
 
-export default compose(
-	withCurrentRoute,
+export default withCurrentRoute(
 	connect( ( state, { currentSection, currentRoute, currentQuery } ) => {
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
 		const shouldShowAppBanner = getShouldShowAppBanner( getSelectedSite( state ) );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
-		const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
+		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
-			startsWith( currentRoute, '/checkout/jetpack' );
+			currentRoute.startsWith( '/checkout/jetpack' );
 		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
 		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
@@ -423,5 +421,5 @@ export default compose(
 			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 			sidebarIsCollapsed: getSidebarIsCollapsed( state ),
 		};
-	} )
-)( Layout );
+	} )( Layout )
+);

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import classNames from 'classnames';
-import { get, startsWith, flowRight as compose } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -16,7 +15,6 @@ import {
 	getCurrentOAuth2Client,
 	showOAuth2Layout,
 } from 'calypso/state/oauth2-clients/ui/selectors';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
@@ -125,24 +123,21 @@ LayoutLoggedOut.propTypes = {
 	showOAuth2Layout: PropTypes.bool,
 };
 
-export default compose(
-	withCurrentRoute,
-	connect( ( state, { currentSection, currentRoute } ) => {
+export default withCurrentRoute(
+	connect( ( state, { currentSection, currentRoute, currentQuery } ) => {
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const sectionTitle = currentSection?.title ?? '';
-		const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
-		const isWhiteLogin = startsWith( currentRoute, '/log-in/new' );
+		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
+		const isWhiteLogin = currentRoute.startsWith( '/log-in/new' );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const noMasterbarForRoute = isJetpackLogin || isWhiteLogin || isJetpackWooDnaFlow;
-		const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
+		const isPopup = '1' === currentQuery?.is_popup;
 		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
-		const isJetpackWooCommerceFlow =
-			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
-		const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
+		const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
+		const wccomFrom = currentQuery?.[ 'wccom-from' ];
 
 		return {
-			currentRoute,
 			isJetpackLogin,
 			isWhiteLogin,
 			isPopup,
@@ -157,5 +152,5 @@ export default compose(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			useOAuth2Layout: showOAuth2Layout( state ),
 		};
-	} )
-)( LayoutLoggedOut );
+	} )( LayoutLoggedOut )
+);

--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 import React, { Component } from 'react';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import './crowdsignal.scss';
@@ -17,9 +16,9 @@ class CrowdsignalOauthMasterbar extends Component {
 		];
 
 		if ( ! document.fonts.check( '12px Recoleta' ) ) {
-			map( crowdsignalFonts, ( font ) => {
+			for ( const font of crowdsignalFonts ) {
 				font.load().then( ( loadedFont ) => document.fonts.add( loadedFont ) );
-			} );
+			}
 		}
 	}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,18 +1,15 @@
 import config from '@automattic/calypso-config';
 import { getLocaleSlug, localize } from 'i18n-calypso';
-import { get, includes, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import { withCurrentRoute } from 'calypso/components/route';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 import { isDefaultLocale, addLocaleToPath } from 'calypso/lib/i18n-utils';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import Item from './item';
 import Masterbar from './masterbar';
 
@@ -50,13 +47,13 @@ class MasterbarLoggedOut extends React.Component {
 
 		let loginUrl = login( {
 			// We may know the email from Jetpack connection details
-			emailAddress: isJetpack && get( currentQuery, 'user_email', false ),
+			emailAddress: isJetpack && ( currentQuery?.user_email ?? false ),
 			isJetpack,
 			locale: getLocaleSlug(),
 			redirectTo,
 		} );
 
-		if ( currentQuery && currentQuery.partner_id ) {
+		if ( currentQuery?.partner_id ) {
 			loginUrl = addQueryArgs( { partner_id: currentQuery.partner_id }, loginUrl );
 		}
 
@@ -82,7 +79,7 @@ class MasterbarLoggedOut extends React.Component {
 		 * Hide signup from Jetpack connect authorization step. This step handles signup as part of
 		 * the flow.
 		 */
-		if ( startsWith( currentRoute, '/jetpack/connect/authorize' ) ) {
+		if ( currentRoute.startsWith( '/jetpack/connect/authorize' ) ) {
 			return null;
 		}
 
@@ -90,21 +87,21 @@ class MasterbarLoggedOut extends React.Component {
 		 * Hide signup from the screen when we have been sent to the login page from a redirect
 		 * by a service provider to authorize a Domain Connect template application.
 		 */
-		const redirectTo = get( currentQuery, 'redirect_to', '' );
+		const redirectTo = currentQuery?.redirect_to ?? '';
 		if ( isDomainConnectAuthorizePath( redirectTo ) ) {
 			return null;
 		}
 
 		let signupUrl = config( 'signup_url' );
-		const signupFlow = get( currentQuery, 'signup_flow' );
+		const signupFlow = currentQuery?.signup_flow;
 		if (
 			// Match locales like `/log-in/jetpack/es`
-			startsWith( currentRoute, '/log-in/jetpack' )
+			currentRoute.startsWith( '/log-in/jetpack' )
 		) {
 			// Basic validation that we're in a valid Jetpack Authorization flow
 			if (
-				includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' ) &&
-				includes( get( currentQuery, 'redirect_to' ), '_wp_nonce' )
+				currentQuery?.redirect_to?.includes( '/jetpack/connect/authorize' ) &&
+				currentQuery?.redirect_to?.includes( '_wp_nonce' )
 			) {
 				/**
 				 * `log-in/jetpack/:locale` is reached as part of the Jetpack connection flow. In
@@ -164,7 +161,4 @@ class MasterbarLoggedOut extends React.Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	currentQuery: getCurrentQueryArguments( state ),
-	currentRoute: getCurrentRoute( state ),
-} ) )( localize( MasterbarLoggedOut ) );
+export default withCurrentRoute( localize( MasterbarLoggedOut ) );

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useMemo, useState, useRef, useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
@@ -21,10 +20,10 @@ function containsSelectedSidebarItem( children ) {
 			return true;
 		}
 
-		if ( get( child, 'props.selected' ) ) {
+		if ( child?.props?.selected ) {
 			selectedItemFound = true;
 		} else {
-			const descendants = get( child, 'props.children' );
+			const descendants = child?.props?.children;
 
 			if ( descendants ) {
 				selectedItemFound = containsSelectedSidebarItem( descendants );


### PR DESCRIPTION
Removes Lodash from all `client/layout/*` components except Guided Tours.

For getting information about the current route, consistently use the `withCurrentRoute` HOC and the `currentRoute` and `currentQuery` props it injects. Don't read this information from Redux.