### PR TITLE
desktop: fix copy shortlink

### DIFF
--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -165,6 +165,7 @@ function showAppWindow() {
 	require( '../window-handlers/debug-tools' )( appWindow );
 	require( '../window-handlers/spellcheck' )( appWindow );
 	require( '../window-handlers/navigation' )( appWindow );
+	require( '../window-handlers/clipboard' )( appWindow );
 
 	platform.setMainWindow( appWindow );
 

--- a/desktop/app/window-handlers/clipboard/index.js
+++ b/desktop/app/window-handlers/clipboard/index.js
@@ -2,8 +2,12 @@ const { ipcMain: ipc, clipboard } = require( 'electron' );
 const log = require( '../../lib/logger' )( 'desktop:clipboard' );
 
 module.exports = function () {
-	ipc.on( 'copy-text-to-clipboard', ( text ) => {
+	ipc.on( 'copy-text-to-clipboard', ( _, text ) => {
 		log.info( 'Copying text to clipboard: ', text );
-		clipboard.writeText( text );
+		try {
+			clipboard.writeText( text );
+		} catch ( e ) {
+			log.error( 'Failed to write to clipboard: ', e );
+		}
 	} );
 };

--- a/desktop/app/window-handlers/clipboard/index.js
+++ b/desktop/app/window-handlers/clipboard/index.js
@@ -1,0 +1,9 @@
+const { ipcMain: ipc, clipboard } = require( 'electron' );
+const log = require( '../../lib/logger' )( 'desktop:clipboard' );
+
+module.exports = function () {
+	ipc.on( 'copy-text-to-clipboard', ( text ) => {
+		log.info( 'Copying text to clipboard: ', text );
+		clipboard.writeText( text );
+	} );
+};

--- a/desktop/public_desktop/preload.js
+++ b/desktop/public_desktop/preload.js
@@ -3,6 +3,7 @@ const { ipcRenderer, contextBridge } = require( 'electron' );
 // Outgoing IPC message channels from Renderer to Main process.
 // Maintain this list in alphabetical order.
 const sendChannels = [
+	'copy-text-to-clipboard',
 	'get-config',
 	'get-settings',
 	'log',


### PR DESCRIPTION
### Description 

This patch, in tandem with WP.com patch D67177-code, fixes the "copy shortlink" item in the desktop app. The root issue is that the `window.prompt` API is not supported by Electron, and so this action would silently fail in the Desktop app.

<p align="center">
<img width="250" alt="action-barcopy-shortlink" src="https://user-images.githubusercontent.com/8979548/134408014-3fd5c5af-342f-4b8e-b73b-f3c138b86a80.png">
</p>

### To Test

1. In your WP.com sandbox, apply the patch D67177-code, and point **both** a test site and the CDN `s0.wp.com` to your sandbox in `/etc/hosts`. 
2. Run the desktop app from this branch: from the `desktop` folder, run the app with `yarn run dev`. Navigate to a post in the sandboxed site. In the bottom-right of the post, select the item "Copy Shortlink" in the action bar. Confirm that the shortlink is copied to your clipboard.
3. In a regular browser, navigate to the same sandboxed site and post. Confirm that existing behavior your browser remains unchanged (i.e. a window prompt is displayed to facilitate the manual copy action).

Fixes Automattic/wp-desktop/issues/993

