### PR TITLE
Skip redirect if page is supported

### DIFF
--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -18,13 +18,21 @@ function isSupportedBrowser( req ) {
 	} );
 }
 
+// We don't want to redirect some of our public landing pages, so we include them
+// here.
+function shouldRedirectPath( path ) {
+	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes' ];
+	return ! allowedPaths.includes( path.slice( 1 ) );
+}
+
 export default () => ( req, res, next ) => {
 	if ( ! config.isEnabled( 'redirect-fallback-browsers' ) ) {
 		next();
 		return;
 	}
 
-	if ( req.path === '/browsehappy' ) {
+	// Permitted paths even if the browser is unsupported.
+	if ( ! shouldRedirectPath( req.path ) ) {
 		next();
 		return;
 	}

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -20,9 +20,20 @@ function isSupportedBrowser( req ) {
 
 // We don't want to redirect some of our public landing pages, so we include them
 // here.
-function shouldRedirectPath( path ) {
-	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes' ];
-	return ! allowedPaths.includes( path.slice( 1 ) );
+function allowPath( path ) {
+	// Strip leading '/'.
+	let parsedPath = path.replace( /^\//, '' );
+	const possiblePathLocales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
+	for ( const locale in possiblePathLocales ) {
+		// Strip leading locale (e.g. 'es/')
+		if ( parsedPath.startsWith( locale ) ) {
+			parsedPath = parsedPath.replace( new RegExp( `^${ locale }/?` ), '' );
+			break;
+		}
+	}
+	// At this point, '/es/themes' is just 'themes', ready to match our allowed paths.
+	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes', 'theme', 'domains' ];
+	return allowedPaths.some( ( p ) => p.startsWith( path ) );
 }
 
 export default () => ( req, res, next ) => {
@@ -32,7 +43,7 @@ export default () => ( req, res, next ) => {
 	}
 
 	// Permitted paths even if the browser is unsupported.
-	if ( ! shouldRedirectPath( req.path ) ) {
+	if ( allowPath( req.path ) ) {
 		next();
 		return;
 	}

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -24,7 +24,7 @@ function allowPath( path ) {
 	// Strip leading '/'.
 	let parsedPath = path.replace( /^\//, '' );
 	const possiblePathLocales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
-	for ( const locale in possiblePathLocales ) {
+	for ( const locale of possiblePathLocales ) {
 		// Strip leading locale (e.g. 'es/')
 		if ( parsedPath.startsWith( locale ) ) {
 			parsedPath = parsedPath.replace( new RegExp( `^${ locale }/?` ), '' );

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -33,7 +33,7 @@ function allowPath( path ) {
 	}
 	// At this point, '/es/themes' is just 'themes', ready to match our allowed paths.
 	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes', 'theme', 'domains' ];
-	return allowedPaths.some( ( p ) => p.startsWith( path ) );
+	return allowedPaths.some( ( p ) => p.startsWith( parsedPath ) );
 }
 
 export default () => ( req, res, next ) => {

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -33,7 +33,7 @@ function allowPath( path ) {
 	}
 	// At this point, '/es/themes' is just 'themes', ready to match our allowed paths.
 	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes', 'theme', 'domains' ];
-	return allowedPaths.some( ( p ) => p.startsWith( parsedPath ) );
+	return allowedPaths.some( ( p ) => parsedPath.startsWith( p ) );
 }
 
 export default () => ( req, res, next ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request
Resolves #56602.

We have a problem where some bots are unable to access public pages. We want to support these bots.

Option 1 is to add their user agents to the list of "supported browsers". (I think I personally lean towards this option.)
Option 2 is to simply not redirect certain public pages. In our team call today, this seemed to be the most favored option, so I've implemented it here :)

Unfortunately, I didn't quickly see a simple way to dynamically allow access to _any_ public page, as the routing logic is set up after the unsupported browser middleware. (E.g. we redirect before we know what pages are available.) Since this is semi-possibly-temporary (if we remove the redirect altogether in the future), I figure a simple list of pages to support is fine. (Plus, this covers the only pages we know about affecting the bot behavior in a negative way.

The reason I like option 1 better is that in this scenario, a user could do all the work of going through the login flow and only afterwards get redirected to the browsehappy page. That's a very negative experience, IMO. Since we want something like `log-in` to also be indexed by bots, just allowing the bot user agent would solve both problems.

### Testing instructions
1. Load calypso.live in IE11
2. Access one of the permitted pages, like "themes". You should not be redirected. (Important: the page may not work.)
4. Access another page, like "posts". You should be redirected to browsehappy.