### PR TITLE
Remove calendly appointment URL

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,6 @@
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
-	"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call",
 	"difm_typeform_id": "YMiXMYId",
 	"features": {
 		"ad-tracking": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable Jetpack onboarding calls.

#### Note

Removing the `calendly_jetpack_appointment_url` configuration key effectively removes the Calendly component from the post-purchase UI because it is only shown when the Calendly URL is available.

On a follow-up PR, we will remove all code related to the onboarding call feature.

#### Testing instructions

There is no way to test this since it's a change that only affects production, but you can more or less replicate it in development if you do the following:

* Add `"calendly_jetpack_appointment_url": "https://calendly.com/jetpack-com/onboarding-call"` to your `config/development.json` file.
* Start Calypso with `yarn start`.
* Complete a site-less purchase.
* In the URL, replace `wordpress.com` with `calypso.localhost:3000` so you can see the local version of the post-purchase UI.
* Confirm that you see the onboarding call component on the right of the screen.
* Remove the configuration key from the `config/development.json` file.
* Stop Calypso.
* Start Calypso with `yarn start`.
* Refresh the post-purchase UI browser window.
* Confirm that you no longer see the onboarding call component on the right of the screen. 

Related to 1200738571375997-as-1200973597420858

#### Demo – before

![image](https://user-images.githubusercontent.com/3418513/133132577-63c535f2-5a6f-4804-a474-10c71102367f.png)

#### Demo – after
![image](https://user-images.githubusercontent.com/3418513/133132604-279d5ad8-221f-430b-9fde-ca79d7eeb750.png)

