### PR TITLE
`QueryTerms`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -1,5 +1,6 @@
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestSiteTerms } from 'calypso/state/terms/actions';
 import { isRequestingTermsForQuery } from 'calypso/state/terms/selectors';
@@ -10,13 +11,21 @@ const request = ( siteId, taxonomy, query ) => ( dispatch, getState ) => {
 	}
 };
 
+function useMemoized( obj ) {
+	const memoObj = useRef();
+	if ( ! isShallowEqual( obj, memoObj.current ) ) {
+		memoObj.current = obj;
+	}
+	return memoObj;
+}
+
 function QueryTerms( { siteId, taxonomy, query = {} } ) {
 	const dispatch = useDispatch();
-	const stringifiedQuery = JSON.stringify( query );
+	const memoizedQuery = useMemoized( query ).current;
 
 	useEffect( () => {
-		dispatch( request( siteId, taxonomy, JSON.parse( stringifiedQuery ) ) );
-	}, [ dispatch, siteId, taxonomy, stringifiedQuery ] );
+		dispatch( request( siteId, taxonomy, memoizedQuery ) );
+	}, [ dispatch, siteId, taxonomy, memoizedQuery ] );
 
 	return null;
 }

--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -16,12 +16,12 @@ function useMemoized( obj ) {
 	if ( ! isShallowEqual( obj, memoObj.current ) ) {
 		memoObj.current = obj;
 	}
-	return memoObj;
+	return memoObj.current;
 }
 
 function QueryTerms( { siteId, taxonomy, query = {} } ) {
 	const dispatch = useDispatch();
-	const memoizedQuery = useMemoized( query ).current;
+	const memoizedQuery = useMemoized( query );
 
 	useEffect( () => {
 		dispatch( request( siteId, taxonomy, memoizedQuery ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryTerms`:
  * refactor away from `UNSAFE_*` lifecycle methods
  * migrate to functional component

#### Testing instructions

On each step below make sure terms (categories, tags, etc) are fetched accordingly:

1. Go to `/settings/taxonomies/category/<site>` (click _Posts > Categories_ from the sidebar)
2. Hit _Add new category_ button and deactivate the _Top level category_ switch
2. Now go to `/settings/taxonomies/post_tag/<site>` (click _Tags_ from the sidebar)
3. Switch your currently active site
5. Go to `/settings/podcasting/<site>`