### PR TITLE
Checkout: Make empty cart CTA button more generic

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -584,7 +584,7 @@ export default function CompositeCheckout( {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
-	// The gotToPreviousPage function and subsequent conditional statement controls the 'back' button functionality on the empty cart page
+	// The goToPreviousPage function and subsequent conditional statement controls the 'back' button functionality on the empty cart page
 
 	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug );
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -586,7 +586,7 @@ export default function CompositeCheckout( {
 
 	// The goToPreviousPage function and subsequent conditional statement controls the 'back' button functionality on the empty cart page
 
-	const checkoutBackUrl = useValidCheckoutBackUrl( siteSlug );
+	const checkoutBackUrl = useValidCheckoutBackUrl( updatedSiteSlug );
 
 	const goToPreviousPage = useCallback( () => {
 		let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
@@ -630,7 +630,10 @@ export default function CompositeCheckout( {
 			// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).
 			console.error( 'Error getting query string in close button' ); // eslint-disable-line no-console
 		}
-
+		if ( closeUrl.startsWith( '/' ) ) {
+			page( closeUrl );
+			return;
+		}
 		window.location.href = closeUrl;
 	}, [ siteSlug, checkoutBackUrl, previousPath, reduxDispatch ] );
 
@@ -654,7 +657,7 @@ export default function CompositeCheckout( {
 							<EmptyCart />
 							<SubmitButtonWrapper>
 								<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
-									{ translate( 'Return to previous page' ) }
+									{ translate( 'Go back' ) }
 								</Button>
 							</SubmitButtonWrapper>
 						</CheckoutStepAreaWrapper>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -33,6 +33,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -123,6 +124,8 @@ export default function CompositeCheckout( {
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
 } ): JSX.Element {
+	const previousPath = useSelector( getPreviousPath );
+
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
 		useSelector(
@@ -590,15 +593,11 @@ export default function CompositeCheckout( {
 		} )
 	) {
 		debug( 'rendering empty cart page' );
-		const goToPlans = () => {
+		const goToPreviousPage = () => {
 			recordEvent( {
 				type: 'EMPTY_CART_CTA_CLICKED',
 			} );
-			if ( updatedSiteSlug ) {
-				page( `/plans/${ updatedSiteSlug }` );
-			} else {
-				page( '/plans' );
-			}
+			page( previousPath );
 		};
 		return (
 			<Fragment>
@@ -608,8 +607,8 @@ export default function CompositeCheckout( {
 						<CheckoutStepAreaWrapper>
 							<EmptyCart />
 							<SubmitButtonWrapper>
-								<Button buttonType="primary" fullWidth onClick={ goToPlans }>
-									{ translate( 'Browse our plans' ) }
+								<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
+									{ translate( 'Return to previous page' ) }
 								</Button>
 							</SubmitButtonWrapper>
 						</CheckoutStepAreaWrapper>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -591,7 +591,7 @@ export default function CompositeCheckout( {
 	const goToPreviousPage = useCallback( () => {
 		let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
 
-		reduxDispatch( recordTracksEvent( 'EMPTY_CART_CTA_CLICKED' ) );
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_empty_cart_clicked' ) );
 
 		if ( checkoutBackUrl ) {
 			window.location.href = checkoutBackUrl;

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -254,12 +254,10 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					);
 				}
 				case 'THANK_YOU_URL_GENERATED':
-					return logStashEvent( 'thank you url generated', {
-						url: action.payload.url,
-					} );
-				case 'EMPTY_CART_CTA_CLICKED':
 					return reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_empty_cart_clicked' )
+						logStashEventAction( 'thank you url generated', {
+							url: action.payload.url,
+						} )
 					);
 				default:
 					debug( 'unknown checkout event', action );

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -254,11 +254,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					);
 				}
 				case 'THANK_YOU_URL_GENERATED':
-					return reduxDispatch(
-						logStashEventAction( 'thank you url generated', {
-							url: action.payload.url,
-						} )
-					);
+					return logStashEvent( 'thank you url generated', {
+						url: action.payload.url,
+					} );
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to resolve this issue 375-gh-Automattic/payments-shilling with Cain's recommendation to return the customer to their previous page.

#### Testing instructions

Prerequisite:
* Open /wp-calypso/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
* Go to the function 'removeProductFromCartAndMaybeRedirect' and comment out the following conditional:
https://github.com/Automattic/wp-calypso/blob/4cb2cf9ed386d406d225aa1cde56b8e70eff6dcd/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts#L68-L72

Test:
* Ensure your cart is empty
* Add any non-plan purchase, such as a domain or email
* Go to cart and remove the newly added purchase, this will bring you to the empty cart page
* Click on "Return to previous page" button, this should redirect you back to the page you were on when you added the purchase (this is considered a success!)

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/16580129/134743911-48299d18-d09f-4e7c-a5ac-1ae5d3c768c7.png)

After 

![image](https://user-images.githubusercontent.com/16580129/134743926-79e4a965-9114-40cd-9972-bc4acff72b04.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 375-gh-Automattic/payments-shilling