### PR TITLE
Onboarding: Avoid to stick navigation to the footer if none of button appears

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -151,23 +151,6 @@ class StepWrapper extends Component {
 		}
 	}
 
-	hasNavigation() {
-		const {
-			hideBack,
-			hideSkip,
-			hideNext,
-			positionInFlow,
-			stepSectionName,
-			allowBackFirstStep,
-			skipButtonAlign,
-		} = this.props;
-
-		const hasBack = ! hideBack && ( positionInFlow > 0 || stepSectionName || allowBackFirstStep );
-		const hasSkip = ! hideSkip && skipButtonAlign === 'top';
-
-		return hasBack || hasSkip || ! hideNext;
-	}
-
 	render() {
 		const {
 			flowName,
@@ -185,7 +168,11 @@ class StepWrapper extends Component {
 			isHorizontalLayout,
 		} = this.props;
 
-		const hasNavigation = this.hasNavigation();
+		const backButton = ! hideBack && this.renderBack();
+		const skipButton =
+			! hideSkip && skipButtonAlign === 'top' && this.renderSkip( { borderless: true } );
+		const nextButton = ! hideNext && this.renderNext();
+		const hasNavigation = backButton || skipButton || nextButton;
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-horizontal-layout': isHorizontalLayout,
 			'is-wide-layout': isWideLayout,
@@ -196,19 +183,14 @@ class StepWrapper extends Component {
 		return (
 			<>
 				<div className={ classes }>
-					{ hasNavigation && (
-						<ActionButtons
-							className="step-wrapper__navigation"
-							sticky={ isReskinnedFlow( flowName ) ? null : false }
-						>
-							{ ! hideBack && this.renderBack() }
-							{ ! hideSkip &&
-								skipButtonAlign === 'top' &&
-								this.renderSkip( { borderless: true, forwardIcon: null } ) }
-							{ ! hideNext && this.renderNext() }
-						</ActionButtons>
-					) }
-
+					<ActionButtons
+						className="step-wrapper__navigation"
+						sticky={ isReskinnedFlow( flowName ) ? null : false }
+					>
+						{ backButton }
+						{ skipButton }
+						{ nextButton }
+					</ActionButtons>
 					{ ! hideFormattedHeader && (
 						<div className="step-wrapper__header">
 							<FormattedHeader

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -151,6 +151,23 @@ class StepWrapper extends Component {
 		}
 	}
 
+	hasNavigation() {
+		const {
+			hideBack,
+			hideSkip,
+			hideNext,
+			positionInFlow,
+			stepSectionName,
+			allowBackFirstStep,
+			skipButtonAlign,
+		} = this.props;
+
+		const hasBack = ! hideBack && ( positionInFlow > 0 || stepSectionName || allowBackFirstStep );
+		const hasSkip = ! hideSkip && skipButtonAlign === 'top';
+
+		return hasBack || hasSkip || ! hideNext;
+	}
+
 	render() {
 		const {
 			flowName,
@@ -168,7 +185,7 @@ class StepWrapper extends Component {
 			isHorizontalLayout,
 		} = this.props;
 
-		const hasNavigation = ! hideBack || ( ! hideSkip && skipButtonAlign === 'top' ) || ! hideNext;
+		const hasNavigation = this.hasNavigation();
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-horizontal-layout': isHorizontalLayout,
 			'is-wide-layout': isWideLayout,

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -49,6 +49,10 @@
 	align-items: center;
 	font-size: 0.875rem;
 
+	&:empty {
+		display: none;
+	}
+
 	@mixin unstick {
 		position: absolute;
 		top: 2px;

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -103,7 +103,7 @@
 	@include break-small {
 		display: block;
 	}
-	
+
 	img {
 		width: 50%;
 	}
@@ -166,7 +166,7 @@
 			margin-bottom: 0;
 		}
 
-		&.has-header-buttons {
+		&.has-navigation {
 			padding-bottom: 60px;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, if the user is on the first step, it still shows navigation bar sticked to the footer and it looks strange. So, I adjust the logic of showing navigation bar and use CSS to hide it in case there is any case I forgot.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/134615484-5654d7bc-da2a-4014-8e88-5073ca722b94.png) | ![image](https://user-images.githubusercontent.com/13596067/134615384-9f48b227-2876-444c-bd17-4b48527f8af3.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` on mobile
* You should not see the navigation bar with white background color sticked to the footer

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


