### PR TITLE
`design-setup-site` step only shows designs that match the theme annotations

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -717,6 +717,7 @@ export function generateSteps( {
 			stepName: 'design-setup-site',
 			props: {
 				largeThumbnails: true,
+				showOnlyThemes: true,
 			},
 			apiRequestFunction: setThemeOnSite,
 			dependencies: [ 'siteSlug' ],

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,4 +1,4 @@
-import DesignPicker from '@automattic/design-picker';
+import DesignPicker, { getAvailableDesigns } from '@automattic/design-picker';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -17,11 +17,13 @@ class DesignPickerStep extends Component {
 		locale: PropTypes.string.isRequired,
 		translate: PropTypes.func,
 		largeThumbnails: PropTypes.bool,
+		showOnlyThemes: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		useHeadstart: true,
 		largeThumbnails: false,
+		showOnlyThemes: false,
 	};
 
 	pickDesign = ( selectedDesign ) => {
@@ -43,11 +45,23 @@ class DesignPickerStep extends Component {
 	};
 
 	renderDesignPicker() {
-		// props.locale obtained via `localize` HoC
+		// Use <DesignPicker>'s preferred designs by default
+		let designs = undefined;
+
+		if ( this.props.showOnlyThemes ) {
+			// Only offering designs that are also available as themes. This means excluding
+			// designs where the `template` has a layout that's different from what the theme's
+			// default Headstart annotation provides.
+			designs = getAvailableDesigns().featured.filter(
+				( { features, template, theme } ) => theme === template && ! features.includes( 'anchorfm' )
+			);
+		}
+
 		return (
 			<DesignPicker
+				designs={ designs }
 				theme={ this.props.isReskinned ? 'light' : 'dark' }
-				locale={ this.props.locale }
+				locale={ this.props.locale } // props.locale obtained via `localize` HoC
 				onSelect={ this.pickDesign }
 				className={ classnames( {
 					'design-picker-step__is-large-thumbnails': this.props.largeThumbnails,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Filter the designs available in the `setup-site` flow so that we only show designs that are also available in the theme gallery


https://user-images.githubusercontent.com/1500769/133202809-5858e37f-fe4a-4e70-965a-e2b375db6ba1.mov


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `setup-site/design-setup-site?siteSlug=<< site url >>`
* Only see designs that are also themes (so no Balan design) and can be selected from `/themes/<< site url >>`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


