### PR TITLE
Users: Add copy explaining why you can't remove the site owner

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -24,6 +24,7 @@ import {
 	requestExternalContributorsRemoval,
 } from 'calypso/state/data-getters';
 import { httpData } from 'calypso/state/data-layer/http-data';
+import { getSite } from 'calypso/state/sites/selectors';
 import withDeleteUser from './with-delete-user';
 
 import './style.scss';
@@ -222,10 +223,10 @@ class DeleteUser extends Component {
 	};
 
 	renderSingleSite = () => {
-		const { translate, user, isJetpack } = this.props;
+		const { translate, isJetpack, isOwnSite } = this.props;
 
 		// A user should not be able to remove the site owner.
-		if ( ! isJetpack && user.ID ) {
+		if ( ! isJetpack && isOwnSite ) {
 			return (
 				<Card className="delete-user__single-site">
 					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
@@ -353,7 +354,10 @@ export default localize(
 			const userId = user && user.ID;
 			const linkedUserId = user && user.linked_user_ID;
 			const externalContributors = siteId ? requestExternalContributors( siteId ) : httpData.empty;
+			const site = getSite( state, siteId );
+
 			return {
+				isOwnSite: site?.capabilities?.own_site,
 				currentUser: getCurrentUser( state ),
 				contributorType: getContributorType(
 					externalContributors,

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -13,8 +13,10 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import Gravatar from 'calypso/components/gravatar';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import User from 'calypso/components/user';
 import accept from 'calypso/lib/accept';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
@@ -220,7 +222,34 @@ class DeleteUser extends Component {
 	};
 
 	renderSingleSite = () => {
-		const { translate } = this.props;
+		const { translate, user, isJetpack } = this.props;
+
+		// A user should not be able to remove the site owner.
+		if ( ! isJetpack && user.ID ) {
+			return (
+				<Card className="delete-user__single-site">
+					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
+					<p className="delete-user__explanation">
+						{ translate(
+							'You cannot delete the site owner. Please transfer ownership of this site to a different account before deleting this user. {{supportLink}}Learn more.{{/supportLink}}',
+							{
+								components: {
+									supportLink: (
+										<InlineSupportLink
+											supportPostId={ 102743 }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
+											) }
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				</Card>
+			);
+		}
+
 		return (
 			<Card className="delete-user__single-site">
 				<form onSubmit={ this.deleteUser }>

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -223,10 +223,10 @@ class DeleteUser extends Component {
 	};
 
 	renderSingleSite = () => {
-		const { translate, isJetpack, isOwnSite } = this.props;
+		const { translate, isJetpack, siteOwner, user } = this.props;
 
 		// A user should not be able to remove the site owner.
-		if ( ! isJetpack && isOwnSite ) {
+		if ( ! isJetpack && user.ID === siteOwner ) {
 			return (
 				<Card className="delete-user__single-site">
 					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
@@ -357,7 +357,7 @@ export default localize(
 			const site = getSite( state, siteId );
 
 			return {
-				isOwnSite: site?.capabilities?.own_site,
+				siteOwner: site?.site_owner,
 				currentUser: getCurrentUser( state ),
 				contributorType: getContributorType(
 					externalContributors,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show a message about the site owner in place of the delete mechanism with an inline support link. This prevents users from attempting to delete the site owner and receiving an ambiguous error as in #56387

**Before**

<img width="1668" alt="Screen Shot 2021-10-05 at 4 04 51 PM" src="https://user-images.githubusercontent.com/2124984/136094842-6d3c808e-e192-4122-8090-1d4c856aefab.png">

**After**

<img width="1667" alt="Screen Shot 2021-10-05 at 4 05 17 PM" src="https://user-images.githubusercontent.com/2124984/136094858-04d3a418-8879-4a2f-887d-0f055ae859da.png">

#### Testing instructions

* Switch to this PR
* Apply D67910-code and D67913-code to your sandbox, and sandbox the API
* Visit the user management area on a site you own (ie. your account created that site) and invite a new dummy user to the site as an administrator
* In a separate browser (incognito won't work locally) log into the dummy user's account and visit user management for that site
* You should not be able to see deletion options for the site owner's account, or delete the site owner's account

Fixes #56387