### PR TITLE
Fix HEIC-disabler Image block error when sandboxed

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/disable-heic-images.js
@@ -5,26 +5,27 @@ import { __ } from '@wordpress/i18n';
 
 const DisableHEICImages = createHigherOrderComponent( ( MediaPlaceholder ) => {
 	return ( props ) => {
-		props.onFilesPreUpload = ( files ) => {
-			if ( files ) {
-				Object.values( files ).forEach( ( file ) => {
-					const filename = file.name;
-					const extension = filename.split( '.' ).pop()?.toLowerCase();
+		return createElement( MediaPlaceholder, {
+			...props,
+			onFilesPreUpload: ( files ) => {
+				if ( files ) {
+					Object.values( files ).forEach( ( file ) => {
+						const filename = file.name;
+						const extension = filename.split( '.' ).pop()?.toLowerCase();
 
-					if ( 'heic' === extension || 'heif' === extension ) {
-						const error = __(
-							'HEIC images are not viewable in the editor. Please convert to a JPG, PNG, or GIF and try again.',
-							'full-site-editing'
-						);
-						props.onError( error );
-						throw Error( error );
-					}
-				} );
-				return files;
-			}
-		};
-
-		return createElement( MediaPlaceholder, props );
+						if ( 'heic' === extension || 'heif' === extension ) {
+							const error = __(
+								'HEIC images are not viewable in the editor. Please convert to a JPG, PNG, or GIF and try again.',
+								'full-site-editing'
+							);
+							props.onError( error );
+							throw Error( error );
+						}
+					} );
+					return files;
+				}
+			},
+		} );
 	};
 }, 'DisableHEICImages' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
See p1632392675160800-slack-C02DQP0FP for initial report and discussion.

h/t to @mreishus, @alshakero and @noahtallen for brainstorming and coming up with the solution! 

This PR fixes an error experienced when inserting an Image block, when wpcom-sandboxed:
```
Uncaught TypeError: can't define property "onFilesPreUpload": Object is not extensible
```

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build and push these changes to your sandbox.
* Open the editor on a wpcom simple site and insert an Image block. You should not see a block error.
* Drag an HEIC image into the Image block. You should get the error message "HEIC images are not supported by the browser."
* Follow the test instructions in #55637 and verify that no regression is introduced by this PR.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

