### PR TITLE
Update wording of Press This

### DIFF
--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -40,7 +40,7 @@ class PressThis extends Component {
 						<ul>
 							<li>
 								{ translate(
-									'Drag and drop the "Press This" button below to your bookmarks bar, or right-click the button to copy the link, then add the link to your favourites.'
+									'Drag and drop the "Press This" button below to your bookmarks bar, or right-click the button to copy the link, then add the link to your favorites.'
 								) }
 							</li>
 							<li>

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -26,23 +26,28 @@ class PressThis extends Component {
 
 		return (
 			<div className="press-this">
-				<Card className="site-settings">
+				<Card className="press-this__card site-settings">
 					<p>
 						{ translate(
-							'Press This is a bookmarklet: a little app that runs in your browser and lets you grab bits of the web.'
+							'{{strong}}Press This{{/strong}} allows you to copy text, images, and video from any web page and add them to a new post on your site, along with an automatic citation.',
+							{ components: { strong: <strong /> } }
 						) }
 					</p>
 					<p>
-						{ translate(
-							'Use Press This to clip text, images and videos from any web page. ' +
-								'Then edit and add more straight from Press This before you save or publish it in a post on your site.'
-						) }
+						<strong>{ translate( 'How to use Press This' ) }</strong>
 					</p>
 					<p>
-						{ translate(
-							'Drag-and-drop the following link to your bookmarks bar or right click it and add it to your favorites ' +
-								'for a posting shortcut.'
-						) }
+						<ul>
+							<li>
+								{ translate(
+									'Drag and drop the "Press This" button below to your bookmarks bar, or right-click the button to copy the link, then add the link to your favourites.'
+								) }
+							</li>
+							<li>
+								{ translate( "Highlight the text or item you'd like to copy into a new post." ) }
+							</li>
+							<li>{ translate( 'Click on the "Press This" bookmarklet / favorite.' ) }</li>
+						</ul>
 					</p>
 					{ site && (
 						<p className="press-this__link-container">

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -23,7 +23,11 @@ const pressThis = function ( postURL ) {
 	} else if ( docGetSel ) {
 		sel = docGetSel();
 	} else {
-		sel = docSel ? docSel.createRange().text : 0;
+		sel = docSel ? docSel.createRange().text : '';
+	}
+
+	if ( ! encodeURIComponent( sel ) ) {
+		sel = doc.title;
 	}
 
 	const url =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* According to https://github.com/Automattic/wp-calypso/issues/51899, our description is not clear. So, updating the wording to make user know how to use it easily!
* Also, using title as content of quote where no text is selected

![image](https://user-images.githubusercontent.com/13596067/134858015-b933bdf1-92ef-404d-b5c0-b742d170791d.png)

https://user-images.githubusercontent.com/13596067/134864404-1ab46077-67be-4c36-bde1-5939802eb0f8.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings > General > Writing
* Check the wording is correct or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/51899
