### PR TITLE
Stats: Remove bottom margin on paragraph tag for large screens

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -154,6 +154,9 @@
 
 	p {
 		color: var( --color-text-subtle );
+		@include breakpoint-deprecated( '>960px' ) {
+			margin-bottom: 0;
+		}
 	}
 
 	.button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove bottom margin on paragraph tag

**Before**

<img width="1116" alt="Screen Shot 2021-09-27 at 10 46 28 AM" src="https://user-images.githubusercontent.com/2124984/134939286-86fe28d3-fab9-4e93-9103-29aa0b4638f9.png">

**After**

<img width="1100" alt="Screen Shot 2021-09-27 at 11 32 09 AM" src="https://user-images.githubusercontent.com/2124984/134939368-39ab9198-2716-4d5f-a2b8-e56d7881af4d.png">


#### Testing instructions

* Switch to this PR
* Navigate to `/stats` and scroll to the bottom
* Make sure the banner margin looks OK :) 


Fixes #56583