### PR TITLE
Enable the backups datepicker in development and staging environments

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -91,26 +91,6 @@
 		padding: initial;
 		background: initial;
 	}
-
-	.button {
-		color: var( --color-neutral-70 );
-
-		&.is-borderless {
-			color: var( --color-text-subtle );
-		}
-
-		&.is-primary {
-			color: var( --color-text-inverted );
-		}
-
-		&.is-primary.is-borderless {
-			color: var( --color-accent );
-		}
-
-		&[disabled] {
-			color: var( --color-neutral-20 );
-		}
-	}
 }
 
 .backup__upsell-icon {

--- a/config/development.json
+++ b/config/development.json
@@ -83,6 +83,7 @@
 		"i18n/translation-scanner": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
+		"jetpack/backups-date-picker": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -53,6 +53,7 @@
 		"i18n/empathy-mode": true,
 		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
+		"jetpack/backups-date-picker": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable the datepicker tool for the Jetpack Backups screen
* Remove some button styles specific to the Wordpress.com Backups screen that were creating conflicts with the output of the search results produced by the datepicker .

#### Testing instructions

* Check this branch out in your local development environment
* Using the site switcher, select a site with Jetpack Backups 
* Navigate to Jetpack > Backups to view the backup screen
* In the Filter bar that shows above the backup details, there should now be a small calendar icon that will show a date-selection pop-over when clicked
![Screen Shot 2021-09-13 at 11 02 45 AM](https://user-images.githubusercontent.com/18016357/133109575-53833c05-d8fe-4f27-a1e3-cb1284b37235.png)

* Select a date range using the date-selection pop-over - the output should update to show backup/ restore events from the selected date range. For reference, the behavior should be the same as is available on cloud.jetpack.com/backup
