### PR TITLE
Remove background colour from skip button in design picker

### DIFF
--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -57,4 +57,8 @@
 			}
 		}
 	}
+
+	.action-buttons {
+		background-color: transparent;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The reskinned design picker has an off-white background, but the `.action-button` that contains the skip button comes with a white background.

A bit subtle, but it annoyed me.

* Made the `.action-button` background transparent when the UI is reskinned.

**Before**

<img width="1142" alt="Screenshot 2021-09-20 at 2 51 44 PM" src="https://user-images.githubusercontent.com/1500769/133953482-1be9cf1d-20e7-4d1f-b032-de501b725636.png">

**After**


<img width="1110" alt="Screenshot 2021-09-20 at 3 02 46 PM" src="https://user-images.githubusercontent.com/1500769/133953506-ffe029b6-0196-468b-b730-babb723100e3.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with `/start?flags=signup/setup-site-after-checkout`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


