### PR TITLE
e2e tests - update site editor component `waitForTemplateParts` method.

### DIFF
--- a/test/e2e/lib/components/site-editor-component.js
+++ b/test/e2e/lib/components/site-editor-component.js
@@ -21,10 +21,14 @@ export default class SiteEditorComponent extends AbstractEditorComponent {
 	}
 
 	async waitForTemplatePartsToLoad() {
-		await this.runInCanvas( async () => {
+		return await this.runInCanvas( async () => {
 			await driverHelper.waitUntilElementNotLocated(
 				this.driver,
-				By.css( '.wp-block-template-part .components-spinner' )
+				By.css( '.wp-block-template-part > .components-spinner' )
+			);
+			await driverHelper.waitUntilElementNotLocated(
+				this.driver,
+				By.css( '.wp-block-template-part > .block-editor-warning' )
 			);
 		} );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the `waitForTemplateParts` method to be more accurate to its purpose.  Fixes tests `specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js` and `specs/specs-wpcom/wp-site-editor-spec.js`

Currently, this method waits for the following selector to not exist in the editor `.wp-block-template-part .components-spinner`.  However, it is possible (and has happened with recent theme updates) that other blocks inside a template part may have their own spinner components.

Here, we update this to only be concerned with spinners that are direct children of the template part.  As this is how gutenberg renders the template part loading state `wp-block-template-part > .components-spinner`.  

We have also added another condition to ensure the template part is not in a warning state `.wp-block-template-part > .block-editor-warning`.  Previously, when template parts were not resolved the spinner component would be in place perpetually.  With more recent Gutenberg updates, when the template part cannot be resolved it renders a warning component.  Thus this extra condition now helps ensure that the template part is properly loaded.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the `specs/specs-wpcom/wp-site-editor-spec.js` test file and verify it no longer fails on the template part assertion.
* Run the `specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js` and verify it no longer fails in the first test.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
