### PR TITLE
Adding new useMyDomain flow to onboarding

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -37,6 +37,10 @@ function UseMyDomainInput( {
 			onClear();
 			return;
 		}
+
+		if ( event.key === ' ' ) {
+			return false;
+		}
 	};
 
 	return (

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -61,7 +61,7 @@ function UseMyDomain( props ) {
 	const [ transferDomainFlowPageSlug, setTransferDomainFlowPageSlug ] = useState(
 		stepSlug.TRANSFER_START
 	);
-	const initialValidation = useRef( isSignupStep );
+	const initialValidation = useRef( null );
 
 	const baseClassName = 'use-my-domain';
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -30,14 +30,12 @@ import './style.scss';
 
 function UseMyDomain( props ) {
 	const {
-		goBack = () => {},
-		initialInputMode = inputMode.domainInput,
+		goBack,
 		initialQuery,
 		isSignupStep = false,
 		onConnect,
 		onTransfer,
 		selectedSite,
-		showHeader = true,
 		transferDomainUrl,
 		initialMode,
 	} = props;
@@ -222,10 +220,6 @@ function UseMyDomain( props ) {
 		setMode( inputMode.transferDomain );
 	};
 
-	const handleTransfer = () => {
-		onTransfer( domainName );
-	};
-
 	const renderDomainInput = () => {
 		return (
 			<UseMyDomainInput
@@ -323,10 +317,12 @@ function UseMyDomain( props ) {
 
 		return (
 			<>
-				<BackButton className={ baseClassName + '__go-back' } onClick={ onGoBack }>
-					<Gridicon icon="arrow-left" size={ 18 } />
-					{ __( 'Back' ) }
-				</BackButton>
+				{ goBack && (
+					<BackButton className={ baseClassName + '__go-back' } onClick={ onGoBack }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ __( 'Back' ) }
+					</BackButton>
+				) }
 				<FormattedHeader
 					brandFont
 					className={ baseClassName + '__page-heading' }
@@ -348,12 +344,10 @@ function UseMyDomain( props ) {
 UseMyDomain.propTypes = {
 	goBack: PropTypes.func,
 	initialQuery: PropTypes.string,
-	initialInputMode: PropTypes.string,
 	isSignupStep: PropTypes.bool,
 	onConnect: PropTypes.func,
 	onTransfer: PropTypes.func,
 	selectedSite: PropTypes.object,
-	showHeader: PropTypes.bool,
 	transferDomainUrl: PropTypes.string,
 };
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -28,18 +28,20 @@ import DomainTransferOrConnect from './transfer-or-connect';
 
 import './style.scss';
 
-function UseMyDomain( {
-	goBack,
-	initialInputMode,
-	initialQuery,
-	isSignupStep,
-	onConnect,
-	onTransfer,
-	selectedSite,
-	showHeader,
-	transferDomainUrl,
-	initialMode,
-} ) {
+function UseMyDomain( props ) {
+	const {
+		goBack = () => {},
+		initialInputMode = UseMyDomain.inputMode.domainInput,
+		initialQuery,
+		isSignupStep = false,
+		onConnect,
+		onTransfer,
+		selectedSite,
+		showHeader = true,
+		transferDomainUrl,
+		initialMode,
+	} = props;
+
 	const { __ } = useI18n();
 	const [ domainAvailabilityData, setDomainAvailabilityData ] = useState( null );
 	const [ domainInboundTransferStatusInfo, setDomainInboundTransferStatusInfo ] = useState( null );
@@ -342,13 +344,6 @@ function UseMyDomain( {
 		</>
 	);
 }
-
-UseMyDomain.defaultProps = {
-	goBack: () => {},
-	initialInputMode: UseMyDomain.inputMode.domainInput,
-	isSignupStep: false,
-	showHeader: true,
-};
 
 UseMyDomain.propTypes = {
 	goBack: PropTypes.func,

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -39,6 +39,7 @@ function UseMyDomain( props ) {
 		transferDomainUrl,
 		showHeader = true,
 		initialMode,
+		onNextStep,
 	} = props;
 
 	const { __ } = useI18n();
@@ -64,6 +65,10 @@ function UseMyDomain( props ) {
 	const initialValidation = useRef( isSignupStep );
 
 	const baseClassName = 'use-my-domain';
+
+	useEffect( () => {
+		if ( initialMode ) setMode( initialMode );
+	}, [ initialMode ] );
 
 	const onGoBack = () => {
 		const prevOwnershipVerificationFlowPageSlug =
@@ -176,6 +181,7 @@ function UseMyDomain( props ) {
 			if ( availabilityErrorMessage ) {
 				setDomainNameValidationError( availabilityErrorMessage );
 			} else {
+				onNextStep?.( { mode: inputMode.transferOrConnect, domain: domainName } );
 				setMode( inputMode.transferOrConnect );
 				setDomainAvailabilityData( availabilityData );
 			}
@@ -184,7 +190,7 @@ function UseMyDomain( props ) {
 		} finally {
 			setIsFetchingAvailability( false );
 		}
-	}, [ domainName, selectedSite, setDomainTransferData, validateDomainName ] );
+	}, [ domainName, selectedSite, setDomainTransferData, validateDomainName, onNextStep ] );
 
 	const onDomainNameChange = ( event ) => {
 		setDomainName( event.target.value );
@@ -214,10 +220,12 @@ function UseMyDomain( props ) {
 	}, [ mode, setDomainTransferData, initialMode ] );
 
 	const showOwnershipVerificationFlow = () => {
+		onNextStep?.( { mode: inputMode.ownershipVerification, domain: domainName } );
 		setMode( inputMode.ownershipVerification );
 	};
 
 	const showTransferDomainFlow = () => {
+		onNextStep?.( { mode: inputMode.transferDomain, domain: domainName } );
 		setMode( inputMode.transferDomain );
 	};
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -31,7 +31,7 @@ import './style.scss';
 function UseMyDomain( props ) {
 	const {
 		goBack = () => {},
-		initialInputMode = UseMyDomain.inputMode.domainInput,
+		initialInputMode = inputMode.domainInput,
 		initialQuery,
 		isSignupStep = false,
 		onConnect,

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -35,6 +35,7 @@ function UseMyDomain( {
 	onConnect,
 	onTransfer,
 	selectedSite,
+	showHeader,
 	transferDomainUrl,
 	initialMode,
 } ) {
@@ -218,6 +219,10 @@ function UseMyDomain( {
 		setMode( inputMode.transferDomain );
 	};
 
+	const handleTransfer = () => {
+		onTransfer( domainName );
+	};
+
 	const renderDomainInput = () => {
 		return (
 			<UseMyDomainInput
@@ -308,22 +313,39 @@ function UseMyDomain( {
 		}
 	}, [ domainName, mode, __ ] );
 
+	const renderHeader = () => {
+		if ( ! showHeader ) {
+			return null;
+		}
+
+		return (
+			<>
+				<BackButton className={ baseClassName + '__go-back' } onClick={ onGoBack }>
+					<Gridicon icon="arrow-left" size={ 18 } />
+					{ __( 'Back' ) }
+				</BackButton>
+				<FormattedHeader
+					brandFont
+					className={ baseClassName + '__page-heading' }
+					headerText={ headerText }
+					align="left"
+				/>
+			</>
+		);
+	};
+
 	return (
 		<>
-			<BackButton className={ baseClassName + '__go-back' } onClick={ onGoBack }>
-				<Gridicon icon="arrow-left" size={ 18 } />
-				{ __( 'Back' ) }
-			</BackButton>
-			<FormattedHeader
-				brandFont
-				className={ baseClassName + '__page-heading' }
-				headerText={ headerText }
-				align="left"
-			/>
+			{ renderHeader() }
 			{ renderContent() }
 		</>
 	);
 }
+
+UseMyDomain.defaultProps = {
+	isSignupStep: false,
+	showHeader: true,
+};
 
 UseMyDomain.propTypes = {
 	goBack: PropTypes.func.isRequired,
@@ -332,6 +354,7 @@ UseMyDomain.propTypes = {
 	onConnect: PropTypes.func,
 	onTransfer: PropTypes.func,
 	selectedSite: PropTypes.object,
+	showHeader: PropTypes.bool,
 	transferDomainUrl: PropTypes.string,
 };
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -37,7 +37,6 @@ function UseMyDomain( props ) {
 		onTransfer,
 		selectedSite,
 		transferDomainUrl,
-		showHeader = true,
 		initialMode,
 		onNextStep,
 	} = props;
@@ -320,10 +319,6 @@ function UseMyDomain( props ) {
 	}, [ domainName, mode, __ ] );
 
 	const renderHeader = () => {
-		if ( ! showHeader ) {
-			return null;
-		}
-
 		return (
 			<>
 				{ goBack && (

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -37,6 +37,7 @@ function UseMyDomain( props ) {
 		onTransfer,
 		selectedSite,
 		transferDomainUrl,
+		showHeader = true,
 		initialMode,
 	} = props;
 
@@ -162,7 +163,7 @@ function UseMyDomain( props ) {
 		try {
 			const availabilityData = await wpcom
 				.domain( domainName )
-				.isAvailable( { apiVersion: '1.3', blog_id: selectedSite.ID, is_cart_pre_check: false } );
+				.isAvailable( { apiVersion: '1.3', blog_id: selectedSite?.ID, is_cart_pre_check: false } );
 
 			await setDomainTransferData();
 

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -30,6 +30,7 @@ import './style.scss';
 
 function UseMyDomain( {
 	goBack,
+	initialInputMode,
 	initialQuery,
 	isSignupStep,
 	onConnect,
@@ -59,7 +60,7 @@ function UseMyDomain( {
 	const [ transferDomainFlowPageSlug, setTransferDomainFlowPageSlug ] = useState(
 		stepSlug.TRANSFER_START
 	);
-	const initialValidation = useRef( null );
+	const initialValidation = useRef( isSignupStep );
 
 	const baseClassName = 'use-my-domain';
 
@@ -343,13 +344,16 @@ function UseMyDomain( {
 }
 
 UseMyDomain.defaultProps = {
+	goBack: () => {},
+	initialInputMode: UseMyDomain.inputMode.domainInput,
 	isSignupStep: false,
 	showHeader: true,
 };
 
 UseMyDomain.propTypes = {
-	goBack: PropTypes.func.isRequired,
+	goBack: PropTypes.func,
 	initialQuery: PropTypes.string,
+	initialInputMode: PropTypes.string,
 	isSignupStep: PropTypes.bool,
 	onConnect: PropTypes.func,
 	onTransfer: PropTypes.func,

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -141,7 +141,7 @@ DomainTransferOrConnect.propTypes = {
 	isSignupStep: PropTypes.bool,
 	onConnect: PropTypes.func,
 	onTransfer: PropTypes.func,
-	selectedSite: PropTypes.object.isRequired,
+	selectedSite: PropTypes.object,
 	transferDomainUrl: PropTypes.string,
 };
 

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -48,7 +48,7 @@ function DomainTransferOrConnect( {
 	const [ inboundTransferStatusInfo, setInboundTransferStatusInfo ] = useState(
 		domainInboundTransferStatusInfo
 	);
-	const [ isFetching, setIsFetching ] = useState( availabilityData === null );
+	const [ isFetching, setIsFetching ] = useState( false );
 
 	const handleConnect = () => {
 		recordMappingButtonClickInUseYourDomain( domain );
@@ -82,7 +82,8 @@ function DomainTransferOrConnect( {
 	// retrieves the availability data by itself if not provided by the parent component
 	useEffect( () => {
 		( async () => {
-			if ( availabilityData && inboundTransferStatusInfo ) return;
+			if ( ( availabilityData && inboundTransferStatusInfo ) || isFetching ) return;
+
 			try {
 				setIsFetching( true );
 				if ( ! availabilityData ) {
@@ -94,19 +95,22 @@ function DomainTransferOrConnect( {
 
 					setAvailabilityData( retrievedAvailabilityData );
 				}
+			} catch {
+				setAvailabilityData( {} );
+			}
 
+			try {
 				if ( ! inboundTransferStatusInfo ) {
 					const inboundTransferStatusResult = await getDomainInboundTransferStatusInfo( domain );
 					setInboundTransferStatusInfo( inboundTransferStatusResult );
 				}
-				setIsFetching( false );
 			} catch {
-				setIsFetching( false );
-				setAvailabilityData( {} );
 				setInboundTransferStatusInfo( {} );
+			} finally {
+				setIsFetching( false );
 			}
 		} )();
-	} );
+	}, [ availabilityData, domain, inboundTransferStatusInfo, isFetching, selectedSite?.ID ] );
 
 	const baseClassName = 'domain-transfer-or-connect';
 

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -122,12 +122,14 @@ function DomainTransferOrConnect( {
 						{ ...optionProps }
 					/>
 				) ) }
-				<div className={ baseClassName + '__support-link' }>
-					{ createInterpolateElement(
-						__( "Not sure what's best for you? <a>We're happy to help!</a>" ),
-						{ a: createElement( 'a', { target: '_blank', href: CALYPSO_CONTACT } ) }
-					) }
-				</div>
+				{ ! isFetching && (
+					<div className={ baseClassName + '__support-link' }>
+						{ createInterpolateElement(
+							__( "Not sure what's best for you? <a>We're happy to help!</a>" ),
+							{ a: createElement( 'a', { target: '_blank', href: CALYPSO_CONTACT } ) }
+						) }
+					</div>
+				) }
 			</Card>
 		</>
 	);

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -88,7 +88,7 @@ function DomainTransferOrConnect( {
 				if ( ! availabilityData ) {
 					const retrievedAvailabilityData = await wpcom.domain( domain ).isAvailable( {
 						apiVersion: '1.3',
-						blog_id: selectedSite.ID,
+						blog_id: selectedSite?.ID,
 						is_cart_pre_check: false,
 					} );
 
@@ -100,7 +100,7 @@ function DomainTransferOrConnect( {
 					setInboundTransferStatusInfo( inboundTransferStatusResult );
 				}
 				setIsFetching( false );
-			} catch {
+			} catch ( error ) {
 				setIsFetching( false );
 				setAvailabilityData( {} );
 				setInboundTransferStatusInfo( {} );

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -100,7 +100,7 @@ function DomainTransferOrConnect( {
 					setInboundTransferStatusInfo( inboundTransferStatusResult );
 				}
 				setIsFetching( false );
-			} catch ( error ) {
+			} catch {
 				setIsFetching( false );
 				setAvailabilityData( {} );
 				setInboundTransferStatusInfo( {} );

--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -37,14 +37,7 @@ export default function OptionContent( {
 					<h2> </h2>
 				</div>
 				<div className="option-content__top-text"></div>
-				<a
-					className="option-content__learn-more"
-					target="_blank"
-					href={ learnMoreLink }
-					rel="noopener noreferrer"
-				>
-					{ __( 'Learn more' ) }
-				</a>
+				<div className="option-content__learn-more"></div>
 			</div>
 		</div>
 	) : (

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -175,6 +175,11 @@
 						@include placeholder( --color-neutral-10 );
 						color: transparent;
 					}
+
+					&__learn-more {
+						width: 70px;
+						margin-top: 2px;
+					}
 				}
 			}
 		}

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -6,15 +6,19 @@ import { domainAddNew } from 'calypso/my-sites/domains/paths';
 
 export function getAvailabilityErrorMessage( { availabilityData, domainName, selectedSite } ) {
 	const { status, mappable, maintenance_end_time, other_site_domain } = availabilityData;
-	const searchPageLink = domainAddNew( selectedSite.slug, domainName );
 
 	if ( domainAvailability.AVAILABLE === status ) {
-		return createInterpolateElement(
-			__( "This domain isn't registered. Did you mean to <a>search for a domain</a> instead?" ),
-			{
-				a: createElement( 'a', { href: searchPageLink } ),
-			}
-		);
+		if ( selectedSite ) {
+			const searchPageLink = domainAddNew( selectedSite.slug, domainName );
+			return createInterpolateElement(
+				__( "This domain isn't registered. Did you mean to <a>search for a domain</a> instead?" ),
+				{
+					a: createElement( 'a', { href: searchPageLink } ),
+				}
+			);
+		}
+
+		return __( "This domain isn't registered. Try again." );
 	}
 
 	const isMappable = domainAvailability.MAPPABLE === mappable;

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -43,7 +43,7 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 		? status
 		: mappable;
 	const maintenanceEndTime = maintenance_end_time ?? null;
-	const site = other_site_domain ?? selectedSite.slug;
+	const site = other_site_domain ?? selectedSite?.slug;
 
 	const errorData = getAvailabilityNotice( domainName, availabilityStatus, {
 		site,

--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -15,7 +15,7 @@ export function getMappingFreeText( { cart, domain, primaryWithPlansOnly, select
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
 	} else if ( primaryWithPlansOnly ) {
-		mappingFreeText = __( 'Included in paid plans' );
+		mappingFreeText = __( 'Included in annual paid plans' );
 	}
 
 	return mappingFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -5,7 +5,13 @@ import {
 	isNextDomainFree,
 } from 'calypso/lib/cart-values/cart-items';
 
-export function getMappingFreeText( { cart, domain, primaryWithPlansOnly, selectedSite } ) {
+export function getMappingFreeText( {
+	cart,
+	domain,
+	primaryWithPlansOnly,
+	selectedSite,
+	isSignupStep,
+} ) {
 	let mappingFreeText;
 
 	if (
@@ -14,7 +20,7 @@ export function getMappingFreeText( { cart, domain, primaryWithPlansOnly, select
 		isDomainBundledWithPlan( cart, domain )
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
-	} else if ( primaryWithPlansOnly ) {
+	} else if ( primaryWithPlansOnly || isSignupStep ) {
 		mappingFreeText = __( 'Included in annual plans' );
 	}
 

--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -15,7 +15,7 @@ export function getMappingFreeText( { cart, domain, primaryWithPlansOnly, select
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
 	} else if ( primaryWithPlansOnly ) {
-		mappingFreeText = __( 'Included in annual paid plans' );
+		mappingFreeText = __( 'Included in annual plans' );
 	}
 
 	return mappingFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -62,6 +62,7 @@ export function getOptionInfo( {
 		domain,
 		primaryWithPlansOnly,
 		selectedSite,
+		isSignupStep,
 	} );
 
 	const mappingPriceText = getMappingPriceText( {

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -9,7 +9,7 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
 		domainProductFreeText = __( 'Free transfer with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
-		domainProductFreeText = __( 'Included in paid plans' );
+		domainProductFreeText = __( 'Included in annual paid plans' );
 	}
 
 	return domainProductFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -9,7 +9,7 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
 		domainProductFreeText = __( 'Free transfer with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
-		domainProductFreeText = __( 'Included in annual paid plans' );
+		domainProductFreeText = __( 'Included in annual plans' );
 	}
 
 	return domainProductFreeText;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -139,10 +139,16 @@ function CheckoutSummaryFeaturesList( props: {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const hasDomainsInCart = responseCart.products.some(
-		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
+		( product ) =>
+			product.is_domain_registration ||
+			product.product_slug === 'domain_transfer' ||
+			product.product_slug === 'domain_map'
 	);
 	const domains = responseCart.products.filter(
-		( product ) => product.is_domain_registration || product.product_slug === 'domain_transfer'
+		( product ) =>
+			product.is_domain_registration ||
+			product.product_slug === 'domain_transfer' ||
+			product.product_slug === 'domain_map'
 	);
 	const hasPlanInCart = responseCart.products.some( ( product ) => isPlan( product ) );
 	const translate = useTranslate();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -972,7 +972,7 @@ describe( 'CompositeCheckout', () => {
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 3 );
 		} );
 	} );
 
@@ -989,7 +989,7 @@ describe( 'CompositeCheckout', () => {
 		await waitFor( () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 2 );
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 5 );
+			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 6 );
 		} );
 	} );
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import { stringify } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { getStepUrl, isFirstStepInFlow } from 'calypso/signup/utils';
@@ -31,6 +32,7 @@ export class NavigationLink extends Component {
 		primary: PropTypes.bool,
 		backIcon: PropTypes.string,
 		forwardIcon: PropTypes.string,
+		queryParams: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -81,7 +83,7 @@ export class NavigationLink extends Component {
 			return this.props.backUrl;
 		}
 
-		const { flowName, signupProgress, stepName, userLoggedIn } = this.props;
+		const { flowName, signupProgress, stepName, userLoggedIn, queryParams } = this.props;
 		const previousStep = this.getPreviousStep( flowName, signupProgress, stepName );
 
 		const stepSectionName = get(
@@ -91,12 +93,15 @@ export class NavigationLink extends Component {
 		);
 
 		const locale = ! userLoggedIn ? getLocaleSlug() : '';
+		const queryString = queryParams ? '?' + stringify( queryParams ) : '';
 
-		return getStepUrl(
-			previousStep.lastKnownFlow || this.props.flowName,
-			previousStep.stepName,
-			stepSectionName,
-			locale
+		return (
+			getStepUrl(
+				previousStep.lastKnownFlow || this.props.flowName,
+				previousStep.stepName,
+				stepSectionName,
+				locale
+			) + queryString
 		);
 	}
 

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -29,6 +29,7 @@ class StepWrapper extends Component {
 		isExternalBackUrl: PropTypes.bool,
 		headerButton: PropTypes.node,
 		isHorizontalLayout: PropTypes.bool,
+		queryParams: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -53,6 +54,7 @@ class StepWrapper extends Component {
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 				backIcon={ isReskinnedFlow( this.props.flowName ) ? 'chevron-left' : undefined }
+				queryParams={ this.props.queryParams }
 			/>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -702,7 +702,12 @@ class DomainsStep extends Component {
 	}
 
 	getPreviousStepUrl() {
-		const basePath = getStepUrl( this.props.flowName, this.props.stepName, 'use-your-domain' );
+		const basePath = getStepUrl(
+			this.props.flowName,
+			this.props.stepName,
+			'use-your-domain',
+			this.getLocale()
+		);
 		const { step, ...queryValues } = parse( window.location.search.replace( '?', '' ) );
 		const currentStep = step ?? this.state?.currentStep;
 
@@ -745,7 +750,7 @@ class DomainsStep extends Component {
 			backUrl = domainManagementRoot();
 			backLabelText = translate( 'Back to All Domains' );
 		} else {
-			backUrl = getStepUrl( this.props.flowName, this.props.stepName );
+			backUrl = getStepUrl( this.props.flowName, this.props.stepName, null, this.getLocale() );
 
 			if ( backUrl === this.props.path ) {
 				backUrl = '/sites/';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -5,11 +5,9 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import MapDomainStep from 'calypso/components/domains/map-domain-step';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
-import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import Notice from 'calypso/components/notice';
 import {
@@ -161,14 +159,6 @@ class DomainsStep extends Component {
 	getLocale() {
 		return ! this.props.userLoggedIn ? this.props.locale : '';
 	}
-
-	getMapDomainUrl = () => {
-		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.getLocale() );
-	};
-
-	getTransferDomainUrl = () => {
-		return getStepUrl( this.props.flowName, this.props.stepName, 'transfer', this.getLocale() );
-	};
 
 	getUseYourDomainUrl = () => {
 		return getStepUrl(
@@ -517,8 +507,8 @@ class DomainsStep extends Component {
 					products={ this.props.productsList }
 					basePath={ this.props.path }
 					promoTlds={ trueNamePromoTlds }
-					mapDomainUrl={ this.getMapDomainUrl() }
-					transferDomainUrl={ this.getTransferDomainUrl() }
+					mapDomainUrl={ this.getUseYourDomainUrl() }
+					transferDomainUrl={ this.getUseYourDomainUrl() }
 					useYourDomainUrl={ this.getUseYourDomainUrl() }
 					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 					onSave={ this.handleSave.bind( this, 'domainForm' ) }
@@ -555,59 +545,8 @@ class DomainsStep extends Component {
 		);
 	};
 
-	mappingForm = () => {
-		const initialState = this.props.step ? this.props.step.mappingForm : undefined;
-		const initialQuery =
-			this.props.step && this.props.step.domainForm && this.props.step.domainForm.lastQuery;
-
-		return (
-			<div className="domains__step-section-wrapper" key="mappingForm">
-				<CalypsoShoppingCartProvider>
-					<MapDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						initialState={ initialState }
-						path={ this.props.path }
-						onRegisterDomain={ this.handleAddDomain }
-						onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
-						onSave={ this.handleSave.bind( this, 'mappingForm' ) }
-						products={ this.props.productsList }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-					/>
-				</CalypsoShoppingCartProvider>
-			</div>
-		);
-	};
-
-	onTransferSave = ( state ) => {
-		this.handleSave( 'transferForm', state );
-	};
-
 	onUseMyDomainConnect = ( { domain } ) => {
 		this.handleAddMapping( 'useYourDomainForm', domain );
-	};
-
-	transferForm = () => {
-		const initialQuery = get( this.props.step, 'domainForm.lastQuery' );
-
-		return (
-			<div className="domains__step-section-wrapper" key="transferForm">
-				<CalypsoShoppingCartProvider>
-					<TransferDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						basePath={ this.props.path }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
-						onRegisterDomain={ this.handleAddDomain }
-						onTransferDomain={ this.handleAddTransfer }
-						onSave={ this.onTransferSave }
-						products={ this.props.productsList }
-					/>
-				</CalypsoShoppingCartProvider>
-			</div>
-		);
 	};
 
 	useYourDomainForm = () => {
@@ -696,14 +635,6 @@ class DomainsStep extends Component {
 	renderContent() {
 		let content;
 		let sideContent;
-
-		if ( 'mapping' === this.props.stepSectionName ) {
-			content = this.mappingForm();
-		}
-
-		if ( 'transfer' === this.props.stepSectionName ) {
-			content = this.transferForm();
-		}
 
 		if ( 'use-your-domain' === this.props.stepSectionName ) {
 			content = this.useYourDomainForm();

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -11,7 +11,6 @@ import { recordUseYourDomainButtonClick } from 'calypso/components/domains/regis
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
-import UseYourDomainStep from 'calypso/components/domains/use-your-domain-step';
 import Notice from 'calypso/components/notice';
 import {
 	domainRegistration,
@@ -584,6 +583,10 @@ class DomainsStep extends Component {
 		this.handleSave( 'transferForm', state );
 	};
 
+	onUseMyDomainConnect = ( { domain } ) => {
+		this.handleAddMapping( 'useYourDomainForm', domain );
+	};
+
 	transferForm = () => {
 		const initialQuery = get( this.props.step, 'domainForm.lastQuery' );
 
@@ -616,22 +619,11 @@ class DomainsStep extends Component {
 					<UseMyDomain
 						analyticsSection={ this.getAnalyticsSection() }
 						basePath={ this.props.path }
-						goBack={ () => {} }
 						initialQuery={ initialQuery }
 						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
 						showHeader={ false }
 						onTransfer={ this.handleAddTransfer }
-					/>
-					<UseYourDomainStep
-						analyticsSection={ this.getAnalyticsSection() }
-						basePath={ this.props.path }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						initialQuery={ initialQuery }
-						isSignupStep
-						mapDomainUrl={ this.getMapDomainUrl() }
-						transferDomainUrl={ this.getTransferDomainUrl() }
-						products={ this.props.productsList }
+						onConnect={ this.onUseMyDomainConnect }
 					/>
 				</CalypsoShoppingCartProvider>
 			</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -701,9 +701,10 @@ class DomainsStep extends Component {
 		);
 	}
 
-	getPreviousStepUrl( currentStep ) {
-		const basePath = '/start/domains/use-your-domain';
+	getPreviousStepUrl() {
+		const basePath = getStepUrl( this.props.flowName, this.props.stepName, 'use-your-domain' );
 		const { step, ...queryValues } = parse( window.location.search.replace( '?', '' ) );
+		const currentStep = step ?? this.state?.currentStep;
 
 		let mode = inputMode.domainInput;
 		switch ( currentStep ) {
@@ -730,26 +731,27 @@ class DomainsStep extends Component {
 			return null;
 		}
 
-		const { isAllDomains, translate, sites, isReskinned } = this.props;
+		const { isAllDomains, translate, isReskinned } = this.props;
 		const source = get( this.props, 'queryObject.source' );
-		const hasSite = Object.keys( sites ).length > 0;
 		let backUrl;
 		let backLabelText;
 		let isExternalBackUrl = false;
 
-		const previousStepBackUrl = this.getPreviousStepUrl( this.state?.currentStep );
+		const previousStepBackUrl = this.getPreviousStepUrl();
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;
-		} else if ( 0 === this.props.positionInFlow && hasSite ) {
-			backUrl = '/sites/';
-			backLabelText = translate( 'Back to My Sites' );
-
-			if ( isAllDomains ) {
-				backUrl = domainManagementRoot();
-				backLabelText = translate( 'Back to All Domains' );
-			}
+		} else if ( isAllDomains ) {
+			backUrl = domainManagementRoot();
+			backLabelText = translate( 'Back to All Domains' );
 		} else {
+			backUrl = getStepUrl( this.props.flowName, this.props.stepName );
+
+			if ( backUrl === this.props.path ) {
+				backUrl = '/sites/';
+				backLabelText = translate( 'Back to My Sites' );
+			}
+
 			const externalBackUrl = getExternalBackUrl( source, this.props.stepSectionName );
 			if ( externalBackUrl ) {
 				backUrl = externalBackUrl;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -356,7 +356,7 @@ class DomainsStep extends Component {
 		this.props.goToNextStep();
 	};
 
-	handleAddTransfer = ( domain, authCode ) => {
+	handleAddTransfer = ( { domain, authCode } ) => {
 		const domainItem = domainTransfer( {
 			domain,
 			extra: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -10,6 +10,7 @@ import RegisterDomainStep from 'calypso/components/domains/register-domain-step'
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import TransferDomainStep from 'calypso/components/domains/transfer-domain-step';
+import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import UseYourDomainStep from 'calypso/components/domains/use-your-domain-step';
 import Notice from 'calypso/components/notice';
 import {
@@ -612,6 +613,16 @@ class DomainsStep extends Component {
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">
 				<CalypsoShoppingCartProvider>
+					<UseMyDomain
+						analyticsSection={ this.getAnalyticsSection() }
+						basePath={ this.props.path }
+						goBack={ () => {} }
+						initialQuery={ initialQuery }
+						isSignupStep
+						mapDomainUrl={ this.getMapDomainUrl() }
+						showHeader={ false }
+						onTransfer={ this.handleAddTransfer }
+					/>
 					<UseYourDomainStep
 						analyticsSection={ this.getAnalyticsSection() }
 						basePath={ this.props.path }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -121,7 +121,7 @@ class DomainsStep extends Component {
 		}
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
 		this.state = {
-			currentStep: inputMode.domainInput,
+			currentStep: null,
 		};
 	}
 
@@ -663,6 +663,12 @@ class DomainsStep extends Component {
 		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
+	resetState() {
+		if ( inputMode.domainInput === this.state?.step ) {
+			this.setState( {} );
+		}
+	}
+
 	renderContent() {
 		let content;
 		let sideContent;
@@ -672,6 +678,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
+			this.resetState();
 			content = this.domainForm();
 		}
 
@@ -702,6 +709,7 @@ class DomainsStep extends Component {
 	}
 
 	getPreviousStepUrl() {
+		if ( 'use-your-domain' !== this.props.stepSectionName ) return null;
 		const basePath = getStepUrl(
 			this.props.flowName,
 			this.props.stepName,
@@ -713,6 +721,7 @@ class DomainsStep extends Component {
 
 		let mode = inputMode.domainInput;
 		switch ( currentStep ) {
+			case null:
 			case inputMode.domainInput:
 				return null;
 
@@ -729,6 +738,10 @@ class DomainsStep extends Component {
 			`${ basePath }?step=${ mode }` +
 			( Object.keys( queryValues ).length ? `&${ stringify( { ...queryValues } ) }` : '' )
 		);
+	}
+
+	removeQueryParam( url ) {
+		return url.split( '?' )[ 0 ];
 	}
 
 	render() {
@@ -752,7 +765,7 @@ class DomainsStep extends Component {
 		} else {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, null, this.getLocale() );
 
-			if ( backUrl === this.props.path ) {
+			if ( backUrl === this.removeQueryParam( this.props.path ) ) {
 				backUrl = '/sites/';
 				backLabelText = translate( 'Back to My Sites' );
 			}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -579,7 +579,7 @@ class DomainsStep extends Component {
 
 	useYourDomainForm = () => {
 		const queryObject = parse( window.location.search.replace( '?', '' ) );
-		const initialQuery = get( this.props.step, 'domainForm.lastQuery' ) ?? queryObject.initialQuery;
+		const initialQuery = get( this.props.step, 'domainForm.lastQuery' ) || queryObject.initialQuery;
 
 		return (
 			<div className="domains__step-section-wrapper" key="useYourDomainForm">

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -12,6 +12,7 @@
 	& .use-my-domain__page-heading {
 		padding-left: 24px;
 		padding-right: 24px;
+		text-align: center;
 	}
 
 	& .use-my-domain,
@@ -189,6 +190,10 @@ body.is-section-signup.is-white-signup {
 
 		.search-component .search-component__icon-navigation {
 			padding: 0 7px;
+		}
+
+		.use-my-domain__page-heading {
+			text-align: left;
 		}
 	}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -4,6 +4,7 @@
 .domains__step-section-wrapper {
 	margin: 0 auto;
 	max-width: 720px;
+	width: 100%;
 }
 
 .is-section-signup .domains__step-content {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .domains__step-section-wrapper {
 	margin: 0 auto;
@@ -226,4 +227,59 @@ body.is-section-signup.is-white-signup {
 			display: none;
 		}
 	}
+}
+
+// blue signup flow-specific styles
+body.is-section-signup:not( .is-white-signup ) {
+	
+    .domains__step-content {
+	
+		a {
+			text-decoration: underline;
+			color: var( --color-text-inverted );
+		}
+
+        .domain-transfer-or-connect {
+
+			&__content {
+				
+				.option-content {
+		
+					&__illustration, &__main, &__action, &__header, &__top-text, &__pricing-text {
+						color: var( --color-text-inverted );
+					}
+
+					&__benefits-item-text, &__pricing-cost {
+						filter: brightness( 0.9 );
+					}
+
+					&__benefits-item .gridicon {
+						fill: var( --studio-green-20 );
+					}
+
+					& + .option-content {
+						border-color: var( --studio-gray-40 );
+					}
+		
+				}
+
+			}
+
+			&__support-link {
+				color: var( --color-text-inverted );
+				filter: brightness( 0.9 );
+			}
+
+		}
+
+		.use-my-domain {
+
+			.form-input-validation.is-error {
+				color: var( --color-error-30 );
+			}
+
+		}
+
+	}
+
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -15,7 +15,9 @@
 	}
 
 	& .use-my-domain,
+	& .connect-domain-step,
 	& .domain-transfer-or-connect__content {
+		background: transparent;
 		box-shadow: none;
 
 		@include break-mobile {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -227,6 +227,10 @@ body.is-section-signup.is-white-signup {
 			display: none;
 		}
 	}
+
+	.signup__step.is-domains {
+		padding: 0 20px;
+	}
 }
 
 // blue signup flow-specific styles

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -3,12 +3,26 @@
 
 .domains__step-section-wrapper {
 	margin: 0 auto;
-	max-width: 720px;
 	width: 100%;
 }
 
 .is-section-signup .domains__step-content {
 	margin-bottom: 50px;
+
+	& .use-my-domain__page-heading {
+		padding-left: 24px;
+		padding-right: 24px;
+	}
+
+	& .use-my-domain,
+	& .domain-transfer-or-connect__content {
+		box-shadow: none;
+
+		@include break-mobile {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
 
 	&.domains__step-content-domain-step {
 		margin-bottom: 20px;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -236,7 +236,12 @@ export class PlansStep extends Component {
 			};
 
 			backUrl =
-				getStepUrl( this.props.flowName, 'domains', 'use-your-domain' ) +
+				getStepUrl(
+					this.props.flowName,
+					'domains',
+					'use-your-domain',
+					! this.props.userLoggedIn ? this.props.locale : ''
+				) +
 				'?' +
 				stringify( queryParams );
 			backLabelText = translate( 'Back' );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -227,7 +227,7 @@ export class PlansStep extends Component {
 		}
 
 		let queryParams;
-		if ( 0 !== this.props.positionInFlow ) {
+		if ( ! isNaN( Number( positionInFlow ) ) && 0 !== positionInFlow ) {
 			const previousStepName = steps[ this.props.positionInFlow - 1 ];
 			const previousStep = this.props.progress?.[ previousStepName ];
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { intersection } from 'lodash';
 import PropTypes from 'prop-types';
-import { parse as parseQs } from 'qs';
+import { parse as parseQs, stringify } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -16,6 +16,7 @@ import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { getStepUrl } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
@@ -223,6 +224,22 @@ export class PlansStep extends Component {
 		if ( 0 === positionInFlow && hasInitializedSitesBackUrl ) {
 			backUrl = hasInitializedSitesBackUrl;
 			backLabelText = translate( 'Back to My Sites' );
+		}
+
+		const isComingFromUseYourDomainStep =
+			'use-your-domain' === this.props.progress?.domains?.stepSectionName;
+
+		if ( 0 !== this.props.positionInFlow && isComingFromUseYourDomainStep ) {
+			const queryParams = {
+				step: 'transfer-or-connect',
+				initialQuery: this.props.progress?.domains?.siteUrl,
+			};
+
+			backUrl =
+				getStepUrl( this.props.flowName, 'domains', 'use-your-domain' ) +
+				'?' +
+				stringify( queryParams );
+			backLabelText = translate( 'Back' );
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the onboading `use-your-domain` step to use the new flow already in use from the domain suggestions pages.

When selecting either the "Do you own it?" or the "Use a domain I own" links, the user will now be taken to the new steps to enter a domain and select whether they want to connect the domain or transfer it.

#### Testing instructions

Make sure that the flow works from both the `/start/domains` page and from the `/domains/add/use-my-domain` page (where it is already in use).

The pages should look something like this (depending on whether the selected domain is transferrable or not):
<img width="1792" alt="Screen Shot 2021-09-22 at 1 18 27 PM" src="https://user-images.githubusercontent.com/1379730/134394384-b9f8695c-73eb-45df-95d4-e1ac417583b0.png">


<img width="1792" alt="Screen Shot 2021-09-22 at 1 18 39 PM" src="https://user-images.githubusercontent.com/1379730/134394403-f3ae0227-6ed1-4ec8-8f9c-c9070aff3dd4.png">

Here is a screen recording showing selecting the domain for transfer:

https://user-images.githubusercontent.com/1379730/134394550-4e6249a8-cb9f-4d2e-98ab-9c87a9a07386.mov

And here is a screen recording showing selecting the domain for connecting (mapping):

https://user-images.githubusercontent.com/1379730/134394649-d0bd7137-6b41-4a36-88be-fabb5773a79e.mov

