### PR TITLE
Convert @automattic/calypso-e2e to ESM

### DIFF
--- a/packages/calypso-e2e/CHANGELOG.md
+++ b/packages/calypso-e2e/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.2.0
+
+- Breaking: Module converted to ESM only.

--- a/packages/calypso-e2e/jest.config.js
+++ b/packages/calypso-e2e/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
 	preset: '../../test/packages/jest-preset.js',
 };

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-e2e",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Tools for e2e tests",
 	"main": "dist/esm/src/index.js",
 	"types": "dist/types/src/index.d.ts",
@@ -14,6 +14,13 @@
 		"e2e",
 		"calypso"
 	],
+	"type": "module",
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
+	"exports": {
+		"import": "./dist/esm/index.js"
+	},
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"config": "^3.3.6",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -19,7 +19,7 @@
 		"decryptconfig": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out ./config/local-$NODE_CONFIG_ENV.json"
 	},
 	"dependencies": {
-		"@automattic/calypso-e2e": "^0.1.0",
+		"@automattic/calypso-e2e": "^0.2.0",
 		"@automattic/mocha-debug-reporter": "^0.1.0",
 		"@automattic/testarmada-magellan-mocha-plugin": "^10.0.0",
 		"@babel/core": "^7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,7 +156,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-e2e@^0.1.0, @automattic/calypso-e2e@workspace:packages/calypso-e2e":
+"@automattic/calypso-e2e@^0.2.0, @automattic/calypso-e2e@workspace:packages/calypso-e2e":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-e2e@workspace:packages/calypso-e2e"
   dependencies:
@@ -39005,7 +39005,7 @@ typescript@^4.4.3:
   version: 0.0.0-use.local
   resolution: "wp-e2e-tests@workspace:test/e2e"
   dependencies:
-    "@automattic/calypso-e2e": ^0.1.0
+    "@automattic/calypso-e2e": ^0.2.0
     "@automattic/mocha-debug-reporter": ^0.1.0
     "@automattic/testarmada-magellan-mocha-plugin": ^10.0.0
     "@babel/core": ^7.2.2


### PR DESCRIPTION
#### Background

See #55855

#### Changes proposed in this Pull Request

* Converts `@automattic/calypso-e2e` to ESM

#### Testing instructions

* Verify all tests are green