### PR TITLE
Wraps "Import from" in the translate function

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -23,7 +23,7 @@ class SitesBlock extends Component {
 	};
 
 	renderFauxSiteSelector() {
-		const { onUrlChange, url } = this.props;
+		const { onUrlChange, translate, url } = this.props;
 		const { error } = this.state;
 		const isError = !! error;
 

--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -39,7 +39,7 @@ class SitesBlock extends Component {
 								className="sites-block__faux-site-selector-label"
 								htmlFor="sites-block__faux-site-selector-url-input"
 							>
-								{ translate( 'Import from...' ) }
+								{ translate( 'Import from…' ) }
 							</FormLabel>
 							<div className="sites-block__faux-site-selector-url">
 								<FormTextInput

--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -39,7 +39,7 @@ class SitesBlock extends Component {
 								className="sites-block__faux-site-selector-label"
 								htmlFor="sites-block__faux-site-selector-url-input"
 							>
-								Import from...
+								{ translate( 'Import from...' ) }
 							</FormLabel>
 							<div className="sites-block__faux-site-selector-url">
 								<FormTextInput


### PR DESCRIPTION
On https://wordpress.com/migrate, the "Import from..." text was not wrapped in the translate function and was showing up in English even when user language is not set to English. 

<img width="697" alt="Screen Shot 2021-09-15 at 4 32 03 PM" src="https://user-images.githubusercontent.com/36699353/133519390-d22cf759-b6d5-4d69-9590-4764e60961d2.png">

To test:
1. Set your account language to one of our Mag-16 languages (not English).
2. Navigate to Tools/import/WordPress or https://wordpress.com/migrate 
3. Confirm that "Import from..." is translated.
