### PR TITLE
Playwright: write new spec for Support: show me where

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -136,7 +136,9 @@ export class SupportComponent {
 		}
 
 		await this.page.click( `:nth-match(${ selector }, ${ target })` );
-		await this.page.click( selectors.readMoreButton );
+		if ( category === 'article' ) {
+			await this.page.click( selectors.readMoreButton );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -13,7 +13,9 @@ export type Features =
 	| 'Priority support';
 
 const selectors = {
+	// Generic
 	button: ( text: string ) => `button:text("${ text }")`,
+	wpLogo: 'div.gutenboarding__header-wp-logo',
 
 	// Start your website
 	siteTitle: '.acquire-intent-text-input__input',
@@ -78,6 +80,13 @@ export class GutenboardingFlow {
 	 */
 	async clickButton( text: string ) {
 		await this.page.click( selectors.button( text ) );
+	}
+
+	/**
+	 * Clicks on the WP Logo on top left.
+	 */
+	async clickWpLogo(): Promise< void > {
+		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.wpLogo ) ] );
 	}
 
 	/* Initial (landing) screen */

--- a/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
@@ -1,0 +1,65 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	LoginFlow,
+	SidebarComponent,
+	SupportComponent,
+	setupHooks,
+	GutenboardingFlow,
+} from '@automattic/calypso-e2e';
+import { Page } from 'playwright';
+
+describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
+	let page: Page;
+
+	setupHooks( ( args: { page: Page } ) => {
+		page = args.page;
+	} );
+
+	describe.each( [
+		{ siteType: 'Simple', user: 'defaultUser' },
+		{ siteType: 'Atomic', user: 'wooCommerceUser' },
+	] )( 'Search and view a support article ($siteType)', function ( { user } ) {
+		let supportComponent: SupportComponent;
+
+		it( 'Log in', async function () {
+			const loginFlow = new LoginFlow( page, user );
+			await loginFlow.logIn();
+		} );
+
+		it( 'Navigate to Tools > Marketing', async function () {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Tools', 'Marketing' );
+		} );
+
+		it( 'Open support popover', async function () {
+			supportComponent = new SupportComponent( page );
+			await supportComponent.openPopover();
+		} );
+
+		it( 'Displays default entries', async function () {
+			await supportComponent.defaultStateShown();
+		} );
+
+		it( 'Enter search keyword', async function () {
+			const keyword = 'domain';
+			await supportComponent.search( keyword );
+		} );
+
+		it( 'Search for help: Create a site', async function () {
+			await supportComponent.search( 'create a site' );
+		} );
+
+		it( 'Click on result under Show me where', async function () {
+			await supportComponent.clickResult( 'where', 1 );
+		} );
+
+		it( 'Exit Gutenboarding flow', async function () {
+			const gutenboardingFlow = new GutenboardingFlow( page );
+			await gutenboardingFlow.clickWpLogo();
+		} );
+	} );
+} );

--- a/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
+++ b/test/e2e/specs/specs-playwright/wp-support__showme-where.ts
@@ -24,6 +24,7 @@ describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
 		{ siteType: 'Atomic', user: 'wooCommerceUser' },
 	] )( 'Search and view a support article ($siteType)', function ( { user } ) {
 		let supportComponent: SupportComponent;
+		let gutenboardingFlow: GutenboardingFlow;
 
 		it( 'Log in', async function () {
 			const loginFlow = new LoginFlow( page, user );
@@ -40,15 +41,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
 			await supportComponent.openPopover();
 		} );
 
-		it( 'Displays default entries', async function () {
-			await supportComponent.defaultStateShown();
-		} );
-
-		it( 'Enter search keyword', async function () {
-			const keyword = 'domain';
-			await supportComponent.search( keyword );
-		} );
-
 		it( 'Search for help: Create a site', async function () {
 			await supportComponent.search( 'create a site' );
 		} );
@@ -57,9 +49,14 @@ describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
 			await supportComponent.clickResult( 'where', 1 );
 		} );
 
+		it( 'Gutenboarding flow is started', async function () {
+			gutenboardingFlow = new GutenboardingFlow( page );
+			await gutenboardingFlow.enterSiteTitle( DataHelper.getRandomPhrase() );
+		} );
+
 		it( 'Exit Gutenboarding flow', async function () {
-			const gutenboardingFlow = new GutenboardingFlow( page );
 			await gutenboardingFlow.clickWpLogo();
+			await page.waitForURL( '**/home/**' );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds new test cases to the `Support` component.

Key changes:
- write test to cover both Simple and Atomic sites.
- search for a text string from the Support popover, then click on an entry under the 'Show me where' category.

Details:

This spec was originally a part of #56473. However, due to good critique raised by @WunderBart, it was decided to split the spec out to a standalone test.

#### Testing instructions

- [x] regular test
  - [x] mobile
  - [x] desktop


