### PR TITLE
Improve wording of purchase cancellation survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -885,7 +885,7 @@ class CancelPurchaseForm extends React.Component {
 				<>
 					<FormattedHeader
 						brandFont
-						headerText={ translate( 'Your thoughts are needed' ) }
+						headerText={ translate( 'Share your feedback' ) }
 						subHeaderText={ translate(
 							'Before you go, please answer a few quick questions to help us improve %(productName)s.',
 							{
@@ -907,7 +907,7 @@ class CancelPurchaseForm extends React.Component {
 			if ( surveyStep === INITIAL_STEP ) {
 				return (
 					<div>
-						<FormSectionHeading>{ translate( 'Your thoughts are needed.' ) }</FormSectionHeading>
+						<FormSectionHeading>{ translate( 'Share your feedback' ) }</FormSectionHeading>
 						<p>
 							{ translate(
 								'Before you go, please answer a few quick questions to help us improve %(productName)s.',


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* Reword the cancellation survey form header to use a more active voice as suggested on  p7DVsv-cCO-p2#comment-37538

#### Testing instructions

* Buy a plan for a site
* Find the purchase in /me/purchases and click it
* Click Remove & refund / cancel
* Click cancel purchase
* The survey should launch with a header of 'Share your feedback'

| Before  | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/93301/134207257-c75b2e79-8d04-4986-83e4-431b17753fe0.png) | ![image](https://user-images.githubusercontent.com/93301/134208676-29a9e147-e183-4bb5-b0a4-a981ce07fa11.png) |



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes:  #56392

Note that the jetpack related cancellation surveys have not been changed - there's a separate issue for unifying the design of the two: #56393
