### PR TITLE
Theme Showcase: Refresh admin menu when switching between block and classic themes

### DIFF
--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -1,12 +1,11 @@
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { requestSitePosts } from 'calypso/state/posts/actions';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { THEME_ACTIVATE_SUCCESS } from 'calypso/state/themes/action-types';
 import {
 	getActiveTheme,
 	getLastThemeQuery,
-	getTheme,
+	getCanonicalTheme,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
@@ -59,9 +58,8 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
 		// When switching from a block-based theme to a classic theme and vice versa, the admin
 		// sidebar toggles site editor and customizer menu item visiblity. The admin bar needs to be
 		// refreshed to see the updates.
-		const sourceSiteId = siteId && isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
-		const previousTheme = getTheme( getState(), sourceSiteId, previousThemeId );
-		const newTheme = getTheme( getState(), sourceSiteId, themeId );
+		const previousTheme = getCanonicalTheme( getState(), siteId, previousThemeId );
+		const newTheme = getCanonicalTheme( getState(), siteId, themeId );
 
 		if (
 			( isClassicTheme( previousTheme ) && isBlockTheme( newTheme ) ) ||

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -29,13 +29,12 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
 			themeStylesheet,
 			siteId,
 		};
-		const themeId = getThemeIdFromStylesheet( themeStylesheet );
 		const previousThemeId = getActiveTheme( getState(), siteId );
 		const query = getLastThemeQuery( getState(), siteId );
 		const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
 		const search_term = search_taxonomies + ( query.search || '' );
 		const trackThemeActivation = recordTracksEvent( 'calypso_themeshowcase_theme_activate', {
-			theme: themeId,
+			theme: getThemeIdFromStylesheet( themeStylesheet ),
 			previous_theme: previousThemeId,
 			source: source,
 			purchased: purchased,

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -5,22 +5,11 @@ import { THEME_ACTIVATE_SUCCESS } from 'calypso/state/themes/action-types';
 import {
 	getActiveTheme,
 	getLastThemeQuery,
-	getCanonicalTheme,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
-
-function isClassicTheme( theme ) {
-	const themeFeatures = theme?.taxonomies?.theme_feature;
-	return themeFeatures && themeFeatures.every( ( feature ) => feature.slug !== 'block-templates' );
-}
-
-function isBlockTheme( theme ) {
-	const themeFeatures = theme?.taxonomies?.theme_feature;
-	return themeFeatures && themeFeatures.some( ( feature ) => feature.slug === 'block-templates' );
-}
 
 /**
  * Returns an action thunk to be used in signalling that a theme has been activated
@@ -55,18 +44,9 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
 		} );
 		dispatch( withAnalytics( trackThemeActivation, action ) );
 
-		// When switching from a block-based theme to a classic theme and vice versa, the admin
-		// sidebar toggles site editor and customizer menu item visiblity. The admin bar needs to be
-		// refreshed to see the updates.
-		const previousTheme = getCanonicalTheme( getState(), siteId, previousThemeId );
-		const newTheme = getCanonicalTheme( getState(), siteId, themeId );
-
-		if (
-			( isClassicTheme( previousTheme ) && isBlockTheme( newTheme ) ) ||
-			( isBlockTheme( previousTheme ) && isClassicTheme( newTheme ) )
-		) {
-			dispatch( requestAdminMenu( siteId ) );
-		}
+		// There are instances where switching themes toggles menu items. This action refreshes
+		// the admin bar to ensure that those updates are displayed in the UI.
+		dispatch( requestAdminMenu( siteId ) );
 
 		// Update pages in case the front page was updated on theme switch.
 		dispatch( requestSitePosts( siteId, { type: 'page' } ) );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -814,47 +814,36 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'should dispatch status update', () => {
-			return pollThemeTransferStatus(
-				siteId,
-				3,
-				'themes',
-				20
-			)( spy ).then( () => {
-				// Two 'progress' then a 'complete'
-				expect( spy ).to.have.callCount( 4 );
-				expect( spy ).to.have.been.calledWith( {
-					type: THEME_TRANSFER_STATUS_RECEIVE,
-					siteId: siteId,
-					transferId: 3,
-					status: 'progress',
-					message: 'in progress',
-					themeId: undefined,
-				} );
-				expect( spy ).to.have.been.calledWith( {
-					type: THEME_TRANSFER_STATUS_RECEIVE,
-					siteId: siteId,
-					transferId: 3,
-					status: 'complete',
-					message: 'all done',
-					themeId: 'mood',
-				} );
+		test( 'should dispatch status update', async () => {
+			await pollThemeTransferStatus( siteId, 3, 'themes', 20 )( spy );
+			// Two 'progress' then a 'complete'
+			expect( spy ).to.have.callCount( 4 );
+			expect( spy ).to.have.been.calledWith( {
+				type: THEME_TRANSFER_STATUS_RECEIVE,
+				siteId: siteId,
+				transferId: 3,
+				status: 'progress',
+				message: 'in progress',
+				themeId: undefined,
+			} );
+			expect( spy ).to.have.been.calledWith( {
+				type: THEME_TRANSFER_STATUS_RECEIVE,
+				siteId: siteId,
+				transferId: 3,
+				status: 'complete',
+				message: 'all done',
+				themeId: 'mood',
 			} );
 		} );
 
-		test( 'should dispatch failure on receipt of error', () => {
-			return pollThemeTransferStatus(
+		test( 'should dispatch failure on receipt of error', async () => {
+			await pollThemeTransferStatus( siteId, 4, 'themes' )( spy );
+			expect( spy ).to.have.been.calledWithMatch( {
+				type: THEME_TRANSFER_STATUS_FAILURE,
 				siteId,
-				4,
-				'themes'
-			)( spy ).then( () => {
-				expect( spy ).to.have.been.calledWithMatch( {
-					type: THEME_TRANSFER_STATUS_FAILURE,
-					siteId,
-					transferId: 4,
-				} );
-				expect( spy ).to.have.been.calledWith( sinon.match.has( 'error', sinon.match.truthy ) );
+				transferId: 4,
 			} );
+			expect( spy ).to.have.been.calledWith( sinon.match.has( 'error', sinon.match.truthy ) );
 		} );
 	} );
 
@@ -889,8 +878,8 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( sinon.match.func );
 			} );
 		} );
-
 		test( 'should dispatch failure on error', () => {
+			/* eslint-disable jest/no-conditional-expect */
 			return initiateThemeTransfer( siteId )( spy ).catch( () => {
 				expect( spy ).to.have.been.calledOnce;
 
@@ -900,6 +889,7 @@ describe( 'actions', () => {
 				} );
 				expect( spy ).to.have.been.calledWith( sinon.match.has( 'error', sinon.match.truthy ) );
 			} );
+			/* eslint-enable jest/no-conditional-expect */
 		} );
 	} );
 

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -429,20 +429,7 @@ describe( 'actions', () => {
 				],
 			},
 		};
-		// classic themes
-		const millerTheme = {
-			id: 'miller',
-			stylesheet: 'pub/miller',
-			taxonomies: {
-				theme_feature: [
-					{
-						name: 'Auto Loading Homepage',
-						slug: 'auto-loading-homepage',
-						term_id: '687694703',
-					},
-				],
-			},
-		};
+		// classic theme
 		const twentyfifteenTheme = {
 			id: 'twentyfifteen',
 			stylesheet: 'pub/twentyfifteen',
@@ -471,7 +458,6 @@ describe( 'actions', () => {
 					wpcom: new ThemeQueryManager( {
 						items: {
 							[ maylandBlocksTheme.id ]: maylandBlocksTheme,
-							[ millerTheme.id ]: millerTheme,
 							[ twentyfifteenTheme.id ]: twentyfifteenTheme,
 						},
 					} ),
@@ -487,20 +473,10 @@ describe( 'actions', () => {
 			},
 		} );
 
-		describe( 'when switching between a classic and a block theme', () => {
-			test( 'should dispatch an action to refresh the admin bar', () => {
+		describe( 'when switching between any theme', () => {
+			test( 'should refresh the admin bar', () => {
 				themeActivated( 'pub/mayland-blocks', 2211667 )( spy, fakeGetState );
 				expect( spy ).to.have.been.calledWith( {
-					type: 'ADMIN_MENU_REQUEST',
-					siteId: 2211667,
-				} );
-			} );
-		} );
-
-		describe( 'when switching between classic themes', () => {
-			test( 'should not dispatch an action to refresh the admin bar', () => {
-				themeActivated( 'pub/miller', 2211667 )( spy, fakeGetState );
-				expect( spy ).not.to.have.been.calledWith( {
 					type: 'ADMIN_MENU_REQUEST',
 					siteId: 2211667,
 				} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -415,6 +415,98 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#themeActivated()', () => {
+		// block theme
+		const maylandBlocksTheme = {
+			id: 'mayland-blocks',
+			stylesheet: 'pub/mayland-blocks',
+			taxonomies: {
+				theme_feature: [
+					{
+						name: 'Block Templates',
+						slug: 'block-templates',
+						term_id: '230717188',
+					},
+				],
+			},
+		};
+		// classic themes
+		const millerTheme = {
+			id: 'miller',
+			stylesheet: 'pub/miller',
+			taxonomies: {
+				theme_feature: [
+					{
+						name: 'Auto Loading Homepage',
+						slug: 'auto-loading-homepage',
+						term_id: '687694703',
+					},
+				],
+			},
+		};
+		const twentyfifteenTheme = {
+			id: 'twentyfifteen',
+			stylesheet: 'pub/twentyfifteen',
+			taxonomies: {
+				theme_feature: [
+					{
+						name: 'Auto Loading Homepage',
+						slug: 'auto-loading-homepage',
+						term_id: '687694703',
+					},
+				],
+			},
+		};
+
+		const fakeGetState = () => ( {
+			themes: {
+				activeThemes: {
+					2211667: 'twentyfifteen',
+				},
+				lastQuery: {
+					2211667: {
+						search: 'simple, white',
+					},
+				},
+				queries: {
+					wpcom: new ThemeQueryManager( {
+						items: {
+							[ maylandBlocksTheme.id ]: maylandBlocksTheme,
+							[ millerTheme.id ]: millerTheme,
+							[ twentyfifteenTheme.id ]: twentyfifteenTheme,
+						},
+					} ),
+				},
+			},
+			sites: {
+				items: {
+					197431737: {
+						ID: 197431737,
+						jetpack: false,
+					},
+				},
+			},
+		} );
+
+		describe( 'when switching between a classic and a block theme', () => {
+			test( 'should dispatch an action to refresh the admin bar', () => {
+				themeActivated( 'pub/mayland-blocks', 2211667 )( spy, fakeGetState );
+				expect( spy ).to.have.been.calledWith( {
+					type: 'ADMIN_MENU_REQUEST',
+					siteId: 2211667,
+				} );
+			} );
+		} );
+
+		describe( 'when switching between classic themes', () => {
+			test( 'should not dispatch an action to refresh the admin bar', () => {
+				themeActivated( 'pub/miller', 2211667 )( spy, fakeGetState );
+				expect( spy ).not.to.have.been.calledWith( {
+					type: 'ADMIN_MENU_REQUEST',
+					siteId: 2211667,
+				} );
+			} );
+		} );
+
 		test( 'should return an action object', () => {
 			const expectedActivationSuccess = {
 				meta: {
@@ -440,29 +532,6 @@ describe( 'actions', () => {
 				themeStylesheet: 'pub/twentysixteen',
 				siteId: 2211667,
 			};
-
-			const fakeGetState = () => ( {
-				themes: {
-					activeThemes: {
-						2211667: 'twentyfifteen',
-					},
-					lastQuery: {
-						2211667: {
-							search: 'simple, white',
-						},
-					},
-					queries: {},
-				},
-				sites: {
-					items: {
-						197431737: {
-							ID: 197431737,
-							jetpack: false,
-						},
-					},
-				},
-			} );
-
 			themeActivated( 'pub/twentysixteen', 2211667 )( spy, fakeGetState );
 			expect( spy ).to.have.been.calledWith( expectedActivationSuccess );
 		} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -451,6 +451,15 @@ describe( 'actions', () => {
 							search: 'simple, white',
 						},
 					},
+					queries: {},
+				},
+				sites: {
+					items: {
+						197431737: {
+							ID: 197431737,
+							jetpack: false,
+						},
+					},
 				},
 			} );
 


### PR DESCRIPTION
When switching from a block-based theme to a classic theme and vice versa, the admin sidebar toggles site editor and customizer menu item visiblity. The admin bar needs to be refreshed to see the updates.

### Changes proposed in this Pull Request

When activating / deactivating an FSE theme, the refresh the admin bar to toggle the Site Editor items.

### Screenshots
#### Before
![2021-09-10 14 43 27](https://user-images.githubusercontent.com/5414230/132920870-75415c03-90ba-4ee5-93d2-5f0e7e58fbb5.gif)

#### After
![2021-09-10 10 28 39](https://user-images.githubusercontent.com/5414230/132893870-a029b937-7dd9-4381-95da-54b9085b2ac1.gif)

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Appearance -> Themes
- Ensure that a block-based theme is activated
- Verify that the `Site Editor` admin menu item is visible
- Switch to any non block-based theme
- Confirm that the `Site Editor` admin menu item disappears

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/54508
