### PR TITLE
chore: Disable jsdoc rules related to param/return descriptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -242,6 +242,11 @@ module.exports = {
 		// Only use known tag names plus `jest-environment`.
 		'jsdoc/check-tag-names': [ 'error', { definedTags: [ 'jest-environment' ] } ],
 
+		// Do not require param/return description, see https://github.com/Automattic/wp-calypso/issues/56330
+		'jsdoc/require-param-description': 'off',
+		'jsdoc/require-param': 'off',
+		'jsdoc/require-returns-description': 'off',
+
 		// Deprecated rule, fails in some valid cases with custom input components
 		'jsx-a11y/label-has-for': 'off',
 


### PR DESCRIPTION
See #56330

#### Changes proposed in this Pull Request

Disable rules:
* jsdoc/require-param-description
* jsdoc/require-param
* jsdoc/require-returns-description

#### Testing instructions

N/A