### PR TITLE
Make masterbar in cloud pricing page wider

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -50,7 +50,7 @@ $z-layers: (
 		'.reader-related-card.card': 0,
 		'.reader-full-post__sidebar-comment-like': 1,
 		'.list-stream__header-follow': 0,
-		'.following__intro-close-icon-bg' : 0,
+		'.following__intro-close-icon-bg': 0,
 		'.form-text-input-with-affixes .form-text-input': 1,
 		'.is-section-signup': 1,
 		'.media-library .search.is-expanded-to-container': 1,
@@ -96,12 +96,14 @@ $z-layers: (
 		'.site-indicator__button': 3,
 		'ul.module-content-list-item-actions.collapsed': 3,
 		'.jetpack-connect__password-form .gridicon': 3,
-		'.jetpack-connect__creds-form-footer .jetpack-connect__creds-form-spinner':3,
+		'.jetpack-connect__creds-form-footer .jetpack-connect__creds-form-spinner': 3,
 		'.site-selector': 10,
 		'.layout__secondary .site-selector': 10,
 		'.range__label': 10,
 		'.sticky-panel.is-sticky .sticky-panel__content': 20,
-		'.main': 20, //TODO: this doesn't always have a stacking context
+		//TODO: this doesn't always have a stacking context
+		'.main': 20,
+		'.jpcom-masterbar': 21,
 		'.main.calypsoify.is-iframe': 20,
 		'.search': 22,
 		'.reader-update-notice': 22,
@@ -113,7 +115,7 @@ $z-layers: (
 		'.feature-example__gradient': 170,
 		'.select-dropdown.is-open .select-dropdown__container': 170,
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
-		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
+		'.sites-dropdown.is-open .sites-dropdown__wrapper': 170,
 		'.inline-help__mobile-overlay': 175,
 		'.floating-help': 176,
 		'.directly-rtm.is-minimized': 176,
@@ -160,8 +162,10 @@ $z-layers: (
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
 		'.support-article-dialog__base.dialog__backdrop': 201001,
-		'.wpcom-site__global-noscript': 300000, // JS off always visible
-		'.is-section-woocommerce .global-notices': 999999, //render notices on top of dialogs
+		'.wpcom-site__global-noscript': 300000,
+		// JS off always visible
+		'.is-section-woocommerce .global-notices': 999999,
+		//render notices on top of dialogs
 		'.webpack-build-monitor': 99999999,
 		'.people-list-item.card.is-compact:focus': 1,
 	),
@@ -171,20 +175,20 @@ $z-layers: (
 	),
 	'.ribbon': (
 		'.ribbon__title::before': -1,
-		'.ribbon__title::after': -1
+		'.ribbon__title::after': -1,
 	),
 	'.environment-badge': (
 		'.environment-badge .environment::before': -1,
-		'.environment-badge .bug-report': 1000
+		'.environment-badge .bug-report': 1000,
 	),
 	'.masterbar': (
 		'.masterbar__notifications-bubble': 99999,
 		'.reader-back': 99999,
 		'.reader-visit-site': 99999,
-		'.reader-profile': 100000
+		'.reader-profile': 100000,
 	),
 	'.detail-page__backdrop': (
-		'.detail-page__action-buttons': 200
+		'.detail-page__action-buttons': 200,
 	),
 	'.popover': (
 		'.input-chrono__input': 1,
@@ -197,11 +201,11 @@ $z-layers: (
 		'.search__input': 10,
 		'.search.is-searching .spinner': 20,
 		'.search .search__open-icon': 20,
-		'.search .search__close-icon': 20
+		'.search .search__close-icon': 20,
 	),
 	'.profile-gravatar__edit-label-wrap': (
 		'.profile-gravatar__edit-label-wrap:after': 0,
-		'.profile-gravatar__edit-label': 1000
+		'.profile-gravatar__edit-label': 1000,
 	),
 	'.media-library__list-item': (
 		'.media-library__list-item.is-selected::after': 10,
@@ -216,77 +220,77 @@ $z-layers: (
 		'.memberships__dialog-section.is-visible': 1,
 	),
 	'.site-settings__taxonomies': (
-		'.card__link-indicator': 1
+		'.card__link-indicator': 1,
 	),
 	'.reader-feed-header': (
 		'.reader-feed-header__site': 0,
-		'.reader-feed-header__follow': 1
+		'.reader-feed-header__follow': 1,
 	),
 	'.reader-feed-header__back-and-follow': (
 		'.card.header-cake': 1,
-		'.reader-feed-header__follow': 1
+		'.reader-feed-header__follow': 1,
 	),
 	'.reader-full-post__sidebar-comment-like': (
 		'.reader-full-post .back-button': 2,
 		'.author-compact-profile__follow .follow-button': 2,
-		'.reader-full-post__visit-site-container': 2
+		'.reader-full-post__visit-site-container': 2,
 	),
 	'.reader-related-card.card': (
-		'.reader-related-card__meta': 1
+		'.reader-related-card__meta': 1,
 	),
 	'.reader-related-card__meta': (
-		'.follow-button': 1
+		'.follow-button': 1,
 	),
 	'.list-stream__header-follow': (
-		'.follow-button': 1
+		'.follow-button': 1,
 	),
 	'.stats-post-summary': (
-		'.section-nav': 1
+		'.section-nav': 1,
 	),
-	'.thank-you-card__header' : (
+	'.thank-you-card__header': (
 		'.thank-you-card__background-icons .gridicon': 1,
 		'.thank-you-card__main-icon': 2,
-		'.thank-you-card__header-detail': 2
+		'.thank-you-card__header-detail': 2,
 	),
 	'.upwork-banner': (
 		'.button.upwork-banner__cta': 2,
-		'.button.upwork-banner__close': 4
+		'.button.upwork-banner__close': 4,
 	),
 	'.checklist__task': (
 		'.checklist__task::before': 10,
-		'.checklist__task-icon': 20
+		'.checklist__task-icon': 20,
 	),
-
 	// The following may be inserted into different areas.
 	// The parent stacking context may be root, or something else depending on where it is inserted.
-	'icon-parent': (
-		'.sidebar__menu .gridicon.gridicons-external': 1
-	),
+	'icon-parent':
+		(
+			'.sidebar__menu .gridicon.gridicons-external': 1,
+		),
 	'screen-reader-text-parent': (
-		'.screen-reader-text:focus': 100000
+		'.screen-reader-text:focus': 100000,
 	),
 	'button-group-parent': (
-		'.button-group .button:focus': 1
+		'.button-group .button:focus': 1,
 	),
 	'progress-indicator-parent': (
-		'.progress-indicator .is-success': 2
+		'.progress-indicator .is-success': 2,
 	),
 	'section-nav-tabs__dropdown-parent': (
 		'.section-nav-tabs__dropdown': 3,
-		'.section-nav-tabs__dropdown.is-open': 4
+		'.section-nav-tabs__dropdown.is-open': 4,
 	),
 	'reader-card-follow-button-parent': (
-		'.reader__card.card .follow-button': 1
+		'.reader__card.card .follow-button': 1,
 	),
 	'.tag-stream__header-follow': (
-		'.follow-button': 1
-	)
+		'.follow-button': 1,
+	),
 );
 
 // allows us to do a nested fetch
 @function map-deep-get( $map, $keys... ) {
 	@each $key in $keys {
-		@if not map-has-key( $map, $key) {
+		@if not map-has-key( $map, $key ) {
 			@warn 'No layer found for `#{$key}` of `[#{ $keys }]` in $z-layers map. Property omitted.';
 			@return map-get( $map, $key );
 		}

--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -162,10 +162,10 @@ $z-layers: (
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
 		'.support-article-dialog__base.dialog__backdrop': 201001,
-		'.wpcom-site__global-noscript': 300000,
 		// JS off always visible
-		'.is-section-woocommerce .global-notices': 999999,
+		'.wpcom-site__global-noscript': 300000,
 		//render notices on top of dialogs
+		'.is-section-woocommerce .global-notices': 999999,
 		'.webpack-build-monitor': 99999999,
 		'.people-list-item.card.is-compact:focus': 1,
 	),

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -5,6 +5,7 @@ import { hideMasterbar } from 'calypso/state/ui/actions';
 import { setLocale } from 'calypso/state/ui/language/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
+import JetpackComMasterbar from './jpcom-masterbar';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
 	const urlQueryArgs = context.query;
@@ -22,6 +23,7 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 	}
 
 	context.store.dispatch( hideMasterbar() );
+	context.nav = <JetpackComMasterbar />;
 	context.header = <Header urlQueryArgs={ urlQueryArgs } />;
 	context.footer = <JetpackComFooter />;
 	next();

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner';
 import { preventWidows } from 'calypso/lib/formatting';
-import JetpackComMasterbar from '../jpcom-masterbar';
 import './style.scss';
 
 const Header: React.FC< Props > = () => {
@@ -11,8 +10,6 @@ const Header: React.FC< Props > = () => {
 
 	return (
 		<>
-			<JetpackComMasterbar />
-
 			<div className="header">
 				<FormattedHeader
 					className="header__main-title"

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -9,9 +9,8 @@
 	align-items: center;
 
 	width: calc( 100% - 4rem );
-	height: 102px;
 	max-width: 1200px;
-	margin: -47px auto 0; // Undo the padding-top set by .layout__content
+	margin: -32px auto 0; // Undo the padding-top set by .layout__content
 	padding: 0 2rem;
 
 	background-color: var( --color-surface );
@@ -19,7 +18,7 @@
 	// Breakpoint taken from jetpack.com, not standard in Calypso
 	@media ( min-width: 661px ) {
 		width: 100%;
-		margin-top: -71px; // Undo the padding-top set by .layout__content
+		margin-top: -52px; // Undo the padding-top set by .layout__content
 		padding: 0;
 	}
 
@@ -27,7 +26,8 @@
 		width: 95vw;
 	}
 
-	@media ( min-width: 901px ) {
+	@media ( min-width: 960px ) {
+		height: 102px;
 		margin-top: -79px; // Undo the padding-top set by .layout__content
 	}
 

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -2,31 +2,45 @@
 @import '@wordpress/base-styles/mixins';
 
 .jpcom-masterbar {
+	display: flex;
+	align-items: center;
+
+	width: calc( 100% - 4rem );
+	height: 102px;
+	max-width: 1200px;
+	margin: -47px auto 0; // Undo the padding-top set by .layout__content
+	padding: 0 2rem;
+
 	background-color: var( --color-surface );
 
-	padding: 1em 16px;
-
-	// Undo the padding-top set by .layout__content for each
-	// screen size.
-	margin-top: -47px;
-
-	// We need to use this deprecated breakpoint because we need
-	// to match Calypso's layout breakpoint also.
-	@include breakpoint-deprecated( '>660px' ) {
-		padding: 20px 0 22px;
-
-		margin-top: -71px;
+	// Breakpoint taken from jetpack.com, not standard in Calypso
+	@media ( min-width: 661px ) {
+		width: 100%;
+		margin-top: -71px; // Undo the padding-top set by .layout__content
+		padding: 0;
 	}
 
-	@include break-large {
-		padding-bottom: 40px;
+	@media ( min-width: 783px ) {
+		width: 95vw;
+	}
 
-		margin-top: -79px;
+	@media ( min-width: 901px ) {
+		margin-top: -79px; // Undo the padding-top set by .layout__content
+	}
+
+	@media ( min-width: 1101px ) {
+		width: 90vw;
+	}
+
+	@media ( min-width: 1301px ) {
+		width: 85vw;
 	}
 }
 
 .jpcom-masterbar__inner {
 	position: relative;
+
+	width: 100%;
 
 	// Breakpoint taken from jetpack.com, not standard in Calypso
 	@media ( min-width: 375px ) {
@@ -40,10 +54,7 @@
 	@include break-large {
 		flex-wrap: nowrap;
 
-		max-width: 1040px;
-
 		margin: 0 auto;
-		padding: 0 32px;
 	}
 }
 

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -2,6 +2,9 @@
 @import '@wordpress/base-styles/mixins';
 
 .jpcom-masterbar {
+	position: relative;
+	z-index: z-index( 'root', '.jpcom-masterbar' );
+
 	display: flex;
 	align-items: center;
 

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -25,7 +25,6 @@ function stringToDuration( duration?: string ): Duration | undefined {
  * slug, otherwise, return null.
  *
  * @param {string} productSlug the slug of a Jetpack product
- *
  * @returns {[string, string] | null} the monthly and yearly slug of a supported Jetpack product
  */
 function getHighlightedProduct( productSlug?: string ): [ string, string ] | null {
@@ -66,6 +65,7 @@ export const productSelect = ( rootUrl: string ): PageJS.Callback => ( context, 
 			siteSlug={ siteParam || context.query.site }
 			urlQueryArgs={ urlQueryArgs }
 			highlightedProducts={ highlightedProducts }
+			nav={ context.nav }
 			header={ context.header }
 			footer={ context.footer }
 			planRecommendation={ planRecommendation }

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -34,6 +34,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	siteSlug: siteSlugProp,
 	rootUrl,
 	urlQueryArgs,
+	nav,
 	header,
 	footer,
 	planRecommendation,
@@ -183,32 +184,36 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	);
 
 	return (
-		<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
-			<PageViewTracker
-				path={ viewTrackerPath }
-				properties={ viewTrackerProps }
-				title="Plans"
-				options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
-			/>
+		<>
+			{ nav }
 
-			{ header }
+			<Main className={ classNames( 'selector__main', iterationClassName ) } wideLayout>
+				<PageViewTracker
+					path={ viewTrackerPath }
+					properties={ viewTrackerProps }
+					title="Plans"
+					options={ { useJetpackGoogleAnalytics: ! isJetpackCloud() } }
+				/>
 
-			<ProductGrid
-				duration={ currentDuration }
-				urlQueryArgs={ urlQueryArgs }
-				planRecommendation={ planRecommendation }
-				onSelectProduct={ selectProduct }
-				onDurationChange={ trackDurationChange }
-				scrollCardIntoView={ scrollCardIntoView }
-				createButtonURL={ createProductURL }
-			/>
+				{ header }
 
-			{ siteId ? <QuerySiteProducts siteId={ siteId } /> : <QueryProductsList type="jetpack" /> }
-			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-			{ siteId && <QuerySites siteId={ siteId } /> }
+				<ProductGrid
+					duration={ currentDuration }
+					urlQueryArgs={ urlQueryArgs }
+					planRecommendation={ planRecommendation }
+					onSelectProduct={ selectProduct }
+					onDurationChange={ trackDurationChange }
+					scrollCardIntoView={ scrollCardIntoView }
+					createButtonURL={ createProductURL }
+				/>
 
-			{ footer }
-		</Main>
+				{ siteId ? <QuerySiteProducts siteId={ siteId } /> : <QueryProductsList type="jetpack" /> }
+				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+				{ siteId && <QuerySites siteId={ siteId } /> }
+
+				{ footer }
+			</Main>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -25,6 +25,7 @@ export type ScrollCardIntoViewCallback = ( arg0: HTMLDivElement, arg1: string ) 
 interface BasePageProps {
 	rootUrl: string;
 	urlQueryArgs: QueryArgs;
+	nav?: ReactNode;
 	header: ReactNode;
 	footer?: ReactNode;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes the masterbar in the cloud pricing page wider, in order to match the bar in Jetpack.com.

Fixes 1196108640073826-as-1200855424245096

Reverts Automattic/wp-calypso#56215

### Implementation notes

I moved the masterbar out of the pricing page layout, to simplify CSS. Having the navigation outside of the `main` tag is also a better accessibility practice.

### Testing instructions

- Download the PR and run both cloud and Calypso
- Visit the pricing page
- Check that the masterbar is as wide as in http://jetpack.com/
- Check that the _Products_ sub menu appears correctly

### Screenshots

#### Jetpack.com

<img width="2032" alt="Screen Shot 2021-09-08 at 11 12 13 AM" src="https://user-images.githubusercontent.com/1620183/132537260-ffd05574-71d7-4ded-9338-4e624f97093a.png">


#### Cloud pricing page

_Before_

<img width="2032" alt="Screen Shot 2021-09-08 at 11 12 19 AM" src="https://user-images.githubusercontent.com/1620183/132537307-56421cae-d457-4d28-80c9-01330f8bf068.png">



_After_

<img width="2032" alt="Screen Shot 2021-09-08 at 11 12 17 AM" src="https://user-images.githubusercontent.com/1620183/132537344-fb361131-7798-431c-bd23-e4298453c496.png">
