### PR TITLE
Playwright: add step to work around the new screen introduced in #56569.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -42,6 +42,9 @@ const selectors = {
 			'Select'
 		) }`,
 
+	// Post-signup design selection (for Free plans only)
+	skipForNowButton: 'button:text("Skip for now")',
+
 	// Language
 	languagePicker: 'a:has(.gutenboarding__header-site-language-label)',
 	languageButton: ( target: string ) => `button:has(span[lang="${ target }"])`,
@@ -213,6 +216,14 @@ export class GutenboardingFlow {
 		// The plan item with the `has-badge` attribute is the one that is recommended based on features.
 		const elementHandle = await this.page.waitForSelector( `${ selectors.planItem }.has-badge` );
 		await elementHandle.waitForSelector( `div:text-is("${ name }")` );
+	}
+
+	/**
+	 * Skips the Design selection screen if WordPress.com Free plan is selected.
+	 */
+	async skipDesign(): Promise< void > {
+		await this.page.waitForLoadState( 'load' );
+		await this.page.click( selectors.skipForNowButton );
 	}
 
 	/* Other actions */

--- a/test/e2e/specs/specs-playwright/wp-signup__free.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__free.ts
@@ -16,6 +16,7 @@ import {
 	BrowserHelper,
 	CloseAccountFlow,
 	LoginFlow,
+	GutenboardingFlow,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
@@ -60,6 +61,11 @@ describe(
 			it( 'Select WordPress.com Free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
 				await signupPickPlanPage.selectPlan( 'Free' );
+			} );
+
+			it( 'Skip the design selection prompt', async function () {
+				const gutenboardingFlow = new GutenboardingFlow( page );
+				await gutenboardingFlow.skipDesign();
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a step to select `skip for now` on the new screen introduced in #56569 as part of Gutenboarding.

Key changes:
- activate the step for Free Plan spec only.

#### Testing instructions

- [x] pre-release tests (ci)
- [x] pre-release tests (local)

Related to #
