### PR TITLE
Add border radius to design picker thumbnails

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -99,6 +99,7 @@
 		border: 1px solid;
 		position: relative;
 		overflow: hidden;
+		border-radius: 4px; /* stylelint-disable-line scales/radii */
 
 		img {
 			position: absolute;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add 4px border radius to thumbnails

<img width="1259" alt="Screenshot 2021-09-29 at 4 24 20 PM" src="https://user-images.githubusercontent.com/1500769/135198302-e17204cd-a5c8-4d2c-be6c-65cce055eee4.png">

Change requested here pdgK6S-78-p2#comment-352

This also adds the border radius in the `/new` flow, but that's ok pdgK6S-7f-p2#comment-237

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/setup-site/design-setup-site?siteSlug=<< site >>`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->