### PR TITLE
Build: remove postcss-custom-properties plugin

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -251,7 +251,6 @@
 		"component-event": "^0.2.0",
 		"component-query": "^0.0.3",
 		"pkg-dir": "^5.0.0",
-		"postcss-custom-properties": "^11.0.0",
 		"process": "^0.11.10",
 		"react-test-renderer": "^16.12.0",
 		"redux-mock-store": "^1.5.4"

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,7 +13,6 @@ const {
 	cssNameFromFilename,
 	shouldTranspileDependency,
 } = require( '@automattic/calypso-build/webpack/util' );
-const calypsoColorSchemes = require( '@automattic/calypso-color-schemes/js' );
 const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
 const InlineConstantExportsPlugin = require( '@automattic/webpack-inline-constant-exports-plugin' );
 const autoprefixerPlugin = require( 'autoprefixer' );
@@ -21,7 +20,6 @@ const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
 const pkgDir = require( 'pkg-dir' );
-const postcssCustomPropertiesPlugin = require( 'postcss-custom-properties' );
 const webpack = require( 'webpack' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const cacheIdentifier = require( '../build-tools/babel/babel-loader-cache-identifier' );
@@ -216,11 +214,7 @@ const webpackConfig = {
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its
 					// own `postcss.config.js` that they use for their webpack bundling process.
 					config: false,
-					plugins: [
-						autoprefixerPlugin(),
-						browserslistEnv === 'defaults' &&
-							postcssCustomPropertiesPlugin( { importFrom: [ calypsoColorSchemes ] } ),
-					].filter( Boolean ),
+					plugins: [ autoprefixerPlugin() ],
 				},
 				prelude: `@use '${ path.join(
 					__dirname,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12500,7 +12500,6 @@ __metadata:
     pkg-dir: ^5.0.0
     portscanner: ^2.2.0
     postcss: ^8.2.6
-    postcss-custom-properties: ^11.0.0
     prismjs: ^1.17.1
     process: ^0.11.10
     prop-types: ^15.7.2


### PR DESCRIPTION
Removes the `postcss-custom-properties` plugin from Calypso webpack configuration. It was adding fallback color properties (like `color: #ffffff`) to CSS files that use CSS variables for colors (`color: var( --color-text )`), for browsers that don't support CSS variables. Because we now only support evergreen browsers, which can all understand CSS variables, this step can be removed.

The `postcss-custom-properties` continues to be used by the `calypso-build` package etc, because it still supports IE11 compatible builds.