### PR TITLE
Playwright: disable testing of `;;;ppp;;;` search keyword in Support.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-support__home-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__home-spec.ts
@@ -34,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 			await supportComponent.search( keyword );
 		} );
 
-		it( 'Search results are shown', async function () {
+		it( 'Search results are shown with a valid search keyword', async function () {
 			const results = await supportComponent.getResults( 'article' );
 			expect( results.length ).toBeGreaterThan( 0 );
 		} );
@@ -47,22 +47,23 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 			await supportComponent.defaultStateShown();
 		} );
 
-		it( 'Enter invalid search keyword', async function () {
+		// Invalid keyword search often takes more than 30s to resolve.
+		// See: https://github.com/Automattic/wp-calypso/issues/55478
+		it.skip( 'Enter invalid search keyword', async function () {
 			const keyword = ';;;ppp;;;';
 			await supportComponent.search( keyword );
 		} );
 
-		it( 'No search results are shown', async function () {
+		it.skip( 'No search results are shown', async function () {
 			await supportComponent.noResultsShown();
 		} );
 
 		it( 'Enter empty search keyword', async function () {
 			const keyword = '        ';
-			await supportComponent.clearSearch();
 			await supportComponent.search( keyword );
 		} );
 
-		it( 'Continues to display default results', async function () {
+		it( 'No search results are shown with an empty search keyword', async function () {
 			await supportComponent.noResultsShown();
 		} );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__popover-spec.ts
@@ -102,14 +102,15 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 			await supportComponent.defaultStateShown();
 		} );
 
-		it( 'Enter invalid search keyword and expect no results to be shown', async function () {
+		// Invalid keyword search often takes more than 30s to resolve.
+		// See: https://github.com/Automattic/wp-calypso/issues/55478
+		it.skip( 'Enter invalid search keyword and expect no results to be shown', async function () {
 			const keyword = ';;;ppp;;;';
 			await supportComponent.search( keyword );
 			await supportComponent.noResultsShown();
 		} );
 
 		it( 'Close support popover', async function () {
-			await supportComponent.clearSearch();
 			await supportComponent.closePopover();
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to disable the problematic keyword noted in the title.

Key changes:
- marking of relevant steps as skipped.
- slightly alter some step names to avoid conflict with same name.

Background details:

This particular step, to search `;;;ppp;;;` and wait for the search to resolve to a `sorry, there were not matches` is a carryover from the Selenium suite.

The problem with this test however is noted in #55478: in some cases the query does not resolve even after 30s. Not only does this affect e2e tests with a false intermittent failure, it is also bad UX if it occurs to end users.

Until there is a hard cap on the query, this test step needs to be disabled to avoid false failures on CI.

#### Testing instructions

- [ ] normal tests
   - [ ] desktop
   - [ ] mobile

Related to #55478
