### PR TITLE
Support restoring WoA-managed plugins and themes

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2220,4 +2220,11 @@ Undocumented.prototype.getAtomicSiteLogs = function ( siteIdOrSlug, start, end, 
 	);
 };
 
+Undocumented.prototype.restoreAtomicPlanSoftware = function ( siteIdOrSlug ) {
+	return this.wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/hosting/restore-plan-software`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
 export default Undocumented;

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -29,6 +29,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import MiscellaneousCard from './miscellaneous-card';
 import PhpVersionCard from './php-version-card';
 import PhpMyAdminCard from './phpmyadmin-card';
+import RestorePlanSoftwareCard from './restore-plan-software-card';
 import SFTPCard from './sftp-card';
 import SiteBackupCard from './site-backup-card';
 import SupportCard from './support-card';
@@ -157,6 +158,7 @@ class Hosting extends Component {
 							<SFTPCard disabled={ isDisabled } />
 							<PhpMyAdminCard disabled={ isDisabled } />
 							<PhpVersionCard disabled={ isDisabled } />
+							<RestorePlanSoftwareCard disabled={ isDisabled } />
 							<MiscellaneousCard disabled={ isDisabled } />
 							<WebServerLogsCard disabled={ isDisabled } />
 						</Column>

--- a/client/my-sites/hosting/restore-plan-software-card/index.js
+++ b/client/my-sites/hosting/restore-plan-software-card/index.js
@@ -1,0 +1,61 @@
+import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
+import CardHeading from 'calypso/components/card-heading';
+import MaterialIcon from 'calypso/components/material-icon';
+import { stripHTML } from 'calypso/lib/formatting/strip-html';
+import wpcom from 'calypso/lib/wp';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+function RestorePlanSoftwareCard( props ) {
+	const {
+		translate,
+		siteId,
+		successNotice: showSuccessNotice,
+		errorNotice: showErrorNotice,
+	} = props;
+
+	function requestRestore() {
+		wpcom
+			.undocumented()
+			.restoreAtomicPlanSoftware( siteId )
+			.then( () => {
+				showSuccessNotice(
+					translate( 'Requested restoration of plugins and themes that come with your plan.' )
+				);
+			} )
+			.catch( ( error ) => {
+				const message =
+					stripHTML( error.message ) ||
+					translate( 'Failed to request restoration of plan plugin and themes.' );
+				showErrorNotice( message );
+			} );
+	}
+
+	return (
+		<Card className="restore-plan-software-card">
+			<MaterialIcon icon="apps" />
+			<CardHeading>{ translate( 'Restore Plugins and Themes' ) }</CardHeading>
+			<p>
+				{ translate(
+					'If your website is missing plugins and themes that come with your plan, you may restore them here.'
+				) }
+			</p>
+			<Button primary onClick={ requestRestore }>
+				{ translate( "Restore Plugins and Themes for My Website's Plan" ) }
+			</Button>
+		</Card>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{
+		successNotice,
+		errorNotice,
+	}
+)( localize( RestorePlanSoftwareCard ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Especially in the case of the eCommerce plan, there are
premium plugins and themes that are difficult for the user to get back
once they delete them. This change adds a card to the Hosting
pane that allows users to restore all software associated with their
plan with a single click.
* NOTE: If there is already an unmanaged version of a plugin or theme on the site, this will likely not replace it. That is something we plan to tackle in a future iteration.

#### Testing instructions

* Pick a WoA test site
* Delete a symlinked plugin or theme that came with your plan
* Go to Calypso's Settings->"Hosting Configuration" page
* Click "Restore Plugins and Themes for My Website's Plan"
* Observe that the deleted plugin or theme symlink has been restored

<img width="743" alt="Screen Shot 2021-09-28 at 12 32 53 PM" src="https://user-images.githubusercontent.com/530877/135128676-305e7fe8-d053-43c7-8fac-475e488615d6.png">


