### PR TITLE
Two small fixes for the server build

### DIFF
--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -68,7 +68,7 @@ function redirectToCalypso( request, response, next ) {
 export default function ( app ) {
 	return app.post(
 		[ '/log-in/apple/callback', '/start/user', '/me/security/social-login' ],
-		bodyParser.urlencoded(),
+		bodyParser.urlencoded( { extended: true } ),
 		loginWithApple,
 		redirectToCalypso
 	);

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -129,7 +129,6 @@ const webpackConfig = {
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'calypso:src', 'module', 'main' ],
-		modules: [ path.join( __dirname, 'extensions' ), 'node_modules' ],
 		alias: {
 			'@automattic/calypso-config': 'calypso/server/config',
 		},


### PR DESCRIPTION
While checking how `webpack-dev-middleware` in the dev server really works (:wave: @fullofcaffeine), I noticed two easily fixable things in the server build:

There is a console warning from the `body-parser` package, namely its `.urlencoded` method used in "Sign in with Apple":
```
body-parser deprecated undefined extended: provide extended option build/server.js:32360:122
```
We need to provide an [explicit value of the `extended` option](https://github.com/expressjs/body-parser#extended), and decide whether the parser should use `qs` or `querystring` package for parsing. I'm just asserting the default value, which is `true`, which means `qs`, which is more powerful (additional security, support for nested values).

The second little patch is removing the `modules` field from `webpack.config.node.js` pointing to the `extensions/` directory. Something I forgot to do in #55655 that removed the extensions.

Both fixes have nothing in common, except that they are server-side, but as they are both simple one-liners, I'm submitting them as one PR.