### PR TITLE
Checkout: use the `handleContactValidationResult` hook to validate contact information for logged-out users

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -148,14 +148,27 @@ export async function validateContactDetails(
 		return isContactValidationResponseValid( validationResult, contactInfo );
 	};
 
-	if (
-		isLoggedOutCart &&
-		! isContactValidationResponseValid(
-			await runLoggedOutEmailValidationCheck( contactInfo, reduxDispatch, translate ),
-			contactInfo
-		)
-	) {
-		return false;
+	if ( isLoggedOutCart ) {
+		const loggedOutValidationResult = await runLoggedOutEmailValidationCheck(
+			contactInfo,
+			reduxDispatch,
+			translate
+		);
+		if ( shouldDisplayErrors ) {
+			handleContactValidationResult( {
+				translate,
+				recordEvent: onEvent,
+				showErrorMessage: showErrorMessageBriefly,
+				paymentMethodId: activePaymentMethod?.id ?? '',
+				validationResult: loggedOutValidationResult,
+				applyDomainContactValidationResults,
+				clearDomainContactErrorMessages,
+			} );
+		}
+
+		if ( ! isContactValidationResponseValid( loggedOutValidationResult, contactInfo ) ) {
+			return false;
+		}
 	}
 
 	return completeValidationCheck( await runContactValidationCheck( contactInfo, responseCart ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/55880 the contact validation logic was refactored to simplify it. However, the refactored version missed one key aspect of the contact validation process for logged-out users. Specifically, the `handleContactValidationResult` hook stopped being called for logged-out users, which had the effect of making the form stop showing any validation error. 

This PR fixes this by adding a call to `handleContactValidationResult` during the validation process for logged-out users.

#### Testing instructions

##### Let's observe the regression
* Visit `https://wordpress.com/checkout/jetpack/jetpack_scan` on an incognito window or making sure you're not logged in to WordPress.com.
* Enter an email address that is associated with a WP.com account.
* Make sure that you don't see any message and can't complete the checkout step.

##### Let's test the fix
* Download this PR.
* Start Calypso Blue with `yarn start`.
* Visit `http://calypso.localhost:3000/checkout/jetpack/jetpack_scan` on an incognito window or making sure you're not logged in to WordPress.com.
* Enter an email address that is associated with a WP.com account.
* Make sure you see the `That email address is already in use. If you have an existing account, please log in.` error message.
* Log in to WordPress.com.
* Make sure that you're back on the Checkout page and logged in to WordPress.com.

Related to 1164141197617539-as-1201066676255494

#### Demo – before
https://user-images.githubusercontent.com/3418513/134930731-d145e2dc-2fae-4130-b405-15032e65b083.mp4

#### Demo – after
https://user-images.githubusercontent.com/3418513/134930496-609db889-6829-42f2-ae97-ceded5cfb619.mp4
