### PR TITLE
Signup: Pass cartKey to components that access the shopping cart

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -14,6 +14,7 @@ import { getFixedDomainSearch, getTld, checkDomainAvailability } from 'calypso/l
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 import { MAP_EXISTING_DOMAIN, INCOMING_DOMAIN_TRANSFER } from 'calypso/lib/url/support';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { getCurrentUser, currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import {
@@ -276,4 +277,4 @@ export default connect(
 		recordInputFocusInMapDomain,
 		recordGoButtonClickInMapDomain,
 	}
-)( withShoppingCart( localize( MapDomainStep ) ) );
+)( withShoppingCart( withCartKey( localize( MapDomainStep ) ) ) );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -79,6 +79,7 @@ import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import wpcom from 'calypso/lib/wp';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
@@ -1637,4 +1638,4 @@ export default connect(
 		hideSitePreview,
 		showSitePreview,
 	}
-)( withShoppingCart( localize( RegisterDomainStep ) ) );
+)( withShoppingCart( withCartKey( localize( RegisterDomainStep ) ) ) );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -36,6 +36,7 @@ import {
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 import { INCOMING_DOMAIN_TRANSFER } from 'calypso/lib/url/support';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainManagementTransferIn } from 'calypso/my-sites/domains/paths';
 import {
 	composeAnalytics,
@@ -720,4 +721,4 @@ export default connect(
 		recordGoButtonClickInTransferDomain,
 		recordMapDomainButtonClick,
 	}
-)( withShoppingCart( localize( TransferDomainStep ) ) );
+)( withShoppingCart( withCartKey( localize( TransferDomainStep ) ) ) );

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -126,4 +127,4 @@ export default connect(
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}
-)( withShoppingCart( DomainTransferOrConnect ) );
+)( withShoppingCart( withCartKey( DomainTransferOrConnect ) ) );

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -28,6 +28,7 @@ import {
 	INCOMING_DOMAIN_TRANSFER,
 	MAP_EXISTING_DOMAIN,
 } from 'calypso/lib/url/support';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import {
@@ -447,4 +448,4 @@ export default connect(
 		recordTransferButtonClickInUseYourDomain,
 		recordMappingButtonClickInUseYourDomain,
 	}
-)( withShoppingCart( localize( UseYourDomainStep ) ) );
+)( withShoppingCart( withCartKey( localize( UseYourDomainStep ) ) ) );

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -13,6 +13,7 @@ import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { hasProduct, siteRedirect } from 'calypso/lib/cart-values/cart-items';
 import { canRedirect } from 'calypso/lib/domains';
 import { withoutHttp } from 'calypso/lib/url';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 
@@ -196,4 +197,4 @@ export default connect( null, {
 	recordInputFocus,
 	recordGoButtonClick,
 	recordFormSubmit,
-} )( withShoppingCart( localize( SiteRedirectStep ) ) );
+} )( withShoppingCart( withCartKey( localize( SiteRedirectStep ) ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After https://github.com/Automattic/wp-calypso/pull/54667, we need to pass the cart key as an argument to `useShoppingCart` and `withShoppingCart` (although there's currently a fallback in place while we migrate). You can read more about the reason behind the change in that PR.

In https://github.com/Automattic/wp-calypso/pull/55843 we migrated some of the components to pass the cart key. This PR migrates the rest that use the cart key in and near signup.

#### Testing instructions

Verify that there are no errors with the following components:

- Map domain step
- Register domain step
- Transfer domain step
- "Use my domain" transfer or connect
- "Use your domain" step
- Site redirect step