### PR TITLE
Ship the design picker onboarding step to all users

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -151,7 +151,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,7 +102,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -109,7 +109,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"site-indicator": true,
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,7 +111,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Note:** Getting this PR ready so we can use it when we're ready to ship.

Deploys Iteration 1 of the blogger onboarding flow as described here: pdgK6S-78-p2
This iteration has been tested using the `/start?flags=signup/setup-site-after-checkout` flag, and this PR simply sets that flag to `true` by default. Users will now get the `setup-site-after-checkout` experience simply by going to `/start` (or `/start/premium`, `onboarding-with-email`, etc.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` and verify that you see the design picker after selecting the free plan or after completing checkout.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
