### PR TITLE
Notifications: assign key to fallback notes

### DIFF
--- a/apps/notifications/src/panel/templates/body.jsx
+++ b/apps/notifications/src/panel/templates/body.jsx
@@ -122,7 +122,7 @@ export class NoteBody extends React.Component {
 					replyBlock = <ReplyBlock key={ blockKey } block={ block.block } />;
 					break;
 				default:
-					body.push( p( html( block.block ) ) );
+					body.push( <div key={ blockKey }>{ p( html( block.block ) ) }</div> );
 					break;
 			}
 		}


### PR DESCRIPTION
When building the notification body for default notes (i.e. billing and stat notes) this assigns a unique key to each block in the note body.

**To test:**
- click on a billing-related note (you can send one to yourself using the pre-renewal notification preview tool in MC)
- verify that you don't see a `Warning: Each child in a list should have a unique "key" prop` warning in the console