### PR TITLE
Memberships: Throw returned error in promise chain in add product thunk

### DIFF
--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -52,6 +52,9 @@ export const requestAddProduct = ( siteId, product, noticeText ) => {
 				product
 			)
 			.then( ( newProduct ) => {
+				if ( newProduct.error ) {
+					throw new Error( newProduct.error );
+				}
 				const membershipProduct = membershipProductFromApi( newProduct.product );
 				dispatch( receiveUpdateProduct( siteId, membershipProduct ) );
 				dispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Throw returned error in promise chain

#### Testing instructions

1. Go to /earn/payments-plans/site on a site without Stripe set up
2. Click on Add a new payment plan
3. Enter any description and click Save
4. You should see the error "Required field connected_destination_account_id is missing"

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #56476
