### PR TITLE
Checkout: pass cartKey to remaining components that access the cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { EDIT_PAYMENT_DETAILS } from 'calypso/lib/url/support';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-service' );
@@ -16,7 +17,8 @@ const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-serv
 export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 	const translate = useTranslate();
 	const locale = useLocale();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	if ( ! responseCart.terms_of_service || responseCart.terms_of_service.length === 0 ) {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import { HappychatButton as HappychatButtonUnstyled } from 'calypso/components/happychat/button';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
@@ -128,7 +129,8 @@ const LoadingButton = styled.p< StyledProps >`
 export default function CheckoutHelpLink(): JSX.Element {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import Coupon from './coupon';
 import joinClasses from './join-classes';
@@ -83,7 +84,8 @@ export default function WPCheckoutOrderReview( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
-	const { responseCart, removeCoupon, couponStatus } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart, removeCoupon, couponStatus } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 
 	const selectedSiteData = useSelector( getSelectedSite );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -136,7 +136,8 @@ function CheckoutSummaryFeaturesList( props: {
 	hasMonthlyPlan: boolean;
 	nextDomainIsFree: boolean;
 } ) {
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const hasDomainsInCart = responseCart.products.some(
 		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
 	);

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -16,6 +16,7 @@ import {
 import { getDomainNameFromReceiptOrCart } from 'calypso/lib/domains/cart-utils';
 import { fetchSitesAndUser } from 'calypso/lib/signup/step-actions/fetch-sites-and-user';
 import { AUTO_RENEWAL } from 'calypso/lib/url/support';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
@@ -72,7 +73,8 @@ export default function useCreatePaymentCompleteCallback( {
 	isJetpackCheckout?: boolean;
 	checkoutFlow?: string;
 } ): PaymentEventCallback {
-	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -22,6 +22,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import { useMemo } from 'react';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	createCreditCardPaymentMethodStore,
 	createCreditCardMethod,
@@ -373,7 +374,8 @@ export default function useCreatePaymentMethods( {
 	storedCards: StoredCard[];
 	siteSlug: string | undefined;
 } ): PaymentMethod[] {
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 
 	const paypalMethod = useCreatePayPal( {} );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -2,6 +2,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 import page from 'page';
 import { useCallback, useState, useRef, useEffect } from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import useValidCheckoutBackUrl from './use-valid-checkout-back-url';
 import type { RemoveProductFromCart, ResponseCart } from '@automattic/shopping-cart';
@@ -16,7 +17,8 @@ export default function useRemoveFromCartAndRedirect(
 	isRemovingProductFromCart: boolean;
 	removeProductFromCartAndMaybeRedirect: RemoveProductFromCart;
 } {
-	const { removeProductFromCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { removeProductFromCart } = useShoppingCart( cartKey );
 
 	// In some cases, the cloud.jetpack.com/pricing page sends a `checkoutBackUrl` url query param to checkout.
 	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug || siteSlugLoggedOutCart );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -9,6 +9,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import WordPressLogo from '../components/wordpress-logo';
 
 export function createFullCreditsMethod() {
@@ -23,7 +24,8 @@ export function createFullCreditsMethod() {
 
 function FullCreditsSubmitButton( { disabled, onClick } ) {
 	const [ items ] = useLineItems();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 
@@ -64,7 +66,8 @@ function ButtonContents( { formStatus, total } ) {
 
 function WordPressCreditsLabel() {
 	const { __ } = useI18n();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 
 	return (
 		<React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
@@ -21,6 +21,7 @@ import {
 	SummaryLine,
 	SummaryDetails,
 } from 'calypso/my-sites/checkout/composite-checkout/components/summary-details';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import WeChatPaymentQRcodeUnstyled from './wechat-payment-qrcode';
 
 const debug = debugFactory( 'calypso:composite-checkout:wechat-payment-method' );
@@ -136,7 +137,8 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 	const { formStatus } = useFormStatus();
 	const { resetTransaction } = useTransactionStatus();
 	const customerName = useSelect( ( select ) => select( 'wechat' ).getCustomerName() );
-	const { responseCart: cart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart: cart } = useShoppingCart( cartKey );
 	const [ stripeResponseWithCode, setStripeResponseWithCode ] = useState( null );
 
 	useScrollQRCodeIntoView( !! stripeResponseWithCode );

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -21,6 +21,7 @@ import {
 	isContactValidationResponseValid,
 	getTaxValidationResult,
 } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
@@ -495,4 +496,4 @@ export default connect(
 	{
 		trackUpsellButtonClick,
 	}
-)( withShoppingCart( localize( UpsellNudge ) ) );
+)( withShoppingCart( withCartKey( localize( UpsellNudge ) ) ) );

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import useCreatePaymentCompleteCallback from 'calypso/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback';
 import existingCardProcessor from 'calypso/my-sites/checkout/composite-checkout/lib/existing-card-processor';
 import getContactDetailsType from 'calypso/my-sites/checkout/composite-checkout/lib/get-contact-details-type';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { BEFORE_SUBMIT } from './constants';
 import Content from './content';
@@ -75,7 +76,8 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ): JSX.E
 	} );
 	const { stripe, stripeConfiguration } = useStripe();
 	const reduxDispatch = useDispatch();
-	const { responseCart } = useShoppingCart();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 	const selectedSite = useSelector( getSelectedSite );
 
 	const contactDetailsType = getContactDetailsType( props.cart );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#### Changes proposed in this Pull Request

After https://github.com/Automattic/wp-calypso/pull/54667, we need to pass the cart key as an argument to `useShoppingCart` and `withShoppingCart` (although there's currently a fallback in place while we migrate). You can read more about the reason behind the change in that PR.

In https://github.com/Automattic/wp-calypso/pull/55843 we migrated some of the components to pass the cart key. This PR migrates the rest that use the cart key in and near checkout.

#### Testing instructions

Verify that there are no errors with the following components:

- Checkout TOS
- Checkout help link
- Checkout order review and summary
- Checkout payment complete callback (you'll need to complete a purchase for this one)
- Checkout payment method creation (just loading checkout will test this)
- Checkout redirect on empty cart (empty a cart and make sure you get redirected)
- Label of full credits payment method (you'll need enough credits to cover an entire purchase and make sure the button looks right)
- WeChat QR code (see below)
- Post-checkout upsell purchase modal (make sure it loads)

##### Testing WeChat Pay

- Apply D45650-code to force WeChat Pay to be available and sandbox the API.
- Add a plan to your cart and visit checkout. 
- Verify that "WeChat Pay" is an option displayed in the final payment step.
- Fill out the "Name" field and submit the payment.
- Verify that you see a QR code appear and it is scrolled into view.
- In a *new window or tab* open the link at the bottom that reads "To open and pay with the wechat pay app directly, click here".
- In the new window, you should see a Stripe test page (no need to complete the purchase).
