### PR TITLE
@automattic/search correctly focuses the search input when opening

### DIFF
--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -212,9 +212,6 @@ const InnerSearch = (
 		setKeyword( '' );
 		setIsOpen( true );
 
-		searchInput.current?.focus();
-		// no need to call `onSearchOpen` as it will be called by `onFocus` once the searcbox is focused
-		// prevent outlines around the open icon after being clicked
 		recordEvent?.( 'Clicked Open Search' );
 	};
 
@@ -252,6 +249,8 @@ const InnerSearch = (
 			return;
 		}
 		if ( isOpen ) {
+			// no need to call `onSearchOpen` as it will be called by `onFocus` once the searcbox is focused
+			// prevent outlines around the open icon after being clicked
 			searchInput.current?.focus();
 			openIcon.current?.blur();
 		}

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -151,6 +151,7 @@ const InnerSearch = (
 	const searchInput = React.useRef< HTMLInputElement >( null );
 	const openIcon = React.useRef< HTMLButtonElement >( null );
 	const overlay = React.useRef< HTMLDivElement >( null );
+	const firstRender = React.useRef< boolean >( true );
 
 	React.useImperativeHandle(
 		forwardedRef,
@@ -214,7 +215,6 @@ const InnerSearch = (
 		searchInput.current?.focus();
 		// no need to call `onSearchOpen` as it will be called by `onFocus` once the searcbox is focused
 		// prevent outlines around the open icon after being clicked
-		openIcon.current?.blur();
 		recordEvent?.( 'Clicked Open Search' );
 	};
 
@@ -243,6 +243,19 @@ const InnerSearch = (
 
 		recordEvent?.( 'Clicked Close Search' );
 	};
+
+	// Focus the searchInput when isOpen flips to true, but ignore initial render
+	React.useEffect( () => {
+		// Do nothing on initial render
+		if ( firstRender.current ) {
+			firstRender.current = false;
+			return;
+		}
+		if ( isOpen ) {
+			searchInput.current?.focus();
+			openIcon.current?.blur();
+		}
+	}, [ isOpen ] );
 
 	const closeListener = keyListener( closeSearch );
 	const openListener = keyListener( openSearch );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clicking the search icon on the plugins page would open the text input, but not focus it. After clicking the search icon, you'd have to click in the text input before you could type.
  * This PR allows the text input to automatically focus after opening the search input. (The code was already attempting to do this, but it did not work.)
* This changes the `@automattic/search` package, so this changes behavior anywhere this package is used.

Before:

https://user-images.githubusercontent.com/39308239/130779262-6fd5318a-fe9f-4ef5-8455-fa53ef152764.mov

After:

https://user-images.githubusercontent.com/937354/134068981-0fc7f935-6867-484d-95f3-fc8bcc97fcba.mp4

#### Mechanism

* Code before this PR
The code [was already attempting to focus the input after opening](https://github.com/Automattic/wp-calypso/blob/1d652f90440b0e5b0877e9d96cf876518fae7a78/packages/search/src/search.tsx#L212-L214). However, it was not working.  `searchInput.current` exists, and the `searchInput.current?.focus();` line was running without errors, but the component was not being focused.
I believe it was due to a combination of:

1.  aria-hidden being tied to the open value ([part1](https://github.com/Automattic/wp-calypso/blob/1d652f90440b0e5b0877e9d96cf876518fae7a78/packages/search/src/search.tsx#L430), [part2](https://github.com/Automattic/wp-calypso/blob/1d652f90440b0e5b0877e9d96cf876518fae7a78/packages/search/src/search.tsx#L326))
2.  setState commands not working immediately, but queuing up a change that will be rerendered later
3.  Elements with aria-hidden not being able to be focused

If this were a class component, I could use the post-update callback of setState (ie: `setState( {isOpen: true}, () => searchInput.current?.focus() )`). However, as far as I know, the hook version of setState doesn't have anything like this. In this PR, I've added a useEffect to run the code after the setState happens, with an additional firstRender ref in order to make sure it only runs when isOpen changes, not on the initial mount.  I think it's a bit awkward, so I'm open to other ideas.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plugins/<siteurl>`
* Click the search icon and start typing

Related to #55706 
