### PR TITLE
Media: Add inline disconnect for Google Photos

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -9,6 +9,7 @@ import SectionNavTabItem from 'calypso/components/section-nav/item';
 import SectionNavTabs from 'calypso/components/section-nav/tabs';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import DataSource from './data-source';
+import GooglePhotosAccount from './google-photos-account';
 
 // These source supply very large images, and there are instances such as
 // the site icon editor, where we want to disable them because the editor
@@ -206,6 +207,9 @@ export class MediaLibraryFilterBar extends Component {
 					{ this.renderSearchSection() }
 				</SectionNav>
 
+				{ this.props.isConnected && 'google_photos' === this.props.source && (
+					<GooglePhotosAccount />
+				) }
 				{ this.renderPlanStorage() }
 			</div>
 		);

--- a/client/my-sites/media-library/google-photos-account.js
+++ b/client/my-sites/media-library/google-photos-account.js
@@ -1,0 +1,82 @@
+import { Button, ScreenReaderText } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import { getKeyringConnectionsByName } from 'calypso/state/sharing/keyring/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const GooglePhotosAccount = ( props ) => {
+	if ( ! props.connection ) {
+		return null;
+	}
+
+	const profileImage = () => {
+		if ( props.connection.external_profile_picture ) {
+			return (
+				<img
+					height="20"
+					width="20"
+					src={ props.connection.external_profile_picture }
+					alt={ props.connection.label }
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+					className="google-photos-account__account-avatar"
+				/>
+			);
+		}
+
+		return (
+			<span
+				className={
+					'google-photos-account__account-avatar is-fallback ' + props.connection.service
+				}
+			>
+				<ScreenReaderText>{ props.connection.label }</ScreenReaderText>
+			</span>
+		);
+	};
+
+	const disconnectButton = () => {
+		if ( props.userHasCaps || props.connection.user_ID === props.userId ) {
+			const deleteConnection = () => props.deleteStoredKeyringConnection( props.connection );
+
+			return (
+				<Button
+					compact
+					onClick={ deleteConnection }
+					className="google-photos-account__account-action disconnect"
+				>
+					{ props.translate( 'Disconnect from Google Photos' ) }
+				</Button>
+			);
+		}
+	};
+
+	return (
+		<div className="google-photos-account">
+			{ profileImage() }
+			<span className="google-photos-account__account-name">
+				{ props.connection.external_name }
+			</span>
+			{ disconnectButton() }
+		</div>
+	);
+};
+
+export default connect(
+	( state ) => {
+		const googleConnection = getKeyringConnectionsByName( state, 'google_photos' );
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			userHasCaps: canCurrentUser( state, siteId, 'edit_others_posts' ),
+			userId: getCurrentUserId( state ),
+			connection: googleConnection.length === 1 ? googleConnection[ 0 ] : null, // There can be only one
+		};
+	},
+	{
+		deleteStoredKeyringConnection,
+	}
+)( localize( GooglePhotosAccount ) );

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -119,13 +119,14 @@
 	}
 
 	.google-photos-account {
-		margin-bottom: 9px;
+		margin-bottom: 17px;
 		box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
 		0 1px 2px var( --color-neutral-0 );
+		flex-shrink: 0;
 		background-color: var( --color-surface );
 		padding: 4px 24px;
 		box-sizing: border-box;
-		width: 30%;
+		width: 250px;
 
 		&:focus {
 			box-shadow: 0 0 0 1px var( --color-border-subtle ),
@@ -134,8 +135,8 @@
 			z-index: 1;
 		}
 
-		@include breakpoint-deprecated( '>960px' ) {
-			margin-bottom: 17px;
+		@include breakpoint-deprecated( '<660px' ) {
+			margin-bottom: 9px;
 		}
 
 		.google-photos-account__account-avatar {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -118,6 +118,43 @@
 		}
 	}
 
+	.google-photos-account {
+		margin-bottom: 9px;
+		box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
+		0 1px 2px var( --color-neutral-0 );
+		background-color: var( --color-surface );
+		padding: 4px 24px;
+		box-sizing: border-box;
+		width: 30%;
+
+		&:focus {
+			box-shadow: 0 0 0 1px var( --color-border-subtle ),
+			inset 0 0 0 2px var( --color-primary-light );
+			outline: none;
+			z-index: 1;
+		}
+
+		@include breakpoint-deprecated( '>960px' ) {
+			margin-bottom: 17px;
+		}
+
+		.google-photos-account__account-avatar {
+			position: relative;
+			top: 1px;
+		}
+
+		.google-photos-account__account-name {
+			font-size: $font-body-small;
+			margin: 0 8px;
+			position: relative;
+			top: -4px;
+		}
+
+		.button {
+			padding: 5px;
+		}
+	}
+
 	.media-library__datasource {
 		box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
 			0 1px 2px var( --color-neutral-0 );

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -128,6 +128,10 @@
 		box-sizing: border-box;
 		width: 250px;
 
+		.editor-media-modal & {
+			margin-bottom: 16px;
+		}
+
 		&:focus {
 			box-shadow: 0 0 0 1px var( --color-border-subtle ),
 			inset 0 0 0 2px var( --color-primary-light );


### PR DESCRIPTION
[Google Photos UX guidelines](https://developers.google.com/photos/library/guides/ux-guidelines#account-and-disconnection) are asking to ensure that customers are always aware that their Google Account is being used and is connected to our app.

This PR adds account information and provides customers with a way to disconnect their account from within the Google Photos integration. It's not pretty, but it's functional. If you have any suggestions as to how we can make it look a little better, please let me know.

#### Changes proposed in this Pull Request

* Add a Google Photos Account component that shows the user avatar, name, and a disconnect button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See the below video for testing steps as well:

* Navigate to the media library and select Google Photos from the drop down.
* If you're not connected yet, connect to your Google Photos library.
* Disconnect the account from the new inline disconnect button
* Navigate to /marketing/connections and see that the account is indeed disconnected

* Open the editor and insert an image block of any kind
* Click Select image (or Select media)
* Click media library
* Follow the above mentioned steps

https://user-images.githubusercontent.com/1398304/134263299-af16fb23-84b5-4fb0-a066-f1e03ab26b5b.mp4




<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See p4hfux-5P7-p2#comment-8601

#### Before

<img width="1548" alt="Screen Shot 2021-09-21 at 4 14 47 PM" src="https://user-images.githubusercontent.com/1398304/134263366-47d89702-df5a-4730-8958-228ce920944b.png">

#### After

<img width="1548" alt="Screen Shot 2021-09-21 at 4 14 13 PM" src="https://user-images.githubusercontent.com/1398304/134263384-f35d33a7-8580-4d31-b20d-1521dccc7866.png">
