### PR TITLE
Improve the site selection rules for `/email/inbox`

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -515,7 +515,9 @@ const navigateToSite = ( siteId, { allSitesPath, allSitesSingleUser, siteBasePat
 			path = '/domains/manage';
 		}
 
-		if ( path.match( /^\/email\// ) ) {
+		if ( path.match( /^\/email\/inbox\/?/ ) ) {
+			path = '/email/inbox';
+		} else if ( path.match( /^\/email\// ) ) {
 			path = '/email';
 		}
 

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -13,9 +13,9 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 
 const commonHandlers = [ siteSelection, navigation ];
 
-const emailInboxAddHeader = ( context, next ) => {
+const emailInboxSiteSelectionHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
-		return translate( 'Select a site to open {{strong}}Inbox{{/strong}}', {
+		return translate( 'Select a site to open {{strong}}My Inbox{{/strong}}', {
 			components: {
 				strong: <strong />,
 			},
@@ -31,7 +31,7 @@ export default function () {
 	page(
 		paths.emailManagementInbox(),
 		siteSelection,
-		emailInboxAddHeader,
+		emailInboxSiteSelectionHeader,
 		sites,
 		makeLayout,
 		clientRender

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -1,4 +1,6 @@
+import { translate } from 'i18n-calypso';
 import page from 'page';
+import React from 'react';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -11,8 +13,37 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 
 const commonHandlers = [ siteSelection, navigation ];
 
+const emailInboxAddHeader = ( context, next ) => {
+	context.getSiteSelectionHeaderText = () => {
+		return translate( 'Select a site to open {{strong}}Inbox{{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} );
+	};
+
+	next();
+};
+
 export default function () {
 	page( paths.emailManagement(), siteSelection, sites, makeLayout, clientRender );
+
+	page(
+		paths.emailManagementInbox(),
+		siteSelection,
+		emailInboxAddHeader,
+		sites,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.emailManagementInbox( ':site' ),
+		...commonHandlers,
+		controller.emailManagementInbox,
+		makeLayout,
+		clientRender
+	);
 
 	registerMultiPage( {
 		paths: [
@@ -165,11 +196,5 @@ export default function () {
 			paths.emailManagementForwarding( ':site', ':domain' ),
 		],
 		handlers: [ ...commonHandlers, controller.emailManagementForwarding, makeLayout, clientRender ],
-	} );
-
-	page( paths.emailManagementInbox(), siteSelection, sites, makeLayout, clientRender );
-	registerMultiPage( {
-		paths: [ paths.emailManagementInbox( ':site' ) ],
-		handlers: [ ...commonHandlers, controller.emailManagementInbox, makeLayout, clientRender ],
 	} );
 }


### PR DESCRIPTION
This PR is a follow up of #56316.

#### Changes proposed in this Pull Request

* Moves the path registration rules close to the top to increase priority
* Adds a middleware to customise the site selection header
* Ensures the site selection rules work when the `/email/inbox` path is active and a site is selected

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* Navigate to [/email/inbox](http://calypso.localhost:3000/email/inbox)
* Confirm that the site selector is brought up
* Confirm that the header is: `Select a site to open Inbox`
* Select a site.
* Confirm that the path if prefixed by `/email/inbox` and new path after selection is in the form `/email/inbox/<site-id>`

#### Other tests
* Check that other `/email` paths work
* `/email` should bring up the site selector
* Ensure that the site selector works well when `/email`  is the active path
* Check other forms like the email comparison form etc 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
