### PR TITLE
`QuerySiteInvites`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-site-invites/index.jsx
+++ b/client/components/data/query-site-invites/index.jsx
@@ -1,40 +1,22 @@
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestSiteInvites } from 'calypso/state/invites/actions';
 import { isRequestingInvitesForSite } from 'calypso/state/invites/selectors';
 
-class QuerySiteInvites extends Component {
-	UNSAFE_componentWillMount() {
-		this.request( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( siteId && ! isRequestingInvitesForSite( getState(), siteId ) ) {
+		dispatch( requestSiteInvites( siteId ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId ) {
-			return;
-		}
+function QuerySiteInvites( { siteId } ) {
+	const dispatch = useDispatch();
 
-		this.request( nextProps );
-	}
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
-	request( props ) {
-		if ( props.requesting || ! props.siteId ) {
-			return;
-		}
-
-		props.requestSiteInvites( props.siteId );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const { siteId } = ownProps;
-		return {
-			requesting: isRequestingInvitesForSite( state, siteId ),
-		};
-	},
-	{ requestSiteInvites }
-)( QuerySiteInvites );
+export default QuerySiteInvites;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is part of a long-term effort to remove usages of `UNSAFE_*` component lifecycle methods.

* `QuerySiteInvites`:
  * refactor away from `UNSAFE_*`
  * migrate to functional component

#### Testing instructions

1. Go to `/people/invites/<site>`
2. Make sure invites are requested and shown as expected
3. Change your currently active site, make sure invites are requested again
