### PR TITLE
Products: Simplify isPlan function

### DIFF
--- a/packages/calypso-products/src/is-plan.js
+++ b/packages/calypso-products/src/is-plan.js
@@ -1,26 +1,5 @@
-import { formatProduct } from './format-product';
-import { isBlogger } from './is-blogger';
-import { isBusiness } from './is-business';
-import { isEcommerce } from './is-ecommerce';
-import { isEnterprise } from './is-enterprise';
-import { isJetpackPlan } from './is-jetpack-plan';
-import { isJpphpBundle } from './is-jpphp-bundle';
-import { isP2Plus } from './is-p2-plus';
-import { isPersonal } from './is-personal';
-import { isPremium } from './is-premium';
+import { getPlansSlugs } from './main';
 
-export function isPlan( product ) {
-	product = formatProduct( product );
-
-	return (
-		isBlogger( product ) ||
-		isPersonal( product ) ||
-		isPremium( product ) ||
-		isBusiness( product ) ||
-		isEcommerce( product ) ||
-		isEnterprise( product ) ||
-		isJetpackPlan( product ) ||
-		isJpphpBundle( product ) ||
-		isP2Plus( product )
-	);
+export function isPlan( { product_slug } ) {
+	return getPlansSlugs().includes( product_slug );
 }

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,4 +1,4 @@
-import { PLAN_HOST_BUNDLE } from './constants';
+import { PLAN_HOST_BUNDLE, PLAN_FREE } from './constants';
 import { getPlansSlugs } from './main';
 
 export function isPlan( {
@@ -8,5 +8,8 @@ export function isPlan( {
 	| { productSlug: never; product_slug: string }
 	| { product_slug: never; productSlug: string } ): boolean {
 	const slug = product_slug ?? productSlug;
+	if ( slug === PLAN_FREE ) {
+		return false;
+	}
 	return getPlansSlugs().includes( slug ) || slug === PLAN_HOST_BUNDLE;
 }

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,5 +1,5 @@
 import { getPlansSlugs } from './main';
 
-export function isPlan( { product_slug } ) {
+export function isPlan( { product_slug }: { product_slug: string } ): boolean {
 	return getPlansSlugs().includes( product_slug );
 }

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,13 +1,10 @@
 import { PLAN_HOST_BUNDLE, PLAN_FREE } from './constants';
 import { getPlansSlugs } from './main';
 
-export function isPlan( {
-	product_slug,
-	productSlug,
-}:
-	| { productSlug: never; product_slug: string }
-	| { product_slug: never; productSlug: string } ): boolean {
-	const slug = product_slug ?? productSlug;
+type SnakeCaseProduct = { product_slug: string };
+type CamelCaseProduct = { productSlug: string };
+export function isPlan( product: SnakeCaseProduct | CamelCaseProduct ): boolean {
+	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
 	if ( slug === PLAN_FREE ) {
 		return false;
 	}

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,5 +1,10 @@
 import { getPlansSlugs } from './main';
 
-export function isPlan( { product_slug }: { product_slug: string } ): boolean {
-	return getPlansSlugs().includes( product_slug );
+export function isPlan( {
+	product_slug,
+	productSlug,
+}:
+	| { productSlug: never; product_slug: string }
+	| { product_slug: never; productSlug: string } ): boolean {
+	return getPlansSlugs().includes( product_slug ?? productSlug );
 }

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,3 +1,4 @@
+import { PLAN_HOST_BUNDLE } from './constants';
 import { getPlansSlugs } from './main';
 
 export function isPlan( {
@@ -6,5 +7,6 @@ export function isPlan( {
 }:
 	| { productSlug: never; product_slug: string }
 	| { product_slug: never; productSlug: string } ): boolean {
-	return getPlansSlugs().includes( product_slug ?? productSlug );
+	const slug = product_slug ?? productSlug;
+	return getPlansSlugs().includes( slug ) || slug === PLAN_HOST_BUNDLE;
 }

--- a/packages/calypso-products/src/is-plan.ts
+++ b/packages/calypso-products/src/is-plan.ts
@@ -1,12 +1,18 @@
-import { PLAN_HOST_BUNDLE, PLAN_FREE } from './constants';
-import { getPlansSlugs } from './main';
+import { PLAN_HOST_BUNDLE, PLAN_WPCOM_ENTERPRISE } from './constants';
+import { getPlansSlugs, isFreePlan } from './main';
 
-type SnakeCaseProduct = { product_slug: string };
-type CamelCaseProduct = { productSlug: string };
-export function isPlan( product: SnakeCaseProduct | CamelCaseProduct ): boolean {
+type HasSnakeCaseProductSlug = { product_slug: string };
+type HasCamelCaseProductSlug = { productSlug: string };
+export function isPlan( product: HasSnakeCaseProductSlug | HasCamelCaseProductSlug ): boolean {
 	const slug = 'product_slug' in product ? product.product_slug : product.productSlug;
-	if ( slug === PLAN_FREE ) {
+	if ( isFreePlan( slug ) ) {
 		return false;
 	}
-	return getPlansSlugs().includes( slug ) || slug === PLAN_HOST_BUNDLE;
+	switch ( slug ) {
+		case PLAN_HOST_BUNDLE:
+		case PLAN_WPCOM_ENTERPRISE:
+			return true;
+		default:
+			return getPlansSlugs().includes( slug );
+	}
 }

--- a/packages/calypso-products/test/is-plan.js
+++ b/packages/calypso-products/test/is-plan.js
@@ -1,0 +1,60 @@
+import {
+	PLAN_BLOGGER,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PREMIUM,
+	PLAN_WPCOM_ENTERPRISE,
+	PLAN_VIP,
+	PLAN_HOST_BUNDLE,
+	PLAN_P2_PLUS,
+	PLAN_P2_FREE,
+	WPCOM_DIFM_LITE,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+} from '../src/constants';
+import { isPlan } from '../src/is-plan';
+
+describe( 'isPlan', () => {
+	it.each( [
+		PLAN_PREMIUM,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PERSONAL_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_ECOMMERCE,
+		PLAN_BLOGGER,
+		PLAN_WPCOM_ENTERPRISE,
+		PLAN_HOST_BUNDLE,
+		PLAN_P2_PLUS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_SECURITY_DAILY,
+		PLAN_JETPACK_SECURITY_REALTIME,
+		PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	] )( 'returns true for %s', ( slug ) => {
+		expect( isPlan( { product_slug: slug } ) ).toBeTruthy();
+		expect( isPlan( { productSlug: slug } ) ).toBeTruthy();
+	} );
+
+	it.each( [
+		'asdljasdlsjadlasjdlkasjd',
+		PLAN_FREE,
+		WPCOM_DIFM_LITE,
+		PLAN_P2_FREE,
+		PLAN_VIP,
+		PLAN_JETPACK_FREE,
+	] )( 'returns false for %s', ( slug ) => {
+		expect( isPlan( { product_slug: slug } ) ).toBeFalsy();
+		expect( isPlan( { productSlug: slug } ) ).toBeFalsy();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR simplifies the `isPlan()` function in the `@automattic/calypso-products` package and converts it to TypeScript. 

Previously the function called a series of other functions (one for each plan product) to determine if a product was a "plan". This is inefficient (the functions each do a lot of processing), repetitive (most of them call the same formatting and query functions), and prone to error (it would be trivially easy to forget to add a new plan to this function). It's also not clear from just reading it how it will behave (since the functions that check by "group" are not easy to follow).

Instead, this PR queries the hard-coded list of plans in the same package for the product slug and uses that to determine if the product is a plan or not, neatly sidestepping most of the previous function's overhead and going directly to the data source which was used by all the other functions. It avoids using product "group" entirely since the products that have each of the referenced groups already have their slugs listed in the data source for plans.

More specifically, the old function checked for:

- WPCOM plans that are in the plans list
  - The blogger plan
  - The personal plan
  - The premium plan
  - The business plan
  - The eCommerce plan
  - The enterprise plan
- Jetpack plans by group, but all plans in the Jetpack group are in the plans list
- P2 plans by group, but all P2 plans are in the plans list
- The JpphpBundle (whatever that is), which is _not_ in the plans list but the function now checks for that explicitly.

#### Testing instructions

This function is used in large and diverse number of places so it's difficult to test them all. The best thing to do is to follow the logic of the old function and verify that the new logic covers all the same cases.