### PR TITLE
FSE: add beta enrollment - skip Style step

### DIFF
--- a/client/landing/gutenboarding/hooks/use-steps.ts
+++ b/client/landing/gutenboarding/hooks/use-steps.ts
@@ -8,12 +8,13 @@ import { usePlanFromPath } from './use-selected-plan';
 
 export default function useSteps(): Array< StepType > {
 	const locale = useLocale();
-	const { hasSiteTitle, hasSelectedDesignWithoutFonts } = useSelect(
+	const { hasSiteTitle, hasSelectedDesignWithoutFonts, isEnrollingInFse } = useSelect(
 		( select ) => {
 			const onboardSelect = select( ONBOARD_STORE );
 			return {
 				hasSiteTitle: onboardSelect.hasSiteTitle(),
 				hasSelectedDesignWithoutFonts: onboardSelect.hasSelectedDesignWithoutFonts(),
+				isEnrollingInFse: onboardSelect.shouldEnrollInFseBeta(),
 			};
 		},
 		[ ONBOARD_STORE ]
@@ -48,8 +49,15 @@ export default function useSteps(): Array< StepType > {
 		];
 	}
 
-	// Remove the Style (fonts) step from the Site Editor flow.
-	if ( isEnabled( 'gutenboarding/site-editor' ) || hasSelectedDesignWithoutFonts ) {
+	// Remove the Style (fonts) step in the following cases:
+	// - Site Editor flow (feature flag)
+	// - the user has selected a design without fonts
+	// - the user is enrolled in Beta FSE
+	if (
+		isEnabled( 'gutenboarding/site-editor' ) ||
+		hasSelectedDesignWithoutFonts ||
+		isEnrollingInFse
+	) {
 		steps = steps.filter( ( step ) => step !== Step.Style );
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -107,12 +107,12 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 	}, [ hasSiteTitle ] );
 
 	const canUseStyleStep = React.useCallback( (): boolean => {
-		return hasSelectedDesign && ! isEnrollingInFse;
-	}, [ hasSelectedDesign, isEnrollingInFse ] );
+		return hasSelectedDesign;
+	}, [ hasSelectedDesign ] );
 
 	const shouldSkipStyleStep = React.useCallback( (): boolean => {
-		return hasSelectedDesignWithoutFonts;
-	}, [ hasSelectedDesignWithoutFonts ] );
+		return hasSelectedDesignWithoutFonts || isEnrollingInFse;
+	}, [ hasSelectedDesignWithoutFonts, isEnrollingInFse ] );
 
 	const canUseFeatureStep = React.useCallback( (): boolean => {
 		return hasSelectedDesign;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -33,6 +33,7 @@ registerStore< State >( STORE_KEY, {
 		'siteTitle',
 		'siteVertical',
 		'wasVerticalSkipped',
+		'shouldEnrollInFseBeta',
 	],
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix routing in `Edit` 
* Fix navigation in `use-steps`
* Add persistance

#### Testing instructions

* Go to `/new/beta`
* Choose "Enroll in beta"
  * Pick a design => land on "Choose a domain" step
  * Go back => land on Beta step

Related to #56175, #54461
