### PR TITLE
Remove translation fallbacks that are no longer needed

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -2,11 +2,10 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useLocale } from '@automattic/i18n-utils';
 import { Button, Card, CardBody, CardFooter, CardMedia, Flex } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { __, hasTranslation } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classNames from 'classnames';
 /**
@@ -101,15 +100,9 @@ function CardNavigation( {
 	onNextCardProgression,
 	onPreviousCardProgression,
 } ) {
-	const localeSlug = useLocale();
 	// These are defined on their own lines because of a minification issue.
 	// __('translations') do not always work correctly when used inside of ternary statements.
-	const startTourLabel =
-		localeSlug === 'en' ||
-		localeSlug === 'en-gb' ||
-		hasTranslation( 'Try it out!', 'full-site-editing' )
-			? __( 'Try it out!', 'full-site-editing' )
-			: __( 'Start Tour', 'full-site-editing' );
+	const startTourLabel = __( 'Try it out!', 'full-site-editing' );
 	const nextLabel = __( 'Next', 'full-site-editing' );
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-content.js
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, hasTranslation } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 const addBlock = 'https://s0.wp.com/i/editor-welcome-tour/slide-add-block.gif';
 const allBlocks = 'https://s0.wp.com/i/editor-welcome-tour/slide-all-blocks.gif';
@@ -22,21 +22,10 @@ function getTourContent( localeSlug ) {
 	return [
 		{
 			heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
-			description:
-				localeSlug === 'en' ||
-				localeSlug === 'en-gb' ||
-				hasTranslation(
-					'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
-					'full-site-editing'
-				)
-					? __(
-							'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
-							'full-site-editing'
-					  )
-					: __(
-							'Continue on with this short tour to learn the fundamentals of the WordPress editor.',
-							'full-site-editing'
-					  ),
+			description: __(
+				'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+				'full-site-editing'
+			),
 			imgSrc: welcome,
 			animation: null,
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#56049 added new copy to the welcome guide, including fallbacks for languages where translations weren't complete yet.

The translation process is now complete:
https://github.com/Automattic/wp-calypso/pull/56049#issuecomment-920780779

This PR removes the old translations that are no longer needed

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this version of ETK to your sandbox
* Open the welcome guide from the menu.
* The new copy appears
* Nothing crashes

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
