### PR TITLE
Jetpack Storge Pricing: Fix padding on the filter bar when sticky

### DIFF
--- a/client/my-sites/plans/jetpack-plans/storage-pricing/style.scss
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/style.scss
@@ -1,5 +1,9 @@
 .storage-pricing__main {
 	.plans-filter-bar {
 		padding: 0;
+
+		&.sticky {
+			padding: 16px 0;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The filter bar padding is set to 0 on the pricing page, so it looked bad when stickied to the top. This fixes that.

Before:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/42627630/134580672-9164bf90-5bb0-40d5-88d6-6c793d1f669b.png">

After:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/42627630/134580590-97c806d1-d9d0-469c-b421-b57303c713cb.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `http://jetpack.cloud.localhost:3001/pricing/storage/:site_slug?flags=jetpack/only-realtime-products`.
2. Scroll down until the filter bar gets sticked to the top.
3. Verify that the padding looks good.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
