### PR TITLE
Slideshow Block: Image captions not reflecting newly updated caption in block editor.

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -31,20 +31,19 @@ class EditorMediaModalDetailFields extends Component {
 
 	constructor() {
 		super( ...arguments );
-
-		// Save changes to server after 1000 second delay
-		this.delayedSaveChange = debounce( this.saveChange, 1000 );
+		this.persistChange = debounce( this._persistChange, 1000 );
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.item && nextProps.item.ID !== this.props.item?.ID ) {
-			this.updateChange( true );
+			this.persistChange.cancel();
+			this._persistChange();
 			this.setState( { modifiedItem: null } );
 		}
 	}
 
 	componentWillUnmount() {
-		this.updateChange( true );
+		this._persistChange();
 	}
 
 	bumpTitleStat = () => {
@@ -71,29 +70,13 @@ class EditorMediaModalDetailFields extends Component {
 		return getMimePrefix( this.props.item ) === prefix;
 	}
 
-	updateChange( saveImmediately = false ) {
-		const siteId = this.props.site?.ID;
-		const itemId = this.props.item?.ID;
-		const modifiedItem = this.state?.modifiedItem;
-		const hasChanges = siteId && itemId && modifiedItem;
-
-		if ( ! hasChanges ) {
+	_persistChange() {
+		if ( ! this.props.site || ! this.state?.modifiedItem ) {
 			return;
 		}
 
-		// Update changes to local state immediately
-		this.props.onUpdate( itemId, modifiedItem );
-
-		// Save changes immediately or after a delay
-		if ( saveImmediately ) {
-			this.saveChange( siteId, modifiedItem );
-		} else {
-			this.delayedSaveChange( siteId, modifiedItem );
-		}
-	}
-
-	saveChange( siteId, modifiedItem ) {
-		this.props.updateMedia( siteId, modifiedItem )
+		this.props.updateMedia( this.props.site.ID, this.state.modifiedItem );
+		this.props.onUpdate( this.props.item.ID, this.state.modifiedItem );
 	}
 
 	setFieldByName = ( name, value ) => {
@@ -103,7 +86,7 @@ class EditorMediaModalDetailFields extends Component {
 			{ [ name ]: value }
 		);
 
-		this.setState( { modifiedItem }, this.updateChange );
+		this.setState( { modifiedItem }, this.persistChange );
 	};
 
 	setFieldValue = ( { target } ) => {

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -32,7 +32,7 @@ class EditorMediaModalDetailFields extends Component {
 	constructor() {
 		super( ...arguments );
 
-		// Save changes to server after 1000 second delay
+		// Save changes to server after 1 second delay
 		this.delayedSaveChange = debounce( this.saveChange, 1000 );
 	}
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -134,7 +134,7 @@ export class EditorMediaModal extends Component {
 			detailSelectedIndex: 0,
 			source: props.source ? props.source : '',
 			gallerySettings: props.initialGallerySettings,
-			selectedItems: props.selectedItems,
+			updatedItems: [],
 		};
 	}
 
@@ -161,7 +161,7 @@ export class EditorMediaModal extends Component {
 
 	confirmSelection = () => {
 		const { view } = this.props;
-		const { selectedItems } = this.state;
+		const selectedItems = this.getSelectedItems();
 
 		if ( areMediaActionsDisabled( view, selectedItems, this.props.isParentReady ) ) {
 			return;
@@ -438,22 +438,29 @@ export class EditorMediaModal extends Component {
 		this.setState( { gallerySettings } );
 	};
 
-	updateItem = ( itemId, detail ) => {
-		const { selectedItems } = this.state;
-		const index = selectedItems.findIndex( ( item ) => item.ID === itemId );
+	updateItem = ( itemId, item ) => {
+		const { updatedItems } = this.state;
 
-		if ( index === -1 ) {
-			return;
-		}
-
-		selectedItems.splice( index, 1, {
-			...selectedItems[ index ],
-			...detail,
-		} );
+		const index = updatedItems.findIndex( ( updatedItem ) => updatedItem.ID === item.ID );
 
 		this.setState( {
-			...this.state,
-			selectedItems,
+			updatedItems:
+				index === -1
+					? [ ...updatedItems, item ]
+					: updatedItems.map( ( updatedItem ) =>
+							updatedItem.itemID === item.ID ? item : updatedItem
+					  ),
+		} );
+	};
+
+	getSelectedItems = () => {
+		const { selectedItems } = this.props;
+		const { updatedItems } = this.state;
+
+		// Apply updated changes over the selected items
+		return selectedItems.map( ( selectedItem ) => {
+			const index = updatedItems.findIndex( ( updatedItem ) => selectedItem.ID === updatedItem.ID );
+			return index > -1 ? { ...selectedItem, ...updatedItems[ index ] } : selectedItem;
 		} );
 	};
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -438,18 +438,18 @@ export class EditorMediaModal extends Component {
 		this.setState( { gallerySettings } );
 	};
 
-	updateItem = ( itemId, item ) => {
+	updateItem = ( itemId, itemChanges ) => {
 		const { updatedItems } = this.state;
 
-		const index = updatedItems.findIndex( ( updatedItem ) => updatedItem.ID === item.ID );
+		const index = updatedItems.findIndex( ( updatedItem ) => updatedItem.ID === itemId );
 
 		this.setState( {
 			updatedItems:
 				index === -1
-					? [ ...updatedItems, item ]
-					: updatedItems.map( ( updatedItem ) =>
-							updatedItem.itemID === item.ID ? item : updatedItem
-					  ),
+					? [ ...updatedItems, itemChanges ]
+					: updatedItems.map( ( updatedItem ) => {
+							return updatedItem.ID === itemId ? { ...updatedItem, ...itemChanges } : updatedItem;
+					  } ),
 		} );
 	};
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -134,6 +134,7 @@ export class EditorMediaModal extends Component {
 			detailSelectedIndex: 0,
 			source: props.source ? props.source : '',
 			gallerySettings: props.initialGallerySettings,
+			selectedItems: props.selectedItems,
 		};
 	}
 
@@ -159,7 +160,8 @@ export class EditorMediaModal extends Component {
 	}
 
 	confirmSelection = () => {
-		const { view, selectedItems } = this.props;
+		const { view } = this.props;
+		const { selectedItems } = this.state;
 
 		if ( areMediaActionsDisabled( view, selectedItems, this.props.isParentReady ) ) {
 			return;
@@ -436,6 +438,25 @@ export class EditorMediaModal extends Component {
 		this.setState( { gallerySettings } );
 	};
 
+	updateItem = ( itemId, detail ) => {
+		const { selectedItems } = this.state;
+		const index = selectedItems.findIndex( ( item ) => item.ID === itemId );
+
+		if ( index === -1 ) {
+			return;
+		}
+
+		selectedItems.splice( index, 1, {
+			...selectedItems[ index ],
+			...detail,
+		} );
+
+		this.setState( {
+			...this.state,
+			selectedItems,
+		} );
+	};
+
 	renderContent() {
 		let content;
 
@@ -448,6 +469,7 @@ export class EditorMediaModal extends Component {
 						selectedIndex={ this.getDetailSelectedIndex() }
 						onRestoreItem={ this.restoreOriginalMedia }
 						onSelectedIndexChange={ this.setDetailSelectedIndex }
+						onUpdateItem={ this.updateItem }
 					/>
 				);
 				break;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR partially fixes the issue https://github.com/Automattic/wp-calypso/issues/51013. 

**What is fixed:**
Image caption on Slideshow block is updated when editing the image caption on media library through the **Block Editor**,

**What is not fixed:**
Image caption on Slideshow block is updated when editing the image caption on media library through **Calypso**.


**Technical changes:**
* Keep a local component state `updatedItems` which contains changes made (like caption) on the `selectedItems`.
* Introduce `getSelectedItems()` which returns selected items with updated local changes (in case saving remotely hasn't happened yet).

## Testing instructions

1. On your block editor, add a Slideshow block with 2 images.
2. Click on the "Edit" button on the block toolbar of the Slideshow block.
3. Media library will open again.
4. Click "Edit" button on the media library to edit the caption of the images.
5. Modify the caption, and click "Insert" button.
6. The newly updated caption should be reflected on the slideshow block.

## Preview

https://user-images.githubusercontent.com/1287077/134908225-adf744a6-ca20-4d18-a8d1-0dd2c12d40e1.mp4

Partially fixes https://github.com/Automattic/wp-calypso/issues/51013
