### PR TITLE
Site Verification Services: Update Support Document Link

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -577,9 +577,9 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 		{
-			link: localizeUrl( 'https://wordpress.com/support/webmaster-tools/' ),
+			link: localizeUrl( 'https://wordpress.com/support/site-verification-services/' ),
 			post_id: 5022,
-			title: translate( 'Webmaster Tools' ),
+			title: translate( 'Site Verification Services' ),
 			description: translate(
 				'Learn how to verify your WordPress.com site for the webmaster tools that many search engines provide.'
 			),

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -317,7 +317,7 @@ class SiteVerification extends Component {
 									supportLink: (
 										<InlineSupportLink
 											supportPostId={ 5022 }
-											supportLink="https://wordpress.com/support/webmaster-tools/"
+											supportLink="https://wordpress.com/support/site-verification-services/"
 										>
 											{ translate( 'full instructions', {
 												comment: 'Full phrase: Read the full instructions',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the Site Verification document to the new link. Since the ID of the page has not changed and a redirect has been established, this isn't actually broken, but it's been requested in #56426. 

#### Testing instructions

Visit `/marketing/traffic/site` and verify that "full instructions" under the "Site verification services" still works. The Inline Help result link should also be updated. 

Fixes #56426