### PR TITLE
Playwright: Create re-usable block smoke testing structure, and migrate jetpack extended blocks

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/audio-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/audio-block.ts
@@ -11,6 +11,7 @@ const selectors = {
  */
 export class AudioBlock {
 	static blockName = 'Audio';
+	static blockEditorSelector = '[aria-label="Block: Audio"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/click-to-tweet-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/click-to-tweet-block.ts
@@ -11,6 +11,7 @@ const selectors = {
 export class ClicktoTweetBlock {
 	// Static properties.
 	static blockName = 'Click to Tweet';
+	static blockEditorSelector = '[aria-label="Block: Click to Tweet"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/dynamic-hr-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/dynamic-hr-block.ts
@@ -10,6 +10,7 @@ const selectors = {
 export class DynamicHRBlock {
 	// Static properties.
 	static blockName = 'Dynamic HR';
+	static blockEditorSelector = '[aria-label="Block: Dynamic HR"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/file-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/file-block.ts
@@ -11,6 +11,7 @@ const selectors = {
  */
 export class FileBlock {
 	static blockName = 'File';
+	static blockEditorSelector = '[aria-label="Block: File"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/hero-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/hero-block.ts
@@ -11,6 +11,7 @@ const selectors = {
 export class HeroBlock {
 	// Static properties.
 	static blockName = 'Hero';
+	static blockEditorSelector = '[aria-label="Block: Hero"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -17,6 +17,7 @@ const selectors = {
  */
 export class ImageBlock {
 	static blockName = 'Image';
+	static blockEditorSelector = '[aria-label="Block: Image"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/index.ts
@@ -6,3 +6,5 @@ export * from './image-block';
 export * from './audio-block';
 export * from './file-block';
 export * from './logos-block';
+export * from './schemas';
+export * from './jetpack-extended';

--- a/packages/calypso-e2e/src/lib/blocks/jetpack-extended/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/jetpack-extended/index.ts
@@ -1,0 +1,1 @@
+export * from './instagram';

--- a/packages/calypso-e2e/src/lib/blocks/jetpack-extended/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/jetpack-extended/index.ts
@@ -1,1 +1,2 @@
 export * from './instagram';
+export * from './twitter';

--- a/packages/calypso-e2e/src/lib/blocks/jetpack-extended/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/jetpack-extended/instagram.ts
@@ -1,0 +1,49 @@
+import { Page } from 'playwright';
+import { BlockComponent } from '..';
+
+interface ConfigurationData {
+	embedUrl: string;
+	expectedPostText: string;
+}
+
+const blockParentSelector = '[aria-label="Block: Embed"]:has-text("Instagram URL")';
+const selectors = {
+	embedUrlInput: `${ blockParentSelector } input`,
+	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
+	publishedInstagramIframe: `iframe.instagram-media`,
+};
+
+/**
+ *
+ */
+export class InstagramBlock implements BlockComponent {
+	private page: Page;
+	private configurationData: ConfigurationData;
+
+	blockName = 'Instagram';
+
+	/**
+	 * Constructs an instance of this block.
+	 *
+	 * @param {Page} page the Playwright page
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( page: Page, configurationData: ConfigurationData ) {
+		this.page = page;
+		this.configurationData = configurationData;
+	}
+
+	/**
+	 *
+	 */
+	async configure(): Promise< void > {
+		await this.page.fill( selectors.embedUrlInput, this.configurationData.embedUrl );
+	}
+
+	/**
+	 *
+	 */
+	async validateAfterPublish(): Promise< void > {
+		throw new Error( 'Method not implemented.' );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/jetpack-extended/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/jetpack-extended/twitter.ts
@@ -3,21 +3,21 @@ import { BlockFlow, EditorContext, PublishedPostContext } from '..';
 
 interface ConfigurationData {
 	embedUrl: string;
-	expectedPostText: string;
+	expectedTweetText: string;
 }
 
-const blockParentSelector = '[aria-label="Block: Embed"]:has-text("Instagram URL")';
+const blockParentSelector = '[aria-label="Block: Embed"]:has-text("Twitter URL")';
 const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
-	editorInstagramIframe: `iframe[title="Embedded content from instagram.com"]`,
-	publishedInstagramIframe: `iframe.instagram-media`,
+	editorTwitterIframe: `iframe[title="Embedded content from twitter"]`,
+	publishedTwitterIframe: `iframe[title="Twitter Tweet"]`,
 };
 
 /**
- * Class representing the flow of using an Instagram block in the editor
+ * Class representing the flow of using a Twitter block in the editor
  */
-export class InstagramBlockFlow implements BlockFlow {
+export class TwitterBlockFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
 
 	/**
@@ -29,7 +29,7 @@ export class InstagramBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Instagram';
+	blockSidebarName = 'Twitter';
 	blockEditorSelector = blockParentSelector;
 
 	/**
@@ -41,21 +41,21 @@ export class InstagramBlockFlow implements BlockFlow {
 		await context.editorIframe.fill( selectors.embedUrlInput, this.configurationData.embedUrl );
 		await context.editorIframe.click( selectors.embedButton );
 		// We should make sure the actual Iframe loads, because it takes a second.
-		await context.editorIframe.waitForSelector( selectors.editorInstagramIframe );
+		await context.editorIframe.waitForSelector( selectors.editorTwitterIframe );
 	}
 
 	/**
 	 * Validate the block in the published post
 	 *
-	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 * @param context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		const instagramIframeElement = await context.page.waitForSelector(
-			selectors.publishedInstagramIframe
+		const twitterIframeElement = await context.page.waitForSelector(
+			selectors.publishedTwitterIframe
 		);
-		const instagramIframeHandle = ( await instagramIframeElement.contentFrame() ) as Frame;
-		await instagramIframeHandle.waitForSelector(
-			`text=${ this.configurationData.expectedPostText }`
+		const twitterIframeHandle = ( await twitterIframeElement.contentFrame() ) as Frame;
+		await twitterIframeHandle.waitForSelector(
+			`text=${ this.configurationData.expectedTweetText }`
 		);
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/logos-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/logos-block.ts
@@ -14,6 +14,7 @@ const selectors = {
  */
 export class LogosBlock {
 	static blockName = 'Logos';
+	static blockEditorSelector = '[aria-label="Block: Logos"]';
 	block: ElementHandle;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/pricing-table-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/pricing-table-block.ts
@@ -17,6 +17,7 @@ const selectors = {
 export class PricingTableBlock {
 	// Static properties.
 	static blockName = 'Pricing Table';
+	static blockEditorSelector = '[aria-label="Block: Pricing Table"]';
 	static gutterValues = gutterValuesArray;
 	block: ElementHandle;
 

--- a/packages/calypso-e2e/src/lib/blocks/schemas.ts
+++ b/packages/calypso-e2e/src/lib/blocks/schemas.ts
@@ -1,14 +1,27 @@
 import { ElementHandle, Frame, Page } from 'playwright';
 
+/**
+ * An interface for block-based flows to enable iterating the same smoke test cases for a set of blocks.
+ */
 export interface BlockFlow {
 	blockSidebarName: string;
 	blockEditorSelector: string;
-	configure( editorContext: EditorContext ): Promise< void >;
-	validateAfterPublish( page: Page ): Promise< void >;
+	configure( context: EditorContext ): Promise< void >;
+	validateAfterPublish( context: PublishedPostContext ): Promise< void >;
 }
 
+/**
+ * An interface representing all the Playwright & DOM context that might be needed when taking actions on a block in the editor.
+ */
 export interface EditorContext {
 	page: Page;
 	editorIframe: Frame;
 	blockHandle: ElementHandle;
+}
+
+/**
+ * An interface representing all the Playwright & DOM context that might be needed when validataing a block in a published post.
+ */
+export interface PublishedPostContext {
+	page: Page;
 }

--- a/packages/calypso-e2e/src/lib/blocks/schemas.ts
+++ b/packages/calypso-e2e/src/lib/blocks/schemas.ts
@@ -1,5 +1,14 @@
-export interface BlockComponent {
-	blockName: string;
-	configure(): Promise< void >;
-	validateAfterPublish(): Promise< void >;
+import { ElementHandle, Frame, Page } from 'playwright';
+
+export interface BlockFlow {
+	blockSidebarName: string;
+	blockEditorSelector: string;
+	configure( editorContext: EditorContext ): Promise< void >;
+	validateAfterPublish( page: Page ): Promise< void >;
+}
+
+export interface EditorContext {
+	page: Page;
+	editorIframe: Frame;
+	blockHandle: ElementHandle;
 }

--- a/packages/calypso-e2e/src/lib/blocks/schemas.ts
+++ b/packages/calypso-e2e/src/lib/blocks/schemas.ts
@@ -1,0 +1,5 @@
+export interface BlockComponent {
+	blockName: string;
+	configure(): Promise< void >;
+	validateAfterPublish(): Promise< void >;
+}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -187,6 +187,16 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 * Dismisses the Welcome Tour (card) if it is present.
+	 */
+	async dismissWelcomeTourIfPresent(): Promise< void > {
+		const frame = await this.getEditorFrame();
+		if ( await frame.isVisible( selectors.welcomeTourCloseButton ) ) {
+			await frame.click( selectors.welcomeTourCloseButton );
+		}
+	}
+
+	/**
 	 * Adds a Gutenberg block from the block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -187,7 +187,7 @@ export class GutenbergEditorPage {
 	}
 
 	/**
-	 * Given a name, adds the Gutenberg block matching the name.
+	 * Adds a Gutenberg block from the block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it
 	 * appears on the label when visible in the block inserter panel.
@@ -197,8 +197,12 @@ export class GutenbergEditorPage {
 	 * 		- Pay with Paypal
 	 * 		- SyntaxHighlighter Code
 	 *
+	 * The block editor selector should select the top level element of a block in the editor.
+	 * For reference, this element will almost always have the ".wp-block" class.
+	 * We recommend using the aria-label for the selector, e.g. '[aria-label="Block: Quote"]'.
+	 *
 	 * @param {string} blockName Name of the block to be inserted.
-	 * @param blockEditorSelector Selector to find the parent block element (".wp-block") in the editor
+	 * @param {string} blockEditorSelector Selector to find the parent block element in the editor.
 	 */
 	async addBlock( blockName: string, blockEditorSelector: string ): Promise< ElementHandle > {
 		const frame = await this.getEditorFrame();

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -219,7 +219,7 @@ export class GutenbergEditorPage {
 		await frame.fill( selectors.blockSearch, blockName );
 		await frame.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );
 		// Confirm the block has been added to the editor body.
-		return await frame.waitForSelector( `*[aria-label="Block: ${ blockName }"].is-selected` );
+		return await frame.waitForSelector( `.is-selected` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -323,9 +323,9 @@ export class GutenbergEditorPage {
 	}
 
 	/**
-	 * Checks whether the editor has any block warnings/errors displaying
+	 * Checks whether the editor has any block warnings/errors displaying.
 	 *
-	 * @returns True if there are block warnings/errors, false otherwise
+	 * @returns True if there are block warnings/errors, false otherwise.
 	 */
 	async editorHasBlockWarnings(): Promise< boolean > {
 		const frame = await this.getEditorFrame();

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -18,6 +18,7 @@ const selectors = {
 	// Within the editor body.
 	blockAppender: '.block-editor-default-block-appender',
 	paragraphBlocks: 'p.block-editor-rich-text__editable',
+	blockWarning: '.block-editor-warning',
 
 	// Top bar selectors.
 	postToolbar: '.edit-post-header',
@@ -186,16 +187,6 @@ export class GutenbergEditorPage {
 	}
 
 	/**
-	 * Dismisses the Welcome Tour (card) if it is present.
-	 */
-	async dismissWelcomeTourIfPresent(): Promise< void > {
-		const frame = await this.getEditorFrame();
-		if ( await frame.isVisible( selectors.welcomeTourCloseButton ) ) {
-			await frame.click( selectors.welcomeTourCloseButton );
-		}
-	}
-
-	/**
 	 * Given a name, adds the Gutenberg block matching the name.
 	 *
 	 * The name is expected to be formatted in the same manner as it
@@ -207,8 +198,9 @@ export class GutenbergEditorPage {
 	 * 		- SyntaxHighlighter Code
 	 *
 	 * @param {string} blockName Name of the block to be inserted.
+	 * @param blockEditorSelector Selector to find the parent block element (".wp-block") in the editor
 	 */
-	async addBlock( blockName: string ): Promise< ElementHandle > {
+	async addBlock( blockName: string, blockEditorSelector: string ): Promise< ElementHandle > {
 		const frame = await this.getEditorFrame();
 
 		// Click on the editor title. This has the effect of dismissing the block inserter
@@ -219,7 +211,7 @@ export class GutenbergEditorPage {
 		await frame.fill( selectors.blockSearch, blockName );
 		await frame.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );
 		// Confirm the block has been added to the editor body.
-		return await frame.waitForSelector( `.is-selected` );
+		return await frame.waitForSelector( `${ blockEditorSelector }.is-selected` );
 	}
 
 	/**
@@ -314,6 +306,16 @@ export class GutenbergEditorPage {
 	async preview(): Promise< void > {
 		const frame = await this.getEditorFrame();
 		await frame.click( selectors.previewButton );
+	}
+
+	/**
+	 * Checks whether the editor has any block warnings/errors displaying
+	 *
+	 * @returns True if there are block warnings/errors, false otherwise
+	 */
+	async editorHasBlockWarnings(): Promise< boolean > {
+		const frame = await this.getEditorFrame();
+		return await frame.isVisible( selectors.blockWarning );
 	}
 
 	/**

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -35,6 +35,13 @@ module.exports = {
 				'jsdoc/check-tag-names': 'off',
 			},
 		},
+		{
+			files: [ 'specs/specs-playwright/shared-specs/**/*' ],
+			rules: {
+				// This directory is used to create shared specs that can be re-used in multiple places.
+				'jest/no-export': 'off',
+			},
+		},
 	],
 	rules: {
 		'import/no-nodejs-modules': 'off',

--- a/test/e2e/docs/style-guide-playwright.md
+++ b/test/e2e/docs/style-guide-playwright.md
@@ -509,7 +509,7 @@ it( 'Search for ${string}' );
 
 Each test file should only contain at most 1 top-level `describe` block.
 
-There is no restriction on the number `describe` blocks that are not top-level, nor a restriction on the depth of `describe` blocks.
+Additionally, you should avoid going too deep on the layers of nested `describe` blocks beneath that top level, as it can make the overall flow of the spec a bit more confusing to follow.
 
 ---
 

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -16,6 +16,7 @@ Refer to the [Playwright style guide](docs/style-guide-playwright.md) for more i
   - [Setup](#setup)
   - [Test step](#test-step)
   - [Hooks](#hooks)
+  - [Block Smoke Testing](#block-smoke-testing)
 
 <!-- /TOC -->
 
@@ -139,3 +140,90 @@ beforeAll( async () => {
 	logoImage = await MediaHelper.createTestImage();
 } );
 ```
+
+## Block Smoke Testing
+
+### Overview
+
+The in-depth testing for a given Gutenberg block should be written and executed in the source repo for that block (e.g. Jetpack, Gutenberg, Newspack).  
+
+However, it is often valuable to perform a very basic smoke test on blocks to ensure they function as intended in the WPCOM & Calypso environment.
+For consistency and ease of test writing and maintenance, all of this block testing is done in a shared format, where the same basic flow is iterated over all the blocks under test.  
+
+With a few exceptions (like media blocks), block smoke tests should be grouped together according to the _source_ of the block. E.g. all the blocks from Newspack should be in the same spec, all of the core Gutenberg blocks
+should be in the same spec, etc. This allows for granular test execution when those sources are updated and the new versions are included in WPCOM.
+
+### How To
+
+1. Create a new class to represent the block flow in the appropriate subdirectory of [calypso-e2e/src/lib/blocks](../../../packages/calypso-e2e/src/lib/blocks).
+2. That class should implement the interface `BlockFlow` defined [here](../../../packages/calypso-e2e/src/lib/blocks/schemas.ts).
+3. By convention, any test data needed to configure or validate during the block flow should be provided to the class in the constructor.
+    - Also by convention, this is usually done in a single object typed locally with an interface called `ConfigurationData`.
+4. In the spec file, simply instantiate (with the needed test data) all the block flows you want to include in that spec, and pass that array to `createBlockTests` found in [specs/specs-playwright/shared-specs/block-testing.ts](../specs/specs-playwright/shared-specs/block-testing.ts).
+
+### Examples
+<details>
+<summary>Block flow class:</summary>
+
+```typescript
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+
+interface ConfigurationData {
+	neededTestString: string;
+	neededTestNumber: number;
+	// ... type however you want, based on what test data you need!
+}
+
+const selectors = {
+	// add selectors here
+};
+
+export class ExampleBlockFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Example';
+	blockEditorSelector = '[aria-label="Block: Example"]';
+
+	async configure( context: EditorContext ): Promise< void > {
+		// use the editor context (things like the editor iframe and Playwrihgt Page) and the configuration data to configure the block in the editor.
+	}
+
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// use the publsihed post context and the configuration data to do a quick validation of the block content in a published post.
+	}
+}
+```
+</details d>
+
+<details>
+<summary>Spec test file:</summary>
+
+```typescript
+/**
+ * @group gutenberg
+ * @group example-blocks
+ */
+
+import { ExampleABlockFlow, ExampleBBlockFlow, BlockFlow } from '@automattic/calypso-e2e';
+import { createBlockTests } from './shared-specs/block-testing';
+
+const blockFlows: BlockFlow[] = [
+	new ExampleABlockFlow( {
+		neededString: 'a test data string needed by block Example A'
+	} ),
+	new ExampleBBlockFlow( {
+		neededObj: { 
+			// an object of test data needed by block Example B
+		}
+	} ),
+];
+
+createBlockTests( 'Example Blocks', blockFlows );
+
+```
+
+</details>

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -48,9 +48,9 @@ To add your spec file to suites, add a jsdoc block at the top of the file, and u
 ```
 
 The current suites used are...
+
 - `calypso-pr` - tests run pre-merge on every Calypso PR.
 - `gutenberg` - WPCOM focused tests run as part of Gutenberg upgrades.
-
 
 ### 3. Import the basics
 
@@ -145,10 +145,10 @@ beforeAll( async () => {
 
 ### Overview
 
-The in-depth testing for a given Gutenberg block should be written and executed in the source repo for that block (e.g. Jetpack, Gutenberg, Newspack).  
+The in-depth testing for a given Gutenberg block should be written and executed in the source repo for that block (e.g. Jetpack, Gutenberg, Newspack).
 
 However, it is often valuable to perform a very basic smoke test on blocks to ensure they function as intended in the WPCOM & Calypso environment.
-For consistency and ease of test writing and maintenance, all of this block testing is done in a shared format, where the same basic flow is iterated over all the blocks under test.  
+For consistency and ease of test writing and maintenance, all of this block testing is done in a shared format, where the same basic flow is iterated over all the blocks under test.
 
 With a few exceptions (like media blocks), block smoke tests should be grouped together according to the _source_ of the block. E.g. all the blocks from Newspack should be in the same spec, all of the core Gutenberg blocks
 should be in the same spec, etc. This allows for granular test execution when those sources are updated and the new versions are included in WPCOM.
@@ -158,10 +158,11 @@ should be in the same spec, etc. This allows for granular test execution when th
 1. Create a new class to represent the block flow in the appropriate subdirectory of [calypso-e2e/src/lib/blocks](../../../packages/calypso-e2e/src/lib/blocks).
 2. That class should implement the interface `BlockFlow` defined [here](../../../packages/calypso-e2e/src/lib/blocks/schemas.ts).
 3. By convention, any test data needed to configure or validate during the block flow should be provided to the class in the constructor.
-    - Also by convention, this is usually done in a single object typed locally with an interface called `ConfigurationData`.
+   - Also by convention, this is usually done in a single object typed locally with an interface called `ConfigurationData`.
 4. In the spec file, simply instantiate (with the needed test data) all the block flows you want to include in that spec, and pass that array to `createBlockTests` found in [specs/specs-playwright/shared-specs/block-testing.ts](../specs/specs-playwright/shared-specs/block-testing.ts).
 
 ### Examples
+
 <details>
 <summary>Block flow class:</summary>
 

--- a/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
@@ -1,0 +1,73 @@
+/* eslint-disable jest/no-export */
+import {
+	DataHelper,
+	BlockFlow,
+	setupHooks,
+	GutenbergEditorPage,
+	LoginFlow,
+	NewPostFlow,
+	EditorContext,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): void {
+	describe( DataHelper.createSuiteTitle( specName ), function () {
+		let page: Page;
+		let gutenbergEditorPage: GutenbergEditorPage;
+
+		setupHooks( ( args ) => {
+			page = args.page;
+		} );
+
+		it( 'Log in and start a new post', async function () {
+			const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
+			await loginFlow.logIn();
+			const newPostFlow = new NewPostFlow( page );
+			await newPostFlow.newPostFromNavbar();
+			gutenbergEditorPage = new GutenbergEditorPage( page );
+			const title = DataHelper.getRandomPhrase();
+			await gutenbergEditorPage.enterTitle( title );
+			await gutenbergEditorPage.dismissWelcomeTourIfPresent();
+		} );
+
+		describe( 'Add and configure blocks in the editor:', function () {
+			for ( const blockFlow of blockFlows ) {
+				describe( blockFlow.blockSidebarName, function () {
+					let editorContext: EditorContext;
+
+					it( 'Add the block from the sidebar', async function () {
+						const blockHandle = await gutenbergEditorPage.addBlock(
+							blockFlow.blockSidebarName,
+							blockFlow.blockEditorSelector
+						);
+						editorContext = {
+							page: page,
+							editorIframe: await gutenbergEditorPage.getEditorFrame(),
+							blockHandle: blockHandle,
+						};
+					} );
+
+					it( 'Configure the block', async function () {
+						await blockFlow.configure( editorContext );
+					} );
+
+					it( 'There are no block warnings or errors in the editor', async function () {
+						expect( await gutenbergEditorPage.editorHasBlockWarnings() ).toBe( false );
+					} );
+				} );
+			}
+		} );
+
+		it( 'Publish and visit post', async function () {
+			await gutenbergEditorPage.publish( { visit: true } );
+		} );
+
+		describe( 'Blocks have expected output in published post:', function () {
+			for ( const blockFlow of blockFlows ) {
+				it( blockFlow.blockSidebarName, async function () {
+					await blockFlow.validateAfterPublish( page );
+				} );
+			}
+		} );
+	} );
+}

--- a/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
@@ -42,47 +42,45 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 			} );
 		} );
 
-		describe( 'Add and configure blocks in the editor:', function () {
+		describe( 'Add and configure blocks in the editor', function () {
 			for ( const blockFlow of blockFlows ) {
-				describe( blockFlow.blockSidebarName, function () {
-					it( 'Add the block from the sidebar', async function () {
-						const blockHandle = await gutenbergEditorPage.addBlock(
-							blockFlow.blockSidebarName,
-							blockFlow.blockEditorSelector
-						);
-						editorContext = {
-							page: page,
-							editorIframe: await gutenbergEditorPage.getEditorFrame(),
-							blockHandle: blockHandle,
-						};
-					} );
+				it( `${ blockFlow.blockSidebarName }: Add the block from the sidebar`, async function () {
+					const blockHandle = await gutenbergEditorPage.addBlock(
+						blockFlow.blockSidebarName,
+						blockFlow.blockEditorSelector
+					);
+					editorContext = {
+						page: page,
+						editorIframe: await gutenbergEditorPage.getEditorFrame(),
+						blockHandle: blockHandle,
+					};
+				} );
 
-					it( 'Configure the block', async function () {
-						await blockFlow.configure( editorContext );
-					} );
+				it( `${ blockFlow.blockSidebarName }: Configure the block`, async function () {
+					await blockFlow.configure( editorContext );
+				} );
 
-					it( 'There are no block warnings or errors in the editor', async function () {
-						expect( await gutenbergEditorPage.editorHasBlockWarnings() ).toBe( false );
-					} );
+				it( `${ blockFlow.blockSidebarName }: There are no block warnings or errors in the editor`, async function () {
+					expect( await gutenbergEditorPage.editorHasBlockWarnings() ).toBe( false );
 				} );
 			}
 		} );
 
-		describe( 'Publishing and validation', function () {
+		describe( 'Publishing the post', function () {
 			it( 'Publish and visit post', async function () {
 				await gutenbergEditorPage.publish( { visit: true } );
 				publishedPostContext = {
 					page: page,
 				};
 			} );
+		} );
 
-			describe( 'Blocks have expected output in published post:', function () {
-				for ( const blockFlow of blockFlows ) {
-					it( blockFlow.blockSidebarName, async function () {
-						await blockFlow.validateAfterPublish( publishedPostContext );
-					} );
-				}
-			} );
+		describe( 'Validating blocks in published post.', function () {
+			for ( const blockFlow of blockFlows ) {
+				it( `${ blockFlow.blockSidebarName }: Expected content is in published post`, async function () {
+					await blockFlow.validateAfterPublish( publishedPostContext );
+				} );
+			}
 		} );
 	} );
 }

--- a/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export */
 import {
 	DataHelper,
 	BlockFlow,

--- a/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
@@ -7,34 +7,45 @@ import {
 	LoginFlow,
 	NewPostFlow,
 	EditorContext,
+	PublishedPostContext,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
+/**
+ * Creates a suite of block smoke tests for a set of block flows.
+ *
+ * @param specName The parent name of the spec to use in the top-level describe. E.g. "CoBlocks"
+ * @param blockFlows A list of block flows to put under test.
+ */
 export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): void {
 	describe( DataHelper.createSuiteTitle( specName ), function () {
 		let page: Page;
 		let gutenbergEditorPage: GutenbergEditorPage;
+		let editorContext: EditorContext;
+		let publishedPostContext: PublishedPostContext;
 
 		setupHooks( ( args ) => {
 			page = args.page;
 		} );
 
-		it( 'Log in and start a new post', async function () {
-			const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
-			await loginFlow.logIn();
-			const newPostFlow = new NewPostFlow( page );
-			await newPostFlow.newPostFromNavbar();
-			gutenbergEditorPage = new GutenbergEditorPage( page );
-			const title = DataHelper.getRandomPhrase();
-			await gutenbergEditorPage.enterTitle( title );
-			await gutenbergEditorPage.dismissWelcomeTourIfPresent();
+		describe( 'Editor set up', function () {
+			it( 'Log in and start a new post', async function () {
+				const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
+				await loginFlow.logIn();
+
+				const newPostFlow = new NewPostFlow( page );
+				await newPostFlow.newPostFromNavbar();
+
+				gutenbergEditorPage = new GutenbergEditorPage( page );
+				const title = DataHelper.getRandomPhrase();
+				await gutenbergEditorPage.enterTitle( title );
+				await gutenbergEditorPage.dismissWelcomeTourIfPresent();
+			} );
 		} );
 
 		describe( 'Add and configure blocks in the editor:', function () {
 			for ( const blockFlow of blockFlows ) {
 				describe( blockFlow.blockSidebarName, function () {
-					let editorContext: EditorContext;
-
 					it( 'Add the block from the sidebar', async function () {
 						const blockHandle = await gutenbergEditorPage.addBlock(
 							blockFlow.blockSidebarName,
@@ -58,16 +69,21 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 			}
 		} );
 
-		it( 'Publish and visit post', async function () {
-			await gutenbergEditorPage.publish( { visit: true } );
-		} );
+		describe( 'Publishing and validation', function () {
+			it( 'Publish and visit post', async function () {
+				await gutenbergEditorPage.publish( { visit: true } );
+				publishedPostContext = {
+					page: page,
+				};
+			} );
 
-		describe( 'Blocks have expected output in published post:', function () {
-			for ( const blockFlow of blockFlows ) {
-				it( blockFlow.blockSidebarName, async function () {
-					await blockFlow.validateAfterPublish( page );
-				} );
-			}
+			describe( 'Blocks have expected output in published post:', function () {
+				for ( const blockFlow of blockFlows ) {
+					it( blockFlow.blockSidebarName, async function () {
+						await blockFlow.validateAfterPublish( publishedPostContext );
+					} );
+				}
+			} );
 		} );
 	} );
 }

--- a/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/block-testing.ts
@@ -38,7 +38,6 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 				gutenbergEditorPage = new GutenbergEditorPage( page );
 				const title = DataHelper.getRandomPhrase();
 				await gutenbergEditorPage.enterTitle( title );
-				await gutenbergEditorPage.dismissWelcomeTourIfPresent();
 			} );
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks-gutter-spec.ts
@@ -33,7 +33,10 @@ describe( DataHelper.createSuiteTitle( 'WPCOM-specific gutter controls' ), () =>
 	} );
 
 	it( 'Insert Pricing Table block', async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( 'Pricing Table' );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			PricingTableBlock.blockName,
+			PricingTableBlock.blockEditorSelector
+		);
 		pricingTableBlock = new PricingTableBlock( blockHandle );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__coblocks.ts
@@ -55,29 +55,44 @@ describe( DataHelper.createSuiteTitle( 'Blocks: CoBlocks' ), function () {
 	} );
 
 	it( `Insert ${ PricingTableBlock.blockName } block and enter price to left table`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( PricingTableBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			PricingTableBlock.blockName,
+			PricingTableBlock.blockEditorSelector
+		);
 		pricingTableBlock = new PricingTableBlock( blockHandle );
 		await pricingTableBlock.enterPrice( 1, pricingTableBlockPrice );
 	} );
 
 	it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
-		await gutenbergEditorPage.addBlock( DynamicHRBlock.blockName );
+		await gutenbergEditorPage.addBlock(
+			DynamicHRBlock.blockName,
+			DynamicHRBlock.blockEditorSelector
+		);
 	} );
 
 	it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( HeroBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			HeroBlock.blockName,
+			HeroBlock.blockEditorSelector
+		);
 		const heroBlock = new HeroBlock( blockHandle );
 		await heroBlock.enterHeading( heroBlockHeading );
 	} );
 
 	it( `Insert ${ ClicktoTweetBlock.blockName } block and enter tweet content`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( ClicktoTweetBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			ClicktoTweetBlock.blockName,
+			ClicktoTweetBlock.blockEditorSelector
+		);
 		const clickToTweetBlock = new ClicktoTweetBlock( blockHandle );
 		await clickToTweetBlock.enterTweetContent( clicktoTweetBlockTweet );
 	} );
 
 	it( `Insert ${ LogosBlock.blockName } block and set image`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( LogosBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			LogosBlock.blockName,
+			LogosBlock.blockEditorSelector
+		);
 		const logosBlock = new LogosBlock( blockHandle );
 		await logosBlock.upload( logoImage.fullpath );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
@@ -1,0 +1,40 @@
+import {
+	GutenbergEditorPage,
+	DataHelper,
+	LoginFlow,
+	setupHooks,
+	NewPostFlow,
+	InstagramBlock,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'WPCOM-specific gutter controls' ), () => {
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let instagramBlock: InstagramBlock;
+	let page: Page;
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	it( 'Log in', async function () {
+		const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
+		await loginFlow.logIn();
+	} );
+
+	it( 'Start new post', async function () {
+		const newPostFlow = new NewPostFlow( page );
+		await newPostFlow.newPostFromNavbar();
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+	} );
+
+	it( 'Insert Instagram block', async function () {
+		instagramBlock = new InstagramBlock( page, {
+			embedUrl: 'https://www.instagram.com/p/BlDOZMil933/',
+			expectedPostText: 'woocommerce',
+		} );
+
+		await gutenbergEditorPage.addBlock( instagramBlock.blockName );
+		await instagramBlock.configure();
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
@@ -1,10 +1,14 @@
-import { InstagramBlockFlow, BlockFlow } from '@automattic/calypso-e2e';
+import { InstagramBlockFlow, TwitterBlockFlow, BlockFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared-specs/block-testing';
 
 const blockFlows: BlockFlow[] = [
 	new InstagramBlockFlow( {
 		embedUrl: 'https://www.instagram.com/p/BlDOZMil933/',
 		expectedPostText: 'woocommerce',
+	} ),
+	new TwitterBlockFlow( {
+		embedUrl: 'https://twitter.com/automattic/status/1360312228415700993',
+		expectedTweetText: '@automattic',
 	} ),
 ];
 

--- a/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
@@ -1,40 +1,11 @@
-import {
-	GutenbergEditorPage,
-	DataHelper,
-	LoginFlow,
-	setupHooks,
-	NewPostFlow,
-	InstagramBlock,
-} from '@automattic/calypso-e2e';
-import { Page } from 'playwright';
+import { InstagramBlockFlow, BlockFlow } from '@automattic/calypso-e2e';
+import { createBlockTests } from './shared-specs/block-testing';
 
-describe( DataHelper.createSuiteTitle( 'WPCOM-specific gutter controls' ), () => {
-	let gutenbergEditorPage: GutenbergEditorPage;
-	let instagramBlock: InstagramBlock;
-	let page: Page;
+const blockFlows: BlockFlow[] = [
+	new InstagramBlockFlow( {
+		embedUrl: 'https://www.instagram.com/p/BlDOZMil933/',
+		expectedPostText: 'woocommerce',
+	} ),
+];
 
-	setupHooks( ( args ) => {
-		page = args.page;
-	} );
-
-	it( 'Log in', async function () {
-		const loginFlow = new LoginFlow( page, 'gutenbergSimpleSiteUser' );
-		await loginFlow.logIn();
-	} );
-
-	it( 'Start new post', async function () {
-		const newPostFlow = new NewPostFlow( page );
-		await newPostFlow.newPostFromNavbar();
-		gutenbergEditorPage = new GutenbergEditorPage( page );
-	} );
-
-	it( 'Insert Instagram block', async function () {
-		instagramBlock = new InstagramBlock( page, {
-			embedUrl: 'https://www.instagram.com/p/BlDOZMil933/',
-			expectedPostText: 'woocommerce',
-		} );
-
-		await gutenbergEditorPage.addBlock( instagramBlock.blockName );
-		await instagramBlock.configure();
-	} );
-} );
+createBlockTests( 'Core blocks extended by Jetpack', blockFlows );

--- a/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__jetpack-extended.ts
@@ -1,3 +1,7 @@
+/**
+ * @group gutenberg
+ */
+
 import { InstagramBlockFlow, TwitterBlockFlow, BlockFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared-specs/block-testing';
 

--- a/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-blocks__media-spec.ts
@@ -53,25 +53,37 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	} );
 
 	it( `${ ImageBlock.blockName } block: upload image file`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( ImageBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			ImageBlock.blockName,
+			ImageBlock.blockEditorSelector
+		);
 		const imageBlock = new ImageBlock( blockHandle );
 		await imageBlock.upload( testFiles.image.fullpath );
 	} );
 
 	it( `${ ImageBlock.blockName } block: upload image file with reserved URL characters`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( ImageBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			ImageBlock.blockName,
+			ImageBlock.blockEditorSelector
+		);
 		const imageBlock = new ImageBlock( blockHandle );
 		await imageBlock.upload( testFiles.image_reserved_name.fullpath );
 	} );
 
 	it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( AudioBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			AudioBlock.blockName,
+			AudioBlock.blockEditorSelector
+		);
 		const audioBlock = new AudioBlock( blockHandle );
 		await audioBlock.upload( testFiles.audio.fullpath );
 	} );
 
 	it( `${ FileBlock.blockName } block: upload audio file`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock( FileBlock.blockName );
+		const blockHandle = await gutenbergEditorPage.addBlock(
+			FileBlock.blockName,
+			FileBlock.blockEditorSelector
+		);
 		const fileBlock = new FileBlock( blockHandle );
 		await fileBlock.upload( testFiles.audio.fullpath );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For full context on WPCOM E2E Playwright transition, see pciE2j-sq-p2.

This PR migrates block smoke tests for a couple blocks that are in core but extended by Jetpack, specifically Instagram and Twitter.

More importantly, it creates the patterns and re-usable spec-generators for use in all block smoke testing. In the proposed end state of the migration, all block smoke testing repeats the same set of test cases for each block under test.

This is done by creating an interface, `BlockFlow`, that each block under test will implement. That interface include methods for how to configure each block in the editor and validate it in the published post. 

Dependencies are injected into implementations of `BlockFlow` in two different places:
1. "Configuration Data", which is test data that is used to configure and validate a specific implementation of a `BlockFlow`, should be passed to the `constructor`. This kind of data is things like a URL to use in an embed, or a quote to use in a text based block, etc.
2. "Context", which is a set of relevant Playwright and DOM pointers at a given point in a test execution, is passed as an argument to the interface methods of `BlockFlow`. This allows each of those method implementations to have whatever Playwright/DOM context they need to configure or validate a block. This context will be the same for all `BlockFlow` implementations and will be created in the shared spec generating code.

The net result of this design is that if a test writer wants to put some blocks under E2E smoke test, they just need to...
1. Create a class to represent each block's flow that implements the interface `BlockFlow`.
2. Instantiate an array of all the block flows they want to include in a spec, passing the block-unique configuration data to be used in each block.
3. Pass that array of block flow instances to `createBlockTests`.
4. ... And that's it!

#### Testing instructions

- [ ] `yarn jest specs/specs-playwright/wp-blocks__jetpack-extended.ts`

Closes #55957