### PR TITLE
Selenium: fix selector for G Suite upsell, now replaced with TItan Email upsell

### DIFF
--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -8,7 +8,9 @@ const searchInputLocator = By.className( 'search-component__input' );
 export default class FindADomainComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.register-domain-step' ) );
-		this.declineGoogleAppsLinkLocator = By.className( 'gsuite-upsell-card__skip-button' );
+		this.emailUpsellLocator = By.className(
+			'email-providers-comparison__titan-mailbox-action-skip'
+		);
 	}
 
 	async waitForResults() {
@@ -82,20 +84,17 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 		);
 	}
 
-	async declineGoogleApps() {
+	async declineEmailUpsell() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			this.declineGoogleAppsLinkLocator,
+			this.emailUpsellLocator,
 			this.explicitWaitMS
 		);
 		try {
-			await driverHelper.waitUntilElementNotLocated(
-				this.driver,
-				this.declineGoogleAppsLinkLocator
-			);
+			await driverHelper.waitUntilElementNotLocated( this.driver, this.emailUpsellLocator );
 		} catch ( err ) {
 			//Sometimes the first click doesn't work. Clicking again
-			await driverHelper.clickWhenClickable( this.driver, this.declineGoogleAppsLinkLocator );
+			await driverHelper.clickWhenClickable( this.driver, this.emailUpsellLocator );
 		}
 	}
 

--- a/test/e2e/specs/specs-calypso/wp-manage-domains__add-a-domain-spec.js
+++ b/test/e2e/specs/specs-calypso/wp-manage-domains__add-a-domain-spec.js
@@ -57,7 +57,7 @@ describe( `[${ host }] Manage Domains - Add a Domain: (${ screenSize }) @paralle
 	it( 'Select .com search result and decline Google Apps offer', async function () {
 		const findADomainComponent = await FindADomainComponent.Expect( this.driver );
 		await findADomainComponent.selectDomainAddress( rootDomain );
-		await findADomainComponent.declineGoogleApps();
+		await findADomainComponent.declineEmailUpsell();
 	} );
 
 	it( 'Go to checkout page and enter registrar details', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the permafailing calypso e2e spec introduced with #55592.

The upsell screen has been replaced with Titan Email, but the corresponding selectors were not changed leading to the test spec looking for a G Suite upsell selector which no longer exists.

#### Testing instructions

- [ ] Selenium desktop/mobile tests pass.

Related to #
