### PR TITLE
chore: Fix eslint rule jsdoc/check-param-names

### DIFF
--- a/client/lib/local-storage-bypass/index.js
+++ b/client/lib/local-storage-bypass/index.js
@@ -74,7 +74,7 @@ export const clear = ( memoryStore ) => {
  *
  * @param {object}   [args]            An arguments object
  * @param {object}   [args.root]       Allow alternate "window" object to support tests in non-browser environments
- * @param {string[]} [arg.allowedKeys] An array of localStorage keys that are proxied to the real localStorage
+ * @param {string[]} [args.allowedKeys] An array of localStorage keys that are proxied to the real localStorage
  */
 export default function ( {
 	root = typeof window === 'undefined' ? undefined : window,

--- a/client/lib/signup/step-actions/passwordless.js
+++ b/client/lib/signup/step-actions/passwordless.js
@@ -6,6 +6,7 @@ import wpcom from 'calypso/lib/wp';
  *
  * @param {Function} callback Callback function
  * @param {object}   data     POST data object
+ * @param {string}   data.email
  */
 export function createPasswordlessUser( callback, { email } ) {
 	wpcom
@@ -20,6 +21,8 @@ export function createPasswordlessUser( callback, { email } ) {
  *
  * @param {Function} callback Callback function
  * @param {object}   data     POST data object
+ * @param {string}   data.email
+ * @param {string}   data.code
  */
 export function verifyPasswordlessUser( callback, { email, code } ) {
 	wpcom

--- a/client/lib/wporg/jsonp.js
+++ b/client/lib/wporg/jsonp.js
@@ -28,8 +28,7 @@ function noop() {}
  *
  * @param {string} url
  * @param {object} query params
- * @param {Function} optional callback
- * @param fn
+ * @param {Function} fn optional callback
  */
 function jsonp( url, query, fn ) {
 	const prefix = '__jp';

--- a/client/my-sites/marketing/connections/services/mailchimp.js
+++ b/client/my-sites/marketing/connections/services/mailchimp.js
@@ -20,9 +20,6 @@ export class Mailchimp extends SharingService {
 
 	/**
 	 * Deletes the passed connections.
-	 *
-	 * @param {Array} connections Optional. Connections to be deleted.
-	 *                            Default: All connections for this service.
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );

--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -4,11 +4,11 @@ import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 } from '@automattic/calypso-products';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { managePurchase } from 'calypso/me/purchases/paths';
-import type { Purchase } from 'calypso/lib/purchases/types';
 import { addQueryArgs } from 'calypso/lib/route';
+import { managePurchase } from 'calypso/me/purchases/paths';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getYearlySlugFromMonthly } from 'calypso/my-sites/plans/jetpack-plans/convert-slug-terms';
+import type { Purchase } from 'calypso/lib/purchases/types';
 import type {
 	PurchaseURLCallback,
 	QueryArgs,
@@ -87,8 +87,6 @@ function buildCheckoutURL(
 /**
  * Get the function for generating the URL for the product checkout page
  *
- * @param {SelectorProduct} product The product to add to the cart
- * @param {boolean} isUpgradeableToYearly Whether the product is upgradeable to yearly
  * @param {string} siteSlug Slug of the site
  * @param {QueryArgs} urlQueryArgs Additional query params appended to url
  */

--- a/client/state/billing-transactions/ui/reducer.js
+++ b/client/state/billing-transactions/ui/reducer.js
@@ -25,6 +25,9 @@ export const app = ( state = null, action ) => {
  *
  * @param  {object} state  Current state
  * @param  {object} action Action payload
+ * @param  {string} action.type
+ * @param  action.month
+ * @param  action.operator
  * @returns {object}        Updated state
  */
 export const date = ( state = { month: null, operator: null }, { type, month, operator } ) => {

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -82,6 +82,8 @@ export const receiveCommentsError = ( { siteId, commentId } ) => ( {
  * @param {object} options options object.
  * @param {number} options.siteId site identifier
  * @param {number} options.postId post identifier
+ * @param {string} options.direction
+ * @param {boolean} options.isPoll
  * @param {string} options.status status filter. Defaults to approved posts
  * @returns {Function} action that requests comments for a given post
  */
@@ -116,7 +118,6 @@ export function requestPostComments( {
  * listed in the API docs:
  *
  * @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
- *
  * @param {object} query API call parameters
  * @param {string} query.listType Type of list to return (required as 'site')
  * @param {number} query.siteId Site identifier
@@ -343,7 +344,6 @@ export const editComment = ( siteId, postId, commentId, comment ) => ( {
  * @param {Array<number>} options.commentIds list of commentIds to expand.
  * @param {number} options.postId postId for the comments to expand.
  * @param {string} options.displayType which displayType to set the comment to.
- *
  * @returns {object} reader expand comments action
  */
 export const expandComments = ( { siteId, commentIds, postId, displayType } ) => ( {

--- a/client/state/data-layer/wpcom/active-promotions/index.js
+++ b/client/state/data-layer/wpcom/active-promotions/index.js
@@ -32,7 +32,8 @@ export const requestActivePromotions = ( action ) =>
  * Dispatches returned WordPress.com active promotions data
  *
  * @param {object} action Redux action
- * @param {Array} active_promotions raw data from active promotions API
+ * @param {object} obj
+ * @param {Array} obj.active_promotions raw data from active promotions API
  * @returns {Array<object>} Redux actions
  */
 export const receiveActivePromotions = ( action, { active_promotions } ) => [

--- a/client/state/data-layer/wpcom/domains/countries-list/index.js
+++ b/client/state/data-layer/wpcom/domains/countries-list/index.js
@@ -36,7 +36,6 @@ export const updateCountriesDomains = ( action, countries ) => ( {
 /**
  * Dispatches a error notice action when the request for the supported countries list fails.
  *
- * @param   {Function} dispatch Redux dispatcher
  * @returns {object}            dispatched error notice action
  */
 export const showCountriesDomainsLoadingError = () =>

--- a/client/state/data-layer/wpcom/jetpack-blogs/product-install-status/index.js
+++ b/client/state/data-layer/wpcom/jetpack-blogs/product-install-status/index.js
@@ -28,6 +28,7 @@ export const requestJetpackProductInstallStatus = ( action ) =>
  * Dispatches a product install status receive action when the request succeeded.
  *
  * @param   {object} action Redux action
+ * @param   {number} action.siteId
  * @param   {object} status Status as returned from the endpoint
  * @returns {object} Dispatched product install status receive action
  */

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
@@ -26,6 +26,7 @@ export const removeConnectedApplication = ( action ) =>
  * Dispatches a user connected application removal success action and notice when the request succeeded.
  *
  * @param   {object} action Redux action
+ * @param   {string} action.appId
  * @returns {object} Dispatched user connected applications add action
  */
 export const handleRemoveSuccess = ( { appId } ) => [

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js
@@ -26,6 +26,7 @@ export const removeApplicationPassword = ( action ) =>
  * Dispatches a user application password removal success action when the request succeeded.
  *
  * @param   {object} action Redux action
+ * @param   {number} action.appPasswordId
  * @returns {object} Dispatched user application passwords add action
  */
 export const handleRemoveSuccess = ( { appPasswordId } ) =>

--- a/client/state/data-layer/wpcom/sites/plan-transfer/index.js
+++ b/client/state/data-layer/wpcom/sites/plan-transfer/index.js
@@ -34,6 +34,7 @@ export const requestPlanOwnershipTransfer = ( action ) =>
  * Dispatches a success notice when the request succeeded.
  *
  * @param   {object} action Redux action
+ * @param   {number} action.siteId
  * @returns {object} Success notice action
  */
 export const handleTransferSuccess = ( { siteId } ) => [
@@ -48,7 +49,9 @@ export const handleTransferSuccess = ( { siteId } ) => [
  * Dispatches an error notice when the request failed.
  *
  * @param   {object} action Redux action
+ * @param   {number} action.siteId
  * @param   {object} error  Error object
+ * @param   {string} error.message
  * @returns {object} Error notice action
  */
 export const handleTransferError = ( { siteId }, { message } ) =>

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -114,6 +114,10 @@ export const updatePlaceholderComment = (
  * dispatches a error notice if creating a new comment request failed
  *
  * @param {object}   action   redux action
+ * @param {number} action.siteId
+ * @param {number} action.postId
+ * @param {number} action.parentCommentId
+ * @param {number} action.placeholderId
  * @param {object} rawError plain error object
  * @returns {Function} thunk
  */

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -14,9 +14,8 @@ const noop = () => {};
  * @example
  * valueLabelToObject( [ { value: 'foo', label: 'bar' }, { value: 'biz', label: 'bat' } ] )
  * // returns { foo: 'bar', biz: 'bat' }
- *
- * @param {ValueLabelRecord[]} pairs - timezone values and display labels
- * @returns {ValueLabelMap} object whose keys are timezone values, values are timezone labels
+ * @param {Array} pairs - timezone values and display labels
+ * @returns {object} object whose keys are timezone values, values are timezone labels
  */
 const timezonePairsToMap = ( pairs ) =>
 	Object.fromEntries( map( pairs, ( { label, value } ) => [ value, label ] ) );
@@ -24,7 +23,6 @@ const timezonePairsToMap = ( pairs ) =>
 /**
  * Normalize data gotten from the REST API making them more Calypso friendly.
  *
- * @param {object} data - REST-API response
  * @returns {object} normalized timezones data.
  */
 export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent } ) => ( {

--- a/client/state/editor/video-editor/reducer.js
+++ b/client/state/editor/video-editor/reducer.js
@@ -7,20 +7,12 @@ import { combineReducers } from 'calypso/state/utils';
 
 /**
  * Tracks poster URL state.
- *
- * @param  {string} state Current poster URL
- * @param  {object} action Action object
- * @returns {string} Updated poster URL
  */
 export const url = ( state = null, { type, posterUrl } ) =>
 	VIDEO_EDITOR_SET_POSTER_URL === type ? posterUrl : state;
 
 /**
  * Tracks poster upload progress state.
- *
- * @param  {number} state Current upload progress of the poster
- * @param  {object} action Action object
- * @returns {number} Updated upload progress of the poster
  */
 export const uploadProgress = ( state = null, { type, percentage } ) => {
 	if ( VIDEO_EDITOR_SHOW_UPLOAD_PROGRESS === type ) {
@@ -36,10 +28,6 @@ export const uploadProgress = ( state = null, { type, percentage } ) => {
 
 /**
  * Tracks whether or not an error should be shown.
- *
- * @param  {boolean} state Whether or not an error was to be shown
- * @param  {object} action Action object
- * @returns {boolean} Whether or not an error should now be shown
  */
 export const showError = ( state, { type } ) => type === VIDEO_EDITOR_SHOW_ERROR;
 

--- a/client/state/exporter/reducer.js
+++ b/client/state/exporter/reducer.js
@@ -55,10 +55,6 @@ export function selectedAdvancedSettings( state = {}, action ) {
 
 /**
  * Tracks the state of the exporter for each site ID
- *
- * @param {object} state  The current state
- * @param {object} action Action object
- * @returns {object}        Updated state
  */
 export function exportingState( state = {}, { type, siteId } ) {
 	switch ( type ) {

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -44,10 +44,6 @@ export const links = ( state = {}, action ) => {
 
 /**
  * Responsible for the help search results links
- *
- * @param {object} state  Current state
- * @param {object} action Action payload
- * @returns {object}        Updated state
  */
 export const supportHistory = ( state = [], { type, items } ) => {
 	switch ( type ) {
@@ -60,10 +56,6 @@ export const supportHistory = ( state = [], { type, items } ) => {
 
 /**
  * The level of support we're offering to this user (represents their highest paid plan).
- *
- * @param {object} state  Current state
- * @param {object} action Action payload
- * @returns {object}        Updated state
  */
 export const supportLevel = ( state = null, { type, level } ) => {
 	switch ( type ) {

--- a/client/state/notifications-panel/reducer.js
+++ b/client/state/notifications-panel/reducer.js
@@ -1,11 +1,6 @@
 import { NOTIFICATIONS_FORCE_REFRESH } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
-/**
- *
- * @param {object} state Current state
- * @param {object} action Action payload
- * @returns {object} Updated state
- */
+
 export const shouldForceRefresh = ( state = false, { type, refresh } ) => {
 	if ( type === NOTIFICATIONS_FORCE_REFRESH ) {
 		return refresh || false;

--- a/client/state/posts/revisions/actions.js
+++ b/client/state/posts/revisions/actions.js
@@ -36,9 +36,6 @@ export const requestPostRevisions = ( siteId, postId, postType = 'posts', compar
 
 /**
  * Action creator function: POST_REVISIONS_RECEIVE
- *
- * @param {object} response diffs, postId, revisions, siteId,
- * @returns {object} action object
  */
 export const receivePostRevisions = ( { diffs, postId, revisions, siteId } ) => ( {
 	type: POST_REVISIONS_RECEIVE,

--- a/client/state/reader-ui/seen-posts/actions.js
+++ b/client/state/reader-ui/seen-posts/actions.js
@@ -17,10 +17,6 @@ export const requestUnseenStatus = () => ( {
 
 /**
  * Receive unseen status for any section
- *
- * @param status.status
- * @param status whether or not we have unseen content in any section
- * @returns {{type: string, status: *}} redux action
  */
 export const receiveUnseenStatus = ( { status } ) => ( {
 	type: READER_UNSEEN_STATUS_RECEIVE,

--- a/client/state/reader/follows/actions.js
+++ b/client/state/reader/follows/actions.js
@@ -47,7 +47,6 @@ const debug = debugModule( 'calypso:redux:reader-follows' );
  * @property {number} date_subscribed The date subscribed. Seconds since epoch.
  * @property {boolean} is_owner Is the current user the owner of this site
  * @property {object} delivery_methods
- *
  */
 
 /**
@@ -124,12 +123,6 @@ export function recordUnfollow( url ) {
 	};
 }
 
-/**
- * Returns an action object to signal that followed sites have been received.
- *
- * @param  {Array}  follows Follows received
- * @returns {object} 		Action object
- */
 export function receiveFollows( { follows, totalCount } ) {
 	return {
 		type: READER_FOLLOWS_RECEIVE,

--- a/client/state/reader/seen-posts/actions.js
+++ b/client/state/reader/seen-posts/actions.js
@@ -105,15 +105,6 @@ export const requestMarkAllAsSeen = ( { identifier, feedIds, feedUrls } ) => ( {
 
 /**
  * Receive mark all as seen for successful requests
- *
- * @param {object} payload method
- * @param payload.section given Reader section
- * @param payload.globalIds list of Calypso Reader specific global ids
- * @param payload.feedIds
- * @param payload.feedUrls
- * @param payload.feedIds
- * @param payload.feedUrls
- * @returns {{section: string, globalIds: *, type: string}} redux action
  */
 export const receiveMarkAllAsSeen = ( { feedIds, feedUrls, globalIds } ) => ( {
 	type: READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE,

--- a/client/state/rewind/backups/reducer.js
+++ b/client/state/rewind/backups/reducer.js
@@ -3,10 +3,6 @@ import { REWIND_BACKUPS_SET } from 'calypso/state/action-types';
 /**
  * Returns the updated backups state after an action has been dispatched. The
  * state maps site ID to the rewind backups object.
- *
- * @param   {object} state  Current state
- * @param   {object} action Action payload
- * @returns {object}        Updated state
  */
 export default ( state = {}, { type, backups } ) =>
 	type === REWIND_BACKUPS_SET ? backups : state;

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -28,7 +28,6 @@ export function getSerializedTermsQuery( query = {} ) {
  * Returns a serialized terms query, excluding any page parameter
  *
  * @param  {object} query  Terms query
- * @param  {number} siteId Optional site ID
  * @returns {string}        Serialized terms query
  */
 export function getSerializedTermsQueryWithoutPage( query ) {


### PR DESCRIPTION
See #56330


#### Changes proposed in this Pull Request

* Fixes `jsdoc/require-param-names`, either by adding the missing parameters or removing the JSDoc block when it doesn't add any value (mostly for reducers)

#### Testing instructions

N/A