### PR TITLE
Playwright: refactor how media upload is handled

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-media; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-media; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -101,8 +101,9 @@ export class MediaPage {
 	async editItem(): Promise< void > {
 		// await this.page.waitForLoadState( 'networkidle', { timeout: 60000 } );
 
-		const itemsSelected = await this.page.isVisible( selectors.selectedItems );
-		if ( ! itemsSelected ) {
+		try {
+			await this.page.waitForSelector( selectors.selectedItems );
+		} catch ( error ) {
 			throw new Error( 'Unable to edit files: no item(s) were selected.' );
 		}
 

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { ElementHandle, Page } from 'playwright';
 import { waitForElementEnabled, clickNavTab } from '../../element-helper';
 
@@ -6,7 +5,7 @@ const selectors = {
 	// Gallery view
 	gallery: '.media-library__content',
 	items: '.media-library__list-item',
-	selectedItems: '.is-selected',
+	selectedItems: '.media-library__list-item.is-selected',
 	placeholder: '.is-placeholder',
 	uploadSpinner: '.media-library__list-item-spinner',
 	notReadyOverlay: `.is-transient`,
@@ -100,7 +99,7 @@ export class MediaPage {
 	 * @throws {Error} If no gallery items are selected.
 	 */
 	async editItem(): Promise< void > {
-		await this.waitUntilLoaded();
+		// await this.page.waitForLoadState( 'networkidle', { timeout: 60000 } );
 
 		const itemsSelected = await this.page.isVisible( selectors.selectedItems );
 		if ( ! itemsSelected ) {
@@ -150,16 +149,8 @@ export class MediaPage {
 	async upload( fullPath: string ): Promise< void > {
 		await this.waitUntilLoaded();
 
-		// Set the file input to the full path of file on disk, which will trigger
-		// elements to be attached to the page.
-		await Promise.all( [
-			// this.page.waitForSelector( selectors.uploadSpinner, { state: 'detached' } ),
-			// this.page.waitForSelector( selectors.notReadyOverlay, { state: 'detached' } ),
-			// this.page.waitForSelector( 'button[data-e2e-button="delete"][disabled]', {
-			// 	state: 'detached',
-			// } ),
-			this.page.setInputFiles( selectors.fileInput, fullPath ),
-		] );
+		// Set the file input to the full path of file on disk.
+		await this.page.setInputFiles( selectors.fileInput, fullPath );
 
 		await Promise.all( [
 			this.page.waitForSelector( 'button[data-e2e-button="delete"][disabled]', {

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -99,8 +99,7 @@ export class MediaPage {
 	 * @throws {Error} If no gallery items are selected.
 	 */
 	async editItem(): Promise< void > {
-		// await this.page.waitForLoadState( 'networkidle', { timeout: 60000 } );
-
+		// Check that an item has been selected.
 		try {
 			await this.page.waitForSelector( selectors.selectedItems );
 		} catch ( error ) {
@@ -172,27 +171,5 @@ export class MediaPage {
 					.then( ( element ) => element.innerText() )
 			);
 		}
-
-		// Wait until the spinner for the file being uploaded is hidden.
-		// This is necessary as Simple and Atomic sites behave slightly differently when rejecting.
-		// For Atomic, a figure and associated spinner are shown briefly in the gallery before rejection.
-		// await Promise.all( [
-		// 	this.page.waitForSelector( `${ itemSelector } .media-library__list-item-spinner`, {
-		// 		state: 'hidden',
-		// 	} ),
-		// 	this.page.waitForSelector( selectors.notReadyOverlay, { state: 'hidden' } ),
-		// ] );
-
-		// // At this point, if the rejection notice is visible, it means the file was not a supported
-		// // file type. Throw the error containing the rejection banner text for handling.
-		// if ( await this.page.isVisible( selectors.uploadRejectionNotice ) ) {
-		// 	throw new Error(
-		// 		await this.page
-		// 			.waitForSelector( selectors.uploadRejectionNotice )
-		// 			.then( ( element ) => element.innerText() )
-		// 	);
-		// } else {
-		// 	return await this.page.waitForSelector( itemSelector );
-		// }
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -10,13 +10,13 @@ const selectors = {
 	uploadSpinner: '.media-library__list-item-spinner',
 	notReadyOverlay: `.is-transient`,
 	editButton: 'button[data-e2e-button="edit"]',
+	deleteButton: 'button[data-e2e-button="delete"]',
 	fileInput: 'input.media-library__upload-button-input',
 	uploadRejectionNotice: 'text=/could not be uploaded/i',
 
 	// Edit File modal
 	editFileModal: '.editor-media-modal__content',
-	editImageButton:
-		'.editor-media-modal-detail__edition-bar .editor-media-modal-detail__edit:visible',
+	editImageButton: 'button:has-text("Edit Image"):visible',
 
 	// Iamge Editor
 	imageEditorCanvas: '.image-editor__canvas-container',
@@ -153,7 +153,8 @@ export class MediaPage {
 		await this.page.setInputFiles( selectors.fileInput, fullPath );
 
 		await Promise.all( [
-			this.page.waitForSelector( 'button[data-e2e-button="delete"][disabled]', {
+			// Delete file button is disabled during uploads.
+			this.page.waitForSelector( `${ selectors.deleteButton }[disabled]`, {
 				state: 'hidden',
 			} ),
 			this.page.waitForSelector( selectors.uploadSpinner, { state: 'hidden' } ),

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -6,21 +6,23 @@ const selectors = {
 	// Gallery view
 	gallery: '.media-library__content',
 	items: '.media-library__list-item',
+	selectedItems: '.is-selected',
 	placeholder: '.is-placeholder',
+	uploadSpinner: '.media-library__list-item-spinner',
 	notReadyOverlay: `.is-transient`,
 	editButton: 'button[data-e2e-button="edit"]',
 	fileInput: 'input.media-library__upload-button-input',
 	uploadRejectionNotice: 'text=/could not be uploaded/i',
 
-	// Modal view
-	mediaModal: '.editor-media-modal__content',
-	mediaModalEditButton:
+	// Edit File modal
+	editFileModal: '.editor-media-modal__content',
+	editImageButton:
 		'.editor-media-modal-detail__edition-bar .editor-media-modal-detail__edit:visible',
-	mediaModalPreview: '.editor-media-modal-detail__preview',
 
-	// Editor view
+	// Iamge Editor
 	imageEditorCanvas: '.image-editor__canvas-container',
-	imageEditorToolbarButton: '.image-editor__toolbar-button',
+	imageEditorToolbarButton: ( text: string ) =>
+		`.image-editor__toolbar-button span:text("${ text }")`,
 	imageEditorResetButton: 'button[data-e2e-button="reset"]',
 	imageEditorCancelButton: 'button[data-e2e-button="cancel"]',
 };
@@ -90,16 +92,32 @@ export class MediaPage {
 	}
 
 	/**
-	 * Given that a gallery item is selected, enter the edit screen.
+	 * Launches the edit item modal where file attributes can be modified.
 	 *
-	 * @returns {Promise<void>} No return value.
+	 * This method expects at least one gallery element supporting editing
+	 * to be selected. If no images are selected, this method will throw.
+	 *
+	 * @throws {Error} If no gallery items are selected.
 	 */
-	async editImage(): Promise< void > {
+	async editItem(): Promise< void > {
 		await this.waitUntilLoaded();
 
+		const itemsSelected = await this.page.isVisible( selectors.selectedItems );
+		if ( ! itemsSelected ) {
+			throw new Error( 'Unable to edit files: no item(s) were selected.' );
+		}
+
 		await this.page.click( selectors.editButton );
-		await this.page.click( selectors.mediaModalEditButton );
-		await this.page.waitForSelector( selectors.imageEditorCanvas );
+	}
+
+	/**
+	 * Launches the image editor from within the edit item modal.
+	 *
+	 * This option is only available for files that are classified as 'images' in WPCOM.
+	 */
+	async editImage(): Promise< void > {
+		await this.page.waitForSelector( selectors.editFileModal );
+		await this.page.click( selectors.editImageButton );
 	}
 
 	/**
@@ -109,8 +127,7 @@ export class MediaPage {
 	 */
 	async rotateImage(): Promise< void > {
 		await this.page.waitForSelector( selectors.imageEditorCanvas );
-		const selector = `${ selectors.imageEditorToolbarButton } span:text("Rotate")`;
-		await this.page.click( selector );
+		await this.page.click( selectors.imageEditorToolbarButton( 'Rotate' ) );
 		await waitForElementEnabled( this.page, selectors.imageEditorResetButton );
 	}
 
@@ -121,7 +138,7 @@ export class MediaPage {
 	 */
 	async cancelImageEdit(): Promise< void > {
 		await this.page.click( selectors.imageEditorCancelButton );
-		await this.page.waitForSelector( selectors.mediaModal );
+		await this.page.waitForSelector( selectors.editFileModal );
 	}
 
 	/**
@@ -130,36 +147,60 @@ export class MediaPage {
 	 * @param {string} fullPath Full path to the file on disk.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async upload( fullPath: string ): Promise< ElementHandle > {
+	async upload( fullPath: string ): Promise< void > {
 		await this.waitUntilLoaded();
 
-		const filename = path.basename( fullPath );
-		const itemSelector = `figure[title="${ filename }"]`;
-
-		await this.page.waitForSelector( selectors.fileInput );
-		// Simulate the action of user selecting a file then clicking confirm.
-		await this.page.setInputFiles( selectors.fileInput, fullPath );
-
-		// Wait until the spinner for the file being uploaded is hidden.
-		// This is necessary as Simple and Atomic sites behave slightly differently when rejecting.
-		// For Atomic, a figure and associated spinner are shown briefly in the gallery before rejection.
+		// Set the file input to the full path of file on disk, which will trigger
+		// elements to be attached to the page.
 		await Promise.all( [
-			this.page.waitForSelector( `${ itemSelector } .media-library__list-item-spinner`, {
+			// this.page.waitForSelector( selectors.uploadSpinner, { state: 'detached' } ),
+			// this.page.waitForSelector( selectors.notReadyOverlay, { state: 'detached' } ),
+			// this.page.waitForSelector( 'button[data-e2e-button="delete"][disabled]', {
+			// 	state: 'detached',
+			// } ),
+			this.page.setInputFiles( selectors.fileInput, fullPath ),
+		] );
+
+		await Promise.all( [
+			this.page.waitForSelector( 'button[data-e2e-button="delete"][disabled]', {
 				state: 'hidden',
 			} ),
+			this.page.waitForSelector( selectors.uploadSpinner, { state: 'hidden' } ),
 			this.page.waitForSelector( selectors.notReadyOverlay, { state: 'hidden' } ),
 		] );
 
-		// At this point, if the rejection notice is visible, it means the file was not a supported
-		// file type. Throw the error containing the rejection banner text for handling.
-		if ( await this.page.isVisible( selectors.uploadRejectionNotice ) ) {
+		// For both Simple and Atomic, the rejection banner is shown after the upload progress
+		// elements are removed from page.
+		const rejected = await this.page.isVisible( selectors.uploadRejectionNotice );
+
+		if ( rejected ) {
 			throw new Error(
 				await this.page
 					.waitForSelector( selectors.uploadRejectionNotice )
 					.then( ( element ) => element.innerText() )
 			);
-		} else {
-			return await this.page.waitForSelector( itemSelector );
 		}
+
+		// Wait until the spinner for the file being uploaded is hidden.
+		// This is necessary as Simple and Atomic sites behave slightly differently when rejecting.
+		// For Atomic, a figure and associated spinner are shown briefly in the gallery before rejection.
+		// await Promise.all( [
+		// 	this.page.waitForSelector( `${ itemSelector } .media-library__list-item-spinner`, {
+		// 		state: 'hidden',
+		// 	} ),
+		// 	this.page.waitForSelector( selectors.notReadyOverlay, { state: 'hidden' } ),
+		// ] );
+
+		// // At this point, if the rejection notice is visible, it means the file was not a supported
+		// // file type. Throw the error containing the rejection banner text for handling.
+		// if ( await this.page.isVisible( selectors.uploadRejectionNotice ) ) {
+		// 	throw new Error(
+		// 		await this.page
+		// 			.waitForSelector( selectors.uploadRejectionNotice )
+		// 			.then( ( element ) => element.innerText() )
+		// 	);
+		// } else {
+		// 	return await this.page.waitForSelector( itemSelector );
+		// }
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -98,7 +98,7 @@ export class MediaPage {
 	 *
 	 * @throws {Error} If no gallery items are selected.
 	 */
-	async editItem(): Promise< void > {
+	async editSelectedItem(): Promise< void > {
 		// Check that an item has been selected.
 		try {
 			await this.page.waitForSelector( selectors.selectedItems );
@@ -114,7 +114,7 @@ export class MediaPage {
 	 *
 	 * This option is only available for files that are classified as 'images' in WPCOM.
 	 */
-	async editImage(): Promise< void > {
+	async launchImageEditor(): Promise< void > {
 		await this.page.waitForSelector( selectors.editFileModal );
 		await this.page.click( selectors.editImageButton );
 	}

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
@@ -18,7 +18,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 	let testImage: TestFile;
 	let page: Page;
 
-	setupHooks( ( args ) => {
+	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;
 	} );
 
@@ -51,8 +51,8 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		} );
 
 		it( 'Launch image editor', async function () {
-			await mediaPage.editItem();
-			await mediaPage.editImage();
+			await mediaPage.editSelectedItem();
+			await mediaPage.launchImageEditor();
 		} );
 
 		it( 'Rotate image', async function () {

--- a/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-media__edit-spec.ts
@@ -47,12 +47,11 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		it( 'Upload image', async function () {
 			// Ideally, we'd not want to upload an image (that's a separate test)
 			// but occasionally, the photo gallery is cleaned out leaving no images.
-			const uploadedImageHandle = await mediaPage.upload( testImage.fullpath );
-			const isVisible = await uploadedImageHandle.isVisible();
-			expect( isVisible ).toBe( true );
+			await mediaPage.upload( testImage.fullpath );
 		} );
 
-		it( 'Click to edit selected image', async function () {
+		it( 'Launch image editor', async function () {
+			await mediaPage.editItem();
 			await mediaPage.editImage();
 		} );
 

--- a/test/e2e/specs/specs-playwright/wp-media__upload-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-media__upload-spec.ts
@@ -54,20 +54,20 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 		} );
 
 		it( 'Upload image and confirm addition to gallery', async () => {
-			const uploadedItem = await mediaPage.upload( testFiles.image.fullpath );
-			assert.strictEqual( await uploadedItem.isVisible(), true );
+			await mediaPage.upload( testFiles.image.fullpath );
 		} );
 
 		it( 'Upload audio and confirm addition to gallery', async () => {
-			const uploadedItem = await mediaPage.upload( testFiles.audio.fullpath );
-			assert.strictEqual( await uploadedItem.isVisible(), true );
+			await mediaPage.upload( testFiles.audio.fullpath );
 		} );
 
 		it( 'Upload an unsupported file type and see the rejection notice', async function () {
 			try {
 				await mediaPage.upload( testFiles.unsupported.fullpath );
-			} catch ( error ) {
-				assert.match( error.message, /could not be uploaded/i );
+			} catch ( error: unknown ) {
+				if ( error instanceof Error ) {
+					assert.match( error.message, /could not be uploaded/i );
+				}
 			}
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors how the media file upload is handled.

Key changes:
- discontinue use of `waitForSelector` in the `upload` method to return a handle to the caller.
- separate the process of actual image editor and bringing up the editor modal (editImage and editItem)
- rename some selectors and modify some into dynamic selectors where appropriate.

Details:

The current implementation of `MediaPage.upload` returns an ElementHandle of the uploaded image to the calling method. This is fine in theory, however in practice it has led to numerous issues in CI where the selector of the file that had been uploaded is not found. 

After much investigation it appears the cause of this is due to the way the image uploads behave in Calypso:
- file is selected for upload.
- while the upload takes place, a placeholder gallery item is added. Spinner and a transient overlay is applied on top of this placeholder item.
- once the upload request is complete, the spinner and transient properties are removed. At this time, the item element is detached and re-attached with the finalized version.
- for image uploads, the thumbnail is then generated. Once generated, the thumbnail is downloaded from the server and the grey placeholder image is replaced with the thumbnail.

For existing implementation, the issue arises somewhere in the last two steps, likely when the original placeholder element is replaced with the semi-finalized element. Backing up this hypothesis is that failure of `waitForSelector` to locate the element for the uploaded item would only intermittently fail with ~8% failure rate, and only for image type uploads.

In any case, the refactored `MediaPage.upload` jettisons the element check, instead preferring a combination of delegating assertion to the calling method & indirect checks.
- delegating assertion: the calling method is expected to run checks (eg. `isVisible`).
- indirect checks: assert that an element (visible only if upload of a file was successful) is shown on page before proceeding.

#### Testing instructions

- [x] normal test
   - [x] mobile
   - [x] desktop
- [x] stress test
   - [x] mobile
   - [x] desktop

Related to #56174
