### PR TITLE
P2: Rename P2 to workspace and space to P2 in strings

### DIFF
--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -36,7 +36,7 @@ function P2Details( {
 			flowName={ flowName }
 			stepName={ stepName }
 			positionInFlow={ positionInFlow }
-			headerText={ translate( "We're almost finished! Your P2 will be:" ) }
+			headerText={ translate( "We're almost finished! Your P2 workspace will be:" ) }
 		>
 			<div className="p2-details">
 				<div className="p2-details__site-part">

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -387,7 +387,7 @@ class P2Site extends React.Component {
 					className="p2-site__validation-site"
 				>
 					<FormLabel htmlFor="site-address-input">
-						{ this.props.translate( 'Choose an address for your P2' ) }
+						{ this.props.translate( 'Choose an address for your P2 workspace' ) }
 					</FormLabel>
 					<FormTextInput
 						id="site-address-input"

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -219,12 +219,12 @@ export function deleteSite( siteId ) {
 					dispatch(
 						errorNotice(
 							translate(
-								'Your P2 has spaces. You must delete all spaces before you can delete this P2.'
+								'Your P2 Workspace has P2s. You must delete all P2s in this workspace before you can delete it.'
 							),
 							{
 								id: siteDeletionNoticeId,
 								showDismiss: false,
-								button: translate( 'Manage P2 spaces' ),
+								button: translate( 'Manage P2s' ),
 								href: hubUrl,
 							}
 						)


### PR DESCRIPTION
#### Changes proposed in this Pull Request
For P2s:
* Changes hub's naming from "P2" to "Workspace" or "P2 Workspace"
* Changes space's naming from "space" to "P2".

#### Testing instructions
* Code review
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See PR 3726-gh-Automattic/p2
