### PR TITLE
Sites: remove the hasConflict computed attribute

### DIFF
--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -53,7 +53,6 @@ describe( 'getPublicSites()', () => {
 				title: 'WordPress.com Example Blog',
 				domain: 'example.com',
 				slug: 'example.com',
-				hasConflict: false,
 				options: {
 					unmapped_url: 'http://example.com',
 				},

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -52,7 +52,6 @@ describe( 'getVisibleSites()', () => {
 				title: 'WordPress.com Example Blog',
 				domain: 'example.com',
 				slug: 'example.com',
-				hasConflict: false,
 				options: {
 					unmapped_url: 'http://example.com',
 				},

--- a/client/state/sites/selectors/get-site-computed-attributes.js
+++ b/client/state/sites/selectors/get-site-computed-attributes.js
@@ -23,7 +23,6 @@ export default function getSiteComputedAttributes( state, siteId ) {
 
 	const computedAttributes = {
 		domain: getSiteDomain( state, siteId ),
-		hasConflict: isSiteConflicting( state, siteId ),
 		options: getSiteOptions( state, siteId ),
 		slug: getSiteSlug( state, siteId ),
 		title: getSiteTitle( state, siteId ),
@@ -36,7 +35,7 @@ export default function getSiteComputedAttributes( state, siteId ) {
 	}
 
 	// we only need to use the unmapped URL for conflicting sites
-	if ( computedAttributes.hasConflict ) {
+	if ( isSiteConflicting( state, siteId ) ) {
 		computedAttributes.URL = getSiteOption( state, siteId, 'unmapped_url' );
 	}
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -122,7 +122,6 @@ describe( 'selectors', () => {
 				title: 'WordPress.com Example Blog',
 				domain: 'example.com',
 				slug: 'example.com',
-				hasConflict: false,
 				jetpack: true,
 				canAutoupdateFiles: true,
 				canUpdateFiles: true,
@@ -188,7 +187,6 @@ describe( 'selectors', () => {
 				title: 'WordPress.com Example Blog',
 				domain: 'example.wordpress.com',
 				slug: 'example.wordpress.com',
-				hasConflict: true,
 				jetpack: false,
 				options: {
 					unmapped_url: 'https://example.wordpress.com',
@@ -3361,7 +3359,6 @@ describe( 'selectors', () => {
 			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
-				hasConflict: false,
 				domain: 'example.wordpress.com',
 				slug: 'example.wordpress.com',
 				options: {},
@@ -3399,7 +3396,6 @@ describe( 'selectors', () => {
 			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
-				hasConflict: true,
 				domain: 'unmapped-url.wordpress.com',
 				slug: 'unmapped-url.wordpress.com',
 				options,

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -47,7 +47,6 @@ describe( 'selectors', () => {
 				name: 'WordPress.com Example Blog',
 				URL: 'https://example.com',
 				domain: 'example.com',
-				hasConflict: false,
 				options: {},
 				slug: 'example.com',
 				title: 'WordPress.com Example Blog',


### PR DESCRIPTION
As a part of effort to remove computed site attributes and compute such information by Redux selectors from raw site data, this PR is removing the `site.hasConflict` attribute. It hasn't been used anywhere, except for computing another computed attribute, `site.URL`, as all consumers are already using the `isSiteConflicting` selector.

**How to test:**
Sufficiently covered by unit tests, there should be no observable behavior change.