### PR TITLE
Headstart site with design annotations after design picker step

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -327,18 +327,11 @@ export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
 		return;
 	}
 
-	const { theme } = selectedDesign;
+	const { theme, template: headstart_template } = selectedDesign;
 
-	Promise.resolve()
-		.then( () =>
-			wpcom.undocumented().changeTheme( siteSlug, { theme, dont_change_homepage: true } )
-		)
-		.then( () =>
-			wpcom.req.post( {
-				path: `/sites/${ siteSlug }/theme-setup`,
-				apiNamespace: 'wpcom/v2',
-			} )
-		)
+	wpcom
+		.undocumented()
+		.changeTheme( siteSlug, { theme, headstart_template, dont_change_homepage: true } )
 		.then( () => {
 			callback();
 		} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When using the design picker flow, the site that's created doesn't have content that matches the thumbnail e.g. Alves thumbnail has Home and Blog, but the site created with Alves has Causes, Donate, Contact, Home and About pages. Some conversation about headstarting here pdgK6S-7f-p2#comment-216

This PR headstarts the site with the same annotation that the design in `/new` would use.

* Pass the `headstart_template` param when switching themes

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Needs to be tested with D66656-code

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

