### PR TITLE
Fix Site Domains title capitalization

### DIFF
--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -26,7 +26,7 @@ export function getDomainTypeText(
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
 			if ( context === domainInfoContext.PAGE_TITLE ) {
-				return __( 'Connected domain' );
+				return __( 'Connected Domain' );
 			}
 
 			return __( 'Managed by external provider' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes #55922. Corrects a small typo on the "domains" word. It should be "Domains".