### PR TITLE
Playwright: More signup spec flakiness fixes - handle async navigation while closing

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -31,7 +31,12 @@ export class AccountSettingsPage {
 	 * Closes the currently logged in user's account.
 	 */
 	async closeAccount(): Promise< void > {
-		await this.page.click( selectors.closeAccountLink );
+		// This async navigation can mess with clicking the next button, so we need to make sure to wait explicitly for that async nav to commplete.
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.click( selectors.closeAccountLink ),
+		] );
+
 		await this.page.click( selectors.closeAccountButton );
 		await this.page.click( selectors.modalContinueButton );
 		const username = await this.page


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixing the other flaky test in #56321 exposed a new point of flakiness in the test, albeit one that is more rare (about a 10% failure rate).

Namely, going from the account settings page to the close account page is an async (React) navigation. We weren't explicitly handling the async nature of that navigation, meaning that occasionally it could mess up clicking the button on the next page.

Now, we handle it!

#### Testing instructions

I ran a local stress test after the changes and haven't seen a failure yet!
