### PR TITLE
Playwright: update selector used in MediaPage.editImage

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { ElementHandle, Page } from 'playwright';
+import { getTargetDeviceName } from '../../browser-helper';
 import { waitForElementEnabled, clickNavTab } from '../../element-helper';
 
 const selectors = {
@@ -13,8 +14,9 @@ const selectors = {
 
 	// Modal view
 	mediaModal: '.editor-media-modal__content',
-	mediaModalEditButton:
-		'.editor-media-modal-detail__edition-bar .editor-media-modal-detail__edit:visible',
+	mediaModalActionBar: ( device: string ) =>
+		`.editor-media-modal-detail__edition-bar.is-${ device }`,
+	mediaModalEditButton: 'button:text("Edit Image")',
 	mediaModalPreview: '.editor-media-modal-detail__preview',
 
 	// Editor view
@@ -97,7 +99,11 @@ export class MediaPage {
 		await this.waitUntilLoaded();
 
 		await this.page.click( selectors.editButton );
-		await this.page.click( selectors.mediaModalEditButton );
+		await this.page.click(
+			`${ selectors.mediaModalActionBar( getTargetDeviceName() ) } ${
+				selectors.mediaModalEditButton
+			}`
+		);
 		await this.page.waitForSelector( selectors.imageEditorCanvas );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to update the selector used in `MediaPage.editImage` to work with both mobile and desktop viewports reliably.

Key changes:
- switch between the two selectors - `is-desktop` and `is-mobile` based on target device size.

#### Testing instructions

- [ ] Media (Edit) tests should not fail on either Playwright tasks.

Fixes #5674
