### PR TITLE
Marketing: Sharing Buttons - Tiny Style Updates

### DIFF
--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -585,6 +585,7 @@
 .sharing-buttons__fieldset label {
 	display: flex;
 	cursor: pointer;
+	font-weight: normal;
 }
 
 .sharing-buttons__fieldset .support-info {
@@ -603,7 +604,7 @@
 	margin: 5px 0;
 	font-size: $font-body-small;
 	font-style: italic;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 }
 
 .sharing-buttons-preview {
@@ -792,7 +793,7 @@
 	font-weight: 600;
 	text-transform: uppercase;
 	text-align: center;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 }
 
 .sharing-buttons-preview.is-placeholder .sharing-buttons-preview__label,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

These changes are genuinely tiny, so should be pretty quick to review:

- Colour contrast update in two places to meet accessibility requirements
- Remove boldness from some labels (caused by not overriding the component's styles)

#### Testing instructions

Compare at `/marketing/sharing-buttons/SITE`.

| Before                                                                                                                                                                | After                                                                                                                                                                 |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1126" alt="Screenshot 2021-09-23 at 17 16 57" src="https://user-images.githubusercontent.com/43215253/134545179-c16a2765-1e93-4e16-ab3e-3cfcda1e182a.png"> | <img width="1183" alt="Screenshot 2021-09-23 at 17 08 36" src="https://user-images.githubusercontent.com/43215253/134545017-b0dbd7ff-b211-479f-85ee-bb5a6ae34062.png"> |

cc @sixhours 