### PR TITLE
Revert @wordpress/browserslist-config

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -48,7 +48,7 @@
 		"@types/webpack-env": "^1.16.2",
 		"@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",
 		"@wordpress/babel-plugin-import-jsx-pragma": "^3.1.0",
-		"@wordpress/browserslist-config": "^4.1.0",
+		"@wordpress/browserslist-config": "^3.0.3",
 		"@wordpress/dependency-extraction-webpack-plugin": "^3.2.1",
 		"autoprefixer": "^10.2.5",
 		"babel-jest": "^27.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@ __metadata:
     "@types/webpack-env": ^1.16.2
     "@wojtekmaj/enzyme-adapter-react-17": ^0.6.3
     "@wordpress/babel-plugin-import-jsx-pragma": ^3.1.0
-    "@wordpress/browserslist-config": ^4.1.0
+    "@wordpress/browserslist-config": ^3.0.3
     "@wordpress/dependency-extraction-webpack-plugin": ^3.2.1
     autoprefixer: ^10.2.5
     babel-jest: ^27.0.6
@@ -7787,6 +7787,13 @@ __metadata:
     tinycolor2: ^1.4.2
     uuid: ^8.3.0
   checksum: c8c680d24d964d85fe442f21a650b8a981924e15ae660304fd443a94e833d9687f37731f7b57b53fa59223686d3c5661e3dad1263bb0e140caebf0b0b3ed5f2e
+  languageName: node
+  linkType: hard
+
+"@wordpress/browserslist-config@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@wordpress/browserslist-config@npm:3.0.3"
+  checksum: 592dd6eaac96887cc8945e2e9169c7df1b74ec439983365b3f8baa4928c571236d981b36fb4b8e94b2d6d009c664eb182bde969eda19f22921804604b8c7414d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #56338
Related p1631866144059200/1631860983.056900-slack-C029GN3KD

#### Background

WPCom Block Editor (WBE) loads a plugin for TinyMCE using the syntax

```
tinymce.PluginManager.add( 'gutenberg-wpcom-iframe-media-modal', ( editor ) => {
...
});
```

The build process for WBE transpiles the files using `@wordpress/browserslist-config`.

Before #54793 we were using `@wordpress/browserslist-config@3.0.3`, which includes IE11. As such, the above code got transpiled to 
```
tinymce_tinymce__WEBPACK_IMPORTED_MODULE_0___default().PluginManager.add('gutenberg-wpcom-iframe-media-modal', function (editor) {...}
```

But with the #54793 upgrade we introduced `@wordpress/browserslist-config@4.1.0`, which only supports modern browser. Therefore, the above code gets transpiled to 
```
tinymce_tinymce__WEBPACK_IMPORTED_MODULE_0___default().PluginManager.add('gutenberg-wpcom-iframe-media-modal', editor => {...}
```

That should be fine, but TineMCE uses `new` to instantiate the plugin. As arrow functions don't support `new`, it breaks.

#### Changes proposed in this Pull Request

Restores old version of @wordpress/browserslist-config to a version that still supports IE11. 
This is a temporary patch to fix the bug asap. Once it is deployed we need to investigate how to update `@wordpress/browserslist-config` without breaking TinyMCE

#### Testing instructions

Deploy wpcom-block-editor to your sandbox and verify #56338 is gone