### PR TITLE
Jetpack Plans: Add Jetpack Backup storage plans page to Calypso Blue

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -9,10 +9,18 @@ import JetpackComMasterbar from './jpcom-masterbar';
 
 export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
 	const urlQueryArgs = context.query;
-	const { locale } = context.params;
+	const { locale, site } = context.params;
 
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
+
+		if ( context.pathname.includes( '/pricing/storage' ) ) {
+			page.redirect(
+				addQueryArgs( urlQueryArgs, `/pricing/storage/${ site || urlQueryArgs.site }` )
+			);
+			return;
+		}
+
 		page.redirect( addQueryArgs( urlQueryArgs, `/pricing` ) );
 		return;
 	}

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,6 +1,6 @@
 import page from 'page';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
-import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
+import jetpackPlans, { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans';
 import { jetpackPricingContext } from './controller';
 import './style.scss';
 
@@ -10,6 +10,7 @@ export default function (): void {
 	page( '/plans/:site', ( { params } ) => page.redirect( `/pricing/${ params.site }` ) );
 	page( '/plans', '/pricing' );
 
+	jetpackStoragePlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );
 	jetpackPlans( '/:locale/pricing', jetpackPricingContext );
 	jetpackPlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );
 }

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -6,10 +6,17 @@ import './style.scss';
 
 export default function (): void {
 	// Redirects
+	page( '/:locale/plans/storage/:site', ( { params } ) =>
+		page.redirect( `/${ params.locale }/pricing/storage/${ params.site }` )
+	);
+	page( '/plans/storage/:site', ( { params } ) =>
+		page.redirect( `/pricing/storage/${ params.site }` )
+	);
 	page( '/:locale/plans', ( { params } ) => page.redirect( `/${ params.locale }/pricing` ) );
 	page( '/plans/:site', ( { params } ) => page.redirect( `/pricing/${ params.site }` ) );
 	page( '/plans', '/pricing' );
 
+	jetpackStoragePlans( '/:locale/pricing', loggedInSiteSelection, jetpackPricingContext );
 	jetpackStoragePlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );
 	jetpackPlans( '/:locale/pricing', jetpackPricingContext );
 	jetpackPlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -1,6 +1,7 @@
 import page from 'page';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
-import jetpackPlans, { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans';
+import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
+import { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans/jetpack-storage-plans';
 import { jetpackPricingContext } from './controller';
 import './style.scss';
 

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -7,7 +7,7 @@ import {
 	wpForTeamsP2PlusNotSupportedRedirect,
 	p2RedirectToHubPlans,
 } from 'calypso/my-sites/controller';
-import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
+import jetpackPlans, { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans';
 import {
 	features,
 	plans,
@@ -85,6 +85,17 @@ export default function () {
 		wpForTeamsP2PlusNotSupportedRedirect,
 		p2RedirectToHubPlans,
 		redirectToCheckout
+	);
+
+	// This is a special plans page just for Jetpack Backup storage plans.
+	// It needs to be defined before the other plans pages so that /plans/storage/:site
+	// will take precedence over /plans/:intervalType?/:site.
+	jetpackStoragePlans(
+		'/plans',
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		redirectToPlansIfNotJetpack,
+		navigation
 	);
 
 	// This route renders the plans page for both WPcom and Jetpack sites.

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -7,7 +7,8 @@ import {
 	wpForTeamsP2PlusNotSupportedRedirect,
 	p2RedirectToHubPlans,
 } from 'calypso/my-sites/controller';
-import jetpackPlans, { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans';
+import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
+import { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans/jetpack-storage-plans';
 import {
 	features,
 	plans,

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -88,6 +88,7 @@ export const jetpackStoragePricing = ( context: PageJS.Context, next: () => void
 	context.header = <StoragePricingHeader />;
 	context.primary = (
 		<StoragePricing
+			nav={ context.nav }
 			header={ context.header }
 			footer={ context.footer }
 			defaultDuration={ stringToDuration( duration ) || duration || TERM_ANNUALLY }

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -1,7 +1,5 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
-import { jetpackPricingContext } from 'calypso/jetpack-cloud/sections/pricing/controller';
 import {
 	doForCurrentCROIteration,
 	Iterations,
@@ -11,19 +9,6 @@ import { jetpackStoragePricing, jetpackFreeWelcome, productSelect } from './cont
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
 	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );
 
-	doForCurrentCROIteration( ( key ) => {
-		if ( Iterations.ONLY_REALTIME_PRODUCTS === key ) {
-			page(
-				`${ rootUrl }/storage/:site`,
-				cloudSiteSelection,
-				jetpackPricingContext,
-				jetpackStoragePricing,
-				makeLayout,
-				clientRender
-			);
-		}
-	} );
-
 	page(
 		`${ rootUrl }/:duration?/:site?`,
 		...rest,
@@ -31,4 +16,18 @@ export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
 		makeLayout,
 		clientRender
 	);
+}
+
+export function jetpackStoragePlans( rootUrl: string, ...rest: PageJS.Callback[] ) {
+	doForCurrentCROIteration( ( key ) => {
+		if ( Iterations.ONLY_REALTIME_PRODUCTS === key ) {
+			page(
+				`${ rootUrl }/storage/:site`,
+				...rest,
+				jetpackStoragePricing,
+				makeLayout,
+				clientRender
+			);
+		}
+	} );
 }

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -1,10 +1,6 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import {
-	doForCurrentCROIteration,
-	Iterations,
-} from 'calypso/my-sites/plans/jetpack-plans/iterations';
-import { jetpackStoragePricing, jetpackFreeWelcome, productSelect } from './controller';
+import { jetpackFreeWelcome, productSelect } from './controller';
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
 	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );
@@ -16,18 +12,4 @@ export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
 		makeLayout,
 		clientRender
 	);
-}
-
-export function jetpackStoragePlans( rootUrl: string, ...rest: PageJS.Callback[] ) {
-	doForCurrentCROIteration( ( key ) => {
-		if ( Iterations.ONLY_REALTIME_PRODUCTS === key ) {
-			page(
-				`${ rootUrl }/storage/:site`,
-				...rest,
-				jetpackStoragePricing,
-				makeLayout,
-				clientRender
-			);
-		}
-	} );
 }

--- a/client/my-sites/plans/jetpack-plans/jetpack-storage-plans.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-storage-plans.ts
@@ -1,0 +1,21 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import {
+	doForCurrentCROIteration,
+	Iterations,
+} from 'calypso/my-sites/plans/jetpack-plans/iterations';
+import { jetpackStoragePricing } from './controller';
+
+export const jetpackStoragePlans = ( rootUrl: string, ...rest: PageJS.Callback[] ) => {
+	doForCurrentCROIteration( ( key ) => {
+		if ( Iterations.ONLY_REALTIME_PRODUCTS === key ) {
+			page(
+				`${ rootUrl }/storage/:site`,
+				...rest,
+				jetpackStoragePricing,
+				makeLayout,
+				clientRender
+			);
+		}
+	} );
+};

--- a/client/my-sites/plans/jetpack-plans/storage-pricing-header/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing-header/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
-import JetpackComMasterbar from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
@@ -11,7 +10,6 @@ export const StoragePricingHeader = () => {
 
 	return (
 		<>
-			<JetpackComMasterbar />
 			<div className="storage-pricing-header">
 				<FormattedHeader
 					className="storage-pricing-header__title"

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -13,6 +13,7 @@ import './style.scss';
 
 interface Props {
 	defaultDuration: Duration;
+	nav: ReactNode;
 	header: ReactNode;
 	footer: ReactNode;
 	urlQueryArgs: QueryArgs;
@@ -21,6 +22,7 @@ interface Props {
 
 export const StoragePricing: React.FC< Props > = ( {
 	defaultDuration = TERM_ANNUALLY,
+	nav,
 	header,
 	footer,
 	urlQueryArgs,
@@ -31,6 +33,7 @@ export const StoragePricing: React.FC< Props > = ( {
 
 	return (
 		<Main className="storage-pricing__main">
+			{ nav }
 			{ header }
 			<PlansFilterBar showDiscountMessage duration={ duration } onDurationChange={ setDuration } />
 			<StorageTierUpgrade


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the new Jetpack Storage pricing page to Calypso Blue.

![image](https://user-images.githubusercontent.com/42627630/134729260-fee65f09-8948-4d8f-a16d-14028cca42ed.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Get a Jetpack site with one of the new 20GB storage plans.
2. Visit `http://calypso.localhost:3000/plans/storage/:site_slug?flags=jetpack/only-realtime-products`. Verify that you see the storage plans page displaying.
3. Regression test the `/plans/:site` page for Jetpack sites.
4. Regression test the `/plans/:interval?/:site` page for regular WordPress.com sites.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1200412004370260-as-1200974406795146