### PR TITLE
Playwright: Add step to wait for comment to be trashed.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
+++ b/test/e2e/specs/specs-playwright/wp-notifications__trash-spec.js
@@ -72,4 +72,9 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	it( 'Delete comment from notification', async function () {
 		await notificationsComponent.clickNotificationAction( 'Trash' );
 	} );
+
+	it( 'Confirm comment is trashed', async function () {
+		await notificationsComponent.waitForUndoMessage();
+		await notificationsComponent.waitForUndoMessageToDisappear();
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a bugfix of the `Notifications` spec.

Key changes:
- make the spec wait and confirm the deletion is successful.

Background details:

In the current form, the `Notifications` spec does not check for the comment trash to be successful before exiting the test.

This means that comment is not actually trashed and remains on the post.

#### Testing instructions

Related to #
