### PR TITLE
Playwright: remove Widget test from Calypso

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-widgets__spec.ts
@@ -1,5 +1,4 @@
 /**
- * @group calypso-pr
  * @group gutenberg
  */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR discontinues execution of the `wp-widgets` spec from Calypso PRs.

This spec was originally a part of the WPCOM Gutenberg spec in Selenium and should be run as part of that build configuration instead.

#### Testing instructions


Related to #
