### PR TITLE
Redirect /plans/:site to /pricing/:site in cloud

### DIFF
--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -7,6 +7,7 @@ import './style.scss';
 export default function (): void {
 	// Redirects
 	page( '/:locale/plans', ( { params } ) => page.redirect( `/${ params.locale }/pricing` ) );
+	page( '/plans/:site', ( { params } ) => page.redirect( `/pricing/${ params.site }` ) );
 	page( '/plans', '/pricing' );
 
 	jetpackPlans( '/:locale/pricing', jetpackPricingContext );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a redirect from `/plans/:site` to `/pricing/:site` in cloud.

### Implementation notes

The `page` library doesn't allow us to use wildcards in both arguments of a redirect. E.g. `/plans/*` > `/pricing/*` is not possible.

### Testing instructions

- Download the PR and run cloud
- With both an authenticated and unauthenticated user:
  - Check that `/plans` redirects to `https://cloud.jetpack.com/pricing`
  - Check that `/:locale/plans` redirects to `/pricing`, with the page in the proper language
  - Check that `/plans/:site` redirects to `/pricing/:site`
