### PR TITLE
chore: Fix eslint rule jsdoc/newline-after-description

### DIFF
--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -16,13 +16,15 @@ const SPACE_CHARACTERS = {
 
 /**
  * Checks whether a character is a space character
+ *
  * @param {string} character character to examine
- * @returns {bool} true if character is a space character, false otherwise
+ * @returns {boolean} true if character is a space character, false otherwise
  */
 const isSpaceCharacter = ( character ) => !! SPACE_CHARACTERS[ character ];
 
 /**
  * Get index of the first character that is not within a tag
+ *
  * @param {string} text text to examine
  * @returns {number} index not within a tag
  */
@@ -49,6 +51,7 @@ const getTaglessIndex = ( text ) => {
 
 /**
  * Gets text content from react element in case that's a leaf element
+ *
  * @param {React.Element} reactElement react element
  * @returns {string|null} returns a text content of the react element or null if it's not a leaf element
  */
@@ -196,6 +199,7 @@ const setChildDirection = ( child, isRtl ) => {
 
 /**
  * Auto direction component that will set direction to child components according to their text content
+ *
  * @param {object.children} props react element props that must contain some children
  * @returns {React.Element} returns a react element with adjusted children
  */

--- a/client/lib/url/decode-utils.ts
+++ b/client/lib/url/decode-utils.ts
@@ -21,6 +21,7 @@ function decodeIfValid(
 /**
  * Wrap decodeURI in a try / catch block to prevent `URIError` on invalid input
  * Passing a non-string value will return an empty string.
+ *
  * @param  encodedURI URI to attempt to decode
  * @returns            Decoded URI (or passed in value on error)
  */
@@ -31,6 +32,7 @@ export function decodeURIIfValid( encodedURI: Stringable | Falsy ): string {
 /**
  * Wrap decodeURIComponent in a try / catch block to prevent `URIError` on invalid input
  * Passing a non-string value will return an empty string.
+ *
  * @param  encodedURIComponent URI component to attempt to decode
  * @returns                     Decoded URI component (or passed in value on error)
  */


### PR DESCRIPTION
See #56330

#### Changes proposed in this Pull Request

* Fixes `jsdoc/newline-after-description`
