### PR TITLE
Playwright: Pre-release tests - use simple slack format

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -783,9 +783,7 @@ object PreReleaseE2ETests : BuildType({
 			notifierSettings = slackNotifier {
 				connection = "PROJECT_EXT_11"
 				sendTo = "#e2eflowtesting-notif"
-				messageFormat = verboseMessageFormat {
-					addBranch = true
-				}
+				messageFormat = simpleMessageFormat()
 			}
 			buildFailedToStart = true
 			buildFailed = true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The slack messages for the pre-release TC tests now use the "simple" message format, which is preferable because it adds nice big symbols to the front to clearly see if things have passed or failed!

#### Testing instructions

Post merge, the slack messages should be in the simple format

Related to #
