### PR TITLE
Playwright: the free signup final(?) flakiness throwdown

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/login-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/login-flow.ts
@@ -65,17 +65,11 @@ export class LoginFlow {
 	 * Log in as the specified user from the WPCOM Log-In endpoint.
 	 * This is the most basic action of logging in.
 	 *
-	 * Sometimes when logging into a site, there will be a redirect to the site specific page,
-	 * e.g. wordpress.com > wordpress.com/home/site. You can provide the specific URL we should be waiting
-	 * for before continuing to get around this.
-	 *
-	 * @param {object} root0 Root keyed object for optional options
-	 * @param {string | undefined} root0.landingUrl The URL we must navigate to before continuing. Use to handle home redirect.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async logIn( { landingUrl }: { landingUrl?: string } = {} ): Promise< void > {
+	async logIn(): Promise< void > {
 		await this.page.goto( getCalypsoURL( 'log-in' ) );
-		await Promise.all( [ this.page.waitForNavigation( { url: landingUrl } ), this.baseflow() ] );
+		await Promise.all( [ this.page.waitForNavigation(), this.baseflow() ] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -4,6 +4,7 @@ const selectors = {
 	// Close account
 	closeAccountLink: `p:text("Close your account permanently")`,
 	closeAccountButton: `button:text("Close account")`,
+	deletedItemsSidebar: 'text=These items will be deleted',
 
 	// Modal
 	modalContinueButton: `button:text("Continue")`,
@@ -31,13 +32,19 @@ export class AccountSettingsPage {
 	 * Closes the currently logged in user's account.
 	 */
 	async closeAccount(): Promise< void > {
-		// This async navigation can mess with clicking the next button, so we need to make sure to wait explicitly for that async nav to commplete.
+		// Wait for the async navigation
 		await Promise.all( [
 			this.page.waitForNavigation(),
 			this.page.click( selectors.closeAccountLink ),
 		] );
 
+		// This page is tricky. All the text and the close account button load in and are "visible",
+		// except they are then covered over with gray boxes. The button is still "clickable", but doesn't do anything.
+		// The only thing that doesn't appear until all the loading is done is the sidebar of items to be deleted.
+		// So we must wait for that text before continuing, or our close account button click can get swallowed!
+		await this.page.waitForSelector( selectors.deletedItemsSidebar );
 		await this.page.click( selectors.closeAccountButton );
+
 		await this.page.click( selectors.modalContinueButton );
 		const username = await this.page
 			.waitForSelector( selectors.usernameSpan )

--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -114,15 +114,21 @@ describe(
 		} );
 
 		describe( 'Delete user account', function () {
-			it( 'Re-login to ensure correct host', async function () {
-				await BrowserManager.clearAuthenticationState( page );
-				const loginPage = new LoginPage( page );
+			let newPage: Page;
+
+			afterAll( async function () {
+				await BrowserManager.closePage( newPage, { closeContext: true } );
+			} );
+
+			it( 'Launch new context to ensure correct host', async function () {
+				newPage = await BrowserManager.newPage( { newContext: true } );
+				const loginPage = new LoginPage( newPage );
 				await loginPage.visit();
 				await loginPage.login( { username: username, password: signupPassword } );
 			} );
 
 			it( 'Close account', async function () {
-				const closeAccountFlow = new CloseAccountFlow( page );
+				const closeAccountFlow = new CloseAccountFlow( newPage );
 				await closeAccountFlow.closeAccount();
 			} );
 		} );

--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -118,10 +118,6 @@ describe(
 		describe( 'Delete user account', function () {
 			let newPage: Page;
 
-			afterAll( async function () {
-				await BrowserManager.closePage( newPage, { closeContext: true } );
-			} );
-
 			it( 'Launch new context to ensure correct host', async function () {
 				newPage = await BrowserManager.newPage( { newContext: true } );
 			} );
@@ -135,7 +131,10 @@ describe(
 					username: username,
 					password: signupPassword,
 				} );
-				await loginFlow.logIn( { landingUrl: expectedLandngUrl } );
+				await Promise.all( [
+					newPage.waitForNavigation( { url: expectedLandngUrl } ),
+					loginFlow.logIn(),
+				] );
 			} );
 
 			it( 'Close account', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The free signup test continues to be plagued by three points of flakiness:
1. Clearing authentication state after the magic link log in is not the most reliable
2. Using the navbar to navigate to `/me` right after login can still get disrupted by the redirect to the `/home/<site>` route
3. The "Close Account" button is "visible" to Playwright while still in its loading state, so it can swallow clicks

These are addressed respectively by...
1. Using a new context to do the last close account piece
2. Extending the login flow to optionally allow for waiting for a specific URL navigation before proceeding
3. Waiting for the specific items which will be deleted, which is the only thing to actually show up as new post-load in the DOM

#### Testing instructions

- Run the free signup spec. I ran several times locally!

Related to #
