### PR TITLE
chore: Revert migration of TypeScript packages to ESM

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
 		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
-		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^2.0.0",
 		"@automattic/calypso-products": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",

--- a/packages/calypso-config/CHANGELOG.md
+++ b/packages/calypso-config/CHANGELOG.md
@@ -1,9 +1,3 @@
-# CHANGELOG
-
-## 1.0.0
-
-- Breaking: Module converted to ESM only. CJS build is not provided anymore.
-
 ## 1.0.0-alpha.0
 
 Extracted from `create-config` and transformed to TypeScript.

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -1,19 +1,14 @@
 {
 	"name": "@automattic/calypso-config",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.0",
 	"description": "The Calypso configuration API.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
 	"sideEffects": true,
-	"exports": {
-		"calypso:src": "./src/index.ts",
-		"import": "./dist/esm/index.js"
-	},
-	"type": "module",
-	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-	},
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
@@ -31,8 +26,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"

--- a/packages/calypso-config/tsconfig-cjs.json
+++ b/packages/calypso-config/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -37,7 +37,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-products#readme",
 	"dependencies": {
-		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-url": "^1.0.0",
 		"i18n-calypso": "^5.0.0",
 		"react": "^17.0.2"

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@wordpress/components": "^17.0.0",
 		"@wordpress/react-i18n": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,7 +134,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-config@^1.0.0, @automattic/calypso-config@workspace:packages/calypso-config":
+"@automattic/calypso-config@^1.0.0-alpha.0, @automattic/calypso-config@workspace:packages/calypso-config":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-config@workspace:packages/calypso-config"
   dependencies:
@@ -185,7 +185,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-products@workspace:packages/calypso-products"
   dependencies:
-    "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/calypso-url": ^1.0.0
     chai: ^4.3.4
     i18n-calypso: ^5.0.0
@@ -324,7 +324,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/design-picker@workspace:packages/design-picker"
   dependencies:
-    "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/onboarding": ^1.0.0
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.0.0
@@ -11894,7 +11894,7 @@ __metadata:
     "@automattic/calypso-analytics": ^1.0.0
     "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
-    "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/calypso-polyfills": ^2.0.0
     "@automattic/calypso-products": ^1.0.0
     "@automattic/calypso-stripe": ^1.0.0


### PR DESCRIPTION
Reverts Automattic/wp-calypso#56459

It produces invalid ESM packages (see the last section of p4TIVU-9Pn-p2)