### PR TITLE
chore: Convert @automattic/calypso-products to ESM

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0",
 		"@automattic/calypso-polyfills": "^2.0.0",
-		"@automattic/calypso-products": "^1.0.0",
+		"@automattic/calypso-products": "^2.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/calypso-url": "^1.0.0",
 		"@automattic/color-studio": "2.5.0",

--- a/packages/calypso-products/CHANGELOG.md
+++ b/packages/calypso-products/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 2.0.0
+
+- Breaking: Module converted to ESM only. CJS build is not provided anymore.

--- a/packages/calypso-products/jest.config.js
+++ b/packages/calypso-products/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	globals: {

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -1,15 +1,11 @@
 {
 	"name": "@automattic/calypso-products",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "This module contains information about the various products sold within calypso, such as product slugs, plan intervals, etc.",
-	"main": "dist/cjs/index.js",
-	"module": "dist/esm/index.js",
-	"types": "dist/types/index.d.ts",
-	"calypso:src": "src/index.ts",
 	"sideEffects": false,
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
@@ -17,6 +13,15 @@
 		"dist",
 		"src"
 	],
+	"type": "module",
+	"engines": {
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+	},
+	"exports": {
+		"calypso:src": "./src/index.ts",
+		"import": "./dist/esm/index.js"
+	},
+	"types": "dist/types/index.d.ts",
 	"keywords": [
 		"checkout",
 		"payments",

--- a/packages/calypso-products/tsconfig-cjs.json
+++ b/packages/calypso-products/tsconfig-cjs.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig",
-	"compilerOptions": {
-		"module": "commonjs",
-		"outDir": "dist/cjs"
-	}
-}

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -37,7 +37,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/wpcom-checkout#readme",
 	"dependencies": {
-		"@automattic/calypso-products": "^1.0.0",
+		"@automattic/calypso-products": "^2.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/shopping-cart": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,7 +181,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-products@^1.0.0, @automattic/calypso-products@workspace:packages/calypso-products":
+"@automattic/calypso-products@^2.0.0, @automattic/calypso-products@workspace:packages/calypso-products":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-products@workspace:packages/calypso-products"
   dependencies:
@@ -1124,7 +1124,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-checkout@workspace:packages/wpcom-checkout"
   dependencies:
-    "@automattic/calypso-products": ^1.0.0
+    "@automattic/calypso-products": ^2.0.0
     "@automattic/calypso-stripe": ^1.0.0
     "@automattic/composite-checkout": ^1.0.0
     "@automattic/shopping-cart": ^2.0.0
@@ -11896,7 +11896,7 @@ __metadata:
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-config": ^1.0.0
     "@automattic/calypso-polyfills": ^2.0.0
-    "@automattic/calypso-products": ^1.0.0
+    "@automattic/calypso-products": ^2.0.0
     "@automattic/calypso-stripe": ^1.0.0
     "@automattic/calypso-url": ^1.0.0
     "@automattic/color-studio": 2.5.0


### PR DESCRIPTION
#### Background

See #55855

#### Changes proposed in this Pull Request

* Converts `@automattic/calypso-products` to ESM

#### Testing instructions

* Verify all tests are green