### PR TITLE
Themes Showcase: show WPcom upsell for Atomic sites

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,22 +1,15 @@
-import {
-	FEATURE_UPLOAD_THEMES,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_SECURITY_REALTIME,
-} from '@automattic/calypso-products';
+import { FEATURE_UPLOAD_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { pickBy } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import Main from 'calypso/components/main';
-import { isPartnerPurchase } from 'calypso/lib/purchases';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { getLastThemeQuery, getThemesFoundForQuery } from 'calypso/state/themes/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { addTracking } from './helpers';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
@@ -44,7 +37,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		filter,
 		getScreenshotOption,
 		isAtomic,
-		purchase,
 		showWpcomThemesList,
 		search,
 		siteId,
@@ -52,54 +44,33 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		tier,
 		translate,
 		requestingSitePlans,
-		siteSlug,
 	} = props;
 
-	const isPartnerPlan = purchase && isPartnerPurchase( purchase );
+	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
 
-	const displayUpsellBanner = ! requestingSitePlans && currentPlan;
-
-	let upsellBanner = null;
-	if ( isAtomic ) {
-		upsellBanner = (
-			<UpsellNudge
-				className="themes__showcase-banner"
-				event="calypso_themes_list_install_themes"
-				feature={ FEATURE_UPLOAD_THEMES }
-				plan={ PLAN_BUSINESS }
-				title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
-				forceHref={ true }
-				showIcon={ true }
-			/>
-		);
-	} else {
-		upsellBanner = (
-			<UpsellNudge
-				forceDisplay
-				title={ translate( 'Upload your own themes' ) }
-				description={ translate(
-					'In addition to uploading your own themes, get comprehensive WordPress' +
-						' security, real-time backups, and unlimited video hosting.'
-				) }
-				event="themes_plans_free_personal_premium"
-				showIcon={ true }
-				href={ `/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_REALTIME }` }
-			/>
-		);
-	}
+	const upsellBanner = (
+		<UpsellNudge
+			className="themes__showcase-banner"
+			event="calypso_themes_list_install_themes"
+			feature={ FEATURE_UPLOAD_THEMES }
+			plan={ PLAN_BUSINESS }
+			title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
+			forceHref={ true }
+			showIcon={ true }
+		/>
+	);
 
 	return (
 		<Main fullWidthLayout className="themes">
 			<SidebarNavigation />
 			<ThemesHeader />
 			<CurrentTheme siteId={ siteId } />
-			{ displayUpsellBanner && ! isAtomic && ! isPartnerPlan && upsellBanner }
 			<ThemeShowcase
 				{ ...props }
 				siteId={ siteId }
 				emptyContent={ showWpcomThemesList ? <div /> : null }
 				isJetpackSite={ true }
-				upsellBanner={ displayUpsellBanner && isAtomic ? upsellBanner : null }
+				upsellBanner={ displayUpsellBanner ? upsellBanner : null }
 			>
 				{ showWpcomThemesList && (
 					<div>
@@ -139,7 +110,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 } );
 
 export default connect( ( state, { siteId, tier } ) => {
-	const siteSlug = getSelectedSiteSlug( state );
 	const currentPlan = getCurrentPlan( state, siteId );
 	const isMultisite = isJetpackSiteMultiSite( state, siteId );
 	const showWpcomThemesList = ! isMultisite;
@@ -153,13 +123,11 @@ export default connect( ( state, { siteId, tier } ) => {
 	}
 	return {
 		currentPlan,
-		purchase: currentPlan ? getByPurchaseId( state, currentPlan.id ) : null,
 		tier,
 		showWpcomThemesList,
 		emptyContent,
 		isAtomic: isAtomicSite( state, siteId ),
 		isMultisite,
 		requestingSitePlans: isRequestingSitePlans( state, siteId ),
-		siteSlug,
 	};
 } )( ConnectedSingleSiteJetpack );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -6,16 +6,16 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
-	const { requestingSitePlans, siteId, isVip, siteSlug, translate } = props;
+	const { currentPlan, isVip, requestingSitePlans, siteId, siteSlug, translate } = props;
 
-	const displayUpsellBanner = ! requestingSitePlans && ! isVip;
+	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 
 	const upsellUrl = `/plans/${ siteSlug }`;
 	let upsellBanner = null;
@@ -53,4 +53,5 @@ export default connect( ( state, { siteId } ) => ( {
 	isVip: isVipSite( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),
+	currentPlan: getCurrentPlan( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );


### PR DESCRIPTION
This is a second take at #56033, after it was partially reverted in #56169. It makes sure to show a WPcom upsell for Atomic Jetpack sites.

**Update:** This also removes the Jetpack upsell that no longer makes sense. https://github.com/Automattic/wp-calypso/pull/56170#issuecomment-917127787

**Atomic site without a plan:**
<img width="1550" alt="Screen Shot 2021-09-10 at 12 06 35 PM" src="https://user-images.githubusercontent.com/942359/132886113-aeb72162-9e4a-42ea-b302-4559cec4a11b.png">

**Atomic site with a Business or Ecommerce plan:**
<img width="1550" alt="Screen Shot 2021-09-10 at 12 20 05 PM" src="https://user-images.githubusercontent.com/942359/132886173-5429e91a-a61b-4282-b0cd-e560c3b41f94.png">

**To test:**
- on an Atomic site without a plan, visit the Calypso Theme Showcase
- verify that an upsell is shown, below the search, and that clicking it takes the user to the feature-limited plans page
- on an Atomic site with a Business or Ecommerce plan, visit the Calypso Theme Showcase
- verify that no upsell is shown
- on a Jetpack site, visit the Calypso Theme Showcase
- verify that no Jetpack nudge is shown