### PR TITLE
chore: Convert @automattic/calypso-color-schemes to ESM

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -24,7 +24,7 @@
 		"sync": "yarn run clean && yarn run build && sh ./bin/wpcom-watch-and-sync.sh"
 	},
 	"dependencies": {
-		"@automattic/calypso-color-schemes": "^2.1.1",
+		"@automattic/calypso-color-schemes": "^3.0.0",
 		"@automattic/calypso-polyfills": "^2.0.0",
 		"calypso": "^0.17.0",
 		"classnames": "^2.3.1",

--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/js' ) ],
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/json' ) ],
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,

--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -1,5 +1,8 @@
 module.exports = () => ( {
 	plugins: {
+		// In theory we don't need to resolve custom properties, as all supported browsers understand CSS variables.
+		// However that would require for Notifications to import @automattic/calypso-color-schemes styles, and they
+		// come with useless bloat for Notifications (namely color schemes).
 		'postcss-custom-properties': {
 			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/json' ) ],
 			// @TODO: Drop `preserve: false` workaround if possible

--- a/client/assets/stylesheets/gutenboarding.scss
+++ b/client/assets/stylesheets/gutenboarding.scss
@@ -1,6 +1,6 @@
 // Color Schemes
 // Currently used only by Calypso dev badge shown in development mode
-@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes';
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -2,7 +2,7 @@
 @import 'vendor';
 
 // Color Schemes
-@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes';
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -1,5 +1,5 @@
 @import '../../variables.scss';
-@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes';
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
 

--- a/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/anchor-error/style.scss
@@ -1,5 +1,5 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
-@import '@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import '@automattic/calypso-color-schemes';
 @import '../../mixins';
 
 .anchor-error__flex-container {

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
 		"@automattic/browser-data-collector": "^2.0.0",
 		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/calypso-build": "^9.0.0",
-		"@automattic/calypso-color-schemes": "^2.1.1",
+		"@automattic/calypso-color-schemes": "^3.0.0",
 		"@automattic/calypso-config": "^1.0.0",
 		"@automattic/calypso-polyfills": "^2.0.0",
 		"@automattic/calypso-products": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
 		"@automattic/babel-plugin-i18n-calypso": "^1.2.0",
 		"@automattic/babel-plugin-transform-wpcalypso-async": "^1.0.1",
 		"@automattic/calypso-build": "^9.0.0",
-		"@automattic/calypso-color-schemes": "^2.1.1",
+		"@automattic/calypso-color-schemes": "^3.0.0",
 		"@automattic/calypso-doctor": "^0.1.0",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "^1.0.0-alpha.1",

--- a/packages/calypso-color-schemes/.gitignore
+++ b/packages/calypso-color-schemes/.gitignore
@@ -1,3 +1,4 @@
 src/__color-studio
 css
 js
+json

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 3.0.0
 
-- Breaking: Module converted to ESM only. CJS build is not provided anymore.
-- Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files.
+- Breaking: Module converted to ESM.
+- Added: It now provides Custom Properties as a JSON file.
+- Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files:
   - Removed dependency `node-sass`
   - Added dependency `sass ^1.32.13`
 - Updated dependencies:

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release Notes
 
-## trunk
+## 3.0.0
 
+- Breaking: Module converted to ESM only. CJS build is not provided anymore.
 - Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files.
   - Removed dependency `node-sass`
   - Added dependency `sass ^1.32.13`

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 3.0.0
 
-- Breaking: Module converted to ESM.
-- Added: It now provides Custom Properties as a JSON file.
+- Breaking: Module converted to ESM. Reaching into package internals is not available anymore, only these imports are available:
+  - `@automattic/calypso-color-schemes` (returns a CSS file)
+  - `@automattic/calypso-color-schemes/js` (returns a CommonJS when used from `require`, ESM when used from `import`)
+  - `@automattic/calypso-color-schemes/json`
+- Added: It now provides Custom Properties as a JSON file. To use them, import from `@automattic/calypso-color-schemes/json`
 - Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files:
   - Removed dependency `node-sass`
   - Added dependency `sass ^1.32.13`

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -33,18 +33,28 @@ Sometimes, `calypso-color-schemes` properties are consumed in JavaScript. To avo
 import { customProperties } from '@automattic/calypso-color-schemes/js'; // mind the js suffix
 ```
 
-Or with `postcss-custom-properties`, and `postcss.config.js` can look like this:
+or
+
+```js
+const { customProperties } = require( '@automattic/calypso-color-schemes/js' );
+```
+
+### Using the JSON output
+
+Like the JS output, a JSON version is provided too. It can be used with `postcss-custom-properties`, and `postcss.config.js` can look like this:
 
 ```js
 module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/js' ) ],
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/json' ) ],
 		},
 	},
 } );
 ```
 
-### Note on using the JS output
+The JS output can't be used this way until https://github.com/postcss/postcss-custom-properties/issues/255 is solved.
 
-The CSS files include variable definitions for all Calypso color schemes (Classic Blue, Contrast, Midnight, ...), but the JS exports include only variables from the `:root` selector, i.e., only the fallback default theme.
+### Note on using the JS/JSON outputs
+
+The CSS files include variable definitions for all Calypso color schemes (Classic Blue, Contrast, Midnight, ...), but the JS/JSON exports include only variables from the `:root` selector, i.e., only the fallback default theme.

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -53,7 +53,7 @@ module.exports = () => ( {
 } );
 ```
 
-The JS output can't be used this way until https://github.com/postcss/postcss-custom-properties/issues/255 is solved.
+The JS output can't be used this way until [this issue](https://github.com/postcss/postcss-custom-properties/issues/255) is solved.
 
 ### Note on using the JS/JSON outputs
 

--- a/packages/calypso-color-schemes/bin/build-css.js
+++ b/packages/calypso-color-schemes/bin/build-css.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-nodejs-modules */
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdirSync, writeFileSync, renameSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import postcss from 'postcss';
@@ -11,29 +11,34 @@ const __dirname = dirname( fileURLToPath( import.meta.url ) );
 
 const INPUT_FILE = join( __dirname, '..', 'src', 'calypso-color-schemes.scss' );
 const OUTPUT_FILE = join( __dirname, '..', 'css', 'index.css' );
-const OUTPUT_JS_FILE = join( __dirname, '..', 'js', 'index.mjs' );
+const OUTPUT_JS_FILE = join( __dirname, '..', 'js', 'index.js' );
+const OUTPUT_CJS_FILE = join( __dirname, '..', 'js', 'index.cjs' );
+const OUTPUT_MJS_FILE = join( __dirname, '..', 'js', 'index.mjs' );
+const OUTPUT_JSON_FILE = join( __dirname, '..', 'json', 'index.json' );
 
-if ( ! existsSync( dirname( OUTPUT_FILE ) ) ) {
-	mkdirSync( dirname( OUTPUT_FILE ), { recursive: true } );
-}
-
-if ( ! existsSync( dirname( OUTPUT_JS_FILE ) ) ) {
-	mkdirSync( dirname( OUTPUT_JS_FILE ), { recursive: true } );
-}
+[ OUTPUT_FILE, OUTPUT_JS_FILE, OUTPUT_MJS_FILE, OUTPUT_JSON_FILE ]
+	.map( ( file ) => dirname( file ) )
+	.forEach( ( dir ) => mkdirSync( dir, { recursive: true } ) );
 
 const output = renderSync( { file: INPUT_FILE } );
-
 writeFileSync( OUTPUT_FILE, output.css );
 
-// export CSS properties into a JavaScript file, so whoever uses it doesn't need to parse CSS over and over
+// export CSS properties into a JavaScript and JSON files, so whoever uses it doesn't need to parse CSS over and over
 postcss( [
 	postcssCustomProperties( {
 		importFrom: OUTPUT_FILE,
-		exportTo: [ OUTPUT_JS_FILE ],
+		exportTo: [ OUTPUT_JS_FILE, OUTPUT_MJS_FILE, OUTPUT_JSON_FILE ],
 	} ),
 ] )
 	.process( output.css, { from: INPUT_FILE } )
+	.then( () => {
+		// postcss-custom-properties ony knows how to export .js (will contain CJS) and .mjs.
+		// However, as this module is an ESM module, Node will assume that the .js file contains ESM, not CJS.
+		//
+		// To fix it, we rename .js to .cjs, and .mjs to .js
+		renameSync( OUTPUT_JS_FILE, OUTPUT_CJS_FILE );
+		renameSync( OUTPUT_MJS_FILE, OUTPUT_JS_FILE );
+	} )
 	.catch( ( e ) => {
-		// eslint-disable-next-line no-console
-		console.error( 'calypso-color-schemes', e );
+		throw e;
 	} );

--- a/packages/calypso-color-schemes/bin/build-css.js
+++ b/packages/calypso-color-schemes/bin/build-css.js
@@ -1,13 +1,17 @@
 /* eslint-disable import/no-nodejs-modules */
-const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
-const { dirname, join } = require( 'path' );
-const postcss = require( 'postcss' );
-const postcssCustomProperties = require( 'postcss-custom-properties' );
-const { renderSync } = require( 'sass' );
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import postcss from 'postcss';
+import postcssCustomProperties from 'postcss-custom-properties';
+import sass from 'sass';
+
+const { renderSync } = sass;
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
 
 const INPUT_FILE = join( __dirname, '..', 'src', 'calypso-color-schemes.scss' );
 const OUTPUT_FILE = join( __dirname, '..', 'css', 'index.css' );
-const OUTPUT_JS_FILE = join( __dirname, '..', 'js', 'index.js' );
+const OUTPUT_JS_FILE = join( __dirname, '..', 'js', 'index.mjs' );
 
 if ( ! existsSync( dirname( OUTPUT_FILE ) ) ) {
 	mkdirSync( dirname( OUTPUT_FILE ), { recursive: true } );

--- a/packages/calypso-color-schemes/bin/prepare-sass-assets.js
+++ b/packages/calypso-color-schemes/bin/prepare-sass-assets.js
@@ -1,6 +1,10 @@
 /* eslint-disable import/no-nodejs-modules */
-const { copyFileSync, existsSync, mkdirSync } = require( 'fs' );
-const { basename, dirname, join } = require( 'path' );
+import { copyFileSync, existsSync, mkdirSync } from 'fs';
+import { createRequire } from 'module';
+import { basename, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
 
 copyAsset( '@automattic/color-studio/dist/color-properties.css' );
 copyAsset( '@automattic/color-studio/dist/color-properties-rgb.css' );
@@ -16,5 +20,6 @@ function copyAsset( assetPath, targetName ) {
 		mkdirSync( dirname( target ), { recursive: true } );
 	}
 
-	copyFileSync( require.resolve( assetPath ), join( target ) );
+	const source = createRequire( import.meta.url ).resolve( assetPath );
+	copyFileSync( source, target );
 }

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -25,13 +25,17 @@
 	},
 	"exports": {
 		".": "./css/index.css",
-		"./js": "./js/index.mjs"
+		"./js": {
+			"import": "./js/index.js",
+			"require": "./js/index.cjs"
+		},
+		"./json": "./json/index.json"
 	},
 	"publishConfig": {
 		"access": "public"
 	},
 	"scripts": {
-		"clean": "npx rimraf js css src/__color-studio",
+		"clean": "npx rimraf js css json src/__color-studio",
 		"prepare": "node bin/prepare-sass-assets.js && node bin/build-css.js"
 	},
 	"devDependencies": {

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "2.1.1",
+	"version": "3.0.0",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
@@ -19,7 +19,14 @@
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
-	"main": "css/index.css",
+	"type": "module",
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
+	"exports": {
+		".": "./css/index.css",
+		"./js": "./js/index.mjs"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,7 +124,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-color-schemes@^2.1.1, @automattic/calypso-color-schemes@workspace:packages/calypso-color-schemes":
+"@automattic/calypso-color-schemes@^3.0.0, @automattic/calypso-color-schemes@workspace:packages/calypso-color-schemes":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-color-schemes@workspace:packages/calypso-color-schemes"
   dependencies:
@@ -667,7 +667,7 @@ __metadata:
   resolution: "@automattic/notifications@workspace:apps/notifications"
   dependencies:
     "@automattic/calypso-build": ^9.0.0
-    "@automattic/calypso-color-schemes": ^2.1.1
+    "@automattic/calypso-color-schemes": ^3.0.0
     "@automattic/calypso-polyfills": ^2.0.0
     calypso: ^0.17.0
     classnames: ^2.3.1
@@ -11893,7 +11893,7 @@ __metadata:
     "@automattic/browser-data-collector": ^2.0.0
     "@automattic/calypso-analytics": ^1.0.0
     "@automattic/calypso-build": ^9.0.0
-    "@automattic/calypso-color-schemes": ^2.1.1
+    "@automattic/calypso-color-schemes": ^3.0.0
     "@automattic/calypso-config": ^1.0.0
     "@automattic/calypso-polyfills": ^2.0.0
     "@automattic/calypso-products": ^1.0.0
@@ -38832,7 +38832,7 @@ typescript@^4.4.3:
     "@automattic/babel-plugin-i18n-calypso": ^1.2.0
     "@automattic/babel-plugin-transform-wpcalypso-async": ^1.0.1
     "@automattic/calypso-build": ^9.0.0
-    "@automattic/calypso-color-schemes": ^2.1.1
+    "@automattic/calypso-color-schemes": ^3.0.0
     "@automattic/calypso-doctor": ^0.1.0
     "@automattic/color-studio": 2.5.0
     "@automattic/components": ^1.0.0-alpha.1


### PR DESCRIPTION
#### Background

See #55855

#### Changes proposed in this Pull Request

* Converts `@automattic/calypso-color-schemes` to ESM
* Forbid internal imports (eg `import '@automattic/calypso-color-schemes/src/calypso-color-schemes'`). Only these exports are provided:
  * `@automattic/calypso-color-schemes` (which points to the CSS above)
  * `@automattic/calypso-color-schemes/js`
  * `@automattic/calypso-color-schemes/json`

#### Testing instructions

* Verify all builds are green
* Verify Gutenboarding colors
* Verify Notifications colors