### PR TITLE
My Email: Improve the sidebar matching  and menu highlighting rules for the /email/inbox route

### DIFF
--- a/client/my-sites/sidebar-unified/utils.jsx
+++ b/client/my-sites/sidebar-unified/utils.jsx
@@ -21,6 +21,17 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		return fragmentIsEqual( path, currentPath, 3 );
 	}
 	/*
+	 * When the current path starts with /email:
+	 *  - ensure that 'email/inbox' only matches Inbox screens
+	 *  - else match both first and second path segments
+	 */
+	if ( pathIncludes( currentPath, 'email', 1 ) ) {
+		if ( pathIncludes( currentPath, 'inbox', 2 ) ) {
+			return fragmentIsEqual( path, currentPath, 2 );
+		}
+		return fragmentIsEqual( path, currentPath, 2 ) && fragmentIsEqual( path, currentPath, 1 );
+	}
+	/*
 	 * If the menu item URL contains 'taxonomies', ignore it when on Settings screens.
 	 * Taxonomies are located under the Posts parent menu; this prevents the Posts parent
 	 * from being highlighted when Settings screens are active.


### PR DESCRIPTION
This PR ensures that sidebar navigation matching rules are refined to ensure that `/email` and `/email/inbox` are treated differently.

By default, paths are matched to menus by looking at the first path segments. This doesn't work for our cases.

#### Changes proposed in this Pull Request

* Adds rules to `itemLinkMatches` so that `/email/inbox` paths only matches to the **Inbox** menu
* Ensures that pre-existing paths prefixed with `/email` still work.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE: You need a sandbox if the My Email navigation hasn't been deployed.

* Patch your sandbox to ensure that the My Email navigation menu appears: D67175-code
* You should see the **Inbox** menu

<img width="500" alt="Screenshot 2021-09-21 at 7 46 53 PM" src="https://user-images.githubusercontent.com/277661/134232378-64db1407-16bb-4764-9a76-b042b347e06a.png">

- Confirm that the **Inbox** menu is only highlighted when URLs like [/email/inbox/<site-name>](http://calypso.localhost:3000/email/inbox/<site-name>) are active
- Confirm that the **Upgrades**/**Emails** menu still works as usually i.e. is only highlighted when URLs prefixed with `/emails` but NOT `/email/inbox` are active
- Check other menus that they aren't broken.

