### PR TITLE
Update wording on auth code verification page for clarity.

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -83,7 +83,7 @@ function ConnectDomainStepLogin( {
 			</p>
 			<p className={ className + '__text' }>
 				{ __(
-					'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
+					'A domain authorization code is a unique code linked only to your domain. It might also be called a secret code, auth code, or EPP code. You can obtain this code from your domain registrar (where the domain is currently registered).'
 				) }
 			</p>
 			<div className={ className + '__authorization-code' }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates to the domain ownership verification/verify ownership page for clarity.

#### Testing instructions

Review the verify ownership page. Make sure the wording matches the image:
<img width="1792" alt="Screen Shot 2021-09-09 at 10 07 52 AM" src="https://user-images.githubusercontent.com/1379730/132783811-145ace69-ffe7-423f-ae8f-bd88e7a2c344.png">
