### PR TITLE
Editor Welcome Tour: Esc key to dismiss tour when minimised

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-focus-handler.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-focus-handler.ts
@@ -32,8 +32,7 @@ const useFocusHandler = ( ref: React.MutableRefObject< null | HTMLElement > ): b
 
 	const handleKeyup = useCallback(
 		( event ) => {
-			// Spacebar & ' ' are for space. See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
-			if ( [ 'Tab', 'Enter', 'Spacebar', ' ' ].includes( event.key ) ) {
+			if ( event.key === 'Tab' ) {
 				if ( ref.current?.contains( event.target ) ) {
 					setHasFocus( true );
 				} else {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-focus-handler.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-focus-handler.ts
@@ -32,7 +32,8 @@ const useFocusHandler = ( ref: React.MutableRefObject< null | HTMLElement > ): b
 
 	const handleKeyup = useCallback(
 		( event ) => {
-			if ( event.key === 'Tab' ) {
+			// Spacebar & ' ' are for space. See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
+			if ( [ 'Tab', 'Enter', 'Spacebar', ' ' ].includes( event.key ) ) {
 				if ( ref.current?.contains( event.target ) ) {
 					setHasFocus( true );
 				} else {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-keydown-handler.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-keydown-handler.ts
@@ -23,7 +23,7 @@ const useKeydownHandler = ( { onEscape, onArrowRight, onArrowLeft }: Props ): vo
 					onEscape && ( onEscape(), ( handled = true ) );
 					break;
 				case 'ArrowRight':
-					onArrowRight && ( onArrowRight(), ( handled = false ) );
+					onArrowRight && ( onArrowRight(), ( handled = true ) );
 					break;
 				case 'ArrowLeft':
 					onArrowLeft && ( onArrowLeft(), ( handled = true ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-keydown-handler.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/hooks/use-keydown-handler.ts
@@ -4,30 +4,29 @@
  */
 import { useEffect, useCallback } from '@wordpress/element';
 
+interface Props {
+	onEscape?: () => void;
+	onArrowRight?: () => void;
+	onArrowLeft?: () => void;
+}
+
 /**
  * A hook the applies the respective callbacks in response to keydown events.
  */
-const useKeydownHandler = (
-	onEscape: () => void,
-	onArrowRight: () => void,
-	onArrowLeft: () => void
-): void => {
+const useKeydownHandler = ( { onEscape, onArrowRight, onArrowLeft }: Props ): void => {
 	const handleKeydown = useCallback(
 		( event: KeyboardEvent ) => {
 			let handled = false;
 
 			switch ( event.key ) {
 				case 'Escape':
-					onEscape();
-					handled = true;
+					onEscape && ( onEscape(), ( handled = true ) );
 					break;
 				case 'ArrowRight':
-					onArrowRight();
-					handled = true;
+					onArrowRight && ( onArrowRight(), ( handled = false ) );
 					break;
 				case 'ArrowLeft':
-					onArrowLeft();
-					handled = true;
+					onArrowLeft && ( onArrowLeft(), ( handled = true ) );
 					break;
 				default:
 					break;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/keyboard-navigation.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/keyboard-navigation.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+/**
+ * Internal dependencies
+ */
+import useFocusHandler from './hooks/use-focus-handler';
+import useKeydownHandler from './hooks/use-keydown-handler';
+
+interface Props {
+	onMinimize: () => void;
+	onDismiss: ( target: string ) => () => void;
+	onNextCardProgression: () => void;
+	onPreviousCardProgression: () => void;
+	focusRef: React.MutableRefObject< null | HTMLElement >;
+	isMinimized: boolean;
+}
+
+const KeyboardNavigation: React.FunctionComponent< Props > = ( {
+	onMinimize,
+	onDismiss,
+	onNextCardProgression,
+	onPreviousCardProgression,
+	focusRef,
+	isMinimized,
+} ) => {
+	function ExpandedTourNav() {
+		useKeydownHandler( {
+			onEscape: onMinimize,
+			onArrowRight: onNextCardProgression,
+			onArrowLeft: onPreviousCardProgression,
+		} );
+		return null;
+	}
+
+	function MinimizedTourNav() {
+		useKeydownHandler( { onEscape: onDismiss( 'esc-key' ) } );
+		return null;
+	}
+
+	const isTourFocused = useFocusHandler( focusRef );
+
+	if ( ! isTourFocused ) {
+		return null;
+	}
+
+	return isMinimized ? <MinimizedTourNav /> : <ExpandedTourNav />;
+};
+
+export default KeyboardNavigation;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/keyboard-navigation.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/keyboard-navigation.tsx
@@ -13,7 +13,7 @@ interface Props {
 	onDismiss: ( target: string ) => () => void;
 	onNextCardProgression: () => void;
 	onPreviousCardProgression: () => void;
-	focusRef: React.MutableRefObject< null | HTMLElement >;
+	tourContainerRef: React.MutableRefObject< null | HTMLElement >;
 	isMinimized: boolean;
 }
 
@@ -22,7 +22,7 @@ const KeyboardNavigation: React.FunctionComponent< Props > = ( {
 	onDismiss,
 	onNextCardProgression,
 	onPreviousCardProgression,
-	focusRef,
+	tourContainerRef,
 	isMinimized,
 } ) => {
 	function ExpandedTourNav() {
@@ -35,11 +35,11 @@ const KeyboardNavigation: React.FunctionComponent< Props > = ( {
 	}
 
 	function MinimizedTourNav() {
-		useKeydownHandler( { onEscape: onDismiss( 'esc-key' ) } );
+		useKeydownHandler( { onEscape: onDismiss( 'esc-key-minimized' ) } );
 		return null;
 	}
 
-	const isTourFocused = useFocusHandler( focusRef );
+	const isTourFocused = useFocusHandler( tourContainerRef );
 
 	if ( ! isTourFocused ) {
 		return null;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -114,7 +114,7 @@ function CardNavigation( {
 			/>
 			<div>
 				{ currentCardIndex === 0 ? (
-					<Button isTertiary={ true } onClick={ () => onDismiss( 'no-thanks-btn' ) }>
+					<Button isTertiary={ true } onClick={ onDismiss( 'no-thanks-btn' ) }>
 						{ __( 'Skip', 'full-site-editing' ) }
 					</Button>
 				) : (
@@ -154,7 +154,7 @@ function CardOverlayControls( { onMinimize, onDismiss } ) {
 					isPrimary
 					icon={ close }
 					iconSize={ 24 }
-					onClick={ () => onDismiss( 'close-btn' ) }
+					onClick={ onDismiss( 'close-btn' ) }
 				></Button>
 			</Flex>
 		</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -11,9 +11,8 @@ import { Icon } from '@wordpress/icons';
 /**
  * Internal Dependencies
  */
-import useFocusHandler from './hooks/use-focus-handler';
-import useKeydownHandler from './hooks/use-keydown-handler';
 import maximize from './icons/maximize';
+import KeyboardNavigation from './keyboard-navigation';
 import WelcomeTourCard from './tour-card';
 import getTourContent from './tour-content';
 
@@ -61,23 +60,6 @@ function LaunchWpcomWelcomeTour() {
 	return <div>{ createPortal( <WelcomeTourFrame />, portalParent ) }</div>;
 }
 
-function KeyboardNavigation( {
-	onMinimize,
-	onNextCardProgression,
-	onPreviousCardProgression,
-	focusRef,
-	isMinimized,
-} ) {
-	function KeydownHandler() {
-		useKeydownHandler( onMinimize, onNextCardProgression, onPreviousCardProgression );
-		return null;
-	}
-
-	const isTourFocused = useFocusHandler( focusRef );
-
-	return isTourFocused && ! isMinimized ? <KeydownHandler /> : null;
-}
-
 function WelcomeTourFrame() {
 	const ref = useRef( null );
 	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
@@ -90,12 +72,14 @@ function WelcomeTourFrame() {
 	const isGutenboarding = window.calypsoifyGutenberg?.isGutenboarding;
 
 	const handleDismiss = ( source ) => {
-		recordTracksEvent( 'calypso_editor_wpcom_tour_dismiss', {
-			is_gutenboarding: isGutenboarding,
-			slide_number: currentCardIndex + 1,
-			action: source,
-		} );
-		setShowWelcomeGuide( false, { openedManually: false } );
+		return () => {
+			recordTracksEvent( 'calypso_editor_wpcom_tour_dismiss', {
+				is_gutenboarding: isGutenboarding,
+				slide_number: currentCardIndex + 1,
+				action: source,
+			} );
+			setShowWelcomeGuide( false, { openedManually: false } );
+		};
 	};
 
 	const handleNextCardProgression = () => {
@@ -132,6 +116,7 @@ function WelcomeTourFrame() {
 		<>
 			<KeyboardNavigation
 				onMinimize={ handleMinimize }
+				onDismiss={ handleDismiss }
 				onNextCardProgression={ handleNextCardProgression }
 				onPreviousCardProgression={ handlePreviousCardProgression }
 				focusRef={ ref }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -61,7 +61,7 @@ function LaunchWpcomWelcomeTour() {
 }
 
 function WelcomeTourFrame() {
-	const ref = useRef( null );
+	const tourContainerRef = useRef( null );
 	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentCardIndex, setCurrentCardIndex ] = useState( 0 );
@@ -119,10 +119,10 @@ function WelcomeTourFrame() {
 				onDismiss={ handleDismiss }
 				onNextCardProgression={ handleNextCardProgression }
 				onPreviousCardProgression={ handlePreviousCardProgression }
-				focusRef={ ref }
+				tourContainerRef={ tourContainerRef }
 				isMinimized={ isMinimized }
 			/>
-			<div className="wpcom-editor-welcome-tour-frame" ref={ ref }>
+			<div className="wpcom-editor-welcome-tour-frame" ref={ tourContainerRef }>
 				{ ! isMinimized ? (
 					<>
 						<WelcomeTourCard


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Improves tour close-out: Use Esc key to dismiss when minimized. 
Partly addresses #56168. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the editor, open the sidebar, and from there click on "Welcome Guide".
- Focus and minimize the tour: Press Esc in expanded view or click the minimize button in the panel. †
- Press Esc again to dismiss the tour entirely.
- An "esc-key" Tracks event should be recorded.

† If the tour is minimized and the focus elsewhere, tabbing into it should give it focus.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56168
