### PR TITLE
wpcom-block-editor: pass --watch argument to each build task

### DIFF
--- a/apps/wpcom-block-editor/bin/npm-run-build.js
+++ b/apps/wpcom-block-editor/bin/npm-run-build.js
@@ -1,7 +1,7 @@
 /**
  * This script is adapted from ../../editing-toolkit/bin/npm-run-build.js
  *
- **** WARNING: No ES6 modules here. Not transpiled! ****
+ *WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
 /* eslint-disable no-console */
@@ -12,7 +12,7 @@ const args = process.argv.slice( 2 );
 
 const argsToCommands = {
 	'--build': 'build:*',
-	'--dev': 'build --watch',
+	'--dev': 'build',
 	'--sync': 'wpcom-sync',
 };
 

--- a/apps/wpcom-block-editor/bin/npm-run-build.js
+++ b/apps/wpcom-block-editor/bin/npm-run-build.js
@@ -1,7 +1,7 @@
 /**
  * This script is adapted from ../../editing-toolkit/bin/npm-run-build.js
  *
- *WARNING: No ES6 modules here. Not transpiled! ****
+ **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
 /* eslint-disable no-console */
@@ -12,7 +12,7 @@ const args = process.argv.slice( 2 );
 
 const argsToCommands = {
 	'--build': 'build:*',
-	'--dev': 'build',
+	'--dev': 'build --watch',
 	'--sync': 'wpcom-sync',
 };
 

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -19,7 +19,7 @@
 		"bundle": "BROWSERSLIST_ENV=wpcom calypso-build --env WP",
 		"build:dev": "yarn run bundle",
 		"build:prod": "NODE_ENV=production yarn run bundle",
-		"build": "yarn clean && npm-run-all --parallel 'build:* --watch'",
+		"build": "yarn clean && npm-run-all --parallel 'build:*'",
 		"clean": "npx rimraf dist",
 		"dev": "node bin/npm-run-build.js --dev",
 		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh"

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -19,7 +19,7 @@
 		"bundle": "BROWSERSLIST_ENV=wpcom calypso-build --env WP",
 		"build:dev": "yarn run bundle",
 		"build:prod": "NODE_ENV=production yarn run bundle",
-		"build": "yarn clean && npm-run-all --parallel 'build:*'",
+		"build": "yarn clean && npm-run-all --parallel 'build:* --watch'",
 		"clean": "npx rimraf dist",
 		"dev": "node bin/npm-run-build.js --dev",
 		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh"

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -19,7 +19,7 @@
 		"bundle": "BROWSERSLIST_ENV=wpcom calypso-build --env WP",
 		"build:dev": "yarn run bundle",
 		"build:prod": "NODE_ENV=production yarn run bundle",
-		"build": "yarn clean && npm-run-all --parallel 'build:*'",
+		"build": "yarn clean && npm-run-all --parallel \"build:* {@}\" --",
 		"clean": "npx rimraf dist",
 		"dev": "node bin/npm-run-build.js --dev",
 		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Restores the script syntax for wpcom-block-editor build commands that passes `--watch` to each individual build command.

(This was previously removed here: https://github.com/Automattic/wp-calypso/pull/51719/files#diff-241e3a26437c16df3755e251c314fd1103466217f4a4f6a9c15f927681706586L22. It may be that this worked before as is, but isn't now with yarn 3 and npm 7.)

May be superseded by #56368, but I'm proposing this quick fix to unblock wpcom-block-editor development.

#### Testing instructions

- `cd apps/wpcom-block-editor`
- `yarn install`
- `yarn dev`

**Before**

```bash
Running the following commands: build --watch
[build --watch] ERROR: Invalid Option: --watch
wp-calypso/node_modules/npm-run-all/lib/run-tasks.js:141
```

**After**

```bash
Running the following commands: build --watch
[build --watch] <w> [webpack-cli] You are using "bail" with "watch". "bail" will still exit webpack when the first error is found.
...
```