### PR TITLE
Notifications: update button styling

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -700,6 +700,16 @@
 		.wpnc__paragraph {
 			word-wrap: break-word;
 			margin-top: $wpnc__padding-large;
+
+			a {
+				text-decoration: underline;
+
+				&.wpnc__button,
+				&.mention {
+					text-decoration: none;
+				}
+			}
+
 			span.list {
 				display: inline-block;
 				margin-left: 2em;
@@ -708,6 +718,7 @@
 					display: block;
 				}
 			}
+
 			.wpnc__gridicon {
 				vertical-align: text-top;
 			}

--- a/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -22,11 +22,12 @@
 		border-width: 1px 1px 2px;
 		color: var( --color-neutral-70 );
 		cursor: pointer;
-		display: inline-block;
-		margin: 0;
+		display: block;
+		margin: 0 24px;
 		outline: 0;
 		overflow: hidden;
 		font-weight: 500;
+		text-align: center;
 		text-overflow: ellipsis;
 		text-decoration: none;
 		vertical-align: top;
@@ -39,6 +40,7 @@
 		appearance: none;
 
 		&:hover {
+			border-color: var( --color-neutral-10 );
 			border-color: var( --color-neutral-20 );
 			color: var( --color-neutral-70 );
 		}
@@ -92,21 +94,26 @@
 
 	// Primary buttons
 	.wpnc__button.is-primary {
-		background: var( --color-primary );
-		border-color: var( --color-primary );
+		background-color: var( --color-accent );
+		border-color: var( --color-accent );
 		color: var( --color-text-inverted );
 
-		&:hover,
-		&:focus {
-			border-color: var( --color-primary-dark );
+		&:active:not( :disabled ),
+		&:hover:not( :disabled ),
+		&:focus:not( :disabled ) {
+			background-color: var( --color-accent-60 );
+			border-color: var( --color-accent-60 );
 			color: var( --color-text-inverted );
 		}
+
 		&[disabled],
-		&:disabled {
-			background: var( --color-primary-5 );
-			border-color: var( --color-primary-20 );
-			color: var( --color-text-inverted );
+		&:disabled,
+		&.disabled {
+			color: var( --color-neutral-20 );
+			background-color: var( --color-surface );
+			border-color: var( --color-neutral-5 );
 		}
+
 		&.is-compact {
 			color: var( --color-text-inverted );
 		}

--- a/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -4,7 +4,7 @@
 
 .wpnc__main {
 	// resets button styles
-	wpnc__button {
+	.wpnc__button {
 		background: transparent;
 		border: none;
 		outline: 0;


### PR DESCRIPTION
This updates the button styling for notifications that add an anchor `type='button'` (i.e. billing-related notifications). It makes `.is-primary` buttons (all added via this method) centered, wider-width, and styled similarly to all other Calypso buttons. It also adds an underline to paragraph links to help with legibility.

Before: (with Nightfall color scheme) | After: (with Nightfall color scheme)
------------ | -------------
![Screen Shot 2021-09-09 at 11 51 43 AM](https://user-images.githubusercontent.com/942359/132721445-131f7ccc-971a-408b-be71-6f544229fed2.png) | ![Screen Shot 2021-09-09 at 11 52 19 AM](https://user-images.githubusercontent.com/942359/132721502-d27669f5-8156-4398-addd-8652f740f2c1.png)

See: 319-gh-Automattic/payments-shilling

**To test:**
- apply D66606-code and send yourself a Renewal Failure email by clicking 'post note to me' from the dev-mc notification previewer (ping me for a link)
- visit calypso.localhost:3000 for your A11n account
- verify that the new notification matches the screenshot above
- view other notifications to make sure that only note paragraph links are underlined