### PR TITLE
Cancellation Flow: Fix Jetpack button variations in cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -164,7 +164,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ..
 		const close = {
 			action: 'close',
 			disabled: disabled,
-			isPrimary: true,
+			isPrimary: steps.LAST_STEP !== cancellationStep,
 			label: translate( "I'll keep it" ),
 		};
 		const next = {
@@ -187,6 +187,7 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ..
 				disabled={ props.disableButtons }
 				busy={ props.disableButtons }
 				onClick={ onSubmit }
+				primary
 				scary
 			>
 				{ props.disableButtons ? cancellingText : cancelText }


### PR DESCRIPTION
Context: p1631176452060400-slack-C0299DMPG

#### Changes proposed in this Pull Request

* In the context of the purchase cancellation flow, this change makes the main cancellation button primary (and scary), and updates the "I'll keep it" button in the last step to be secondary (and not conflict with the primary destructive button).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Run `yarn start`
* Go to http://calypso.localhost:3000/me/purchases/
* Open a website you own that has a Jetpack plan
* Make sure the buttons look like the screenshot below

| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/5714212/133008421-c38cdace-3f4d-4284-bd2c-07cba6bce409.png) | ![image](https://user-images.githubusercontent.com/5714212/133008344-ee03c4e3-7d55-4b24-9eb8-772fa90bc40a.png)|


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->