### PR TITLE
Remove yearly products experiment in cloud

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useMemo, useRef, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
-import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
@@ -99,9 +98,6 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const currentPlanSlug = currentPlan?.product_slug || null;
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_jetpack_pricing_page_without_monthly'
-	);
 
 	// Retrieve and cache the plans array, which might be already translated.
 	useEffect( () => {
@@ -155,20 +151,8 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		}
 	};
 
-	const filterBar = useMemo( () => {
-		if ( isLoadingExperimentAssignment ) {
-			return (
-				<div className="product-grid__filter-bar-placeholder">
-					<div></div>
-				</div>
-			);
-		}
-
-		if ( experimentAssignment?.variationName === 'treatment' ) {
-			return null;
-		}
-
-		return (
+	const filterBar = useMemo(
+		() => (
 			<div className="product-grid__filter-bar">
 				<PlansFilterBar
 					showDiscountMessage
@@ -176,13 +160,9 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					duration={ duration }
 				/>
 			</div>
-		);
-	}, [
-		onDurationChange,
-		duration,
-		isLoadingExperimentAssignment,
-		experimentAssignment?.variationName,
-	] );
+		),
+		[ onDurationChange, duration ]
+	);
 
 	const featuredPlans = getForCurrentCROIteration( {
 		[ Iterations.ONLY_REALTIME_PRODUCTS ]: [

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -68,30 +68,12 @@
 	}
 }
 
-.product-grid__filter-bar,
-.product-grid__filter-bar-placeholder {
+.product-grid__filter-bar {
 	height: 63px;
 	margin-bottom: 70px;
 
 	@include break-small {
 		margin-bottom: 50px;
-	}
-}
-
-.product-grid__filter-bar-placeholder {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	width: 250px;
-	margin-left: auto;
-	margin-right: auto;
-
-	> :first-child {
-		@include placeholder();
-
-		width: 100%;
-		height: 24px;
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR reverts the experiment implemented in #55905. It makes the term toggle visible in the cloud pricing page for all users.

### Testing instructions

- Download the PR and run cloud
- Visit the pricing page
- Delete the experiment entry in your browser local storage

<img width="967" alt="Screen Shot 2021-09-01 at 3 59 47 PM" src="https://user-images.githubusercontent.com/1620183/131735954-981ef6e2-576e-4e5f-81ad-d83b496f095d.png">

- Check that you can see the term toggle
- Verify that the toggle works as expected