### PR TITLE
Purchases: Display warning before Atomic revert

### DIFF
--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -70,6 +70,10 @@
 		color: var( --color-text-inverted );
 		opacity: 0.5;
 	}
+
+	.components-button.is-secondary:focus {
+		box-shadow: inset 0 0 0 1px var( --color-neutral-10 );
+	}
 }
 
 .blank-canvas__header {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -30,6 +30,7 @@ import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-supp
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -107,24 +108,21 @@ class CancelPurchaseForm extends React.Component {
 
 	shouldUseBlankCanvasLayout = () => {
 		const { isJetpack, purchase } = this.props;
-		if ( isPlan( purchase ) ) {
-			return ! isJetpack;
-		}
-
-		return false;
+		return isPlan( purchase ) && ! isJetpack;
 	};
 
 	getAllSurveySteps = () => {
 		const { purchase, shouldRevertAtomicSite } = this.props;
-		if ( this.shouldUseBlankCanvasLayout() ) {
-			if ( shouldRevertAtomicSite ) {
-				return [ FEEDBACK_STEP, ATOMIC_REVERT_STEP ];
-			}
-
-			return [ FEEDBACK_STEP ];
-		}
 
 		if ( isPlan( purchase ) ) {
+			if ( this.shouldUseBlankCanvasLayout() ) {
+				if ( shouldRevertAtomicSite ) {
+					return [ FEEDBACK_STEP, ATOMIC_REVERT_STEP ];
+				}
+
+				return [ FEEDBACK_STEP ];
+			}
+
 			return [ INITIAL_STEP, FINAL_STEP ];
 		}
 
@@ -896,7 +894,7 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	surveyContent() {
-		const { translate, isImport, isJetpack, showSurvey } = this.props;
+		const { translate, isImport, isJetpack, showSurvey, site } = this.props;
 		const { atomicRevertCheckOne, atomicRevertCheckTwo, surveyStep } = this.state;
 		const productName = isJetpack ? translate( 'Jetpack' ) : translate( 'WordPress.com' );
 
@@ -965,6 +963,9 @@ class CancelPurchaseForm extends React.Component {
 								'To make sure you have everything after you cancel, you can download a backup and easily restore or migrate your site.'
 							) }
 						</p>
+						<ExternalLink icon href={ `/backup/${ site.slug }` }>
+							{ translate( 'Go to your backups' ) }
+						</ExternalLink>
 					</div>
 				</div>
 			);

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1183,6 +1183,8 @@ class CancelPurchaseForm extends React.Component {
 		} = this.props;
 
 		if ( isPlan( purchase ) && ! isJetpack ) {
+			const steps = this.getAllSurveySteps();
+
 			return (
 				<>
 					<QueryPlans />
@@ -1195,6 +1197,16 @@ class CancelPurchaseForm extends React.Component {
 									? translate( 'Remove plan' )
 									: translate( 'Cancel plan' ) }
 								<span className="cancel-purchase-form__site-slug">{ site.slug }</span>
+								{ steps.length > 1 && (
+									<span className="cancel-purchase-form__step">
+										{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
+											args: {
+												currentStep: steps.indexOf( surveyStep ) + 1,
+												totalSteps: steps.length,
+											},
+										} ) }
+									</span>
+								) }
 							</BlankCanvas.Header>
 							<BlankCanvas.Content>{ this.surveyContent() }</BlankCanvas.Content>
 							<BlankCanvas.Footer>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -14,6 +14,7 @@ import { Dialog, Button } from '@automattic/components';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 import {
 	Button as GutenbergButton,
+	CheckboxControl,
 	SelectControl,
 	TextareaControl,
 	TextControl,
@@ -21,7 +22,7 @@ import {
 import { localize } from 'i18n-calypso';
 import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { cloneElement } from 'react';
 import { connect } from 'react-redux';
 import pluginsThemesImage from 'calypso/assets/images/customer-home/illustration--task-connect-social-accounts.svg';
 import downgradeImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
@@ -43,7 +44,10 @@ import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
-import { getDowngradePlanRawPrice } from 'calypso/state/purchases/selectors';
+import {
+	getDowngradePlanRawPrice,
+	shouldRevertAtomicSiteBeforeDeactivation,
+} from 'calypso/state/purchases/selectors';
 import getSupportVariation, {
 	SUPPORT_HAPPYCHAT,
 } from 'calypso/state/selectors/get-inline-help-support-variation';
@@ -65,7 +69,7 @@ import { radioTextOption, radioSelectOption } from './radio-option';
 import BusinessATStep from './step-components/business-at-step';
 import DowngradeStep from './step-components/downgrade-step';
 import UpgradeATStep from './step-components/upgrade-at-step';
-import { INITIAL_STEP, FINAL_STEP, FEEDBACK_STEP } from './steps';
+import { ATOMIC_REVERT_STEP, FEEDBACK_STEP, FINAL_STEP, INITIAL_STEP } from './steps';
 
 import './style.scss';
 
@@ -101,12 +105,27 @@ class CancelPurchaseForm extends React.Component {
 		return ! this.props.isJetpack;
 	};
 
+	shouldUseBlankCanvasLayout = () => {
+		const { isJetpack, purchase } = this.props;
+		if ( isPlan( purchase ) ) {
+			return ! isJetpack;
+		}
+
+		return false;
+	};
+
 	getAllSurveySteps = () => {
-		if ( isPlan( this.props.purchase ) ) {
-			if ( this.props.isJetpack ) {
-				return [ INITIAL_STEP, FINAL_STEP ];
+		const { purchase, shouldRevertAtomicSite } = this.props;
+		if ( this.shouldUseBlankCanvasLayout() ) {
+			if ( shouldRevertAtomicSite ) {
+				return [ FEEDBACK_STEP, ATOMIC_REVERT_STEP ];
 			}
+
 			return [ FEEDBACK_STEP ];
+		}
+
+		if ( isPlan( purchase ) ) {
+			return [ INITIAL_STEP, FINAL_STEP ];
 		}
 
 		return [ FINAL_STEP ];
@@ -144,6 +163,8 @@ class CancelPurchaseForm extends React.Component {
 			importQuestionText: '',
 			isSubmitting: false,
 			upsell: '',
+			atomicRevertCheckOne: false,
+			atomicRevertCheckTwo: false,
 		};
 	}
 
@@ -176,7 +197,7 @@ class CancelPurchaseForm extends React.Component {
 			upsell: '',
 		};
 
-		if ( this.state.surveyStep === FEEDBACK_STEP ) {
+		if ( this.shouldUseBlankCanvasLayout() ) {
 			const { purchase } = this.props;
 			if ( value === 'couldNotInstall' && isWpComBusinessPlan( purchase.productSlug ) ) {
 				newState.upsell = 'business-atomic';
@@ -423,7 +444,7 @@ class CancelPurchaseForm extends React.Component {
 	renderQuestionOne = () => {
 		const reasons = {};
 		const { translate } = this.props;
-		const { questionOneOrder, questionOneRadio, questionOneText, surveyStep, upsell } = this.state;
+		const { questionOneOrder, questionOneRadio, questionOneText, upsell } = this.state;
 		const { productSlug: productBeingRemoved } = this.props.purchase;
 
 		// get all downgradable plans and products for downgrade question dropdown
@@ -514,7 +535,7 @@ class CancelPurchaseForm extends React.Component {
 			},
 		];
 
-		if ( surveyStep === FEEDBACK_STEP ) {
+		if ( this.shouldUseBlankCanvasLayout() ) {
 			const optionKeys = [ ...questionOneOrder ];
 			optionKeys.unshift( '' ); // Placeholder.
 
@@ -619,7 +640,7 @@ class CancelPurchaseForm extends React.Component {
 	renderQuestionTwo = () => {
 		const reasons = {};
 		const { translate } = this.props;
-		const { questionTwoOrder, questionTwoRadio, questionTwoText, surveyStep } = this.state;
+		const { questionTwoOrder, questionTwoRadio, questionTwoText } = this.state;
 
 		if ( questionTwoOrder.length === 0 ) {
 			return null;
@@ -666,7 +687,7 @@ class CancelPurchaseForm extends React.Component {
 			},
 		];
 
-		if ( surveyStep === FEEDBACK_STEP ) {
+		if ( this.shouldUseBlankCanvasLayout() ) {
 			const optionKeys = [ ...questionTwoOrder ];
 			optionKeys.unshift( '' ); // Placeholder.
 
@@ -725,7 +746,7 @@ class CancelPurchaseForm extends React.Component {
 	renderImportQuestion = () => {
 		const reasons = [];
 		const { translate } = this.props;
-		const { importQuestionRadio, importQuestionText, surveyStep } = this.state;
+		const { importQuestionRadio, importQuestionText } = this.state;
 
 		const options = [
 			{
@@ -748,7 +769,7 @@ class CancelPurchaseForm extends React.Component {
 			},
 		];
 
-		if ( surveyStep === FEEDBACK_STEP ) {
+		if ( this.shouldUseBlankCanvasLayout() ) {
 			// Add placeholder.
 			options.unshift( {
 				value: '',
@@ -799,9 +820,8 @@ class CancelPurchaseForm extends React.Component {
 
 	renderFreeformQuestion = () => {
 		const { translate, isImport } = this.props;
-		const { surveyStep } = this.state;
 
-		if ( surveyStep === FEEDBACK_STEP ) {
+		if ( this.shouldUseBlankCanvasLayout() ) {
 			if ( ! isSurveyFilledIn( this.state, isImport ) ) {
 				// Do not display this question unless user has already answered previous questions.
 				return null;
@@ -877,12 +897,12 @@ class CancelPurchaseForm extends React.Component {
 
 	surveyContent() {
 		const { translate, isImport, isJetpack, showSurvey } = this.props;
-		const { surveyStep } = this.state;
+		const { atomicRevertCheckOne, atomicRevertCheckTwo, surveyStep } = this.state;
 		const productName = isJetpack ? translate( 'Jetpack' ) : translate( 'WordPress.com' );
 
 		if ( surveyStep === FEEDBACK_STEP ) {
 			return (
-				<>
+				<div className="cancel-purchase-form__feedback">
 					<FormattedHeader
 						brandFont
 						headerText={ translate( 'Your thoughts are needed' ) }
@@ -899,7 +919,54 @@ class CancelPurchaseForm extends React.Component {
 						{ this.renderQuestionTwo() }
 						{ this.renderFreeformQuestion() }
 					</div>
-				</>
+				</div>
+			);
+		}
+
+		if ( surveyStep === ATOMIC_REVERT_STEP ) {
+			return (
+				<div className="cancel-purchase-form__atomic-revert">
+					<FormattedHeader
+						brandFont
+						headerText={ translate( 'Proceed with caution' ) }
+						subHeaderText={ translate(
+							'In order to cancel your plan, we must {{strong}}revert{{/strong}} your site back to the point when you installed your first plugin or custom theme.',
+							{
+								args: { productName },
+								// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+								components: { strong: <strong className="is-highlighted" /> },
+							}
+						) }
+					/>
+					<p>
+						{ translate(
+							'Please {{strong}}confirm and check{{/strong}} the following items before you continue with plan deactivation:',
+							{ components: { strong: <strong /> } }
+						) }
+					</p>
+					<CheckboxControl
+						label={ translate(
+							'Any themes/plugins you have installed on the site will be removed, along with their data.'
+						) }
+						checked={ atomicRevertCheckOne }
+						onChange={ ( isChecked ) => this.setState( { atomicRevertCheckOne: isChecked } ) }
+					/>
+					<CheckboxControl
+						label={ translate(
+							'Your site will return to its original settings and theme right before the first plugin or custom theme was installed.'
+						) }
+						checked={ atomicRevertCheckTwo }
+						onChange={ ( isChecked ) => this.setState( { atomicRevertCheckTwo: isChecked } ) }
+					/>
+					<div className="cancel-purchase-form__backups">
+						<h4>{ translate( 'Would you like to download the backup of your site?' ) }</h4>
+						<p>
+							{ translate(
+								'To make sure you have everything after you cancel, you can download a backup and easily restore or migrate your site.'
+							) }
+						</p>
+					</div>
+				</div>
 			);
 		}
 
@@ -955,52 +1022,71 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	clickNext = () => {
-		const { isImport } = this.props;
-		if ( this.state.isRemoving || ! isSurveyFilledIn( this.state, isImport ) ) {
-			return;
-		}
 		this.changeSurveyStep( nextStep );
 	};
 
 	clickPrevious = () => {
-		if ( this.state.isRemoving ) {
-			return;
-		}
 		this.changeSurveyStep( previousStep );
 	};
 
 	getStepButtons = () => {
 		const { flowType, translate, disableButtons, purchase, isImport } = this.props;
-		const { isSubmitting, surveyStep } = this.state;
-		const disabled = disableButtons || isSubmitting;
+		const { atomicRevertCheckOne, atomicRevertCheckTwo, isSubmitting, surveyStep } = this.state;
+		const isCancelling = disableButtons || isSubmitting;
 
-		if ( surveyStep === FEEDBACK_STEP ) {
-			let actionText;
-			if ( flowType === CANCEL_FLOW_TYPE.REMOVE ) {
-				actionText = disabled ? translate( 'Removing…' ) : translate( 'Remove plan' );
-			} else {
-				actionText = disabled ? translate( 'Cancelling…' ) : translate( 'Cancel plan' );
+		const allSteps = this.getAllSurveySteps();
+		const isFirstStep = surveyStep === allSteps[ 0 ];
+		const isLastStep = surveyStep === allSteps[ allSteps.length - 1 ];
+
+		if ( this.shouldUseBlankCanvasLayout() ) {
+			const buttons = [];
+
+			let canGoNext = ! isCancelling;
+			if ( surveyStep === FEEDBACK_STEP ) {
+				canGoNext = isSurveyFilledIn( this.state, isImport );
+			} else if ( surveyStep === ATOMIC_REVERT_STEP ) {
+				canGoNext = atomicRevertCheckOne && atomicRevertCheckTwo;
 			}
-			return (
-				<>
-					<GutenbergButton disabled={ disabled } isPrimary onClick={ this.closeDialog }>
-						{ translate( 'Keep my plan' ) }
+
+			buttons.push(
+				<GutenbergButton disabled={ isCancelling } isPrimary onClick={ this.closeDialog }>
+					{ translate( 'Keep my plan' ) }
+				</GutenbergButton>
+			);
+
+			if ( ! isLastStep ) {
+				buttons.push(
+					<GutenbergButton disabled={ ! canGoNext } isDefault onClick={ this.clickNext }>
+						{ translate( 'Next' ) }
 					</GutenbergButton>
+				);
+			}
+
+			if ( isLastStep ) {
+				let actionText;
+				if ( flowType === CANCEL_FLOW_TYPE.REMOVE ) {
+					actionText = isCancelling ? translate( 'Removing…' ) : translate( 'Remove plan' );
+				} else {
+					actionText = isCancelling ? translate( 'Cancelling…' ) : translate( 'Cancel plan' );
+				}
+				buttons.push(
 					<GutenbergButton
 						isDefault
-						isBusy={ disabled }
-						disabled={ disabled || ! isSurveyFilledIn( this.state, isImport ) }
+						isBusy={ isCancelling }
+						disabled={ ! canGoNext }
 						onClick={ this.onSubmit }
 					>
 						{ actionText }
 					</GutenbergButton>
-				</>
-			);
+				);
+			}
+
+			return buttons;
 		}
 
 		const close = {
 			action: 'close',
-			disabled,
+			disabled: isCancelling,
 			label: translate( "I'll Keep It" ),
 		};
 		const chat = (
@@ -1012,19 +1098,19 @@ class CancelPurchaseForm extends React.Component {
 		);
 		const next = {
 			action: 'next',
-			disabled: disabled || ! isSurveyFilledIn( this.state, isImport ),
+			disabled: isCancelling || ! isSurveyFilledIn( this.state, isImport ),
 			label: translate( 'Next Step' ),
 			onClick: this.clickNext,
 		};
 		const prev = {
 			action: 'prev',
-			disabled,
+			disabled: isCancelling,
 			label: translate( 'Previous Step' ),
 			onClick: this.clickPrevious,
 		};
 		const cancel = {
 			action: 'cancel',
-			disabled,
+			disabled: isCancelling,
 			label: translate( 'Cancel Now' ),
 			onClick: this.onSubmit,
 			isPrimary: true,
@@ -1049,8 +1135,7 @@ class CancelPurchaseForm extends React.Component {
 			firstButtons.unshift( chat );
 		}
 
-		const allSteps = this.getAllSurveySteps();
-		if ( surveyStep === allSteps[ allSteps.length - 1 ] ) {
+		if ( isLastStep ) {
 			const stepsCount = allSteps.length;
 			const prevButton = stepsCount > 1 ? [ prev ] : [];
 
@@ -1062,7 +1147,7 @@ class CancelPurchaseForm extends React.Component {
 			}
 		}
 
-		return firstButtons.concat( surveyStep === allSteps[ 0 ] ? [ next ] : [ prev, next ] );
+		return firstButtons.concat( isFirstStep ? [ next ] : [ prev, next ] );
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -1113,7 +1198,11 @@ class CancelPurchaseForm extends React.Component {
 							<BlankCanvas.Content>{ this.surveyContent() }</BlankCanvas.Content>
 							<BlankCanvas.Footer>
 								<div className="cancel-purchase-form__actions">
-									<div className="cancel-purchase-form__buttons">{ this.getStepButtons() }</div>
+									<div className="cancel-purchase-form__buttons">
+										{ this.getStepButtons().map( ( button, key ) =>
+											cloneElement( button, { key } )
+										) }
+									</div>
 									{ ( isChatAvailable || isChatActive ) &&
 										supportVariation === SUPPORT_HAPPYCHAT && (
 											<PrecancellationChatButton
@@ -1156,6 +1245,7 @@ export default connect(
 		downgradePlanPrice: getDowngradePlanRawPrice( state, purchase ),
 		supportVariation: getSupportVariation( state ),
 		site: getSite( state, purchase.siteId ),
+		shouldRevertAtomicSite: shouldRevertAtomicSiteBeforeDeactivation( state, purchase.id ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/components/marketing-survey/cancel-purchase-form/steps.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps.js
@@ -1,3 +1,4 @@
-export const INITIAL_STEP = 'initial_step';
-export const FINAL_STEP = 'final_step';
+export const ATOMIC_REVERT_STEP = 'atomic_revert_step';
 export const FEEDBACK_STEP = 'feedback_step';
+export const FINAL_STEP = 'final_step';
+export const INITIAL_STEP = 'initial_step';

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -50,18 +50,91 @@
 	vertical-align: middle;
 }
 
+.cancel-purchase-form__feedback,
+.cancel-purchase-form__atomic-revert {
+	max-width: 730px;
+	margin: 0 auto 3rem;
+}
+
 .cancel-purchase-form__feedback-questions {
 	max-width: 540px;
-	margin: 0 auto 3rem;
+	margin: 0 auto;
 }
 
 .cancel-purchase-form__feedback-question {
 	margin-bottom: 1.5rem;
 }
 
+.cancel-purchase-form__atomic-revert {
+	.formatted-header {
+		margin-bottom: 1.5rem;
+	}
+
+	> p {
+		color: var( --studio-gray-50 );
+
+		@include break-small {
+			text-align: center;
+		}
+	}
+
+	strong.is-highlighted {
+		background-color: var( --studio-yellow-5 );
+		padding: 0.25rem 0.5rem;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
+		color: var( --stugio-gray-80 );
+	}
+
+	.components-base-control__field {
+		background-color: var( --studio-white );
+		padding: 0.8125rem 1.25rem;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
+		box-shadow: 0 1px 2px rgb( 0 0 0 / 5% );
+		border: 1px solid var( --studio-gray-5 );
+		display: flex;
+		align-items: center;
+
+		.components-checkbox-control__label {
+			font-size: 0.875rem;
+			color: var( --studio-gray-60 );
+		}
+
+		.components-checkbox-control__input[type=checkbox]:checked {
+			background: var( --studio-black );
+			border-color: var( --studio-black );
+		}
+
+		.components-checkbox-control__input[type=checkbox]:focus {
+			box-shadow: 0 0 0 2px var( --studio-white ), 0 0 0 4px var( --studio-black );
+		}
+
+		.components-checkbox-control__input-container,
+		.components-checkbox-control__input[type=checkbox],
+		svg.components-checkbox-control__checked {
+			width: 1rem;
+			height: 1rem;
+		}
+
+		svg.components-checkbox-control__checked {
+			left: 0;
+			top: 0;
+		}
+	}
+}
+
+.cancel-purchase-form__backups {
+	background-color: var( --studio-blue-0 );
+	border: 1px solid var( --studio-blue-5 );
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 5px;
+	padding: 1.25rem;
+}
+
 .cancel-purchase-form__actions {
 	@include break-small {
-		max-width: 700px;
+		max-width: 730px;
 		display: block;
 		margin: 0 auto;
 		text-align: center;
@@ -79,7 +152,7 @@
 		&::after {
 			content: '';
 			display: block;
-			width: 700px;
+			width: 730px;
 			height: 0;
 			border-top: 1px solid var( --studio-gray-5 );
 			top: 50%;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -130,6 +130,15 @@
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 5px;
 	padding: 1.25rem;
+	margin-top: 2rem;
+	font-size: 0.875rem;
+
+	h4 {
+		color: var( --studio-gray-80 );
+		font-weight: 600;
+		margin-bottom: 0.5rem;
+		font-size: 1rem;
+	}
 }
 
 .cancel-purchase-form__actions {

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -50,6 +50,16 @@
 	vertical-align: middle;
 }
 
+.cancel-purchase-form__step {
+	position: absolute;
+	right: 1.5rem;
+	display: none;
+
+	@include break-small {
+		display: inline-block;
+	}
+}
+
 .cancel-purchase-form__feedback,
 .cancel-purchase-form__atomic-revert {
 	max-width: 730px;


### PR DESCRIPTION
Fixes #55239.
Fixes #55240.


#### Changes proposed in this Pull Request

Displays a warning prior cancelling a plan from an Atomic site informing that all third party plugins/themes and their content will be removed. It also provides a link to download a backup.

<img width="1275" alt="Screen Shot 2021-09-21 at 12 45 00" src="https://user-images.githubusercontent.com/1233880/134157526-6066c342-afa8-45ff-bad7-340a4250b04c.png">

#### Testing instructions

- Use the Calypso live link below and append `?flags=atomic/automated-revert` at the end of the URL.
- Go to Upgrades > Purchases.
- Select the site plan.
- Go through the removal/cancellation flow.
- Make sure you get the feedback form as first step.
- Make sure that "Step 1 of 2" is displayed in the header.
- Make sure you can go to the next step after filling the form.
- Make sure you get the proceed with caution form as second step.
- - Make sure that "Step 2 of 2" is displayed in the header.
- Make sure the link to the backup works correctly.
- Make sure you are required to tick all the checkboxes before being submitting the form.
- Submit the form.
- Make sure you get a success notification indicating the removal/cancellation has been queued.
- Manually run the `atomic_subscription_revert_after_lossless_import` async job (see testing instructions in D66763-code).
- Reload Calypso.
- Make sure the Atomic site is on a Free plan now.
