### PR TITLE
Onboarding: Refine navigation buttons

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -116,6 +116,12 @@ function isWPForTeamsFlow( flowName ) {
 	return flowName === 'p2';
 }
 
+function showProgressIndicator( flowName ) {
+	const DISABLED_PROGRESS_INDICATOR_FLOWS = [ 'pressable-nux', 'setup-site' ];
+
+	return ! DISABLED_PROGRESS_INDICATOR_FLOWS.includes( flowName );
+}
+
 class Signup extends React.Component {
 	static propTypes = {
 		store: PropTypes.object.isRequired,
@@ -697,8 +703,6 @@ class Signup extends React.Component {
 			return this.props.siteId && waitToRenderReturnValue;
 		}
 
-		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
-
 		const isReskinned = isReskinnedFlow( this.props.flowName );
 
 		return (
@@ -709,7 +713,7 @@ class Signup extends React.Component {
 						shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
 						isReskinned={ isReskinned }
 						rightComponent={
-							showProgressIndicator && (
+							showProgressIndicator( this.props.flowName ) && (
 								<FlowProgressIndicator
 									positionInFlow={ this.getPositionInFlow() }
 									flowLength={ this.getInteractiveStepsCount() }

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -28,12 +28,17 @@ export class NavigationLink extends Component {
 		allowBackFirstStep: PropTypes.bool,
 		rel: PropTypes.string,
 		borderless: PropTypes.bool,
+		primary: PropTypes.bool,
+		backIcon: PropTypes.string,
+		forwardIcon: PropTypes.string,
 	};
 
 	static defaultProps = {
 		labelText: '',
 		allowBackFirstStep: false,
 		borderless: true,
+		backIcon: 'arrow-left',
+		forwardIcon: 'arrow-right',
 	};
 
 	getPreviousStep( flowName, signupProgress, currentStepName ) {
@@ -124,7 +129,7 @@ export class NavigationLink extends Component {
 	}
 
 	render() {
-		const { translate, labelText, borderless } = this.props;
+		const { translate, labelText, borderless, primary, backIcon, forwardIcon } = this.props;
 
 		if (
 			this.props.positionInFlow === 0 &&
@@ -140,7 +145,7 @@ export class NavigationLink extends Component {
 		let text;
 
 		if ( this.props.direction === 'back' ) {
-			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
+			backGridicon = backIcon ? <Gridicon icon={ backIcon } size={ 18 } /> : null;
 			if ( labelText ) {
 				text = labelText;
 			} else {
@@ -149,7 +154,7 @@ export class NavigationLink extends Component {
 		}
 
 		if ( this.props.direction === 'forward' ) {
-			forwardGridicon = <Gridicon icon="arrow-right" size={ 18 } />;
+			forwardGridicon = forwardIcon ? <Gridicon icon={ forwardIcon } size={ 18 } /> : null;
 			text = labelText ? labelText : translate( 'Skip for now' );
 		}
 
@@ -161,6 +166,7 @@ export class NavigationLink extends Component {
 
 		return (
 			<Button
+				primary={ primary }
 				borderless={ borderless }
 				className={ buttonClasses }
 				href={ this.getBackUrl() }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -80,7 +80,6 @@ class StepWrapper extends Component {
 					stepName={ stepName }
 					labelText={ skipLabelText }
 					cssClass={ classNames( 'step-wrapper__navigation-link', {
-						primary: skipAsPrimary,
 						'has-skip-heading': skipHeadingText,
 						'has-underline': ! skipAsPrimary,
 					} ) }
@@ -130,25 +129,28 @@ class StepWrapper extends Component {
 			isLargeSkipLayout,
 			isWideLayout,
 			skipButtonAlign,
+			skipAsPrimary,
 			align,
 		} = this.props;
 
-		const hasHeaderButtons = headerButton;
+		const hasNavigation = ! hideBack || ( ! hideSkip && skipButtonAlign === 'top' );
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-wide-layout': isWideLayout,
 			'is-large-skip-layout': isLargeSkipLayout,
-			'has-header-buttons': hasHeaderButtons,
+			'has-navigation': hasNavigation,
 		} );
 
 		return (
 			<>
 				<div className={ classes }>
-					<div className="step-wrapper__navigation">
-						{ ! hideBack && this.renderBack() }
-						{ ! hideSkip &&
-							skipButtonAlign === 'top' &&
-							this.renderSkip( { borderless: true, forwardIcon: null } ) }
-					</div>
+					{ hasNavigation && (
+						<ActionButtons className="step-wrapper__navigation">
+							{ ! hideBack && this.renderBack() }
+							{ ! hideSkip &&
+								skipButtonAlign === 'top' &&
+								this.renderSkip( { borderless: ! skipAsPrimary, forwardIcon: null } ) }
+						</ActionButtons>
+					) }
 
 					{ ! hideFormattedHeader && (
 						<div className="step-wrapper__header">
@@ -158,7 +160,9 @@ class StepWrapper extends Component {
 								subHeaderText={ this.subHeaderText() }
 								align={ align }
 							/>
-							{ headerButton && <ActionButtons>{ headerButton }</ActionButtons> }
+							{ headerButton && (
+								<div className="step-wrapper__header-button">{ headerButton }</div>
+							) }
 						</div>
 					) }
 

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import NavigationLink from 'calypso/signup/navigation-link';
+import { isReskinnedFlow } from '../utils';
 import './style.scss';
 
 class StepWrapper extends Component {
@@ -49,7 +50,7 @@ class StepWrapper extends Component {
 				rel={ this.props.isExternalBackUrl ? 'external' : '' }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
-				backIcon="chevron-left"
+				backIcon={ isReskinnedFlow( this.props.flowName ) ? 'chevron-left' : undefined }
 			/>
 		);
 	}
@@ -150,6 +151,7 @@ class StepWrapper extends Component {
 
 	render() {
 		const {
+			flowName,
 			stepContent,
 			headerButton,
 			hideFormattedHeader,
@@ -173,7 +175,10 @@ class StepWrapper extends Component {
 			<>
 				<div className={ classes }>
 					{ hasNavigation && (
-						<ActionButtons className="step-wrapper__navigation">
+						<ActionButtons
+							className="step-wrapper__navigation"
+							sticky={ isReskinnedFlow( flowName ) ? null : false }
+						>
 							{ ! hideBack && this.renderBack() }
 							{ ! hideSkip &&
 								skipButtonAlign === 'top' &&

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -14,13 +14,14 @@ class StepWrapper extends Component {
 		hideFormattedHeader: PropTypes.bool,
 		hideBack: PropTypes.bool,
 		hideSkip: PropTypes.bool,
+		hideNext: PropTypes.bool,
 		// Allows to force a back button in the first step for example.
 		// You should only force this when you're passing a backUrl.
 		allowBackFirstStep: PropTypes.bool,
 		skipLabelText: PropTypes.string,
 		skipHeadingText: PropTypes.string,
 		skipButtonAlign: PropTypes.oneOf( [ 'top', 'bottom' ] ),
-		skipAsPrimary: PropTypes.bool,
+		nextLabelText: PropTypes.string,
 		// Displays an <hr> above the skip button and adds more white space
 		isLargeSkipLayout: PropTypes.bool,
 		isExternalBackUrl: PropTypes.bool,
@@ -30,7 +31,7 @@ class StepWrapper extends Component {
 	static defaultProps = {
 		allowBackFirstStep: false,
 		skipButtonAlign: 'bottom',
-		skipAsPrimary: false,
+		hideNext: true,
 	};
 
 	renderBack() {
@@ -58,7 +59,6 @@ class StepWrapper extends Component {
 			shouldHideNavButtons,
 			skipHeadingText,
 			skipLabelText,
-			skipAsPrimary,
 			defaultDependencies,
 			flowName,
 			stepName,
@@ -79,15 +79,44 @@ class StepWrapper extends Component {
 					flowName={ flowName }
 					stepName={ stepName }
 					labelText={ skipLabelText }
-					cssClass={ classNames( 'step-wrapper__navigation-link', {
+					cssClass={ classNames( 'step-wrapper__navigation-link', 'has-underline', {
 						'has-skip-heading': skipHeadingText,
-						'has-underline': ! skipAsPrimary,
 					} ) }
 					borderless={ borderless }
-					primary={ skipAsPrimary }
 					forwardIcon={ forwardIcon }
 				/>
 			</div>
+		);
+	}
+
+	renderNext() {
+		const {
+			shouldHideNavButtons,
+			nextLabelText,
+			defaultDependencies,
+			flowName,
+			stepName,
+			goToNextStep,
+			translate,
+		} = this.props;
+
+		if ( shouldHideNavButtons || ! goToNextStep ) {
+			return null;
+		}
+
+		return (
+			<NavigationLink
+				direction="forward"
+				goToNextStep={ goToNextStep }
+				defaultDependencies={ defaultDependencies }
+				flowName={ flowName }
+				stepName={ stepName }
+				labelText={ nextLabelText || translate( 'Continue' ) }
+				cssClass="step-wrapper__navigation-link"
+				borderless={ false }
+				primary
+				forwardIcon={ null }
+			/>
 		);
 	}
 
@@ -126,14 +155,14 @@ class StepWrapper extends Component {
 			hideFormattedHeader,
 			hideBack,
 			hideSkip,
+			hideNext,
 			isLargeSkipLayout,
 			isWideLayout,
 			skipButtonAlign,
-			skipAsPrimary,
 			align,
 		} = this.props;
 
-		const hasNavigation = ! hideBack || ( ! hideSkip && skipButtonAlign === 'top' );
+		const hasNavigation = ! hideBack || ( ! hideSkip && skipButtonAlign === 'top' ) || ! hideNext;
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-wide-layout': isWideLayout,
 			'is-large-skip-layout': isLargeSkipLayout,
@@ -148,7 +177,8 @@ class StepWrapper extends Component {
 							{ ! hideBack && this.renderBack() }
 							{ ! hideSkip &&
 								skipButtonAlign === 'top' &&
-								this.renderSkip( { borderless: ! skipAsPrimary, forwardIcon: null } ) }
+								this.renderSkip( { borderless: true, forwardIcon: null } ) }
+							{ ! hideNext && this.renderNext() }
 						</ActionButtons>
 					) }
 

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -20,6 +20,7 @@ class StepWrapper extends Component {
 		skipLabelText: PropTypes.string,
 		skipHeadingText: PropTypes.string,
 		skipButtonAlign: PropTypes.oneOf( [ 'top', 'bottom' ] ),
+		skipAsPrimary: PropTypes.bool,
 		// Displays an <hr> above the skip button and adds more white space
 		isLargeSkipLayout: PropTypes.bool,
 		isExternalBackUrl: PropTypes.bool,
@@ -29,6 +30,7 @@ class StepWrapper extends Component {
 	static defaultProps = {
 		allowBackFirstStep: false,
 		skipButtonAlign: 'bottom',
+		skipAsPrimary: false,
 	};
 
 	renderBack() {
@@ -46,30 +48,48 @@ class StepWrapper extends Component {
 				rel={ this.props.isExternalBackUrl ? 'external' : '' }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
+				backIcon="chevron-left"
 			/>
 		);
 	}
 
-	renderSkip( { borderless } ) {
-		if ( ! this.props.shouldHideNavButtons && this.props.goToNextStep ) {
-			return (
-				<div className="step-wrapper__skip-wrapper">
-					{ this.props.skipHeadingText && (
-						<div className="step-wrapper__skip-heading">{ this.props.skipHeadingText }</div>
-					) }
-					<NavigationLink
-						direction="forward"
-						goToNextStep={ this.props.goToNextStep }
-						defaultDependencies={ this.props.defaultDependencies }
-						flowName={ this.props.flowName }
-						stepName={ this.props.stepName }
-						labelText={ this.props.skipLabelText }
-						cssClass={ this.props.skipHeadingText && 'navigation-link--has-skip-heading' }
-						borderless={ borderless }
-					/>
-				</div>
-			);
+	renderSkip( { borderless, forwardIcon } ) {
+		const {
+			shouldHideNavButtons,
+			skipHeadingText,
+			skipLabelText,
+			skipAsPrimary,
+			defaultDependencies,
+			flowName,
+			stepName,
+			goToNextStep,
+		} = this.props;
+
+		if ( shouldHideNavButtons || ! goToNextStep ) {
+			return null;
 		}
+
+		return (
+			<div className="step-wrapper__skip-wrapper">
+				{ skipHeadingText && <div className="step-wrapper__skip-heading">{ skipHeadingText }</div> }
+				<NavigationLink
+					direction="forward"
+					goToNextStep={ goToNextStep }
+					defaultDependencies={ defaultDependencies }
+					flowName={ flowName }
+					stepName={ stepName }
+					labelText={ skipLabelText }
+					cssClass={ classNames( 'step-wrapper__navigation-link', {
+						primary: skipAsPrimary,
+						'has-skip-heading': skipHeadingText,
+						'has-underline': ! skipAsPrimary,
+					} ) }
+					borderless={ borderless }
+					primary={ skipAsPrimary }
+					forwardIcon={ forwardIcon }
+				/>
+			</div>
+		);
 	}
 
 	headerText() {
@@ -113,7 +133,7 @@ class StepWrapper extends Component {
 			align,
 		} = this.props;
 
-		const hasHeaderButtons = headerButton || ( ! hideSkip && skipButtonAlign === 'top' );
+		const hasHeaderButtons = headerButton;
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-wide-layout': isWideLayout,
 			'is-large-skip-layout': isLargeSkipLayout,
@@ -123,7 +143,12 @@ class StepWrapper extends Component {
 		return (
 			<>
 				<div className={ classes }>
-					{ ! hideBack && this.renderBack() }
+					<div className="step-wrapper__navigation">
+						{ ! hideBack && this.renderBack() }
+						{ ! hideSkip &&
+							skipButtonAlign === 'top' &&
+							this.renderSkip( { borderless: true, forwardIcon: null } ) }
+					</div>
 
 					{ ! hideFormattedHeader && (
 						<div className="step-wrapper__header">
@@ -133,16 +158,7 @@ class StepWrapper extends Component {
 								subHeaderText={ this.subHeaderText() }
 								align={ align }
 							/>
-							{ hasHeaderButtons && (
-								<ActionButtons>
-									{ headerButton }
-									{ ! hideSkip && skipButtonAlign === 'top' && (
-										<div className="step-wrapper__buttons is-top-buttons">
-											{ this.renderSkip( { borderless: false } ) }
-										</div>
-									) }
-								</ActionButtons>
-							) }
+							{ headerButton && <ActionButtons>{ headerButton }</ActionButtons> }
 						</div>
 					) }
 

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -41,7 +41,7 @@
 .step-wrapper__header-button {
 	@include breakpoint-deprecated( '<660px' ) {
 		flex-basis: 100%;
-		margin-bottom: -16px;
+		padding: 0 20px;
 	}
 }
 
@@ -50,19 +50,26 @@
 	align-items: center;
 	font-size: 0.875rem;
 
-	@include break-small {
-		&,
-		&:not( .is-sticky ) {
-			position: absolute;
-			top: 2px;
-			left: 11px;
-			right: 16px;
-			margin: 0;
-		}
+	@mixin unstick {
+		position: absolute;
+		top: 2px;
+		left: 11px;
+		right: 16px;
+		padding: 0;
+		border: none;
+		margin: 0;
+		background-color: transparent;
 	}
 
-	.step-wrapper__skip-wrapper {
-		margin-left: auto;
+	&.no-sticky {
+		@include unstick;
+		height: 36px;
+	}
+
+	&:not( .is-sticky ) {
+		@include break-small {
+			@include unstick;
+		}
 	}
 
 	.step-wrapper__navigation-link {
@@ -78,5 +85,10 @@
 			// override unessecary super specificity added by another class
 			padding-top: 0 !important;
 		}
+	}
+
+	.step-wrapper__navigation-link.forward,
+	.step-wrapper__skip-wrapper {
+		margin-left: auto;
 	}
 }

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .step-wrapper__header {
 	display: flex;
 	justify-content: space-between;
@@ -5,6 +8,10 @@
 
 	.formatted-header {
 		flex-grow: 1;
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		flex-wrap: wrap;
 	}
 }
 
@@ -31,30 +38,28 @@
 	}
 }
 
-.step-wrapper__buttons.is-top-buttons {
-	margin-left: auto;
-	margin-bottom: 0;
-	font-size: 0.875rem;
-
-	.navigation-link {
-		height: 42px;
-		min-width: 160px;
-		color: #2c3338;
-
-		svg {
-			display: none;
-		}
+.step-wrapper__header-button {
+	@include breakpoint-deprecated( '<660px' ) {
+		flex-basis: 100%;
+		margin-bottom: -16px;
 	}
 }
 
-.step-wrapper__navigation {
-	position: absolute;
-	top: 6px;
-	left: 11px;
-	right: 16px;
+.step-wrapper__navigation.action-buttons {
 	display: flex;
 	align-items: center;
 	font-size: 0.875rem;
+
+	@include break-small {
+		&,
+		&:not( .is-sticky ) {
+			position: absolute;
+			top: 2px;
+			left: 11px;
+			right: 16px;
+			margin: 0;
+		}
+	}
 
 	.step-wrapper__skip-wrapper {
 		margin-left: auto;
@@ -63,11 +68,6 @@
 	.step-wrapper__navigation-link {
 		font-size: 0.875rem;
 		font-weight: 500; /* stylelint-disable-line */
-
-		&.primary {
-			position: absolute;
-			right: 0;
-		}
 
 		&.has-underline {
 			text-decoration: underline;

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -46,3 +46,37 @@
 		}
 	}
 }
+
+.step-wrapper__navigation {
+	position: absolute;
+	top: 6px;
+	left: 11px;
+	right: 16px;
+	display: flex;
+	align-items: center;
+	font-size: 0.875rem;
+
+	.step-wrapper__skip-wrapper {
+		margin-left: auto;
+	}
+
+	.step-wrapper__navigation-link {
+		font-size: 0.875rem;
+		font-weight: 500; /* stylelint-disable-line */
+
+		&.primary {
+			position: absolute;
+			right: 0;
+		}
+
+		&.has-underline {
+			text-decoration: underline;
+		}
+
+		&.has-skip-heading {
+			transform: translateY( -3px );
+			// override unessecary super specificity added by another class
+			padding-top: 0 !important;
+		}
+	}
+}

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -38,7 +38,7 @@
 
 	// Ugly, but necessary to cancel out some signup styles
 	// without causing regressions to other parts of `/start`
-	button {
+	button:not( .is-primary ) {
 		body.is-section-signup .layout:not( .dops ) & {
 			font-size: inherit;
 			padding-top: 0;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -136,7 +136,7 @@ body.is-section-signup .layout.gravatar {
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
-		button:not( .is-compact ) {
+		button:not( .is-compact ):not( .is-primary ) {
 			font-size: $font-body;
 			padding-top: 12px;
 			padding-bottom: 14px;
@@ -407,6 +407,12 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: 24px;
+		}
+	}
+
+	.step-wrapper__header-button {
+		@include breakpoint-deprecated( '<660px' ) {
+			margin-bottom: -16px;
 		}
 	}
 
@@ -795,5 +801,11 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	button.is-primary {
 		box-shadow: none;
 		border: 0;
+	}
+
+	.inline-help {
+		@include breakpoint-deprecated( '<660px' ) {
+			bottom: 74px;
+		}
 	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -142,13 +142,6 @@ body.is-section-signup .layout.gravatar {
 			padding-bottom: 14px;
 		}
 	}
-
-	// Back button
-	.navigation-link.button.back {
-		position: absolute;
-		top: 6px;
-		left: 11px;
-	}
 }
 
 // The container wrapped around every
@@ -391,16 +384,21 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
-	.navigation-link.button.back {
-		svg {
-			display: none;
-		}
-
-		color: $gray-50;
-		top: 23px;
+	.step-wrapper__navigation {
+		top: 22px;
 		left: 72px;
-		text-decoration: underline;
-		font-weight: normal;
+
+		.navigation-link.button.is-borderless {
+			color: $gray-100;
+
+			svg {
+				width: 20px;
+				height: 20px;
+				top: 5px;
+				margin-right: 2px;
+				fill: $gray-100;
+			}
+		}
 	}
 
 	.step-wrapper__header {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -169,7 +169,7 @@ body.is-section-signup .layout:not( .dops ) .step-wrapper {
 			margin-bottom: 0;
 		}
 
-		&.has-header-buttons {
+		&.has-navigation {
 			padding-bottom: 60px;
 		}
 	}
@@ -385,9 +385,6 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	}
 
 	.step-wrapper__navigation {
-		top: 22px;
-		left: 72px;
-
 		.navigation-link.button.is-borderless {
 			color: $gray-100;
 
@@ -399,11 +396,14 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 				fill: $gray-100;
 			}
 		}
+
+		@include break-small {
+			left: 72px;
+		}
 	}
 
 	.step-wrapper__header {
-		margin-top: 48px;
-		margin-bottom: 40px;
+		margin: 48px 20px 40px;
 
 		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: 24px;
@@ -779,6 +779,16 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		.formatted-header__subtitle button.is-borderless {
 			font-weight: 500; /* stylelint-disable-line */
 			color: var( --studio-gray-90 );
+		}
+	}
+
+	.signup__step.is-design,
+	.signup__step.is-design-setup-site {
+		.step-wrapper__header {
+			@include breakpoint-deprecated( '<660px' ) {
+				margin-left: 0;
+				margin-right: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

According to EuqfSnWpfYx8fgiBlVmbuA-fi-2119%3A4657, we have new navigation buttons for reskinned flow including a back button with an icon, skip, and next button on the top-right corner. Also, these navigation buttons will stick to the footer in mobile view.

Here are the changes:
* For reskinned flow
  * Show the icon of back button. **This one affect all of the reskinned flow.** If we only want to apply this for `setup-site` flow, I can change this one.
  * Support skip button as black underlined text on the top-right corner. **This one only affect setup-site flow** because the `skipButtonAlign` should be `top` and only `setup-site` flow use it.
  * Support continue button as primary button on the top-right corner. **This one only be used for design preview**.
  * The back, skip and continue button would stick to the footer in the mobile view. **This one affect all of the reskinned flow.**
  * Don't show progress indicator for setup-site flow 
* For non-reskinned flow
  * Nothing would be changed.


##### Back

<img width="100%" src="https://user-images.githubusercontent.com/13596067/133597457-3cbee648-f02f-4dd0-9266-0932513ff91b.png" />

<img width="300" src="https://user-images.githubusercontent.com/13596067/133599109-f87f21a3-ad61-449a-86b2-9cf9037b6820.png" />

##### Skip

<img width="100%" src="https://user-images.githubusercontent.com/13596067/133597497-cb81da3e-a058-4e16-9f5d-e72250560448.png" />

<img width="300" src="https://user-images.githubusercontent.com/13596067/133598220-b36cf6e3-8812-47e0-906a-d1b1e63e0537.png" />

##### Next

<img width="100%" src="https://user-images.githubusercontent.com/13596067/133598613-77ee3af7-d54f-4859-adb3-3147121fc901.png" />

<img width="300" src="https://user-images.githubusercontent.com/13596067/133598968-5c103816-d390-4f38-9414-750cfaaaded7.png" />

##### Keep non-reskinned unchanged

<img width="100%" src="https://user-images.githubusercontent.com/13596067/133609108-c948fa64-68af-436b-b32e-712badd3bb06.png" />

<img width="300" src="https://user-images.githubusercontent.com/13596067/133609439-4d608062-ebd1-4c26-884e-727596a01f6a.png" />

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Check the back button and skip button are correct on desktop and mobile.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/56274