### PR TITLE
Add cachebuster param to Google Photos logo in marketing connections

### DIFF
--- a/client/my-sites/marketing/connections/services/google-photos.js
+++ b/client/my-sites/marketing/connections/services/google-photos.js
@@ -65,7 +65,7 @@ export class GooglePhotos extends SharingService {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<img
 				className="sharing-service__logo"
-				src="/calypso/images/sharing/google-photos-logo.svg"
+				src="/calypso/images/sharing/google-photos-logo.svg?v=20210921"
 				width="48"
 				height="48"
 				alt=""

--- a/client/my-sites/marketing/connections/services/google-photos.js
+++ b/client/my-sites/marketing/connections/services/google-photos.js
@@ -21,9 +21,6 @@ export class GooglePhotos extends SharingService {
 
 	/**
 	 * Deletes the passed connections.
-	 *
-	 * @param {Array} connections Optional. Connections to be deleted.
-	 *                            Default: All connections for this service.
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add cachebuster param to Google Photos logo in marketing connections
* After #56281 is deployed, https://wordpress.com/calypso/images/sharing/google-photos-logo.svg is still displaying the old style logo
* Defeated by changing to https://wordpress.com/calypso/images/sharing/google-photos-logo.svg?v=20210921 which shows the new style logo
* Fix taken from https://github.com/Automattic/wp-calypso/pull/25589

#### Testing instructions

* Visit `http://calypso.localhost:3000/marketing/connections/<siteurl>`
* See new google photos logo
Old logo:
![2021-09-21_10-07](https://user-images.githubusercontent.com/937354/134197425-6eabf60e-a199-4b84-a1da-f4e73efb8d4e.png)
New Logo:
![2021-09-21_10-08](https://user-images.githubusercontent.com/937354/134197438-93258a3e-1781-42d3-8353-f2c08aac630a.png)


Related to #56251
