### PR TITLE
Use recommended themes for design-picker step

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -15,8 +15,6 @@ import './style.scss';
 // themes? e.g. `link-in-bio` or `no-fold`
 const STATIC_PREVIEWS = [ 'bantry', 'sigler', 'miller', 'pollard', 'paxton', 'jones', 'baker' ];
 
-const SUBJECTS_TO_EXCLUDE = [ 'podcast' ];
-
 class DesignPickerStep extends Component {
 	static propTypes = {
 		goToNextStep: PropTypes.func.isRequired,
@@ -74,23 +72,16 @@ class DesignPickerStep extends Component {
 			// component itself. The `/new` environment needs helpers for making authenticated requests to
 			// the theme API before we can do this.
 			// taxonomies.theme_subject probably maps to category
-			designs = this.props.themes
-				.filter(
-					( { taxonomies } ) =>
-						! taxonomies.theme_subject?.find( ( subject ) =>
-							SUBJECTS_TO_EXCLUDE.includes( subject.slug )
-						)
-				)
-				.map( ( { id, name } ) => ( {
-					categories: [],
-					features: [],
-					is_premium: false,
-					slug: id,
-					template: id,
-					theme: id,
-					title: name,
-					...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-				} ) );
+			designs = this.props.themes.map( ( { id, name } ) => ( {
+				categories: [],
+				features: [],
+				is_premium: false,
+				slug: id,
+				template: id,
+				theme: id,
+				title: name,
+				...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+			} ) );
 		}
 
 		return (

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -102,6 +102,7 @@ class DesignPickerStep extends Component {
 				className={ classnames( {
 					'design-picker-step__is-large-thumbnails': this.props.largeThumbnails,
 				} ) }
+				highResThumbnails
 			/>
 		);
 	}

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -15,6 +15,11 @@ import './style.scss';
 // themes? e.g. `link-in-bio` or `no-fold`
 const STATIC_PREVIEWS = [ 'bantry', 'sigler', 'miller', 'pollard', 'paxton', 'jones', 'baker' ];
 
+const EXCLUDED_THEMES = [
+	// The Ryu theme doesn't currently have any annotations
+	'ryu',
+];
+
 class DesignPickerStep extends Component {
 	static propTypes = {
 		goToNextStep: PropTypes.func.isRequired,
@@ -72,16 +77,18 @@ class DesignPickerStep extends Component {
 			// component itself. The `/new` environment needs helpers for making authenticated requests to
 			// the theme API before we can do this.
 			// taxonomies.theme_subject probably maps to category
-			designs = this.props.themes.map( ( { id, name } ) => ( {
-				categories: [],
-				features: [],
-				is_premium: false,
-				slug: id,
-				template: id,
-				theme: id,
-				title: name,
-				...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-			} ) );
+			designs = this.props.themes
+				.filter( ( { id } ) => ! EXCLUDED_THEMES.includes( id ) )
+				.map( ( { id, name } ) => ( {
+					categories: [],
+					features: [],
+					is_premium: false,
+					slug: id,
+					template: id,
+					theme: id,
+					title: name,
+					...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+				} ) );
 		}
 
 		return (

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -23,7 +23,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, loca
 		url={ getDesignUrl( design, locale ) }
 		aria-labelledby={ makeOptionId( design ) }
 		alt=""
-		options={ mShotOptions() }
+		options={ mShotOptions( design ) }
 		scrollable={ design.preview !== 'static' }
 	/>
 );

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -16,14 +16,15 @@ const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name
 interface DesignPreviewImageProps {
 	design: Design;
 	locale: string;
+	highRes: boolean;
 }
 
-const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale } ) => (
+const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale, highRes } ) => (
 	<MShotsImage
 		url={ getDesignUrl( design, locale ) }
 		aria-labelledby={ makeOptionId( design ) }
 		alt=""
-		options={ mShotOptions( design ) }
+		options={ mShotOptions( design, highRes ) }
 		scrollable={ design.preview !== 'static' }
 	/>
 );
@@ -33,6 +34,7 @@ interface DesignButtonProps {
 	locale: string;
 	onSelect: ( design: Design ) => void;
 	premiumBadge?: React.ReactNode;
+	highRes: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -40,6 +42,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	onSelect,
 	design,
 	premiumBadge,
+	highRes,
 } ) => {
 	const { __ } = useI18n();
 
@@ -69,7 +72,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					</div>
 				) : (
 					<div className="design-picker__image-frame-inside">
-						<DesignPreviewImage design={ design } locale={ locale } />
+						<DesignPreviewImage design={ design } locale={ locale } highRes={ highRes } />
 					</div>
 				) }
 			</span>
@@ -98,6 +101,7 @@ export interface DesignPickerProps {
 	isGridMinimal?: boolean;
 	theme?: 'dark' | 'light';
 	className?: string;
+	highResThumbnails?: boolean;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -110,6 +114,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isGridMinimal,
 	theme = 'light',
 	className,
+	highResThumbnails = false,
 } ) => {
 	return (
 		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>
@@ -121,6 +126,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						locale={ locale }
 						onSelect={ onSelect }
 						premiumBadge={ premiumBadge }
+						highRes={ highResThumbnails }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -25,9 +25,9 @@ export const getDesignUrl = ( design: Design, locale: string ): string => {
 };
 
 // Used for both prefetching and loading design screenshots
-export const mShotOptions = (): MShotsOptions => {
+export const mShotOptions = ( { preview }: Design ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
-	return { vpw: 1600, vph: 1600, w: 600, screen_height: 3600 };
+	return { vpw: 1600, vph: preview === 'static' ? 1040 : 1600, w: 600, screen_height: 3600 };
 };
 
 interface AvailableDesignsOptions {

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -25,9 +25,14 @@ export const getDesignUrl = ( design: Design, locale: string ): string => {
 };
 
 // Used for both prefetching and loading design screenshots
-export const mShotOptions = ( { preview }: Design ): MShotsOptions => {
+export const mShotOptions = ( { preview }: Design, highRes: boolean ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
-	return { vpw: 1600, vph: preview === 'static' ? 1040 : 1600, w: 600, screen_height: 3600 };
+	return {
+		vpw: 1600,
+		vph: preview === 'static' ? 1040 : 1600,
+		w: highRes ? 1200 : 600,
+		screen_height: 3600,
+	};
 };
 
 interface AvailableDesignsOptions {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fetch `auto-loading-homepage` themes using API and display them in design picker step
* Exclude `podcast` themes (the gutenboarding design picker excludes "anchorfm" designs by default)
* Generate a smaller thumbnail if we know the theme isn't intended to have content "below the fold"
* Fetch a higher resolution thumbnail

https://user-images.githubusercontent.com/1500769/134621481-638b5498-21c6-4fd6-b6fe-8c3906af1680.mov

FYI @michaeldcain 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/start`, choose free plan, will land on the design picker
* Test with non-`en` user and thumbnails should be translated

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
