### PR TITLE
Fix blog-stickers API being used by non-a8c users

### DIFF
--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { reduxGetState, reduxDispatch } from 'calypso/lib/redux-bridge';
 import wpcom from 'calypso/lib/wp';
@@ -25,7 +26,7 @@ export function cancelAndRefundPurchase( purchaseId, data, onComplete ) {
 			apiNamespace: 'wpcom/v2',
 		},
 		( error, response ) => {
-			if ( ! error ) {
+			if ( ! error && config.isEnabled( 'atomic/automated-revert' ) ) {
 				// Some purchases cancellations set a blog sticker to lock the site from
 				// cancelling more purchases, so we update the list of stickers in case
 				// we need to handle that lock in the UI.

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -833,7 +833,9 @@ class ManagePurchase extends Component {
 					<QueryUserPurchases userId={ this.props.userId } />
 				) }
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
-				{ purchase?.siteId && <QueryBlogStickers blogId={ purchase.siteId } /> }
+				{ purchase?.siteId && config.isEnabled( 'atomic/automated-revert' ) && (
+					<QueryBlogStickers blogId={ purchase.siteId } />
+				) }
 				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ siteId } themeId={ purchase.meta } /> }
 
 				<HeaderCake backHref={ this.props.purchaseListUrl }>

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import i18n from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -89,11 +90,13 @@ export const removePurchase = ( purchaseId, userId ) => ( dispatch, getState ) =
 					dispatch( requestHappychatEligibility() );
 				}
 
-				// Some purchases removals set a blog sticker to lock the site from
-				// removing more purchases, so we update the list of stickers in case
-				// we need to handle that lock in the UI.
-				const purchase = getByPurchaseId( getState(), purchaseId );
-				dispatch( listBlogStickers( purchase.siteId ) );
+				if ( config.isEnabled( 'atomic/automated-revert' ) ) {
+					// Some purchases removals set a blog sticker to lock the site from
+					// removing more purchases, so we update the list of stickers in case
+					// we need to handle that lock in the UI.
+					const purchase = getByPurchaseId( getState(), purchaseId );
+					dispatch( listBlogStickers( purchase.siteId ) );
+				}
 
 				resolve( data );
 			} )


### PR DESCRIPTION
Customers on the manage purchase screen, and after removing a purchase
were getting a message saying "Sorry, we had a problem retrieving blog
stickers. Please try again.". This was because the blog stickers API
is limited to A12s

PR #55381 introduced a change to allow atomic plans be removed/cancelled
by self service, this was gated behind a atomic/automated-revert feature
flag until the backend was ready. Part of the implemention used the blog
stickers API to check for the absence of a flag, however this was check
was not behind a feature flag.

#### Changes proposed in this Pull Request

* Move the newly added calls to the blog stickers API behind the feature flag.

#### Testing instructions

For each of these scenarios:
 * As a non-a8c user, with purchases go to /me/purchases and click on a purchase
 * As a non-a8c user, click on a purchase and go through the refund process

1. Wait for a second to ensure you didn't get a notice about stickers
2. Look in the browser dev console there should be no calls to the blog-stickers API



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Introduced in #55194
Reported on #56483
