### PR TITLE
Domains: Pass cartKey to components that access the shopping cart

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -26,6 +26,7 @@ import {
 	GSUITE_BASIC_SLUG,
 	GSUITE_BUSINESS_SLUG,
 } from 'calypso/lib/gsuite/constants';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 
 export class CartItem extends React.Component {
 	removeFromCart = ( event ) => {
@@ -345,4 +346,4 @@ export class CartItem extends React.Component {
 	}
 }
 
-export default withShoppingCart( localize( withLocalizedMoment( CartItem ) ) );
+export default withShoppingCart( withCartKey( localize( withLocalizedMoment( CartItem ) ) ) );

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -2,6 +2,7 @@ import { withShoppingCart } from '@automattic/shopping-cart';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { getAllCartItems } from 'calypso/lib/cart-values/cart-items';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import PopoverCart from './popover-cart';
 
 class HeaderCart extends React.Component {
@@ -42,4 +43,4 @@ class HeaderCart extends React.Component {
 	}
 }
 
-export default withShoppingCart( HeaderCart );
+export default withShoppingCart( withCartKey( HeaderCart ) );

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -11,6 +11,7 @@ import React from 'react';
 import Count from 'calypso/components/count';
 import HeaderButton from 'calypso/components/header-button';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
 import CartButtons from './cart-buttons';
@@ -157,4 +158,4 @@ class PopoverCart extends React.Component {
 	}
 }
 
-export default withShoppingCart( localize( PopoverCart ) );
+export default withShoppingCart( withCartKey( localize( PopoverCart ) ) );

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -25,6 +25,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import HeaderCart from 'calypso/my-sites/checkout/cart/header-cart';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
@@ -300,4 +301,4 @@ export default connect(
 		recordAddDomainButtonClick,
 		recordRemoveDomainButtonClick,
 	}
-)( withShoppingCart( localize( DomainSearch ) ) );
+)( withShoppingCart( withCartKey( localize( DomainSearch ) ) ) );

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -13,6 +13,7 @@ import Notice from 'calypso/components/notice';
 import { fillInSingleCartItemAttributes } from 'calypso/lib/cart-values';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import wp from 'calypso/lib/wp';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
@@ -253,4 +254,4 @@ export default connect(
 	{
 		successNotice,
 	}
-)( withShoppingCart( localize( MapDomain ) ) );
+)( withShoppingCart( withCartKey( localize( MapDomain ) ) ) );

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -14,6 +14,7 @@ import {
 	domainTransfer,
 	updatePrivacyForDomain,
 } from 'calypso/lib/cart-values/cart-items';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -192,4 +193,4 @@ export default connect( ( state ) => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
-} ) )( withShoppingCart( TransferDomain ) );
+} ) )( withShoppingCart( withCartKey( TransferDomain ) ) );

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -48,6 +48,7 @@ import {
 	transformMailboxForCart,
 	validateMailboxes as validateTitanMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
@@ -751,4 +752,4 @@ export default connect(
 			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
 		};
 	}
-)( withShoppingCart( localize( EmailProvidersComparison ) ) );
+)( withShoppingCart( withCartKey( localize( EmailProvidersComparison ) ) ) );

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -29,6 +29,7 @@ import {
 	newUsers,
 	validateAgainstExistingUsers,
 } from 'calypso/lib/gsuite/new-users';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
@@ -296,4 +297,4 @@ export default connect(
 		};
 	},
 	{ recordTracksEvent: recordTracksEventAction }
-)( withShoppingCart( localize( GSuiteAddUsers ) ) );
+)( withShoppingCart( withCartKey( localize( GSuiteAddUsers ) ) ) );

--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -28,6 +28,7 @@ import {
 	transformMailboxForCart,
 	validateMailboxes,
 } from 'calypso/lib/titan/new-mailbox';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/gsuite-add-users/add-users-placeholder';
 import {
@@ -309,4 +310,4 @@ export default connect(
 		};
 	},
 	{ recordTracksEvent: recordTracksEventAction }
-)( withShoppingCart( withLocalizedMoment( localize( TitanAddMailboxes ) ) ) );
+)( withShoppingCart( withCartKey( withLocalizedMoment( localize( TitanAddMailboxes ) ) ) ) );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -42,6 +42,7 @@ import { getDiscountByName } from 'calypso/lib/discounts';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -1021,7 +1022,7 @@ const ConnectedPlanFeatures = connect(
 	{
 		recordTracksEvent,
 	}
-)( withShoppingCart( localize( PlanFeatures ) ) );
+)( withShoppingCart( withCartKey( localize( PlanFeatures ) ) ) );
 
 /* eslint-enable */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After https://github.com/Automattic/wp-calypso/pull/54667, we need to pass the cart key as an argument to `useShoppingCart` and `withShoppingCart` (although there's currently a fallback in place while we migrate). You can read more about the reason behind the change in that PR.

In https://github.com/Automattic/wp-calypso/pull/55843 we migrated some of the components to pass the cart key. This PR migrates the rest in domain flows.

#### Testing instructions

Verify that there are no errors with the following components:

- G Suite upgrade
- Domain map page
- Transfer domain page
- Domain search page
- Popover cart (test its use in the domain search page to get all the changed components)
- Email providers comparison page
- G Suite add users page
- Titan add mailbox page
- Plans page
