### PR TITLE
Add boilerplate components for transfer flow

### DIFF
--- a/client/components/domains/connect-domain-step/constants.jsx
+++ b/client/components/domains/connect-domain-step/constants.jsx
@@ -5,6 +5,7 @@ export const modeType = {
 	ADVANCED: 'advanced',
 	DONE: 'done',
 	OWNERSHIP_VERIFICATION: 'ownership_verification',
+	TRANSFER: 'transfer',
 };
 
 export const stepType = {
@@ -15,6 +16,8 @@ export const stepType = {
 	CONNECTED: 'connected',
 	VERIFYING: 'verifying',
 	ENTER_AUTH_CODE: 'enter_auth_code',
+	UNLOCK_DOMAIN: 'unlock_domain',
+	FINALIZE: 'finalize',
 };
 
 export const stepSlug = {
@@ -30,6 +33,10 @@ export const stepSlug = {
 	ADVANCED_CONNECTED: 'advanced_connected',
 	OWNERSHIP_VERIFICATION_LOGIN: 'ownership_verification_login',
 	OWNERSHIP_VERIFICATION_AUTH_CODE: 'ownership_verification_auth_code',
+	TRANSFER_START: 'transfer_start',
+	TRANSFER_LOGIN: 'transfer_login',
+	TRANSFER_UNLOCK: 'transfer_unlock',
+	TRANSFER_AUTH_CODE: 'transfer_auth_code',
 };
 
 export const defaultDomainSetupInfo = {

--- a/client/components/domains/connect-domain-step/page-definitions.js
+++ b/client/components/domains/connect-domain-step/page-definitions.js
@@ -1,4 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import TransferDomainStepAuthCode from 'calypso/components/domains/connect-domain-step/transfer-domain-step-auth-code';
+import TransferDomainStepLogin from 'calypso/components/domains/connect-domain-step/transfer-domain-step-login';
+import TransferDomainStepStart from 'calypso/components/domains/connect-domain-step/transfer-domain-step-start';
+import TransferDomainStepUnlock from 'calypso/components/domains/connect-domain-step/transfer-domain-step-unlock';
 import ConnectDomainStepAdvancedRecords from './connect-domain-step-advanced-records';
 import ConnectDomainStepAdvancedStart from './connect-domain-step-advanced-start';
 import ConnectDomainStepDone from './connect-domain-step-done';
@@ -100,6 +104,44 @@ export const connectADomainOwnershipVerificationStepsDefinition = {
 		name: __( 'Verify ownership' ),
 		component: ConnectDomainStepOwnershipAuthCode,
 		prev: stepSlug.OWNERSHIP_VERIFICATION_LOGIN,
+	},
+};
+
+export const transferDomainStepsDefinition = {
+	[ stepSlug.TRANSFER_START ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.START,
+		component: TransferDomainStepStart,
+		next: stepSlug.TRANSFER_LOGIN,
+	},
+	[ stepSlug.TRANSFER_LOGIN ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: __( 'Log in to provider' ),
+		component: TransferDomainStepLogin,
+		next: stepSlug.TRANSFER_UNLOCK,
+		prev: stepSlug.TRANSFER_START,
+	},
+	[ stepSlug.TRANSFER_UNLOCK ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.UNLOCK_DOMAIN,
+		name: __( 'Unlock domain' ),
+		component: TransferDomainStepUnlock,
+		next: stepSlug.TRANSFER_AUTH_CODE,
+		prev: stepSlug.TRANSFER_LOGIN,
+	},
+	[ stepSlug.TRANSFER_AUTH_CODE ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.ENTER_AUTH_CODE,
+		name: __( 'Get domain authorization code' ),
+		component: TransferDomainStepAuthCode,
+		next: 'unused transfer domain step',
+		prev: stepSlug.TRANSFER_UNLOCK,
+	},
+	[ 'unused transfer domain step' ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.FINALIZE,
+		name: __( 'Finalize transfer' ),
 	},
 };
 

--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ConnectDomainStepOwnershipAuthCode from 'calypso/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code';
+
+const TransferDomainStepAuthCode = ( props ) => {
+	return <ConnectDomainStepOwnershipAuthCode { ...props } />;
+};
+
+export default TransferDomainStepAuthCode;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ConnectDomainStepLogin from 'calypso/components/domains/connect-domain-step/connect-domain-step-login';
+
+const TransferDomainStepLogin = ( props ) => {
+	return <ConnectDomainStepLogin { ...props } />;
+};
+
+export default TransferDomainStepLogin;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ConnectDomainStepSuggestedStart from 'calypso/components/domains/connect-domain-step/connect-domain-step-suggested-start';
+
+const TransferDomainStepStart = ( props ) => {
+	return <ConnectDomainStepSuggestedStart { ...props } />;
+};
+
+export default TransferDomainStepStart;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -1,0 +1,30 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import PropTypes from 'prop-types';
+import React from 'react';
+import ConnectDomainStepWrapper from 'calypso/components/domains/connect-domain-step/connect-domain-step-wrapper';
+
+const TransferDomainStepUnlock = ( { className, onNextStep, ...props } ) => {
+	const { __ } = useI18n();
+
+	const stepContent = (
+		<div className={ className + '__domain-unlock' }>
+			<div className={ className + '__actions' }>
+				<Button primary onClick={ onNextStep }>
+					{ __( "I've unlocked my domain" ) }
+				</Button>
+			</div>
+		</div>
+	);
+
+	return (
+		<ConnectDomainStepWrapper className={ className } stepContent={ stepContent } { ...props } />
+	);
+};
+
+TransferDomainStepUnlock.propTypes = {
+	className: PropTypes.string.isRequired,
+	onNextStep: PropTypes.func.isRequired,
+};
+
+export default TransferDomainStepUnlock;

--- a/config/development.json
+++ b/config/development.json
@@ -60,6 +60,7 @@
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,6 +36,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,6 +39,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,6 +42,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're getting ready to add a new transfer domain flow. This PR adds the boilerplate components for this flow and a feature flag to gate use of the new flow.

Note: This code is not complete, but only a starting point for additional features that will be added in subsequent PRs.

#### Testing instructions

Start the "Use a domain I own" flow with the `?flags=domains/new-transfer-flow` query string.

Inspect the code.