### PR TITLE
Update templates for Flakey E2E and Bug Report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,7 +55,7 @@ body:
     attributes:
       value: |
         ---
-        ### Additional context
+        ## Additional context
 
         Please provide whatever additional information you have available to you. If not, please scroll to the bottom and submit the issue.
   - type: dropdown
@@ -90,7 +90,9 @@ body:
     attributes:
       value: |
         ---
-          ### Issue severity
+        ## Issue severity
+
+        Please provide details around how often the issue is reproducible & how many users are affected.
   - type: dropdown
     id: reproducibility
     attributes:
@@ -99,11 +101,13 @@ body:
         - Consistent
         - Intermittent
         - Once
+    validations:
+      required: true
   - type: dropdown
     id: users-affected
     attributes:
       label: Severity
-      description: Approximately how many users are impacted?
+      description: How many users are impacted? A guess is fine.
       options:
         - One
         - Some (< 50%)
@@ -113,7 +117,6 @@ body:
     id: workarounds
     attributes:
       label: Available workarounds?
-      description: Is a workaround possible? What is the impact of this issue to users?
       options:
         - No and the platform is unusable
         - No but the platform is still usable

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,129 @@
+name: Bug Report
+description: Helps us improve our product!
+labels: "Needs triage, [Type] Bug"
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for contributing!
+
+        Please write a clear title, then fill in as much details as possible.
+
+        __Avoid using image hosting services such as Cloudup, Droplr, Imgur, etc., to link to media.__
+        Instead, attach screenshot(s) or recording(s) directly in any of the text areas below: click, then drag and drop.
+  - type: textarea
+    id: summary
+    attributes:
+        label: Quick summary
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start at `site-domain.com/blog`.
+        2. Click on any blog post.
+        3. Click on the 'Like' button.
+        4. ...
+
+        Attach any media by drag and dropping or selecting upload.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+      placeholder: |
+        e.g. The post should be liked.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      placeholder: |
+        e.g. Clicking the button does nothing visibly.
+    validations:
+      required: true
+  - type: input
+    id: issue_context
+    attributes:
+      label: Context
+      placeholder: |
+        e.g. Customer report, details of your exploratory testing, etc.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Additional context
+
+        Please provide whatever additional information you have available to you. If not, please scroll to the bottom and submit the issue.
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: (You may select more than one)
+      options:
+        - Google Chrome/Chromium
+        - Mozilla Firefox
+        - Microsoft Edge
+        - Apple Safari
+        - iOS Safari
+        - Android Chrome
+      multiple: true
+  - type: dropdown
+    id: site-type
+    attributes:
+      label: Simple/Atomic
+      description: (You may select more than one)
+      options:
+        - Simple
+        - Atomic
+      multiple: true
+  - type: textarea
+    id: other_notes
+    attributes:
+      label: Other notes
+      placeholder: |
+        e.g. Logs, CLI or console errors, notes, observations, etc.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+          ### Issue severity
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      options:
+        - Consistent
+        - Intermittent
+        - Once
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Severity
+      description: Approximately how many users are impacted?
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      description: Is a workaround possible? What is the impact of this issue to users?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+  - type: textarea
+    id: workarounds-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
+      placeholder: |
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml
@@ -10,19 +10,15 @@ body:
   - type: input
     id: spec
     attributes:
-      label: Spec
-      description: Name of the spec file that is flaky.
+      label: Spec file
       placeholder: eg. wp-likes__post.js
     validations:
       required: true
   - type: input
     id: suite
     attributes:
-      label: Suite
-      description: Name of the suite or step that is flaky.
-      placeholder: eg. Like a new Post
-    validations:
-      required: true
+      label: Suite or step
+      placeholder: eg. Like new post
   - type: dropdown
     id: framework
     attributes:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to update the template used for the following:

- flakey e2e
- bug report

Key changes:
- migrate `bug report` template to use GitHub issue forms.
- update wording and field requirement for `flakey e2e`.

#### Testing instructions

- [Bug Report](https://github.com/Automattic/wp-calypso/blob/update/bug-report-template/.github/ISSUE_TEMPLATE/bug_report.yml)
- [Flakey e2e](https://github.com/Automattic/wp-calypso/blob/update/bug-report-template/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml)
