### PR TITLE
Editor Welcome: fix overlay controls on touch devices

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/style-tour.scss
@@ -149,19 +149,29 @@ $welcome-tour-button-background-color: #32373c; // former $dark-gray-700. TODO: 
 		min-width: 32px;
 		height: 32px;
 		background: $welcome-tour-button-background-color;
-		opacity: 0;
 		transition: opacity 200ms;
+		opacity: 0.7;
+
+		&:active {
+			opacity: 0.9;
+		}
 	}
 
-	.wpcom-editor-welcome-tour-frame:hover &,
-	.wpcom-editor-welcome-tour-frame:focus-within &,
-	&.welcome-tour-card__overlay-controls-visible {
+	@media ( hover: hover ) and ( pointer: fine ) {
+		// styles only applicable for hoverable viewports with precision pointing devices connected (eg: mouse)
 		.components-button {
-			opacity: 0.7;
+			opacity: 0;
+		}
 
-			&:hover,
-			&:focus {
-				opacity: 0.9;
+		.wpcom-editor-welcome-tour-frame:hover &,
+		.wpcom-editor-welcome-tour-frame:focus-within & {
+			.components-button {
+				opacity: 0.7;
+
+				&:hover,
+				&:focus {
+					opacity: 0.9;
+				}
 			}
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -1,9 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLocale } from '@automattic/i18n-utils';
-import { subscribeIsMobile, isMobile } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { __, hasTranslation } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -129,15 +128,6 @@ function CardNavigation( { cardIndex, lastCardIndex, onDismiss, setCurrentCardIn
 }
 
 function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
-	const [ isMobileView, setIsMobileView ] = useState( isMobile() );
-
-	useEffectOnlyOnce( () => {
-		const unsubscribe = subscribeIsMobile( ( isNarrow ) => setIsMobileView( isNarrow ) );
-		return function cleanup() {
-			unsubscribe();
-		};
-	} );
-
 	const handleOnMinimize = () => {
 		onMinimize( true );
 		recordTracksEvent( 'calypso_editor_wpcom_tour_minimize', {
@@ -145,9 +135,7 @@ function CardOverlayControls( { onMinimize, onDismiss, slideNumber } ) {
 			slide_number: slideNumber,
 		} );
 	};
-	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls', {
-		'welcome-tour-card__overlay-controls-visible': isMobileView,
-	} );
+	const buttonClasses = classNames( 'welcome-tour-card__overlay-controls' );
 
 	return (
 		<div className={ buttonClasses }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Show Welcome Tour overlay controls by default on all devices.
* Consider hiding the controls and showing them on hover/focus as a progressive enhancement
* Use [CSS level 5 media queries](https://www.w3.org/TR/mediaqueries-5/#mf-interaction) to target only the hoverable viewports with precision pointing devices connected
* Stop using 	`welcome-tour-card__overlay-controls-visible` CSS class
* Cleanup welcome tour JS used for mobile CSS targeting

#### Testing instructions
* Sandbox a site
* Run ETK dev
* Test the editor welcome tour on a huge tablet
* Overlay controls should be visible by default

#### Screenshots
* Before
<img width="500" alt="Screenshot 2021-09-10 at 11 39 50" src="https://user-images.githubusercontent.com/14192054/132826079-ef89deb0-5523-4e34-a94f-e39f4f5284c0.png">

* After
<img width="500" alt="Screenshot 2021-09-10 at 11 39 13" src="https://user-images.githubusercontent.com/14192054/132826092-35214651-6485-45c7-b18d-2e27473e0334.png">

Fixes https://github.com/Automattic/wp-calypso/issues/55821
