### PR TITLE
Theme Info Sheet: Add beta badge to FSE block themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -31,6 +31,7 @@ import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
+import { isFullSiteEditingTheme } from 'calypso/my-sites/themes/is-full-site-editing-theme';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import ThemePreview from 'calypso/my-sites/themes/theme-preview';
@@ -56,7 +57,6 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { isFullSiteEditingTheme } from 'calypso/utils';
 import ThemeDownloadCard from './theme-download-card';
 import ThemeFeaturesCard from './theme-features-card';
 import ThemeNotFoundError from './theme-not-found-error';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -614,6 +614,7 @@ class ThemeSheet extends Component {
 	renderButton = () => {
 		const { getUrl } = this.props.defaultOption;
 		const label = this.getDefaultOptionLabel();
+		const price = this.renderPrice();
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
 		const { isActive } = this.props;
 
@@ -626,9 +627,11 @@ class ThemeSheet extends Component {
 				target={ isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
-				<Badge type="info" className="theme__sheet-badge-beta">
-					{ this.props.isWpcomTheme && this.renderPrice() }
-				</Badge>
+				{ price && this.props.isWpcomTheme && (
+					<Badge type="info" className="theme__sheet-badge-beta">
+						{ price }
+					</Badge>
+				) }
 			</Button>
 		);
 	};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -189,7 +189,7 @@ class ThemeSheet extends Component {
 				<span className="theme__sheet-bar-title">
 					{ title }
 					{ isFullSiteEditingTheme( { taxonomies } ) && (
-						<Badge type="warning-clear" className="theme__badge-beta">
+						<Badge type="warning-clear" className="theme__sheet-badge-beta">
 							{ translate( 'Beta' ) }
 						</Badge>
 					) }
@@ -622,11 +622,13 @@ class ThemeSheet extends Component {
 				className="theme__sheet-primary-button"
 				href={ getUrl ? getUrl( this.props.id ) : null }
 				onClick={ this.onButtonClick }
-				primary={ isActive }
+				primary
 				target={ isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
-				{ this.props.isWpcomTheme && this.renderPrice() }
+				<Badge type="info" className="theme__sheet-badge-beta">
+					{ this.props.isWpcomTheme && this.renderPrice() }
+				</Badge>
 			</Button>
 		);
 	};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import AsyncLoad from 'calypso/components/async-load';
+import Badge from 'calypso/components/badge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
@@ -55,6 +56,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isFullSiteEditingTheme } from 'calypso/utils';
 import ThemeDownloadCard from './theme-download-card';
 import ThemeFeaturesCard from './theme-features-card';
 import ThemeNotFoundError from './theme-not-found-error';
@@ -176,15 +178,22 @@ class ThemeSheet extends Component {
 	};
 
 	renderBar = () => {
+		const { author, name, taxonomies, translate } = this.props;
+
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
-		const title = this.props.name || placeholder;
-		const tag = this.props.author
-			? this.props.translate( 'by %(author)s', { args: { author: this.props.author } } )
-			: placeholder;
+		const title = name || placeholder;
+		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
 
 		return (
 			<div className="theme__sheet-bar">
-				<span className="theme__sheet-bar-title">{ title }</span>
+				<span className="theme__sheet-bar-title">
+					{ title }
+					{ isFullSiteEditingTheme( { taxonomies } ) && (
+						<Badge type="warning-clear" className="theme__badge-beta">
+							{ translate( 'Beta' ) }
+						</Badge>
+					) }
+				</span>
 				<span className="theme__sheet-bar-tag">{ tag }</span>
 			</div>
 		);

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -11,12 +11,17 @@
 }
 
 .theme__sheet-bar-title {
-	display: block;
+	display: flex;
+	align-items: flex-end;
 	font-size: $font-title-large;
 	font-weight: 400;
 	padding-top: 78px;
 	padding-left: 25px;
 	line-height: 1;
+
+	.theme__badge-beta {
+		margin-left: 10px;
+	}
 }
 
 .theme__sheet-bar-tag {
@@ -106,7 +111,9 @@
 
 .theme__sheet-action-bar-cost-upgrade {
 	text-transform: uppercase;
+	/* stylelint-disable declaration-property-unit-allowed-list */
 	font-size: 90%;
+	/*stylelint-enable declaration-property-unit-allowed-list */
 }
 
 .theme__sheet-screenshot {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -19,7 +19,7 @@
 	padding-left: 25px;
 	line-height: 1;
 
-	.theme__badge-beta {
+	.theme__sheet-badge-beta {
 		background-color: white;
 		font-weight: bold;
 		margin-left: 10px;
@@ -77,6 +77,11 @@
 	right: 50%;
 	margin-right: 20px;
 
+	.theme__sheet-badge-beta {
+		background-color: var( --color-surface );
+		margin-left: 10px;
+	}
+
 	@include breakpoint-deprecated( '<960px' ) {
 		margin-right: 0;
 		position: absolute;
@@ -106,9 +111,7 @@
 .theme__sheet-action-bar-cost {
 	font-weight: 600;
 	color: #4ab866;
-	margin-left: 10px;
 	display: inline-block;
-	max-width: 50%;
 }
 
 .theme__sheet-action-bar-cost-upgrade {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -20,6 +20,8 @@
 	line-height: 1;
 
 	.theme__badge-beta {
+		background-color: white;
+		font-weight: bold;
 		margin-left: 10px;
 	}
 }


### PR DESCRIPTION
Dependent on code refactored in https://github.com/Automattic/wp-calypso/pull/56123

### Changes proposed in this Pull Request
Add a Beta label to the theme info sheet title banner for block-based themes. Also makes the "Activate this design" button a primary button as requested by @onuro.

### Screenshots
#### Before
<img width="1278" alt="Screen Shot 2021-09-13 at 3 09 26 PM" src="https://user-images.githubusercontent.com/5414230/133163122-85831bae-8c07-4876-a2c3-8e21854307d5.png">

#### After
<img width="1267" alt="Screen Shot 2021-09-15 at 10 51 50 AM" src="https://user-images.githubusercontent.com/5414230/133484499-a2d8715c-b739-4b46-b282-e87bc13b34ba.png">

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Appearance -> Themes
- Confirm current themes that support block-templates have a Beta badge

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/54508
