### PR TITLE
calypso-build: use global default for publicPath of file assets

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## trunk
 
-- Droped `cache-loader`, as it is not compatible with Webpack 5.
+- Dropped `cache-loader`, as it is not compatible with Webpack 5.
 - Dropped `cacheDirectory` option in Sass loader
 - Updated dependencies:
   - sass to ^1.37.5
   - sass-loader to ^12.1.0
 - Set `quietDeps: true` in dart sass options. This avoids printing deprecation
   warnings for stylesheets imported from node_modules.
+- Stopped defaulting `publicPath` option to `/` in `webpack/file-loader`, using the global default that treats paths as relative to the importing script URL.
 
 ## 9.0.0
 

--- a/packages/calypso-build/webpack/file-loader.js
+++ b/packages/calypso-build/webpack/file-loader.js
@@ -13,7 +13,7 @@ const path = require( 'path' );
 module.exports.loader = ( {
 	outputPath = 'images/',
 	name = '[name]-[hash][ext]',
-	publicPath = '/',
+	publicPath,
 	emitFile = true,
 } = {} ) => ( {
 	test: /\.(?:gif|jpg|jpeg|png|svg)$/i,


### PR DESCRIPTION
The `FileLoader` config in `calypso-build` defaults the `publicPath` for image assets to `/`. We never want that, most webpack configs provide a different value, and the default is difficult to reset -- Jetpack [has a patch](https://github.com/Automattic/jetpack/pull/20972) by @sdixon194 that does exactly that. So this PR removes the default.

How this option manifests in an observable way: let's say we build the `wpcom-block-editor` with `calypso-build` and it produces the following folder:
```
dist/
  wpcom.editor.min.js
  images/
    icon.svg
```
We deploy the `dist` folder to `widgets.wp.com` and the assets have URLs:
```
https://widgets.wp.com/wpcom-block-editor/wpcom.editor.min.js
https://widgets.wp.com/wpcom-block-editor/images/icon.svg
```
Now when `publicPath` was `/` and the webpack-produced script was constructing an URL for the image, it would construct
```
/images/icon.svg
```
because we specified the path to be absolute. But that wouldn't work because the file at `https://widgets.wp.com/images/icon.svg` isn't there? What we really want is to use a path relative to the importing script, i.e.,
```
images/icon.svg
```
that resolves to the right URL.

**How to test:**
I've been looking for usages of `calypso-build` that i) use the default `file-loader` without overriding `publicPath` and ii) import some image assets like SVGs. And I found only one: the `wpcom-block-editor-nux` plugin in Editing Toolkit. It loads images like `block-picker.svg` and my reasoning is that these URLs were broken and this PR fixes them. @noahtallen @simison @ramonjd can you confirm whether `wpcom-block-editor-nux` is used at all these days? I don't know where it's loaded and under what circumstances.