### PR TITLE
Design Picker: Apply page layout and font settings

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -335,17 +335,23 @@ export function setThemeAndDesignOnSite( callback, { siteSlug, selectedDesign } 
 	}
 
 	const { theme, template, fonts } = selectedDesign;
-	const options = {
-		theme_with_repo_slug: `pub/${ theme }`,
-		template,
-		font_base: fonts?.base,
-		font_headings: fonts?.headings,
-		save_existing: false,
-	};
 
-	wpcom.undocumented().changeThemeAndDesign( siteSlug, options, function ( errors ) {
-		callback( isEmpty( errors ) ? undefined : [ errors ] );
-	} );
+	wpcom.req.post(
+		{
+			path: `/sites/${ siteSlug }/theme-and-design-setup`,
+			apiNamespace: 'wpcom/v2',
+			body: {
+				theme_with_repo_slug: `pub/${ theme }`,
+				template,
+				font_base: fonts?.base,
+				font_headings: fonts?.headings,
+				save_existing: false,
+			},
+		},
+		( errors ) => {
+			callback( isEmpty( errors ) ? undefined : [ errors ] );
+		}
+	);
 }
 
 export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxStore ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -314,25 +314,36 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	} );
 }
 
-export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, selectedDesign } ) {
-	const options = {};
-
-	if ( themeSlugWithRepo ) {
-		options.theme = themeSlugWithRepo.split( '/' )[ 1 ];
-	} else if ( selectedDesign ) {
-		options.theme = selectedDesign.theme;
-		options.template = selectedDesign.template;
-		options.font_base = selectedDesign.fonts?.base;
-		options.font_headings = selectedDesign.fonts?.headings;
-	}
-
-	if ( ! options.theme ) {
+export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
+	if ( isEmpty( themeSlugWithRepo ) ) {
 		defer( callback );
 
 		return;
 	}
 
-	wpcom.undocumented().changeTheme( siteSlug, options, function ( errors ) {
+	const theme = themeSlugWithRepo.split( '/' )[ 1 ];
+
+	wpcom.undocumented().changeTheme( siteSlug, { theme }, function ( errors ) {
+		callback( isEmpty( errors ) ? undefined : [ errors ] );
+	} );
+}
+
+export function setThemeAndDesignOnSite( callback, { siteSlug, selectedDesign } ) {
+	if ( ! selectedDesign ) {
+		defer( callback );
+		return;
+	}
+
+	const { theme, template, fonts } = selectedDesign;
+	const options = {
+		theme_with_repo_slug: `pub/${ theme }`,
+		template,
+		font_base: fonts?.base,
+		font_headings: fonts?.headings,
+		save_existing: false,
+	};
+
+	wpcom.undocumented().changeThemeAndDesign( siteSlug, options, function ( errors ) {
 		callback( isEmpty( errors ) ? undefined : [ errors ] );
 	} );
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -315,21 +315,24 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 }
 
 export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, selectedDesign } ) {
-	let theme = '';
+	const options = {};
 
 	if ( themeSlugWithRepo ) {
-		theme = themeSlugWithRepo.split( '/' )[ 1 ];
+		options.theme = themeSlugWithRepo.split( '/' )[ 1 ];
 	} else if ( selectedDesign ) {
-		theme = selectedDesign.theme;
+		options.theme = selectedDesign.theme;
+		options.template = selectedDesign.template;
+		options.font_base = selectedDesign.fonts?.base;
+		options.font_headings = selectedDesign.fonts?.headings;
 	}
 
-	if ( ! theme ) {
+	if ( ! options.theme ) {
 		defer( callback );
 
 		return;
 	}
 
-	wpcom.undocumented().changeTheme( siteSlug, { theme }, function ( errors ) {
+	wpcom.undocumented().changeTheme( siteSlug, options, function ( errors ) {
 		callback( isEmpty( errors ) ? undefined : [ errors ] );
 	} );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1708,10 +1708,29 @@ Undocumented.prototype.addVipDomainMapping = function ( siteId, domainName, fn )
  * @param {Function} fn
  */
 Undocumented.prototype.changeTheme = function ( siteSlug, data, fn ) {
-	debug( '/site/:site_id/themes/mine' );
+	debug( '/sites/:site_id/themes/mine' );
 	return this.wpcom.req.post(
 		{
 			path: '/sites/' + siteSlug + '/themes/mine',
+			body: data,
+		},
+		fn
+	);
+};
+
+/*
+ * Change the theme and design of a given site.
+ *
+ * @param {string} [siteSlug]
+ * @param {string} [data]
+ * @param {Function} fn
+ */
+Undocumented.prototype.changeThemeAndDesign = function ( siteSlug, data, fn ) {
+	debug( '/sites/:site_id/theme-and-design-setup' );
+	return this.wpcom.req.post(
+		{
+			path: `/sites/${ siteSlug }/theme-and-design-setup`,
+			apiNamespace: 'wpcom/v2',
 			body: data,
 		},
 		fn

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1718,25 +1718,6 @@ Undocumented.prototype.changeTheme = function ( siteSlug, data, fn ) {
 	);
 };
 
-/*
- * Change the theme and design of a given site.
- *
- * @param {string} [siteSlug]
- * @param {string} [data]
- * @param {Function} fn
- */
-Undocumented.prototype.changeThemeAndDesign = function ( siteSlug, data, fn ) {
-	debug( '/sites/:site_id/theme-and-design-setup' );
-	return this.wpcom.req.post(
-		{
-			path: `/sites/${ siteSlug }/theme-and-design-setup`,
-			apiNamespace: 'wpcom/v2',
-			body: data,
-		},
-		fn
-	);
-};
-
 Undocumented.prototype.resetPasswordForMailbox = function ( domainName, mailbox, fn ) {
 	debug( '/domains/:domainName/google-apps/:mailbox/get-new-password' );
 	return this.wpcom.req.post(

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -27,6 +27,7 @@ export function generateSteps( {
 	createSiteWithCart = noop,
 	currentPage = noop,
 	setThemeOnSite = noop,
+	setThemeAndDesignOnSite = noop,
 	addDomainToCart = noop,
 	launchSiteApi = noop,
 	isPlanFulfilled = noop,
@@ -718,7 +719,7 @@ export function generateSteps( {
 			props: {
 				largeThumbnails: true,
 			},
-			apiRequestFunction: setThemeOnSite,
+			apiRequestFunction: setThemeAndDesignOnSite,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],
 			optionalDependencies: [ 'selectedDesign' ],

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -14,6 +14,7 @@ import {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	maybeRemoveStepForUserlessCheckout,
+	setThemeAndDesignOnSite,
 } from 'calypso/lib/signup/step-actions';
 import { generateSteps } from './steps-pure';
 
@@ -26,6 +27,7 @@ export default generateSteps( {
 	createSiteWithCart,
 	currentPage,
 	setThemeOnSite,
+	setThemeAndDesignOnSite,
 	addDomainToCart,
 	launchSiteApi,
 	isPlanFulfilled,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Applies page layout and font settings after selecting design

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D66656-code to your sandbox and sandbox your API 
* Go to `/start/setup-site?siteSlug=<your_site>`
* Select design such as `Balan`
* Go to your home page
* Check layout and font settings is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55604