### PR TITLE
Support: Track all Contact Form submissions in a consistent way

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -93,6 +93,7 @@ export class HelpContactForm extends React.PureComponent {
 			value: PropTypes.any,
 			requestChange: PropTypes.func.isRequired,
 		} ),
+		variationSlug: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -164,6 +165,16 @@ export class HelpContactForm extends React.PureComponent {
 		if ( tracksEvent ) {
 			recordTracksEvent( tracksEvent, { selected_option: selectedOption } );
 		}
+	};
+
+	trackSubmit = () => {
+		const { compact, currentUserLocale, variationSlug } = this.props;
+
+		recordTracksEvent( 'calypso_contact_form_submit', {
+			compact,
+			currentUserLocale,
+			variationSlug,
+		} );
 	};
 
 	getSibylQuery = () => ( this.state.subject + ' ' + this.state.message ).trim();
@@ -394,6 +405,8 @@ export class HelpContactForm extends React.PureComponent {
 
 		const analyseSiteData = this.analyseSiteData();
 
+		this.trackSubmit();
+
 		this.props.onSubmit( {
 			howCanWeHelp,
 			howYouFeel,
@@ -429,6 +442,8 @@ export class HelpContactForm extends React.PureComponent {
 		this.props.recordTracksEventAction( 'calypso_happychat_a_b_native_ticket_selected', {
 			locale: currentUserLocale,
 		} );
+
+		this.trackSubmit();
 
 		this.props.additionalSupportOption.onSubmit( {
 			howCanWeHelp,

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -172,8 +172,8 @@ export class HelpContactForm extends React.PureComponent {
 
 		recordTracksEvent( 'calypso_contact_form_submit', {
 			compact,
-			currentUserLocale,
-			variationSlug,
+			locale: currentUserLocale,
+			support_variation: variationSlug,
 		} );
 	};
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -537,6 +537,7 @@ class HelpContact extends React.Component {
 				value: savedContactForm,
 				requestChange: ( contactForm ) => ( savedContactForm = contactForm ),
 			},
+			variationSlug,
 		};
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a new Tracks events that's embedded right in the Contact Form component, to track every time the form is submitted. It passes along a few custom properties:

- `compact` — Tells whether the submission was from the full Contact page, or the FAB / Inline Help
- `locale` — The user's locale (useful to debug localized support concerns)
- `support_variation` — Which variant of support this was (Ticket / Chat / Directly / Forum / Overflow / Upwork)

This will give more visibility and trackability into our inbound support requests.

#### Testing instructions

Submit both the FAB / Inline Help contact form, and the Contact page form (/help/contact) from a few users with different levels of support. Watch Tracks Live for the `calypso_contact_form_submit` event to make sure it's coming through. Make sure the support request has made it through.