### PR TITLE
Playwright: adjust PlansPage POM behavior and spec to remove hanging `waitForNavigation` calls.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -645,7 +645,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-plans; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -645,7 +645,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for x in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-plans; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -49,7 +49,7 @@ export class PlansPage {
 	/**
 	 * Wait until the page is loaded and stable.
 	 */
-	async waitUntilLoaded(): Promise< void > {
+	private async waitUntilLoaded(): Promise< void > {
 		await this.page.waitForLoadState( 'load' );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -47,12 +47,20 @@ export class PlansPage {
 	}
 
 	/**
+	 * Wait until the page is loaded and stable.
+	 */
+	async waitUntilLoaded(): Promise< void > {
+		await this.page.waitForLoadState( 'load' );
+	}
+
+	/**
 	 * Validates that the provided plan name is the title of the active plan in the My Plan tab of the Plans page. Throws if it isn't.
 	 *
 	 * @param {Plan} expectedPlan Name of the expected plan.
 	 * @throws If the expected plan title is not found in the timeout period.
 	 */
 	async validateActivePlanInMyPlanTab( expectedPlan: Plan ): Promise< void > {
+		await this.waitUntilLoaded();
 		await this.page.waitForSelector( selectors.myPlanTitle( expectedPlan ) );
 	}
 
@@ -63,6 +71,7 @@ export class PlansPage {
 	 * @throws If the expected tab name is not the active tab.
 	 */
 	async validateActiveNavigationTab( expectedTab: PlansPageTab ): Promise< void > {
+		await this.waitUntilLoaded();
 		const targetDevice = getTargetDeviceName();
 
 		// For mobile sized viewport, the currently selected tab name will be shown alongside the
@@ -99,6 +108,7 @@ export class PlansPage {
 		plan: Plan;
 		buttonText: PlanActionButton;
 	} ): Promise< void > {
+		await this.waitUntilLoaded();
 		const selector = selectors.actionButton( {
 			viewport: getTargetDeviceName(),
 			plan: plan,
@@ -106,6 +116,5 @@ export class PlansPage {
 		} );
 		// These action buttons trigger real page navigations.
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selector ) ] );
-		await this.page.waitForLoadState( 'load' );
 	}
 }

--- a/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts
@@ -73,15 +73,10 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 		} );
 
 		it( 'Remove plan from cart', async function () {
-			// This removal is going to trigger an automatic asynchronous navigation back to the Plans page. Let's make sure we're ready for it!
-			await Promise.all( [
-				page.waitForNavigation(),
-				cartCheckoutPage.removeCartItem( cartItemForPremiumPlan ),
-			] );
+			await cartCheckoutPage.removeCartItem( cartItemForPremiumPlan );
 		} );
 
 		it( 'Automatically land back on "Plans" tab of Plans page', async function () {
-			await page.waitForLoadState( 'load' );
 			plansPage = new PlansPage( page );
 			await plansPage.validateActiveNavigationTab( 'Plans' );
 		} );
@@ -99,15 +94,10 @@ describe( DataHelper.createSuiteTitle( 'Plans: Purchases' ), function () {
 		} );
 
 		it( 'Remove Business plan from cart', async function () {
-			// This removal is going to trigger an automatic asynchronous navigation back to the Plans page. Let's make sure we're ready for it!
-			await Promise.all( [
-				page.waitForNavigation(),
-				cartCheckoutPage.removeCartItem( cartItemForBusinessPlan ),
-			] );
+			await cartCheckoutPage.removeCartItem( cartItemForBusinessPlan );
 		} );
 
 		it( 'Automatically land back on "Plans" tab of Plans page', async function () {
-			await page.waitForLoadState( 'load' );
 			plansPage = new PlansPage( page );
 			await plansPage.validateActiveNavigationTab( 'Plans' );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adjusts the behavior of PlansPage POM.

Key changes:
- remove `waitForNavigation` calls from spec.
- new `waitUntilLoaded` method that is called before any action that may be timing sensitive.

Background:

In some cases, due to unexpected behavior of Calypso a `waitForNavigation` call may be left hanging:

```
page.waitForNavigation: Timeout 30000ms exceeded.
=========================== logs ===========================
waiting for navigation until "load"
  navigated to "https://container-xenodochial-gates.calypso.live/plans/e2eflowtesting3.wordpress.com"
============================================================
at Object.<anonymous> (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/specs-playwright/wp-plans__purchases-spec.ts:78:10)
```

Changes in this PR propose to remove unnecessary `waitForNavigation` calls, instead opting to rely on subsequent calls' auto-wait to handle navigation.

Additionally, calls to wait for the load state to reach  `load` is added to most methods.

#### Testing instructions

- [ ]  stress test
    - [ ] mobile
    - [ ] desktop
- [ ] regular test
  - [ ] mobile
  - [ ] desktop

Fixes #56300
