### PR TITLE
P2: fix CSS hiding global notices

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -18,6 +18,7 @@ import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice, infoNotice } from 'calypso/state/notices/actions';
+import { hideMasterbar } from 'calypso/state/ui/actions';
 import normalizeInvite from './utils/normalize-invite';
 
 import './style.scss';
@@ -61,6 +62,10 @@ class InviteAccept extends React.Component {
 			// Replace the plain invite key with the strengthened key
 			// from the url: invite key + secret
 			invite.inviteKey = inviteKey;
+
+			if ( invite?.site?.is_wpforteams_site ) {
+				this.props.hideMasterbar();
+			}
 
 			this.handleFetchInvite( false, invite );
 		} catch ( error ) {
@@ -254,5 +259,6 @@ class InviteAccept extends React.Component {
 export default connect( ( state ) => ( { user: getCurrentUser( state ) } ), {
 	successNotice,
 	infoNotice,
+	hideMasterbar,
 	redirectToLogout,
 } )( localize( InviteAccept ) );

--- a/client/my-sites/invites/p2/style.scss
+++ b/client/my-sites/invites/p2/style.scss
@@ -8,7 +8,6 @@
 	left: 0;
 	bottom: 0;
 	width: 100vw;
-	z-index: 200;
 	background: #fff;
 	color: var( --p2-color-text );
 	font-family: var( --p2-font-inter );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug that was inadvertently hiding global notices for the `accept-invite` signup screen for P2 sites. This bug was due to a CSS workaround that forced a white background and hid the masterbar.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a P2 invite link in incognito, to get the signup screen.
* Trigger a global notice (error) by entering the same string for both username and password.
* Verify that you get an error notice on the upper right corner of the screen (see screenshot below).
* Notice that the form remains disabled. This issue is unrelated and will be fixed in #56200

<img width="800" alt="Screen Shot 2021-09-13 at 9 15 47 PM" src="https://user-images.githubusercontent.com/730823/133090257-1d1d16d7-4d3d-4e53-8b39-9762a3f13365.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
