### PR TITLE
Site editor tracking tests - skip general nav-sidebar test and update iframe selector

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -9,7 +9,7 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 		super( driver, By.css( '.edit-site-header' ), url );
 		this.editorType = editorType;
 
-		this.editoriFrameLocator = By.css( '.calypsoify.is-iframe iframe' );
+		this.editoriFrameLocator = By.css( '.calypsoify.is-iframe iframe.is-loaded' );
 		this.editorCanvasiFrameLocator = By.css( 'iframe[name="editor-canvas"]' );
 	}
 

--- a/test/e2e/lib/gutenberg/tracking/general-tests.js
+++ b/test/e2e/lib/gutenberg/tracking/general-tests.js
@@ -220,8 +220,15 @@ export function createGeneralTests( { it, editorType, postType, baseContext = un
 	it( `Block editor sidebar toggle should not trigger the "wpcom_block_editor_close_click" event`, async function () {
 		const editor = await EditorComponent.Expect( this.driver, gutenbergEditorType );
 
-		// The button that triggers the block editor sidebar is not available on mobile
-		if ( editor.screenSize === 'mobile' && editorType === 'post' ) {
+		const shouldSkipThisTest =
+			// The button that triggers the block editor sidebar is not available on mobile
+			( editor.screenSize === 'mobile' && editorType === 'post' ) ||
+			// Site editor's nav sidebar is temporarily disabled on dotcom.
+			// Related Issue - https://github.com/Automattic/wp-calypso/issues/54460
+			// Related PR - https://github.com/Automattic/wp-calypso/pull/55471
+			editorType === 'site';
+
+		if ( shouldSkipThisTest ) {
 			return this.skip();
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Recently the nav sidebar was removed from the site editor for beta testing purposes and related tests in the site editor tracking spec we skipped.  However, we forgot to skip a related test in the general-tests section that runs for all editor types.  Here we skip this test as well for the site editor.

We also update the selector for switching to the iframe, as the process of switching to the correct frame on editor component initialization has become unreliable causing the site editor tests to immediately fail at their first step ~50% of the time.  Much thanks to @fullofcaffeine for finding a way to update the selector to be more reliable! (as he also has also noted in https://github.com/Automattic/wp-calypso/pull/56253)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the `wp-calypso-gutenberg-site-editor-tracking-spec.js` and verify is consistently passes the first tests, skips the expected general test for the nav sidebar toggle, and all tests should pass at this point.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56098.
