### PR TITLE
Fix i18n picker layout

### DIFF
--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -128,7 +128,7 @@ function LanguagePicker< TLanguage extends Language >( {
 	const searchPlaceholder = __( 'Search languages…' );
 
 	return (
-		<Flex className="language-picker-component" align="left">
+		<Flex className="language-picker-component" align="left" direction="column" expanded={ false }>
 			<FlexBlock className="language-picker-component__heading">
 				<Flex justify="space-between" align="left">
 					<FlexItem className="language-picker-component__title wp-brand-font">

--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -1,14 +1,32 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import Search from '@automattic/search';
-import { Button, CustomSelectControl, Flex, FlexBlock, FlexItem } from '@wordpress/components';
+import {
+	Button,
+	CustomSelectControl,
+	Flex as WpFlex,
+	FlexBlock,
+	FlexItem,
+} from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState } from 'react';
 import { getSearchedLanguages, LocalizedLanguageNames } from './search';
 import type { Language, LanguageGroup } from './Language';
-import type { ReactNode } from 'react';
+import type { ReactNode, ComponentType } from 'react';
 
 import './style.scss';
+
+// TODO: Definitely typed is out of date with the latest wp components, so we need
+// to override the props for the Flex component to get everything working for now.
+// Remove once definitely typed is updated, or if we can consume types directly
+// from wp components.
+const Flex = WpFlex as ComponentType< {
+	className?: string;
+	align?: string;
+	direction?: string;
+	expanded?: boolean;
+	justify?: string;
+} >;
 
 type Props< TLanguage extends Language > = {
 	onSelectLanguage: ( language: TLanguage ) => void;

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -30,7 +30,7 @@
 
 		.components-custom-select-control__button {
 			// less the width of the search button plus the border
-			width: calc( 100% - 52px );
+			width: calc( 100% - 60px );
 			height: 100%;
 			font-size: 0.875rem;
 		}
@@ -136,11 +136,16 @@
 		}
 	}
 
+	$language_button_width: 165px;
+
 	.language-picker-component__language-buttons {
 		display: flex;
 		flex-wrap: wrap;
 		align-content: flex-start;
 		width: 100%;
+
+		// Allow up to five columns of buttons.
+		max-width: $language_button_width * 5;
 
 		@include break-small() {
 			width: initial;
@@ -150,7 +155,7 @@
 	.language-picker-component__language-button {
 		width: 100%;
 		@include break-small() {
-			width: 165px;
+			width: $language_button_width;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request



The i18n picker layout can become broken. I noticed that language picker is written with `flex` components from `@wordpress/components`. That package was updated from v13.x to v17.x in the React 17 PR. I notice this line in the changelog from the v14 release: `Flex, FlexBlock, and FlexItem components have been re-written from the ground up (#31297).`

Looking at the rendered markup for the language picker, it looked like it was getting incorrect values for `flex-grow` and `flex-direction`. From the [source code](https://github.com/WordPress/gutenberg/blob/1620d517274476321fdbc65fc1eeca0ef985ad39/packages/components/src/flex/flex/hook.js#L45-L54), it looks like the default value for `expanded` is `true` and `direction` is set to `row`. Since we do not set these props, the layout was broken. After setting them to `false` and `column`, the layout appears to be fixed.

Also, I had to override the type for the flex component because definitely typed is out of date. I was unable to fix it by using yarn patches, or by removing definitely typed. So we might have to do more work in the future to properly resolve the type problem.

resolves #56372

![Screenshot from 2021-09-22 18-43-46](https://user-images.githubusercontent.com/6265975/134443502-dbcd38d0-d047-4e95-a5a3-24a00941fb7a.png)

![Screenshot from 2021-09-22 18-44-20](https://user-images.githubusercontent.com/6265975/134443507-ab47a4d7-d196-482c-9453-bd179884bbd1.png)

#### Testing instructions
1. Load calypso.live.
2. Open the language picker under `me/account`. Change the language.
3. After the page refreshes, the language picker should still look okay. Previously, the layout would become broken after the redirect.
4. Open gutenboarding `/new`. Open the language picker at the top right of the page.
5. The layout should look correct. Previously, the layout was broken.

see https://github.com/Automattic/wp-calypso/issues/56372 for examples of what it looked like broken.