### PR TITLE
Redirect premium themes URL to the /themes route

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -114,3 +114,12 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 	}
 	res.redirect( '/theme/' + [ theme, redirectedSection, site ].filter( Boolean ).join( '/' ) );
 }
+
+export function redirectTiers( { res, originalUrl }, next ) {
+	const redirectUrl = originalUrl.replace( /\/(free|premium)/, '' );
+	if ( redirectUrl === originalUrl ) {
+		return next();
+	}
+
+	res.redirect( 301, redirectUrl );
+}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -116,7 +116,7 @@ export function redirectToThemeDetails( { res, params: { site, theme, section } 
 }
 
 export function redirectTiers( { res, originalUrl }, next ) {
-	const redirectUrl = originalUrl.replace( /\/(free|premium)/, '' );
+	const redirectUrl = originalUrl.replace( /\/(free|premium|type)/g, '' );
 	if ( redirectUrl === originalUrl ) {
 		return next();
 	}

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -51,10 +51,12 @@ export default function ( router ) {
 			'/themes/:site?/type/:tier(free|premium)',
 			'/themes/:site?/search/:search/type/:tier(free|premium)',
 		],
+		redirectTiers,
 		redirectSearchAndType
 	);
 	router(
 		[ '/themes/:site?/filter/:filter', '/themes/:site?/filter/:filter/type/:tier(free|premium)' ],
+		redirectTiers,
 		redirectFilterAndType
 	);
 	router(

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -12,6 +12,7 @@ import {
 	redirectSearchAndType,
 	redirectFilterAndType,
 	redirectToThemeDetails,
+	redirectTiers,
 } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
 
@@ -31,6 +32,7 @@ export default function ( router ) {
 	];
 	router(
 		showcaseRoutes,
+		redirectTiers,
 		ssrSetupLocale,
 		fetchThemeFilters,
 		validateVertical,

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -656,11 +656,6 @@ function wpcomPages( app ) {
 		res.redirect( redirectUrl );
 	} );
 
-	app.get( '/themes/premium', function ( req, res ) {
-		const redirectUrl = '/themes';
-		res.redirect( 301, redirectUrl );
-	} );
-
 	// Landing pages for domains-related emails
 	app.get(
 		'/domain-services/:action',

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -658,7 +658,7 @@ function wpcomPages( app ) {
 
 	app.get( '/themes/premium', function ( req, res ) {
 		const redirectUrl = '/themes';
-		res.redirect( redirectUrl );
+		res.redirect( 301, redirectUrl );
 	} );
 
 	// Landing pages for domains-related emails

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -656,6 +656,11 @@ function wpcomPages( app ) {
 		res.redirect( redirectUrl );
 	} );
 
+	app.get( '/themes/premium', function ( req, res ) {
+		const redirectUrl = '/themes';
+		res.redirect( redirectUrl );
+	} );
+
 	// Landing pages for domains-related emails
 	app.get(
 		'/domain-services/:action',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info: pNEWy-e9X-p2#comment-53613

This redirects from `/themes/premium` to `/themes`. This is part of an effort to retire the Premium Theme Program.
This also redirects by removing any theme route which contains a `type` parameter (ie. `free` or `premium`).

#### Testing instructions

##### Logged Out
* Make sure these routes redirect properly: 
  - `/themes/premium` -> `/themes`
  - `/es/themes/premium` -> `/es/themes`
  - `/themes/portfolio/free` -> `/themes/portfolio`
  - `/themes/portfolio/premium/filter/author-bio` -> `/themes/portfolio/filter/author-bio`

##### Logged In
* Go to `/themes`
* Select a site if requested
* Make sure these routes redirect properly: 
  - `/themes/{SITE_NAME}/type/premium` -> `/themes/{SITE_NAME}`
  - `/themes/{SITE_NAME}/search/store/type/free` -> `/themes/{SITE_NAME}?s=store`
  - `/themes/{SITE_NAME}/filter/author-bio/type/premium` -> `themes/filter/author-bio/{SITE_NAME}`
