### PR TITLE
Remove feature flag for new domain transfer flow to enable it for all users

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
 import { __, sprintf } from '@wordpress/i18n';
@@ -213,9 +212,7 @@ function UseMyDomain( {
 						? showOwnershipVerificationFlow
 						: onConnect
 				}
-				onTransfer={
-					config.isEnabled( 'domains/new-transfer-flow' ) ? showTransferDomainFlow : onTransfer
-				}
+				onTransfer={ onTransfer ?? showTransferDomainFlow }
 				transferDomainUrl={ transferDomainUrl }
 			/>
 		);

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -14,11 +14,7 @@ import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import {
-	getOptionInfo,
-	connectDomainAction,
-	defaultTransferDomainAction as defaultTransferHandler,
-} from '../utilities';
+import { getOptionInfo, connectDomainAction } from '../utilities';
 import OptionContent from './option-content';
 
 import './style.scss';
@@ -52,9 +48,7 @@ function DomainTransferOrConnect( {
 
 	const handleTransfer = () => {
 		recordTransferButtonClickInUseYourDomain( domain );
-
-		const transferHandler = onTransfer ?? defaultTransferHandler;
-		transferHandler( { domain, selectedSite, transferDomainUrl }, () => setActionClicked( false ) );
+		onTransfer( { domain, selectedSite, transferDomainUrl }, () => setActionClicked( false ) );
 	};
 
 	const content = getOptionInfo( {

--- a/client/components/domains/use-my-domain/utilities/default-transfer-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/default-transfer-domain-action.js
@@ -1,9 +1,0 @@
-import page from 'page';
-import { domainTransferIn } from 'calypso/my-sites/domains/paths';
-
-export const transferDomainAction = ( { domain, selectedSite, transferDomainUrl } ) => {
-	// TODO: This will be replaced with a new transfer in flow in a near-term future update.
-	const defaultTransferUrl = domainTransferIn( selectedSite.slug, domain, true );
-	const transferUrl = transferDomainUrl ?? defaultTransferUrl;
-	page( transferUrl );
-};

--- a/client/components/domains/use-my-domain/utilities/index.js
+++ b/client/components/domains/use-my-domain/utilities/index.js
@@ -10,4 +10,3 @@ export { getTransferSalePriceText } from './get-transfer-sale-price-text';
 export { isFreeTransfer } from './is-free-transfer';
 export { optionInfo } from './option-info';
 export { transferDomainAction } from './transfer-domain-action';
-export { transferDomainAction as defaultTransferDomainAction } from './default-transfer-domain-action';

--- a/config/development.json
+++ b/config/development.json
@@ -60,7 +60,6 @@
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,7 +37,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,7 +42,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/new-transfer-flow": false,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're ready to deploy the new transfer flow for all users, so we can remove the feature flag and the now unused default transfer action.

#### Testing instructions

Select the "Use a domain I own" option from the `/domains/manage` page. Enter a transferrable domain and walk through the transfer flow to add the domain to the cart. Make sure the domain is correctly added to the cart and that the flow detects locked/unlocked domains and correct/incorrect auth codes.