### PR TITLE
Fix typo in `Once the transfer is done you can can point %(domain)s to your WordPress.com site.`

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer.tsx
@@ -48,7 +48,7 @@ const domainTransferThankYouProps = ( {
 					stepKey: 'domain_transfer_whats_next_transfer_info',
 					stepTitle: translate( 'Point the domain to your site' ),
 					stepDescription: translate(
-						'Once the transfer is done you can can point %(domain)s to your WordPress.com site.',
+						'Once the transfer is done you can point %(domain)s to your WordPress.com site.',
 						{
 							args: {
 								domain,


### PR DESCRIPTION
Fixed the typo in the phrase `Once the transfer is done you can can point %(domain)s to your WordPress.com site.`

#### Changes proposed in this Pull Request

* Removed the duplicate `can` in `Once the transfer is done you can can point %(domain)s to your WordPress.com site.`
