### PR TITLE
Onboarding: Keep white background color of sticked navigation buttons on mobile

### DIFF
--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -59,6 +59,8 @@
 	}
 
 	.action-buttons {
-		background-color: transparent;
+		@include break-small {
+			background-color: transparent;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We remove the background color via https://github.com/Automattic/wp-calypso/pull/56388 but we still need it when the navigation buttons sticked to the footer. So, change the background color to transparent only when the device is not mobile.

##### Before
![image](https://user-images.githubusercontent.com/13596067/134458626-01c77379-f1a9-4a83-8781-a1fa485d19fd.png)

##### After

![image](https://user-images.githubusercontent.com/13596067/134458649-1afd8034-7406-4c1c-baf2-9a80542f78b1.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>`
* Switch device to mobile
* Check the background color of navigation buttons sticked to the footer is correct.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/56388
