### PR TITLE
Jetpack Cloud: Add Path Verification to Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
@@ -68,13 +68,6 @@ export interface FormErrors {
 
 export const INITIAL_FORM_ERRORS: FormErrors = {};
 
-export const mergeFoundCredentials = ( foundCredentials: Credentials, formState: FormState ) => ( {
-	...formState,
-	...foundCredentials,
-	type: undefined,
-	protocol: foundCredentials.type,
-} );
-
 export const validate = ( formState: FormState, mode: FormMode ): FormErrors => {
 	const formErrors: FormErrors = {};
 	// user checking

--- a/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
+++ b/client/jetpack-cloud/sections/settings/advanced-credentials/form.ts
@@ -1,4 +1,5 @@
 import { TranslateResult, translate } from 'i18n-calypso';
+import { filePathValidator } from 'calypso/lib/validation';
 
 export enum FormMode {
 	Password,
@@ -102,6 +103,14 @@ export const validate = ( formState: FormState, mode: FormMode ): FormErrors => 
 	if ( typeof formState.port === 'string' ) {
 		formErrors.port = {
 			message: translate( 'Please enter a valid port number.' ),
+			waitForInteraction: true,
+		};
+	}
+
+	const pathValidationResult = filePathValidator( formState.path );
+	if ( formState.path !== '' && pathValidationResult !== null ) {
+		formErrors.path = {
+			message: pathValidationResult.message,
 			waitForInteraction: true,
 		};
 	}

--- a/client/lib/validation/README.md
+++ b/client/lib/validation/README.md
@@ -1,0 +1,3 @@
+# Validation Library
+
+A collection of validation methods for data.

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -14,7 +14,7 @@ const validateFilePath: validator< string > = (
 	}
 	if ( filePathBackSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use Forward Slashes, "/", in path.' ),
+			message: translate( 'Use forward slashes, "/", in path.' ).toString(),
 		};
 	}
 	const invalidCharacters = pathToValidate
@@ -37,7 +37,7 @@ const validateFilePath: validator< string > = (
 
 	if ( filePathMultiSlashRegExp.test( pathToValidate ) ) {
 		return {
-			message: translate( 'Use only single slashes, "/", in path.' ),
+			message: translate( 'Use only single slashes, "/", in path.' ).toString(),
 		};
 	}
 

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -3,6 +3,7 @@ import { ValidationError, validator } from './types';
 
 const filePathRegExp = /^\/$|^(\/[\w-]+)+\/?$/;
 const filePathBackSlashRegExp = /^\\$|^(\\[\w-]+)+\\?$/;
+const filePathMultiSlashRegExp = /^\/+$|^(\/+[\w-]+)+\/*$/;
 const validFilePathChars = /[\w\-/]/g;
 
 const validateFilePath: validator< string > = (
@@ -33,7 +34,13 @@ const validateFilePath: validator< string > = (
 			).toString(),
 		};
 	}
-	// TODO: possible
+
+	if ( filePathMultiSlashRegExp.test( pathToValidate ) ) {
+		return {
+			message: translate( 'Use only single slashes, "/", in path.' ),
+		};
+	}
+
 	return {
 		message: translate( 'Not a valid file path.' ).toString(),
 	};

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -19,9 +19,14 @@ const validateFilePath: validator< string > = (
 	const invalidCharacters = pathToValidate.replace( validFilePathChars, '' );
 	if ( invalidCharacters.length > 0 ) {
 		return {
-			message: translate( 'Path contains invalid character "%s".', {
-				args: [ invalidCharacters ],
-			} ).toString(),
+			message: translate(
+				'Path contains invalid character "%s".',
+				'Path contains invalid characters "%s".',
+				{
+					args: [ invalidCharacters ],
+					count: invalidCharacters.length,
+				}
+			).toString(),
 		};
 	}
 	// TODO: possible

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -1,8 +1,8 @@
 import { translate } from 'i18n-calypso';
 import { ValidationError, validator } from './types';
 
-const filePathRegExp = /^(\/[\w-]+)+\/?$/;
-const filePathBackSlashRegExp = /^(\\[\w-]+)+\\?$/;
+const filePathRegExp = /^\/$|^(\/[\w-]+)+\/?$/;
+const filePathBackSlashRegExp = /^\\$|^(\\[\w-]+)+\\?$/;
 const validFilePathChars = /[\w\-/]/g;
 
 const validateFilePath: validator< string > = (

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -16,7 +16,11 @@ const validateFilePath: validator< string > = (
 			message: translate( 'Use Forward Slashes, "/", in path.' ),
 		};
 	}
-	const invalidCharacters = pathToValidate.replace( validFilePathChars, '' );
+	const invalidCharacters = pathToValidate
+		.replace( validFilePathChars, '' )
+		.split( '' )
+		.filter( ( character, index, array ) => array.indexOf( character ) === index )
+		.join( '' );
 	if ( invalidCharacters.length > 0 ) {
 		return {
 			message: translate(

--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -1,0 +1,33 @@
+import { translate } from 'i18n-calypso';
+import { ValidationError, validator } from './types';
+
+const filePathRegExp = /^(\/[\w-]+)+\/?$/;
+const filePathBackSlashRegExp = /^(\\[\w-]+)+\\?$/;
+const validFilePathChars = /[\w\-/]/g;
+
+const validateFilePath: validator< string > = (
+	pathToValidate: string
+): null | ValidationError => {
+	if ( filePathRegExp.test( pathToValidate ) ) {
+		return null;
+	}
+	if ( filePathBackSlashRegExp.test( pathToValidate ) ) {
+		return {
+			message: translate( 'Use Forward Slashes, "/", in path.' ),
+		};
+	}
+	const invalidCharacters = pathToValidate.replace( validFilePathChars, '' );
+	if ( invalidCharacters.length > 0 ) {
+		return {
+			message: translate( 'Path contains invalid character "%s".', {
+				args: [ invalidCharacters ],
+			} ).toString(),
+		};
+	}
+	// TODO: possible
+	return {
+		message: translate( 'Not a valid file path.' ).toString(),
+	};
+};
+
+export default validateFilePath;

--- a/client/lib/validation/index.ts
+++ b/client/lib/validation/index.ts
@@ -1,0 +1,1 @@
+export { default as filePathValidator } from './file-path';

--- a/client/lib/validation/test/file-path.ts
+++ b/client/lib/validation/test/file-path.ts
@@ -5,6 +5,10 @@ describe( 'filePathValidator', () => {
 		expect( filePathValidator( '/abc' ) ).toBeNull();
 	} );
 
+	test( 'should validate a path to root', () => {
+		expect( filePathValidator( '/' ) ).toBeNull();
+	} );
+
 	test( 'should reject a path with no slashes', () => {
 		expect( filePathValidator( 'abc' ) ).not.toBeNull();
 	} );
@@ -27,4 +31,18 @@ describe( 'filePathValidator', () => {
 			expect( filePathValidator( path ) ).not.toBeNull();
 		}
 	);
+
+	test( 'should reject a path with a non-valid character', () => {
+		expect( filePathValidator( '/abc*' ) ).toHaveProperty(
+			'message',
+			'Path contains invalid character "*".'
+		);
+	} );
+
+	test( 'should reject a path with multiple non-valid characters', () => {
+		expect( filePathValidator( '/abc*/efg&' ) ).toHaveProperty(
+			'message',
+			'Path contains invalid characters "*&".'
+		);
+	} );
 } );

--- a/client/lib/validation/test/file-path.ts
+++ b/client/lib/validation/test/file-path.ts
@@ -28,7 +28,10 @@ describe( 'filePathValidator', () => {
 	test.each( [ [ '//' ], [ '/abc//def' ], [ '/abc//' ], [ '///' ], [ '/a///b/c' ] ] )(
 		'should reject a path with two or more adjacent slashes',
 		( path ) => {
-			expect( filePathValidator( path ) ).not.toBeNull();
+			expect( filePathValidator( path ) ).toHaveProperty(
+				'message',
+				'Use only single slashes, "/", in path.'
+			);
 		}
 	);
 

--- a/client/lib/validation/test/file-path.ts
+++ b/client/lib/validation/test/file-path.ts
@@ -1,0 +1,22 @@
+import { filePathValidator } from '..';
+
+describe( 'filePathValidator', () => {
+	test( 'should validate a basic path', () => {
+		expect( filePathValidator( '/abc' ) ).toBeNull();
+	} );
+
+	test( 'should reject a path with no slashes', () => {
+		expect( filePathValidator( 'abc' ) ).not.toBeNull();
+	} );
+
+	test( 'should reject a path with backslashes', () => {
+		expect( filePathValidator( '\\abc' ) ).toHaveProperty(
+			'message',
+			'Use Forward Slashes, "/", in path.'
+		);
+	} );
+
+	test( 'should validate a deep path', () => {
+		expect( filePathValidator( '/abc/def/xyz/' ) ).toBeNull();
+	} );
+} );

--- a/client/lib/validation/test/file-path.ts
+++ b/client/lib/validation/test/file-path.ts
@@ -16,7 +16,7 @@ describe( 'filePathValidator', () => {
 	test( 'should reject a path with backslashes', () => {
 		expect( filePathValidator( '\\abc' ) ).toHaveProperty(
 			'message',
-			'Use Forward Slashes, "/", in path.'
+			'Use forward slashes, "/", in path.'
 		);
 	} );
 

--- a/client/lib/validation/test/file-path.ts
+++ b/client/lib/validation/test/file-path.ts
@@ -19,4 +19,12 @@ describe( 'filePathValidator', () => {
 	test( 'should validate a deep path', () => {
 		expect( filePathValidator( '/abc/def/xyz/' ) ).toBeNull();
 	} );
+
+	// NOTE: We've seen support tickets with exactly this issue
+	test.each( [ [ '//' ], [ '/abc//def' ], [ '/abc//' ], [ '///' ], [ '/a///b/c' ] ] )(
+		'should reject a path with two or more adjacent slashes',
+		( path ) => {
+			expect( filePathValidator( path ) ).not.toBeNull();
+		}
+	);
 } );

--- a/client/lib/validation/types.ts
+++ b/client/lib/validation/types.ts
@@ -1,5 +1,5 @@
 export interface ValidationError {
-	message: ;
+	message: string;
 }
 
 export type validator< T > = ( data: T ) => null | ValidationError;

--- a/client/lib/validation/types.ts
+++ b/client/lib/validation/types.ts
@@ -1,0 +1,5 @@
+export interface ValidationError {
+	message: ;
+}
+
+export type validator< T > = ( data: T ) => null | ValidationError;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Verification Lib to Calypso with types
* Add File Path Validator to the new Validation lib
* Add support for path validation to the add credentials form in Calypso Green

<img width="715" alt="Screen Shot 2021-09-21 at 11 22 18 AM" src="https://user-images.githubusercontent.com/2810519/134226294-5363c45b-77ce-4aa1-8311-09c9f36bbd18.png">

##### Next Steps
* Add verification to the other to Calypso forms with an install path

#### Testing instructions

1. Navigate to `/settings/:siteSlug?host=generic` on the branch in Calypso Green for a site without credentials already given.
2. Input incorrect values to the path and see how it handles incorrect input.