### PR TITLE
Playwright: add more suites to pre-release tests

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-editor__post-basic-flow-spec.ts
@@ -1,5 +1,6 @@
 /**
  * @group calypso-pr
+ * @group calypso-release
  * @group gutenberg
  */
 

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -1,5 +1,6 @@
 /**
  * @group calypso-pr
+ * @group calypso-release
  */
 
 import {

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -1,5 +1,4 @@
 /**
- * @group calypso-pr
  * @group calypso-release
  */
 
@@ -66,16 +65,16 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 		await gutenboardingFlow.validateRecommendedPlan( 'Business' );
 	} );
 
-	it.skip( 'Select free plan', async function () {
+	it( 'Select free plan', async function () {
 		await gutenboardingFlow.selectPlan( 'Free' );
 	} );
 
-	it.skip( 'See the Gutenberg editor', async function () {
+	it( 'See the Gutenberg editor', async function () {
 		const gutenbergEditorPage = new GutenbergEditorPage( page );
 		await gutenbergEditorPage.waitUntilLoaded();
 	} );
 
-	it.skip( `Delete created site`, async function () {
+	it( `Delete created site`, async function () {
 		const settingsURL = DataHelper.getCalypsoURL( `settings/general/${ siteURL }` );
 		await page.goto( settingsURL, { waitUntil: 'load' } );
 		const generalSettingsPage = new GeneralSettingsPage( page );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds two more suites to the pre-release tests:
- `wp-editor_post-basic-flow-spec.ts` - This is such a core workflow, we should make sure it persists cleanly after merge with trunk. Pretty cheap to run!
- `wp-gutenboarding__happy-path.ts` - Onboarding to a new site is mission critical, we should make sure it works cleanly after merge with trunk. Also, as this grows to include site purchasing, it will become more and more "expensive", and so should be run pre-release instead of pre-merge.

#### Testing instructions

Pull PR, build, etc. and

`yarn jest --group=calypso-release`


