### PR TITLE
Redirect /plans to /pricing in Jetpack cloud

### DIFF
--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,9 +1,14 @@
+import page from 'page';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import { jetpackPricingContext } from './controller';
 import './style.scss';
 
 export default function (): void {
-	jetpackPlans( `/:locale/pricing`, jetpackPricingContext );
-	jetpackPlans( `/pricing`, loggedInSiteSelection, jetpackPricingContext );
+	// Redirects
+	page( '/:locale/plans', ( { params } ) => page.redirect( `/${ params.locale }/pricing` ) );
+	page( '/plans', '/pricing' );
+
+	jetpackPlans( '/:locale/pricing', jetpackPricingContext );
+	jetpackPlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -469,7 +469,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud-pricing',
-		paths: [ '/pricing', '/[^\\/]+/pricing' ],
+		paths: [ '/pricing', '/[^\\/]+/pricing', '/plans', '/[^\\/]+/plans' ],
 		module: 'calypso/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

http://cloud.jetpack.com/plans redirects to http://wordpress.com/pricing. It should redirect to http://cloud.jetpack.com/pricing instead. This PR fixes it.

Fixes 1164141197617539-as-1200973313450479

### Testing instructions

- Download the PR and run cloud
- For both the authenticated and non authenticated use cases, check that:
  - Visiting `http://jetpack.cloud.localhost:3000/plans` redirects you to `http://jetpack.cloud.localhost:3000/pricing`
  - Visiting `http://jetpack.cloud.localhost:3000/:locale/plans` redirects you to `http://jetpack.cloud.localhost:3000/pricing`, with the page displayed in the proper language
