### PR TITLE
Signup Design Picker: use recommended themes

### DIFF
--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -25,18 +25,27 @@ interface DesignPreviewImageProps {
 	locale: string;
 }
 
-const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale } ) =>
-	isEnabled( 'gutenboarding/mshot-preview' ) ? (
-		<MShotsImage
-			url={ getDesignUrl( design, locale ) }
-			aria-labelledby={ makeOptionId( design ) }
-			alt=""
-			options={ mShotOptions() }
-			scrollable={ design.preview !== 'static' }
-		/>
-	) : (
+const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale } ) => {
+	if ( design.image ) {
+		return <img alt="" aria-labelledby={ makeOptionId( design ) } src={ design.image } />;
+	}
+
+	if ( isEnabled( 'gutenboarding/mshot-preview' ) ) {
+		return (
+			<MShotsImage
+				url={ getDesignUrl( design, locale ) }
+				aria-labelledby={ makeOptionId( design ) }
+				alt=""
+				options={ mShotOptions() }
+				scrollable={ design.preview !== 'static' }
+			/>
+		);
+	}
+
+	return (
 		<img alt="" aria-labelledby={ makeOptionId( design ) } src={ getDesignImageUrl( design ) } />
 	);
+};
 
 interface DesignButtonProps {
 	design: Design;

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -13,6 +13,7 @@ export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm
 export interface Design {
 	categories: Array< string >;
 	fonts?: FontPair;
+	image?: string;
 	is_alpha?: boolean;
 	is_fse?: boolean;
 	is_premium: boolean;


### PR DESCRIPTION
**DO NOT MERGE**

This is just a test to see the work required to use recommended themes (the selection from the default view of the Theme Showcase) with the Design Picker, instead of Gutenberg template designs.

<img width="1547" alt="Screen Shot 2021-09-20 at 8 09 57 PM" src="https://user-images.githubusercontent.com/942359/134093034-006bfa3e-eb34-42eb-9250-4d4449a4c8a0.png">

**To test:**
- visit calypso.localhost:3000/start?flags=signup/setup-site-after-checkout
- after Signup, you'll be redirected to the design picker
- verify that the themes in the design picker match the Theme Showcase
- verify that picking a theme properly sets it on your site