### PR TITLE
Playwright: run tests headlessly.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -638,7 +638,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}
@@ -752,11 +752,12 @@ object PreReleaseE2ETests : BuildType({
 				export LOCALE=en
 				export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 				export DEBUG=pw:api
+				export HEADLESS=1
 
 				# Decrypt config
 				openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"
 
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-release
+				yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-release
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -638,7 +638,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-reader
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -627,6 +627,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG_ENV=test
 					export PLAYWRIGHT_BROWSERS_PATH=0
 					export TEAMCITY_VERSION=2021
+					export HEADLESS=1
 
 					# Decrypt config
 					openssl aes-256-cbc -md sha1 -d -in ./config/encrypted.enc -out ./config/local-test.json -k "%CONFIG_E2E_ENCRYPTION_KEY%"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -638,7 +638,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-reader
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -36,6 +36,7 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 
 	it( 'Visit latest post', async function () {
 		await readerPage.visitPost( { index: 1 } );
+		throw new Error();
 	} );
 
 	it( 'Comment and confirm it is shown', async function () {

--- a/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
+++ b/test/e2e/specs/specs-playwright/wp-reader__view-spec.ts
@@ -36,7 +36,6 @@ describe( DataHelper.createSuiteTitle( 'Reader: View and Comment' ), function ()
 
 	it( 'Visit latest post', async function () {
 		await readerPage.visitPost( { index: 1 } );
-		throw new Error();
 	} );
 
 	it( 'Comment and confirm it is shown', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to run Playwright tests headlessly.

By some accounts, Playwright runs faster in headless mode [GitHub](https://github.com/microsoft/playwright/issues/2025#issuecomment-621288067).

Anecdotally, running a selection of test specs locally with both headful and headless modes show some difference:

Headless:
```
  [WPCOM] Blocks: CoBlocks: (mobile) @parallel
    ✓ Log in (2541 ms)
    ✓ Start new post (5238 ms)
    ✓ Enter post title (274 ms)
    ✓ Insert Pricing Table block and enter price to left table (2098 ms)
    ✓ Insert Dynamic HR block (996 ms)
    ✓ Insert Hero block and enter heading (1227 ms)
    ✓ Insert Click to Tweet block and enter tweet content (1163 ms)
    ✓ Insert Logos block and set image (2063 ms)
    ✓ Publish and visit post (7967 ms)
    ✓ Confirm Pricing Table block is visible in published post (35 ms)
    ✓ Confirm Dynamic HR block is visible in published post (24 ms)
    ✓ Confirm Hero block is visible in published post (76 ms)
    ✓ Confirm Click to Tweet block is visible in published post (57 ms)
    ✓ Confirm Logos block is visible in published post (29 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        27.382 s, estimated 32 s
```

Headful:
```
  [WPCOM] Blocks: CoBlocks: (mobile) @parallel
    ✓ Log in (2871 ms)
    ✓ Start new post (5304 ms)
    ✓ Enter post title (503 ms)
    ✓ Insert Pricing Table block and enter price to left table (1691 ms)
    ✓ Insert Dynamic HR block (773 ms)
    ✓ Insert Hero block and enter heading (1126 ms)
    ✓ Insert Click to Tweet block and enter tweet content (1072 ms)
    ✓ Insert Logos block and set image (2098 ms)
    ✓ Publish and visit post (7711 ms)
    ✓ Confirm Pricing Table block is visible in published post (44 ms)
    ✓ Confirm Dynamic HR block is visible in published post (24 ms)
    ✓ Confirm Hero block is visible in published post (31 ms)
    ✓ Confirm Click to Tweet block is visible in published post (18 ms)
    ✓ Confirm Logos block is visible in published post (26 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        31.934 s, estimated 42 s
```

#### Testing instructions

- [x] desktop tests pass
- [x] mobile tests pass
- [x] pre-release tests pass