### PR TITLE
Playwright: Fix flaky signup spec and decouple magic link login from rest of script

### DIFF
--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -55,6 +55,7 @@ export class NavbarComponent {
 	 * Click on `Me` on top right of the Home dashboard.
 	 */
 	async clickMe(): Promise< void > {
+		await this.pageSettled();
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.meButton ) ] );
 	}
 

--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -117,6 +117,14 @@ describe(
 		} );
 
 		describe( 'Delete user account', function () {
+			// Magic link login will always land on the https://wordpress.com host, so we need to reset host for rest of test.
+			it( 'Re-login to ensure correct host', async function () {
+				await BrowserManager.clearAuthenticationState( page );
+				const loginPage = new LoginPage( page );
+				await loginPage.visit();
+				await loginPage.login( { username: username, password: signupPassword } );
+			} );
+
 			it( 'Navigate to Me > Account Settings', async function () {
 				const navbarComponent = new NavbarComponent( page );
 				await navbarComponent.clickMe();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes two issues with the free signup Playwright spec.

1. As documented in #56318, the signup spec has had some flakeyness. The issue happens after logging in with the magic link and trying to navigate to the `/me` page.

There's a race condition that happens when trying to navigate right after logging in with the magic link. Logging in through the magic link goes through several different redirects (real and "fake" react navigations) before settling. The navbar button to navigate to `/me` technically becomes visible and active before everything has settled. So what happens is that `wordpress.com` loads, Playwright clicks the button to navigate to `/me`, then there is a navigation to `wordpress.com/home/<site name>`, and that navigation takes the script out of the `/me` page and back to the home page.

2. All magic links use the `wordpress.com` host. This means if you continue anything in the spec after using a magic link login, you are no longer testing your target host of Calypso. This means the deletion part of the spec is always running against  staging/prod.

Both of of these are solved with the same solution - after following the magic link, force a re-login at the correct host before carrying on with the rest of the spec.

#### Testing instructions
- Update your `calypsoBaseURL` in config to point to a different host, like `wpcalypso.wordpress.com`
- [x] `TARGET_DEVICE=mobile yarn jest specs/specs-playwright/wp-signup__free.ts`
- [x] `TARGET_DEVICE=desktop yarn jest specs/specs-playwright/wp-signup__free.ts`

Fixes #56318 
