### PR TITLE
Changes manage plugins destination to WP Admin.

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -17,7 +17,7 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
+import { getSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import WithItemsToUpdate from './to-update';
 import ActivityLogTaskUpdate from './update';
 
@@ -27,7 +27,6 @@ import './style.scss';
  * Checks if the supplied core update, plugins, or themes are being updated.
  *
  * @param {Array} updatables List of plugin, theme or core update objects to check their update status.
- *
  * @returns {boolean}  True if one or more plugins or themes are updating.
  */
 const isItemUpdating = ( updatables ) =>
@@ -38,7 +37,6 @@ const isItemUpdating = ( updatables ) =>
  *
  * @param {string} updateSlug  Plugin or theme slug, or 'wordpress' for core updates.
  * @param {Array}  updateQueue Collection of plugins or themes currently queued to be updated.
- *
  * @returns {boolean}   True if the plugin or theme is enqueued to be updated.
  */
 const isItemEnqueued = ( updateSlug, updateQueue ) => !! find( updateQueue, { slug: updateSlug } );
@@ -130,14 +128,13 @@ class ActivityLogTasklist extends Component {
 	 *
 	 * @returns {object} Action to redirect to plugins management.
 	 */
-	goManagePlugins = () => this.props.goManagePlugins( this.props.siteSlug );
+	goManagePlugins = () => this.props.goManagePlugins( this.props.siteAdminUrl );
 
 	/**
 	 * Goes to single theme or plugin management screen.
 	 *
 	 * @param {string} slug Plugin or theme slug, like "hello-dolly" or "dara".
 	 * @param {string} type Indicates if it's "plugin" or "theme".
-	 *
 	 * @returns {object} Action to redirect to plugin management.
 	 */
 	goToPage = ( slug, type ) => this.props.goToPage( slug, type, this.props.siteSlug );
@@ -430,7 +427,6 @@ class ActivityLogTasklist extends Component {
  * @param {string}  state            Current state of update progress.
  * @param {boolean} isUpdateComplete If update actually produced what is expected to be after a successful update.
  *                                   In themes, the 'update' prop of the theme object is nullified when an update is succesful.
- *
  * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
  * the update is running, failed, or was successfully completed, respectively.
  */
@@ -455,7 +451,6 @@ const getNormalizedStatus = ( state, isUpdateComplete ) => {
  *
  * @param {number} siteId  Site Id.
  * @param {string} themeId Theme slug.
- *
  * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
  * the update is running, failed, or was successfully completed, respectively.
  */
@@ -497,7 +492,6 @@ const getStatusForCore = ( siteId, coreVersion ) => {
  * @param {Array}  itemList Collection of plugins/themes that will be updated.
  * @param {number} siteId   ID of the site where the plugin/theme is installed.
  * @param {object} state    App state tree.
- *
  * @returns {Array} List of plugins/themes to update with their status.
  */
 const makeUpdatableList = ( itemList, siteId, state = null ) =>
@@ -514,7 +508,6 @@ const makeUpdatableList = ( itemList, siteId, state = null ) =>
  *
  * @param {number} siteId  Site Id.
  * @param {string} themeId Theme slug.
- *
  * @returns {*} Stored data container for request.
  */
 const updateTheme = ( siteId, themeId ) =>
@@ -534,7 +527,6 @@ const updateTheme = ( siteId, themeId ) =>
  * Start updating WordPress core on the specified site.
  *
  * @param {number} siteId  Site Id.
- *
  * @returns {*} Stored data container for request.
  */
 const updateCore = ( siteId ) =>
@@ -558,6 +550,7 @@ const mapStateToProps = ( state, { siteId, plugins, themes, core } ) => {
 		siteName: site.name,
 		pluginWithUpdate: makeUpdatableList( plugins, siteId, state ),
 		themeWithUpdate: makeUpdatableList( themes, siteId ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		coreWithUpdate: isEmpty( core )
 			? []
 			: [
@@ -590,9 +583,9 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		dispatch( recordTracksEvent( 'calypso_activitylog_tasklist_dismiss_all' ) ),
 	trackDismiss: ( { type, slug } ) =>
 		dispatch( recordTracksEvent( `calypso_activitylog_tasklist_dismiss_${ type }`, { slug } ) ),
-	goManagePlugins: ( siteSlug ) => {
+	goManagePlugins: ( siteAdminUrl ) => {
 		dispatch( recordTracksEvent( 'calypso_activitylog_tasklist_manage_plugins' ) );
-		page( `/plugins/manage/${ siteSlug }` );
+		page( `${ siteAdminUrl }plugins.php` );
 	},
 	goToPage: ( slug, type, siteSlug ) => {
 		const tracksEvent =

--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -394,30 +394,30 @@ class ActivityLogTasklist extends Component {
 							  )
 							: translate( 'You have one update available' )
 					}
-					{ /* { 1 < numberOfUpdates && ( */ }
-					<SplitButton
-						compact
-						primary
-						label={ translate( 'Update all' ) }
-						onClick={ this.updateAll }
-						disabled={ 0 < queued.length }
-					>
-						<PopoverMenuItem
-							onClick={ this.goManagePlugins }
-							className="activity-log-tasklist__menu-item"
-							icon="cog"
+					{ 1 < numberOfUpdates && (
+						<SplitButton
+							compact
+							primary
+							label={ translate( 'Update all' ) }
+							onClick={ this.updateAll }
+							disabled={ 0 < queued.length }
 						>
-							<span>{ translate( 'Manage plugins' ) }</span>
-						</PopoverMenuItem>
-						<PopoverMenuItem
-							onClick={ this.dismiss }
-							className="activity-log-tasklist__menu-item"
-							icon="trash"
-						>
-							<span>{ translate( 'Dismiss all' ) }</span>
-						</PopoverMenuItem>
-					</SplitButton>
-					{ /* ) } */ }
+							<PopoverMenuItem
+								onClick={ this.goManagePlugins }
+								className="activity-log-tasklist__menu-item"
+								icon="cog"
+							>
+								<span>{ translate( 'Manage plugins' ) }</span>
+							</PopoverMenuItem>
+							<PopoverMenuItem
+								onClick={ this.dismiss }
+								className="activity-log-tasklist__menu-item"
+								icon="trash"
+							>
+								<span>{ translate( 'Dismiss all' ) }</span>
+							</PopoverMenuItem>
+						</SplitButton>
+					) }
 				</div>
 				{ showExpandedView && this.showAllItemsToUpdate( itemsToUpdate ) }
 				{ ! showExpandedView &&

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -37,7 +37,6 @@ import {
 	getSiteSlug,
 	getCustomizerUrl,
 	getSiteProducts,
-	getSiteAdminUrl,
 	isJetpackMinimumVersion,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -57,7 +56,6 @@ interface Props {
 		| undefined;
 	widgetCustomizerPaneUrl: URL | null;
 	sitePurchases: Purchase[];
-	siteAdminUrl: string;
 }
 
 class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
@@ -166,7 +164,6 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 			translate,
 			vaultpressFinished,
 			hasVideoHosting,
-			siteAdminUrl,
 		} = this.props;
 
 		const isRewindActive = rewindState === 'active' || rewindState === 'provisioning';
@@ -284,7 +281,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 							'Choose which WordPress plugins you want to keep automatically updated.'
 						) }
 						duration={ this.getDuration( 3 ) }
-						href={ `${ siteAdminUrl }plugins.php` }
+						href={ `/plugins/manage/${ siteSlug }` }
 						onClick={ this.handleTaskStart( {
 							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_PLUGIN_UPDATES,
 							tourId: 'jetpackPluginUpdates',
@@ -419,7 +416,6 @@ function mapStateToProps( state ) {
 			hasFeature( state, siteId, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ) &&
 			( ! isJetpackOfferResetPlan( planSlug ) || isMinimumVersion ),
 		sitePurchases: getSitePurchases( state, siteId ),
-		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 	};
 }
 

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -37,6 +37,7 @@ import {
 	getSiteSlug,
 	getCustomizerUrl,
 	getSiteProducts,
+	getSiteAdminUrl,
 	isJetpackMinimumVersion,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -56,6 +57,7 @@ interface Props {
 		| undefined;
 	widgetCustomizerPaneUrl: URL | null;
 	sitePurchases: Purchase[];
+	siteAdminUrl: string;
 }
 
 class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
@@ -164,6 +166,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 			translate,
 			vaultpressFinished,
 			hasVideoHosting,
+			siteAdminUrl,
 		} = this.props;
 
 		const isRewindActive = rewindState === 'active' || rewindState === 'provisioning';
@@ -281,7 +284,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 							'Choose which WordPress plugins you want to keep automatically updated.'
 						) }
 						duration={ this.getDuration( 3 ) }
-						href={ `/plugins/manage/${ siteSlug }` }
+						href={ `${ siteAdminUrl }plugins.php` }
 						onClick={ this.handleTaskStart( {
 							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_PLUGIN_UPDATES,
 							tourId: 'jetpackPluginUpdates',
@@ -416,6 +419,7 @@ function mapStateToProps( state ) {
 			hasFeature( state, siteId, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ) &&
 			( ! isJetpackOfferResetPlan( planSlug ) || isMinimumVersion ),
 		sitePurchases: getSitePurchases( state, siteId ),
+		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 	};
 }
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -45,7 +45,12 @@ import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-s
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getSitePlan, isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import {
+	getSitePlan,
+	isJetpackSite,
+	isRequestingSites,
+	getSiteAdminUrl,
+} from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -363,11 +368,10 @@ export class PluginsBrowser extends Component {
 			return null;
 		}
 
-		const { siteSlug, translate } = this.props;
-		const site = siteSlug ? '/' + siteSlug : '';
+		const { siteAdminUrl, translate } = this.props;
 
 		return (
-			<Button className="plugins-browser__button" href={ '/plugins/manage' + site }>
+			<Button className="plugins-browser__button" href={ `${ siteAdminUrl }plugins.php` }>
 				<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
 			</Button>
 		);
@@ -557,6 +561,7 @@ export default flow(
 				isFetchingPluginsByCategoryPopular: isFetchingPluginsList( state, 'popular' ),
 				isFetchingPluginsByCategoryFeatured: isFetchingPluginsList( state, 'featured' ),
 				isFetchingPluginsBySearchTerm: isFetchingPluginsList( state, null, search ),
+				siteAdminUrl: getSiteAdminUrl( state, selectedSiteId ),
 			};
 		},
 		{

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -368,10 +368,19 @@ export class PluginsBrowser extends Component {
 			return null;
 		}
 
-		const { siteAdminUrl, translate } = this.props;
+		const { siteAdminUrl, siteSlug, translate } = this.props;
+		const site = siteSlug ? '/' + siteSlug : '';
+
+		// When no site is selected eg `/plugins` or when Jetpack is self hosted
+		// show the Calypso Plugins Manage page.
+		// In any other case, redirect to current site WP Admin.
+		const managePluginsDestination =
+			! siteAdminUrl || this.props.jetpackNonAtomic
+				? `/plugins/manage${ site }`
+				: `${ siteAdminUrl }plugins.php`;
 
 		return (
-			<Button className="plugins-browser__button" href={ `${ siteAdminUrl }plugins.php` }>
+			<Button className="plugins-browser__button" href={ managePluginsDestination }>
 				<span className="plugins-browser__button-text">{ translate( 'Manage plugins' ) }</span>
 			</Button>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the destination of "Manage Plugins" button in Calypso Plugins page to link to WP Admin

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Plugins Browser**
|Before | After|
-------|------
|![SS 2021-09-15 at 17 48 51](https://user-images.githubusercontent.com/12430020/133456280-3abdbaf7-45f9-43a2-9a20-95de33b11b71.gif)|![SS 2021-09-15 at 17 50 46](https://user-images.githubusercontent.com/12430020/133456530-c5978f60-ae6e-4c85-a876-3de6fe43f171.gif)|

- Visit `http://calypso.localhost:3000/plugins/[DOMAIN]` of an Atomic site
- Click "Manage Plugins"
- You should be redirected to `/wp-admin/plugins.php`

**Jetpack Checklist**
|Before | After|
|-------|------|
|![SS 2021-09-15 at 20 09 09](https://user-images.githubusercontent.com/12430020/133478598-1ecc12dc-6d7b-4f38-9f75-a4861b774e68.gif)|![SS 2021-09-15 at 21 14 31](https://user-images.githubusercontent.com/12430020/133487317-bc64e0eb-3802-4689-8f8b-e1f7fe66ea6f.gif)|

- Visit `http://calypso.localhost:3000/plans/my-plan/[DOMAIN]` of a Jetpack self hosted site
- Click "Automatic Plugin Updates" -> "Try it" (you might need to go to `wp-admin/plugins.php` and disable auto-updates)
- You should be redirected to `/wp-admin/plugins.php`

**Jetpack Activity Log**
|Before | After|
|-------|------|
|![SS 2021-09-15 at 21 15 41](https://user-images.githubusercontent.com/12430020/133487453-a3660f32-f8e6-430f-bdbd-b9adc7592995.gif)|![SS 2021-09-15 at 21 17 42](https://user-images.githubusercontent.com/12430020/133487739-62804961-a55a-4f24-ae23-faaaf460f3d2.gif)|


- Visit `http://calypso.localhost:3000/activity-log/[DOMAIN]` of a Jetpack self hosted site or Atomic site
- Click the drop down right next to "Update All" -> "Manage Plugins" (you might need to go to `wp-admin/plugins.php` and have some outdated plugins)
- You should be redirected to `/wp-admin/plugins.php`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #56267
