### PR TITLE
Playwright: restructure the ReaderPage POM and Reader spec.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for i in {1..200}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-reader; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..200}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-reader; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -86,6 +86,6 @@ export class ReaderPage {
 		await elementHandle.scrollIntoViewIfNeeded();
 		await this.page.fill( selectors.commentTextArea, comment );
 		await this.page.click( selectors.commentSubmitButton );
-		await this.page.waitForSelector( selectors.commentContentLocator( comment ) );
+		await this.page.waitForLoadState( 'networkidle' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -29,6 +29,13 @@ export class ReaderPage {
 	}
 
 	/**
+	 * Waits until the page is considered to be loaded.
+	 */
+	private async waitUntilLoaded(): Promise< void > {
+		await this.page.waitForLoadState( 'load' );
+	}
+
+	/**
 	 * Get the URL of the latest post in Reader
 	 *
 	 * @returns {Promise<string>} String of URL for latest post.
@@ -73,6 +80,8 @@ export class ReaderPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async comment( comment: string ): Promise< void > {
+		await this.waitUntilLoaded();
+
 		const elementHandle = await this.page.waitForSelector( selectors.commentTextArea );
 		await elementHandle.scrollIntoViewIfNeeded();
 		await this.page.fill( selectors.commentTextArea, comment );

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -5,7 +5,7 @@ const selectors = {
 	readerCard: '.reader-post-card',
 	visitSiteLink: '.reader-visit-link',
 	actionButton: ( action: 'Share' | 'Comment' ) =>
-		`.reader-post-actions__item:has(span:has-text("${ action }"))`,
+		`.reader-post-actions__item:has-text("${ action }")`,
 
 	commentTextArea: '.comments__form textarea',
 	commentSubmitButton: '.comments__form button:text("Send")',
@@ -41,13 +41,26 @@ export class ReaderPage {
 	/**
 	 * Visits a post in the Reader.
 	 *
+	 * This method supports either a 1-indexed number or partial or full string matching.
+	 *
+	 * 	index: 1-indexed value, starting from top of page.
+	 * 	text: partial or full text matching of text contained in a reader entry. If multiple
+	 * 		matches are found,  the first match is used.
+	 *
 	 * @param param0 Keyed object parameter.
 	 * @param {number} param0.index n-th post to view on the reader page. 1-indexed.
+	 * @param {string} param0.text Text string to match.
+	 * @throws {Error} If neither index or text are specified.
 	 */
-	async visitPost( { index }: { index?: number } = {} ): Promise< void > {
+	async visitPost( { index, text }: { index?: number; text?: string } = {} ): Promise< void > {
 		let selector = '';
+
 		if ( index ) {
 			selector = `:nth-match(${ selectors.readerCard }, ${ index })`;
+		} else if ( text ) {
+			selector = `${ selectors.readerCard }:has-text("${ text }")`;
+		} else {
+			throw new Error( 'Unable to select and visit post - specify one of index or text.' );
 		}
 
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selector ) ] );

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -1,16 +1,16 @@
 import { Page } from 'playwright';
 
 const selectors = {
-	readerPageLocator: '.reader__content',
-	readerVisitLink: '.reader-visit-link',
-	shareButtonLocator: '.reader-share__button',
-	firstComboCardPostLocator: '.reader-combined-card__post-title-link',
-	siteContentLocator: '.site-selector__sites .site__content',
-	commentButtonLocator: '.comment-button',
-	commentTextAreaLocator: '.comments__form textarea',
-	commentSubmitLocator: '.comments__form button:text("Send")',
+	// Reader main stream
+	readerCard: '.reader-post-card',
+	visitSiteLink: '.reader-visit-link',
+	actionButton: ( action: 'Share' | 'Comment' ) =>
+		`.reader-post-actions__item:has(span:has-text("${ action }"))`,
+
+	commentTextArea: '.comments__form textarea',
+	commentSubmitButton: '.comments__form button:text("Send")',
 	commentContentLocator: ( commentText: string ) =>
-		`.comments__comment-content :text( '${ commentText }' )`,
+		`.comments__comment :text( '${ commentText }' )`,
 };
 
 /**
@@ -29,32 +29,28 @@ export class ReaderPage {
 	}
 
 	/**
-	 * Verifies that we are actually on the Reader Page
-	 *
-	 * @returns {Promise<void>} No return value.
-	 */
-	private async verifyReaderPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.readerPageLocator );
-	}
-
-	/**
 	 * Get the URL of the latest post in Reader
 	 *
 	 * @returns {Promise<string>} String of URL for latest post.
 	 */
 	async siteOfLatestPost(): Promise< string > {
-		const href = await this.page.getAttribute( selectors.readerVisitLink, 'href' );
+		const href = await this.page.getAttribute( selectors.visitSiteLink, 'href' );
 		return new URL( href ? href : '' ).host;
 	}
 
 	/**
-	 * Share latest post in Reader
+	 * Visits a post in the Reader.
 	 *
-	 * @returns {Promise<void>} No return value.
+	 * @param param0 Keyed object parameter.
+	 * @param {number} param0.index n-th post to view on the reader page. 1-indexed.
 	 */
-	async shareLatestPost(): Promise< void > {
-		await this.page.click( selectors.shareButtonLocator );
-		await this.page.click( selectors.siteContentLocator );
+	async visitPost( { index }: { index?: number } = {} ): Promise< void > {
+		let selector = '';
+		if ( index ) {
+			selector = `:nth-match(${ selectors.readerCard }, ${ index })`;
+		}
+
+		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selector ) ] );
 	}
 
 	/**
@@ -63,19 +59,11 @@ export class ReaderPage {
 	 * @param {string} comment Text of the comment.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async commentOnLatestPost( comment: string ): Promise< void > {
-		await this.page.click( selectors.commentButtonLocator );
-		await this.page.fill( selectors.commentTextAreaLocator, comment );
-		await this.page.click( selectors.commentSubmitLocator );
-	}
-
-	/**
-	 * Wait for the comment with the specified text to display.
-	 *
-	 * @param {string} comment Text of the comment.
-	 * @returns {Promise<void>} No return value.
-	 */
-	async waitForCommentToAppear( comment: string ): Promise< void > {
+	async comment( comment: string ): Promise< void > {
+		const elementHandle = await this.page.waitForSelector( selectors.commentTextArea );
+		await elementHandle.scrollIntoViewIfNeeded();
+		await this.page.fill( selectors.commentTextArea, comment );
+		await this.page.click( selectors.commentSubmitButton );
 		await this.page.waitForSelector( selectors.commentContentLocator( comment ) );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -29,21 +29,17 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 
 	it( 'View the Reader stream', async function () {
 		readerPage = new ReaderPage( page );
-		await readerPage.verifyReaderPage();
-	} );
-
-	it( 'The latest post is on the expected test site', async function () {
 		const testSiteForNotifications = DataHelper.config.get( 'testSiteForNotifications' );
 		const siteOfLatestPost = await readerPage.siteOfLatestPost();
 		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
 	} );
 
-	it( 'Comment on the latest post', async function () {
-		await readerPage.commentOnLatestPost( comment );
+	it( 'Visit latest post', async function () {
+		await readerPage.visitPost( { index: 1 } );
 	} );
 
-	it( 'Wait for the comment to appear', async function () {
-		await readerPage.waitForCommentToAppear( comment );
+	it( 'Comment and confirm it is shown', async function () {
+		await readerPage.comment( comment );
 	} );
 
 	it( 'Log in as test site owner', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR restructure the selectors and methods of the ReaderPage to be more generic, as well as reorganizing the test steps.

Key changes:
- include waits for navigation state where appropriate.
- make methods more generic (eg. `clickAction` instead of `clickCommentButton`).
- restructure test steps to eliminate unnecessary steps.

Background details:

Reader spec has intermittently failed (albeit rarely). When it fails, the error logs are typically the same as shown in #56227.

The suspicion is that the comment left on a post is now shown on the page because the text area is not fully in view when the comment is submitted.

Furthermore, methods that go better together such as commenting and verifying the comment is on page, have been merged together. Methods that should be separate, such as opening the post then leaving a comment, have been split into its own methods.

#### Testing instructions

- [x] stress test
    - [x] desktop
    - [x] mobile
- [x] regular test
    - [x] desktop
    - [x] mobile

To test locally:

1. pull branch.
2. transpile code.
3. run the following tests:
    a. wp-reader
Run with this template:

```
TARGET_DEVICE=<mobile or desktop> yarn jest specs/specs-playwright/wp-reader
```

Related to #56227