### PR TITLE
P2: customize login page

### DIFF
--- a/client/assets/stylesheets/_p2-extends.scss
+++ b/client/assets/stylesheets/_p2-extends.scss
@@ -58,6 +58,21 @@
 	}
 }
 
+%p2-form-input-validation {
+	font-size: var( --p2-font-size-form-xxs );
+	line-height: 1.5;
+	padding: 8px 0 0 2px;
+	margin-bottom: 1rem;
+
+	svg {
+		display: none;
+	}
+
+	&.is-error {
+		color: var( --p2-color-error );
+	}
+}
+
 // Button
 %p2-form-button {
 	background-color: var( --p2-color-button );

--- a/client/assets/stylesheets/_p2-extends.scss
+++ b/client/assets/stylesheets/_p2-extends.scss
@@ -13,21 +13,21 @@
 	line-height: 1.5;
 	padding: 14px 16px;
 
-	&:hover,
-	&:focus {
+	&:hover:enabled,
+	&:focus:enabled {
 		border-color: var( --p2-color-link );
 	}
 
-	&:focus,
-	&:focus:hover {
+	&:focus:enabled,
+	&:focus:hover:enabled {
 		box-shadow: 0 0 0 1px var( --p2-color-link );
 	}
 
 	&.is-error {
 		border-color: var( --p2-color-error );
 
-		&:focus,
-		&:focus:hover {
+		&:focus:enabled,
+		&:focus:hover:enabled {
 			box-shadow: 0 0 0 1px var( --p2-color-error );
 		}
 	}
@@ -104,10 +104,17 @@
 		&:focus {
 			background-color: var( --p2-color-link-dark );
 		}
+
+		&[disabled] {
+			opacity: 0.5;
+			background-color: var( --p2-color-link );
+			color: var( --p2-color-white );
+		}
 	}
 
 	&[disabled] {
 		background-color: var( --p2-color-button );
+		color: var( --p2-color-text-light );
 		cursor: default;
 	}
 }

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -200,6 +200,7 @@ class Login extends Component {
 			isJetpack,
 			isGutenboarding,
 			isJetpackWooCommerceFlow,
+			isP2Login,
 			wccomFrom,
 			isManualRenewalImmediateLoginAttempt,
 			linkingSocialService,
@@ -367,6 +368,13 @@ class Login extends Component {
 		} else if ( fromSite ) {
 			// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
 			postHeader = <VisitSite siteSlug={ fromSite } />;
+		} else if ( isP2Login ) {
+			headerText = translate( 'Log in' );
+			postHeader = (
+				<p className="login__header-subtitle">
+					{ translate( 'Enter your details to log in to your account.' ) }
+				</p>
+			);
 		}
 
 		if ( isGutenboarding ) {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -481,12 +481,13 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client } = this.props;
+		const { isJetpack, isP2Login, oauth2Client } = this.props;
 		return (
 			<div
 				className={ classNames( 'login', {
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
+					'is-p2': isP2Login,
 				} ) }
 			>
 				{ this.renderHeader() }

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -423,6 +423,7 @@ class Login extends Component {
 			domain,
 			isJetpack,
 			isGutenboarding,
+			isP2Login,
 			privateSite,
 			twoFactorAuthType,
 			twoFactorEnabled,
@@ -476,6 +477,7 @@ class Login extends Component {
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
 				isGutenboarding={ isGutenboarding }
+				isP2Login={ isP2Login }
 				locale={ locale }
 				userEmail={ userEmail }
 				handleUsernameChange={ handleUsernameChange }

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -489,13 +489,12 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, isP2Login, oauth2Client } = this.props;
+		const { isJetpack, oauth2Client } = this.props;
 		return (
 			<div
 				className={ classNames( 'login', {
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
-					'is-p2': isP2Login,
 				} ) }
 			>
 				{ this.renderHeader() }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -440,6 +440,27 @@ export class LoginForm extends Component {
 		);
 	}
 
+	renderChangeUsername() {
+		return (
+			<button type="button" className="login__form-change-username" onClick={ this.resetView }>
+				<Gridicon icon="arrow-left" size={ 18 } />
+				{ includes( this.state.usernameOrEmail, '@' )
+					? this.props.translate( 'Change Email Address' )
+					: this.props.translate( 'Change Username' ) }
+			</button>
+		);
+	}
+
+	renderUsernameorEmailLabel() {
+		if ( this.props.isP2Login ) {
+			return this.props.translate( 'Your email address or username' );
+		}
+
+		return this.isPasswordView()
+			? this.renderChangeUsername()
+			: this.props.translate( 'Email Address or Username' );
+	}
+
 	render() {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 
@@ -450,6 +471,7 @@ export class LoginForm extends Component {
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
 			isGutenboarding,
+			isP2Login,
 			isJetpackWooDnaFlow,
 			wccomFrom,
 			currentRoute,
@@ -503,22 +525,7 @@ export class LoginForm extends Component {
 								) }
 							</p>
 						) }
-						<FormLabel htmlFor="usernameOrEmail">
-							{ this.isPasswordView() ? (
-								<button
-									type="button"
-									className="login__form-change-username"
-									onClick={ this.resetView }
-								>
-									<Gridicon icon="arrow-left" size={ 18 } />
-									{ includes( this.state.usernameOrEmail, '@' )
-										? this.props.translate( 'Change Email Address' )
-										: this.props.translate( 'Change Username' ) }
-								</button>
-							) : (
-								this.props.translate( 'Email Address or Username' )
-							) }
-						</FormLabel>
+						<FormLabel htmlFor="usernameOrEmail">{ this.renderUsernameorEmailLabel() }</FormLabel>
 
 						<FormTextInput
 							autoCapitalize="off"
@@ -558,6 +565,8 @@ export class LoginForm extends Component {
 									) }
 							</FormInputValidation>
 						) }
+
+						{ isP2Login && this.isPasswordView() && this.renderChangeUsername() }
 
 						<div
 							className={ classNames( 'login__form-password', {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -267,9 +267,67 @@
 .layout.is-p2-login {
 	background: #fff;
 
+	.wp-login__main.main {
+		max-width: 450px;
+	}
+
 	.login__form-header {
 		margin-bottom: 5px;
 		font-weight: 700;
 		font-size: var( --p2-font-size-form-xl );
+	}
+
+	.login__form-terms {
+		margin-top: 24px;
+		margin-bottom: 8px;
+	}
+
+	.login__form, .login__social {
+		box-shadow: none;
+	}
+
+	.login button {
+		border-radius: 50px; /* stylelint-disable-line */
+		margin: 0 0 12px;
+		width: 100%;
+		display: flex;
+		justify-content: center;
+		font-size: var( --p2-font-size-form-s );
+		background-color: var( --p2-color-button );
+		color: var( --p2-color-text );
+		border: none;
+		padding: 16px 24px;
+		line-height: 1.3;
+		transition: 0.2s ease-in-out;
+
+		&:hover {
+			background-color: var( --p2-color-button-dark );
+		}
+
+		&.is-primary {
+			color: #fff;
+			background-color: var( --p2-color-link );
+
+			&:hover {
+				background-color: var( --p2-color-link-dark );
+			}
+		}
+	}
+
+	.wp-login__links {
+		display: flex;
+
+		a {
+			border-bottom: none;
+			font-size: var( --p2-font-size-form-xs );
+			font-weight: 400;
+			padding: 24px 4px;
+			text-decoration: underline;
+			color: var( --p2-color-link );
+
+			&:hover {
+				color: var( --p2-color-link-dark );
+			}
+		}
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -263,3 +263,13 @@
 	position: initial;
 	text-transform: initial;
 }
+
+.layout.is-p2-login {
+	background: #fff;
+
+	.login__form-header {
+		margin-bottom: 5px;
+		font-weight: 700;
+		font-size: var( --p2-font-size-form-xl );
+	}
+}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -277,6 +277,10 @@
 		padding: 0 25px;
 	}
 
+	.form-text-input {
+		@extend %p2-form-input-text;
+	}
+
 	.login__form-header {
 		margin-bottom: 5px;
 		font-weight: 700;
@@ -294,6 +298,14 @@
 
 	.login button {
 		@extend %p2-form-button;
+
+		&.login__form-change-username {
+			background: none;
+			color: var( --p2-color-link );
+			font-size: var( --p2-font-size-form-xs );
+			padding: 12px 0;
+			width: auto;
+		}
 	}
 
 	.wp-login__links {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -281,6 +281,10 @@
 		@extend %p2-form-input-text;
 	}
 
+	.form-input-validation {
+		@extend %p2-form-input-validation;
+	}
+
 	.form-password-input {
 		@extend %p2-form-input-password;
 	}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -293,7 +293,7 @@
 
 	.login__form-terms {
 		margin-top: 24px;
-		margin-bottom: 8px;
+		margin-bottom: 1rem;
 	}
 
 	.login__form, .login__social {
@@ -320,18 +320,20 @@
 			border-bottom: none;
 			font-size: var( --p2-font-size-form-xs );
 			font-weight: 400;
-			padding: 24px 4px;
+			margin: 24px 4px;
+			padding: 0;
 		}
 	}
 
 	.login__divider {
 		color: var( --p2-color-border );
 		font-size: var( --p2-font-size-form-xs );
-		margin: 0 auto;
+		margin: 0 auto 1rem;
 		max-width: 400px;
 		overflow: hidden;
 		text-align: center;
 		width: 100%;
+		text-transform: none;
 
 		&::before,
 		&::after {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import 'calypso/assets/stylesheets/_p2-extends.scss';
 
 .layout:not( .is-jetpack-woocommerce-flow ):not( .is-jetpack-woo-dna-flow ):not( .is-wccom-oauth-flow ) {
 	.login.is-jetpack {
@@ -268,7 +269,12 @@
 	background: #fff;
 
 	.wp-login__main.main {
-		max-width: 450px;
+		max-width: 490px;
+		padding: 0 20px;
+	}
+
+	form {
+		padding: 0 25px;
 	}
 
 	.login__form-header {
@@ -287,47 +293,18 @@
 	}
 
 	.login button {
-		border-radius: 50px; /* stylelint-disable-line */
-		margin: 0 0 12px;
-		width: 100%;
-		display: flex;
-		justify-content: center;
-		font-size: var( --p2-font-size-form-s );
-		background-color: var( --p2-color-button );
-		color: var( --p2-color-text );
-		border: none;
-		padding: 16px 24px;
-		line-height: 1.3;
-		transition: 0.2s ease-in-out;
-
-		&:hover {
-			background-color: var( --p2-color-button-dark );
-		}
-
-		&.is-primary {
-			color: #fff;
-			background-color: var( --p2-color-link );
-
-			&:hover {
-				background-color: var( --p2-color-link-dark );
-			}
-		}
+		@extend %p2-form-button;
 	}
 
 	.wp-login__links {
 		display: flex;
 
 		a {
-			border-bottom: none;
+			@extend %p2-link;
 			font-size: var( --p2-font-size-form-xs );
+			border-bottom: none;
 			font-weight: 400;
 			padding: 24px 4px;
-			text-decoration: underline;
-			color: var( --p2-color-link );
-
-			&:hover {
-				color: var( --p2-color-link-dark );
-			}
 		}
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -286,9 +286,9 @@
 	}
 
 	.login__form-header {
-		margin-bottom: 5px;
-		font-weight: 700;
 		font-size: var( --p2-font-size-form-xl );
+		font-weight: 700;
+		margin-bottom: 5px;
 	}
 
 	.login__form-terms {
@@ -317,10 +317,41 @@
 
 		a {
 			@extend %p2-link;
-			font-size: var( --p2-font-size-form-xs );
 			border-bottom: none;
+			font-size: var( --p2-font-size-form-xs );
 			font-weight: 400;
 			padding: 24px 4px;
+		}
+	}
+
+	.login__divider {
+		color: var( --p2-color-border );
+		font-size: var( --p2-font-size-form-xs );
+		margin: 0 auto;
+		max-width: 400px;
+		overflow: hidden;
+		text-align: center;
+		width: 100%;
+
+		&::before,
+		&::after {
+			background-color: var( --p2-color-border );
+			content: '';
+			display: inline-block;
+			height: 1px;
+			position: relative;
+			vertical-align: middle;
+			width: 50%;
+		}
+
+		&::before {
+			margin-left: -50%;
+			right: 0.5em;
+		}
+
+		&::after {
+			left: 0.5em;
+			margin-right: -50%;
 		}
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -281,6 +281,10 @@
 		@extend %p2-form-input-text;
 	}
 
+	.form-password-input {
+		@extend %p2-form-input-password;
+	}
+
 	.login__form-header {
 		margin-bottom: 5px;
 		font-weight: 700;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -266,15 +266,76 @@
 }
 
 .layout.is-p2-login {
-	background: #fff;
+	background: var( --p2-color-white );
+	font-family: var( --p2-font-inter );
+	color: var( --p2-color-text );
+	letter-spacing: -0.01em;
+	min-height: 100%;
+	display: flex;
+	flex-direction: column;
+
+	a {
+		@extend %p2-link;
+	}
+
+	&.is-section-login {
+		padding-bottom: 0;
+		min-height: auto;
+	}
+
+	&.is-section-login.has-no-masterbar .layout__content {
+		padding: 0;
+		height: 100%;
+	}
+
+	.layout__primary {
+		padding: 0;
+		height: 100%;
+
+		> div {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+		}
+	}
 
 	.wp-login__main.main {
-		max-width: 490px;
-		padding: 0 20px;
+		padding: 96px 24px 0;
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+
+		@include break-mobile {
+			padding: 80px 20px 0;
+			max-width: 400px;
+		}
+	}
+
+	.login__form-header-wrapper {
+		margin-bottom: 3em;
 	}
 
 	form {
-		padding: 0 25px;
+		padding: 0;
+		margin-bottom: 3em;
+	}
+
+	.login__form {
+		padding: 0;
+		margin-bottom: 2em;
+		box-shadow: none;
+	}
+
+	.login__form-userdata {
+		margin-bottom: 2em;
+	}
+
+	.login__form label {
+		font-size: var( --p2-font-size-form-xxs );
+		color: var( --p2-color-text );
+		font-weight: 500; /* stylelint-disable-line */
+		margin-bottom: 0.5em;
+		line-height: 1.8;
 	}
 
 	.form-text-input {
@@ -290,18 +351,41 @@
 	}
 
 	.login__form-header {
-		font-size: var( --p2-font-size-form-xl );
-		font-weight: 700;
-		margin-bottom: 5px;
+		color: var( --p2-color-text );
+		font-size: var( --p2-font-size-form-xxl );
+		font-weight: 900; /* stylelint-disable-line */
+		text-align: center;
+		line-height: 1.3;
+		margin-top: 0;
+		margin-bottom: 0.5em;
+	}
+
+	.login__header-subtitle {
+		line-height: 1.8;
+		color: var( --p2-color-text );
+		margin-bottom: 0;
 	}
 
 	.login__form-terms {
-		margin-top: 24px;
 		margin-bottom: 1rem;
+		color: var( --p2-color-text );
 	}
 
-	.login__form, .login__social {
+	.login__form-action {
+		button:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.login__social {
+		padding: 0;
 		box-shadow: none;
+		margin-bottom: 2em;
+	}
+
+	.login__social-tos {
+		color: var( --p2-color-text );
+		margin: 1em 0 0;
 	}
 
 	.login button {
@@ -318,21 +402,27 @@
 
 	.wp-login__links {
 		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin-bottom: 2em;
 
 		a {
 			@extend %p2-link;
-			border-bottom: none;
+			border-bottom: 1px solid currentColor;
 			font-size: var( --p2-font-size-form-xs );
 			font-weight: 400;
-			margin: 24px 4px;
+			margin: 0 0 0.8em;
 			padding: 0;
+			line-height: 1.5;
+			display: inline-block;
+			width: auto;
 		}
 	}
 
 	.login__divider {
 		color: var( --p2-color-border );
 		font-size: var( --p2-font-size-form-xs );
-		margin: 0 auto 1rem;
+		margin: 0 auto 2rem;
 		max-width: 400px;
 		overflow: hidden;
 		text-align: center;

--- a/client/blocks/signup-form/p2.scss
+++ b/client/blocks/signup-form/p2.scss
@@ -34,18 +34,7 @@
 	}
 
 	.form-input-validation {
-		font-size: var( --p2-font-size-form-xxs );
-		line-height: 1.5;
-		padding: 8px 0 0 2px;
-		margin-bottom: 1rem;
-
-		svg {
-			display: none;
-		}
-
-		&.is-error {
-			color: var( --p2-color-error );
-		}
+		@extend %p2-form-input-validation;
 	}
 
 	.form-password-input {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -25,6 +25,7 @@ const LayoutLoggedOut = ( {
 	isPopup,
 	isJetpackWooCommerceFlow,
 	isJetpackWooDnaFlow,
+	isP2Login,
 	wccomFrom,
 	masterbarIsHidden,
 	oauth2Client,
@@ -57,6 +58,7 @@ const LayoutLoggedOut = ( {
 		'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 		'is-wccom-oauth-flow': isWooOAuth2Client( oauth2Client ) && wccomFrom,
+		'is-p2-login': isP2Login,
 	};
 
 	let masterbar = null;
@@ -130,7 +132,7 @@ export default withCurrentRoute(
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isWhiteLogin = currentRoute.startsWith( '/log-in/new' );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
-		const isP2Login = currentRoute.startsWith( '/log-in' ) && 'p2' === currentQuery?.from;
+		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
 		const noMasterbarForRoute = isJetpackLogin || isWhiteLogin || isJetpackWooDnaFlow || isP2Login;
 		const isPopup = '1' === currentQuery?.is_popup;
 		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
@@ -143,6 +145,7 @@ export default withCurrentRoute(
 			isPopup,
 			isJetpackWooCommerceFlow,
 			isJetpackWooDnaFlow,
+			isP2Login,
 			wccomFrom,
 			masterbarIsHidden:
 				! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -130,7 +130,8 @@ export default withCurrentRoute(
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isWhiteLogin = currentRoute.startsWith( '/log-in/new' );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
-		const noMasterbarForRoute = isJetpackLogin || isWhiteLogin || isJetpackWooDnaFlow;
+		const isP2Login = currentRoute.startsWith( '/log-in' ) && 'p2' === currentQuery?.from;
+		const noMasterbarForRoute = isJetpackLogin || isWhiteLogin || isJetpackWooDnaFlow || isP2Login;
 		const isPopup = '1' === currentQuery?.is_popup;
 		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -26,6 +26,7 @@ const enhanceContextWithLogin = ( context ) => {
 		<WPLogin
 			isJetpack={ isJetpack === 'jetpack' }
 			isGutenboarding={ isGutenboarding === 'new' }
+			isP2Login={ query && query.from === 'p2' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -115,10 +115,10 @@ export class Login extends Component {
 	}
 
 	renderFooter() {
-		const { isJetpack, isGutenboarding, translate } = this.props;
+		const { isJetpack, isGutenboarding, isP2Login, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
 
-		if ( isJetpack || isGutenboarding ) {
+		if ( isJetpack || isGutenboarding || isP2Login ) {
 			return null;
 		}
 
@@ -196,6 +196,7 @@ export class Login extends Component {
 			isLoggedIn,
 			isJetpack,
 			isGutenboarding,
+			isP2Login,
 			oauth2Client,
 			privateSite,
 			socialConnect,
@@ -216,7 +217,7 @@ export class Login extends Component {
 		const isJetpackMagicLinkSignUpFlow =
 			isJetpack && config.isEnabled( 'jetpack/magic-link-signup' );
 
-		const shouldRenderFooter = ! socialConnect && ! isJetpackMagicLinkSignUpFlow;
+		const shouldRenderFooter = ! socialConnect && ! isJetpackMagicLinkSignUpFlow && ! isP2Login;
 
 		const footer = (
 			<>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -104,6 +104,29 @@ export class Login extends Component {
 		this.setState( { usernameOrEmail } );
 	}
 
+	renderP2Logo() {
+		return (
+			<div className="wp-login__p2-logo">
+				<img src="/calypso/images/p2/logo.png" width="67" height="32" alt="P2 logo" />
+			</div>
+		);
+	}
+
+	renderP2PoweredBy() {
+		return (
+			<div className="wp-login__p2-powered-by">
+				<img
+					src="/calypso/images/p2/w-logo.png"
+					className="wp-login__p2-powered-by-logo"
+					alt="WP.com logo"
+				/>
+				<span className="wp-login__p2-powered-by-text">
+					{ this.props.translate( 'Powered by WordPress.com' ) }
+				</span>
+			</div>
+		);
+	}
+
 	renderI18nSuggestions() {
 		const { locale, path, isLoginView } = this.props;
 
@@ -263,6 +286,7 @@ export class Login extends Component {
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		return (
 			<div>
+				{ this.props.isP2Login && this.renderP2Logo() }
 				<Main className="wp-login__main">
 					{ this.renderI18nSuggestions() }
 
@@ -276,6 +300,7 @@ export class Login extends Component {
 				</Main>
 
 				{ this.renderFooter() }
+				{ this.props.isP2Login && this.renderP2PoweredBy() }
 			</div>
 		);
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -244,6 +244,7 @@ export class Login extends Component {
 				clientId={ clientId }
 				isJetpack={ isJetpack }
 				isGutenboarding={ isGutenboarding }
+				isP2Login={ isP2Login }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -217,7 +217,7 @@ export class Login extends Component {
 		const isJetpackMagicLinkSignUpFlow =
 			isJetpack && config.isEnabled( 'jetpack/magic-link-signup' );
 
-		const shouldRenderFooter = ! socialConnect && ! isJetpackMagicLinkSignUpFlow && ! isP2Login;
+		const shouldRenderFooter = ! socialConnect && ! isJetpackMagicLinkSignUpFlow;
 
 		const footer = (
 			<>
@@ -227,6 +227,7 @@ export class Login extends Component {
 						privateSite={ privateSite }
 						twoFactorAuthType={ twoFactorAuthType }
 						isGutenboarding={ isGutenboarding }
+						isP2Login={ isP2Login }
 						signupUrl={ signupUrl }
 						usernameOrEmail={ this.state.usernameOrEmail }
 					/>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -288,6 +288,7 @@ export class LoginLinks extends Component {
 		const {
 			currentRoute,
 			isGutenboarding,
+			isP2Login,
 			locale,
 			oauth2Client,
 			pathname,
@@ -303,6 +304,13 @@ export class LoginLinks extends Component {
 
 		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
 			return null;
+		}
+
+		if ( isP2Login && query?.redirect_to ) {
+			const urlParts = getUrlParts( query.redirect_to );
+			if ( urlParts.pathname.startsWith( '/accept-invite/' ) ) {
+				return null;
+			}
 		}
 
 		return (

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -114,11 +114,20 @@ export class LoginLinks extends Component {
 		return login( loginParameters );
 	};
 
+	getLoginLinkText = () => {
+		if ( this.props.isP2Login ) {
+			return this.props.translate( 'Get a login link on your email' );
+		}
+
+		return this.props.translate( 'Email me a login link' );
+	};
+
 	renderBackLink() {
 		if (
 			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
 			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			this.props.isGutenboarding
+			this.props.isGutenboarding ||
+			this.props.isP2Login
 		) {
 			return null;
 		}
@@ -234,7 +243,7 @@ export class LoginLinks extends Component {
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 			>
-				{ this.props.translate( 'Email me a login link' ) }
+				{ this.getLoginLinkText() }
 			</a>
 		);
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -547,3 +547,29 @@ $image-height: 47px;
 		margin-top: 24px;
 	}
 }
+
+.wp-login__p2-logo {
+	position: absolute;
+	top: 24px;
+	left: 24px;
+}
+
+.wp-login__p2-powered-by {
+	margin: 24px 0 auto;
+	width: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+.wp-login__p2-powered-by-logo {
+	width: 20px;
+	height: 20px;
+	display: inline-block;
+	margin-bottom: 3px;
+	margin-right: 8px;
+}
+
+.wp-login__p2-powered-by-text {
+	font-size: var( --p2-font-size-form-xs );
+}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -555,7 +555,7 @@ $image-height: 47px;
 }
 
 .wp-login__p2-powered-by {
-	margin: 24px 0 auto;
+	margin: 24px 0;
 	width: 100%;
 	display: flex;
 	justify-content: center;
@@ -566,10 +566,9 @@ $image-height: 47px;
 	width: 20px;
 	height: 20px;
 	display: inline-block;
-	margin-bottom: 3px;
 	margin-right: 8px;
 }
 
 .wp-login__p2-powered-by-text {
-	font-size: var( --p2-font-size-form-xs );
+	font-size: var( --p2-font-size-form-xxs );
 }

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -39,7 +39,12 @@ class InviteAcceptLoggedOut extends Component {
 	};
 
 	clickSignInLink = () => {
-		const signInLink = login( { redirectTo: window.location.href } );
+		const linkParams = { redirectTo: window.location.href };
+		if ( get( this.props.invite, 'site.is_wpforteams_site', false ) ) {
+			linkParams.from = 'p2';
+		}
+
+		const signInLink = login( linkParams );
 		recordTracksEvent( 'calypso_invite_accept_logged_out_sign_in_link_click' );
 		window.location = signInLink;
 	};
@@ -153,7 +158,7 @@ class InviteAcceptLoggedOut extends Component {
 			return this.renderSignInLinkOnly();
 		}
 
-		if ( this.props.invite?.site?.is_wpforteams_site ) {
+		if ( get( this.props.invite, 'site.is_wpforteams_site', false ) ) {
 			return P2InviteAcceptLoggedOut( {
 				...this.props,
 				onClickSignInLink: this.clickSignInLink,

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -52,24 +52,25 @@
 }
 
 .p2-step-wrapper__footer {
-	text-align: center;
 	margin-top: auto;
 	padding-top: 24px;
 	padding-bottom: 24px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	line-height: 1.5;
 }
 
 .p2-step-wrapper__w-logo {
 	width: 20px;
 	height: 20px;
-	display: inline-block;
-	margin-bottom: 3px;
+	display: block;
 	margin-right: 8px;
 	vertical-align: middle;
 }
 
 .p2-step-wrapper__footer-text {
 	font-size: var( --p2-font-size-form-xxs );
-	line-height: 17px;
 }
 
 .p2-step-wrapper button {

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -13,7 +13,7 @@ function getRedirectToAfterLoginUrl( { flowName } ) {
 }
 
 function getLoginLink( { flowName, locale } ) {
-	return login( { redirectTo: getRedirectToAfterLoginUrl( { flowName } ), locale } );
+	return login( { redirectTo: getRedirectToAfterLoginUrl( { flowName } ), locale, from: 'p2' } );
 }
 
 function P2Details( {

--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -13,7 +13,12 @@ function getRedirectToAfterLoginUrl( { flowName } ) {
 }
 
 function getLoginLink( { flowName, locale } ) {
-	return login( { redirectTo: getRedirectToAfterLoginUrl( { flowName } ), locale, from: 'p2' } );
+	return login( {
+		redirectTo: getRedirectToAfterLoginUrl( { flowName } ),
+		locale,
+		signupUrl: '/start/p2/user',
+		from: 'p2',
+	} );
 }
 
 function P2Details( {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -23,6 +23,7 @@ body.is-section-signup {
 	&.is-p2-signup {
 		background: var( --p2-color-white );
 		color: var( --p2-color-text );
+		letter-spacing: -0.01em;
 
 		&.has-loading-screen-signup {
 			background: var( --p2-color-text );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Based #55746

* Customizes the login page for P2 flows, as described in p9lV3a-2Lp-p2. This is part of the P2 Onboarding project.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Regression test: verify that non-P2 flows have the regular login screen.
* Check that nothing looks broken for the following:
    * login screen when accepting P2 invites
    * login screen for the `/start/p2` flow
* Check that login works the same -- login errors are displayed as appropriate, login succeeds as appropriate.
* Known behavior: 
    * The `Create new account` link at the bottom of the login page resets the signup flow, throwing back the user to Step 1. This link becomes necessary only when the user mis-clicks in Step 2, clicking "Log In" instead of "Sign up". Hitting the back button also resets the signup flow. 
    * A successful login resets the signup flow, throwing back the user to Step 1. This is also the behavior for other wpcom flows. 

#### Screens

**New P2 login screen (username/email step)**
<img width="800" alt="Screen Shot 2021-09-21 at 11 38 45 PM" src="https://user-images.githubusercontent.com/730823/134202349-b643f10e-1226-4eaa-ac60-6e17b42dd51c.png">


**New P2 login screen (password step, with validation error)**
<img width="800" alt="Screen Shot 2021-09-21 at 11 39 09 PM" src="https://user-images.githubusercontent.com/730823/134202411-3d661d45-fe31-4bd3-a00e-9e895cf05b1b.png">

