### PR TITLE
Replace LazyRender with intersection observer library

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -1,6 +1,6 @@
 import { map, chunk } from 'lodash';
 import React from 'react';
-import LazyRender from 'react-lazily-render';
+import { InView } from 'react-intersection-observer';
 import ReadmeViewer from 'calypso/components/readme-viewer';
 import ComponentPlayground from 'calypso/devdocs/design/component-playground';
 import Placeholder from 'calypso/devdocs/devdocs-async-load/placeholder';
@@ -127,11 +127,13 @@ const Collection = ( {
 			{ map( chunk( examples.slice( examplesToMount ), examplesToMount ), ( exampleGroup ) => {
 				const groupKey = map( exampleGroup, ( example ) => example.key ).join( '_' );
 				return (
-					<LazyRender key={ groupKey }>
-						{ ( shouldRender ) =>
-							shouldRender ? exampleGroup : <Placeholder count={ examplesToMount } />
-						}
-					</LazyRender>
+					<InView key={ groupKey } triggerOnce>
+						{ ( { inView, ref } ) => (
+							<div ref={ ref }>
+								{ inView ? exampleGroup : <Placeholder count={ examplesToMount } /> }
+							</div>
+						) }
+					</InView>
 				);
 			} ) }
 		</div>

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -5,7 +5,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
 import React, { Component } from 'react';
-import LazyRender from 'react-lazily-render';
+import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -275,9 +275,11 @@ class ListAll extends Component {
 		return (
 			<React.Fragment key={ `domain-item-${ index }-${ domain.name }` }>
 				{ domain?.blogId && ! isContactEmailEditContext ? (
-					<LazyRender>
-						{ ( render ) => ( render ? this.renderQuerySiteDomainsOnce( domain.blogId ) : null ) }
-					</LazyRender>
+					<InView triggerOnce>
+						{ ( { inView, ref } ) => (
+							<div ref={ ref }>{ inView && this.renderQuerySiteDomainsOnce( domain.blogId ) }</div>
+						) }
+					</InView>
 				) : (
 					this.renderQuerySiteDomainsOnce( domain.blogId )
 				) }

--- a/client/package.json
+++ b/client/package.json
@@ -191,7 +191,6 @@
 		"react-dom": "^16.12.0",
 		"react-element-to-jsx-string": "^14.1.0",
 		"react-intersection-observer": "^8.32.1",
-		"react-lazily-render": "^1.2.0",
 		"react-live": "^1.12.0",
 		"react-modal": "^3.11.1",
 		"react-native": "^0.63.4",

--- a/client/package.json
+++ b/client/package.json
@@ -190,6 +190,7 @@
 		"react-day-picker": "^7.4.0",
 		"react-dom": "^16.12.0",
 		"react-element-to-jsx-string": "^14.1.0",
+		"react-intersection-observer": "^8.32.1",
 		"react-lazily-render": "^1.2.0",
 		"react-live": "^1.12.0",
 		"react-modal": "^3.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12777,6 +12777,7 @@ __metadata:
     react-day-picker: ^7.4.0
     react-dom: ^16.12.0
     react-element-to-jsx-string: ^14.1.0
+    react-intersection-observer: ^8.32.1
     react-lazily-render: ^1.2.0
     react-live: ^1.12.0
     react-modal: ^3.11.1
@@ -32242,6 +32243,15 @@ fsevents@~2.1.2:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
   checksum: 64282953f1e9318501ae9ff64dc955845fce0b543577fcc5b6a5cf786d9a1872edadc5df5821d830a8510ecf629e9a220b323e5cd45b091508939f71ea332239
+  languageName: node
+  linkType: hard
+
+"react-intersection-observer@npm:^8.32.1":
+  version: 8.32.1
+  resolution: "react-intersection-observer@npm:8.32.1"
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0
+  checksum: a555a32c581361dc71954df47329f007f5cc8280b79c24377b5b03622e036749fd4a8cc80489f6956a084faf49532621af8715a540c42d7bb37686951359f661
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12778,7 +12778,6 @@ __metadata:
     react-dom: ^16.12.0
     react-element-to-jsx-string: ^14.1.0
     react-intersection-observer: ^8.32.1
-    react-lazily-render: ^1.2.0
     react-live: ^1.12.0
     react-modal: ^3.11.1
     react-native: ^0.63.4
@@ -32269,17 +32268,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-lazily-render@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "react-lazily-render@npm:1.2.0"
-  dependencies:
-    scrollparent: ^2.0.1
-  peerDependencies:
-    react: ^16.1.1
-  checksum: d259b7acd2250cbe73fe247879d9972f8a38ecc448b1d291781aabc16a557e74c07c96deddf48efe62f2b92fc2582dee6487227b5fe63898f428bf4e75fa335b
-  languageName: node
-  linkType: hard
-
 "react-lifecycles-compat@npm:^3.0.0, react-lifecycles-compat@npm:^3.0.4":
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
@@ -35146,13 +35134,6 @@ resolve@^2.0.0-next.3:
     ajv: ^6.12.5
     ajv-keywords: ^3.5.2
   checksum: 55a8da802a5f8f0ce6f68b6a139f3261cb423bd23795766da866a0f5738fc40303370fbe0c3eeba60b2a91c569ad7ce5318fea455f8fe866098c5a3a6b9050b0
-  languageName: node
-  linkType: hard
-
-"scrollparent@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "scrollparent@npm:2.0.1"
-  checksum: 1d2e235ba5315725d5bf88946664c72772e32be32bd4555798148f9745e0bc83cd07a2db2faea1c143dee02f84002275338905357cdd43577ec440d5e446de0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
We use a library called `react-lazily-render` to delay rendering a component until it scrolls into a view. This library appears to be unmaintained and doesn't list a react peer dependency for react 17. I discussed the domains list usage with @hambai, and one of their goals is for the page to be used for people managing a high number of domains. So performance is important on the page, and I didn't want to remove the library to set them back. There may be other ways to solve the same problem, such as `useAsyncList` in `@wordpress/compose`, but the ergonomics are a lot different from the current use cases and would require more of a rewrite. 

Instead, I found this library: https://www.npmjs.com/package/react-intersection-observer. It has a lot of benefits compared to forking or writing our own library:

- Well maintained
- Popular
- Doesn't add any extra transitive dependencies
- Is a drop-in replacement for the current library
- Uses intersection observer to handle this behavior in a more modern/performant way

This was very easy to switch out, as the following approach replicates the `LazyRender` component:
```js
import { InView } from 'react-intersection-observer';

// `triggerOnce` means that `inView` is permanently set to true after the element scrolls into view.
// E.g. we don't listen to further updates to the visibility state. This is the behavior of LazyRender

// The ref <div /> is the element whose visibility is tracked.
<InView triggerOnce>
  { ( { inView, ref } ) => (
    <div ref={ ref }>
      { inView ? <DelayedRender /> : <Placeholder /> }
    </div>
  ) }
</InView>
```

### Testing instructions
1. Load http://calypso.localhost:3000/domains/manage, making sure to use a small viewport so that not very many domains are rendered at once. _Note: if the entries are pre-populated, you need to log out and log back in (or clear cache) so that they are fulfilled from network instead of cache._ After the domain list loads, you'll notice a placeholder for details of each entry in the domains list. This element is the one being lazily rendered. After the details fill in for the visible elements, scroll down and ensure that the placeholder is rendered first, and then the details are filled in after you scroll into view. You can also double check the network tab to verify that extra network requests are made only after you scroll these further domain entries into view.  
2. Test the different collections of components in dev docs and verify that components out of the viewport are rendered after they get scrolled into view.
