### PR TITLE
Remove is_previewable site computed attribute

### DIFF
--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import WebPreview from 'calypso/components/web-preview';
 import { addQueryArgs } from 'calypso/lib/route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
-import { getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteOption, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { closePreview } from 'calypso/state/ui/preview/actions';
 import {
@@ -69,7 +69,7 @@ class SitePreview extends Component {
 	}
 
 	render() {
-		if ( ! this.props.selectedSite || ! this.props.selectedSite.is_previewable ) {
+		if ( ! this.props.selectedSitePreviewable ) {
 			debug( 'a preview is not available for this site' );
 			return null;
 		}
@@ -100,6 +100,7 @@ function mapStateToProps( state ) {
 		selectedSiteId,
 		selectedSiteUrl: siteUrl.replace( /::/g, '/' ),
 		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
+		selectedSitePreviewable: isSitePreviewable( state, selectedSiteId ),
 		previewUrl: getPreviewUrl( state ),
 		isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),
 	};

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -33,7 +33,6 @@ class TaxonomyManagerListItem extends Component {
 		translate: PropTypes.func,
 		siteUrl: PropTypes.string,
 		slug: PropTypes.string,
-		isPreviewable: PropTypes.bool,
 		recordGoogleEvent: PropTypes.func,
 		bumpStat: PropTypes.func,
 	};
@@ -217,7 +216,6 @@ export default connect(
 		const siteSettings = getSiteSettings( state, siteId );
 		const canSetAsDefault = taxonomy === 'category';
 		const isDefault = canSetAsDefault && get( siteSettings, [ 'default_category' ] ) === term.ID;
-		const isPreviewable = get( site, 'is_previewable' );
 		const siteSlug = get( site, 'slug' );
 		const siteUrl = get( site, 'URL' );
 		const isPodcastingCategory =
@@ -226,7 +224,6 @@ export default connect(
 		return {
 			canSetAsDefault,
 			isDefault,
-			isPreviewable,
 			siteId,
 			siteSlug,
 			siteUrl,

--- a/client/components/web-preview/README.md
+++ b/client/components/web-preview/README.md
@@ -34,11 +34,10 @@ With those constraints in mind, usage is the following:
 </WithPreviewProps>;
 ```
 
-`isPreviewable` should be a boolean to determine whether the URL should be loaded in WebPreview or externally. Bear in mind that not all front-end links are previewable — Jetpack sites, for instance, may not be supported for a number of reasons, including absent HTTPS support. As of this writing, a suggestion is to rely on the `getSite` (state/sites/selectors) selector, which relies on `lib/site/computed-attributes` to return a `is_previewable` attribute:
+`isPreviewable` should be a boolean to determine whether the URL should be loaded in WebPreview or externally. Bear in mind that not all front-end links are previewable — Jetpack sites, for instance, may not be supported for a number of reasons, including absent HTTPS support. As of this writing, a suggestion is to rely on the `isSitePreviewable` (state/sites/selectors) selector:
 
 ```jsx
-const site = getSite( state, siteId );
-const isPreviewable = get( site, 'is_previewable' );
+const isPreviewable = isSitePreviewable( state, siteId );
 
 <WithPreviewProps url={ url } isPreviewable={ isPreviewable }>
 	{ ( props ) => {

--- a/client/state/guided-tours/contexts/is-selected-site-previewable.js
+++ b/client/state/guided-tours/contexts/is-selected-site-previewable.js
@@ -1,5 +1,5 @@
-import { get } from 'lodash';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isSitePreviewable } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Returns true if the selected site can be previewed
@@ -8,4 +8,4 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * @returns {boolean} True if selected site can be previewed, false otherwise.
  */
 export const isSelectedSitePreviewable = ( state ) =>
-	get( getSelectedSite( state ), 'is_previewable', false );
+	isSitePreviewable( state, getSelectedSiteId( state ) );

--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -54,7 +54,6 @@ describe( 'getPublicSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_previewable: false,
 				options: {
 					unmapped_url: 'http://example.com',
 				},

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -53,7 +53,6 @@ describe( 'getVisibleSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_previewable: false,
 				options: {
 					unmapped_url: 'http://example.com',
 				},

--- a/client/state/sites/selectors/get-site-computed-attributes.js
+++ b/client/state/sites/selectors/get-site-computed-attributes.js
@@ -7,7 +7,6 @@ import getSiteSlug from './get-site-slug';
 import getSiteTitle from './get-site-title';
 import isJetpackSite from './is-jetpack-site';
 import isSiteConflicting from './is-site-conflicting';
-import isSitePreviewable from './is-site-previewable';
 
 /**
  * Returns computed properties of the site object.
@@ -25,7 +24,6 @@ export default function getSiteComputedAttributes( state, siteId ) {
 	const computedAttributes = {
 		domain: getSiteDomain( state, siteId ),
 		hasConflict: isSiteConflicting( state, siteId ),
-		is_previewable: !! isSitePreviewable( state, siteId ),
 		options: getSiteOptions( state, siteId ),
 		slug: getSiteSlug( state, siteId ),
 		title: getSiteTitle( state, siteId ),

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -123,7 +123,6 @@ describe( 'selectors', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_previewable: true,
 				jetpack: true,
 				canAutoupdateFiles: true,
 				canUpdateFiles: true,
@@ -191,7 +190,6 @@ describe( 'selectors', () => {
 				slug: 'example.wordpress.com',
 				hasConflict: true,
 				jetpack: false,
-				is_previewable: true,
 				options: {
 					unmapped_url: 'https://example.wordpress.com',
 				},
@@ -3353,7 +3351,6 @@ describe( 'selectors', () => {
 			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
-				is_previewable: false,
 				hasConflict: false,
 				domain: 'example.wordpress.com',
 				slug: 'example.wordpress.com',
@@ -3392,7 +3389,6 @@ describe( 'selectors', () => {
 			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
-				is_previewable: true,
 				hasConflict: true,
 				domain: 'unmapped-url.wordpress.com',
 				slug: 'unmapped-url.wordpress.com',

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -48,7 +48,6 @@ describe( 'selectors', () => {
 				URL: 'https://example.com',
 				domain: 'example.com',
 				hasConflict: false,
-				is_previewable: false,
 				options: {},
 				slug: 'example.com',
 				title: 'WordPress.com Example Blog',


### PR DESCRIPTION
Removes the `site.is_previewable` computed property from a site object and replaces usages with the `isSitePreviewable` selector. Eventually, we should remove all computed properties, store only the raw `site` objects from the REST API in state, and compute derived values just-in-time with selectors.

**How to test:**
Verify that previewing a site from the "site home" icon in sidebar works. And also that the "View" action in ellipsis menu on the Calypso Posts and Pages pages show a modal with a post preview.