### PR TITLE
Payment Management: Remove Undocumented API calls

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
@@ -31,33 +31,6 @@ export async function saveCreditCard( {
 	return response;
 }
 
-interface UpdateCreditCard {
-	token: string;
-	stripeConfiguration: StripeConfiguration;
-	useAsPrimaryPaymentMethod: boolean;
-}
-
-export async function updateCreditCard( {
-	token,
-	stripeConfiguration,
-	useAsPrimaryPaymentMethod,
-}: UpdateCreditCard ): Promise< StoredCardEndpointResponse > {
-	const updatedCreditCardApiParams = getParamsForApi( {
-		cardToken: token,
-		stripeConfiguration,
-		useAsPrimaryPaymentMethod,
-	} );
-	const response = await wpcom.updateCreditCard( updatedCreditCardApiParams );
-
-	if ( response.error ) {
-		recordTracksEvent( 'calypso_partner_portal_update_credit_card_error' );
-		throw new Error( response );
-	}
-
-	recordTracksEvent( 'calypso_partner_portal_update_credit_card' );
-	return response;
-}
-
 function getParamsForApi( {
 	cardToken,
 	stripeConfiguration,

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api.ts
@@ -1,8 +1,6 @@
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import wpcomFactory from 'calypso/lib/wp';
+import wp from 'calypso/lib/wp';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
-
-const wpcom = wpcomFactory.undocumented();
 
 type StoredCardEndpointResponse = unknown;
 
@@ -21,7 +19,15 @@ export async function saveCreditCard( {
 		useAsPrimaryPaymentMethod,
 	} );
 
-	const response = await wpcom.me().storedCardAdd( token, additionalData );
+	const response = await wp.req.post(
+		{
+			path: '/me/stored-cards',
+		},
+		{
+			payment_key: token,
+			...( additionalData ?? {} ),
+		}
+	);
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_partner_portal_add_new_credit_card_error' );
 		throw new Error( response );

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -98,35 +98,6 @@ UndocumentedMe.prototype.setPeerReferralLinkEnable = function ( enable, callback
 	return this.wpcom.req.post( args, callback );
 };
 
-/**
- * Get a list of the user's stored cards
- *
- * @param {object} [cardToken] Payment key
- * @param {object} [additionalData] Any additional data to send in the request
- * @returns {Promise} A promise for the request
- */
-UndocumentedMe.prototype.storedCardAdd = function ( cardToken, additionalData = {} ) {
-	debug( '/me/stored-cards', cardToken, additionalData );
-
-	return this.wpcom.req.post(
-		{
-			path: '/me/stored-cards',
-		},
-		{
-			payment_key: cardToken,
-			use_for_existing: true,
-			...additionalData,
-		}
-	);
-};
-
-UndocumentedMe.prototype.storedCardDelete = function ( card, callback ) {
-	const args = {
-		path: '/me/stored-cards/' + card.stored_details_id + '/delete',
-	};
-	return this.wpcom.req.post( args, callback );
-};
-
 UndocumentedMe.prototype.backupCodes = function ( callback ) {
 	const args = {
 		apiVersion: '1.1',

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -809,25 +809,6 @@ Undocumented.prototype.getAllowedPaymentMethods = function () {
 };
 
 /**
- * Assign a stored payment method to a subscription.
- *
- * @param {string} subscriptionId The subscription ID (a.k.a. purchase ID) to be assigned
- * @param {string} stored_details_id The payment method ID to assign
- * @param {Function} [fn] The callback function
- */
-Undocumented.prototype.assignPaymentMethod = function ( subscriptionId, stored_details_id, fn ) {
-	debug( '/upgrades/assign-payment-method query', { subscriptionId, stored_details_id } );
-	return this.wpcom.req.post(
-		{
-			path: '/upgrades/' + subscriptionId + '/assign-payment-method',
-			body: { stored_details_id },
-			apiVersion: '1',
-		},
-		fn
-	);
-};
-
-/**
  * Returns a PayPal Express URL to redirect to for confirming the creation of a billing agreement.
  *
  * @param {string} subscription_id The subscription ID (a.k.a. purchase ID) to assign the billing agreement to after it is created

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -801,17 +801,6 @@ Undocumented.prototype.getSiteFeatures = function ( siteDomain, fn ) {
 };
 
 /**
- * Get a list of the user's stored cards
- *
- * @param {Function} [fn] The callback function.
- * @returns {Promise} Returns a promise when the `callback` is not provided.
- */
-Undocumented.prototype.getStoredCards = function ( fn ) {
-	debug( '/me/stored-cards query' );
-	return this.wpcom.req.get( { path: '/me/stored-cards' }, fn );
-};
-
-/**
  * Get a list of the user's stored payment methods
  *
  * @param {object} query The query parameters

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -801,14 +801,6 @@ Undocumented.prototype.getSiteFeatures = function ( siteDomain, fn ) {
 };
 
 /**
- * Get a list of the user's allowed payment methods
- */
-Undocumented.prototype.getAllowedPaymentMethods = function () {
-	debug( '/me/allowed-payment-methods query' );
-	return this.wpcom.req.get( { path: '/me/allowed-payment-methods' } );
-};
-
-/**
  * Return a list of third-party services that WordPress.com can integrate with for a specific site
  *
  * @param {number|string} siteId The site ID or domain

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -809,31 +809,6 @@ Undocumented.prototype.getAllowedPaymentMethods = function () {
 };
 
 /**
- * Returns a PayPal Express URL to redirect to for confirming the creation of a billing agreement.
- *
- * @param {string} subscription_id The subscription ID (a.k.a. purchase ID) to assign the billing agreement to after it is created
- * @param {string} success_url The URL to return the user to for a successful billing agreement creation
- * @param {string} cancel_url The URL to return the user to if they cancel the billing agreement creation
- * @param {Function} [fn] The callback function
- */
-Undocumented.prototype.createPayPalAgreement = function (
-	subscription_id,
-	success_url,
-	cancel_url,
-	fn
-) {
-	debug( '/payment-methods/create-paypal-agreement', { subscription_id, success_url, cancel_url } );
-	return this.wpcom.req.post(
-		{
-			path: '/payment-methods/create-paypal-agreement',
-			body: { subscription_id, success_url, cancel_url },
-			apiVersion: '1',
-		},
-		fn
-	);
-};
-
-/**
  * Return a list of third-party services that WordPress.com can integrate with for a specific site
  *
  * @param {number|string} siteId The site ID or domain

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -801,18 +801,6 @@ Undocumented.prototype.getSiteFeatures = function ( siteDomain, fn ) {
 };
 
 /**
- * Get a list of the user's stored payment methods
- *
- * @param {object} query The query parameters
- * @param {Function} [fn] The callback function.
- * @returns {Promise} Returns a promise when the `callback` is not provided.
- */
-Undocumented.prototype.getPaymentMethods = function ( query, fn ) {
-	debug( '/me/payment-methods query', { query } );
-	return this.wpcom.req.get( '/me/payment-methods', query, fn );
-};
-
-/**
  * Get a list of the user's allowed payment methods
  */
 Undocumented.prototype.getAllowedPaymentMethods = function () {

--- a/client/me/purchases/manage-purchase/change-payment-method/use-fetch-available-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-fetch-available-payment-methods.ts
@@ -1,11 +1,7 @@
 import { useReducer, useEffect, useRef } from 'react';
 import wp from 'calypso/lib/wp';
 
-const wpcom = wp.undocumented();
-
-// Aliasing wpcom functions explicitly bound to wpcom is required here;
-// otherwise we get `this is not defined` errors.
-const wpcomGetAllowedPaymentMethods = () => wpcom.getAllowedPaymentMethods();
+const wpcomGetAllowedPaymentMethods = () => wp.req.get( { path: '/me/allowed-payment-methods' } );
 
 export default function useFetchAvailablePaymentMethods(): AvailablePaymentMethodsState {
 	const isSubscribed = useRef< boolean >( true );

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -19,7 +19,12 @@ const wpcom = wp.undocumented();
 const wpcomAssignPaymentMethod = (
 	subscriptionId: string,
 	stored_details_id: string
-): Promise< unknown > => wpcom.assignPaymentMethod( subscriptionId, stored_details_id );
+): Promise< unknown > =>
+	wp.req.post( {
+		path: '/upgrades/' + subscriptionId + '/assign-payment-method',
+		body: { stored_details_id },
+		apiVersion: '1',
+	} );
 const wpcomCreatePayPalAgreement = (
 	subscriptionId: string,
 	successUrl: string,

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -15,7 +15,6 @@ import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
-const wpcom = wp.undocumented();
 const wpcomAssignPaymentMethod = (
 	subscriptionId: string,
 	stored_details_id: string
@@ -26,10 +25,15 @@ const wpcomAssignPaymentMethod = (
 		apiVersion: '1',
 	} );
 const wpcomCreatePayPalAgreement = (
-	subscriptionId: string,
-	successUrl: string,
-	cancelUrl: string
-): Promise< string > => wpcom.createPayPalAgreement( subscriptionId, successUrl, cancelUrl );
+	subscription_id: string,
+	success_url: string,
+	cancel_url: string
+): Promise< string > =>
+	wp.req.post( {
+		path: '/payment-methods/create-paypal-agreement',
+		body: { subscription_id, success_url, cancel_url },
+		apiVersion: '1',
+	} );
 
 export async function assignNewCardProcessor(
 	{

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -79,11 +79,7 @@ const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
 const { select, registerStore } = defaultRegistry;
 
-const wpcom = wp.undocumented();
-
-// Aliasing wpcom functions explicitly bound to wpcom is required here;
-// otherwise we get `this is not defined` errors.
-const wpcomGetStoredCards = (): StoredCard[] => wpcom.getStoredCards();
+const wpcomGetStoredCards = (): StoredCard[] => wp.req.get( { path: '/me/stored-cards' } );
 
 export default function CompositeCheckout( {
 	siteSlug,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -85,7 +85,6 @@ export default function CompositeCheckout( {
 	siteSlug,
 	siteId,
 	productAliasFromUrl,
-	getStoredCards,
 	overrideCountryList,
 	redirectTo,
 	feature,
@@ -107,7 +106,6 @@ export default function CompositeCheckout( {
 	siteSlug: string | undefined;
 	siteId: number | undefined;
 	productAliasFromUrl?: string | undefined;
-	getStoredCards?: () => StoredCard[];
 	overrideCountryList?: CountryListItem[];
 	redirectTo?: string | undefined;
 	feature?: string | undefined;
@@ -307,7 +305,7 @@ export default function CompositeCheckout( {
 	);
 
 	const { storedCards, isLoading: isLoadingStoredCards, error: storedCardsError } = useStoredCards(
-		getStoredCards || wpcomGetStoredCards,
+		wpcomGetStoredCards,
 		Boolean( isLoggedOutCart )
 	);
 

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -30,9 +30,8 @@ export const fetchStoredCards = () => ( dispatch ) => {
 		type: STORED_CARDS_FETCH,
 	} );
 
-	return wp
-		.undocumented()
-		.getPaymentMethods( { expired: 'include' } )
+	return wp.req
+		.get( '/me/payment-methods', { expired: 'include' } )
 		.then( ( data ) => {
 			dispatch( {
 				type: STORED_CARDS_FETCH_COMPLETED,

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -13,10 +13,17 @@ import {
 import 'calypso/state/stored-cards/init';
 
 export const addStoredCard = ( cardData ) => ( dispatch ) => {
-	return wp
-		.undocumented()
-		.me()
-		.storedCardAdd( cardData.token, cardData.additionalData )
+	return wp.req
+		.post(
+			{
+				path: '/me/stored-cards',
+			},
+			{
+				payment_key: cardData.token,
+				use_for_existing: true,
+				...( cardData.additionalData ?? {} ),
+			}
+		)
 		.then( ( item ) => {
 			dispatch( {
 				type: STORED_CARDS_ADD_COMPLETED,

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -61,7 +61,7 @@ export const deleteStoredCard = ( card ) => ( dispatch ) => {
 
 	return Promise.all(
 		card.allStoredDetailsIds.map( ( storedDetailsId ) =>
-			wp.undocumented().me().storedCardDelete( { stored_details_id: storedDetailsId } )
+			wp.req.post( { path: '/me/stored-cards/' + storedDetailsId + '/delete' } )
 		)
 	)
 		.then( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Using the `Undocumented` library of API functions has been deprecated (see p4TIVU-9KX-p2). This PR removes their use in all payment method management applications (in payment method management and checkout) by calling the endpoints directly.

#### Testing instructions

##### Verify new cards can be saved

1. Make sure you have at least one active subscription.
1. Visit the account-level purchase management page at `/me/purchases`.
1. Click on an active subscription.
1. On the following page, click "Change Payment Method" or "Add Payment Method" below the purchase.
1. Click "Credit or debit card" in the list of options, enter a new card, and submit the form.
2. Verify that the card is saved and assigned to the subscription.

##### Verify saved cards are listed

1. Visit `/me/purchases/payment-methods`.
2. Verify that you see the saved card in the list.

##### Verify PayPal agreements are added

1. Return to the "Change Payment Method" or "Add Payment Method" page.
1. Click "PayPal" in the list of options, submit the form, and confirm the agreement.
2. Verify that the payment method is assigned to PayPal.

##### Verify payment methods can be reassigned

1. Return to the "Change Payment Method" or "Add Payment Method" page.
2. Select a different saved card from the list and submit the form (you may need to add another saved card).
2. Verify that the card is assigned to the subscription.

##### Verify that checkout has stored cards

1. Add a product to your cart and visit checkout.
2. Verify that you see your saved card(s) in the list of payment methods at checkout.

##### Verify that stored cards can be deleted

1. Visit `/me/purchases/payment-methods`.
2. Click "Delete" to remove a stored card.
3. Verify that the card has been removed.