### PR TITLE
Playwright: change artifact name to use test suite name.

### DIFF
--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -8,7 +8,7 @@ import type { Page, Video } from 'playwright';
 
 // These are defined in our custom Jest environment (test/e2e/lib/jest/environment.js)
 declare const __CURRENT_TEST_FAILED__: boolean;
-declare const __CURRENT_TEST_NAME__: string;
+declare const __CURRENT_SUITE_NAME__: string;
 
 /**
  * Generates a filename using the test name and a date string.
@@ -58,14 +58,14 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 	} );
 
 	afterAll( async () => {
-		const testName = __CURRENT_TEST_NAME__;
+		const suiteName = __CURRENT_SUITE_NAME__;
 
 		// Take screenshot for failed tests
 		if ( __CURRENT_TEST_FAILED__ ) {
 			const fileName = path.join(
 				tempDir,
 				'screenshots',
-				`${ getTestNameWithTime( testName ) }.png`
+				`${ getTestNameWithTime( suiteName ) }.png`
 			);
 			await mkdir( path.dirname( fileName ), { recursive: true } );
 			await page.screenshot( { path: fileName } );
@@ -81,7 +81,7 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 			const destination = path.join(
 				tempDir,
 				'screenshots',
-				`${ getTestNameWithTime( testName ) }.webm`
+				`${ getTestNameWithTime( suiteName ) }.webm`
 			);
 			try {
 				await rename( original, destination );

--- a/test/e2e/lib/jest/environment.js
+++ b/test/e2e/lib/jest/environment.js
@@ -7,12 +7,11 @@ class JestEnvironmentE2E extends JestEnvironmentNode {
 	async handleTestEvent( event ) {
 		switch ( event.name ) {
 			case 'setup':
-				this.global.__CURRENT_TEST_NAME__ = null;
 				this.global.__CURRENT_TEST_FAILED__ = false;
 				break;
 
 			case 'test_start':
-				this.global.__CURRENT_TEST_NAME__ = event.test.name;
+				this.global.__CURRENT_SUITE_NAME__ = event.test.parent.name;
 
 				if ( this.testFailed ) {
 					event.test.mode = 'skip';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to change the name used for the screenshot and video recording to the suite name.

Key changes:
- alter the hook to use suite name.

Details:

When a test fails, artifacts that are generated use the last test step that executed. This is good in theory; however, the test step of the failing step is not necessarily the step that _actually_ failed, but possibly the subsequent step.

In other cases when the hook fails, the last step of the entire suite is used for the artifact name, which is incorrect.

Furthermore, those looking at tests often have a specific suite in mind, not the test step name. Add to the confusion that test steps may not necessarily make it clear of the suite that it belongs to.

Closes #56363 and #55177.
