### PR TITLE
Google Analytics: Fix No Page View for Logged-out Pages

### DIFF
--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -4,7 +4,7 @@ import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytic
 import { retarget as retargetAdTrackers } from 'calypso/lib/analytics/ad-tracking';
 import { retargetFullStory } from 'calypso/lib/analytics/fullstory';
 import { updateQueryParamsTracking } from 'calypso/lib/analytics/sem';
-import { saveCouponQueryArgument } from 'calypso/lib/analytics/utils';
+import { refreshCountryCodeCookieGdpr, saveCouponQueryArgument } from 'calypso/lib/analytics/utils';
 import { gaRecordPageView } from './ga';
 import { processQueue } from './queue';
 import { referRecordPageView } from './refer';
@@ -15,7 +15,7 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 	setTimeout( () => {
 		// Tracks, Google Analytics, Refer platform.
 		recordTracksPageViewWithPageParams( urlPath, params );
-		gaRecordPageView( urlPath, pageTitle, options?.useJetpackGoogleAnalytics );
+		safeGoogleAnalyticsPageView( urlPath, pageTitle, options?.useJetpackGoogleAnalytics );
 		referRecordPageView();
 
 		// Retargeting.
@@ -29,4 +29,13 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 		// Process queue.
 		processQueue();
 	}, 0 );
+}
+
+async function safeGoogleAnalyticsPageView(
+	urlPath,
+	pageTitle,
+	useJetpackGoogleAnalytics = false
+) {
+	await refreshCountryCodeCookieGdpr();
+	gaRecordPageView( urlPath, pageTitle, useJetpackGoogleAnalytics );
 }

--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -16,11 +16,12 @@ export default async function refreshCountryCodeCookieGdpr() {
 	}
 
 	if ( refreshCountryCodeCookieGdprRequest === null ) {
-		refreshCountryCodeCookieGdprRequest = requestCountryCode();
+		refreshCountryCodeCookieGdprRequest = requestCountryCode().then( ( countryCode ) =>
+			setCountryCodeCookie( countryCode )
+		);
 	}
 
-	const countryCode = await refreshCountryCodeCookieGdprRequest;
-	setCountryCodeCookie( countryCode );
+	await refreshCountryCodeCookieGdprRequest;
 	refreshCountryCodeCookieGdprRequest = null;
 }
 

--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -1,6 +1,8 @@
 import cookie from 'cookie';
 import debug from './debug';
 
+let refreshCountryCodeCookieGdprRequest = null;
+
 /**
  * Refreshes the GDPR `country_code` cookie every 6 hours (like A8C_Analytics wpcom plugin).
  *
@@ -13,20 +15,34 @@ export default async function refreshCountryCodeCookieGdpr() {
 		return;
 	}
 
-	try {
-		// cache buster
-		const v = new Date().getTime();
-		const res = await fetch( 'https://public-api.wordpress.com/geo/?v=' + v );
-		if ( ! res.ok ) {
-			throw new Error( await res.body() );
-		}
-
-		const json = await res.json();
-		setCountryCodeCookie( json.country_short );
-	} catch ( err ) {
-		debug( 'refreshCountryCodeCookieGdpr: error: ', err );
-		setCountryCodeCookie( 'unknown' );
+	if ( refreshCountryCodeCookieGdprRequest === null ) {
+		refreshCountryCodeCookieGdprRequest = requestCountryCode();
 	}
+
+	const countryCode = await refreshCountryCodeCookieGdprRequest;
+	setCountryCodeCookie( countryCode );
+	refreshCountryCodeCookieGdprRequest = null;
+}
+
+function requestCountryCode() {
+	// cache buster
+	const v = new Date().getTime();
+	return fetch( 'https://public-api.wordpress.com/geo/?v=' + v )
+		.then( ( res ) => {
+			if ( ! res.ok ) {
+				return res.body().then( ( body ) => {
+					throw new Error( body );
+				} );
+			}
+			return res.json();
+		} )
+		.then( ( json ) => {
+			return json.country_short;
+		} )
+		.catch( ( err ) => {
+			debug( 'refreshCountryCodeCookieGdpr: error: ', err );
+			return 'unknown';
+		} );
 }
 
 function setCountryCodeCookie( countryCode ) {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -48,6 +48,7 @@ jest.mock( 'calypso/state/sites/selectors' );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
 jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
+jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

##### Abstract

Without a user logged in  loading Calypso will not register a page view initially ( perhaps depending on the speed of network requests ) since the request to `public-api.wordpress.com/geo` will not return in time to OK the tracking. This is affecting the Jetpack tracking situation especially hard since we have a cross-domain flow of 

`jetpack.com` -> `cloud.jetpack.com/pricing` -> `wordpress.com/checkout`

which will be affected by this issue twice.

##### Changes

* Use an asynchronous function to retrieve the country code before firing a Google Analytics page view without blocking the page view function
* Refactor `refreshCountryCodeCookieGdpr` function to only allow one request at a time

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. set `ad-tracking` to true in `jetpack-cloud-development.json`, and boot calypso green on trunk ( not the branch yet )
2. navigate to `jetpack.cloud.localhost:3000/pricing` in an incognito window, and enter `localStorage.setItem( 'debug', 'calypso:analytics:ga' );` into the dev tools console
3. delete the `county_code` cookie and refresh the page
4. verify `calypso:analytics:ga [Disallowed] analytics recordPageView(` appears in your console
5. switch to this branch
6. delete the `county_code` cookie and refresh the page
7. verify `calypso:analytics:ga Recording Page View ~ [URL: /pricing] ` appears in your console

Related to #55667
