### PR TITLE
SEO Tools: enable archive_title for non-AT Business plan sites

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,10 +1,16 @@
+import { FEATURE_ADVANCED_SEO } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { CompositeDecorator, Editor, EditorState, Modifier, SelectionState } from 'draft-js';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { buildSeoTitle, isJetpackMinimumVersion } from 'calypso/state/sites/selectors';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import {
+	buildSeoTitle,
+	isJetpackMinimumVersion,
+	isJetpackSite,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { fromEditor, mapTokenTitleForEditor, toEditor } from './parser';
 import Token from './token';
@@ -294,6 +300,12 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	let shouldShowSeoArchiveTitleButton = false;
 	if ( isJetpackMinimumVersion( state, siteId, '10.2-alpha' ) ) {
+		shouldShowSeoArchiveTitleButton = true;
+	} else if (
+		! isJetpackSite( state, siteId ) &&
+		hasActiveSiteFeature( state, siteId, FEATURE_ADVANCED_SEO )
+	) {
+		// For non-AT Business plan sites which get SEO features.
 		shouldShowSeoArchiveTitleButton = true;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows the SEO `Archive Title` button for non-AT WPcom Business plan sites.
* This is a small follow-up to: https://github.com/Automattic/wp-calypso/pull/56084#issuecomment-917191737

#### Testing instructions

* After pulling changes, on a non-AT WPcom Business plan site, make sure you can see the `Archive Title` button at `/marketing/traffic/example.com`, and that you can add and save the token.
