### PR TITLE
Remove wpcom.undocumented() methods for /help endpoints

### DIFF
--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -110,20 +110,17 @@ export function initialize() {
 		return directlyPromise;
 	}
 
-	directlyPromise = wpcom
-		.undocumented()
-		.getDirectlyConfiguration()
-		.then( ( { isAvailable } ) => {
-			if ( ! isAvailable ) {
-				return Promise.reject(
-					new Error( 'Directly Real-Time Messaging is not available at this time.' )
-				);
-			}
+	directlyPromise = wpcom.req.get( '/help/directly/mine' ).then( ( { isAvailable } ) => {
+		if ( ! isAvailable ) {
+			return Promise.reject(
+				new Error( 'Directly Real-Time Messaging is not available at this time.' )
+			);
+		}
 
-			configureGlobals();
-			insertDOM();
-			return loadDirectlyScript();
-		} );
+		configureGlobals();
+		insertDOM();
+		return loadDirectlyScript();
+	} );
 
 	return directlyPromise;
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1798,19 +1798,6 @@ Undocumented.prototype.uploadExportFile = function ( siteId, params ) {
 	} );
 };
 
-Undocumented.prototype.getQandA = function ( query, site, fn ) {
-	debug( 'help-contact-qanda/ searchQuery {query}' );
-
-	return this.wpcom.req.get(
-		'/help/qanda',
-		{
-			query,
-			site,
-		},
-		fn
-	);
-};
-
 // TODO: remove this once the auto-renewal toggle has been fully rolled out.
 Undocumented.prototype.cancelPurchase = function ( purchaseId, fn ) {
 	debug( 'upgrades/{purchaseId}/disable-auto-renew' );
@@ -1863,83 +1850,6 @@ Undocumented.prototype.cancelPlanTrial = function ( planId, fn ) {
 	return this.wpcom.req.post(
 		{
 			path: `/upgrades/${ planId }/cancel-plan-trial`,
-		},
-		fn
-	);
-};
-
-/**
- * Get the Directly configuration for the current user
- *
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.getDirectlyConfiguration = function ( fn ) {
-	return this.wpcom.req.get(
-		{
-			apiVersion: '1.1',
-			path: '/help/directly/mine',
-		},
-		fn
-	);
-};
-
-Undocumented.prototype.submitKayakoTicket = function (
-	subject,
-	message,
-	locale,
-	client,
-	isChatOverflow,
-	fn
-) {
-	debug( 'submitKayakoTicket' );
-
-	return this.wpcom.req.post(
-		{
-			path: '/help/tickets/kayako/new',
-			body: { subject, message, locale, client, is_chat_overflow: isChatOverflow },
-		},
-		fn
-	);
-};
-
-Undocumented.prototype.getKayakoConfiguration = function ( fn ) {
-	return this.wpcom.req.get(
-		{
-			path: '/help/tickets/kayako/mine',
-		},
-		fn
-	);
-};
-
-/**
- * Get the olark configuration for the current user
- *
- * @param {object} client - current user
- * @param {Function} fn The callback function
- */
-Undocumented.prototype.getOlarkConfiguration = function ( client, fn ) {
-	return this.wpcom.req.get(
-		{
-			apiVersion: '1.1',
-			path: '/help/olark/mine',
-			body: { client },
-		},
-		fn
-	);
-};
-
-Undocumented.prototype.submitSupportForumsTopic = function (
-	subject,
-	message,
-	locale,
-	client,
-	fn
-) {
-	return this.wpcom.req.post(
-		{
-			path: '/help/forums/support/topics/new',
-			body: { subject, message, locale, client },
 		},
 		fn
 	);

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -20,7 +20,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { resemblesUrl } from 'calypso/lib/url';
-import wpcomLib from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 import HelpResults from 'calypso/me/help/help-results';
 import {
 	bumpStat,
@@ -39,11 +39,6 @@ import { requestSite } from 'calypso/state/sites/actions';
 import { generateSubjectFromMessage } from './utils';
 
 import './style.scss';
-
-/**
- * Module variables
- */
-const wpcom = wpcomLib.undocumented();
 
 const trackSibylClick = ( event, helpLink ) =>
 	composeAnalytics(
@@ -219,8 +214,8 @@ export class HelpContactForm extends React.PureComponent {
 			? config( 'jetpack_support_blog' )
 			: config( 'wpcom_support_blog' );
 
-		wpcom
-			.getQandA( query, site )
+		wpcom.req
+			.get( '/help/qanda', { query, site } )
 			.then( ( qanda ) =>
 				this.setState( {
 					qanda: Array.isArray( qanda ) ? qanda : [],

--- a/client/state/happychat/user/actions.js
+++ b/client/state/happychat/user/actions.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 import {
 	HAPPYCHAT_ELIGIBILITY_SET,
@@ -21,10 +20,8 @@ export const setPresalePrecancellationAvailability = ( availability ) => ( {
 } );
 
 export const requestHappychatEligibility = () => ( dispatch ) => {
-	const clientSlug = config( 'client_slug' );
-	wpcom
-		.undocumented()
-		.getOlarkConfiguration( clientSlug )
+	wpcom.req
+		.get( '/help/olark/mine' )
 		.then( ( configuration ) => {
 			dispatch( setHappyChatEligibility( configuration.isUserEligible ) );
 			dispatch( setPresalePrecancellationAvailability( configuration.availability ) );

--- a/client/state/help/ticket/actions.js
+++ b/client/state/help/ticket/actions.js
@@ -29,9 +29,8 @@ export const ticketSupportConfigurationRequest = () => ( dispatch ) => {
 
 	dispatch( requestAction );
 
-	return wpcom
-		.undocumented()
-		.getKayakoConfiguration()
+	return wpcom.req
+		.get( '/help/tickets/kayako/mine' )
 		.then( ( configuration ) => {
 			dispatch( ticketSupportConfigurationRequestSuccess( configuration ) );
 		} )


### PR DESCRIPTION
Removes `wpcom.undocumented()` methods for all `/help/*` endpoints and replaces them with direct `wpcom.req.{get,post}` calls.