### PR TITLE
Checkout: Move getPriceTierForUnits to calypso-products package

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-line-item.tsx
@@ -11,6 +11,7 @@ import {
 	isGoogleWorkspaceProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteOrGoogleWorkspaceProductSlug,
+	getPriceTierForUnits,
 } from '@automattic/calypso-products';
 import {
 	CheckoutModal,
@@ -31,7 +32,6 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import getPriceTierForUnits from 'calypso/my-sites/plans/jetpack-plans/get-price-tier-for-units';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import {

--- a/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
@@ -1,10 +1,9 @@
-import { JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
+import { JETPACK_SEARCH_PRODUCTS, getPriceTierForUnits } from '@automattic/calypso-products';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { createElement } from 'react';
 import ExternalLink from 'calypso/components/external-link';
-import getPriceTierForUnits from 'calypso/my-sites/plans/jetpack-plans/get-price-tier-for-units';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
-import { PriceTierEntry } from 'calypso/state/products-list/selectors/get-product-price-tiers';
+import type { PriceTierEntry } from '@automattic/calypso-products';
 
 /**
  * Gets tooltip for product.

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -13,7 +13,7 @@ import {
 	isRequestingSiteProducts,
 } from 'calypso/state/sites/products/selectors';
 import type { SelectorProduct } from './types';
-import type { PriceTierEntry } from 'calypso/state/products-list/selectors/get-product-price-tiers';
+import type { PriceTierEntry } from '@automattic/calypso-products';
 
 interface ItemPrices {
 	isFetching: boolean | null;

--- a/client/state/products-list/selectors/get-product-price-tiers.ts
+++ b/client/state/products-list/selectors/get-product-price-tiers.ts
@@ -1,19 +1,11 @@
 import { getProductBySlug } from './get-product-by-slug';
+import type { PriceTierEntry } from '@automattic/calypso-products';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/products-list/init';
 
 type Product = {
 	price_tier_list: PriceTierEntry[];
 };
-
-export interface PriceTierEntry {
-	minimum_units: number;
-	maximum_units?: undefined | null | number;
-	minimum_price_display: string;
-	minimum_price_monthly_display: string;
-	maximum_price_display?: string | null | undefined;
-	maximum_price_monthly_display?: string | null | undefined;
-}
 
 /**
  * Returns the price tiers of the specified product.

--- a/packages/calypso-products/src/get-price-tier-for-units.ts
+++ b/packages/calypso-products/src/get-price-tier-for-units.ts
@@ -1,6 +1,13 @@
-import type { PriceTierEntry } from 'calypso/state/products-list/selectors/get-product-price-tiers';
+export interface PriceTierEntry {
+	minimum_units: number;
+	maximum_units?: undefined | null | number;
+	minimum_price_display: string;
+	minimum_price_monthly_display: string;
+	maximum_price_display?: string | null | undefined;
+	maximum_price_monthly_display?: string | null | undefined;
+}
 
-export default function getPriceTierForUnits(
+export function getPriceTierForUnits(
 	tiers: PriceTierEntry[],
 	units: number
 ): PriceTierEntry | null {

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -5,3 +5,4 @@ export * from './constants';
 export * from './product-values';
 export * from './get-interval-type-for-term';
 export * from './gsuite-product-slug';
+export * from './get-price-tier-for-units';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the function `getPriceTierForUnits()` and its associated data type `PriceTierEntry` to the `@automattic/calypso-products` package. The function is pure so it doesn't require any dependencies. By moving these outside of calypso, this allows us to use them in non-calypso contexts, like the wp-admin masterbar cart (https://github.com/Automattic/wp-calypso/pull/52890).

<img width="496" alt="Screen Shot 2021-09-10 at 8 26 09 PM" src="https://user-images.githubusercontent.com/2036909/132929996-1aa511f1-8dda-4bca-9dbc-a895ff1c2670.png">


#### Testing instructions

- Using a Jetpack site, visit the `/plans` page.
- Add Jetpack Search ("Site Search") to your cart.
- When you reach checkout, verify that you see text like "Up to X records" or "More than X records" displayed below the line item.