### PR TITLE
Fix Pricing Page in Edge Case of Different Blue and Green Calypso Logins

### DIFF
--- a/client/jetpack-cloud/controller.ts
+++ b/client/jetpack-cloud/controller.ts
@@ -217,7 +217,10 @@ export function noSite(
  * @param {PageJS.Context} context Route context
  * @param {Function} next Next middleware function
  */
-export function cloudSiteSelection( context: PageJS.Context, next: () => void ): void {
+export async function cloudSiteSelection(
+	context: PageJS.Context,
+	next: () => void
+): Promise< void > {
 	const siteFragment = parseSiteFragment( context );
 
 	if ( noSite( siteFragment, context ) ) {
@@ -225,8 +228,15 @@ export function cloudSiteSelection( context: PageJS.Context, next: () => void ):
 	}
 
 	if ( siteFragment ) {
-		siteSelectionWithFragment( siteFragment, context, next );
+		if ( context.path.startsWith( '/pricing' ) ) {
+			const { id } = await fetchSite( context, siteFragment );
+			if ( ! id ) {
+				await siteSelectionWithoutFragment( context, next );
+				return;
+			}
+		}
+		await siteSelectionWithFragment( siteFragment, context, next );
 	} else {
-		siteSelectionWithoutFragment( context, next );
+		await siteSelectionWithoutFragment( context, next );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add check for Calypso Green site selection to avoid issues where a site is connected to a different WordPress.com account on Calypso Green and Blue.

#### Testing instructions

**Requires 2 WordPress.com test accounts**

1. Boot Calypso Green on Trunk
2. Login to `jetpack.cloud.localhost:3000` with the first WordPress.com account
3. Make sure the first WordPress.com test account has a connected Jetpack site with a paid plan.
4. Log out of the first account on WordPress.com and log into the second
5. Create and connect a new Jetpack site
6. Boot Calypso Green on branch
7. Navigate to `jetpack.cloud.localhost:3000/pricing/:siteSlug` with the slug of the new site
8. Verify that the page loads correctly, with no repeated network requests or console errors
9. Navigate to `jetpack.cloud.localhost:3000/pricing/:siteSlug` with the slug of the site from step 3
10. Verify the correct plan for the site is marked as "You own this product"
