### PR TITLE
Welcome Tour: Focus the Next/Begin button when tour loads

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -33,7 +33,7 @@ function WelcomeTourCard( {
 	onNextCardProgression,
 	onPreviousCardProgression,
 	isGutenboarding,
-	tourStartFocusedRef,
+	focusedOnLaunchRef,
 } ) {
 	const { description, heading, imgSrc } = cardContent;
 	const isLastCard = currentCardIndex === lastCardIndex;
@@ -86,7 +86,7 @@ function WelcomeTourCard( {
 						setCurrentCardIndex={ setCurrentCardIndex }
 						onNextCardProgression={ onNextCardProgression }
 						onPreviousCardProgression={ onPreviousCardProgression }
-						tourStartFocusedRef={ tourStartFocusedRef }
+						focusedOnLaunchRef={ focusedOnLaunchRef }
 					></CardNavigation>
 				) }
 			</CardFooter>
@@ -101,7 +101,7 @@ function CardNavigation( {
 	setCurrentCardIndex,
 	onNextCardProgression,
 	onPreviousCardProgression,
-	tourStartFocusedRef,
+	focusedOnLaunchRef,
 } ) {
 	// These are defined on their own lines because of a minification issue.
 	// __('translations') do not always work correctly when used inside of ternary statements.
@@ -130,7 +130,7 @@ function CardNavigation( {
 					className="welcome-tour-card__next-btn"
 					isPrimary={ true }
 					onClick={ onNextCardProgression }
-					ref={ tourStartFocusedRef }
+					ref={ focusedOnLaunchRef }
 				>
 					{ currentCardIndex === 0 ? startTourLabel : nextLabel }
 				</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-card.js
@@ -33,6 +33,7 @@ function WelcomeTourCard( {
 	onNextCardProgression,
 	onPreviousCardProgression,
 	isGutenboarding,
+	tourStartFocusedRef,
 } ) {
 	const { description, heading, imgSrc } = cardContent;
 	const isLastCard = currentCardIndex === lastCardIndex;
@@ -85,6 +86,7 @@ function WelcomeTourCard( {
 						setCurrentCardIndex={ setCurrentCardIndex }
 						onNextCardProgression={ onNextCardProgression }
 						onPreviousCardProgression={ onPreviousCardProgression }
+						tourStartFocusedRef={ tourStartFocusedRef }
 					></CardNavigation>
 				) }
 			</CardFooter>
@@ -99,6 +101,7 @@ function CardNavigation( {
 	setCurrentCardIndex,
 	onNextCardProgression,
 	onPreviousCardProgression,
+	tourStartFocusedRef,
 } ) {
 	// These are defined on their own lines because of a minification issue.
 	// __('translations') do not always work correctly when used inside of ternary statements.
@@ -127,6 +130,7 @@ function CardNavigation( {
 					className="welcome-tour-card__next-btn"
 					isPrimary={ true }
 					onClick={ onNextCardProgression }
+					ref={ tourStartFocusedRef }
 				>
 					{ currentCardIndex === 0 ? startTourLabel : nextLabel }
 				</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -68,6 +68,7 @@ function LaunchWpcomWelcomeTour() {
 
 function WelcomeTourFrame() {
 	const tourContainerRef = useRef( null );
+	const tourStartFocusedRef = useRef( null );
 	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentCardIndex, setCurrentCardIndex ] = useState( 0 );
@@ -115,6 +116,11 @@ function WelcomeTourFrame() {
 		} );
 	};
 
+	useEffect( () => {
+		// focus the Next/Begin button as the first interactive element when tour loads
+		setTimeout( () => tourStartFocusedRef.current?.focus() );
+	}, [] );
+
 	// Preload card images
 	cardContent.forEach( ( card ) => ( new window.Image().src = card.imgSrc ) );
 
@@ -144,6 +150,7 @@ function WelcomeTourFrame() {
 							onNextCardProgression={ handleNextCardProgression }
 							onPreviousCardProgression={ handlePreviousCardProgression }
 							isGutenboarding={ isGutenboarding }
+							tourStartFocusedRef={ tourStartFocusedRef }
 						/>
 					</>
 				) : (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.js
@@ -68,7 +68,7 @@ function LaunchWpcomWelcomeTour() {
 
 function WelcomeTourFrame() {
 	const tourContainerRef = useRef( null );
-	const tourStartFocusedRef = useRef( null );
+	const focusedOnLaunchRef = useRef( null );
 	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ currentCardIndex, setCurrentCardIndex ] = useState( 0 );
@@ -118,7 +118,7 @@ function WelcomeTourFrame() {
 
 	useEffect( () => {
 		// focus the Next/Begin button as the first interactive element when tour loads
-		setTimeout( () => tourStartFocusedRef.current?.focus() );
+		setTimeout( () => focusedOnLaunchRef.current?.focus() );
 	}, [] );
 
 	// Preload card images
@@ -150,7 +150,7 @@ function WelcomeTourFrame() {
 							onNextCardProgression={ handleNextCardProgression }
 							onPreviousCardProgression={ handlePreviousCardProgression }
 							isGutenboarding={ isGutenboarding }
-							tourStartFocusedRef={ tourStartFocusedRef }
+							focusedOnLaunchRef={ focusedOnLaunchRef }
 						/>
 					</>
 				) : (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Moves focus to the Next/Begin button in the tour as the first interactive element when tour loads
Fixes #55635

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Sandbox a site, checkout branch, and `yarn dev --sync` from `apps/editing-toolkit` to sync sandbox.
- Go to the editor, open the sidebar, and from there click on "Welcome Guide".
- Tour should be focused and keyboard navigation enabled. 
- Focus should be on the "Try it out!" button.
- Reload the page with the tour open. Focus should behave the same.

![Kapture 2021-09-24 at 14 58 26](https://user-images.githubusercontent.com/1705499/134670676-c9ee5bb5-7078-41d2-b62e-f4f4c4107f16.gif)

**On load:**

<img width="409" alt="Screenshot 2021-09-24 at 3 24 31 PM" src="https://user-images.githubusercontent.com/1705499/134673790-c13fa639-174f-41a2-be4a-bbcc98492945.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Notes

An alternative would be to always focus the "Next" button on every card change, not just once on load. Not sure if ideal, as we still have the arrow keys to navigate directly once focused.
