### PR TITLE
Connected Applications: Sort List Alphabetically

### DIFF
--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { times, sortBy } from 'lodash';
+import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -17,6 +17,7 @@ import ReauthRequired from 'calypso/me/reauth-required';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
+import getCurrentIntlCollator from 'calypso/state/selectors/get-current-intl-collator';
 
 import './style.scss';
 
@@ -63,7 +64,7 @@ class ConnectedApplications extends PureComponent {
 	}
 
 	renderConnectedApps() {
-		const { apps } = this.props;
+		const { apps, intlCollator } = this.props;
 
 		if ( apps === null ) {
 			return this.renderPlaceholders();
@@ -73,10 +74,14 @@ class ConnectedApplications extends PureComponent {
 			return this.renderEmptyContent();
 		}
 
-		// Some applications (eg. gravatar-upload) are in lower case.
-		return sortBy( apps, ( app ) => app.title.toLowerCase() ).map( ( connection ) => (
-			<ConnectedAppItem connection={ connection } key={ connection.ID } />
-		) );
+		// Sorts the list into alphabetical order then displays them.
+		return apps
+			.sort( ( a, b ) => {
+				return intlCollator.compare( a.title, b.title );
+			} )
+			.map( ( connection ) => (
+				<ConnectedAppItem connection={ connection } key={ connection.ID } />
+			) );
 	}
 
 	renderConnectedAppsList() {
@@ -123,4 +128,5 @@ class ConnectedApplications extends PureComponent {
 
 export default connect( ( state ) => ( {
 	apps: getConnectedApplications( state ),
+	intlCollator: getCurrentIntlCollator( state ),
 } ) )( localize( ConnectedApplications ) );

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
-import { times } from 'lodash';
+import { times, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -73,7 +73,8 @@ class ConnectedApplications extends PureComponent {
 			return this.renderEmptyContent();
 		}
 
-		return apps.map( ( connection ) => (
+		// Some applications (eg. gravatar-upload) are in lower case.
+		return sortBy( apps, ( app ) => app.title.toLowerCase() ).map( ( connection ) => (
 			<ConnectedAppItem connection={ connection } key={ connection.ID } />
 		) );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Orders the Connected Applications list alphabetically

#### Testing instructions

Visit `/me/security/connected-applications` on an account with multiple applications connected, then verify that they're alphabetically sorted in a case insensitive way.

| Before                                                                                                                                                                | After                                                                                                                                                                 |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1099" alt="Screenshot 2021-09-28 at 18 48 55" src="https://user-images.githubusercontent.com/43215253/135139295-11d7d557-30da-4147-a8ca-82175fdc78d4.png"> | <img width="1121" alt="Screenshot 2021-09-28 at 18 48 52" src="https://user-images.githubusercontent.com/43215253/135139274-93421916-c5fe-4f99-b651-7b44d671f072.png"> |

cc @sixhours

Fixes #56610
