### PR TITLE
Plans: Rename 'hidden' features to 'included' features

### DIFF
--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -79,8 +79,8 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 			const sitePlanDetails = getPlan( sitePlan.product_slug );
 			productsList = [
 				...productsList,
-				...sitePlanDetails.getHiddenFeatures(),
-				...( sitePlanDetails.getInferiorHiddenFeatures?.() ?? [] ),
+				...sitePlanDetails.getIncludedFeatures(),
+				...( sitePlanDetails.getInferiorFeatures?.() ?? [] ),
 			];
 		}
 		return !! productsList.find( productSlugTest );

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -34,7 +34,7 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 	const currentPlan =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
 	const includedInPlanProducts: string[] =
-		( currentPlan && getPlan( currentPlan )?.getHiddenFeatures() ) || [];
+		( currentPlan && getPlan( currentPlan )?.getIncludedFeatures() ) || [];
 
 	// Owned products from direct purchases
 	const purchasedProducts =

--- a/client/state/selectors/site-has-subscription.tsx
+++ b/client/state/selectors/site-has-subscription.tsx
@@ -37,8 +37,8 @@ export default function siteHasSubscription(
 		productsList = [
 			...productsList,
 			...[ sitePlan.product_slug ],
-			...sitePlanDetails.getHiddenFeatures(),
-			...( sitePlanDetails.getInferiorHiddenFeatures?.() ?? [] ),
+			...sitePlanDetails.getIncludedFeatures(),
+			...( sitePlanDetails.getInferiorFeatures?.() ?? [] ),
 		];
 	}
 	return productsList.some( ( product ) => subscriptionSlug.includes( product ) );

--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -42,6 +42,10 @@ export function getPlansSlugs() {
 	return Object.keys( getPlans() );
 }
 
+/**
+ * @param   {string} planKey - A key that represents a plan.
+ * @returns {import("./types.ts").Plan} A Plan object that corresponds to the supplied key.
+ */
 export function getPlan( planKey ) {
 	if ( Object.prototype.toString.apply( planKey ) === '[object Object]' ) {
 		if ( Object.values( PLANS_LIST ).includes( planKey ) ) {

--- a/packages/calypso-products/src/main.js
+++ b/packages/calypso-products/src/main.js
@@ -131,7 +131,6 @@ export function planHasFeature( plan, feature ) {
  *
  * @param {object|string} plan	Plan object or plan name
  * @param {[string]} features	Array of feature names
- *
  * @returns {boolean}			Whether or not the specified plan has one of the features
  */
 export function planHasAtLeastOneFeature( plan, features ) {
@@ -157,7 +156,7 @@ export function getAllFeaturesForPlan( plan ) {
 		'getSignupFeatures',
 		'getBlogSignupFeatures',
 		'getPortfolioSignupFeatures',
-		'getHiddenFeatures',
+		'getIncludedFeatures',
 	].reduce(
 		( featuresArray, featureMethodName ) => [
 			...( planConstantObj?.[ featureMethodName ]?.() ?? [] ),
@@ -178,7 +177,7 @@ export function getAllFeaturesForPlan( plan ) {
  */
 export function planHasSuperiorFeature( plan, feature ) {
 	const planConstantObj = getPlan( plan );
-	const features = planConstantObj.getInferiorHiddenFeatures?.() ?? [];
+	const features = planConstantObj.getInferiorFeatures?.() ?? [];
 
 	return features.includes( feature );
 }
@@ -340,7 +339,6 @@ export function isP2PlusPlan( planSlug ) {
 
 /**
  * @see findSimilarPlansKeys
- *
  * @param {string|object} planKey Source plan to compare to
  * @param {object} diff Properties that should differ in matched plan. @see planMatches
  * @returns {string|undefined} Matched plan

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -269,8 +269,8 @@ const getPlanBloggerDetails = () => ( {
 		FEATURE_ALL_FREE_FEATURES,
 	],
 	// Features not displayed but used for checking plan abilities
-	getHiddenFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
-	getInferiorHiddenFeatures: () => [],
+	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
+	getInferiorFeatures: () => [],
 } );
 
 const getPlanPersonalDetails = () => ( {
@@ -330,8 +330,8 @@ const getPlanPersonalDetails = () => ( {
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 	],
 	// Features not displayed but used for checking plan abilities
-	getHiddenFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
-	getInferiorHiddenFeatures: () => [],
+	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
+	getInferiorFeatures: () => [],
 } );
 
 const getPlanEcommerceDetails = () => ( {
@@ -431,7 +431,7 @@ const getPlanEcommerceDetails = () => ( {
 		PREMIUM_DESIGN_FOR_STORES,
 	],
 	// Features not displayed but used for checking plan abilities
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
 		FEATURE_GOOGLE_MY_BUSINESS,
 		FEATURE_CLOUDFLARE_ANALYTICS,
@@ -439,7 +439,7 @@ const getPlanEcommerceDetails = () => ( {
 		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 		FEATURE_SEO_PREVIEW_TOOLS,
 	],
-	getInferiorHiddenFeatures: () => [],
+	getInferiorFeatures: () => [],
 } );
 
 const getPlanPremiumDetails = () => ( {
@@ -511,8 +511,8 @@ const getPlanPremiumDetails = () => ( {
 		FEATURE_GOOGLE_ANALYTICS,
 	],
 	// Features not displayed but used for checking plan abilities
-	getHiddenFeatures: () => [ FEATURE_AUDIO_UPLOADS, FEATURE_CLOUDFLARE_ANALYTICS ],
-	getInferiorHiddenFeatures: () => [],
+	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS, FEATURE_CLOUDFLARE_ANALYTICS ],
+	getInferiorFeatures: () => [],
 } );
 
 const getPlanBusinessDetails = () => ( {
@@ -603,14 +603,14 @@ const getPlanBusinessDetails = () => ( {
 		FEATURE_SFTP_DATABASE,
 	],
 	// Features not displayed but used for checking plan abilities
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_AUDIO_UPLOADS,
 		FEATURE_GOOGLE_MY_BUSINESS,
 		FEATURE_CLOUDFLARE_ANALYTICS,
 		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 		FEATURE_SEO_PREVIEW_TOOLS,
 	],
-	getInferiorHiddenFeatures: () => [],
+	getInferiorFeatures: () => [],
 } );
 
 const getJetpackPersonalDetails = () => ( {
@@ -630,7 +630,7 @@ const getJetpackPersonalDetails = () => ( {
 		),
 	getPlanCardFeatures: () => [ FEATURE_BACKUP_DAILY_V2, FEATURE_ANTISPAM_V2 ],
 	getBillingTimeFrame: () => i18n.translate( 'per year' ),
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 		FEATURE_BACKUP_ARCHIVE_30,
 		FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -669,7 +669,7 @@ const getJetpackPremiumDetails = () => ( {
 			'Your site is being secured and you have access to marketing tools and priority support.'
 		),
 	getPlanCardFeatures: () => [ FEATURE_BACKUP_DAILY_V2, FEATURE_SCAN_V2, FEATURE_ANTISPAM_V2 ],
-	getHiddenFeatures: () =>
+	getIncludedFeatures: () =>
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -727,7 +727,7 @@ const getJetpackBusinessDetails = () => ( {
 		FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		FEATURE_ANTISPAM_V2,
 	],
-	getHiddenFeatures: () =>
+	getIncludedFeatures: () =>
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -755,10 +755,7 @@ const getJetpackBusinessDetails = () => ( {
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
 			FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 		] ),
-	getInferiorHiddenFeatures: () => [
-		FEATURE_JETPACK_BACKUP_DAILY,
-		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
-	],
+	getInferiorFeatures: () => [ FEATURE_JETPACK_BACKUP_DAILY, FEATURE_JETPACK_BACKUP_DAILY_MONTHLY ],
 } );
 
 const getPlanJetpackSecurityDailyDetails = () => ( {
@@ -777,7 +774,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 		FEATURE_ANTISPAM_V2,
 		FEATURE_VIDEO_HOSTING_V2,
 	],
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_JETPACK_BACKUP_DAILY,
 		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		FEATURE_JETPACK_SCAN_DAILY,
@@ -821,7 +818,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 		FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 	],
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_JETPACK_BACKUP_REALTIME,
 		FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 		FEATURE_JETPACK_SCAN_DAILY,
@@ -838,7 +835,7 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 		FEATURE_GOOGLE_ANALYTICS,
 		FEATURE_PREMIUM_SUPPORT,
 	],
-	getInferiorHiddenFeatures: () => [
+	getInferiorFeatures: () => [
 		FEATURE_JETPACK_BACKUP_DAILY,
 		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		FEATURE_BACKUP_ARCHIVE_30,
@@ -861,7 +858,7 @@ const getPlanJetpackSecurityT1Details = () => ( {
 		FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 	],
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_JETPACK_BACKUP_T1_YEARLY,
 		FEATURE_JETPACK_BACKUP_T1_MONTHLY,
 		FEATURE_JETPACK_SCAN_DAILY,
@@ -878,7 +875,7 @@ const getPlanJetpackSecurityT1Details = () => ( {
 		FEATURE_GOOGLE_ANALYTICS,
 		FEATURE_PREMIUM_SUPPORT,
 	],
-	getInferiorHiddenFeatures: () => [
+	getInferiorFeatures: () => [
 		FEATURE_JETPACK_BACKUP_DAILY,
 		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		FEATURE_BACKUP_ARCHIVE_30,
@@ -901,7 +898,7 @@ const getPlanJetpackSecurityT2Details = () => ( {
 		FEATURE_PRODUCT_SCAN_REALTIME_V2,
 		FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 	],
-	getHiddenFeatures: () => [
+	getIncludedFeatures: () => [
 		FEATURE_JETPACK_BACKUP_T2_YEARLY,
 		FEATURE_JETPACK_BACKUP_T2_MONTHLY,
 		FEATURE_JETPACK_SCAN_DAILY,
@@ -918,7 +915,7 @@ const getPlanJetpackSecurityT2Details = () => ( {
 		FEATURE_GOOGLE_ANALYTICS,
 		FEATURE_PREMIUM_SUPPORT,
 	],
-	getInferiorHiddenFeatures: () => [
+	getInferiorFeatures: () => [
 		FEATURE_JETPACK_BACKUP_DAILY,
 		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		FEATURE_BACKUP_ARCHIVE_30,
@@ -946,7 +943,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 		FEATURE_CRM_V2,
 		FEATURE_PRODUCT_SEARCH_V2,
 	],
-	getHiddenFeatures: () =>
+	getIncludedFeatures: () =>
 		isEnabled( 'jetpack/only-realtime-products' )
 			? [
 					FEATURE_JETPACK_BACKUP_T2_YEARLY,
@@ -990,7 +987,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 					FEATURE_GOOGLE_ANALYTICS,
 					FEATURE_PREMIUM_SUPPORT,
 			  ],
-	getInferiorHiddenFeatures: () => [
+	getInferiorFeatures: () => [
 		FEATURE_JETPACK_BACKUP_DAILY,
 		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 		FEATURE_BACKUP_ARCHIVE_30,
@@ -1041,8 +1038,8 @@ export const PLANS_LIST = {
 			FEATURE_FREE_THEMES_SIGNUP,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'for life' ),
-		getHiddenFeatures: () => [],
-		getInferiorHiddenFeatures: () => [],
+		getIncludedFeatures: () => [],
+		getInferiorFeatures: () => [],
 	},
 
 	[ PLAN_BLOGGER ]: {
@@ -1340,7 +1337,7 @@ export const PLANS_LIST = {
 					' — perfectly packaged and optimized for everyone.'
 			),
 		getBillingTimeFrame: () => i18n.translate( 'for life' ),
-		getHiddenFeatures: () => [
+		getIncludedFeatures: () => [
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
 			FEATURE_TRAFFIC_TOOLS,
@@ -1512,12 +1509,12 @@ export const PLANS_LIST = {
 
 		// TODO: no idea about this, copied from the WP.com Premium plan.
 		// Features not displayed but used for checking plan abilities
-		getHiddenFeatures: () => [
+		getIncludedFeatures: () => [
 			FEATURE_AUDIO_UPLOADS,
 			FEATURE_JETPACK_SEARCH,
 			FEATURE_JETPACK_SEARCH_MONTHLY,
 		],
-		getInferiorHiddenFeatures: () => [],
+		getInferiorFeatures: () => [],
 
 		// TODO: Calypso requires this prop but we probably don't need it. Refactor Calypso?
 		getAudience: () => i18n.translate( 'Best for bloggers' ),

--- a/packages/calypso-products/src/plans-list.js
+++ b/packages/calypso-products/src/plans-list.js
@@ -995,6 +995,10 @@ const getPlanJetpackCompleteDetails = () => ( {
 } );
 
 // DO NOT import. Use `getPlan` instead.
+/**
+ * @typedef {import( "./types").Plan} Plan
+ * @type	{Object.<string, Plan>}
+ */
 export const PLANS_LIST = {
 	[ PLAN_FREE ]: {
 		group: GROUP_WPCOM,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -83,6 +83,21 @@ export interface Plan {
 	getTitle: () => TranslateResult;
 	getDescription: () => TranslateResult;
 	getTagline: () => TranslateResult;
+
+	/**
+	 * Features that are included as part of this plan.
+	 *
+	 * NOTE: Some parts of Calypso use the result of this method
+	 * to determine what a given plan *may* be capable of doing
+	 * before verifying with an API.
+	 */
 	getIncludedFeatures?: () => Feature[];
+
+	/**
+	 * Features that are superseded by another feature included in this plan.
+	 *
+	 * Example: if a plan has 1TB of storage space,
+	 * a feature for 20GB of storage space would be inferior to it.
+	 */
 	getInferiorFeatures?: () => Feature[];
 }

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -83,6 +83,6 @@ export interface Plan {
 	getTitle: () => TranslateResult;
 	getDescription: () => TranslateResult;
 	getTagline: () => TranslateResult;
-	getHiddenFeatures?: () => Feature[];
-	getInferiorHiddenFeatures?: () => Feature[];
+	getIncludedFeatures?: () => Feature[];
+	getInferiorFeatures?: () => Feature[];
 }


### PR DESCRIPTION
On the Plans interface, we have a concept of "hidden" features and "inferior hidden" features. The word "hidden" is opaque by definition, can have wide-ranging implications, and is confusing for people who aren't already deeply familiar with this part of Calypso. As far as I can tell, though, we use it to mean the following:

* **Hidden** features: features that are included as part of a plan;
* ***Inferior* hidden** features: features that are not included as part of the plan, because the plan already includes a feature that's more desirable (e.g., 1TB of storage vs 20GB).

Assuming this understanding is correct, I think it will alleviate a lot of confusion and make our code more readable if we change the names of `getHiddenFeatures` and `getInferiorHiddenFeatures` to `getIncludedFeatures` and `getInferiorFeatures`, respectively.

#### Changes proposed in this Pull Request

* Rename `Plan#getHiddenFeatures` to `getIncludedFeatures`.
* Rename `Plan#getInferiorHiddenFeatures` to `getInferiorFeatures`.
* Add documentation to `getIncludedFeatures` and `getInferiorFeatures`, to explicitly describe their purpose.
* Add JSDoc annotations to `@automattic/calypso-products#getPlan`, to explicitly define that it returns a `Plan` object.

#### Testing instructions

This PR is purely janitorial and should not cause changes to *any* behavior inside Calypso.

* Visit and interact with all Plans-related pages, including: product grids, My Plan, purchase management, checkout, etc.
* Verify you see no changes in behavior.
* Verify all unit tests still pass.