### PR TITLE
Directly: Enable on Contact page, and enable for all English locales

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -364,11 +364,6 @@ class HelpContact extends React.Component {
 		return this.props.isHappychatAvailable && this.props.isHappychatUserEligible;
 	};
 
-	shouldUseDirectly = () => {
-		const isEn = this.props.currentUserLocale === 'en';
-		return isEn && ! this.props.isDirectlyFailed;
-	};
-
 	recordCompactSubmit = ( variation ) => {
 		if ( this.props.compact ) {
 			this.props.recordTracksEventAction( 'calypso_inlinehelp_contact_submit', {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -61,6 +61,7 @@ import getInlineHelpSupportVariation, {
 import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
 import getSupportLevel from 'calypso/state/selectors/get-support-level';
 import hasUserAskedADirectlyQuestion from 'calypso/state/selectors/has-user-asked-a-directly-question';
+import isDirectlyFailed from 'calypso/state/selectors/is-directly-failed';
 import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
 import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uninitialized';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
@@ -148,11 +149,7 @@ class HelpContact extends React.Component {
 	};
 
 	prepareDirectlyWidget = () => {
-		if (
-			this.hasDataToDetermineVariation() &&
-			this.props.supportVariation === SUPPORT_DIRECTLY &&
-			this.props.isDirectlyUninitialized
-		) {
+		if ( this.props.isDirectlyUninitialized ) {
 			this.props.initializeDirectly();
 		}
 	};
@@ -575,8 +572,9 @@ class HelpContact extends React.Component {
 			this.props.ticketSupportConfigurationReady || null != this.props.ticketSupportRequestError;
 		const happychatReadyOrDisabled =
 			! config.isEnabled( 'happychat' ) || this.props.isHappychatUserEligible !== null;
+		const directlyReadyOrError = this.props.isDirectlyReady || this.props.isDirectlyFailed;
 
-		return ticketReadyOrError && happychatReadyOrDisabled;
+		return ticketReadyOrError && happychatReadyOrDisabled && directlyReadyOrError;
 	};
 
 	shouldShowPreloadForm = () => {
@@ -751,6 +749,7 @@ export default connect(
 			getUserInfo: getHappychatUserInfo( state ),
 			hasHappychatLocalizedSupport: hasHappychatLocalizedSupport( state ),
 			hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
+			isDirectlyFailed: isDirectlyFailed( state ),
 			isDirectlyReady: isDirectlyReady( state ),
 			isDirectlyUninitialized: isDirectlyUninitialized( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { startsWith } from 'lodash';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
@@ -32,7 +31,10 @@ export default function getSupportVariation( state ) {
 		return SUPPORT_TICKET;
 	}
 
-	if ( startsWith( getCurrentUserLocale( state ), 'en' ) && isDirectlyReady( state ) ) {
+	if (
+		config( 'english_locales' ).includes( getCurrentUserLocale( state ) ) &&
+		isDirectlyReady( state )
+	) {
 		return SUPPORT_DIRECTLY;
 	}
 

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { startsWith } from 'lodash';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
@@ -31,7 +32,7 @@ export default function getSupportVariation( state ) {
 		return SUPPORT_TICKET;
 	}
 
-	if ( getCurrentUserLocale( state ) === 'en' && isDirectlyReady( state ) ) {
+	if ( startsWith( getCurrentUserLocale( state ), 'en' ) && isDirectlyReady( state ) ) {
 		return SUPPORT_DIRECTLY;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We'd notices two bugs in Directly:

1. We want it available for all English speakers, but it was only available for `en` and not `en-gb`
2. It was only showing on the FAB contact form, not the Contact page form (see pcbce7-1zv-p2)

This PR fixes both of those issues. This will likely double the number of contacts reaching Directly, so deployment should be paired with reducing Directly throttle by half, and monitoring closely for the following days to tune as needed.

#### Testing instructions

Test both the FAB contact form and Contact page (/help/contact) with a user having Chat and Ticket support, to make sure the experience for them is unchanged.

Then create a new user with no paid upgrades so they are not eligible for Chat or Tickets. Sandbox the public API and modify the response of `/help/directly/mine` to force Directly to be available or unavailable (to test both scenarios).

Set your Free user's language to `English`:
- When Directly is available, should get Directly in both the FAB and Contact page.
- When Directly is unavailable, should get Forums in both the FAB and Contact page.

Set your Free user's language to `English (UK)`:
- When Directly is available, should get Directly in both the FAB and Contact page.
- When Directly is unavailable, should get Forums in both the FAB and Contact page.

Set your Free user's language to any other language:
- Should get Forums in both FAB and Contact page, whether or not Directly is available.
