### PR TITLE
Add automattic/search to client dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
 		"@automattic/popup-monitor": "^1.0.0",
 		"@automattic/react-virtualized": "^9.22.3",
 		"@automattic/request-external-access": "^1.0.0",
+		"@automattic/search": "^1.0.0",
 		"@automattic/shopping-cart": "^2.0.0",
 		"@automattic/social-previews": "^1.0.1",
 		"@automattic/state-utils": "^1.0.0-alpha.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12369,6 +12369,7 @@ __metadata:
     "@automattic/popup-monitor": ^1.0.0
     "@automattic/react-virtualized": ^9.22.3
     "@automattic/request-external-access": ^1.0.0
+    "@automattic/search": ^1.0.0
     "@automattic/shopping-cart": ^2.0.0
     "@automattic/social-previews": ^1.0.1
     "@automattic/state-utils": ^1.0.0-alpha.4


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In or around https://github.com/Automattic/wp-calypso/pull/49207 (that's the first usage I can find but there could be others, eg: https://github.com/Automattic/wp-calypso/pull/51718), calypso began using the `@automattic/search` package, but it was never added to the package dependencies for `client`. This PR adds the missing dependency.

#### Testing instructions

Make sure calypso builds.