### PR TITLE
Clone Activity log: Make Clone button visible on rewindable activities

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -248,7 +248,7 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div className="activity-log-item__action">
-				{ ! showCredentialsButton && (
+				{ ! showCredentialsButton && ! enableClone && (
 					<Button compact={ isCompact } disabled={ disableRestore } onClick={ createRewind }>
 						<Gridicon icon="history" size={ 18 } /> { translate( 'Restore' ) }
 					</Button>
@@ -269,9 +269,11 @@ class ActivityLogItem extends Component {
 					</Button>
 				) }
 
-				<Button compact={ isCompact } disabled={ disableBackup } onClick={ createBackup }>
-					<Gridicon icon="cloud-download" size={ 18 } /> { translate( 'Download' ) }
-				</Button>
+				{ ! enableClone && (
+					<Button compact={ isCompact } disabled={ disableBackup } onClick={ createBackup }>
+						<Gridicon icon="cloud-download" size={ 18 } /> { translate( 'Download' ) }
+					</Button>
+				) }
 
 				{ enableClone && this.renderCloneAction() }
 			</div>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -192,13 +192,8 @@ class ActivityLogItem extends Component {
 
 	renderItemAction() {
 		const {
-			enableClone,
-			activity: { activityIsRewindable, activityName, activityMeta },
+			activity: { activityName, activityMeta },
 		} = this.props;
-
-		if ( enableClone ) {
-			return activityIsRewindable ? this.renderCloneAction() : null;
-		}
 
 		switch ( activityName ) {
 			case 'rewind__scan_result_found':
@@ -214,16 +209,14 @@ class ActivityLogItem extends Component {
 		const { translate } = this.props;
 
 		return (
-			<div className="activity-log-item__action">
-				<Button
-					className="activity-log-item__clone-action"
-					primary
-					compact
-					onClick={ this.performCloneAction }
-				>
-					{ translate( 'Clone from here' ) }
-				</Button>
-			</div>
+			<Button
+				className="activity-log-item__clone-action"
+				primary
+				compact
+				onClick={ this.performCloneAction }
+			>
+				{ translate( 'Clone from here' ) }
+			</Button>
 		);
 	};
 
@@ -239,6 +232,7 @@ class ActivityLogItem extends Component {
 			createRewind,
 			disableBackup,
 			disableRestore,
+			enableClone,
 			siteId,
 			siteSlug,
 			trackAddCreds,
@@ -278,6 +272,8 @@ class ActivityLogItem extends Component {
 				<Button compact={ isCompact } disabled={ disableBackup } onClick={ createBackup }>
 					<Gridicon icon="cloud-download" size={ 18 } /> { translate( 'Download' ) }
 				</Button>
+
+				{ enableClone && this.renderCloneAction() }
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the `clone` button is not showing on the Clone activity log whenever a user wants to clone an older backup instead of cloning the latest one.  This is happening because the section where it was being rendered ( `.activity-log-item .foldable-card__secondary` ) is now being hidden after recent CSS changes.
This PR moves the button to the same section as the Restore and Download buttons, so the button becomes visible again. 

#### Testing instructions
You'll need two Jetpack-connected sites to test the clone feature.

1. Apply this patch and Launch Calypso locally
2- Open `calypso.localhost` on your browser and choose _Jetpack connected site 1_
3- go to` settings` > `general`, and under `Site tools` click on `Clone`.
4- Add the credentials of your _Jetpack connected site 2_
5- Select `Clone previous state` 
6- Confirm that the button is showing and works.
7- Go to `calypso.localhost` and open `Jetpack` > `Activity log` on the left menu.
8- Confirm that the Clone button is not showing. 


#### Related links

Github bug report:
6969-gh-Automattic/jpop-issues