### PR TITLE
Domains: Fix default old Transfer flow

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -17,7 +17,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import {
 	getOptionInfo,
 	connectDomainAction,
-	transferDomainAction as defaultTransferHandler,
+	defaultTransferDomainAction as defaultTransferHandler,
 } from '../utilities';
 import OptionContent from './option-content';
 

--- a/client/components/domains/use-my-domain/utilities/default-transfer-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/default-transfer-domain-action.js
@@ -1,0 +1,9 @@
+import page from 'page';
+import { domainTransferIn } from 'calypso/my-sites/domains/paths';
+
+export const transferDomainAction = ( { domain, selectedSite, transferDomainUrl } ) => {
+	// TODO: This will be replaced with a new transfer in flow in a near-term future update.
+	const defaultTransferUrl = domainTransferIn( selectedSite.slug, domain, true );
+	const transferUrl = transferDomainUrl ?? defaultTransferUrl;
+	page( transferUrl );
+};

--- a/client/components/domains/use-my-domain/utilities/index.js
+++ b/client/components/domains/use-my-domain/utilities/index.js
@@ -10,3 +10,4 @@ export { getTransferSalePriceText } from './get-transfer-sale-price-text';
 export { isFreeTransfer } from './is-free-transfer';
 export { optionInfo } from './option-info';
 export { transferDomainAction } from './transfer-domain-action';
+export { transferDomainAction as defaultTransferDomainAction } from './default-transfer-domain-action';


### PR DESCRIPTION
#### Changes proposed in this Pull Request
#56379 added a bug where the old transfer flow couldn't be accessed. This PR fixes it.

#### Testing instructions
- Go to the "Use a domain I own" flow;
- Check that the old transfer flow is displayed on the "Transfer" option if you don't have the `domains/new-transfer-flow` feature flag;
- Check that the new transfer flow is displayed if you have the flag active.