### PR TITLE
Checkout: Convert WPCheckoutOrderSummary to TypeScript

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -6,7 +6,7 @@ import {
 	FormStatus,
 	useFormStatus,
 } from '@automattic/composite-checkout';
-import { ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
@@ -22,6 +22,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -305,7 +305,7 @@ function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number | undefined }
 				return (
 					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isSupported={ isSupported }>
 						{ isSupported ? (
-							<WPCheckoutCheckIcon id={ String( feature ) } />
+							<WPCheckoutCheckIcon id={ encodeURIComponent( feature ) } />
 						) : (
 							<WPCheckoutCrossIcon />
 						) }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -23,15 +23,18 @@ import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
 
+// This will make converting to TS less noisy. The order of components can be reorganized later
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
 export default function WPCheckoutOrderSummary( {
 	siteId,
 	onChangePlanLength,
 	nextDomainIsFree = false,
 }: {
-	siteId: number;
-	onChangePlanLength: ( uuid: string, productSlug: string, productId: string ) => void;
-	nextDomainIsFree?: boolean
-}  ): JSX.Element {
+	siteId: number | undefined;
+	onChangePlanLength: ( uuid: string, productSlug: string, productId: number ) => void;
+	nextDomainIsFree?: boolean;
+} ): JSX.Element {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 	const cartKey = useCartKey();
@@ -105,7 +108,12 @@ function LoadingCheckoutSummaryFeaturesList() {
 	);
 }
 
-function SwitchToAnnualPlan( { plan, onChangePlanLength }: { plan: ResponseCartProduct; onChangePlanLength: ( uuid: string, productSlug: string, productId: string ) => void;
+function SwitchToAnnualPlan( {
+	plan,
+	onChangePlanLength,
+}: {
+	plan: ResponseCartProduct;
+	onChangePlanLength: ( uuid: string, productSlug: string, productId: number ) => void;
 } ): JSX.Element {
 	const translate = useTranslate();
 	const handleClick = () => {
@@ -123,7 +131,7 @@ function SwitchToAnnualPlan( { plan, onChangePlanLength }: { plan: ResponseCartP
 }
 
 function CheckoutSummaryFeaturesList( props: {
-	siteId: number;
+	siteId: number | undefined;
 	hasMonthlyPlan: boolean;
 	nextDomainIsFree: boolean;
 } ) {
@@ -137,8 +145,8 @@ function CheckoutSummaryFeaturesList( props: {
 	const hasPlanInCart = responseCart.products.some( ( product ) => isPlan( product ) );
 	const translate = useTranslate();
 	const siteId = props.siteId;
-	const isJetpackNotAtomic = useSelector(
-		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
+	const isJetpackNotAtomic = useSelector( ( state ) =>
+		siteId ? isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) : undefined
 	);
 	const { hasMonthlyPlan = false } = props;
 
@@ -195,7 +203,13 @@ function CheckoutSummaryFeaturesList( props: {
 	);
 }
 
-function SupportText( { hasPlanInCart, isJetpackNotAtomic }: { hasPlanInCart?: boolean; isJetpackNotAtomic?: boolean | null} ) {
+function SupportText( {
+	hasPlanInCart,
+	isJetpackNotAtomic,
+}: {
+	hasPlanInCart?: boolean;
+	isJetpackNotAtomic?: boolean | null;
+} ) {
 	const translate = useTranslate();
 
 	if ( hasPlanInCart && ! isJetpackNotAtomic ) {
@@ -205,7 +219,15 @@ function SupportText( { hasPlanInCart, isJetpackNotAtomic }: { hasPlanInCart?: b
 	return <span>{ translate( 'Customer support via email' ) }</span>;
 }
 
-function CheckoutSummaryFeaturesListDomainItem( { domain, hasMonthlyPlan, nextDomainIsFree }: { domain: ResponseCartProduct; hasMonthlyPlan: boolean; nextDomainIsFree: boolean } ) {
+function CheckoutSummaryFeaturesListDomainItem( {
+	domain,
+	hasMonthlyPlan,
+	nextDomainIsFree,
+}: {
+	domain: ResponseCartProduct;
+	hasMonthlyPlan: boolean;
+	nextDomainIsFree: boolean;
+} ) {
 	const translate = useTranslate();
 	const bundledText = translate( 'free for one year' );
 	const bundledDomain = translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
@@ -239,13 +261,17 @@ function CheckoutSummaryFeaturesListDomainItem( { domain, hasMonthlyPlan, nextDo
 
 	return (
 		<CheckoutSummaryFeaturesListItem isSupported={ isSupported }>
-			{ isSupported ? <WPCheckoutCheckIcon id={`feature-list-domain-item-${domain.meta}`} /> : <WPCheckoutCrossIcon /> }
+			{ isSupported ? (
+				<WPCheckoutCheckIcon id={ `feature-list-domain-item-${ domain.meta }` } />
+			) : (
+				<WPCheckoutCrossIcon />
+			) }
 			{ label }
 		</CheckoutSummaryFeaturesListItem>
 	);
 }
 
-function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number } ) {
+function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number | undefined } ) {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -256,7 +282,9 @@ function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number } ) {
 	const hasRenewalInCart = responseCart.products.some(
 		( product ) => product.extra.purchaseType === 'renewal'
 	);
-	const planHasDomainCredit = useSelector( ( state ) => hasDomainCredit( state, siteId ) );
+	const planHasDomainCredit = useSelector(
+		( state ) => siteId && hasDomainCredit( state, siteId )
+	);
 	const planFeatures = getPlanFeatures(
 		planInCart,
 		translate,
@@ -275,7 +303,11 @@ function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number } ) {
 
 				return (
 					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isSupported={ isSupported }>
-						{ isSupported ? <WPCheckoutCheckIcon id={String(feature)} /> : <WPCheckoutCrossIcon /> }
+						{ isSupported ? (
+							<WPCheckoutCheckIcon id={ String( feature ) } />
+						) : (
+							<WPCheckoutCrossIcon />
+						) }
 						{ feature }
 					</CheckoutSummaryFeaturesListItem>
 				);
@@ -347,7 +379,7 @@ const StyledGridicon = styled( Gridicon )`
 
 const WPCheckoutCrossIcon = () => <StyledGridicon icon="cross" size={ 20 } />;
 
-const CheckoutSummaryFeaturesListItem = styled('li')<{isSupported?: boolean}>`
+const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean } >`
 	margin-bottom: 4px;
 	padding-left: 24px;
 	position: relative;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -305,7 +305,7 @@ function CheckoutSummaryPlanFeatures( { siteId }: { siteId: number | undefined }
 				return (
 					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isSupported={ isSupported }>
 						{ isSupported ? (
-							<WPCheckoutCheckIcon id={ encodeURIComponent( feature ) } />
+							<WPCheckoutCheckIcon id={ feature.replace( /[^\w]/g, '_' ) } />
 						) : (
 							<WPCheckoutCrossIcon />
 						) }

--- a/packages/composite-checkout/src/components/shared-icons.tsx
+++ b/packages/composite-checkout/src/components/shared-icons.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 import React from 'react';
 
 const CheckIconSvg = styled.svg`
@@ -33,11 +32,6 @@ export function CheckIcon( { className, id }: { className?: string; id: string }
 		</CheckIconSvg>
 	);
 }
-
-CheckIcon.propTypes = {
-	className: PropTypes.string,
-	id: PropTypes.string,
-};
 
 export function ErrorIcon( { className }: { className?: string } ): JSX.Element {
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR converts the `WPCheckoutOrderSummary` component to TypeScript.

<img width="352" alt="Screen Shot 2021-09-15 at 12 26 06 PM" src="https://user-images.githubusercontent.com/2036909/133472245-fe949b56-9f00-41ed-8422-54093267f59f.png">


#### Testing instructions

Visit checkout with a product in the cart and verify that the sidebar loads (collapses to a heading at mobile width).