### PR TITLE
Playwright: address flakiness when selecting invited user in PeoplePage.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-invite__revoke.ts; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for i in {1..100}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-invite__revoke.ts; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -39,6 +39,13 @@ export class PeoplePage {
 	}
 
 	/**
+	 *
+	 */
+	async waitUntilLoaded(): Promise< void > {
+		await this.page.waitForLoadState( 'load' );
+	}
+
+	/**
 	 * Clicks on the navigation tab (desktop) or dropdown (mobile).
 	 *
 	 * @param {string} name Name of the tab to click.
@@ -92,6 +99,8 @@ export class PeoplePage {
 	 * Click on the `Invite` button to navigate to the invite user page.
 	 */
 	async clickInviteUser(): Promise< void > {
+		await this.waitUntilLoaded();
+
 		await Promise.all( [
 			this.page.waitForNavigation(),
 			this.page.click( selectors.invitePeopleButton ),
@@ -104,13 +113,20 @@ export class PeoplePage {
 	 * @param {string} emailAddress Email address of the pending user.
 	 */
 	async selectInvitedUser( emailAddress: string ): Promise< void > {
-		await this.page.click( selectors.invitedUser( emailAddress ) );
+		await this.waitUntilLoaded();
+
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.click( selectors.invitedUser( emailAddress ) ),
+		] );
 	}
 
 	/**
 	 * Revokes the pending invite.
 	 */
 	async revokeInvite(): Promise< void > {
+		await this.waitUntilLoaded();
+
 		await this.page.click( selectors.revokeInviteButton );
 		await this.page.waitForSelector( selectors.inviteRevokedMessage );
 	}

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -52,6 +52,16 @@ export class PeoplePage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: PeoplePageTabs ): Promise< void > {
+		// For Invites tab, wait for the full request to be completed.
+		if ( name === 'Invites' ) {
+			await Promise.all( [
+				this.page.waitForResponse(
+					( response ) => response.url().includes( 'invites?' ) && response.status() === 200
+				),
+				clickNavTab( this.page, name ),
+			] );
+			return;
+		}
 		await clickNavTab( this.page, name );
 	}
 
@@ -113,13 +123,6 @@ export class PeoplePage {
 	 * @param {string} emailAddress Email address of the pending user.
 	 */
 	async selectInvitedUser( emailAddress: string ): Promise< void > {
-		await this.waitUntilLoaded();
-
-		// Ensure the card for the invited user is stable and loaded before clicking,
-		// otherwise the click is ignored.
-		const elementHandle = await this.page.waitForSelector( selectors.invitedUser( emailAddress ) );
-		await elementHandle.waitForElementState( 'stable' );
-
 		await Promise.all( [
 			this.page.waitForNavigation(),
 			this.page.click( selectors.invitedUser( emailAddress ) ),

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -39,7 +39,7 @@ export class PeoplePage {
 	}
 
 	/**
-	 *
+	 * Wait until the page is loaded.
 	 */
 	async waitUntilLoaded(): Promise< void > {
 		await this.page.waitForLoadState( 'load' );
@@ -114,6 +114,11 @@ export class PeoplePage {
 	 */
 	async selectInvitedUser( emailAddress: string ): Promise< void > {
 		await this.waitUntilLoaded();
+
+		// Ensure the card for the invited user is stable and loaded before clicking,
+		// otherwise the click is ignored.
+		const elementHandle = await this.page.waitForSelector( selectors.invitedUser( emailAddress ) );
+		await elementHandle.waitForElementState( 'stable' );
 
 		await Promise.all( [
 			this.page.waitForNavigation(),

--- a/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
+++ b/test/e2e/specs/specs-playwright/wp-invite__revoke.ts
@@ -9,6 +9,7 @@ import {
 	SidebarComponent,
 	InvitePeoplePage,
 	PeoplePage,
+	BrowserManager,
 	setupHooks,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
@@ -27,7 +28,7 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 	let peoplePage: PeoplePage;
 	let page: Page;
 
-	setupHooks( ( args ) => {
+	setupHooks( ( args: { page: Page } ) => {
 		page = args.page;
 	} );
 
@@ -41,7 +42,7 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 		await sidebarComponent.navigate( 'Users', 'All Users' );
 	} );
 
-	it( `Create new invite for test user`, async function () {
+	it( 'Invite test user to the site', async function () {
 		peoplePage = new PeoplePage( page );
 		await peoplePage.clickInviteUser();
 
@@ -53,14 +54,7 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 		} );
 	} );
 
-	it( 'Revoke the invite for test user', async function () {
-		await sidebarComponent.navigate( 'Users', 'All Users' );
-		await peoplePage.clickTab( 'Invites' );
-		await peoplePage.selectInvitedUser( testEmailAddress );
-		await peoplePage.revokeInvite();
-	} );
-
-	it( `Invite email was received for test user`, async function () {
+	it( 'Invite email was received for test user', async function () {
 		const emailClient = new EmailClient();
 		const message = await emailClient.getLastEmail( {
 			inboxId: inboxId,
@@ -76,9 +70,17 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 		adjustedInviteLink = DataHelper.adjustInviteLink( acceptInviteLink );
 	} );
 
-	it( `Ensure invite link is no longer valid`, async function () {
-		await page.goto( adjustedInviteLink );
+	it( 'Revoke the invite for test user', async function () {
+		await sidebarComponent.navigate( 'Users', 'All Users' );
+		await peoplePage.clickTab( 'Invites' );
+		await peoplePage.selectInvitedUser( testEmailAddress );
+		await peoplePage.revokeInvite();
+	} );
 
-		await page.waitForSelector( `:text("Oops, that invite is not valid")` );
+	it( `Ensure invite link is no longer valid`, async function () {
+		const testPage = await BrowserManager.newPage( { newContext: true } );
+		await testPage.goto( adjustedInviteLink );
+
+		await testPage.waitForSelector( `:text("Oops, that invite is not valid")` );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to fix the flakiness encountered in about 1% of the instances.

Key changes:
- add a wait for `load` state to be fired before attempting to interact with the invited users list.
- wrap click methods in `waitForNavigation` where appropriate.
- reorder the test steps to use the a new BrowserContext to check the invite link.

#### Testing instructions

- [x] stress test
  - [x]  mobile
  - [x] desktop
- [x] regular test
  - [x] mobile
  - [x] desktop

Closes #56472.