### PR TITLE
Emails: Fix small 15px gap in thank you page for Professional Email

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -16,8 +16,6 @@ import './style.scss';
 const ThankYouContainer = styled.div`
 	background-color: #fff;
 	-ms-overflow-style: none;
-	/* Negative value to counteract default content padding */
-	margin-top: calc( -79px + var( --masterbar-height ) );
 `;
 
 const ThankYouSectionTitle = styled.h1`

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -1,6 +1,15 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.layout.focus-content.is-section-checkout-thank-you.has-no-sidebar {
+	background: var( --studio-white );
+
+	div.layout__content {
+		padding-right: 0;
+		padding-left: 0;
+	}
+}
+
 .thank-you__container-header img {
 	max-width: 200px;
 
@@ -38,8 +47,15 @@
 }
 
 .thank-you__step-cta > a.button:not( .is-primary ) {
-	border-color: var( --color-accent );
-	color: var( --color-accent );
+	border-color: var( --studio-gray-10 );
+	color: var( --studio-gray-80 );
+	background-color: var( --studio-white );
+}
+
+.thank-you__step-cta > a.button {
+	border-color: var( --studio-pink-50 );
+	color: var( --studio-white );
+	background-color: var( --studio-pink-50 );
 }
 
 .thank-you__help-link {
@@ -58,4 +74,27 @@
 
 .thank-you__help-text {
 	margin-bottom: 0.5em;
+}
+
+.thank-you {
+
+	&__container {
+
+		margin-top: calc( -79px + var( --masterbar-height ) );
+
+		@include breakpoint-deprecated( '<660px' ) {
+			margin-top: -1px;
+		}
+	}
+
+	&__header {
+		&-title {
+			line-height: 40px;
+		}
+
+		&-subtitle {
+			padding-top: 4px;
+			margin-bottom: 0;
+		}
+	}
 }

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -1,48 +1,14 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.layout.focus-content.is-section-checkout-thank-you.has-no-sidebar {
+.is-section-checkout-thank-you {
 	background: var( --studio-white );
+}
 
+.layout.focus-content.is-section-checkout-thank-you.has-no-sidebar {
 	div.layout__content {
 		padding-right: 0;
 		padding-left: 0;
-	}
-}
-
-.thank-you__container-header img {
-	max-width: 200px;
-
-	@media ( max-width: 782px ) {
-		max-width: 150px;
-	}
-}
-
-.thank-you__container-header {
-	flex-direction: column;
-	text-align: center;
-	align-items: center;
-}
-
-.thank-you__step-cta {
-	margin-left: auto;
-	margin-top: 6px;
-	@media ( max-width: $break-mobile ) {
-		margin: 0 auto 20px 0;
-	}
-}
-
-.thank-you__step {
-	flex-direction: column;
-	@include break-mobile {
-		flex-direction: row;
-	}
-
-	div > p {
-		margin-bottom: 12px;
-		@include break-mobile {
-			margin-bottom: 24px;
-		}
 	}
 }
 
@@ -95,6 +61,108 @@
 		&-subtitle {
 			padding-top: 4px;
 			margin-bottom: 0;
+		}
+	}
+}
+
+.thank-you__container {
+
+	margin-top: calc( -79px + var( --masterbar-height ) );
+
+	@include breakpoint-deprecated( '<960px' ) {
+		margin-top: calc( -71px + var( --masterbar-height ) );
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		margin-top: -1px;
+	}
+}
+
+.thank-you {
+
+	&__header {
+		&-title {
+			line-height: 40px;
+		}
+
+		&-subtitle {
+			padding-top: 4px;
+			margin-bottom: 0;
+		}
+	}
+
+	&__body {
+		@include break-zoomed-in {
+			margin-top: 32px;
+		}
+
+		@include break-small {
+			margin-top: 50px;
+		}
+
+		div {
+			min-width: 144px;
+		}
+
+		& > div {
+			padding: 0 24px;
+		}
+	}
+
+	&__step {
+		padding-bottom: 24px;
+		align-items: center;
+		flex-direction: column;
+
+		@include break-mobile {
+			flex-direction: row;
+		}
+
+		div > p {
+			@include break-mobile {
+				margin-bottom: 0;
+			}
+		}
+
+		&-cta {
+			margin-top: 0;
+			margin-left: auto;
+
+			@include break-zoomed-in {
+				width: 100%;
+			}
+
+			@include break-mobile {
+				width: 144px;
+			}
+		}
+	}
+
+	&__container-header {
+		width: auto;
+		background-color: var( --studio-blue-50 );
+		padding: 0 20px 35px;
+		box-sizing: border-box;
+		text-align: center;
+		height: auto;
+		flex-direction: column;
+		align-items: center;
+
+
+		img {
+			max-width: 260px;
+		}
+
+		&-content {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			padding-top: 30px;
+			color: var( --studio-white );
+
+			&-title {
+				font-size: 2rem;
+			}
 		}
 	}
 }

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -63,33 +63,6 @@
 			margin-bottom: 0;
 		}
 	}
-}
-
-.thank-you__container {
-
-	margin-top: calc( -79px + var( --masterbar-height ) );
-
-	@include breakpoint-deprecated( '<960px' ) {
-		margin-top: calc( -71px + var( --masterbar-height ) );
-	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		margin-top: -1px;
-	}
-}
-
-.thank-you {
-
-	&__header {
-		&-title {
-			line-height: 40px;
-		}
-
-		&-subtitle {
-			padding-top: 4px;
-			margin-bottom: 0;
-		}
-	}
 
 	&__body {
 		@include break-zoomed-in {

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -112,15 +112,14 @@
 	}
 
 	&__container-header {
-		width: auto;
-		background-color: var( --studio-blue-50 );
-		padding: 0 20px 35px;
-		box-sizing: border-box;
-		text-align: center;
-		height: auto;
-		flex-direction: column;
 		align-items: center;
-
+		background-color: var( --studio-blue-50 );
+		box-sizing: border-box;
+		flex-direction: column;
+		height: auto;
+		padding: 0 20px 35px;
+		text-align: center;
+		width: auto;
 
 		img {
 			max-width: 260px;

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -12,70 +12,17 @@
 }
 
 .checkout-thank-you__domains {
-	&.thank-you__container {
-
-		margin-top: calc( -79px + var( --masterbar-height ) );
-
-		@include breakpoint-deprecated( '<960px' ) {
-			margin-top: calc( -71px + var( --masterbar-height ) );
-		}
-
-		@include breakpoint-deprecated( '<660px' ) {
-			margin-top: -1px;
-		}
-	}
-
 	.thank-you {
 
-		&__header {
-			&-title {
-				line-height: 40px;
-			}
-
-			&-subtitle {
-				padding-top: 4px;
-				margin-bottom: 0;
-			}
-		}
-
 		&__body {
-			@include break-zoomed-in {
-				margin-top: 32px;
-			}
-
-			@include break-small {
-				margin-top: 50px;
-			}
-
-			div {
-				min-width: 144px;
-			}
-
 			.domain-thank-you__button {
 				width: 144px;
-			}
-
-			& > div {
-				padding: 0 24px;
 			}
 		}
 
 		&__step {
-			padding-bottom: 24px;
-			align-items: center;
-
-			div > p {
-				@include break-mobile {
-					margin-bottom: 0;
-				}
-			}
-
 			&-cta {
-				margin-top: 0;
-
 				@include break-zoomed-in {
-					width: 100%;
-
 					.domain-thank-you__button {
 						margin-top: 4px;
 						width: 100%;
@@ -83,8 +30,6 @@
 				}
 
 				@include break-mobile {
-					width: 144px;
-
 					.domain-thank-you__button {
 						margin-top: 0;
 						width: 144px;
@@ -93,31 +38,6 @@
 
 				.domain-thank-you__button {
 					padding: 8px;
-				}
-			}
-		}
-
-		&__container-header {
-			width: auto;
-			background-color: var( --studio-blue-50 );
-			padding: 0 20px 35px;
-			box-sizing: border-box;
-			text-align: center;
-			height: auto;
-
-			img {
-				max-width: 260px;
-			}
-
-			&-content {
-				display: flex;
-				flex-direction: column;
-				align-items: center;
-				padding-top: 30px;
-				color: var( --studio-white );
-
-				&-title {
-					font-size: 2rem;
 				}
 			}
 		}

--- a/client/my-sites/checkout/checkout-thank-you/domains/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/domains/style.scss
@@ -4,7 +4,7 @@
 
 .is-section-checkout-thank-you {
 	background: var( --studio-white );
-	
+
 	.layout__content {
 		padding-right: 0;
 		padding-left: 0;
@@ -13,13 +13,13 @@
 
 .checkout-thank-you__domains {
 	&.thank-you__container {
-		
+
 		margin-top: calc( -79px + var( --masterbar-height ) );
-	
+
 		@include breakpoint-deprecated( '<960px' ) {
 			margin-top: calc( -71px + var( --masterbar-height ) );
 		}
-	
+
 		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: -1px;
 		}
@@ -81,7 +81,7 @@
 						width: 100%;
 					}
 				}
-				
+
 				@include break-mobile {
 					width: 144px;
 

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -117,6 +117,7 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 		<ThankYou
 			headerClassName={ 'titan-set-up-thank-you__header' }
 			sections={ [ titanThankYouSection ] }
+			containerClassName={ 'titan-set-up-thank-you__container' }
 			showSupportSection={ true }
 			thankYouImage={ thankYouImage }
 			thankYouTitle={ title ?? translate( 'Your email is now ready to use' ) }

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -117,7 +117,6 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 		<ThankYou
 			headerClassName={ 'titan-set-up-thank-you__header' }
 			sections={ [ titanThankYouSection ] }
-			containerClassName={ 'titan-set-up-thank-you__container' }
 			showSupportSection={ true }
 			thankYouImage={ thankYouImage }
 			thankYouTitle={ title ?? translate( 'Your email is now ready to use' ) }

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -5,7 +5,7 @@
 	margin-left: 4px;
 }
 
-.thank-you__container {
+.titan-set-up-thank-you__container {
 	margin: calc( -79px + var( --masterbar-height ) ) -32px -33px -34px;
 
 	@media ( max-width: 660px ) {

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -6,7 +6,8 @@
 }
 
 .thank-you__container {
-	margin: -32px -32px -33px -34px;
+	margin: calc( -79px + var( --masterbar-height ) ) -32px -33px -34px;
+
 	@media ( max-width: 660px ) {
 		padding: 0 32px 34px 34px;
 	}

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -4,11 +4,3 @@
 .titan-set-up-thank-you__icon-external {
 	margin-left: 4px;
 }
-
-.titan-set-up-thank-you__container {
-	margin: calc( -79px + var( --masterbar-height ) ) -32px -33px -34px;
-
-	@media ( max-width: 660px ) {
-		padding: 0 32px 34px 34px;
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Thank you page hero card has a small 15px gap between MasterBar and the Thank you page itself. The fix just adds into the equation the MasterBar height, so the gap is not prefixed and it's a formula:

`calc( -79px + var( --masterbar-height ) )`

In addition this Pull Request is unifying the two only styles that ThankYou component uses. So it requires less customisation when using this component.

#### Testing instructions

1. Go to Upgrades -> Emails
2. Buy or add a mailbox (Professional Email)
3. Check the thank you page is not showing an empty gap in the top side as per the below table.

To test the domain Thank you Page please, refer to this [Pull Request](https://github.com/Automattic/wp-calypso/pull/55675)

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/133805988-e2bea6ce-1a74-4f3d-9253-120e6e9a7ca6.png) | ![image](https://user-images.githubusercontent.com/5689927/133805894-925edb33-0ae3-4733-a555-861811faea39.png)

#### Mobile
Email | Domain
------------ | -------------
![thank you titan](https://user-images.githubusercontent.com/5689927/135115197-1b970201-6793-48ca-988f-29eb749d5a6a.gif) | ![domain you titan](https://user-images.githubusercontent.com/5689927/135115214-fb0a55b0-6667-47a1-b75c-a3386a26cd30.gif)

#### Remarks

This issue is not replicable with old purchases, or reloading the site. In this case the order of stylesheet loading is different and makes not possible to replicate the issue.

Related to {1200182182542585-as-1201006404457937}
