### PR TITLE
desktop: Refine response to notification bell click 

### DIFF
--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -109,8 +109,8 @@ const init = () => {
 				// If we're in a WP-Desktop context, window.electron will
 				// be set. Let the app know that the notifications panel
 				// has been toggled.
-				if ( window.electron ) {
-					window.electron.send( 'notifications-panel-toggled' );
+				if ( window && window.parent && window.parent.electron ) {
+					window.parent.electron.send( 'notifications-panel-toggled' );
 				}
 			}
 		} )

--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -109,8 +109,8 @@ const init = () => {
 				// If we're in a WP-Desktop context, window.electron will
 				// be set. Let the app know that the notifications panel
 				// has been toggled.
-				if ( window && window.parent && window.parent.electron ) {
-					window.parent.electron.send( 'notifications-panel-toggled' );
+				if ( window && window.parent ) {
+					window.parent.postMessage( { message: 'notifications-panel-toggled' }, '*' );
 				}
 			}
 		} )

--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -105,6 +105,13 @@ const init = () => {
 			if ( 'toggleVisibility' === action ) {
 				isVisible = ! hidden;
 				refresh();
+
+				// If we're in a WP-Desktop context, window.electron will
+				// be set. Let the app know that the notifications panel
+				// has been toggled.
+				if ( window.electron ) {
+					window.electron.send( 'notifications-panel-toggled' );
+				}
 			}
 		} )
 	);

--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -100,11 +100,6 @@ const init = () => {
 
 				isShowing = showing;
 				refresh();
-			}
-
-			if ( 'toggleVisibility' === action ) {
-				isVisible = ! hidden;
-				refresh();
 
 				// If we're in a WP-Desktop context, window.electron will
 				// be set. Let the app know that the notifications panel
@@ -112,6 +107,11 @@ const init = () => {
 				if ( window && window.parent ) {
 					window.parent.postMessage( { message: 'notifications-panel-toggled' }, '*' );
 				}
+			}
+
+			if ( 'toggleVisibility' === action ) {
+				isVisible = ! hidden;
+				refresh();
 			}
 		} )
 	);

--- a/client/lib/desktop-listeners/index.js
+++ b/client/lib/desktop-listeners/index.js
@@ -6,6 +6,11 @@ import { getStatsPathForTab } from 'calypso/lib/route';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+/* Deprecated:
+NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET
+Remove event and usage on or after 2022-01-01
+https://github.com/Automattic/wp-calypso/pull/56415
+*/
 import { NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET } from 'calypso/state/desktop/window-events';
 import { setForceRefresh as forceNotificationsRefresh } from 'calypso/state/notifications-panel/actions';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -44,6 +49,11 @@ const DesktopListeners = {
 		window.electron.receive( 'navigate', this.onNavigate.bind( this ) );
 		window.electron.receive( 'request-user-login-status', this.sendUserLoginStatus );
 
+		/* Deprecated:
+		NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET
+		Remove event and usage on or after 2022-01-01
+		See: https://github.com/Automattic/wp-calypso/pull/56415
+		*/
 		window.addEventListener(
 			NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET,
 			this.resetUnseenNotifications.bind( this )
@@ -70,6 +80,11 @@ const DesktopListeners = {
 		this.selectedSite = site;
 	},
 
+	/* Deprecated:
+	NOTIFY_DESKTOP_NOTIFICATIONS_UNSEEN_COUNT_RESET
+	Remove event and usage on or after 2022-01-01
+	See: https://github.com/Automattic/wp-calypso/pull/56415
+	*/
 	// window event
 	resetUnseenNotifications: function () {
 		debug( 'Reseting unseen notification count' );

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -143,8 +143,6 @@ function showAppWindow() {
 		return Settings.toRenderer();
 	} );
 
-	mainView.webContents.loadURL( appUrl );
-
 	mainWindow.on( 'close', function () {
 		const currentURL = mainView.webContents.getURL();
 		log.info( `Closing main window, last location: '${ currentURL }'` );
@@ -167,6 +165,8 @@ function showAppWindow() {
 	require( '../window-handlers/navigation' )( appWindow );
 
 	platform.setMainWindow( appWindow );
+
+	mainView.webContents.loadURL( appUrl );
 
 	return mainWindow;
 }

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -30,7 +30,20 @@ function updateNotificationBadge() {
 }
 
 module.exports = function ( { window, view } ) {
-	ipc.on( 'clear-notices-count', function () {
+	view.webContents.on( 'did-finish-load', () => {
+		const code = `
+			if ( typeof masterbarItems === 'undefined' ) {
+				console.log( 'Hello hello' );
+				const masterbarItems = document.getElementsByClassName( 'masterbar__notifications' );
+				if ( masterbarItems && masterbarItems.length > 0 ) {
+					const bell = masterbarItems[0];
+					bell.addEventListener("click",function(){window.electron.send( 'reset-unread-count' );});
+				}
+			}`;
+		view.webContents.executeJavaScript( code );
+	} );
+
+	ipc.on( 'reset-unread-count', function () {
 		if ( notificationBadgeCount > 0 ) {
 			log.info( 'Notification badge count reset' );
 			notificationBadgeCount = 0;

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -31,6 +31,7 @@ function updateNotificationBadge() {
 
 module.exports = function ( { window, view } ) {
 	ipc.on( 'notifications-panel-toggled', function () {
+		log.info( 'Notifications panel toggled' );
 		if ( notificationBadgeCount > 0 ) {
 			log.info( 'Notification badge count reset' );
 			notificationBadgeCount = 0;

--- a/desktop/app/window-handlers/notifications/index.js
+++ b/desktop/app/window-handlers/notifications/index.js
@@ -30,20 +30,7 @@ function updateNotificationBadge() {
 }
 
 module.exports = function ( { window, view } ) {
-	view.webContents.on( 'did-finish-load', () => {
-		const code = `
-			if ( typeof masterbarItems === 'undefined' ) {
-				console.log( 'Hello hello' );
-				const masterbarItems = document.getElementsByClassName( 'masterbar__notifications' );
-				if ( masterbarItems && masterbarItems.length > 0 ) {
-					const bell = masterbarItems[0];
-					bell.addEventListener("click",function(){window.electron.send( 'reset-unread-count' );});
-				}
-			}`;
-		view.webContents.executeJavaScript( code );
-	} );
-
-	ipc.on( 'reset-unread-count', function () {
+	ipc.on( 'notifications-panel-toggled', function () {
 		if ( notificationBadgeCount > 0 ) {
 			log.info( 'Notification badge count reset' );
 			notificationBadgeCount = 0;

--- a/desktop/public_desktop/index.html
+++ b/desktop/public_desktop/index.html
@@ -61,7 +61,7 @@
 		});
 	};
 
-	function relayIframeMessaged() {
+	function RelayIframeMessage() {
 		window.addEventListener( 'message', ( event ) => {
 			if ( event.data ) {
 				const { message, payload } = event.data;
@@ -71,6 +71,8 @@
 	}
 
 	var nav = new Navigate();
+
+	var relay = new RelayIframeMessage()
 		</script>
 	</body>
 </html>

--- a/desktop/public_desktop/index.html
+++ b/desktop/public_desktop/index.html
@@ -29,38 +29,48 @@
 			</div>
 		</div>
 		<script>
-      function handleDoubleClick() {
-        const titleBar = document.getElementById('title-bar');
-        titleBar.addEventListener('dblclick', function () {
-          window.electron.send('title-bar-double-click');
-        });
-      }
-      handleDoubleClick();
-			function Navigate() {
-				const titleBarButtons = document.getElementById( 'title-bar-buttons' );
-				// Override title bar button padding on window load (Linux, Windows)
-				window.addEventListener( 'load', function() {
-					const padding = window.electron.styles.titleBarPaddingLeft;
-					titleBarButtons.style.paddingLeft = padding;
-				})
+	function handleDoubleClick() {
+		const titleBar = document.getElementById('title-bar');
+		titleBar.addEventListener('dblclick', function () {
+		window.electron.send('title-bar-double-click');
+		});
+	}
+	handleDoubleClick();
 
-				const backButton = document.getElementById( 'nav-button-back' );
-				backButton.addEventListener( 'click', function() {
-					window.electron.send( 'back-button-clicked' );
-				});
+	function Navigate() {
+		const titleBarButtons = document.getElementById( 'title-bar-buttons' );
+		// Override title bar button padding on window load (Linux, Windows)
+		window.addEventListener( 'load', function() {
+			const padding = window.electron.styles.titleBarPaddingLeft;
+			titleBarButtons.style.paddingLeft = padding;
+		})
 
-				const forwardButton = document.getElementById( 'nav-button-forward' );
-				forwardButton.addEventListener( 'click', function() {
-					window.electron.send( 'forward-button-clicked' );
-				});
+		const backButton = document.getElementById( 'nav-button-back' );
+		backButton.addEventListener( 'click', function() {
+			window.electron.send( 'back-button-clicked' );
+		});
 
-				const homeButton = document.getElementById( 'nav-button-home' );
-				homeButton.addEventListener( 'click', function() {
-					window.electron.send( 'home-button-clicked' );
-				});
-			};
+		const forwardButton = document.getElementById( 'nav-button-forward' );
+		forwardButton.addEventListener( 'click', function() {
+			window.electron.send( 'forward-button-clicked' );
+		});
 
-			var nav = new Navigate();
+		const homeButton = document.getElementById( 'nav-button-home' );
+		homeButton.addEventListener( 'click', function() {
+			window.electron.send( 'home-button-clicked' );
+		});
+	};
+
+	function relayIframeMessaged() {
+		window.addEventListener( 'message', ( event ) => {
+			if ( event.data ) {
+				const { message, payload } = event.data;
+				window.electron.send( message, data );
+			}
+		} )
+	}
+
+	var nav = new Navigate();
 		</script>
 	</body>
 </html>

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -15,6 +15,7 @@ const sendChannels = [
 	'user-login-status',
 	'view-post-clicked',
 	'print',
+	'reset-unread-count',
 	'secrets',
 	'toggle-dev-tools',
 	'title-bar-double-click',

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -3,23 +3,23 @@ const { ipcRenderer, contextBridge } = require( 'electron' );
 // Outgoing IPC message channels from Renderer to Main process.
 // Maintain this list in alphabetical order.
 const sendChannels = [
+	'back-button-clicked',
+	'clear-notices-count',
 	'get-config',
 	'get-settings',
-	'log',
-	'request-site-response',
-	'clear-notices-count',
-	'back-button-clicked',
 	'forward-button-clicked',
 	'home-button-clicked',
-	'user-auth',
-	'user-login-status',
-	'view-post-clicked',
+	'log',
+	'magic-link-set-password',
+	'notifications-panel-toggled',
 	'print',
-	'reset-unread-count',
+	'request-site-response',
 	'secrets',
 	'toggle-dev-tools',
 	'title-bar-double-click',
-	'magic-link-set-password',
+	'user-auth',
+	'user-login-status',
+	'view-post-clicked',
 ];
 
 // Incoming IPC message channels from Main process to Renderer.


### PR DESCRIPTION
### Description

Ideally, the notification badge count would be reset whenever the notification bell is clicked. However, the current implementation relies on an IPC event sent from Calypso, which appears to work inconsistently as the user may not always be in a Calypso context (e.g. when interacting with an Atomic site).

This implementation attempts to make this action more consistent by inspecting the DOM of the loaded page directly.

Note: we'll need to deprecate the existing IPC event sent from Calypso, however we can't do this right away since this would affect existing users. We should deprecate this event and related code after allowing enough time to update to a newer version of the application that handles this from the Main process. 