### PR TITLE
desktop(notifications): add automattcher case and URL fallback

### DIFF
--- a/desktop/app/lib/notifications/viewmodel/index.js
+++ b/desktop/app/lib/notifications/viewmodel/index.js
@@ -29,6 +29,7 @@ function parseNote( note ) {
 	const siteId = note.meta.ids.site;
 	const postId = note.meta.ids.post;
 	const commentId = note.meta.ids.comment;
+	const fallbackUrl = note.url ? note.url : null;
 
 	const isApproved = getApprovedStatus( note );
 
@@ -55,6 +56,10 @@ function parseNote( note ) {
 			break;
 		default:
 			navigate = null;
+	}
+
+	if ( ! navigate ) {
+		navigate = fallbackUrl;
 	}
 
 	return {

--- a/desktop/app/lib/notifications/viewmodel/index.js
+++ b/desktop/app/lib/notifications/viewmodel/index.js
@@ -35,6 +35,7 @@ function parseNote( note ) {
 	let navigate = null;
 
 	switch ( type ) {
+		case 'automattcher':
 		case 'post':
 			navigate = `/read/blogs/${ siteId }/posts/${ postId }`;
 			break;

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -101,7 +101,10 @@ module.exports = function ( { window, view } ) {
 				if ( navigate ) {
 					// if we have a specific URL, then navigate Calypso there
 					log.info( `Navigating user to URL: ${ navigate }` );
-					if ( isCalypso( view ) ) {
+
+					if ( navigate.startsWith( 'http' ) ) {
+						view.webContents.loadURL( navigate );
+					} else if ( isCalypso( view ) ) {
 						log.info( `Navigating to '${ navigate }'` );
 						view.webContents.send( 'navigate', navigate );
 					} else {

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -108,8 +108,9 @@ module.exports = function ( { window, view } ) {
 						log.info( `Navigating to '${ navigate }'` );
 						view.webContents.send( 'navigate', navigate );
 					} else {
-						log.info( `Navigating to '${ webBase + navigate }'` );
-						view.webContents.loadURL( webBase + navigate );
+						const path = stripLeadingSlashFromPath( navigate );
+						log.info( `Navigating to '${ webBase + path }'` );
+						view.webContents.loadURL( webBase + path );
 					}
 				} else {
 					// else just display the notifications panel
@@ -135,3 +136,7 @@ module.exports = function ( { window, view } ) {
 		}
 	} );
 };
+
+function stripLeadingSlashFromPath( path ) {
+	return path.replace( /^\/+/g, '' );
+}


### PR DESCRIPTION
### Description

TIL of the `automattcher` notification type, which we're adding to the notification parsing logic in this PR. In addition, this PR also uses the raw note URL as a fallback to increase the chances of always having a valid location to navigate to when a notification is clicked.