### PR TITLE
Shopping Cart: Do not update cart when contact details have not changed

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -220,9 +220,9 @@ export default function WPCheckout( {
 			} );
 		} else {
 			updateLocation( {
-				countryCode: contactInfo.countryCode?.value ?? '',
-				postalCode: contactInfo.postalCode?.value ?? '',
-				subdivisionCode: contactInfo.state?.value ?? '',
+				countryCode: contactInfo.countryCode?.value || undefined,
+				postalCode: contactInfo.postalCode?.value || undefined,
+				subdivisionCode: contactInfo.state?.value || undefined,
 			} );
 		}
 	}, [ activePaymentMethod, updateLocation, contactInfo ] );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -219,13 +219,17 @@ export default function WPCheckout( {
 				subdivisionCode: '',
 			} );
 		} else {
+			// The tax form does not include a subdivisionCode field but the server
+			// will sometimes fill it in so we should not try to update it when the
+			// field does not exist.
+			const subdivisionCode = contactDetailsType === 'tax' ? undefined : contactInfo.state?.value;
 			updateLocation( {
-				countryCode: contactInfo.countryCode?.value || undefined,
-				postalCode: contactInfo.postalCode?.value || undefined,
-				subdivisionCode: contactInfo.state?.value || undefined,
+				countryCode: contactInfo.countryCode?.value,
+				postalCode: contactInfo.postalCode?.value,
+				subdivisionCode,
 			} );
 		}
-	}, [ activePaymentMethod, updateLocation, contactInfo ] );
+	}, [ activePaymentMethod, updateLocation, contactInfo, contactDetailsType ] );
 
 	useUpdateCartLocationWhenPaymentMethodChanges( activePaymentMethod, updateCartContactDetails );
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -220,8 +220,8 @@ export default function WPCheckout( {
 			} );
 		} else {
 			// The tax form does not include a subdivisionCode field but the server
-			// will sometimes fill it in so we should not try to update it when the
-			// field does not exist.
+			// will sometimes fill in the value on the cart itself so we should not
+			// try to update it when the field does not exist.
 			const subdivisionCode = contactDetailsType === 'tax' ? undefined : contactInfo.state?.value;
 			updateLocation( {
 				countryCode: contactInfo.countryCode?.value,

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -347,7 +347,6 @@ export class UpsellNudge extends React.Component {
 			this.props.shoppingCartManager.updateLocation( {
 				countryCode,
 				postalCode,
-				subdivisionCode: null,
 			} );
 			this.props.shoppingCartManager.replaceProductsInCart( [ this.props.product ] );
 			return;

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -132,20 +132,14 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		postal_code: oldPostalCode = '',
 		subdivision_code: oldSubdivisionCode = '',
 	} = cart.tax?.location;
-	if (
-		location.countryCode === undefined &&
-		location.postalCode === undefined &&
-		location.subdivisionCode === undefined
-	) {
-		return false;
-	}
-	if ( newCountryCode !== oldCountryCode ) {
+
+	if ( location.countryCode !== undefined && newCountryCode !== oldCountryCode ) {
 		return true;
 	}
-	if ( newPostalCode !== oldPostalCode ) {
+	if ( location.postalCode !== undefined && newPostalCode !== oldPostalCode ) {
 		return true;
 	}
-	if ( newSubdivisionCode !== oldSubdivisionCode ) {
+	if ( location.subdivisionCode !== undefined && newSubdivisionCode !== oldSubdivisionCode ) {
 		return true;
 	}
 	return false;

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -122,15 +122,30 @@ export function doesCartLocationDifferFromResponseCartLocation(
 	cart: TempResponseCart,
 	location: CartLocation
 ): boolean {
-	const { countryCode, postalCode, subdivisionCode } = location;
-	const isMissing = ( value: null | undefined | string ) => value === null || value === undefined;
-	if ( ! isMissing( countryCode ) && cart.tax.location.country_code !== countryCode ) {
+	const {
+		countryCode: newCountryCode = '',
+		postalCode: newPostalCode = '',
+		subdivisionCode: newSubdivisionCode = '',
+	} = location;
+	const {
+		country_code: oldCountryCode = '',
+		postal_code: oldPostalCode = '',
+		subdivision_code: oldSubdivisionCode = '',
+	} = cart.tax?.location;
+	if (
+		location.countryCode === undefined &&
+		location.postalCode === undefined &&
+		location.subdivisionCode === undefined
+	) {
+		return false;
+	}
+	if ( newCountryCode !== oldCountryCode ) {
 		return true;
 	}
-	if ( ! isMissing( postalCode ) && cart.tax.location.postal_code !== postalCode ) {
+	if ( newPostalCode !== oldPostalCode ) {
 		return true;
 	}
-	if ( ! isMissing( subdivisionCode ) && cart.tax.location.subdivision_code !== subdivisionCode ) {
+	if ( newSubdivisionCode !== oldSubdivisionCode ) {
 		return true;
 	}
 	return false;

--- a/packages/shopping-cart/src/shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/shopping-cart-reducer.ts
@@ -271,7 +271,12 @@ function shoppingCartReducer(
 
 		case 'SET_LOCATION':
 			if ( doesCartLocationDifferFromResponseCartLocation( state.responseCart, action.location ) ) {
-				debug( 'setting location on cart', action.location );
+				debug(
+					'changing location on cart from',
+					state.responseCart.tax.location,
+					'to',
+					action.location
+				);
 				return {
 					...state,
 					responseCart: addLocationToResponseCart( state.responseCart, action.location ),

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -319,9 +319,9 @@ export interface IntroductoryOfferTerms {
 }
 
 export interface CartLocation {
-	countryCode: string | null;
-	postalCode: string | null;
-	subdivisionCode: string | null;
+	countryCode?: string;
+	postalCode?: string;
+	subdivisionCode?: string;
 }
 
 export interface ResponseCartProductExtra {

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -240,6 +240,13 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 		);
 		expect( result ).toBe( false );
 	} );
+	it( 'returns false if all are the same, subdivisionCode is missing, and remote subdivisionCode is not missing', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			postalCode: '90210',
+		} );
+		expect( result ).toBe( false );
+	} );
 	it( 'returns false if no new location codes are provided and a remote location exists', function () {
 		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
 			countryCode: undefined,

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -199,7 +199,48 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 		} );
 		expect( result ).toBe( false );
 	} );
-	it( 'returns false if no location codes are provided', function () {
+	it( 'returns false if all are the same and subdivisionCode is empty', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation(
+			{
+				...cartWithLocation,
+				tax: {
+					...cartWithLocation.tax,
+					location: {
+						country_code: 'US',
+						subdivision_code: '',
+						postal_code: '90210',
+					},
+				},
+			},
+			{
+				countryCode: 'US',
+				subdivisionCode: '',
+				postalCode: '90210',
+			}
+		);
+		expect( result ).toBe( false );
+	} );
+	it( 'returns false if all are the same, subdivisionCode is empty, and remote subdivisionCode is missing', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation(
+			{
+				...cartWithLocation,
+				tax: {
+					...cartWithLocation.tax,
+					location: {
+						country_code: 'US',
+						postal_code: '90210',
+					},
+				},
+			},
+			{
+				countryCode: 'US',
+				subdivisionCode: '',
+				postalCode: '90210',
+			}
+		);
+		expect( result ).toBe( false );
+	} );
+	it( 'returns false if no new location codes are provided and a remote location exists', function () {
 		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
 			countryCode: undefined,
 			subdivisionCode: undefined,


### PR DESCRIPTION
#### Summary

In brief, this makes checkout load faster if there are cached contact details by not requiring an extra shopping cart request.

#### Changes proposed in this Pull Request

When checkout first loads, it downloads the current version of the shopping cart, which includes tax location data in the form of country code, postal code, and subdivision code. Currently, subdivision code is not used by the checkout tax form, so assuming no domains are in the cart, it will always be `undefined`. Next, if there are saved contact details, checkout validates them and then updates the cart with their values. As mentioned, if no domain in the cart, this includes only the country code and postal code. Currently, undefined contact fields are passed to the shopping cart as empty strings instead.

When the location update request reaches the shopping cart manager, it checks to see if the requested location matches the one already in the cart. This prevents making unnecessary cart updates when the update would have no effect. Unfortunately there are a few issues with this process that can cause the check to think that the contact details have changed when they have not.

First, the request always includes all three location properties, and if the previously saved cart has no subdivision, the cart manager notices that the old `undefined` subdivision doesn't match the new `''` subdivision, concluding that the location has changed and submitting an unnecessary update. This PR modifies the location comparison function to treat `undefined` as equal to `''` and so that it ignores updates to fields which are not requested.

Second, the endpoint itself sometimes fills in the subdivision code before returning data. So if you submit a postal code of `10001` and a country code of `US`, the shopping cart response will also include a subdivision of `NY`. Since the tax contact form does not include a subdivision field, this data is ignored. When the form is next submitted, however, it submits an empty string as the subdivision code, and the cart manager correctly notices that `'NY'` does not match `''`, concludes that the location has changed, and submits an unnecessary update. This PR modifies the submission code to avoid touching the subdivision code at all if the tax form is being submitted.

#### Testing instructions

- Use an account which has saved contact details (you've made a previous purchase).
- Have your browser's network devtools open to look for calls to the `/me/shopping-cart` endpoint.
- Visit checkout with a non-domain product in the cart.
- Verify that you see one `GET` request (this may occur before you reach checkout if coming from another page) and no `POST` request to the `/me/shopping-cart` endpoint.
- Modify the postal code in the checkout contact form and submit the changes.
- Verify that you see one new `POST` request to the endpoint.
- Edit the contact form again and submit the changes without altering the fields.
- Verify that you see no new `POST` requests to the endpoint.