### PR TITLE
Update domain item expiration message

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -163,17 +163,9 @@ export function resolveDomainStatus(
 			}
 
 			if ( isExpiringSoon( domain, 30 ) ) {
-				const translationArgs = {
+				const expiresMessage = translate( 'Domain registration expires on %(expiryDate)s', {
 					args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
-				};
-
-				const expiresMessage =
-					null !== domain.bundledPlanSubscriptionId
-						? translate(
-								'Domain registration expires with your plan on %(expiryDate)s',
-								translationArgs
-						  )
-						: translate( 'Domain registration expires on %(expiryDate)s', translationArgs );
+				} );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
 					return {

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -22,17 +22,14 @@ export function resolveDomainStatus(
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
 			if ( isExpiringSoon( domain, 30 ) ) {
-				const translationArgs = {
-					args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
-				};
-
 				const expiresMessage =
 					null !== domain.bundledPlanSubscriptionId
-						? translate(
-								'Domain connection expires with your plan on %(expiryDate)s',
-								translationArgs
-						  )
-						: translate( 'Domain connection expires on %(expiryDate)s', translationArgs );
+						? translate( 'Domain connection expires with your plan on %(expiryDate)s', {
+								args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
+						  } )
+						: translate( 'Domain connection expires in %(days)s', {
+								args: { days: moment( domain.expiry ).fromNow( true ) },
+						  } );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
 					return {

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -22,9 +22,17 @@ export function resolveDomainStatus(
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
 			if ( isExpiringSoon( domain, 30 ) ) {
-				const expiresMessage = translate( 'Expires in %(days)s', {
-					args: { days: moment( domain.expiry ).fromNow( true ) },
-				} );
+				const translationArgs = {
+					args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
+				};
+
+				const expiresMessage =
+					null !== domain.bundledPlanSubscriptionId
+						? translate(
+								'Domain connection expires with your plan on %(expiryDate)s',
+								translationArgs
+						  )
+						: translate( 'Domain connection expires on %(expiryDate)s', translationArgs );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
 					return {
@@ -155,9 +163,17 @@ export function resolveDomainStatus(
 			}
 
 			if ( isExpiringSoon( domain, 30 ) ) {
-				const expiresMessage = translate( 'Expires in %(days)s', {
-					args: { days: moment( domain.expiry ).fromNow( true ) },
-				} );
+				const translationArgs = {
+					args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
+				};
+
+				const expiresMessage =
+					null !== domain.bundledPlanSubscriptionId
+						? translate(
+								'Domain registration expires with your plan on %(expiryDate)s',
+								translationArgs
+						  )
+						: translate( 'Domain registration expires on %(expiryDate)s', translationArgs );
 
 				if ( isExpiringSoon( domain, 5 ) ) {
 					return {

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -163,8 +163,8 @@ export function resolveDomainStatus(
 			}
 
 			if ( isExpiringSoon( domain, 30 ) ) {
-				const expiresMessage = translate( 'Domain registration expires on %(expiryDate)s', {
-					args: { expiryDate: moment( domain.expiry ).format( 'LL' ) },
+				const expiresMessage = translate( 'Expires in %(days)s', {
+					args: { days: moment( domain.expiry ).fromNow( true ) },
 				} );
 
 				if ( isExpiringSoon( domain, 5 ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes https://github.com/Automattic/wp-calypso/issues/56155. 
Updates the expiration message for domain items. 

#### Domain connection bundled with plan
<img width="480" alt="domain-mapping-with-bundle" src="https://user-images.githubusercontent.com/18705930/133833647-4217acc0-2848-4c42-8fdb-4de517d47070.png">

#### Domain connection not bundled with plan
![domain-mapping-without-bundle](https://user-images.githubusercontent.com/18705930/133841879-8dc504af-54c6-4836-8c58-9f776c713d48.png)


#### Testing instructions

- Go to the domain management page;
- Check that mapped domains that are close to expiration will show the updated message;
- Make sure that tests pass.