### PR TITLE
Clean up InlineHelpContactView and HelpContact

### DIFF
--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -1,45 +1,35 @@
-import React, { Fragment } from 'react';
-import { connect } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import InlineHelpForumView from 'calypso/blocks/inline-help/inline-help-forum-view';
 import PlaceholderLines from 'calypso/blocks/inline-help/placeholder-lines';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import HelpContact from 'calypso/me/help/help-contact';
-import { getHelpSelectedSite } from 'calypso/state/help/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getInlineHelpSupportVariation, {
 	SUPPORT_FORUM,
 } from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 
-const InlineHelpContactView = ( {
-	/* eslint-disable no-shadow */
-	isSupportVariationDetermined = false,
-	/* eslint-enable no-shadow */
-	supportVariation,
-	selectedSite,
-} ) => {
-	if ( ! isSupportVariationDetermined ) {
+function InlineHelpContactViewLoaded() {
+	const dispatch = useDispatch();
+	const supportVariation = useSelector( getInlineHelpSupportVariation );
+
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_inlinehelp_contact_view', {
+				support_variation: supportVariation,
+			} )
+		);
+	}, [ dispatch, supportVariation ] );
+
+	return supportVariation === SUPPORT_FORUM ? <InlineHelpForumView /> : <HelpContact compact />;
+}
+
+export default function InlineHelpContactView() {
+	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
+
+	if ( ! supportVariationDetermined ) {
 		return <PlaceholderLines />;
 	}
 
-	return (
-		<Fragment>
-			<TrackComponentView
-				eventName="calypso_inlinehelp_contact_view"
-				eventProperties={ {
-					support_variation: supportVariation,
-				} }
-			/>
-			{ supportVariation === SUPPORT_FORUM ? (
-				<InlineHelpForumView />
-			) : (
-				<HelpContact compact selectedSite={ selectedSite } />
-			) }
-		</Fragment>
-	);
-};
-
-export default connect( ( state ) => ( {
-	supportVariation: getInlineHelpSupportVariation( state ),
-	isSupportVariationDetermined: isSupportVariationDetermined( state ),
-	selectedSite: getHelpSelectedSite( state ),
-} ) )( InlineHelpContactView );
+	return <InlineHelpContactViewLoaded />;
+}

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import i18n from 'i18n-calypso';
 import React from 'react';
 import { login } from 'calypso/lib/paths';
@@ -54,6 +53,6 @@ export function contact( context, next ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <ContactComponent clientSlug={ config( 'client_slug' ) } />;
+	context.primary = <ContactComponent />;
 	next();
 }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -43,7 +43,7 @@ import {
 	askQuestion as askDirectlyQuestion,
 	initialize as initializeDirectly,
 } from 'calypso/state/help/directly/actions';
-import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
+import { getHelpSelectedSite } from 'calypso/state/help/selectors';
 import {
 	isTicketSupportConfigurationReady,
 	getTicketSupportRequestError,
@@ -204,7 +204,7 @@ class HelpContact extends React.Component {
 				subject,
 				message: kayakoMessage,
 				locale: currentUserLocale,
-				client: this.props.clientSlug,
+				client: config( 'client_slug' ),
 				is_chat_overflow: supportVariation === SUPPORT_CHAT_OVERFLOW,
 			} )
 			.then( () => {
@@ -320,7 +320,7 @@ class HelpContact extends React.Component {
 				subject,
 				message: forumMessage,
 				locale: currentUserLocale,
-				client: this.props.clientSlug,
+				client: config( 'client_slug' ),
 			} )
 			.then( ( data ) => {
 				this.setState( {
@@ -745,8 +745,9 @@ class HelpContact extends React.Component {
 
 export default connect(
 	( state ) => {
-		const helpSelectedSiteId = getHelpSelectedSiteId( state );
+		const selectedSite = getHelpSelectedSite( state );
 		return {
+			selectedSite,
 			currentUserLocale: getCurrentUserLocale( state ),
 			currentUser: getCurrentUser( state ),
 			getUserInfo: getHappychatUserInfo( state ),
@@ -760,7 +761,7 @@ export default connect(
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
-			shouldStartHappychatConnection: ! isRequestingSites( state ) && helpSelectedSiteId,
+			shouldStartHappychatConnection: ! isRequestingSites( state ) && selectedSite,
 			isRequestingSites: isRequestingSites( state ),
 			supportVariation: getInlineHelpSupportVariation( state ),
 			activeSupportTickets: getActiveSupportTickets( state ),


### PR DESCRIPTION
Several cleanups of the `InlineHelpContactView` and `HelpContact` component.

My main motivation was to remove usage of the `<TrackComponentView />` component from `InlineHelpContactView`, as its job can be done by dispatching a `recordTracksEvent` action on component mount (in `useEffect`). This PR does exactly that, plus converting the Redux usage in the component from `connect` to `useDispatch` and `useSelect`.

Then I noticed the `HelpContact` usage in `InlineHelpContactView`. We don't need to pass the `selectedSite` prop to the `HelpContact` component. That component can fetch it from Redux itself. To achieve that, we just need to replace `getHelpSelectedSiteId` selector by `getHelpSelectedSite` in `HelpContact`.

Another prop that `HelpContact` doesn't need is `clientSlug`. It can be retrieved by calling `config( 'client_slug' )` directly inside the component.