### PR TITLE
Skip Global Styles Tracks Tests

### DIFF
--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -415,7 +415,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 		createGeneralTests( { it, editorType: 'site', baseContext: 'template' } );
 
-		describe( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
+		describe.skip( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
 			it( 'when Global Styles sidebar is opened', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 
@@ -513,7 +513,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 		} );
 
-		describe( 'Tracks "wpcom_block_editor_global_styles_update"', function () {
+		describe.skip( 'Tracks "wpcom_block_editor_global_styles_update"', function () {
 			before( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 				await editor.toggleGlobalStyles();
@@ -566,7 +566,7 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 		} );
 
-		describe( 'Tracks "wpcom_block_editor_global_styles_save"', function () {
+		describe.skip( 'Tracks "wpcom_block_editor_global_styles_save"', function () {
 			before( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
 				await editor.toggleGlobalStyles();

--- a/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
+++ b/test/e2e/specs/specs-wpcom/wp-calypso-gutenberg-site-editor-tracking-spec.js
@@ -415,6 +415,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 
 		createGeneralTests( { it, editorType: 'site', baseContext: 'template' } );
 
+		// Temporarily skip these tests until we can update track events / tests to handle the new
+		// interface.  https://github.com/Automattic/wp-calypso/pull/56544
 		describe.skip( 'Tracks "wpcom_block_editor_global_styles_tab_selected', function () {
 			it( 'when Global Styles sidebar is opened', async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
@@ -513,6 +515,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 		} );
 
+		// Temporarily skip these tests until we can update track events / tests to handle the new
+		// interface.  https://github.com/Automattic/wp-calypso/pull/56544
 		describe.skip( 'Tracks "wpcom_block_editor_global_styles_update"', function () {
 			before( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );
@@ -566,6 +570,8 @@ describe( `[${ host }] Calypso Gutenberg Site Editor Tracking: (${ screenSize })
 			} );
 		} );
 
+		// Temporarily skip these tests until we can update track events / tests to handle the new
+		// interface.  https://github.com/Automattic/wp-calypso/pull/56544
 		describe.skip( 'Tracks "wpcom_block_editor_global_styles_save"', function () {
 			before( async function () {
 				const editor = await SiteEditorComponent.Expect( this.driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The core Global Styles interface has recently been updated in Gutenberg as of v11.6.  This causes all Global Styles tracks event tests to fail, and requires some tracks events to be updated accordingly.

Here, we skip these tests until we are able to make the required updates.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verified the corresponding tests are skipped when running the `wp-calypso-gutenberg-site-editor-tracking-spec` suite.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
