### PR TITLE
Fix/janitorial block editor #56497

### DIFF
--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -2,7 +2,7 @@
 
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch, select, subscribe } from '@wordpress/data';
-import { RichTextToolbarButton } from '@wordpress/editor';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { toggleFormat, registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
 import { get } from 'lodash';
 

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -1,8 +1,7 @@
 /* global wpcomGutenberg */
-
+import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch, select, subscribe } from '@wordpress/data';
-import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { toggleFormat, registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
 import { get } from 'lodash';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaced `RichTextToolbarButton` import package from `editor` to `block-editor`

#### Testing instructions
* Open block editor, verify there are no warnings in the console:
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #56497

cc @simison @mmtr 