### PR TITLE
Playwright: NotificationComponent to wait before clicking on action.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( targetDevice: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-reader; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -642,7 +642,7 @@ fun playwrightBuildType( targetDevice: String, buildUuid: String ): BuildType {
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-reader; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -1,8 +1,12 @@
 import { ElementHandle, Page } from 'playwright';
 
 const selectors = {
+	// Notificatins panel (including sub-panels)
 	comment: '.wpnc__comment',
 	singleViewPanel: '.wpnc__single-view',
+
+	// Comment actions
+	commentAction: ( action: string ) => `button.wpnc__action-link:has-text("${ action }"):visible`,
 	undoLocator: '.wpnc__undo-item',
 };
 /**
@@ -53,8 +57,9 @@ export class NotificationsComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNotificationAction( action: 'Trash' ): Promise< void > {
-		const selector = `*css=button >> text=${ action }`;
-		await this.page.click( selector );
+		const elementHandle = await this.page.waitForSelector( selectors.singleViewPanel );
+		await elementHandle.waitForElementState( 'stable' );
+		await this.page.click( selectors.commentAction( action ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -1,7 +1,7 @@
 import { ElementHandle, Page } from 'playwright';
 
 const selectors = {
-	// Notificatins panel (including sub-panels)
+	// Notifications panel (including sub-panels)
 	comment: '.wpnc__comment',
 	singleViewPanel: '.wpnc__single-view',
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a wait (after clicking on a notification) for the pane to expand fully prior to clicking on any actions.

Key changes:
- refactor selector to use dynamic selectors.
- add a wait for the notification item single view panel to reach  `stable` state.

#### Testing instructions

- [x] stress test must pass.
  - [x] mobile
  - [x] desktop
- [x] all other tests pass.

Related to #
