### PR TITLE
Jetpack site-less Checkout: remove link to schedule onboarding call

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you-completed.tsx
@@ -7,7 +7,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isProductsListFetching as getIsProductListFetching,
@@ -16,7 +15,6 @@ import {
 import getJetpackCheckoutSupportTicketDestinationSiteId from 'calypso/state/selectors/get-jetpack-checkout-support-ticket-destination-site-id';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
-import { useSetCalendlyListenerEffect } from './hooks';
 import { getActivationCompletedLink } from './utils';
 
 import './style.scss';
@@ -29,7 +27,6 @@ interface Props {
 
 const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 	productSlug,
-	receiptId = 0,
 	jetpackTemporarySiteId = 0,
 } ) => {
 	const translate = useTranslate();
@@ -42,20 +39,6 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 	);
 
 	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
-
-	const happinessAppointmentLink = addQueryArgs(
-		{
-			receiptId,
-			siteId: jetpackTemporarySiteId,
-		},
-		'/checkout/jetpack/schedule-happiness-appointment'
-	);
-
-	useSetCalendlyListenerEffect( {
-		productSlug,
-		receiptId,
-		jetpackTemporarySiteId,
-	} );
 
 	const destinationSiteId = useSelector( ( state ) =>
 		getJetpackCheckoutSupportTicketDestinationSiteId( state, jetpackTemporarySiteId )
@@ -103,38 +86,11 @@ const JetpackCheckoutSitelessThankYouCompleted: FC< Props > = ( {
 						{ title }
 					</h1>
 					{ ! automaticTransferSucceeded && (
-						<>
-							<p>
-								{ translate(
-									'As soon as your subscription is activated you will receive a confirmation email from our Happiness Engineers.'
-								) }
-							</p>
-							<p>
-								{ translate(
-									'If you prefer to setup Jetpack with the help of our Happiness Engineers, {{a}}schedule a 15 minute call now{{/a}}.',
-									{
-										components: {
-											a: (
-												<a
-													className="jetpack-checkout-siteless-thank-you-completed__link"
-													onClick={ () =>
-														dispatch(
-															recordTracksEvent(
-																'calypso_siteless_checkout_happiness_link_clicked',
-																{
-																	product_slug: productSlug,
-																}
-															)
-														)
-													}
-													href={ happinessAppointmentLink }
-												/>
-											),
-										},
-									}
-								) }
-							</p>
-						</>
+						<p>
+							{ translate(
+								'As soon as your subscription is activated you will receive a confirmation email from our Happiness Engineers.'
+							) }
+						</p>
 					) }
 					{ automaticTransferSucceeded && (
 						<>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-siteless-thank-you.tsx
@@ -24,7 +24,6 @@ import {
 	getProductName,
 } from 'calypso/state/products-list/selectors';
 import getJetpackCheckoutSupportTicketStatus from 'calypso/state/selectors/get-jetpack-checkout-support-ticket-status';
-import { useSetCalendlyListenerEffect } from './hooks';
 import type { UserData } from 'calypso/lib/user/user';
 
 interface Props {
@@ -133,9 +132,6 @@ const JetpackCheckoutSitelessThankYou: FC< Props > = ( {
 			} );
 		}
 	}, [ calendlyUrl, currentUser, dispatch, productSlug ] );
-
-	// Update the ZD ticket linked to `receiptId` after the user has scheduled a call.
-	useSetCalendlyListenerEffect( { productSlug, receiptId, jetpackTemporarySiteId } );
 
 	useEffect( () => {
 		if ( supportTicketStatus === 'success' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove link to schedule onboarding call from the Thank You Completed post-purchase UI.

#### Testing instructions

* Start Calypso with `yarn start`.
* Visit `http://calypso.localhost:3000/checkout/jetpack/thank-you-completed/no-site/jetpack_security_daily_monthly?siteId=1&receiptId=1`.
* Make sure you don't see a link to schedule an onboarding call.

Related to 1200738571375997-as-1200975051750093

#### Demo – before
![image](https://user-images.githubusercontent.com/3418513/133158182-423756a2-6382-4124-8992-7cc5cfbb96bc.png)

#### Demo – after
![image](https://user-images.githubusercontent.com/3418513/133158159-695ff418-5e4d-4d2f-8f12-1a22cd8fa5db.png)