### PR TITLE
Design Picker: Add design preview

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -231,7 +231,7 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		if ( ! this.props.disableRedirects && this.checkForIframeLoadFailure( caller ) ) {
+		if ( this.checkForIframeLoadFailure( caller ) ) {
 			if ( this.props.showClose ) {
 				window.open( this.state.iframeUrl, '_blank' );
 				this.props.onClose();
@@ -391,8 +391,6 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
-	// Disable page redirect if loading iframe is failed
-	disableRedirects: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -267,7 +267,7 @@ export class WebPreviewContent extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, toolbarComponent: ToolbarComponent } = this.props;
 
 		const className = classNames( this.props.className, 'web-preview__inner', {
 			'is-touch': this._hasTouch,
@@ -288,7 +288,7 @@ export class WebPreviewContent extends Component {
 
 		return (
 			<div className={ className } ref={ this.setWrapperElement }>
-				<Toolbar
+				<ToolbarComponent
 					setDeviceViewport={ this.setDeviceViewport }
 					device={ this.state.device }
 					{ ...this.props }
@@ -390,6 +390,8 @@ WebPreviewContent.propTypes = {
 	isInlineHelpPopoverVisible: PropTypes.bool,
 	// A post object used to override the selected post in the SEO preview
 	overridePost: PropTypes.object,
+	// A customized Toolbar element
+	toolbarComponent: PropTypes.elementType,
 };
 
 WebPreviewContent.defaultProps = {
@@ -411,6 +413,7 @@ WebPreviewContent.defaultProps = {
 	hasSidebar: false,
 	isModalWindow: false,
 	overridePost: null,
+	toolbarComponent: Toolbar,
 };
 
 const mapState = ( state ) => {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -1,4 +1,3 @@
-import { parse as parseUrl } from 'url';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import classNames from 'classnames';
 import debugModule from 'debug';
@@ -232,7 +231,7 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		if ( this.checkForIframeLoadFailure( caller ) ) {
+		if ( ! this.props.disableRedirects && this.checkForIframeLoadFailure( caller ) ) {
 			if ( this.props.showClose ) {
 				window.open( this.state.iframeUrl, '_blank' );
 				this.props.onClose();
@@ -250,7 +249,7 @@ export class WebPreviewContent extends Component {
 		// and they make it possible to redirect to wp-login.php since it cannot be displayed in this
 		// iframe OR redirected to using <a href="" target="_top">.
 		if ( this.props.isPrivateAtomic ) {
-			const { protocol, host } = parseUrl( this.props.externalUrl );
+			const { protocol, host } = new URL( this.props.externalUrl );
 			this.iframe.contentWindow.postMessage( { connected: 'calypso' }, `${ protocol }//${ host }` );
 		}
 	};
@@ -392,6 +391,8 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
+	// Disable page redirect if loading iframe is failed
+	disableRedirects: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -99,7 +99,7 @@
 	@include break-small {
 		display: block;
 	}
-	
+
 	img {
 		width: 50%;
 	}

--- a/client/signup/steps/design-picker/icons.jsx
+++ b/client/signup/steps/design-picker/icons.jsx
@@ -1,0 +1,46 @@
+import { Path, SVG, Rect } from '@wordpress/components';
+import React from 'react';
+
+export const computer = (
+	<SVG width="55" height="55" viewBox="0 0 55 55">
+		<Path
+			d="M10.4258 15.75C10.4258 15.0596 10.9854 14.5 11.6758 14.5H43.3239C44.0143 14.5 44.5739 15.0596 44.5739 15.75V38.463H10.4258V15.75Z"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+		<Path
+			d="M4.58301 38.667C4.58301 37.5624 5.47844 36.667 6.58301 36.667H48.4163C49.5209 36.667 50.4163 37.5624 50.4163 38.667V40.1045H4.58301V38.667Z"
+			fill="currentColor"
+		/>
+	</SVG>
+);
+
+export const tablet = (
+	<SVG width="48" height="48" viewBox="0 0 48 48">
+		<Rect
+			x="10.75"
+			y="8.75"
+			width="26.5"
+			height="30.5"
+			rx="1.25"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+		<Rect x="20" y="32" width="8" height="3" fill="currentColor" />
+	</SVG>
+);
+
+export const phone = (
+	<SVG width="40" height="40" viewBox="0 0 40 40">
+		<Rect
+			x="12.417"
+			y="7.41699"
+			width="16"
+			height="25.1667"
+			rx="1.25"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+		<Rect x="18.333" y="26.667" width="5" height="2.5" fill="currentColor" />
+	</SVG>
+);

--- a/client/signup/steps/design-picker/icons.jsx
+++ b/client/signup/steps/design-picker/icons.jsx
@@ -1,5 +1,4 @@
 import { Path, SVG, Rect } from '@wordpress/components';
-import React from 'react';
 
 export const computer = (
 	<SVG width="55" height="55" viewBox="0 0 55 55">

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -60,7 +60,6 @@ class DesignPickerStep extends Component {
 	updateScrollPosition() {
 		if ( this.props.stepSectionName ) {
 			this.setState( { scrollTop: document.scrollingElement.scrollTop } );
-			document.scrollingElement.scrollTop = 0;
 		} else {
 			// Defer restore scroll position to ensure DesignPicker is rendered
 			window.setTimeout( () => {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -45,6 +45,7 @@ class DesignPickerStep extends Component {
 
 	state = {
 		selectedDesign: null,
+		scrollTop: 0,
 	};
 
 	componentDidMount() {
@@ -54,6 +55,19 @@ class DesignPickerStep extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.stepSectionName !== this.props.stepSectionName ) {
 			this.updateSelectedDesign();
+			this.updateScrollPosition();
+		}
+	}
+
+	updateScrollPosition() {
+		if ( this.props.stepSectionName ) {
+			this.setState( { scrollTop: document.scrollingElement.scrollTop } );
+			document.scrollingElement.scrollTop = 0;
+		} else {
+			// Defer restore scroll position to ensure DesignPicker is rendered
+			window.setTimeout( () => {
+				document.scrollingElement.scrollTop = this.state.scrollTop;
+			} );
 		}
 	}
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -167,7 +167,7 @@ class DesignPickerStep extends Component {
 			: '';
 
 		return (
-			<div className="design-picker__preview">
+			<>
 				<QueryTheme siteId="wpcom" themeId={ selectedDesign.theme } />
 				<WebPreview
 					className="design-picker__web-preview"
@@ -184,7 +184,7 @@ class DesignPickerStep extends Component {
 					) }
 					toolbarComponent={ PreviewToolbar }
 				/>
-			</div>
+			</>
 		);
 	}
 
@@ -212,6 +212,7 @@ class DesignPickerStep extends Component {
 			return (
 				<StepWrapper
 					{ ...this.props }
+					className="design-picker__preview"
 					fallbackHeaderText={ designTitle }
 					headerText={ designTitle }
 					fallbackSubHeaderText={ '' }

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -168,7 +168,7 @@ class DesignPickerStep extends Component {
 		} = this.props;
 
 		const { selectedDesign } = this.state;
-		const previewUrl = getDesignUrl( selectedDesign, locale );
+		const previewUrl = getDesignUrl( selectedDesign, locale, { iframe: true } );
 
 		return (
 			<WebPreview
@@ -183,8 +183,6 @@ class DesignPickerStep extends Component {
 					components: { strong: <strong /> },
 				} ) }
 				toolbarComponent={ PreviewToolbar }
-				// Avoid page direct because checkForIframeLoadFailure inside the WebPreview returns true but I'm not sure why
-				disableRedirects
 			/>
 		);
 	}

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,5 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { isBlankCanvasDesign } from '@automattic/design-picker';
+import { withMobileBreakpoint } from '@automattic/viewport-react';
+import { compose } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -200,7 +202,7 @@ class DesignPickerStep extends Component {
 	}
 
 	render() {
-		const { isReskinned, translate } = this.props;
+		const { isReskinned, isBreakpointActive: isMobile, translate } = this.props;
 		const { selectedDesign } = this.state;
 		const headerText = this.headerText();
 		const subHeaderText = this.subHeaderText();
@@ -218,7 +220,7 @@ class DesignPickerStep extends Component {
 					fallbackSubHeaderText={ '' }
 					subHeaderText={ '' }
 					stepContent={ this.renderDesignPreview() }
-					align={ 'center' }
+					align={ isMobile ? 'left' : 'center' }
 					hideSkip
 					hideNext={ false }
 					nextLabelText={ translate( 'Start with %(designTitle)s', {
@@ -244,12 +246,16 @@ class DesignPickerStep extends Component {
 	}
 }
 
-export default connect(
-	( state, { stepSectionName: themeId } ) => {
-		return {
-			demoUrl: themeId ? getThemeDemoUrl( state, themeId, 'wpcom' ) : '',
-			themes: getRecommendedThemes( state, 'auto-loading-homepage' ),
-		};
-	},
-	{ fetchRecommendedThemes, submitSignupStep }
-)( localize( DesignPickerStep ) );
+export default compose(
+	connect(
+		( state, { stepSectionName: themeId } ) => {
+			return {
+				demoUrl: themeId ? getThemeDemoUrl( state, themeId, 'wpcom' ) : '',
+				themes: getRecommendedThemes( state, 'auto-loading-homepage' ),
+			};
+		},
+		{ fetchRecommendedThemes, submitSignupStep }
+	),
+	withMobileBreakpoint,
+	localize
+)( DesignPickerStep );

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -5,6 +5,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import QueryTheme from 'calypso/components/data/query-theme';
 import WebPreview from 'calypso/components/web-preview';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -12,7 +13,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getRecommendedThemes as fetchRecommendedThemes } from 'calypso/state/themes/actions';
-import { getRecommendedThemes } from 'calypso/state/themes/selectors';
+import { getRecommendedThemes, getThemeDemoUrl } from 'calypso/state/themes/selectors';
 import PreviewToolbar from './preview-toolbar';
 import './style.scss';
 
@@ -147,25 +148,27 @@ class DesignPickerStep extends Component {
 
 	renderDesignPreview() {
 		const {
+			demoUrl,
 			signupDependencies: { siteSlug },
 			translate,
 		} = this.props;
 
 		const { selectedDesign } = this.state;
 
-		const previewUrl = addQueryArgs(
-			{
-				theme: `pub/${ selectedDesign.theme }`,
-				hide_banners: true,
-				demo: true,
-				iframe: true,
-				theme_preview: true,
-			},
-			`//${ siteSlug }`
-		);
+		const previewUrl = demoUrl
+			? addQueryArgs(
+					{
+						demo: true,
+						iframe: true,
+						theme_preview: true,
+					},
+					demoUrl
+			  )
+			: '';
 
 		return (
 			<div className="design-picker__preview">
+				<QueryTheme siteId="wpcom" themeId={ selectedDesign.theme } />
 				<WebPreview
 					className="design-picker__web-preview"
 					showPreview
@@ -241,8 +244,9 @@ class DesignPickerStep extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, { stepSectionName: themeId } ) => {
 		return {
+			demoUrl: themeId ? getThemeDemoUrl( state, themeId, 'wpcom' ) : '',
 			themes: getRecommendedThemes( state, 'auto-loading-homepage' ),
 		};
 	},

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import DesignPicker from '@automattic/design-picker';
+import DesignPicker, { isBlankCanvasDesign } from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -197,25 +197,28 @@ class DesignPickerStep extends Component {
 	}
 
 	render() {
-		const { isReskinned } = this.props;
+		const { isReskinned, translate } = this.props;
 		const { selectedDesign } = this.state;
 		const headerText = this.headerText();
 		const subHeaderText = this.subHeaderText();
 
 		if ( selectedDesign ) {
+			const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
+			const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
+
 			return (
 				<StepWrapper
 					{ ...this.props }
-					fallbackHeaderText={ selectedDesign.title }
-					headerText={ selectedDesign.title }
+					fallbackHeaderText={ designTitle }
+					headerText={ designTitle }
 					fallbackSubHeaderText={ '' }
 					subHeaderText={ '' }
 					stepContent={ this.renderDesignPreview() }
 					align={ 'center' }
 					hideSkip
 					hideNext={ false }
-					nextLabelText={ this.props.translate( 'Start with %(designTitle)s', {
-						args: { designTitle: selectedDesign.title },
+					nextLabelText={ translate( 'Start with %(designTitle)s', {
+						args: { designTitle },
 					} ) }
 					goToNextStep={ this.submitDesign }
 				/>

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -101,6 +101,17 @@ class DesignPickerStep extends Component {
 	}
 
 	pickDesign = ( selectedDesign ) => {
+		// Design picker preview will submit the defaultDependencies via next button,
+		// So only do this when the user picks the design directly
+		this.props.submitSignupStep(
+			{
+				stepName: this.props.stepName,
+			},
+			{
+				selectedDesign,
+			}
+		);
+
 		this.submitDesign( selectedDesign );
 	};
 
@@ -113,15 +124,6 @@ class DesignPickerStep extends Component {
 			theme: `pub/${ selectedDesign?.theme }`,
 			template: selectedDesign?.template,
 		} );
-
-		this.props.submitSignupStep(
-			{
-				stepName: this.props.stepName,
-			},
-			{
-				selectedDesign,
-			}
-		);
 
 		this.props.goToNextStep();
 	};
@@ -206,6 +208,7 @@ class DesignPickerStep extends Component {
 		if ( selectedDesign ) {
 			const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 			const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
+			const defaultDependencies = { selectedDesign };
 
 			return (
 				<StepWrapper
@@ -222,6 +225,7 @@ class DesignPickerStep extends Component {
 					nextLabelText={ translate( 'Start with %(designTitle)s', {
 						args: { designTitle },
 					} ) }
+					defaultDependencies={ defaultDependencies }
 					goToNextStep={ this.submitDesign }
 				/>
 			);

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -87,12 +87,14 @@ class DesignPickerStep extends Component {
 	}
 
 	pickDesign = ( selectedDesign ) => {
+		this.submitDesign( selectedDesign );
+	};
+
+	previewDesign = ( selectedDesign ) => {
 		page( getStepUrl( this.props.flowName, this.props.stepName, selectedDesign.theme ) );
 	};
 
-	submitDesign = () => {
-		const { selectedDesign } = this.state;
-
+	submitDesign = ( selectedDesign = this.state.selectedDesign ) => {
 		recordTracksEvent( 'calypso_signup_select_design', {
 			theme: `pub/${ selectedDesign?.theme }`,
 			template: selectedDesign?.template,
@@ -136,6 +138,7 @@ class DesignPickerStep extends Component {
 				theme={ this.props.isReskinned ? 'light' : 'dark' }
 				locale={ this.props.locale } // props.locale obtained via `localize` HoC
 				onSelect={ this.pickDesign }
+				onPreview={ this.previewDesign }
 				highResThumbnails
 				showCategoryFilter={ isEnabled( 'signup/design-picker-categories' ) }
 			/>

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -1,0 +1,62 @@
+import { Button, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+import './preview-toolbar.scss';
+
+const possibleDevices = [ 'computer', 'tablet', 'phone' ];
+
+const DesignPickerPreviewToolbar = ( {
+	device: currentDevice,
+	externalUrl,
+	setDeviceViewport,
+	translate,
+} ) => {
+	const devices = React.useRef( {
+		computer: { title: translate( 'Desktop' ), icon: 'computer' },
+		tablet: { title: translate( 'Tablet' ), icon: 'tablet' },
+		phone: { title: translate( 'Phone' ), icon: 'phone' },
+	} );
+
+	return (
+		<div className="preview-toolbar__toolbar">
+			<div className="preview-toolbar__devices">
+				{ possibleDevices.map( ( device ) => (
+					<Button
+						key={ device }
+						borderless
+						aria-label={ devices.current[ device ].title }
+						className={ classNames( 'preview-toolbar__button', {
+							'is-selected': device === currentDevice,
+						} ) }
+						onClick={ () => setDeviceViewport( device ) }
+					>
+						<Gridicon size={ 18 } icon={ devices.current[ device ].icon } />
+					</Button>
+				) ) }
+			</div>
+			<div className="preview-toolbar__browser-header">
+				<svg width="40" height="8">
+					<g>
+						<rect width="8" height="8" rx="4" />
+						<rect x="16" width="8" height="8" rx="4" />
+						<rect x="32" width="8" height="8" rx="4" />
+					</g>
+				</svg>
+				<span className="preview-toolbar__browser-url">{ externalUrl }</span>
+			</div>
+		</div>
+	);
+};
+
+DesignPickerPreviewToolbar.propTypes = {
+	// The device to display, used for setting preview dimensions
+	device: PropTypes.string,
+	// The site URL
+	externalUrl: PropTypes.string,
+	// Called when a device button is clicked
+	setDeviceViewport: PropTypes.func,
+};
+
+export default localize( DesignPickerPreviewToolbar );

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -1,8 +1,10 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
+import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { computer, tablet, phone } from './icons';
 import './preview-toolbar.scss';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ];
@@ -14,9 +16,9 @@ const DesignPickerPreviewToolbar = ( {
 	translate,
 } ) => {
 	const devices = React.useRef( {
-		computer: { title: translate( 'Desktop' ), icon: 'computer' },
-		tablet: { title: translate( 'Tablet' ), icon: 'tablet' },
-		phone: { title: translate( 'Phone' ), icon: 'phone' },
+		computer: { title: translate( 'Desktop' ), icon: computer },
+		tablet: { title: translate( 'Tablet' ), icon: tablet },
+		phone: { title: translate( 'Phone' ), icon: phone },
 	} );
 
 	return (
@@ -32,7 +34,7 @@ const DesignPickerPreviewToolbar = ( {
 						} ) }
 						onClick={ () => setDeviceViewport( device ) }
 					>
-						<Gridicon size={ 18 } icon={ devices.current[ device ].icon } />
+						<Icon size={ 24 } icon={ devices.current[ device ].icon } />
 					</Button>
 				) ) }
 			</div>

--- a/client/signup/steps/design-picker/preview-toolbar.jsx
+++ b/client/signup/steps/design-picker/preview-toolbar.jsx
@@ -12,6 +12,7 @@ const possibleDevices = [ 'computer', 'tablet', 'phone' ];
 const DesignPickerPreviewToolbar = ( {
 	device: currentDevice,
 	externalUrl,
+	showDeviceSwitcher,
 	setDeviceViewport,
 	translate,
 } ) => {
@@ -23,21 +24,23 @@ const DesignPickerPreviewToolbar = ( {
 
 	return (
 		<div className="preview-toolbar__toolbar">
-			<div className="preview-toolbar__devices">
-				{ possibleDevices.map( ( device ) => (
-					<Button
-						key={ device }
-						borderless
-						aria-label={ devices.current[ device ].title }
-						className={ classNames( 'preview-toolbar__button', {
-							'is-selected': device === currentDevice,
-						} ) }
-						onClick={ () => setDeviceViewport( device ) }
-					>
-						<Icon size={ 24 } icon={ devices.current[ device ].icon } />
-					</Button>
-				) ) }
-			</div>
+			{ showDeviceSwitcher && (
+				<div className="preview-toolbar__devices">
+					{ possibleDevices.map( ( device ) => (
+						<Button
+							key={ device }
+							borderless
+							aria-label={ devices.current[ device ].title }
+							className={ classNames( 'preview-toolbar__button', {
+								'is-selected': device === currentDevice,
+							} ) }
+							onClick={ () => setDeviceViewport( device ) }
+						>
+							<Icon size={ 24 } icon={ devices.current[ device ].icon } />
+						</Button>
+					) ) }
+				</div>
+			) }
 			<div className="preview-toolbar__browser-header">
 				<svg width="40" height="8">
 					<g>
@@ -57,6 +60,8 @@ DesignPickerPreviewToolbar.propTypes = {
 	device: PropTypes.string,
 	// The site URL
 	externalUrl: PropTypes.string,
+	// Show device viewport switcher
+	showDeviceSwitcher: PropTypes.bool,
 	// Called when a device button is clicked
 	setDeviceViewport: PropTypes.func,
 };

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -5,6 +5,8 @@
 	// Move spinner to the bottom of browser header
 	& ~ hr.spinner-line {
 		top: 16px;
+		left: 50%;
+		transform: translateX( -50% );
 
 		@include break-small {
 			top: 68px;
@@ -30,7 +32,7 @@
 }
 
 // Need the extra specificity here to override core
-.preview-toolbar__button.preview-toolbar__button {
+.button.preview-toolbar__button {
 	color: var( --studio-gray-10 );
 	height: auto;
 	margin: 0 13px;

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -24,13 +24,9 @@
 }
 
 .preview-toolbar__devices {
-	display: none;
+	display: flex;
 	justify-content: center;
 	margin-bottom: 25px;
-
-	@include break-small {
-		display: flex;
-	}
 }
 
 // Need the extra specificity here to override core

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -1,7 +1,14 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/mixins';
+
 .preview-toolbar__toolbar {
 	// Move spinner to the bottom of browser header
 	& ~ hr.spinner-line {
-		top: 68px;
+		top: 16px;
+
+		@include break-small {
+			top: 68px;
+		}
 	}
 
 	.preview-toolbar__browser-header,
@@ -17,9 +24,13 @@
 }
 
 .preview-toolbar__devices {
-	display: flex;
+	display: none;
 	justify-content: center;
 	margin-bottom: 25px;
+
+	@include break-small {
+		display: flex;
+	}
 }
 
 .preview-toolbar__button {
@@ -54,15 +65,11 @@
 		top: 50%;
 		transform: translateY( -50% );
 		fill: rgba( 0, 0, 0, 0.12 );
-
-		@include breakpoint-deprecated( '<660px' ) {
-			display: none;
-		}
 	}
 }
 
 .preview-toolbar__browser-url {
-	display: block;
+	display: none;
 	width: 60%;
 	height: 24px;
 	line-height: 24px;
@@ -81,5 +88,9 @@
 	&::before {
 		content: 'https://';
 		color: #8c8f94;
+	}
+
+	@include break-small {
+		display: block;
 	}
 }

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -1,0 +1,85 @@
+.preview-toolbar__toolbar {
+	// Move spinner to the bottom of browser header
+	& ~ hr.spinner-line {
+		top: 68px;
+	}
+
+	.preview-toolbar__browser-header,
+	& ~ hr.spinner-line {
+		.is-tablet & {
+			max-width: 783px;
+		}
+
+		.is-phone & {
+			max-width: 460px;
+		}
+	}
+}
+
+.preview-toolbar__devices {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 25px;
+}
+
+.preview-toolbar__button {
+	margin: 0 13px;
+
+	svg {
+		fill: #c3c4c7;
+	}
+
+	&.is-selected svg {
+		fill: #000000;
+	}
+}
+
+.preview-toolbar__browser-header {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: relative;
+	max-width: 100%;
+	height: 40px;
+	border: 1px solid rgba( 0, 0, 0, 0.12 );
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px 6px 0 0;
+	margin: 0 auto;
+	box-sizing: border-box;
+	transition: max-width 0.2s ease-out;
+
+	svg {
+		position: absolute;
+		left: 20px;
+		top: 50%;
+		transform: translateY( -50% );
+		fill: rgba( 0, 0, 0, 0.12 );
+
+		@include breakpoint-deprecated( '<660px' ) {
+			display: none;
+		}
+	}
+}
+
+.preview-toolbar__browser-url {
+	display: block;
+	width: 60%;
+	height: 24px;
+	line-height: 24px;
+	padding: 0 8px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 8px;
+	color: #000000;
+	background: #f6f6f7;
+	font-size: $font-body-extra-small;
+	font-weight: normal;
+	text-align: center;
+	cursor: default;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	&::before {
+		content: 'https://';
+		color: #8c8f94;
+	}
+}

--- a/client/signup/steps/design-picker/preview-toolbar.scss
+++ b/client/signup/steps/design-picker/preview-toolbar.scss
@@ -33,15 +33,21 @@
 	}
 }
 
-.preview-toolbar__button {
+// Need the extra specificity here to override core
+.preview-toolbar__button.preview-toolbar__button {
+	color: var( --studio-gray-10 );
+	height: auto;
 	margin: 0 13px;
+	transition: color 0.1s ease-in-out;
 
-	svg {
-		fill: #c3c4c7;
+	&.is-selected,
+	&:hover,
+	&:focus {
+		color: var( --studio-black );
 	}
 
-	&.is-selected svg {
-		fill: #000000;
+	svg {
+		fill: none;
 	}
 }
 

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -65,6 +65,13 @@
 .design-picker__preview {
 	height: 860px;
 	padding-bottom: 30px;
+
+	@include break-small {
+		.step-wrapper__header,
+		.step-wrapper__content {
+			transform: translateY( -68px );
+		}
+	}
 }
 
 .design-picker__web-preview {

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -66,7 +66,8 @@
 	padding-bottom: 30px;
 
 	.step-wrapper__content {
-		height: 540px;
+		height: calc( 100vh - 256px );
+		max-height: 540px;
 	}
 
 	@include break-small {
@@ -76,7 +77,7 @@
 		}
 
 		.step-wrapper__content {
-			height: 866px;
+			max-height: 960px;
 		}
 	}
 }

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -61,3 +61,22 @@
 		}
 	}
 }
+
+.design-picker__preview {
+	height: 860px;
+	padding-bottom: 30px;
+}
+
+.design-picker__web-preview {
+	.web-preview__frame-wrapper.is-resizable {
+		background-color: transparent;
+	}
+
+	.web-preview__frame {
+		border: 1px solid rgba( 0, 0, 0, 0.12 );
+		border-top-width: 0;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 0 0 6px 6px;
+		box-sizing: border-box;
+	}
+}

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -63,27 +63,34 @@
 }
 
 .design-picker__preview {
-	height: 860px;
 	padding-bottom: 30px;
+
+	.step-wrapper__content {
+		height: 540px;
+	}
 
 	@include break-small {
 		.step-wrapper__header,
 		.step-wrapper__content {
-			transform: translateY( -68px );
+			transform: translateY( -48px );
+		}
+
+		.step-wrapper__content {
+			height: 866px;
 		}
 	}
 }
 
 .design-picker__web-preview {
-	.web-preview__frame-wrapper.is-resizable {
-		background-color: transparent;
-	}
-
-	.web-preview__frame {
+	.web-preview__placeholder {
 		border: 1px solid rgba( 0, 0, 0, 0.12 );
 		border-top-width: 0;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 0 0 6px 6px;
 		box-sizing: border-box;
+	}
+
+	.web-preview__frame-wrapper.is-resizable {
+		background-color: transparent;
 	}
 }

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -82,15 +82,15 @@
 }
 
 .design-picker__web-preview {
-	.web-preview__placeholder {
+	.web-preview__frame-wrapper.is-resizable {
+		background-color: transparent;
+	}
+
+	.web-preview__frame {
 		border: 1px solid rgba( 0, 0, 0, 0.12 );
 		border-top-width: 0;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 0 0 6px 6px;
 		box-sizing: border-box;
-	}
-
-	.web-preview__frame-wrapper.is-resizable {
-		background-color: transparent;
 	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -774,6 +774,14 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 				margin-right: 0;
 			}
 		}
+
+		.design-picker__preview .step-wrapper__header {
+			margin-top: 40px;
+
+			@include break-mobile {
+				margin-top: 28px;
+			}
+		}
 	}
 
 	button.is-primary {

--- a/packages/calypso-build/jest/mocks/match-media.js
+++ b/packages/calypso-build/jest/mocks/match-media.js
@@ -1,0 +1,17 @@
+// Attempt not to define matchMedia if Jest isn't running in JSDOM environment
+// See more: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+if ( typeof window !== 'undefined' ) {
+	Object.defineProperty( window, 'matchMedia', {
+		writable: true,
+		value: jest.fn().mockImplementation( ( query ) => ( {
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: jest.fn(), // deprecated
+			removeListener: jest.fn(), // deprecated
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn(),
+			dispatchEvent: jest.fn(),
+		} ) ),
+	} );
+}

--- a/packages/design-picker/jest.config.js
+++ b/packages/design-picker/jest.config.js
@@ -2,5 +2,9 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	setupFilesAfterEnv: [ '@testing-library/jest-dom/extend-expect', 'jest-canvas-mock' ],
+	setupFilesAfterEnv: [
+		'@testing-library/jest-dom/extend-expect',
+		'jest-canvas-mock',
+		'@automattic/calypso-build/jest/mocks/match-media',
+	],
 };

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button, Tooltip } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -149,8 +150,15 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	onPreview,
 	...props
 } ) => {
+	const isDesktop = useDesktopBreakpoint();
+
 	if ( ! onPreview ) {
 		return <DesignButton { ...props } />;
+	}
+
+	// Show the preview directly when selecting the design if the device is not desktop
+	if ( ! isDesktop ) {
+		return <DesignButton { ...props } onSelect={ onPreview } />;
 	}
 
 	return (

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { Tooltip } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
@@ -101,9 +102,73 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	);
 };
 
+interface DesignButtonCoverProps {
+	design: Design;
+	onSelect: ( design: Design ) => void;
+	onPreview: ( design: Design ) => void;
+}
+
+const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
+	design,
+	onSelect,
+	onPreview,
+} ) => {
+	const { __ } = useI18n();
+	const isBlankCanvas = isBlankCanvasDesign( design );
+	const designTitle = isBlankCanvas ? __( 'Blank Canvas' ) : design.title;
+
+	return (
+		<div className="design-button-cover">
+			<div className="design-button-cover__button-groups">
+				<Button
+					className="design-button-cover__button"
+					isPrimary
+					onClick={ () => onSelect( design ) }
+				>
+					{
+						// translators: %s is the title of design with currency. Eg: Alves
+						sprintf( __( 'Start with %s', __i18n_text_domain__ ), designTitle )
+					}
+				</Button>
+				<Button className="design-button-cover__button" onClick={ () => onPreview( design ) }>
+					{
+						// translators: %s is the title of design with currency. Eg: Alves
+						sprintf( __( 'Preview %s', __i18n_text_domain__ ), designTitle )
+					}
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+interface DesignButtonContainerProps extends DesignButtonProps {
+	onPreview?: ( design: Design ) => void;
+}
+
+const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
+	onPreview,
+	...props
+} ) => {
+	if ( ! onPreview ) {
+		return <DesignButton { ...props } />;
+	}
+
+	return (
+		<div className="design-button-container">
+			<DesignButtonCover
+				design={ props.design }
+				onSelect={ props.onSelect }
+				onPreview={ onPreview }
+			/>
+			<DesignButton { ...props } />
+		</div>
+	);
+};
+
 export interface DesignPickerProps {
 	locale: string;
 	onSelect: ( design: Design ) => void;
+	onPreview?: ( design: Design ) => void;
 	designs?: Design[];
 	premiumBadge?: React.ReactNode;
 	isGridMinimal?: boolean;
@@ -115,6 +180,7 @@ export interface DesignPickerProps {
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
 	onSelect,
+	onPreview,
 	designs = getAvailableDesigns().featured.filter(
 		// By default, exclude anchorfm-specific designs
 		( design ) => design.features.findIndex( ( f ) => f === 'anchorfm' ) < 0
@@ -156,11 +222,12 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			) }
 			<div className={ isGridMinimal ? 'design-picker__grid-minimal' : 'design-picker__grid' }>
 				{ filteredDesigns.map( ( design ) => (
-					<DesignButton
+					<DesignButtonContainer
 						key={ design.slug }
 						design={ design }
 						locale={ locale }
 						onSelect={ onSelect }
+						onPreview={ onPreview }
 						premiumBadge={ premiumBadge }
 						highRes={ highResThumbnails }
 					/>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -45,6 +45,7 @@ interface DesignButtonProps {
 	onSelect: ( design: Design ) => void;
 	premiumBadge?: React.ReactNode;
 	highRes: boolean;
+	disabled?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -53,6 +54,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	design,
 	premiumBadge,
 	highRes,
+	disabled,
 } ) => {
 	const { __ } = useI18n();
 
@@ -65,6 +67,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	return (
 		<button
 			className="design-picker__design-option"
+			disabled={ disabled }
 			data-e2e-button={ design.is_premium ? 'paidOption' : 'freeOption' }
 			onClick={ () => onSelect( design ) }
 		>
@@ -168,7 +171,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 				onSelect={ props.onSelect }
 				onPreview={ onPreview }
 			/>
-			<DesignButton { ...props } />
+			<DesignButton { ...props } disabled />
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button, Tooltip } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -150,7 +150,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	onPreview,
 	...props
 } ) => {
-	const isDesktop = useDesktopBreakpoint();
+	const isDesktop = useViewportMatch( 'large' );
 
 	if ( ! onPreview ) {
 		return <DesignButton { ...props } />;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -110,6 +110,7 @@
 		position: relative;
 		overflow: hidden;
 		border-radius: 4px; /* stylelint-disable-line scales/radii */
+		transition: border-color 0.15s ease-in-out;
 
 		img {
 			position: absolute;
@@ -205,6 +206,13 @@
 			}
 		}
 	}
+
+	.design-button-container:hover,
+	.design-button-container:focus-within {
+		.design-picker__design-option .design-picker__image-frame {
+			border-color: var( --studio-white );
+		}
+	}
 }
 
 // light theme styles
@@ -248,6 +256,13 @@
 			}
 		}
 	}
+
+	.design-button-container:hover,
+	.design-button-container:focus-within {
+		.design-picker__design-option .design-picker__image-frame {
+			border-color: var( --studio-blue-20 );
+		}
+	}
 }
 
 .design-button-container {
@@ -270,7 +285,7 @@
 		justify-content: center;
 		z-index: 1;
 		opacity: 0;
-		transition: opacity 0.3s ease-in-out;
+		transition: opacity 0.15s ease-in-out;
 
 		&::before {
 			content: '';
@@ -305,7 +320,8 @@
 		}
 	}
 
-	&:hover {
+	&:hover,
+	&:focus-within {
 		.design-button-cover {
 			opacity: 1;
 		}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -265,7 +265,7 @@
 		right: 0;
 		top: 0;
 		bottom: 0;
-		display: flex;
+		display: none;
 		align-items: center;
 		justify-content: center;
 		z-index: 1;
@@ -282,8 +282,8 @@
 			z-index: -1;
 		}
 
-		@include breakpoint-deprecated( '<660px' ) {
-			display: none;
+		@include break-medium {
+			display: flex;
 		}
 	}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -106,6 +106,7 @@
 		width: 100%;
 		height: 0;
 		border: 1px solid;
+		box-sizing: border-box;
 		position: relative;
 		overflow: hidden;
 		border-radius: 4px; /* stylelint-disable-line scales/radii */
@@ -245,6 +246,68 @@
 					opacity: 0;
 				}
 			}
+		}
+	}
+}
+
+.design-button-container {
+	position: relative;
+	display: flex;
+	font-size: $font-body-small;
+
+	.design-picker__design-option {
+		flex: 1;
+	}
+
+	.design-button-cover {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1;
+		opacity: 0;
+		transition: opacity 0.3s ease-in-out;
+
+		&::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			width: 100%;
+			padding-top: 66%;
+			background-color: rgba( 255, 255, 255, 0.72 );
+			z-index: -1;
+		}
+
+		@include breakpoint-deprecated( '<660px' ) {
+			display: none;
+		}
+	}
+
+	.design-button-cover__button-groups {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.design-button-cover__button {
+		justify-content: center;
+		font-size: inherit;
+		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		line-height: 20px;
+
+		&:not( .is-primary ) {
+			border: 1px solid #c3c4c7;
+			background: #ffffff;
+		}
+	}
+
+	&:hover {
+		.design-button-cover {
+			opacity: 1;
 		}
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -305,7 +305,10 @@
 	.design-button-cover__button-groups {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+
+		.design-button-cover__button:not( :first-child ) {
+			margin-top: 8px;
+		}
 	}
 
 	.design-button-cover__button {

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -5,6 +5,7 @@ export {
 	availableDesignsConfig,
 	getAvailableDesigns,
 	getFontTitle,
+	getDesignUrl,
 	isBlankCanvasDesign,
 } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -35,3 +35,7 @@ export interface Design {
 	 */
 	hide?: boolean;
 }
+
+export interface DesignUrlOptions {
+	iframe?: boolean;
+}

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -3,10 +3,14 @@ import { addQueryArgs } from '@wordpress/url';
 import { availableDesignsConfig } from './available-designs-config';
 import { shuffleArray } from './shuffle';
 import type { MShotsOptions } from '../components/mshots-image';
-import type { Design } from '../types';
+import type { Design, DesignUrlOptions } from '../types';
 import type { AvailableDesigns } from './available-designs-config';
 
-export const getDesignUrl = ( design: Design, locale: string ): string => {
+export const getDesignUrl = (
+	design: Design,
+	locale: string,
+	options: DesignUrlOptions = {}
+): string => {
 	const theme = encodeURIComponent( design.theme );
 	const template = encodeURIComponent( design.template );
 
@@ -20,6 +24,7 @@ export const getDesignUrl = ( design: Design, locale: string ): string => {
 			viewport_height: 700,
 			language: locale,
 			use_screenshot_overrides: true,
+			...options,
 		}
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
 
* Implement `DesignButtonCover` to show the `Start` and `Preview` buttons when you hover on the design so that we can choose different options.
* Use `stepSectionName` to decide the selected design and then we can preview and back easliy.
* Use `/template/demo` endpoint to show the preview with translation. The only problem I have no idea is that when I use this endpoint as previewUrl for `<WebPreview />` component, it will misunderstand the loading result as failure and redirect the whole page. Therefore, I use `disableRedirects` to fix this problem temporarily
* Use next button base on https://github.com/Automattic/wp-calypso/pull/56311 to show `Start with <theme>` button on the top-right corner.
* Make `<WebPreview />` component accept `toolbarComponent` so that we can customize the toolbar we need
* Don't show `DesignButtonCover`  on mobile because it cannot preview different device

##### Demo
https://user-images.githubusercontent.com/13596067/133767836-3f3536ae-bab2-41d3-8a98-a97a29b26e0f.mov

##### Preview with translation

![image](https://user-images.githubusercontent.com/13596067/134478619-e28c56fc-4458-45d9-ad51-b86ee6459ffd.png)


#### Dev Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply D67443-code and follow its TEST PLAN~ (**Deployed**), but ensure pointing your API to production because iframe preview doesn't work on the sandbox. See: p1632891540262700-slack-C029SB8JT8S
* Go to `/start/setup-site?siteSlug=<your_site>`
* Hover on the design
* Select `Preview <design_name>`
* Choose different devices
* Click `Start with <design_name>` button at top-right corner

#### User Facing (non-dev)  Testing instructions
* Go to `https://container-vigilant-gould.calypso.live/start/domains?flags=signup/setup-site-after-checkout`
* Go through the signup flow and get to the Design Picker
* Hover on any design
* Select `Preview <design_name>`
* Choose different devices
* Click `Start with <design_name>` button at top-right corner

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56302