### PR TITLE
Playwright: refactor BrowserManager methods to reduce dependencies.

### DIFF
--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -109,17 +109,11 @@ export function targetGutenbergEdge(): boolean {
  * @returns {LaunchOptions} Logger configuration.
  */
 export async function getDefaultLoggerConfiguration(): Promise< LaunchOptions > {
-	const { testPath } = getState() as { testPath: string };
-	const sanitizedTestFilename = path.basename( testPath, path.extname( testPath ) );
-	const resultsPath = path.join( process.cwd(), 'results' );
-	await mkdir( resultsPath, { recursive: true } );
-	const tempDir = await mkdtemp( path.join( resultsPath, sanitizedTestFilename + '-' ) );
-
 	return {
 		logger: {
 			log: async ( name: string, severity: string, message: string ) => {
 				await appendFile(
-					path.join( tempDir, 'playwright.log' ),
+					path.join( await getArtifactDir(), 'playwright.log' ),
 					`${ new Date().toISOString() } ${ process.pid } ${ name } ${ severity }: ${ message }\n`
 				);
 			},
@@ -127,4 +121,20 @@ export async function getDefaultLoggerConfiguration(): Promise< LaunchOptions > 
 			isEnabled: ( name: string ) => name === 'api',
 		},
 	};
+}
+
+/**
+ * Returns the artifact directory where logs, screenshots and video recordings are stored.
+ *
+ * @returns {Promise<string>} Path to the artifdact directory.
+ */
+export async function getArtifactDir(): Promise< string > {
+	const { testPath } = getState() as { testPath: string };
+	const sanitizedTestFilename = path.basename( testPath, path.extname( testPath ) );
+	const resultsPath = path.join( process.cwd(), 'results' );
+	await mkdir( resultsPath, { recursive: true } );
+	const out = await mkdtemp( path.join( resultsPath, sanitizedTestFilename + '-' ) );
+	console.log( out );
+	// return await mkdtemp( path.join( resultsPath, sanitizedTestFilename + '-' ) );
+	return out;
 }

--- a/packages/calypso-e2e/src/browser-helper.ts
+++ b/packages/calypso-e2e/src/browser-helper.ts
@@ -133,8 +133,5 @@ export async function getArtifactDir(): Promise< string > {
 	const sanitizedTestFilename = path.basename( testPath, path.extname( testPath ) );
 	const resultsPath = path.join( process.cwd(), 'results' );
 	await mkdir( resultsPath, { recursive: true } );
-	const out = await mkdtemp( path.join( resultsPath, sanitizedTestFilename + '-' ) );
-	console.log( out );
-	// return await mkdtemp( path.join( resultsPath, sanitizedTestFilename + '-' ) );
-	return out;
+	return await mkdtemp( path.join( resultsPath, sanitizedTestFilename + '-' ) );
 }

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -102,6 +102,24 @@ export async function startBrowser( browserType: BrowserType ): Promise< Browser
 }
 
 /**
+ * Closes the target page passed in as parameter, and optionally closes the BrowserContext as well.
+ *
+ * @param {Page} page Target page to close.
+ * @param param0 Parameter object.
+ * @param {boolean} param0.closeContext Whether to also close the BrowserContext to which the page belongs.
+ */
+export async function closePage(
+	page: Page,
+	{ closeContext = false }: { closeContext?: boolean } = {}
+): Promise< void > {
+	if ( closeContext ) {
+		await page.context().close();
+	} else {
+		await page.close();
+	}
+}
+
+/**
  * Terminates the Browser instance.
  *
  * Once a Browser instance is terminated, all open contexts and pages are also terminated.

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -5,7 +5,11 @@
 
 import config from 'config';
 import { BrowserType } from 'playwright';
-import { getHeadless, getLaunchConfiguration } from './browser-helper';
+import {
+	getDefaultLoggerConfiguration,
+	getHeadless,
+	getLaunchConfiguration,
+} from './browser-helper';
 import type { Browser, BrowserContext, Logger, Page } from 'playwright';
 
 export let browser: Browser;
@@ -67,7 +71,7 @@ export async function newPage( {
 
 	// If caller wants the Page object in a new BrowserContext.
 	if ( newContext ) {
-		const newContext = await newBrowserContext();
+		const newContext = await newBrowserContext( await getDefaultLoggerConfiguration() );
 		return await newContext.newPage();
 	}
 

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -11,7 +11,7 @@ import type { Browser, BrowserContext, Logger, Page } from 'playwright';
 export let browser: Browser;
 
 export interface LaunchOptions {
-	logger: Logger[ 'log' ];
+	logger: Logger;
 }
 
 /**
@@ -34,12 +34,9 @@ export async function newBrowserContext(
 	// Get basic configuration (devices, browser agent string, etc).
 	const config = getLaunchConfiguration( browser.version() );
 
+	// Add logging details.
 	if ( launchOptions?.logger ) {
-		// Add logging details.
-		config.logger = {
-			isEnabled: ( name ) => name === 'api',
-			log: launchOptions.logger,
-		};
+		config.logger = launchOptions.logger;
 	}
 
 	// Launch a new BrowserContext with launch configuration.

--- a/packages/calypso-e2e/src/browser-manager.ts
+++ b/packages/calypso-e2e/src/browser-manager.ts
@@ -4,8 +4,8 @@
  */
 
 import config from 'config';
-import { chromium } from 'playwright';
-import { getLaunchConfiguration } from './browser-helper';
+import { BrowserType } from 'playwright';
+import { getHeadless, getLaunchConfiguration } from './browser-helper';
 import type { Browser, BrowserContext, Logger, Page } from 'playwright';
 
 export let browser: Browser;
@@ -15,49 +15,68 @@ export interface LaunchOptions {
 }
 
 /**
- * Familiar entrypoint to initialize the browser from a test writer's perspective.
+ * Returns a new instance of a BrowserContext object.
  *
- * @param launchOptions Options to pass to `browser.newContext()`.
- * @returns {Promise<Page>} New Page instance.
- */
-export async function start( launchOptions: LaunchOptions ): Promise< Page > {
-	return await launchPage( launchOptions );
-}
-
-/**
- * Returns a new instance of a Page.
+ * A BrowserContext represents an isolated environment, akin to incognito mode.
+ * Instances of BrowserContext do not share cookies or authenticated states with other contexts.
  *
- * This function wraps and sets additional parameters before returning a new instance
- * of a Page.
- * Page represents a tab in a browser where the actual test are run.
- *
- * @param launchOptions Options to pass to `browser.newContext()`.
- * @returns {Promise<Page>} New Page instance.
- */
-export async function launchPage( launchOptions: LaunchOptions ): Promise< Page > {
-	const browserContext = await launchBrowserContext( launchOptions );
-	return await browserContext.newPage();
-}
-
-/**
- * Returns a new instance of a BrowserContext.
- *
- * A BrowserContext represents an isolated environment, akin to incognito mode
- * inside which a single test suite is run.
- * BrowserContexts are cheap to create and incur low overhead costs while allowing
- * for parallelization of test suites.
- *
- * @param options Options to pass to `browser.newContext()`.
- * @param {Logger} options.logger Logger sink for Playwright logging.
+ * @param {LaunchOptions} [launchOptions] Options to pass to `browser.newContext()`.
  * @returns {Promise<BrowserContext>} New BrowserContext instance.
+ * @throws {Error} If no instance of a browser is found.
  */
-export async function launchBrowserContext( { logger }: LaunchOptions ): Promise< BrowserContext > {
-	// If no existing instance of a Browser, then launch a new instance.
+export async function newBrowserContext(
+	launchOptions?: LaunchOptions
+): Promise< BrowserContext > {
 	if ( ! browser ) {
-		browser = await launchBrowser();
+		throw new Error( 'No browser instance found.' );
 	}
 
-	return await browser.newContext( getLaunchConfiguration( browser.version(), { logger } ) );
+	// Get basic configuration (devices, browser agent string, etc).
+	const config = getLaunchConfiguration( browser.version() );
+
+	if ( launchOptions?.logger ) {
+		// Add logging details.
+		config.logger = {
+			isEnabled: ( name ) => name === 'api',
+			log: launchOptions.logger,
+		};
+	}
+
+	// Launch a new BrowserContext with launch configuration.
+	return await browser.newContext( config );
+}
+
+/**
+ * Returns a new instance of a Page object.
+ *
+ * If the optional parameter `context` is provivided, this method will return a
+ * new instance of a Page belonging to the supplied BrowserContext.
+ * Alternatively, if optional parameter
+ * Otherwise, a new instance of a Page is returned from the most recent BrowserContext.
+ *
+ * @param param0 Keyed object parameter.
+ * @param {BrowserContext} [param0.context] BrowserContext on which the new Page should be created.
+ * @param {boolean} [param0.newContext] If a new BrowserContext is desired.
+ * @returns {Promise<Page>} Instance of a new Page object.
+ */
+export async function newPage( {
+	context,
+	newContext = false,
+}: { context?: BrowserContext; newContext?: boolean } = {} ): Promise< Page > {
+	// If caller supplies the target BrowserContext.
+	if ( context ) {
+		return await context.newPage();
+	}
+
+	// If caller wants the Page object in a new BrowserContext.
+	if ( newContext ) {
+		const newContext = await newBrowserContext();
+		return await newContext.newPage();
+	}
+
+	// Default case - launch a new Page object in the most recent BrowserContext.
+	const contexts = browser.contexts();
+	return await contexts[ contexts.length - 1 ].newPage();
 }
 
 /**
@@ -67,15 +86,19 @@ export async function launchBrowserContext( { logger }: LaunchOptions ): Promise
  * Considerable overhead and costs are incurred when launching a new Browser instance.
  * Where possible, use BrowserContexts.
  *
+ * @param {BrowserType} browserType Type of browser to use.
  * @returns {Promise<Browser>} New Browser instance.
  */
-export async function launchBrowser(): Promise< Browser > {
-	const isHeadless = process.env.HEADLESS === 'true' || config.has( 'headless' );
+export async function startBrowser( browserType: BrowserType ): Promise< Browser > {
+	if ( browser ) {
+		return browser;
+	}
 
-	return await chromium.launch( {
-		headless: isHeadless,
+	browser = await browserType.launch( {
+		headless: getHeadless(),
 		args: [ '--window-position=0,0' ],
 	} );
+	return browser;
 }
 
 /**
@@ -86,7 +109,7 @@ export async function launchBrowser(): Promise< Browser > {
  *
  * @returns {Promise<void>} No return value.
  */
-export async function close(): Promise< void > {
+export async function closeBrowser(): Promise< void > {
 	if ( browser ) {
 		await browser.close();
 	} else {

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -35,9 +35,10 @@ function getTestNameWithTime( testName: string ): string {
  */
 export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): void => {
 	let page: Page;
-	const tempDir = getArtifactDir();
+	let tempDir: string;
 
 	beforeAll( async () => {
+		tempDir = await getArtifactDir();
 		// Get default logging configuration, which will create a directory to store
 		// artifacts.
 		const loggingConfiguration = await getDefaultLoggerConfiguration();

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -49,11 +49,15 @@ export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): vo
 		await startBrowser( chromium );
 		// Launch context with logging.
 		const context = await newBrowserContext( {
-			logger: async ( name, severity, message ) => {
-				await appendFile(
-					path.join( tempDir, 'playwright.log' ),
-					`${ new Date().toISOString() } ${ process.pid } ${ name } ${ severity }: ${ message }\n`
-				);
+			logger: {
+				log: async ( name: string, severity: string, message: string ) => {
+					await appendFile(
+						path.join( tempDir, 'playwright.log' ),
+						`${ new Date().toISOString() } ${ process.pid } ${ name } ${ severity }: ${ message }\n`
+					);
+				},
+				// Default to verbose Playwright API logs.
+				isEnabled: ( name: string ) => name === 'api',
 			},
 		} );
 		// Launch a new page within the context.

--- a/packages/calypso-e2e/src/hooks.ts
+++ b/packages/calypso-e2e/src/hooks.ts
@@ -2,7 +2,7 @@ import { mkdir, rename } from 'fs/promises';
 import path from 'path';
 import { beforeAll, afterAll } from '@jest/globals';
 import { chromium, Page, Video } from 'playwright';
-import { getDefaultLoggerConfiguration } from './browser-helper';
+import { getDefaultLoggerConfiguration, getArtifactDir } from './browser-helper';
 import { closeBrowser, startBrowser, newBrowserContext, browser } from './browser-manager';
 import { getDateString } from './data-helper';
 
@@ -35,7 +35,7 @@ function getTestNameWithTime( testName: string ): string {
  */
 export const setupHooks = ( callback: ( { page }: { page: Page } ) => void ): void => {
 	let page: Page;
-	let tempDir: string;
+	const tempDir = getArtifactDir();
 
 	beforeAll( async () => {
 		// Get default logging configuration, which will create a directory to store

--- a/packages/calypso-e2e/test/browser-helper.test.ts
+++ b/packages/calypso-e2e/test/browser-helper.test.ts
@@ -94,11 +94,9 @@ describe( 'BrowserHelper Tests', function () {
 			'Returns expected values in launch configuration for target device $name',
 			function ( { name, browser_version } ) {
 				process.env.TARGET_DEVICE = name;
-				const dummy_logger = ( name: string, message: string | Error ) =>
-					console.log( `${ name } ${ message }` );
 				const expected_e2e_test_string = 'wp-e2e-tests';
 
-				const config = getLaunchConfiguration( browser_version, { logger: dummy_logger } );
+				const config = getLaunchConfiguration( browser_version );
 				expect( config.userAgent ).toContain( expected_e2e_test_string );
 				expect( config.userAgent ).toContain( browser_version );
 			}

--- a/test/e2e/specs/specs-playwright/wp-signup__paid.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__paid.ts
@@ -116,13 +116,15 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ), function 
 		} );
 
 		it( 'Verify site is not yet launched', async function () {
-			const testContext = await BrowserManager.browser.newContext();
-			const testPage = await testContext.newPage();
+			// Obtain a new Page in a separate BrowserContext.
+			const testPage = await BrowserManager.newPage( { newContext: true } );
 			// TODO: make a utility to obtain the blog URL.
 			await testPage.goto( `https://${ blogName }.wordpress.com` );
+			// View site without logging in.
 			const comingSoonPage = new ComingSoonPage( testPage );
 			await comingSoonPage.validateComingSoonState();
-			await testContext.close();
+			// Dispose the test page and context.
+			await BrowserManager.closePage( testPage, { closeContext: true } );
 		} );
 
 		it( 'Start site launch', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors methods in the BrowserManager to reduce dependencies and to promote less tighter coupling.

Key changes:
- instead of a top-down approach where the initial method calls more methods further down, prefer a flatter approach.
- move helper methods to BrowserHelper.
- make `LaunchOptions` an optional parameter.
- change test specs to use the new methods to launch BrowserContext/Pages.

Details:

There is one notable issue with the existing incarnation of BrowserManager, BrowserHelper and Jest hooks: it is not trivial to call a method in BrowserManager to arbitrarily launch a new Page or BrowserContext. This is largely due to the parameter `LaunchOptions` used to set the logging parameters. 

The initial LaunchOptions would be passed into the `start()` method in the Jest hook, and subsequently passed down to all methods that `start()` calls.

This refactor reorganizes the methods in BrowserManager such that the call stack is flatter, with each method performing one task and returning. The expectation is now on the calling method to call the steps in sequence, as required.

The change in method structure also allows LaunchOptions to be made unnecessary on all but one method (`newBrowserContext`). On the `newBrowserContext` method, LaunchOptions is also an optional parameter that if specified will add to the launch configuration for the BrowserContext. 

#### Testing instructions

- [x] standard tests
   - [x] mobile
   - [x] desktop

Related to #
