### PR TITLE
Change editor POM init waits for stability

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -7,7 +7,6 @@ const selectors = {
 	// iframe and editor
 	editorFrame: '.calypsoify.is-iframe iframe.is-loaded',
 	editorTitle: '.editor-post-title__input',
-	editorBody: '.edit-post-visual-editor',
 
 	// Block inserter
 	blockInserterToggle: 'button.edit-post-header-toolbar__inserter-toggle',
@@ -68,8 +67,10 @@ export class GutenbergEditorPage {
 	 */
 	async waitUntilLoaded(): Promise< Frame > {
 		const frame = await this.getEditorFrame();
-		await this.page.waitForLoadState( 'networkidle', { timeout: 60000 } );
-		await frame.waitForSelector( selectors.editorBody );
+		await this.page.waitForLoadState( 'load' );
+		// Traditionally we try to avoid waits not related to the current flow. However, we need a stable way to identify loading being done.
+		// NetworkIdle takes too long here, so the most reliable alternative is the title being visible.
+		await frame.waitForSelector( selectors.editorTitle );
 		return frame;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, we waited for the `networkIdle` event in the editor page when it first loads before continuing. However, this event can be really unpredictable or take a really long time, cause false positives.

Now, we wait for the visibility of the post/page title, giving a more reliable indicator

#### Testing instructions

Test in CI should pass.

I ran a local stress test of the Basic Post Flow, and it passed!
