### PR TITLE
Move screen options tab to avoid happychat overlap

### DIFF
--- a/client/components/screen-options-tab/style.scss
+++ b/client/components/screen-options-tab/style.scss
@@ -12,7 +12,7 @@ $screen-options-icon-border-y: 7px;
 .screen-options-tab {
 	position: fixed;
 	top: var( --masterbar-height );
-	right: 20px;
+	right: 32px;
 	z-index: z-index( 'root', '.screen-options-tab' );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the screen options tab to the left by 12 pixels
  * Before: `right: 20px;`
  * After: `right: 32px;`
* This is to avoid an overlap occurring with the happychat close button:

Before (overlap, 20px):
![2021-09-16_15-03](https://user-images.githubusercontent.com/937354/133680611-b78d08ff-8a04-4488-a674-e60419cc68f3.png)

After (no overlap, 32px):
![2021-09-16_15-04](https://user-images.githubusercontent.com/937354/133680637-88859b08-ca47-4f48-b040-b8c68dd32e7b.png)

I am worried about the possibility of this causing other issues. How safe is it to move this?

#### Testing instructions

* Start a Live Chat session at https://wordpress.com/help/contact as if you were a customer
* Navigate to a page that has the screen options tab, like the posts page, while the chat is open


Related to #56308
