### PR TITLE
Onboarding: Fix incorrect the front page url after running headstart

### DIFF
--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -49,5 +49,8 @@ export default createSelector(
 			woocommerce_setup: getSiteUrl( state, siteId ) + '/wp-admin/admin.php?page=wc-admin',
 		};
 	},
-	( state, siteId ) => [ getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY ) ]
+	( state, siteId ) => [
+		getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY ),
+		getFrontPageEditorUrl( state, siteId ),
+	]
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the `get-checklist-task-urls` selector, it doesn't put the `frontPageUrl` as deps so that even if we fetch the latest site data which has latest front page id (the old one might be deleted) and it still uses the wrong one. So, I add `getFrontPageEditorUrl` to fix this problem.
* Note that the behavior when clicking `Quick links > Edit homepage` is correct, so we don't need to change it

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=signup/setup-site-after-checkout`
* Finish the signup flow and DON'T skip choose the design
* When you land in My Home, click Update your homepage > Edit homepage
* See the editor opens the correct homepage or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1632468533122900-slack-C029SB8JT8S