### PR TITLE
Add new module to query mailboxes across a site

### DIFF
--- a/client/data/emails/use-get-mailboxes.js
+++ b/client/data/emails/use-get-mailboxes.js
@@ -1,0 +1,14 @@
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export const useGetMailboxes = ( siteId, queryOptions = {} ) => {
+	return useQuery(
+		[ 'emails/mailboxes', siteId ],
+		() =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/emails/mailboxes`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		queryOptions
+	);
+};

--- a/client/data/emails/use-get-mailboxes.js
+++ b/client/data/emails/use-get-mailboxes.js
@@ -1,6 +1,13 @@
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
+/**
+ * Get the associated mailboxes for a given site
+ *
+ * @param {number} siteId Site identifier
+ * @param {object} queryOptions Query options
+ * @returns {data, error, isLoading} Returns an object with the requested mailboxes
+ */
 export const useGetMailboxes = ( siteId, queryOptions = {} ) => {
 	return useQuery(
 		[ 'emails/mailboxes', siteId ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A new React-query module is added to fetch mailboxes for all domains in a site
* The query uses the new `/emails/mailboxes` route that is being developed to support the My Email project

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I'm not sure how to test this. More or less this is just a query that does a remote call to the backend, especially since the backend is still in development.


