### PR TITLE
`QueryWhois`: refactor away from `UNSAFE_componentWillMount`

### DIFF
--- a/client/components/data/query-whois/index.jsx
+++ b/client/components/data/query-whois/index.jsx
@@ -1,29 +1,27 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestWhois } from 'calypso/state/domains/management/actions';
 import isRequestingWhois from 'calypso/state/selectors/is-requesting-whois';
 
-class QueryWhois extends Component {
-	UNSAFE_componentWillMount() {
-		if ( this.props.isRequesting ) {
-			return;
-		}
-		this.props.requestWhois( this.props.domain );
+const request = ( domain ) => ( dispatch, getState ) => {
+	if ( domain && ! isRequestingWhois( getState(), domain ) ) {
+		dispatch( requestWhois( domain ) );
 	}
+};
 
-	render() {
-		return null;
-	}
+function QueryWhois( { domain } ) {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( request( domain ) );
+	}, [ dispatch, domain ] );
+
+	return null;
 }
 
 QueryWhois.propTypes = {
 	domain: PropTypes.string.isRequired,
-	isRequesting: PropTypes.bool.isRequired,
-	requestWhois: PropTypes.func.isRequired,
 };
 
-export default connect(
-	( state, { domain } ) => ( { isRequesting: isRequestingWhois( state, domain ) } ),
-	{ requestWhois }
-)( QueryWhois );
+export default QueryWhois;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is part of a long-term effort to remove usages of `UNSAFE_*` component lifecycle methods.

* `QueryWhois`:
  * refactor away from `UNSAFE_componentWillMount`
  * migrate to functional component

#### Testing instructions

1. Change the email address of a domain you own (you can change it back after testing)
2. Make sure you see a verification pending notice like shown in the screenshot below<br />(on `/domains/manage/<site>/edit/<domain>`)

<img width="724" alt="Screenshot 2021-09-24 at 10 53 45" src="https://user-images.githubusercontent.com/9202899/134647918-ba3f7781-6882-46b9-95d7-3bfccda910c6.png">



Please note, the `<QueryWhois />` component isn't rendered anymore at the time you see the notice.
