### PR TITLE
Fix Date and Time Format saving in non-English languages

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -250,14 +250,6 @@ Undocumented.prototype.scheduleJetpackFullysync = function ( siteId, fn ) {
 	return this.wpcom.req.post( { path: endpointPath }, {}, fn );
 };
 
-// Used to preserve backslash in some known settings fields like custom time and date formats.
-function encode_backslash( value ) {
-	if ( typeof value !== 'string' || value.indexOf( '\\' ) === -1 ) {
-		return value;
-	}
-	return value.replace( /\\/g, '\\\\' );
-}
-
 /**
  * GET/POST site settings
  *
@@ -281,14 +273,6 @@ Undocumented.prototype.settings = function ( siteId, method = 'get', data = {}, 
 
 	if ( 'get' === method ) {
 		return this.wpcom.req.get( path, { apiVersion }, fn );
-	}
-
-	// special treatment to preserve backslash in date_format
-	if ( body.date_format ) {
-		body.date_format = encode_backslash( body.date_format );
-	}
-	if ( body.time_format ) {
-		body.time_format = encode_backslash( body.time_format );
 	}
 
 	return this.wpcom.req.post( { path }, { apiVersion }, body, fn );

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -43,7 +43,13 @@ export class DateTimeFormat extends Component {
 			fields: { date_format: dateFormat, time_format: timeFormat },
 		} = nextProps;
 
-		if ( ! this.state.isLoadingSettings || '' === dateFormat || '' === timeFormat ) {
+		const localeDifferent = this.props.locale !== nextProps.locale;
+
+		if (
+			( ! this.state.isLoadingSettings && ! localeDifferent ) ||
+			'' === dateFormat ||
+			'' === timeFormat
+		) {
 			return;
 		}
 

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -54,7 +54,7 @@ export class DateTimeFormat extends Component {
 		} );
 	}
 
-	setFormat = ( name, defaultFormats ) => ( event ) => {
+	setFormat = ( name, defaultFormats, event ) => {
 		const { value: format } = event.currentTarget;
 		this.props.updateFields( { [ `${ name }_format` ]: format } );
 		this.setState( {
@@ -62,9 +62,9 @@ export class DateTimeFormat extends Component {
 		} );
 	};
 
-	setDateFormat = this.setFormat( 'date', getDefaultDateFormats() );
+	setDateFormat = ( event ) => this.setFormat( 'date', getDefaultDateFormats(), event );
 
-	setTimeFormat = this.setFormat( 'time', getDefaultTimeFormats() );
+	setTimeFormat = ( event ) => this.setFormat( 'time', getDefaultTimeFormats(), event );
 
 	setCustomFormat = ( name ) => ( event ) => {
 		const { value: format } = event.currentTarget;


### PR DESCRIPTION
#### Testing instructions

* On `/me/account`, change your language to PT BR Português do Brasil. (On your first time through, you might want to skip this, just to see how the section is supposed to work in english.)
* Visit `/settings/writing/<siteurl>` for a site, or Configurações -> Escrita
* Expand the *Formato de data e hora:* section
![2021-09-13_15-27](https://user-images.githubusercontent.com/937354/133151658-5c14a901-750b-4d04-bef2-b6fe51bfea37.png)
* Experiment with setting different date and time settings, saving, and reloading.
* Everything should work as expected. I have outlined the issues that we're fixing in [this comment](https://github.com/Automattic/wp-calypso/issues/55807#issuecomment-918452741).

#### Changes proposed in this Pull Request

* I'm making 3 main fixes here.
* (1) 7c4047835a5 - Remove the currying used in `setTimeFormat()` and `setDateFormat()`. 
  * Previously, this used a technique to initialize `setTimeFormat()` and `setDateFormat()` when the component is first initialized. This means it only called `getDefaultDateFormats()` and  `getDefaultTimeFormats()` once. The issue was, this was happening before the user's locale was loaded. The `translate()` function would return results for English, which means that default formats in non-English languages would be incorrectly detected as custom formats. Now, it calls `getDefaultDateFormats()` and  `getDefaultTimeFormats()` whenever `setTimeFormat()` and `setDateFormat()` are called - which is late enough for the user's locale to be loaded. It's very slightly less efficient, but should not matter in practical terms.
* (2) dbe44803cbd9 - Allow the `customDateFormat` and `customTimeFormat` state variables to change when a user's locale is loaded.
  *  Previously, the code that initializes these values was only allowed to run once. The problem is, it would run before the user's locale was loaded, leaving the site to believe that default formats in non-English languages are custom formats. I changed this to allow the init code to rerun when the locale changes.
  * I also considered completely removing the [`UNSAFE_componentWillReceiveProps`](https://github.com/Automattic/wp-calypso/blob/03394d4173868efb34f4bb6a63ac58b796cc8dd5/client/my-sites/site-settings/date-time-format/index.jsx#L41-L55) and simply moving the code to the render function, i.e. `isCustom={ ! includes( getDefaultDateFormats(), dateFormat ) }`. The entire thing looks like a micro-optimization which is not needed. Any thoughts about this?
* (3) 87f5ebaf3 - Removed custom handling of `date_format` and `time_format` fields to add extra slashes before POSTing. This was added in #34611 over two years ago. It appears to me that this is no longer needed due to changes happening sometime in the last two years, as removing this code fixes several issues, and the original issue this was added to fix no longer happens with the code removed.

Related to #55807, #53339
