### PR TITLE
Fix Site Domains title for mapped domains

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -102,7 +102,7 @@ export const sslStatuses = {
 	SSL_ACTIVE: 'active',
 };
 
-export const domainTitleContext = {
+export const domainInfoContext = {
 	DOMAIN_ITEM: 'DOMAIN_ITEM',
 	PAGE_TITLE: 'PAGE_TITLE',
 };

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -101,3 +101,8 @@ export const sslStatuses = {
 	SSL_PENDING: 'pending',
 	SSL_ACTIVE: 'active',
 };
+
+export const domainTitleContext = {
+	DOMAIN_ITEM: 'DOMAIN_ITEM',
+	PAGE_TITLE: 'PAGE_TITLE',
+};

--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -1,4 +1,4 @@
-import { type as domainTypes, domainTitleContext } from './constants';
+import { type as domainTypes, domainInfoContext } from './constants';
 
 /**
  * Translate function placeholder.
@@ -21,11 +21,11 @@ function translatePlaceholder( string ) {
 export function getDomainTypeText(
 	domain = {},
 	__ = translatePlaceholder,
-	context = domainTitleContext.DOMAIN_ITEM
+	context = domainInfoContext.DOMAIN_ITEM
 ) {
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
-			if ( context === domainTitleContext.PAGE_TITLE ) {
+			if ( context === domainInfoContext.PAGE_TITLE ) {
 				return __( 'Connected domain' );
 			}
 

--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -1,4 +1,4 @@
-import { type as domainTypes } from './constants';
+import { type as domainTypes, domainTitleContext } from './constants';
 
 /**
  * Translate function placeholder.
@@ -15,11 +15,20 @@ function translatePlaceholder( string ) {
  *
  * @param   {Object}   domain Domain object
  * @param   {Function} __     Translate function
+ * @param   {string} context  Context of the returned text (DOMAIN_ITEM: item of a domain list, PAGE_TITLE: title when managing the domain)
  * @returns {string}          Domain type text
  */
-export function getDomainTypeText( domain = {}, __ = translatePlaceholder ) {
+export function getDomainTypeText(
+	domain = {},
+	__ = translatePlaceholder,
+	context = domainTitleContext.DOMAIN_ITEM
+) {
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
+			if ( context === domainTitleContext.PAGE_TITLE ) {
+				return __( 'Connected domain' );
+			}
+
 			return __( 'Managed by external provider' );
 
 		case domainTypes.REGISTERED:

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -7,7 +7,7 @@ import { getSelectedDomain, getDomainTypeText } from 'calypso/lib/domains';
 import {
 	registrar as registrarNames,
 	type as domainTypes,
-	domainTitleContext,
+	domainInfoContext,
 } from 'calypso/lib/domains/constants';
 import { getWpcomDomain } from 'calypso/lib/domains/get-wpcom-domain';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
@@ -52,7 +52,7 @@ class Edit extends React.Component {
 		if ( this.props.hasDomainOnlySite ) {
 			return this.props.translate( 'Parked Domain' );
 		}
-		return getDomainTypeText( domain, this.props.translate, domainTitleContext.PAGE_TITLE );
+		return getDomainTypeText( domain, this.props.translate, domainInfoContext.PAGE_TITLE );
 	}
 
 	getDetailsForType = ( type ) => {

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -4,7 +4,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
 import { getSelectedDomain, getDomainTypeText } from 'calypso/lib/domains';
-import { registrar as registrarNames, type as domainTypes } from 'calypso/lib/domains/constants';
+import {
+	registrar as registrarNames,
+	type as domainTypes,
+	domainTitleContext,
+} from 'calypso/lib/domains/constants';
 import { getWpcomDomain } from 'calypso/lib/domains/get-wpcom-domain';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import MaintenanceCard from 'calypso/my-sites/domains/domain-management/components/domain/maintenance-card';
@@ -48,7 +52,7 @@ class Edit extends React.Component {
 		if ( this.props.hasDomainOnlySite ) {
 			return this.props.translate( 'Parked Domain' );
 		}
-		return getDomainTypeText( domain, this.props.translate );
+		return getDomainTypeText( domain, this.props.translate, domainTitleContext.PAGE_TITLE );
 	}
 
 	getDetailsForType = ( type ) => {


### PR DESCRIPTION
Fixes #55922. Sets "Connected domain Settings" as the title for the connected (mapped) domains management page.

![image](https://user-images.githubusercontent.com/18705930/133722746-91e88d05-3d68-47cf-8a41-00f2014f71db.png)

#### Testing instructions
- Make sure that tests pass; 
- The title when managing a mapped domain should be "Connected domain Settings". 
- The domain item list for the site should still show "Managed by external provider" as the description.