### PR TITLE
Media: Update Google Photos verbiage

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -75,6 +75,15 @@ const SharingServiceAction = ( {
 		);
 	}
 
+	// See: https://developers.google.com/photos/library/guides/ux-guidelines
+	if ( 'google_photos' === service.ID && '/marketing/connections/:site' !== path ) {
+		return (
+			<Button primary onClick={ onClick } disabled={ isPending }>
+				{ translate( 'Connect to Google Photos' ) }
+			</Button>
+		);
+	}
+
 	if ( 'mailchimp' === service.ID && status === 'not-connected' ) {
 		return (
 			<div>

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -325,7 +325,7 @@ export class MediaLibraryContent extends React.Component {
 	renderGooglePhotosConnect() {
 		const { translate } = this.props;
 		const connectMessage = translate(
-			'To show your Google Photos library you need to connect your Google account.'
+			'To get started, connect your site to your Google Photos library.'
 		);
 
 		return (

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -18,7 +18,12 @@ class MediaLibraryListNoContent extends Component {
 
 		//TODO: handle each service with individual messages
 		if ( 'google_photos' === source ) {
-			return translate( "You don't have any photos in your Google library.", {
+			if ( 'videos' === filter ) {
+				return translate( "You don't have any videos in your Google Photos library.", {
+					comment: 'Media no results',
+				} );
+			}
+			return translate( "You don't have any images in your Google Photos library.", {
 				comment: 'Media no results',
 			} );
 		}
@@ -77,7 +82,7 @@ class MediaLibraryListNoContent extends Component {
 				</UploadButton>
 			);
 		} else if ( 'google_photos' === this.props.source ) {
-			line = this.props.translate( 'New photos may take a few minutes to appear.' );
+			line = this.props.translate( 'New images and videos may take a few minutes to appear.' );
 		}
 
 		return (


### PR DESCRIPTION
Clarifies the Google Photos context as outlined in their [UX guidelines](https://developers.google.com/photos/library/guides/ux-guidelines).

#### Changes proposed in this Pull Request

* Updated body and button text as well as button importance to bring it in line with the Media library.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Media library
* Click on the top left dropdown for the various media libraries and select "Google Photos"
* The changes should be visible.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See p4hfux-5P7-p2#comment-8601

#### Before

<img width="1548" alt="Screen Shot 2021-09-21 at 4 05 28 PM" src="https://user-images.githubusercontent.com/1398304/134259487-6a149b71-b1c6-4e05-bb69-cf16d5ccda28.png">

#### After

<img width="1548" alt="Screen Shot 2021-09-21 at 4 05 10 PM" src="https://user-images.githubusercontent.com/1398304/134259478-f6ef42c2-d9bf-4d89-8e4e-0f6156dc33b3.png">

