### PR TITLE
Send user to home after creating a site

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -110,13 +110,7 @@ export default function useOnSiteCreation(): void {
 			clearLastNonEditorRoute();
 			setSelectedSite( newSite.blogid );
 
-			let destination;
-			if ( design?.is_fse ) {
-				destination = `/home/${ newSite.site_slug }/`;
-			} else {
-				destination = `/page/${ newSite.site_slug }/home`;
-			}
-			window.location.href = destination;
+			window.location.href = `/home/${ newSite.site_slug }/`;
 		}
 	}, [
 		flow,

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -112,7 +112,7 @@ export default function useOnSiteCreation(): void {
 
 			let destination;
 			if ( design?.is_fse ) {
-				destination = `/site-editor/${ newSite.site_slug }/`;
+				destination = `/home/${ newSite.site_slug }/`;
 			} else {
 				destination = `/page/${ newSite.site_slug }/home`;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to redirect the users to my home after creating a site.

#### Testing instructions

1. Create a new site by going to `/new`;
3. Finish creating your site.

You should be redirected to `/home/mysite.wordpress.com`.

Resolves #56289.

Doesn't have any test. I created an issue so we can add it in the future when we include E2E tests for FSE: #56597.