### PR TITLE
Domains: Add Unlock step and Start step components to the new Transfer flow

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -10,6 +10,7 @@ import {
 	stepsHeadingAdvanced,
 	stepsHeadingOwnershipVerification,
 	stepsHeadingSuggested,
+	stepsHeadingTransfer,
 	stepSlug,
 } from './constants';
 
@@ -29,6 +30,9 @@ export default function ConnectDomainStepLogin( {
 
 	useEffect( () => {
 		switch ( mode ) {
+			case modeType.TRANSFER:
+				setHeading( stepsHeadingTransfer );
+				return;
 			case modeType.SUGGESTED:
 				setHeading( stepsHeadingSuggested );
 				return;

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -46,6 +46,12 @@ export const defaultDomainSetupInfo = {
 	},
 } as const;
 
+export const domainLockStatusType = {
+	LOCKED: 'locked',
+	UNLOCKED: 'unlocked',
+	UNKNOWN: 'unknown',
+} as const;
+
 export const stepsHeadingSuggested = __( 'Suggested setup' );
 export const stepsHeadingAdvanced = __( 'Advanced setup' );
 export const stepsHeadingOwnershipVerification = __( 'Verify domain ownership' );

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -49,6 +49,7 @@ export const defaultDomainSetupInfo = {
 export const stepsHeadingSuggested = __( 'Suggested setup' );
 export const stepsHeadingAdvanced = __( 'Advanced setup' );
 export const stepsHeadingOwnershipVerification = __( 'Verify domain ownership' );
+export const stepsHeadingTransfer = __( 'Initial setup' );
 
 export const authCodeStepDefaultDescription = __(
 	'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'

--- a/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
+++ b/client/components/domains/connect-domain-step/domain-step-auth-code.tsx
@@ -20,11 +20,14 @@ const DomainStepAuthCode = ( {
 	progressStepList,
 	selectedSite,
 	buttonMessage,
+	customHeading,
 }: DomainStepAuthCodeProps ) => {
 	const { __ } = useI18n();
 	const [ authCode, setAuthCode ] = useState( '' );
 	const [ connectInProgress, setConnectInProgress ] = useState( false );
 	const [ authCodeError, setAuthCodeError ] = useState< ( string | undefined ) | null >( null );
+
+	const heading = customHeading ?? stepsHeadingOwnershipVerification;
 
 	const getVerificationData = () => {
 		return {
@@ -101,7 +104,7 @@ const DomainStepAuthCode = ( {
 	return (
 		<ConnectDomainStepWrapper
 			className={ className }
-			heading={ stepsHeadingOwnershipVerification }
+			heading={ heading }
 			progressStepList={ progressStepList }
 			pageSlug={ pageSlug }
 			stepContent={ stepContent }

--- a/client/components/domains/connect-domain-step/page-definitions.js
+++ b/client/components/domains/connect-domain-step/page-definitions.js
@@ -107,7 +107,7 @@ export const connectADomainOwnershipVerificationStepsDefinition = {
 	},
 };
 
-export const transferDomainStepsDefinition = {
+export const transferLockedDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_START ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.START,
@@ -133,10 +133,40 @@ export const transferDomainStepsDefinition = {
 	[ stepSlug.TRANSFER_AUTH_CODE ]: {
 		mode: modeType.TRANSFER,
 		step: stepType.ENTER_AUTH_CODE,
-		name: __( 'Get domain authorization code' ),
+		name: __( 'Authorize the transfer' ),
 		component: TransferDomainStepAuthCode,
 		next: 'unused transfer domain step',
 		prev: stepSlug.TRANSFER_UNLOCK,
+	},
+	[ 'unused transfer domain step' ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.FINALIZE,
+		name: __( 'Finalize transfer' ),
+	},
+};
+
+export const transferUnlockedDomainStepsDefinition = {
+	[ stepSlug.TRANSFER_START ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.START,
+		component: TransferDomainStepStart,
+		next: stepSlug.TRANSFER_LOGIN,
+	},
+	[ stepSlug.TRANSFER_LOGIN ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: __( 'Log in to provider' ),
+		component: TransferDomainStepLogin,
+		next: stepSlug.TRANSFER_AUTH_CODE,
+		prev: stepSlug.TRANSFER_START,
+	},
+	[ stepSlug.TRANSFER_AUTH_CODE ]: {
+		mode: modeType.TRANSFER,
+		step: stepType.ENTER_AUTH_CODE,
+		name: __( 'Authorize the transfer' ),
+		component: TransferDomainStepAuthCode,
+		next: 'unused transfer domain step',
+		prev: stepSlug.TRANSFER_LOGIN,
 	},
 	[ 'unused transfer domain step' ]: {
 		mode: modeType.TRANSFER,

--- a/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-auth-code.jsx
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { transferDomainAction } from 'calypso/components/domains/use-my-domain/utilities';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { authCodeStepDefaultDescription } from './constants';
+import { authCodeStepDefaultDescription, stepsHeadingTransfer } from './constants';
 import DomainStepAuthCode from './domain-step-auth-code';
 
 import './style.scss';
@@ -27,6 +27,7 @@ const TransferDomainStepAuthCode = ( {
 	return (
 		<DomainStepAuthCode
 			buttonMessage={ __( 'Check readiness for transfer' ) }
+			customHeading={ stepsHeadingTransfer }
 			authCodeDescription={ authCodeDescription }
 			className={ className }
 			domain={ domain }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import ConnectDomainStepLogin from 'calypso/components/domains/connect-domain-step/connect-domain-step-login';
-import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
 
 const TransferDomainStepLogin = ( props ) => {
-	return <ConnectDomainStepLogin { ...props } heading={ stepsHeadingTransfer } />;
+	return <ConnectDomainStepLogin { ...props } />;
 };
 
 export default TransferDomainStepLogin;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ConnectDomainStepLogin from 'calypso/components/domains/connect-domain-step/connect-domain-step-login';
+import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
 
 const TransferDomainStepLogin = ( props ) => {
-	return <ConnectDomainStepLogin { ...props } />;
+	return <ConnectDomainStepLogin heading={ stepsHeadingTransfer } { ...props } />;
 };
 
 export default TransferDomainStepLogin;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-login.jsx
@@ -3,7 +3,7 @@ import ConnectDomainStepLogin from 'calypso/components/domains/connect-domain-st
 import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
 
 const TransferDomainStepLogin = ( props ) => {
-	return <ConnectDomainStepLogin heading={ stepsHeadingTransfer } { ...props } />;
+	return <ConnectDomainStepLogin { ...props } heading={ stepsHeadingTransfer } />;
 };
 
 export default TransferDomainStepLogin;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.jsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import ConnectDomainStepSuggestedStart from 'calypso/components/domains/connect-domain-step/connect-domain-step-suggested-start';
-
-const TransferDomainStepStart = ( props ) => {
-	return <ConnectDomainStepSuggestedStart { ...props } />;
-};
-
-export default TransferDomainStepStart;

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -34,13 +34,13 @@ export default function TransferDomainStepStart( {
 				{ __( 'It takes 10-20 minutes to set up.' ) }
 				<br />
 				{ __(
-					'It takes 10-20 minutes to set up. It can take up to 5 days for the domain to be transferred, depending on your provider.'
+					'It can take up to 5 days for the domain to be transferred, depending on your provider.'
 				) }
-				<br />
-				<br />
+			</p>
+			<p className={ className + '__text' }>
 				{ createInterpolateElement(
 					__(
-						'If you would like to have your domain point to your WordPress.com site faster, <a>consider connecting your domain</a> first.'
+						'If you would like to have your domain point to your WordPress.com site faster, consider <a>connecting your domain</a> first.'
 					),
 					{
 						a: createElement( 'a', {

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -1,0 +1,67 @@
+import { Button } from '@automattic/components';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
+import CardHeading from 'calypso/components/card-heading';
+import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
+import MaterialIcon from 'calypso/components/material-icon';
+import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
+import './style.scss';
+import { StartStepProps } from './types';
+
+export default function TransferDomainStepStart( {
+	className,
+	pageSlug,
+	onNextStep,
+	progressStepList,
+}: StartStepProps ): JSX.Element {
+	const { __ } = useI18n();
+	const switchToDomainConnect = () => null;
+
+	const stepContent = (
+		<div className={ className + '__transfer-start' }>
+			<p className={ className + '__text' }>
+				{ __(
+					'For this setup you will need to log in to your current domain provider and go through a few steps.'
+				) }
+			</p>
+			<CardHeading tagName="h2" className={ className + '__sub-heading' }>
+				<MaterialIcon className={ className + '__sub-heading-icon' } size={ 24 } icon="timer" />
+				{ __( 'How long will it take?' ) }
+			</CardHeading>
+			<p className={ className + '__text' }>
+				{ __( 'It takes 10-20 minutes to set up.' ) }
+				<br />
+				{ __(
+					'It takes 10-20 minutes to set up. It can take up to 5 days for the domain to be transferred, depending on your provider.'
+				) }
+				<br />
+				<br />
+				{ createInterpolateElement(
+					__(
+						'If you would like to have your domain point to your WordPress.com site faster, <a>consider connecting your domain</a> first.'
+					),
+					{
+						a: createElement( 'a', {
+							className: 'connect-domain-step__change_mode_link',
+							onClick: switchToDomainConnect,
+						} ),
+					}
+				) }
+			</p>
+			<Button primary onClick={ onNextStep }>
+				{ __( 'Start setup' ) }
+			</Button>
+		</div>
+	);
+
+	return (
+		<ConnectDomainStepWrapper
+			className={ className }
+			heading={ stepsHeadingTransfer }
+			progressStepList={ progressStepList }
+			pageSlug={ pageSlug }
+			stepContent={ stepContent }
+		/>
+	);
+}

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -14,6 +14,7 @@ export default function TransferDomainStepStart( {
 	pageSlug,
 	onNextStep,
 	progressStepList,
+	isFetchingDomainLockStatus,
 }: StartStepProps ): JSX.Element {
 	const { __ } = useI18n();
 	const switchToDomainConnect = () => null;
@@ -49,7 +50,7 @@ export default function TransferDomainStepStart( {
 					}
 				) }
 			</p>
-			<Button primary onClick={ onNextStep }>
+			<Button primary onClick={ onNextStep } busy={ isFetchingDomainLockStatus }>
 				{ __( 'Start setup' ) }
 			</Button>
 		</div>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -2,12 +2,23 @@ import { Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
+import CardHeading from 'calypso/components/card-heading';
 import ConnectDomainStepWrapper from 'calypso/components/domains/connect-domain-step/connect-domain-step-wrapper';
-import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
+import {
+	stepsHeadingTransfer,
+	domainLockStatusType,
+} from 'calypso/components/domains/connect-domain-step/constants';
+import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
 
-const TransferDomainStepUnlock = ( { className, onNextStep, domain, ...props } ) => {
+const TransferDomainStepUnlock = ( {
+	className,
+	onNextStep,
+	domain,
+	domainLockStatus: initialDomainLockStatus,
+	...props
+} ) => {
 	const { __ } = useI18n();
 
 	const [ checkInProgress, setCheckInProgress ] = useState( false );
@@ -32,19 +43,40 @@ const TransferDomainStepUnlock = ( { className, onNextStep, domain, ...props } )
 		}
 	};
 
+	const lockedDomainContent =
+		initialDomainLockStatus === domainLockStatusType.UNLOCKED ? null : (
+			<CardHeading tagName="h2" className={ className + '__sub-heading' }>
+				<MaterialIcon className={ className + '__sub-heading-icon' } size={ 24 } icon="lock" />
+				{ initialDomainLockStatus === domainLockStatusType.LOCKED
+					? __( 'Your domain is locked' )
+					: __( "Can't get the domain's lock status" ) }
+			</CardHeading>
+		);
+
+	const lockedDomainDescription = __(
+		'Domain providers lock domains to prevent unauthorized transfers. You’ll need to unlock it on your domain provider’s settings page. Some domain providers require you to contact them via their customer support to unlock it.'
+	);
+
+	const unkownLockStatusAdditionalDescription = (
+		<>{ __( 'Please check that your domain is unlocked.' ) + ' ' }</>
+	);
+
 	const stepContent = (
 		<div className={ className + '__domain-unlock' }>
 			{ domainStatusError && ! checkInProgress && (
 				<Notice
 					status="is-error"
 					showDismiss={ false }
-					text="Your domain is still locked. If you’ve already unlocked it, wait a few minutes and try again."
+					text={ __(
+						'Your domain is still locked. If you’ve already unlocked it, wait a few minutes and try again.'
+					) }
 				></Notice>
 			) }
+			{ lockedDomainContent }
 			<p className={ className + '__text' }>
-				{ __(
-					'Domain providers lock domains to prevent unauthorized transfers. You’ll need to unlock it on your domain provider’s settings page. Some domain providers require you to contact them via their customer support to unlock it.'
-				) }
+				{ initialDomainLockStatus === domainLockStatusType.UNKNOWN &&
+					unkownLockStatusAdditionalDescription }
+				{ lockedDomainDescription }
 				<br />
 				<br />
 				{ __( 'It might take a few minutes for any changes to take effect.' ) }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -77,8 +77,8 @@ const TransferDomainStepUnlock = ( {
 				{ initialDomainLockStatus === domainLockStatusType.UNKNOWN &&
 					unkownLockStatusAdditionalDescription }
 				{ lockedDomainDescription }
-				<br />
-				<br />
+			</p>
+			<p>
 				{ __( 'It might take a few minutes for any changes to take effect.' ) }
 				<br />
 				{ __( 'Once you have unlocked your domain click on the button below to proceed.' ) }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import ConnectDomainStepWrapper from 'calypso/components/domains/connect-domain-step/connect-domain-step-wrapper';
+import { stepsHeadingTransfer } from 'calypso/components/domains/connect-domain-step/constants';
 import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
 
@@ -59,7 +60,12 @@ const TransferDomainStepUnlock = ( { className, onNextStep, domain, ...props } )
 	);
 
 	return (
-		<ConnectDomainStepWrapper className={ className } stepContent={ stepContent } { ...props } />
+		<ConnectDomainStepWrapper
+			heading={ stepsHeadingTransfer }
+			className={ className }
+			stepContent={ stepContent }
+			{ ...props }
+		/>
 	);
 };
 

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -78,7 +78,7 @@ const TransferDomainStepUnlock = ( {
 					unkownLockStatusAdditionalDescription }
 				{ lockedDomainDescription }
 			</p>
-			<p>
+			<p className={ className + '__text' }>
 				{ __( 'It might take a few minutes for any changes to take effect.' ) }
 				<br />
 				{ __( 'Once you have unlocked your domain click on the button below to proceed.' ) }

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -1,16 +1,53 @@
 import { Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ConnectDomainStepWrapper from 'calypso/components/domains/connect-domain-step/connect-domain-step-wrapper';
+import Notice from 'calypso/components/notice';
+import wpcom from 'calypso/lib/wp';
 
-const TransferDomainStepUnlock = ( { className, onNextStep, ...props } ) => {
+const TransferDomainStepUnlock = ( { className, onNextStep, domain, ...props } ) => {
 	const { __ } = useI18n();
+
+	const [ checkInProgress, setCheckInProgress ] = useState( false );
+	const [ domainStatusError, setDomainStatusError ] = useState( null );
+
+	const getDomainLockStatus = useCallback( async () => {
+		setCheckInProgress( true );
+		const { unlocked } = await wpcom.undocumented().getInboundTransferStatus( domain );
+		setCheckInProgress( false );
+		return unlocked;
+	}, [ domain, setCheckInProgress ] );
+
+	const checkDomainLockStatus = async () => {
+		const isDomainUnlocked = await getDomainLockStatus();
+		if ( isDomainUnlocked ) onNextStep();
+		else {
+			setDomainStatusError( 'Your domain is locked' );
+		}
+	};
 
 	const stepContent = (
 		<div className={ className + '__domain-unlock' }>
+			{ domainStatusError && ! checkInProgress && (
+				<Notice
+					status="is-error"
+					showDismiss={ false }
+					text="Your domain is still locked. If you’ve already unlocked it, wait a few minutes and try again."
+				></Notice>
+			) }
+			<p className={ className + '__text' }>
+				{ __(
+					'Domain providers lock domains to prevent unauthorized transfers. You’ll need to unlock it on your domain provider’s settings page. Some domain providers require you to contact them via their customer support to unlock it.'
+				) }
+				<br />
+				<br />
+				{ __( 'It might take a few minutes for any changes to take effect.' ) }
+				<br />
+				{ __( 'Once you have unlocked your domain click on the button below to proceed.' ) }
+			</p>
 			<div className={ className + '__actions' }>
-				<Button primary onClick={ onNextStep }>
+				<Button primary onClick={ checkDomainLockStatus } busy={ checkInProgress }>
 					{ __( "I've unlocked my domain" ) }
 				</Button>
 			</div>

--- a/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-unlock.jsx
@@ -20,10 +20,14 @@ const TransferDomainStepUnlock = ( { className, onNextStep, domain, ...props } )
 	}, [ domain, setCheckInProgress ] );
 
 	const checkDomainLockStatus = async () => {
-		const isDomainUnlocked = await getDomainLockStatus();
-		if ( isDomainUnlocked ) onNextStep();
-		else {
-			setDomainStatusError( 'Your domain is locked' );
+		try {
+			const isDomainUnlocked = await getDomainLockStatus();
+			if ( isDomainUnlocked ) onNextStep();
+			else {
+				setDomainStatusError( 'Your domain is locked' );
+			}
+		} catch {
+			setDomainStatusError( 'Can’t get the domain’s lock status' );
 		}
 	};
 

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -34,6 +34,7 @@ export type StartStepProps = {
 	onNextStep: () => void;
 	stepContent: JSX.Element;
 	progressStepList: Record< PossibleSlugs, string >;
+	isFetchingDomainLockStatus: boolean;
 	setPage: ( page: PossibleSlugs ) => void;
 };
 

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -43,6 +43,7 @@ export type DomainStepAuthCodeProps = {
 	buttonMessage: string;
 	className: string;
 	domain: string;
+	customHeading?: string;
 	onBeforeValidate: () => void;
 	validateHandler: AuthCodeValidationHandler;
 	pageSlug: PossibleSlugs;

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -27,6 +27,15 @@ export type AuthCodeValidationHandler = (
 	onDone?: ( error?: Maybe< AuthCodeValidationError >, callbackData?: unknown ) => void
 ) => unknown;
 
+export type StartStepProps = {
+	className: string;
+	pageSlug: PossibleSlugs;
+	onNextStep: () => void;
+	stepContent: JSX.Element;
+	progressStepList: Record< PossibleSlugs, string >;
+	setPage: ( page: PossibleSlugs ) => void;
+};
+
 export type DomainStepAuthCodeProps = {
 	authCodeDescription: JSX.Element;
 	buttonMessage: string;

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -28,6 +28,7 @@ export type AuthCodeValidationHandler = (
 ) => unknown;
 
 export type StartStepProps = {
+	domain: string;
 	className: string;
 	pageSlug: PossibleSlugs;
 	onNextStep: () => void;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds the Unlock and Start step components to the new Transfer flow (Use a domain I own). 
This is part of the domain transfer flow redesign detailed in pcYYhz-hK-p2.

#### Preview

#### Start step
![image](https://user-images.githubusercontent.com/18705930/134562833-7ec830ac-a39a-48c1-9f0c-8d1e8f2a9084.png)

#### Unlock step - when the domain is locked
![image](https://user-images.githubusercontent.com/18705930/134562811-31426302-95fa-4f22-be38-54687f592dd6.png)

#### Unlock step - when checking for the lock status and the domain hasn't been unlocked yet
![image](https://user-images.githubusercontent.com/18705930/134562940-def34422-f2d8-4d2f-b812-d962926b93cd.png)

#### Unlock step - when the domain lock status can't be retrieved
![image](https://user-images.githubusercontent.com/18705930/134561698-ba16f40c-e5c0-465e-b993-078f62cc669b.png)

#### Unlock step is omitted if the domain is unlocked
![image](https://user-images.githubusercontent.com/18705930/134562667-9526210c-23ca-44ce-ab01-586d7b8d1143.png)


#### Testing instructions
- Start the "Use a domain I own" flow with the ?flags=domains/new-transfer-flow query string;
- Check that selecting the "Transfer" option shows the steps added on this PR;
  - Test with locked and unlocked domains. If you don't have an unlocked/locked domain, you can hack the backend to test it.
- Make sure that the "Connect" option was not affected by any of the changes.
