### PR TITLE
Checkout: Move getIntroductoryOfferIntervalDisplay to wpcom-checkout package

### DIFF
--- a/client/lib/purchases/utils.ts
+++ b/client/lib/purchases/utils.ts
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import type { Purchase } from './types';
 
 /**
@@ -13,69 +12,4 @@ export function getPurchaseByProductSlug(
 	slug: string
 ): Purchase | undefined {
 	return purchases.find( ( purchase ) => purchase.productSlug === slug );
-}
-
-export function getIntroductoryOfferIntervalDisplay(
-	translate: ReturnType< typeof useTranslate >,
-	intervalUnit: string,
-	intervalCount: number,
-	isFreeTrial: boolean
-): string {
-	let text = String( translate( 'Discount for first period' ) );
-	if ( isFreeTrial ) {
-		if ( intervalUnit === 'month' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'First month free' ) );
-			} else {
-				text = String(
-					translate( 'First %(numberOfMonths)d months free', {
-						args: {
-							numberOfMonths: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-		if ( intervalUnit === 'year' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'First year free' ) );
-			} else {
-				text = String(
-					translate( 'First %(numberOfYears)d years free', {
-						args: {
-							numberOfYears: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-	} else {
-		if ( intervalUnit === 'month' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first month' ) );
-			} else {
-				text = String(
-					translate( 'Discount for first %(numberOfMonths)d months', {
-						args: {
-							numberOfMonths: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-		if ( intervalUnit === 'year' ) {
-			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first year' ) );
-			} else {
-				text = String(
-					translate( 'Discount for first %(numberOfYears)d years', {
-						args: {
-							numberOfYears: intervalCount,
-						},
-					} )
-				);
-			}
-		}
-	}
-	return text;
 }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -10,6 +10,7 @@ import {
 	isJetpackProduct,
 	getProductFromSlug,
 } from '@automattic/calypso-products';
+import { getIntroductoryOfferIntervalDisplay } from '@automattic/wpcom-checkout';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
@@ -34,7 +35,6 @@ import {
 	isWithinIntroductoryOfferPeriod,
 	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
-import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
 import { TITAN_MAIL_MONTHLY_SLUG } from 'calypso/lib/titan/constants';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';

--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -20,12 +20,16 @@ import {
 	Button,
 } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { isWpComProductRenewal, getSublabel, getLabel } from '@automattic/wpcom-checkout';
+import {
+	isWpComProductRenewal,
+	getSublabel,
+	getLabel,
+	getIntroductoryOfferIntervalDisplay,
+} from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { getIntroductoryOfferIntervalDisplay } from 'calypso/lib/purchases/utils';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import getPriceTierForUnits from 'calypso/my-sites/plans/jetpack-plans/get-price-tier-for-units';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';

--- a/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
+++ b/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
@@ -1,0 +1,66 @@
+import { useTranslate } from 'i18n-calypso';
+
+export function getIntroductoryOfferIntervalDisplay(
+	translate: ReturnType< typeof useTranslate >,
+	intervalUnit: string,
+	intervalCount: number,
+	isFreeTrial: boolean
+): string {
+	let text = String( translate( 'Discount for first period' ) );
+	if ( isFreeTrial ) {
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'First month free' ) );
+			} else {
+				text = String(
+					translate( 'First %(numberOfMonths)d months free', {
+						args: {
+							numberOfMonths: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'First year free' ) );
+			} else {
+				text = String(
+					translate( 'First %(numberOfYears)d years free', {
+						args: {
+							numberOfYears: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+	} else {
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'Discount for first month' ) );
+			} else {
+				text = String(
+					translate( 'Discount for first %(numberOfMonths)d months', {
+						args: {
+							numberOfMonths: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = String( translate( 'Discount for first year' ) );
+			} else {
+				text = String(
+					translate( 'Discount for first %(numberOfYears)d years', {
+						args: {
+							numberOfYears: intervalCount,
+						},
+					} )
+				);
+			}
+		}
+	}
+	return text;
+}

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -22,3 +22,4 @@ export * from './payment-methods/existing-credit-card';
 export { isWpComProductRenewal } from './is-wpcom-product-renewal';
 export { isValueTruthy } from './is-value-truthy';
 export * from './checkout-labels';
+export * from './get-introductory-offer-interval-display';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This moves the function `getIntroductoryOfferIntervalDisplay` to the `@automattic/wpcom-checkout` package. The function has nearly no dependencies of its own and by moving it outside of calypso, we gain the ability to use it in other use-cases, such as the wp-admin masterbar (https://github.com/Automattic/wp-calypso/pull/52890).

![introductory-offer-text](https://user-images.githubusercontent.com/2036909/132929273-80ee0e0f-a644-4d88-b4ad-e09d27bf4600.png)

#### Testing instructions

- Set your currency to anything _except_ USD, DKK, or EUR.

Next you'll need to add Titan mail to your cart. You can do this in several ways. Here's one:

- Visit `/domains/add/[YOUR SITE HERE]`.
- Add a domain registration to your cart.
- On the next page you should see an email upsell; add "Professional Email" (Titan) to your cart.
- When you reach checkout, verify that the introductory offer text is displayed below the line item. It will read something like "First X months free", "Discount for first X months", or "Discount for first period".