### PR TITLE
Purchases: Remove hasTranslation from translated strings

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
-import i18nCalypso, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
@@ -46,22 +46,14 @@ function BillingHistory(): JSX.Element {
 			<FormattedHeader
 				brandFont
 				headerText={ titles.sectionTitle }
-				subHeaderText={
-					i18nCalypso.hasTranslation(
-						'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
-					)
-						? translate(
-								'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="billing" showIcon={ false } />
-										),
-									},
-								}
-						  )
-						: translate( 'View, print, and email your receipts.' )
-				}
+				subHeaderText={ translate(
+					'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
+						},
+					}
+				) }
 				align="left"
 			/>
 			<QueryBillingTransactions />

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -1,4 +1,4 @@
-import i18nCalypso, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -24,22 +24,16 @@ function PaymentMethods(): JSX.Element {
 			<FormattedHeader
 				brandFont
 				headerText={ titles.sectionTitle }
-				subHeaderText={
-					i18nCalypso.hasTranslation(
-						'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
-					)
-						? translate(
-								'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
-										),
-									},
-								}
-						  )
-						: translate( 'Add or delete payment methods for your account.' )
-				}
+				subHeaderText={ translate(
+					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+							),
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation section="paymentMethods" />

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
-import i18nCalypso, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -72,22 +72,14 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 				brandFont
 				className="billing-history__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={
-					i18nCalypso.hasTranslation(
-						'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
-					)
-						? translate(
-								'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="billing" showIcon={ false } />
-										),
-									},
-								}
-						  )
-						: translate( 'View, print, and email your receipts for this site.' )
-				}
+				subHeaderText={ translate(
+					'View, print, and email your receipts for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="billing" showIcon={ false } />,
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Billing History' } siteSlug={ siteSlug } />

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import i18nCalypso, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -62,22 +62,14 @@ export function Purchases(): JSX.Element {
 				brandFont
 				className="purchases__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={
-					i18nCalypso.hasTranslation(
-						'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
-					)
-						? translate(
-								'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="purchases" showIcon={ false } />
-										),
-									},
-								}
-						  )
-						: translate( 'View, manage, or cancel your plan and other purchases for this site.' )
-				}
+				subHeaderText={ translate(
+					'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Active Upgrades' } siteSlug={ siteSlug } />

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
-import i18nCalypso, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React, { useCallback, useMemo, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -66,22 +66,16 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ): JSX.Elemen
 				brandFont
 				className="payment-methods__page-heading"
 				headerText={ titles.sectionTitle }
-				subHeaderText={
-					i18nCalypso.hasTranslation(
-						'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
-					)
-						? translate(
-								'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
-										),
-									},
-								}
-						  )
-						: translate( 'Add or delete payment methods for your account.' )
-				}
+				subHeaderText={ translate(
+					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink supportContext="payment_methods" showIcon={ false } />
+							),
+						},
+					}
+				) }
 				align="left"
 			/>
 			<PurchasesNavigation sectionTitle={ 'Payment Methods' } siteSlug={ siteSlug } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will remove the hasTranslation functions from **[these files](https://github.com/Automattic/wp-calypso/pull/55876/files).** 

Note
--------------
Currently, we are waiting on Hebrew and Japanese to finish translation before we merge this PR https://translate.wordpress.com/deliverables/overview/6513935/

--------------

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch Calypso to a non-English language
2. Go to http://calypso.localhost:3000/me/purchases 
3. Ensure that the sub-headers listed on the **Purchases**, **Billing**, **Payment methods** tabs are in your selected language
4. Go to http://calypso.localhost:3000/purchases/subscriptions/[YOURSITEDOMAIN]
5. Repeat step 3

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55876
