### PR TITLE
Invites: re-enable form on signup failure

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -21,6 +21,7 @@ import { createAccount, acceptInvite } from 'calypso/state/invites/actions';
  * Module variables
  */
 const debug = debugModule( 'calypso:invite-accept:logged-out' );
+const noop = () => {};
 
 class InviteAcceptLoggedOut extends React.Component {
 	state = { bearerToken: false, userData: false, submitting: false };
@@ -43,7 +44,7 @@ class InviteAcceptLoggedOut extends React.Component {
 		window.location = signInLink;
 	};
 
-	submitForm = ( form, userData ) => {
+	submitForm = ( form, userData, _, afterSubmitCallback = noop ) => {
 		const { invite } = this.props;
 
 		this.setState( { submitting: true } );
@@ -67,7 +68,8 @@ class InviteAcceptLoggedOut extends React.Component {
 				debug( 'Create account error: ' + JSON.stringify( error ) );
 				store.remove( 'invite_accepted' );
 				this.setState( { submitting: false } );
-			} );
+			} )
+			.finally( afterSubmitCallback );
 	};
 
 	renderFormHeader = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes an issue where the form stays disabled when the signup fails (error response from API call).
* Issue: [The call to submitForm()](https://github.com/Automattic/wp-calypso/blob/bd218273fa8de0a7a29e6817250400f3632502ca/client/blocks/signup-form/index.jsx#L397) provides a callback to handle resetting of state, but is not being received and run.

**BEFORE: form is still disabled even when API call has returned**
<img width="1679" alt="Screen Shot 2021-09-13 at 7 43 51 PM" src="https://user-images.githubusercontent.com/730823/133078799-c1f9dbff-9643-4c85-aa85-d3891d2a39cd.png">


**AFTER: form gets re-enabled when API call returns**
<img width="1679" alt="Screen Shot 2021-09-13 at 7 44 38 PM" src="https://user-images.githubusercontent.com/730823/133079029-b529735c-1951-4d25-b529-6e0f0fd06cfd.png">




#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on simple, non-P2 sites*
* Send a user invite to your test email address.
* Open the invite link on incognito, to get the signup form.
* Trigger the error by entering the same string for username and password.
* Before proposed fix: notice that the error is displayed, but the form remains disabled.
* After proposed fix: notice that the form gets re-enabled as the error is displayed.
* Regression test: check that successful signups still work.

\* P2 sites have a CSS issue that inadvertently hides the error notice. This will be fixed in a separate issue.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
