### PR TITLE
build: Fail e2e if docker doesn't build

### DIFF
--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -3,8 +3,10 @@ package _self.projects
 import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
@@ -28,6 +30,7 @@ object E2ETests : BuildType({
 
 	dependencies {
 		snapshot(BuildDockerImage) {
+			onDependencyFailure = FailureAction.FAIL_TO_START
 		}
 	}
 

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -6,7 +6,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -3,6 +3,7 @@ package _self.projects
 import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
@@ -573,6 +574,7 @@ fun seleniumBuildType( viewportName: String, buildUuid: String): BuildType  {
 
 		dependencies {
 			snapshot(BuildDockerImage) {
+				onDependencyFailure = FailureAction.FAIL_TO_START
 			}
 		}
 	}
@@ -700,6 +702,7 @@ fun playwrightBuildType( viewportName: String, buildUuid: String ): BuildType {
 
 		dependencies {
 			snapshot(BuildDockerImage) {
+				onDependencyFailure = FailureAction.FAIL_TO_START
 			}
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/block-helpers.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/block-helpers.test.ts
@@ -1,7 +1,5 @@
 import { getCategoryWithFallbacks } from '.';
 
-const a = 1;
-
 jest.mock( '@wordpress/blocks', () => ( {
 	getCategories: () => [ { slug: 'foobar' }, { slug: 'barfoo' } ],
 } ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/block-helpers.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-helpers/block-helpers.test.ts
@@ -1,5 +1,7 @@
 import { getCategoryWithFallbacks } from '.';
 
+const a = 1;
+
 jest.mock( '@wordpress/blocks', () => ( {
 	getCategories: () => [ { slug: 'foobar' }, { slug: 'barfoo' } ],
 } ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Configure TeamCity to fail E2E builds if the dependencies (i.e. the docker image) can't be built.

From the docs (https://www.jetbrains.com/help/teamcity/snapshot-dependencies.html#Suitable+Builds):

> Mark build as failed to start: the dependent build will not run and will be marked as "Failed to start".
