### PR TITLE
build: Simplify generation of assets list

### DIFF
--- a/bin/loader-stats.js
+++ b/bin/loader-stats.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const path = require( 'path' );
-const stats = require( path.join( __dirname, '..', 'build', 'assets-evergreen.json' ) );
+const stats = require( path.join( __dirname, '..', 'build', 'assets.json' ) );
 const gzipSize = require( 'gzip-size' );
 const _ = require( 'lodash' );
 

--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -4,7 +4,7 @@ import asyncHandler from 'express-async-handler';
 import { defaults, groupBy, flatten } from 'lodash';
 
 const ASSETS_PATH = path.resolve( __dirname, '../../../build' );
-const ASSETS_FILE = path.join( ASSETS_PATH, `assets-evergreen.json` );
+const ASSETS_FILE = path.join( ASSETS_PATH, `assets.json` );
 const EMPTY_ASSETS = { js: [], 'css.ltr': [], 'css.rtl': [] };
 
 const getAssetType = ( asset ) => {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -246,7 +246,7 @@ const buildApp = ( environment ) => {
 				],
 			};
 			mockFs( {
-				'./build/assets-evergreen.json': JSON.stringify( assets ),
+				'./build/assets.json': JSON.stringify( assets ),
 				'./public/evergreen/languages/lang-revisions.json': JSON.stringify( { es: 1234 } ),
 			} );
 			tearDown.push( () => mockFs.restore() );

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -284,9 +284,8 @@ const webpackConfig = {
 			minify: ! isDevelopment,
 		} ),
 		new AssetsWriter( {
-			filename: `assets-${ browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv }.json`,
+			filename: `assets.json`,
 			path: path.join( outputDir, 'build' ),
-			assetExtraPath: extraPath,
 		} ),
 		shouldCheckForDuplicatePackages && new DuplicatePackageCheckerPlugin(),
 		shouldCheckForCycles &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Replace name `assets-evergreen.json` with just `assets.json`

Now that `fallback` is gone, the `-evergreen` suffix doesn't add any value.


#### Testing instructions

* Checkout this branch and check `yarn start` works
* Checkout this branch and check `yarn build-clien && ./bin/loader-stats.js` works
* Verify tests are green