### PR TITLE
Emails: Logic to show either inbox selector or domains picker or domains CTA buy

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -7,6 +7,7 @@ import TitanManageMailboxes from 'calypso/my-sites/email/email-management/titan-
 import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan-management-iframe';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
+import InboxManagement from 'calypso/my-sites/email/inbox-management';
 import TitanAddMailboxes from 'calypso/my-sites/email/titan-add-mailboxes';
 import TitanSetUpMailbox from 'calypso/my-sites/email/titan-set-up-mailbox';
 import TitanSetUpThankYou from 'calypso/my-sites/email/titan-set-up-thank-you';
@@ -122,7 +123,7 @@ export default {
 	},
 
 	emailManagementInbox( pageContext, next ) {
-		pageContext.primary = null;
+		pageContext.primary = <InboxManagement />;
 		next();
 	},
 };

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -20,7 +20,7 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
-import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetUpMailbox, isUnderEmailInbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -118,14 +118,18 @@ class EmailManagementHome extends React.Component {
 			page( emailManagementTitanSetUpMailbox( selectedSite.slug, selectedSite.domain ) );
 		}
 
+		const emailListActive = isUnderEmailInbox( currentRoute ) ? null : (
+			<EmailListActive
+				domains={ domainsWithEmail }
+				selectedSiteSlug={ selectedSite.slug }
+				currentRoute={ currentRoute }
+				selectedSiteId={ selectedSiteId }
+			/>
+		);
+
 		return this.renderContentWithHeader(
 			<>
-				<EmailListActive
-					domains={ domainsWithEmail }
-					selectedSiteSlug={ selectedSite.slug }
-					currentRoute={ currentRoute }
-					selectedSiteId={ selectedSiteId }
-				/>
+				{ emailListActive }
 				<EmailListInactive
 					domains={ domainsWithNoEmail }
 					selectedSiteSlug={ selectedSite.slug }

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -47,18 +47,24 @@ class EmailManagementHome extends React.Component {
 		selectedSiteId: PropTypes.number.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
 		context: PropTypes.string,
+		emailListInactiveHeader: PropTypes.element,
+		onlyDomainsWithoutSubscription: PropTypes.bool,
+		sectionHeaderLabel: PropTypes.string,
 	};
 
 	render() {
 		const {
+			canManageSite,
+			currentRoute,
 			domains,
+			emailListInactiveHeader,
 			hasSiteDomainsLoaded,
 			hasSitesLoaded,
-			canManageSite,
-			selectedSite,
+			onlyDomainsWithoutSubscription,
 			selectedDomainName,
-			currentRoute,
+			selectedSite,
 			selectedSiteId,
+			sectionHeaderLabel,
 		} = this.props;
 
 		if ( ! hasSiteDomainsLoaded || ! hasSitesLoaded || ! selectedSite ) {
@@ -123,18 +129,20 @@ class EmailManagementHome extends React.Component {
 
 		return this.renderContentWithHeader(
 			<>
-				{ ! isUnderEmailManagementInbox( currentRoute ) && (
+				{ ! onlyDomainsWithoutSubscription && (
 					<EmailListActive
-						domains={ domainsWithEmail }
-						selectedSiteSlug={ selectedSite.slug }
 						currentRoute={ currentRoute }
+						domains={ domainsWithEmail }
 						selectedSiteId={ selectedSiteId }
+						selectedSiteSlug={ selectedSite.slug }
 					/>
 				) }
 				<EmailListInactive
-					domains={ domainsWithNoEmail }
-					selectedSiteSlug={ selectedSite.slug }
 					currentRoute={ currentRoute }
+					domains={ domainsWithNoEmail }
+					header={ emailListInactiveHeader }
+					sectionHeaderLabel={ sectionHeaderLabel }
+					selectedSiteSlug={ selectedSite.slug }
 				/>
 			</>
 		);

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -20,7 +20,10 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
-import { emailManagementTitanSetUpMailbox, isUnderEmailManagementInbox } from 'calypso/my-sites/email/paths';
+import {
+	emailManagementTitanSetUpMailbox,
+	isUnderEmailManagementInbox,
+} from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -43,6 +43,7 @@ class EmailManagementHome extends React.Component {
 		selectedDomainName: PropTypes.string,
 		selectedSiteId: PropTypes.number.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
+		context: PropTypes.string,
 	};
 
 	render() {

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -20,7 +20,7 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
-import { emailManagementTitanSetUpMailbox, isUnderEmailInbox } from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetUpMailbox, isUnderEmailManagementInbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -118,18 +118,16 @@ class EmailManagementHome extends React.Component {
 			page( emailManagementTitanSetUpMailbox( selectedSite.slug, selectedSite.domain ) );
 		}
 
-		const emailListActive = isUnderEmailInbox( currentRoute ) ? null : (
-			<EmailListActive
-				domains={ domainsWithEmail }
-				selectedSiteSlug={ selectedSite.slug }
-				currentRoute={ currentRoute }
-				selectedSiteId={ selectedSiteId }
-			/>
-		);
-
 		return this.renderContentWithHeader(
 			<>
-				{ emailListActive }
+				{ ! isUnderEmailManagementInbox( currentRoute ) && (
+					<EmailListActive
+						domains={ domainsWithEmail }
+						selectedSiteSlug={ selectedSite.slug }
+						currentRoute={ currentRoute }
+						selectedSiteId={ selectedSiteId }
+					/>
+				) }
 				<EmailListInactive
 					domains={ domainsWithNoEmail }
 					selectedSiteSlug={ selectedSite.slug }

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -20,10 +20,7 @@ import EmailListInactive from 'calypso/my-sites/email/email-management/home/emai
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
-import {
-	emailManagementTitanSetUpMailbox,
-	isUnderEmailManagementInbox,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import SidebarNavigation from 'calypso/my-sites/sidebar-navigation';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -48,7 +45,7 @@ class EmailManagementHome extends React.Component {
 		selectedSiteSlug: PropTypes.string.isRequired,
 		context: PropTypes.string,
 		emailListInactiveHeader: PropTypes.element,
-		onlyDomainsWithoutSubscription: PropTypes.bool,
+		showActiveDomainList: PropTypes.bool,
 		sectionHeaderLabel: PropTypes.string,
 	};
 
@@ -60,7 +57,7 @@ class EmailManagementHome extends React.Component {
 			emailListInactiveHeader,
 			hasSiteDomainsLoaded,
 			hasSitesLoaded,
-			onlyDomainsWithoutSubscription,
+			showActiveDomainList,
 			selectedDomainName,
 			selectedSite,
 			selectedSiteId,
@@ -129,7 +126,7 @@ class EmailManagementHome extends React.Component {
 
 		return this.renderContentWithHeader(
 			<>
-				{ ! onlyDomainsWithoutSubscription && (
+				{ ! showActiveDomainList && (
 					<EmailListActive
 						currentRoute={ currentRoute }
 						domains={ domainsWithEmail }
@@ -140,7 +137,7 @@ class EmailManagementHome extends React.Component {
 				<EmailListInactive
 					currentRoute={ currentRoute }
 					domains={ domainsWithNoEmail }
-					header={ emailListInactiveHeader }
+					headerComponent={ emailListInactiveHeader }
 					sectionHeaderLabel={ sectionHeaderLabel }
 					selectedSiteSlug={ selectedSite.slug }
 				/>

--- a/client/my-sites/email/email-management/email-home.jsx
+++ b/client/my-sites/email/email-management/email-home.jsx
@@ -57,7 +57,7 @@ class EmailManagementHome extends React.Component {
 			emailListInactiveHeader,
 			hasSiteDomainsLoaded,
 			hasSitesLoaded,
-			showActiveDomainList,
+			showActiveDomainList = true,
 			selectedDomainName,
 			selectedSite,
 			selectedSiteId,
@@ -126,7 +126,7 @@ class EmailManagementHome extends React.Component {
 
 		return this.renderContentWithHeader(
 			<>
-				{ ! showActiveDomainList && (
+				{ showActiveDomainList && (
 					<EmailListActive
 						currentRoute={ currentRoute }
 						domains={ domainsWithEmail }

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -1,5 +1,6 @@
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import React from 'react';
 import SectionHeader from 'calypso/components/section-header';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
@@ -10,7 +11,7 @@ class EmailListInactive extends React.Component {
 		const {
 			currentRoute,
 			domains,
-			header,
+			headerComponent,
 			sectionHeaderLabel,
 			selectedSiteSlug,
 			translate,
@@ -40,12 +41,21 @@ class EmailListInactive extends React.Component {
 
 		return (
 			<div className="email-list-inactive">
-				{ header }
+				{ headerComponent }
 				<SectionHeader label={ sectionHeaderLabel ?? translate( 'Other domains' ) } />
 				{ emailListItems }
 			</div>
 		);
 	}
 }
+
+EmailListInactive.propTypes = {
+	currentRoute: PropTypes.string,
+	domains: PropTypes.array,
+	headerComponent: PropTypes.element,
+	sectionHeaderLabel: PropTypes.string,
+	selectedSiteSlug: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
 
 export default localize( EmailListInactive );

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -7,7 +7,7 @@ import SectionHeader from 'calypso/components/section-header';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import {
 	emailManagementPurchaseNewEmailAccount,
-	isUnderEmailInbox,
+	isUnderEmailManagementInbox,
 } from 'calypso/my-sites/email/paths';
 
 class EmailListInactive extends React.Component {
@@ -20,14 +20,10 @@ class EmailListInactive extends React.Component {
 
 		return (
 			<>
-				<PromoCard
-					isPrimary={ true }
-					title={ translate( 'Pick a domain to get started' ) }
-					image={ image }
-				>
+				<PromoCard title={ translate( 'Pick a domain to get started' ) } image={ image }>
 					<p>
 						{ translate(
-							'Pick a domain from your available domains below to add email service to it.'
+							'Pick a domain from your available domains below to add an email solution.'
 						) }
 					</p>
 				</PromoCard>
@@ -43,11 +39,11 @@ class EmailListInactive extends React.Component {
 			return null;
 		}
 
-		const sectionHeaderLabel = isUnderEmailInbox( currentRoute )
+		const sectionHeaderLabel = isUnderEmailManagementInbox( currentRoute )
 			? translate( 'Domains' )
 			: translate( 'Other domains' );
 
-		const mainHeader = isUnderEmailInbox( currentRoute ) ? this.getMainHeader() : null;
+		const mainHeader = isUnderEmailManagementInbox( currentRoute ) ? this.getMainHeader() : null;
 
 		const emailListItems = domains.map( ( domain ) => {
 			return (

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -1,17 +1,53 @@
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import PromoCard from 'calypso/components/promo-section/promo-card';
 import SectionHeader from 'calypso/components/section-header';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
-import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
+import {
+	emailManagementPurchaseNewEmailAccount,
+	isUnderEmailInbox,
+} from 'calypso/my-sites/email/paths';
 
 class EmailListInactive extends React.Component {
+	getMainHeader() {
+		const { translate } = this.props;
+		const image = {
+			path: emailIllustration,
+			align: 'right',
+		};
+
+		return (
+			<>
+				<PromoCard
+					isPrimary={ true }
+					title={ translate( 'Pick a domain to get started' ) }
+					image={ image }
+				>
+					<p>
+						{ translate(
+							'Pick a domain from your available domains below to add email service to it.'
+						) }
+					</p>
+				</PromoCard>
+				<br />
+			</>
+		);
+	}
+
 	render() {
 		const { selectedSiteSlug, currentRoute, domains, translate } = this.props;
 
 		if ( domains.length < 1 ) {
 			return null;
 		}
+
+		const sectionHeaderLabel = isUnderEmailInbox( currentRoute )
+			? translate( 'Domains' )
+			: translate( 'Other domains' );
+
+		const mainHeader = isUnderEmailInbox( currentRoute ) ? this.getMainHeader() : null;
 
 		const emailListItems = domains.map( ( domain ) => {
 			return (
@@ -34,7 +70,8 @@ class EmailListInactive extends React.Component {
 
 		return (
 			<div className="email-list-inactive">
-				<SectionHeader label={ translate( 'Other domains' ) } />
+				{ mainHeader }
+				<SectionHeader label={ sectionHeaderLabel } />
 				{ emailListItems }
 			</div>
 		);

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -7,14 +7,7 @@ import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/p
 
 class EmailListInactive extends React.Component {
 	render() {
-		const {
-			currentRoute,
-			domains,
-			header,
-			sectionHeaderLabel,
-			selectedSiteSlug,
-			translate,
-		} = this.props;
+		const { currentRoute, domains, header, sectionHeaderLabel, selectedSiteSlug, translate } = this.props;
 		if ( domains.length < 1 ) {
 			return null;
 		}
@@ -41,7 +34,7 @@ class EmailListInactive extends React.Component {
 		return (
 			<div className="email-list-inactive">
 				{ header }
-				<SectionHeader label={ sectionHeaderLabel } />
+				<SectionHeader label={ sectionHeaderLabel ?? translate( 'Other domains' ) } />
 				{ emailListItems }
 			</div>
 		);

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -7,7 +7,14 @@ import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/p
 
 class EmailListInactive extends React.Component {
 	render() {
-		const { currentRoute, domains, header, sectionHeaderLabel, selectedSiteSlug, translate } = this.props;
+		const {
+			currentRoute,
+			domains,
+			header,
+			sectionHeaderLabel,
+			selectedSiteSlug,
+			translate,
+		} = this.props;
 		if ( domains.length < 1 ) {
 			return null;
 		}

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -7,11 +7,17 @@ import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/p
 
 class EmailListInactive extends React.Component {
 	render() {
-		const { currentRoute, domains, header, sectionLabel, selectedSiteSlug, translate } = this.props;
+		const {
+			currentRoute,
+			domains,
+			header,
+			sectionHeaderLabel,
+			selectedSiteSlug,
+			translate,
+		} = this.props;
 		if ( domains.length < 1 ) {
 			return null;
 		}
-		const sectionHeaderLabel = sectionLabel ? sectionLabel : translate( 'Other domains' );
 
 		const emailListItems = domains.map( ( domain ) => {
 			return (

--- a/client/my-sites/email/email-management/home/email-list-inactive.jsx
+++ b/client/my-sites/email/email-management/home/email-list-inactive.jsx
@@ -1,49 +1,17 @@
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
-import PromoCard from 'calypso/components/promo-section/promo-card';
 import SectionHeader from 'calypso/components/section-header';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
-import {
-	emailManagementPurchaseNewEmailAccount,
-	isUnderEmailManagementInbox,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 
 class EmailListInactive extends React.Component {
-	getMainHeader() {
-		const { translate } = this.props;
-		const image = {
-			path: emailIllustration,
-			align: 'right',
-		};
-
-		return (
-			<>
-				<PromoCard title={ translate( 'Pick a domain to get started' ) } image={ image }>
-					<p>
-						{ translate(
-							'Pick a domain from your available domains below to add an email solution.'
-						) }
-					</p>
-				</PromoCard>
-				<br />
-			</>
-		);
-	}
-
 	render() {
-		const { selectedSiteSlug, currentRoute, domains, translate } = this.props;
-
+		const { currentRoute, domains, header, sectionLabel, selectedSiteSlug, translate } = this.props;
 		if ( domains.length < 1 ) {
 			return null;
 		}
-
-		const sectionHeaderLabel = isUnderEmailManagementInbox( currentRoute )
-			? translate( 'Domains' )
-			: translate( 'Other domains' );
-
-		const mainHeader = isUnderEmailManagementInbox( currentRoute ) ? this.getMainHeader() : null;
+		const sectionHeaderLabel = sectionLabel ? sectionLabel : translate( 'Other domains' );
 
 		const emailListItems = domains.map( ( domain ) => {
 			return (
@@ -66,7 +34,7 @@ class EmailListInactive extends React.Component {
 
 		return (
 			<div className="email-list-inactive">
-				{ mainHeader }
+				{ header }
 				<SectionHeader label={ sectionHeaderLabel } />
 				{ emailListItems }
 			</div>

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -1,0 +1,35 @@
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
+import { hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const InboxManagement = ( { domains } ) => {
+	const nonWPCOMDomains = domains.filter( ( domain ) => ! domain.isWPCOMDomain );
+	const WPCOMDomains = domains.filter( ( domain ) => domain.isWPCOMDomain );
+	const hasSubscription = WPCOMDomains.some( ( domain ) => hasEmailSubscription( domain ) );
+
+	//EmailManagementHome logic will handle the case where there is only one domain to show directly the email comparison
+	//and also if there is no domain so, it will show a CTA to buy domain
+	if ( ! hasSubscription && nonWPCOMDomains?.length >= 1 && WPCOMDomains?.length === 0 ) {
+		return (
+			<CalypsoShoppingCartProvider>
+				<EmailManagementHome />
+			</CalypsoShoppingCartProvider>
+		);
+	}
+
+	//If we are at this point it means that we've at least have one subscription to show in mailbox selector
+	return <h1>Handle Mailbox Placeholder</h1>;
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+		domains: getDomainsBySiteId( state, siteId ),
+	};
+} )( localize( InboxManagement ) );

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -9,12 +9,13 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const InboxManagement = ( { domains } ) => {
 	const nonWPCOMDomains = domains.filter( ( domain ) => ! domain.isWPCOMDomain );
-	const WPCOMDomains = domains.filter( ( domain ) => domain.isWPCOMDomain );
-	const hasSubscription = WPCOMDomains.some( ( domain ) => hasEmailSubscription( domain ) );
+	const domainsWithSubscriptions = nonWPCOMDomains.filter( ( domain ) =>
+		hasEmailSubscription( domain )
+	);
 
 	//EmailManagementHome logic will handle the case where there is only one domain to show directly the email comparison
 	//and also if there is no domain so, it will show a CTA to buy domain
-	if ( ! hasSubscription && nonWPCOMDomains?.length >= 1 && WPCOMDomains?.length === 0 ) {
+	if ( domainsWithSubscriptions.length === 0 || domainsWithSubscriptions.length > 1 ) {
 		return (
 			<CalypsoShoppingCartProvider>
 				<EmailManagementHome />

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -8,7 +8,6 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const InboxManagement = ( { domains } ) => {
-
 	const domainsWithSubscriptions = domains.filter(
 		( domain ) => ! domain.isWPCOMDomain && hasEmailSubscription( domain )
 	);

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -24,7 +24,7 @@ const InboxManagement = ( { domains } ) => {
 					isPrimary={ true }
 					title={ translate( 'Pick a domain to get started' ) }
 					image={ image }
-					className={ 'is-inbox-card' }
+					className={ 'inbox-management__is-inbox-card' }
 				>
 					<p>{ translate( 'Pick one of your domains below to add an email solution.' ) }</p>
 				</PromoCard>

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -15,7 +15,7 @@ const InboxManagement = ( { domains } ) => {
 
 	//EmailManagementHome logic will handle the case where there is only one domain to show directly the email comparison
 	//and also if there is no domain so, it will show a CTA to buy domain
-	if ( domainsWithSubscriptions.length === 0 || domainsWithSubscriptions.length > 1 ) {
+	if ( domainsWithSubscriptions.length === 0 ) {
 		return (
 			<CalypsoShoppingCartProvider>
 				<EmailManagementHome />
@@ -24,7 +24,7 @@ const InboxManagement = ( { domains } ) => {
 	}
 
 	//If we are at this point it means that we've at least have one subscription to show in mailbox selector
-	return <h1>Handle Mailbox Placeholder</h1>;
+	return <h1>Placeholder</h1>;
 };
 
 export default connect( ( state ) => {

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -45,7 +45,7 @@ const InboxManagement = ( { domains } ) => {
 				<EmailManagementHome
 					emailListInactiveHeader={ getMainHeader() }
 					sectionHeaderLabel={ translate( 'Domains' ) }
-					showActiveDomainList={ true }
+					showActiveDomainList={ false }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -8,9 +8,9 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const InboxManagement = ( { domains } ) => {
-	const nonWPCOMDomains = domains.filter( ( domain ) => ! domain.isWPCOMDomain );
-	const domainsWithSubscriptions = nonWPCOMDomains.filter( ( domain ) =>
-		hasEmailSubscription( domain )
+
+	const domainsWithSubscriptions = domains.filter(
+		( domain ) => ! domain.isWPCOMDomain && hasEmailSubscription( domain )
 	);
 
 	//EmailManagementHome logic will handle the case where there is only one domain to show directly the email comparison

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -1,6 +1,8 @@
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
+import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import PromoCard from 'calypso/components/promo-section/promo-card';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 import { hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
@@ -8,6 +10,26 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const InboxManagement = ( { domains } ) => {
+	function getMainHeader() {
+		const image = {
+			path: emailIllustration,
+			align: 'right',
+		};
+
+		return (
+			<>
+				<PromoCard
+					isPrimary={ true }
+					title={ translate( 'Pick a domain to get started' ) }
+					image={ image }
+				>
+					<p>{ translate( 'Pick one of your domains below to add an email solution.' ) }</p>
+				</PromoCard>
+				<br />
+			</>
+		);
+	}
+
 	const domainsWithSubscriptions = domains.filter(
 		( domain ) => ! domain.isWPCOMDomain && hasEmailSubscription( domain )
 	);
@@ -17,7 +39,11 @@ const InboxManagement = ( { domains } ) => {
 	if ( domainsWithSubscriptions.length === 0 ) {
 		return (
 			<CalypsoShoppingCartProvider>
-				<EmailManagementHome />
+				<EmailManagementHome
+					emailListInactiveHeader={ getMainHeader() }
+					sectionHeaderLabel={ translate( 'Domains' ) }
+					onlyDomainsWithoutSubscription={ true }
+				/>
 			</CalypsoShoppingCartProvider>
 		);
 	}

--- a/client/my-sites/email/inbox-management/index.js
+++ b/client/my-sites/email/inbox-management/index.js
@@ -9,6 +9,8 @@ import { hasEmailSubscription } from 'calypso/my-sites/email/email-management/ho
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+import './style.scss';
+
 const InboxManagement = ( { domains } ) => {
 	function getMainHeader() {
 		const image = {
@@ -22,6 +24,7 @@ const InboxManagement = ( { domains } ) => {
 					isPrimary={ true }
 					title={ translate( 'Pick a domain to get started' ) }
 					image={ image }
+					className={ 'is-inbox-card' }
 				>
 					<p>{ translate( 'Pick one of your domains below to add an email solution.' ) }</p>
 				</PromoCard>
@@ -42,7 +45,7 @@ const InboxManagement = ( { domains } ) => {
 				<EmailManagementHome
 					emailListInactiveHeader={ getMainHeader() }
 					sectionHeaderLabel={ translate( 'Domains' ) }
-					onlyDomainsWithoutSubscription={ true }
+					showActiveDomainList={ true }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/inbox-management/style.scss
+++ b/client/my-sites/email/inbox-management/style.scss
@@ -1,4 +1,4 @@
-.is-inbox-card {
+.inbox-management__is-inbox-card {
 	div.action-panel__figure.align-right {
 		max-width: 170px;
 	}

--- a/client/my-sites/email/inbox-management/style.scss
+++ b/client/my-sites/email/inbox-management/style.scss
@@ -1,0 +1,5 @@
+.is-inbox-card {
+	div.action-panel__figure.align-right {
+		max-width: 170px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request adds the logic to show in upgrade->emails mailboxes if we have mailboxes to show. It will show either add a domain CTA or select domain if we have available ones.

#### Testing instructions

Have the following sites ready:
Site with no domains, site with one domain and no email subscription, sites with more than one domain with email subscriptions, and a site with mailboxes configured

**Test 1, Site with no domains:**
1. Go to the url: /inbox/{your-site-slug-with-no-domains}
2. Check that the inbox management screen is presenting you with a CTA to buy a domain

![image](https://user-images.githubusercontent.com/5689927/134048948-3db4d443-9997-4390-9c27-b079149058c1.png)

**Test 2, site with one domain and no email subscription**
1. Go to the url: /inbox/{your-site-slug-with-domain-and-no-email}
2. Check that the inbox management screen is presenting you with email comparison page

![image](https://user-images.githubusercontent.com/5689927/134049602-ee938ff5-db4b-4610-84d8-09ea54e79d65.png)

**Test 3, have a site with several domains without subscriptions**
1. Go to the url: /inbox/{your-site-with-several-domains-and-no-emails}
2. Check that the inbox management screen is presenting you with a domain selector, that takes you to email comparison page.

![image](https://user-images.githubusercontent.com/5689927/134499928-c4dbc539-a004-4d28-b37f-9b4d1a041750.png)

**Test 4, have a site with minimum a domain with subscriptions**
1. Go to the url: /inbox/{your-site-with-at-least-a-domain-and-emails}
2. Check that the inbox management screen is presenting you with a placeholder screen, this screen will be developed shortly.

#### Regression Test

The component `EmailListInactive` has been "upgraded" to change it's wording when it is being used in the mailbox component. Also, the component `EmailsHome` has been updated to do not show active domains (domains with subscriptions) when it is presented from inbox management screen. We need to check that the component `EmailsHome`  keeps working as it was doing it before:

BEFORE | AFTER
------------ | -------------
![image](https://user-images.githubusercontent.com/5689927/134046870-994aa932-ddb9-4da2-8d10-a4fb46e2cb17.png) | ![image](https://user-images.githubusercontent.com/5689927/134048264-5c98b25f-7fbf-4625-9458-eb293e3f5142.png)

Related to {1200182182542585-as-1200879615791996}
