### PR TITLE
My Email: Adopt /inbox as route

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -515,9 +515,7 @@ const navigateToSite = ( siteId, { allSitesPath, allSitesSingleUser, siteBasePat
 			path = '/domains/manage';
 		}
 
-		if ( path.match( /^\/email\/inbox\/?/ ) ) {
-			path = '/email/inbox';
-		} else if ( path.match( /^\/email\// ) ) {
+		if ( path.match( /^\/email\// ) ) {
 			path = '/email';
 		}
 

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -171,9 +171,9 @@ export function emailManagementEdit(
 
 export function emailManagementInbox( siteName = null ) {
 	if ( siteName ) {
-		return `${ emailManagementPrefix }/inbox/${ siteName }`;
+		return `/inbox/${ siteName }`;
 	}
-	return `${ emailManagementPrefix }/inbox`;
+	return `/inbox`;
 }
 
 export function isUnderEmailManagementAll( path ) {

--- a/client/sections.js
+++ b/client/sections.js
@@ -248,6 +248,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'inbox',
+		paths: [ '/inbox' ],
+		module: 'calypso/my-sites/email',
+		group: 'sites',
+	},
+	{
 		name: 'checkout',
 		paths: [ '/checkout' ],
 		module: 'calypso/my-sites/checkout',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This diff upgrades the current route `/email/inbox` to `/inbox`, which works well with the nav unification efforts and existing sidebar convention.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the path `/inbox` brings up the site selector
* Confirm that URLs of the format `/inbox/<site-slug>` load up the configured component. In this case a blank page in addition to the menu.


