### PR TITLE
Playwright: migrate spec for Signup: Domains Only flow.

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -15,6 +15,18 @@ export interface PaymentDetails {
 	postalCode: string;
 }
 
+export interface RegistrarDetails {
+	firstName: string;
+	lastName: string;
+	email: string;
+	phone: string;
+	countryCode: string;
+	address: string;
+	city: string;
+	stateCode: string;
+	postalCode: string;
+}
+
 export type CreditCardIssuers = 'Visa';
 
 /**
@@ -174,6 +186,25 @@ export function getTestPaymentDetails(): PaymentDetails {
 		cvv: '999',
 		countryCode: 'TR', // Set to Turkey to force Strip to process payments.
 		postalCode: '06123',
+	};
+}
+
+/**
+ * Returns an object containing test domain registrar details.
+ *
+ * @param {string} email Email address of the user.
+ */
+export function getTestDomainRegistrarDetails( email: string ): RegistrarDetails {
+	return {
+		firstName: 'End to End',
+		lastName: 'Testing',
+		email: email,
+		phone: '0422 888 888',
+		countryCode: 'AU',
+		address: '888 Queen Street',
+		city: 'Brisbane',
+		stateCode: 'QLD',
+		postalCode: '4000',
 	};
 }
 

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -1,6 +1,6 @@
 import { Frame, Page } from 'playwright';
 import { getTargetDeviceName } from '../../browser-helper';
-import type { PaymentDetails } from '../../data-helper';
+import type { PaymentDetails, RegistrarDetails } from '../../data-helper';
 import type { TargetDevice } from '../../types';
 
 const selectors = {
@@ -21,6 +21,17 @@ const selectors = {
 	removeCouponButton: ( coupon: string ) =>
 		`button[aria-label="Remove Coupon: ${ coupon } from cart"]`,
 	saveOrderButton: 'button[aria-label="Save your order"]',
+
+	// Registrar information
+	firstNameInput: `input[aria-describedby="validation-field-first-name"]`,
+	lastNameInput: `input[aria-describedby="validation-field-last-name"]`,
+	phoneInput: `input[name="phone"]`,
+	phoneSelect: 'select.phone-input__country-select',
+	countrySelect: 'select[aria-describedby="validation-field-country-code"]',
+	addressInput: 'input[aria-describedby="validation-field-address-1"]',
+	cityInput: 'input[aria-describedby="validation-field-city"]',
+	stateSelect: 'select[aria-describedby="validation-field-state"]',
+	postalCodeInput: 'input[aria-describedby="validation-field-postal-code"]',
 
 	// Tax information
 	countryCode: `select[aria-labelledby="country-selector-label"]`,
@@ -189,6 +200,23 @@ export class CartCheckoutPage {
 		 ).contentFrame() ) as Frame;
 		const cvvInput = await cvvFrame.waitForSelector( selectors.cardCVVInput );
 		await cvvInput.fill( paymentDetails.cvv );
+	}
+
+	/**
+	 * Enter domain registrar information.
+	 *
+	 * @param {RegistrarDetails} registrarDetails Domain registrar details.
+	 */
+	async enterDomainRegistrarDetails( registrarDetails: RegistrarDetails ): Promise< void > {
+		await this.page.fill( selectors.firstNameInput, registrarDetails.firstName );
+		await this.page.fill( selectors.lastNameInput, registrarDetails.lastName );
+		await this.page.selectOption( selectors.phoneSelect, registrarDetails.countryCode );
+		await this.page.fill( selectors.phoneInput, registrarDetails.phone );
+		await this.page.selectOption( selectors.countrySelect, registrarDetails.countryCode );
+		await this.page.fill( selectors.addressInput, registrarDetails.address );
+		await this.page.fill( selectors.cityInput, registrarDetails.city );
+		await this.page.selectOption( selectors.stateSelect, registrarDetails.stateCode );
+		await this.page.fill( selectors.postalCodeInput, registrarDetails.postalCode );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -32,6 +32,8 @@ const selectors = {
 	cityInput: 'input[aria-describedby="validation-field-city"]',
 	stateSelect: 'select[aria-describedby="validation-field-state"]',
 	postalCodeInput: 'input[aria-describedby="validation-field-postal-code"]',
+	submitRegistrarInformationButton:
+		'button[aria-label="Continue with the entered contact details"]',
 
 	// Tax information
 	countryCode: `select[aria-labelledby="country-selector-label"]`,
@@ -167,6 +169,24 @@ export class CartCheckoutPage {
 	}
 
 	/**
+	 * Enter domain registrar information.
+	 *
+	 * @param {RegistrarDetails} registrarDetails Domain registrar details.
+	 */
+	async enterDomainRegistrarDetails( registrarDetails: RegistrarDetails ): Promise< void > {
+		await this.page.fill( selectors.firstNameInput, registrarDetails.firstName );
+		await this.page.fill( selectors.lastNameInput, registrarDetails.lastName );
+		await this.page.selectOption( selectors.phoneSelect, registrarDetails.countryCode );
+		await this.page.fill( selectors.phoneInput, registrarDetails.phone );
+		await this.page.selectOption( selectors.countrySelect, registrarDetails.countryCode );
+		await this.page.fill( selectors.addressInput, registrarDetails.address );
+		await this.page.fill( selectors.cityInput, registrarDetails.city );
+		await this.page.selectOption( selectors.stateSelect, registrarDetails.stateCode );
+		await this.page.fill( selectors.postalCodeInput, registrarDetails.postalCode );
+		await this.page.click( selectors.submitRegistrarInformationButton );
+	}
+
+	/**
 	 * Enter billing/tax details.
 	 *
 	 * @param {PaymentDetails} paymentDetails Object implementing the PaymentDetails interface.
@@ -200,23 +220,6 @@ export class CartCheckoutPage {
 		 ).contentFrame() ) as Frame;
 		const cvvInput = await cvvFrame.waitForSelector( selectors.cardCVVInput );
 		await cvvInput.fill( paymentDetails.cvv );
-	}
-
-	/**
-	 * Enter domain registrar information.
-	 *
-	 * @param {RegistrarDetails} registrarDetails Domain registrar details.
-	 */
-	async enterDomainRegistrarDetails( registrarDetails: RegistrarDetails ): Promise< void > {
-		await this.page.fill( selectors.firstNameInput, registrarDetails.firstName );
-		await this.page.fill( selectors.lastNameInput, registrarDetails.lastName );
-		await this.page.selectOption( selectors.phoneSelect, registrarDetails.countryCode );
-		await this.page.fill( selectors.phoneInput, registrarDetails.phone );
-		await this.page.selectOption( selectors.countrySelect, registrarDetails.countryCode );
-		await this.page.fill( selectors.addressInput, registrarDetails.address );
-		await this.page.fill( selectors.cityInput, registrarDetails.city );
-		await this.page.selectOption( selectors.stateSelect, registrarDetails.stateCode );
-		await this.page.fill( selectors.postalCodeInput, registrarDetails.postalCode );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -154,13 +154,24 @@ export class CartCheckoutPage {
 	 * and a full stop for decimals. Notably, Continental Europe uses the reverse notation
 	 * and this method will produce an unexpected result.
 	 *
-	 * @returns {number} Total value of items in cart.
+	 * If optional parameter `rawString` is specified, the string as obtained is returned.
+	 *
+	 * @param param0 Object parameter.
+	 * @param {boolean} param0.rawString If true, the raw string is returned.
+	 * @returns {Promise<number|string>} Total value of items in cart.
 	 */
-	async getCheckoutTotalAmount(): Promise< number > {
+	async getCheckoutTotalAmount( { rawString = false }: { rawString?: boolean } = {} ): Promise<
+		number | string
+	> {
 		const elementHandle = await this.page.waitForSelector(
 			selectors.totalAmount( getTargetDeviceName() )
 		);
 		const stringAmount = await elementHandle.innerText();
+		if ( rawString ) {
+			// Returns the raw string.
+			return stringAmount;
+		}
+
 		const parsedAmount = stringAmount.replace( /,/g, '' ).match( /\d+\.?\d*/g );
 		if ( ! parsedAmount?.length ) {
 			throw new Error( 'Unable to locate or parse cart amount.' );

--- a/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/individual-purchase-page.ts
@@ -17,7 +17,7 @@ const selectors = {
 	// Purchased item actions: domains
 	deleteDomainCard: 'a:has-text("Delete your domain permanently")',
 	cancelDomainButton: 'button:has-text("Cancel Domain and Refund")',
-	cancelDomainReasonOption: 'select.confirm-cancel-domain__reasons-dropdown form-select',
+	cancelDomainReasonOption: 'select.confirm-cancel-domain__reasons-dropdown',
 	cancelDomainReasonTextArea: 'textarea.confirm-cancel-domain__reason-details',
 	cancelDomainCheckbox: 'input.form-checkbox',
 
@@ -107,6 +107,8 @@ export class IndividualPurchasePage {
 		await this.page.check( selectors.cancelDomainCheckbox );
 
 		await Promise.all( [
+			// Extended timeout here due to this process often taking long time for
+			// domain-only accounts.
 			this.page.waitForNavigation( { timeout: 60000 } ),
 			this.page.click( selectors.button( 'Cancel Domain' ) ),
 		] );

--- a/test/e2e/specs/specs-playwright/wp-signup__domain.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__domain.ts
@@ -1,0 +1,125 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	DomainSearchComponent,
+	setupHooks,
+	BrowserManager,
+	CloseAccountFlow,
+	UserSignupPage,
+	CartCheckoutPage,
+	SidebarComponent,
+	NavbarComponent,
+	IndividualPurchasePage,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), function () {
+	const inboxId = DataHelper.config.get( 'signupInboxId' ) as string;
+	const username = `e2eflowtestingdomainonly${ DataHelper.getTimestamp() }`;
+	const email = DataHelper.getTestEmailAddress( {
+		inboxId: inboxId,
+		prefix: username,
+	} );
+	const signupPassword = DataHelper.config.get( 'passwordForNewTestSignUps' ) as string;
+
+	let page: Page;
+	let domainSearchComponent: DomainSearchComponent;
+	let cartCheckoutPage: CartCheckoutPage;
+
+	setupHooks( ( args ) => {
+		page = args.page;
+	} );
+
+	describe( 'Signup via /start/domain', function () {
+		it( 'Navigate to /start/domain', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/start/domain' ) );
+		} );
+
+		it( 'Set store cookie', async function () {
+			await BrowserManager.setStoreCookie( page, { currency: 'JPY' } );
+		} );
+
+		it( 'Search for a domain', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( username + '.live' );
+		} );
+
+		it( 'Select a .live domain', async function () {
+			await domainSearchComponent.selectDomain( '.live' );
+		} );
+
+		it( 'Select to buy just the domain', async function () {
+			await page.click( 'button:text("Just buy a domain")' );
+		} );
+
+		it( 'Sign up for a WordPress.com account', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			await userSignupPage.signup( email, username, signupPassword );
+		} );
+
+		it( 'Land in checkout cart', async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+			const totalAmount = await cartCheckoutPage.getCheckoutTotalAmount();
+			expect( totalAmount ).toBeGreaterThan( 0 );
+		} );
+
+		it( 'Prices are shown in Japanese Yen', async function () {
+			const buttonText = await cartCheckoutPage.getPaymentButtonText();
+			buttonText.startsWith( '¥' );
+		} );
+
+		it( 'Enter registrar details', async function () {
+			await cartCheckoutPage.enterDomainRegistrarDetails(
+				DataHelper.getTestDomainRegistrarDetails( email )
+			);
+		} );
+
+		it( 'Enter credit card details', async function () {
+			await cartCheckoutPage.enterPaymentDetails( DataHelper.getTestPaymentDetails() );
+		} );
+
+		it( 'Check out', async function () {
+			await cartCheckoutPage.purchase();
+		} );
+	} );
+
+	describe( 'Manage Domain', function () {
+		let individualPurchasePage: IndividualPurchasePage;
+
+		it( 'Click My Sites', async function () {
+			// This step is affected by an issue with page redirect
+			// of the post-checkout page.
+			// See: https://github.com/Automattic/wp-calypso/issues/56548
+			const navbarCompnent = new NavbarComponent( page );
+			await navbarCompnent.clickMySites();
+		} );
+
+		it( 'Navigate to Settings', async function () {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Settings' );
+		} );
+
+		it( 'Manage domain', async function () {
+			await page.click( 'a:text("Manage domain")' );
+		} );
+
+		it( 'Turn off auto-renew', async function () {
+			individualPurchasePage = new IndividualPurchasePage( page );
+			await individualPurchasePage.turnOffAutoRenew();
+		} );
+
+		it( 'Delete domain purchase', async function () {
+			await individualPurchasePage.deleteDomain();
+		} );
+	} );
+
+	describe( 'Delete user account', function () {
+		it( 'Close account', async function () {
+			const closeAccountFlow = new CloseAccountFlow( page );
+			await closeAccountFlow.closeAccount();
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-signup__domain.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__domain.ts
@@ -65,11 +65,6 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 			expect( totalAmount ).toBeGreaterThan( 0 );
 		} );
 
-		it( 'Prices are shown in Japanese Yen', async function () {
-			const buttonText = await cartCheckoutPage.getPaymentButtonText();
-			buttonText.startsWith( '¥' );
-		} );
-
 		it( 'Enter registrar details', async function () {
 			await cartCheckoutPage.enterDomainRegistrarDetails(
 				DataHelper.getTestDomainRegistrarDetails( email )
@@ -78,6 +73,13 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 
 		it( 'Enter credit card details', async function () {
 			await cartCheckoutPage.enterPaymentDetails( DataHelper.getTestPaymentDetails() );
+		} );
+
+		it( 'Prices are shown in Japanese Yen', async function () {
+			const cartAmount = ( await cartCheckoutPage.getCheckoutTotalAmount( {
+				rawString: true,
+			} ) ) as string;
+			expect( cartAmount.startsWith( '¥' ) ).toBe( true );
 		} );
 
 		it( 'Check out', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the Signup: Domains Only flow from the Selenium suite.

Key changes:
- new methods in `DataHelper` to generate test domain registrar details.
- new methods in relevant pages to enter forms.

Details:

This migration stayed faithful to the Selenium version of the test. The only additional step tested is the `Turn of auto-renew` step to verify interaction with the 'purchased' domain.

During the development of this test case, I ran across an issue with the post-purchase page:
https://github.com/Automattic/wp-calypso/issues/56548


#### Testing instructions

- [x] pr tests
  - [x] mobile
  - [x] desktop
- [x] pre-release tests 

Related to #
 