### PR TITLE
Shopping Cart: pass cartKey to remaining components that access the cart

### DIFF
--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { hasStaleItem } from 'calypso/lib/cart-values/cart-items';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getNoticeLastTimeShown } from 'calypso/state/notices/selectors';
@@ -22,7 +23,8 @@ function useShowStaleCartNotice() {
 	);
 	const sectionName = useSelector( getSectionName );
 	const reduxDispatch = useDispatch();
-	const { responseCart, isPendingUpdate } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart, isPendingUpdate } = useShoppingCart( cartKey );
 	const translate = useTranslate();
 
 	useEffect( () => {

--- a/client/my-sites/marketplace/components/marketplace-shopping-cart/index.tsx
+++ b/client/my-sites/marketplace/components/marketplace-shopping-cart/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { LineItem } from 'calypso/my-sites/checkout/composite-checkout/components/wp-line-item';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	MobileHiddenHorizontalRule,
 	FullWidthButton,
@@ -154,7 +155,8 @@ export default function MarketplaceShoppingCart(
 		isExpandedBasketView,
 		toggleExpandedBasketView,
 	} = props;
-	const { responseCart, isLoading, isPendingUpdate } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart, isLoading, isPendingUpdate } = useShoppingCart( cartKey );
 	const { products, sub_total_display } = responseCart;
 	const isBasketLoading = isLoading || isPendingUpdate;
 	const translate = useTranslate();

--- a/client/my-sites/marketplace/pages/marketplace-domain-upsell/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-domain-upsell/index.tsx
@@ -14,6 +14,7 @@ import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { MarketplaceHeaderTitle } from 'calypso/my-sites/marketplace/components';
 import MarketplaceShoppingCart from 'calypso/my-sites/marketplace/components/marketplace-shopping-cart';
 import {
@@ -69,7 +70,8 @@ function CalypsoWrappedMarketplaceDomainUpsell(): JSX.Element {
 		undefined
 	);
 	const [ isExpandedBasketView, setIsExpandedBasketView ] = useState( false );
-	const { addProductsToCart, removeProductFromCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { addProductsToCart, removeProductFromCart } = useShoppingCart( cartKey );
 	const previousPath = useSelector( getPreviousPath );
 	const selectedSite = useSelector( getSelectedSite );
 	const domainObject = useSelector( ( state ) =>

--- a/client/my-sites/marketplace/pages/marketplace-product-details/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-details/index.tsx
@@ -8,6 +8,7 @@ import { isAtomicSiteWithoutBusinessPlan } from 'calypso/blocks/eligibility-warn
 import Notice from 'calypso/components/notice';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { marketplaceDebugger } from 'calypso/my-sites/marketplace/constants';
 import { getDefaultPluginInProduct } from 'calypso/my-sites/marketplace/marketplace-product-definitions';
 import { IProductGroupCollection, IProductCollection } from 'calypso/my-sites/marketplace/types';
@@ -39,7 +40,8 @@ function MarketplacePluginDetails( {
 	const displayCost = useSelector( ( state ) => getProductDisplayCost( state, productSlug ) );
 
 	const translate = useTranslate();
-	const { replaceProductsInCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { replaceProductsInCart } = useShoppingCart( cartKey );
 	const products = useSelector( getProductsList );
 	const isProductListLoading = useSelector( ( state ) => isProductsListFetching( state ) );
 	const selectedSiteId = useSelector( getSelectedSiteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After https://github.com/Automattic/wp-calypso/pull/54667, we need to pass the cart key as an argument to `useShoppingCart` and `withShoppingCart` (although there's currently a fallback in place while we migrate). You can read more about the reason behind the change in that PR.

In https://github.com/Automattic/wp-calypso/pull/55843 we migrated some of the components to pass the cart key. This PR migrates the rest not covered by https://github.com/Automattic/wp-calypso/pull/56257, https://github.com/Automattic/wp-calypso/pull/56259, or https://github.com/Automattic/wp-calypso/pull/56258.

#### Testing instructions

Verify that there are no errors rendering the following components:

- Stale cart items notice
- Marketplace
