### PR TITLE
Add `/plans` to the valid cloud unauthenticated routes

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -158,8 +158,10 @@ const oauthTokenMiddleware = () => {
 		const loggedOutRoutes = [ '/start', '/api/oauth/token', '/connect' ];
 
 		if ( isJetpackCloud() && config.isEnabled( 'jetpack/pricing-page' ) ) {
-			loggedOutRoutes.push( '/pricing' );
-			getLanguageSlugs().forEach( ( slug ) => loggedOutRoutes.push( `/${ slug }/pricing` ) );
+			loggedOutRoutes.push( '/pricing', '/plans' );
+			getLanguageSlugs().forEach( ( slug ) =>
+				loggedOutRoutes.push( `/${ slug }/pricing`, `/${ slug }/plans` )
+			);
 		}
 
 		// Forces OAuth users to the /login page if no token is present
@@ -338,7 +340,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	if ( ! currentUser ) {
 		// Dead-end the sections the user can't access when logged out
 		page( '*', function ( context, next ) {
-			//see server/pages/index for prod redirect
+			// see server/pages/index for prod redirect
 			if ( '/plans' === context.pathname ) {
 				const queryFor = context.query && context.query.for;
 				if ( queryFor && 'jetpack' === queryFor ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR should be the last step to make `/plans` redirect to `/pricing` in Jetpack cloud. It makes the redirect effective when unauthenticated.

Fixes 1164141197617539-as-1200973313450479

Previous PRs, for reference: #56217, #56240

### Testing instructions

- Download the PR and run cloud
- For both the authenticated and non authenticated use cases, check that:
  - Visiting `http://jetpack.cloud.localhost:3000/plans` redirects you to `http://jetpack.cloud.localhost:3000/pricing`
  - Visiting `http://jetpack.cloud.localhost:3000/:locale/plans` redirects you to `http://jetpack.cloud.localhost:3000/pricing`, with the page displayed in the proper language