### PR TITLE
Reader - tweak styles on following settings popover

### DIFF
--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -18,22 +18,30 @@
 	fill: var( --color-neutral-20 );
 	height: 18px;
 	position: relative;
-		top: 4px;
-		left: -4px;
+	top: 4px;
+	left: -4px;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		left: -1px;
 	}
 }
 
+.reader-popover.popover .popover__inner {
+	background: var( --color-surface );
+}
+
 .reader-popover__wrapper {
 	.segmented-control {
 		background: inherit;
-		padding: 0 12px 17px 16px;
+		padding: 0 12px 10px 16px;
 	}
 
 	.segmented-control__link {
 		background: var( --color-surface );
+
+		span {
+			font-size: $font-body-extra-small;
+		}
 	}
 
 	.form-label {
@@ -48,18 +56,26 @@
 	.reader-site-notification-settings__popout-toggle:nth-child( 4 ) {
 		display: flex;
 	}
+
+	.components-base-control.components-toggle-control {
+		line-height: 1.25rem;
+		height: 1.25rem;
+	}
 }
 
 .reader-site-notification-settings__popout-toggle,
 .reader-site-notification-settings__popout-instructions {
-	border-top: 1px solid var( --color-neutral-10 );
-	color:var( --color-neutral-70 );
+	color: var( --color-neutral-70 );
 	font-size: $font-body-small;
 	padding: 10px 15px;
 	text-align: left;
 
 	&:first-child {
 		border-top: 0;
+		padding-top: 15px;
+	}
+	&:last-child {
+		padding-bottom: 15px;
 	}
 }
 
@@ -67,7 +83,8 @@
 .reader-site-notification-settings__popout-instructions-hint {
 	color: var( --color-text-subtle );
 	font-size: $font-body-extra-small;
-	margin-bottom: 0;
+	margin-bottom: -2px;
+	margin-top: 10px;
 }
 
 .reader-site-notification-settings__popout-hint {

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -26,6 +26,16 @@
 	}
 }
 
+.reader-popover.popover.is-bottom .popover__arrow::before,
+.reader-popover.popover.is-bottom-left .popover__arrow::before,
+.reader-popover.popover.is-bottom-right .popover__arrow::before {
+	border: 10px solid var( --color-surface );
+	border-bottom-style: solid;
+	border-left-color: transparent;
+	border-right-color: transparent;
+	border-top: none;
+}
+
 .reader-popover.popover .popover__inner {
 	background: var( --color-surface );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This diff updates styling on the per-blog notification settings popup on `/following/manage`, as discussed in https://github.com/Automattic/wp-calypso/issues/56117

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this diff locally and navigate to http://calypso.localhost:3000/following/manage
* Verify that updated styles have been applied

Before:
![image](https://user-images.githubusercontent.com/13437011/134040916-1291d8da-1fe0-4e80-aa51-12fac62eba8e.png)


After:
![image](https://user-images.githubusercontent.com/13437011/134040378-605fdf06-3499-45b8-820d-fc32a10a1d31.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56117
