### PR TITLE
Build: remove guard that emitted images only for evergreen builds

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -143,7 +143,6 @@ const fileLoader = FileConfig.loader(
 				// Build off `outputPath` for a result like `/…/public/evergreen/../images/`.
 				publicPath: '/calypso/images/',
 				outputPath: '../images/',
-				emitFile: browserslistEnv === defaultBrowserslistEnv, // Only output files once.
 		  }
 );
 


### PR DESCRIPTION
Removes a check that guarantees that image assets are output only during `evergreen` build, not during any other like `fallback`. This was useful when we were building both `evergreen` and `fallback` in parallel, and prevented overwriting files in a shared folder.