### PR TITLE
Playwright: restructure Support test to eliminate dependency on result counts

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -695,7 +695,7 @@ fun playwrightBuildType( targetDevice: String, buildUuid: String ): BuildType {
 		}
 
 		failureConditions {
-			executionTimeoutMin = 20
+			executionTimeoutMin = 45
 		}
 
 		dependencies {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -695,7 +695,7 @@ fun playwrightBuildType( targetDevice: String, buildUuid: String ): BuildType {
 		}
 
 		failureConditions {
-			executionTimeoutMin = 45
+			executionTimeoutMin = 20
 		}
 
 		dependencies {

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -177,7 +177,7 @@ export class SupportComponent {
 			this.page.waitForResponse(
 				( response ) => response.url().includes( 'search?' ) && response.status() === 200
 			),
-			this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'detached' } ),
+			this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'hidden' } ),
 			this.page.waitForSelector( selectors.spinner, { state: 'hidden' } ),
 			this.page.fill( selectors.searchInput, text ),
 		] );

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -172,24 +172,15 @@ export class SupportComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async search( text: string ): Promise< void > {
-		// if ( text.trim() ) {
-		// If there is valid search string, then there should be a network request made.
 		// Wait for the response to the request and ensure the status is HTTP 200.
 		await Promise.all( [
 			this.page.waitForResponse(
-				( response ) => response.url().includes( 'search?' ) && response.status() === 200,
-				{ timeout: 60000 }
+				( response ) => response.url().includes( 'search?' ) && response.status() === 200
 			),
 			this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'detached' } ),
-			this.page.waitForSelector( selectors.spinner, { state: 'hidden', timeout: 60000 } ),
+			this.page.waitForSelector( selectors.spinner, { state: 'hidden' } ),
 			this.page.fill( selectors.searchInput, text ),
 		] );
-		// } else {
-		// If invalid search string (eg. '     '), then no request is made.
-		await this.page.fill( selectors.searchInput, text );
-		// }
-
-		// In all cases, wait for the 'load' state to be fired.
 		await this.page.waitForLoadState( 'load' );
 	}
 

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -1,9 +1,10 @@
-import assert from 'assert';
 import { ElementHandle, Page } from 'playwright';
+
+type SupportResultType = 'article' | 'where';
 
 const selectors = {
 	// Components
-	supportButton: '.inline-help__button',
+	supportPopoverButton: '.inline-help__button',
 	supportPopover: '.inline-help__popover',
 	searchInput: '[aria-label="Search"]',
 	clearSearch: '[aria-label="Close Search"]',
@@ -12,14 +13,13 @@ const selectors = {
 
 	// Results
 	resultsPlaceholder: '.inline-help__results-placeholder-item',
-	resultsList: '.inline-help__results',
-	results: '.inline-help__results-item',
+	results: ( category: string ) => `[aria-labelledby="${ category }"] .inline-help__results-item`,
+	defaultResultsMessage: 'h3:text("This might interest you")',
 
 	// Result types
-	supportItems: '[aria-labelledby="inline-search--api_help"] li',
-	adminItems: '[aria-labelledby="inline-search--admin_section"] li',
-	emptyResults:
-		'text="Sorry, there were no matches. Here are some of the most searched for help pages for this section:"',
+	supportCategory: 'inline-search--api_help',
+	whereCategory: 'inline-search--admin_section',
+	emptyResults: ':has-text("Sorry, there were no matches.")',
 
 	// Article
 	readMoreButton: 'text=Read more',
@@ -43,21 +43,13 @@ export class SupportComponent {
 	}
 
 	/**
-	 * Click on the support button (?).
-	 * This method will toggle the status of the support popover.
-	 * If the support popover is closed, it will be opened.
-	 * If the support popover is open, it will be closed.
 	 *
-	 * @returns {Promise<void>} No return value.
 	 */
-	async clickSupportButton(): Promise< void > {
-		const isPopoverOpen = await this.page.isVisible( selectors.supportPopover );
-
-		if ( isPopoverOpen ) {
-			await this.closePopover();
-		} else {
-			await this.openPopover();
-		}
+	async waitForQueryComplete(): Promise< void > {
+		await Promise.all( [
+			this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'hidden' } ),
+			this.page.waitForSelector( selectors.spinner, { state: 'hidden' } ),
+		] );
 	}
 
 	/**
@@ -66,7 +58,7 @@ export class SupportComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async openPopover(): Promise< void > {
-		await this.page.click( selectors.supportButton );
+		await this.page.click( selectors.supportPopoverButton );
 		await this.page.waitForSelector( selectors.supportPopover, { state: 'visible' } );
 	}
 
@@ -76,7 +68,7 @@ export class SupportComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async closePopover(): Promise< void > {
-		await this.page.click( selectors.supportButton );
+		await this.page.click( selectors.supportPopoverButton );
 		await this.page.waitForSelector( selectors.supportPopover, { state: 'hidden' } );
 	}
 
@@ -94,80 +86,26 @@ export class SupportComponent {
 	/* Result methods */
 
 	/**
+	 * Checks whether the Support popover/card is in a default state (ie. no search keyword).
+	 */
+	async defaultStateShown(): Promise< void > {
+		await this.page.waitForSelector( selectors.defaultResultsMessage );
+	}
+
+	/**
 	 * Given a selector, returns an array of ElementHandles that match the given selector.
-	 * Prior to selecing the elements, this method will wait for the 'domcontentloaded' event
-	 * to be fired.
+	 * Prior to selecing the elements, this method will wait for the 'load' event.
 	 *
-	 * @param {string} selector Selector on page to look for.
+	 * @param {SupportResultType} category Type of support result item shown.
 	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles that match the given selector.
 	 */
-	async getResults( selector: string ): Promise< ElementHandle[] > {
-		await this.page.waitForLoadState( 'domcontentloaded' );
-		return await this.page.$$( selector );
-	}
+	async getResults( category: SupportResultType ): Promise< ElementHandle[] > {
+		await this.waitForQueryComplete();
 
-	/* Returns the overall number of results, not distinguishing the support & admin results. */
-
-	/**
-	 * Returns an array of ElementHandles that reference support entries regardless of its
-	 * classification on page (admin links, support articles, suggestions).
-	 *
-	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles matching the broad definition of support items.
-	 */
-	async getOverallResults(): Promise< ElementHandle[] > {
-		return await this.getResults( selectors.results );
-	}
-
-	/**
-	 * Returns the number of support items that are shown on screen regardless of its classification.
-	 *
-	 * @returns {Promise<number>} Number of search result items shown in the popover.
-	 */
-	async getOverallResultsCount(): Promise< number > {
-		const items = await this.getOverallResults();
-		return items.length;
-	}
-
-	/* Returns the results for support entries. */
-
-	/**
-	 * Returns an array of ElementHandles that are of the support article category.
-	 *
-	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles referencing support pages.
-	 */
-	async getSupportResults(): Promise< ElementHandle[] > {
-		return await this.getResults( selectors.supportItems );
-	}
-
-	/**
-	 * Returns the number of support items that are of the support article category.
-	 *
-	 * @returns {Promise<number>} Number of search result items that link to support pages.
-	 */
-	async getSupportResultsCount(): Promise< number > {
-		const items = await this.getSupportResults();
-		return items.length;
-	}
-
-	/* Returns the results for admin entries. */
-
-	/**
-	 * Returns an array of ElementHandles that are of the administrative links category.
-	 *
-	 * @returns {Promise<ElementHandle[]>} Array of ElementHandles referencing administrative pages.
-	 */
-	async getAdminResults(): Promise< ElementHandle[] > {
-		return await this.getResults( selectors.adminItems );
-	}
-
-	/**
-	 * Returns the number of support items that are of the administrative links category.
-	 *
-	 * @returns {Promise<number>} Number of search result items that link to administrative pages.
-	 */
-	async getAdminResultsCount(): Promise< number > {
-		const items = await this.getAdminResults();
-		return items.length;
+		if ( category === 'article' ) {
+			return await this.page.$$( selectors.results( selectors.supportCategory ) );
+		}
+		return await this.page.$$( selectors.results( selectors.whereCategory ) );
 	}
 
 	/**
@@ -175,37 +113,29 @@ export class SupportComponent {
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	async noResults(): Promise< void > {
+	async noResultsShown(): Promise< void > {
 		// Note that even for a search query like ;;;ppp;;; that produces no search results,
 		// some links are shown in the popover under the heading `Helpful resources for this section`.
-		const adminResults = await this.getAdminResults();
-		assert.deepStrictEqual( [], adminResults );
-		const supportResults = await this.getSupportResults();
-		assert.deepStrictEqual( [], supportResults );
 		await this.page.waitForSelector( selectors.emptyResults );
 	}
 
 	/* Interaction with results */
+
 	/**
 	 * Click on the nth result specified by the target value.
 	 *
-	 * @param {number} target The nth result to click.
-	 * @returns {Promise<void>} No return value.
-	 * @throws {Error} If the specified target exceeds the number of results shown on page.
+	 * @param {SupportResultType} category Type of support result item shown.
+	 * @param {number} target The nth result to click under the type of result.
 	 */
-	async clickResult( target: number ): Promise< void > {
-		const popOver = await this.page.waitForSelector( selectors.supportPopover );
-		await popOver.waitForElementState( 'stable' );
-		const items = await this.getOverallResults();
-
-		const resultCount = items.length;
-		if ( resultCount < target ) {
-			throw new Error(
-				`Support popover shows ${ resultCount } entries, was asked to click on entry ${ target }`
-			);
+	async clickResult( category: SupportResultType, target: number ): Promise< void > {
+		let selector: string;
+		if ( category === 'article' ) {
+			selector = selectors.results( selectors.supportCategory );
+		} else {
+			selector = selectors.results( selectors.whereCategory );
 		}
 
-		await items[ target ].click();
+		await this.page.click( `:nth-match(${ selector }, ${ target })` );
 		await this.page.click( selectors.readMoreButton );
 	}
 
@@ -242,22 +172,22 @@ export class SupportComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async search( text: string ): Promise< void > {
-		if ( text.trim() ) {
-			// If there is valid search string, then there should be a network request made.
-			// Wait for the response to the request and ensure the status is HTTP 200.
-			await Promise.all( [
-				this.page.waitForResponse(
-					( response ) => response.url().includes( 'search?' ) && response.status() === 200,
-					{ timeout: 60000 }
-				),
-				this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'detached' } ),
-				this.page.waitForSelector( selectors.spinner, { state: 'hidden', timeout: 60000 } ),
-				this.page.fill( selectors.searchInput, text ),
-			] );
-		} else {
-			// If invalid search string (eg. '     '), then no request is made.
-			await this.page.fill( selectors.searchInput, text );
-		}
+		// if ( text.trim() ) {
+		// If there is valid search string, then there should be a network request made.
+		// Wait for the response to the request and ensure the status is HTTP 200.
+		await Promise.all( [
+			this.page.waitForResponse(
+				( response ) => response.url().includes( 'search?' ) && response.status() === 200,
+				{ timeout: 60000 }
+			),
+			this.page.waitForSelector( selectors.resultsPlaceholder, { state: 'detached' } ),
+			this.page.waitForSelector( selectors.spinner, { state: 'hidden', timeout: 60000 } ),
+			this.page.fill( selectors.searchInput, text ),
+		] );
+		// } else {
+		// If invalid search string (eg. '     '), then no request is made.
+		await this.page.fill( selectors.searchInput, text );
+		// }
 
 		// In all cases, wait for the 'load' state to be fired.
 		await this.page.waitForLoadState( 'load' );

--- a/test/e2e/specs/specs-playwright/wp-support__home-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__home-spec.ts
@@ -23,11 +23,10 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 			await loginFlow.logIn();
 		} );
 
-		it( 'Displays default entries on card', async function () {
+		it( 'Displays default entries', async function () {
 			supportComponent = new SupportComponent( page );
 			await supportComponent.showSupportCard();
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			expect( defaultResults ).toBeGreaterThanOrEqual( 5 );
+			await supportComponent.defaultStateShown();
 		} );
 
 		it( 'Enter valid search keyword', async function () {
@@ -36,11 +35,8 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 		} );
 
 		it( 'Search results are shown', async function () {
-			const supportCount = await supportComponent.getSupportResultsCount();
-			expect( supportCount ).toBe( 4 );
-
-			const adminCount = await supportComponent.getAdminResultsCount();
-			expect( adminCount ).toBe( 3 );
+			const results = await supportComponent.getResults( 'article' );
+			expect( results.length ).toBeGreaterThan( 0 );
 		} );
 
 		it( 'Clear keyword', async function () {
@@ -48,14 +44,7 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 		} );
 
 		it( 'Default entries are shown again', async function () {
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			expect( defaultResults ).toBeGreaterThanOrEqual( 5 );
-
-			const supportResults = await supportComponent.getSupportResultsCount();
-			expect( supportResults ).toBe( 0 );
-
-			const adminResults = await supportComponent.getAdminResultsCount();
-			expect( adminResults ).toBe( 0 );
+			await supportComponent.defaultStateShown();
 		} );
 
 		it( 'Enter invalid search keyword', async function () {
@@ -64,7 +53,7 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 		} );
 
 		it( 'No search results are shown', async function () {
-			await supportComponent.noResults();
+			await supportComponent.noResultsShown();
 		} );
 
 		it( 'Enter empty search keyword', async function () {
@@ -74,8 +63,7 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 		} );
 
 		it( 'Continues to display default results', async function () {
-			const defaultResults = await supportComponent.getOverallResultsCount();
-			expect( defaultResults ).toBeGreaterThanOrEqual( 5 );
+			await supportComponent.noResultsShown();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR restructures the `Support` specs to remove a source of intermittent flakiness.

Key changes:
- restructure test steps to no longer rely on assertions against number of test results.
- rename some methods to be more accurate.
- adjust execution flow to account for recent changes made to the Support component that alter its behavior when invalid search strings are provided.

Background details:

The Support tests were one of the early migrations that kept true to the Selenium way of doing things, including asserting on the number of results that were displayed. This is unreliable and due to recent changes to the Support component in general, this instability has spiked.

Previously, entering an invalid search string (eg. '      ') would result in either no request being made to the server. At some point, this was changed to actually submit a request, and this had the unintended consequence of breaking the test expectations.

In order to not couple the implementation from the test case so tightly, this PR removes assertions of number of results shown, instead opting to ensure that _some result_ is shown. For queries producing no results, presence of the standard notice text is checked.

#### Testing instructions

- [x] stress test is passed
   - [x] mobile
   - [x] desktop
- [x] regular test is passed
   - [x] mobile
   - [x] desktop

Fixes #55990