### PR TITLE
Theme Showcase: Fix for Atomic themes no loading

### DIFF
--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -23,7 +23,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 		return <Main fullWidthLayout className="themes" />;
 	}
 
-	if ( isJetpack && ! isAtomic ) {
+	if ( isJetpack ) {
 		return (
 			<SingleSiteThemeShowcaseJetpack
 				{ ...props }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -2,7 +2,6 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -10,7 +9,7 @@ import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const { activeTheme, isJetpack, isAtomic, siteId, translate } = props;
+	const { activeTheme, isJetpack, siteId, translate } = props;
 
 	const getScreenshotOption = ( themeId ) => {
 		return activeTheme === themeId ? 'customize' : 'info';
@@ -56,7 +55,6 @@ export default connect( ( state ) => {
 	return {
 		siteId: selectedSiteId,
 		isJetpack: isJetpackSite( state, selectedSiteId ),
-		isAtomic: isAtomicSite( state, selectedSiteId ),
 		activeTheme: getActiveTheme( state, selectedSiteId ),
 	};
 } )( localize( SingleSiteThemeShowcaseWithOptions ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Partial revert of #56033 which broke the ability to search themes on Atomic sites.

#### Testing instructions

* Switch to this PR, navigate to `/themes` on an Atomic site
* Make sure you can load and search all themes under the All Themes tab
* Make sure simple and Jetpack sites still work as expected

Fixes #56085