### PR TITLE
Update design picker typography to increase contrast

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -150,7 +150,6 @@
 		align-items: center;
 		display: inline-flex;
 		flex-wrap: wrap; // If theme name and premium badge don't fit on one line
-		justify-content: center;
 		margin-top: 8px;
 		width: 100%;
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -132,8 +132,9 @@
 	}
 
 	.design-picker__image-frame-blank-canvas__title {
-		color: var( --studio-gray-40 );
-		font-weight: 600;
+		color: var( --studio-gray-80 );
+		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		font-size: $font-title-small;
 	}
 
 	.design-picker__image-frame-inside {
@@ -162,7 +163,8 @@
 	.design-picker__option-name {
 		align-items: center;
 		display: inline-flex;
-		font-size: $font-body-small;
+		font-size: $font-body;
+		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 		margin-top: -0.1em;
 	}
 
@@ -198,7 +200,7 @@
 // light theme styles
 .design-picker.design-picker--theme-light {
 	.design-picker__option-name {
-		color: var( --studio-gray-40 );
+		color: var( --studio-gray-80 );
 	}
 	.design-picker__design-option {
 		.design-picker__image-frame {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use darker grey for text
* Use 500 for the font weight
* Bump font size
* Left align theme names (not included in the screenshots below)


<img width="1259" alt="Screenshot 2021-09-29 at 4 54 38 PM" src="https://user-images.githubusercontent.com/1500769/135200635-dbeb2e09-9cfd-4cde-88ff-fe3ba176c430.png">

<img width="1259" alt="Screenshot 2021-09-29 at 4 54 32 PM" src="https://user-images.githubusercontent.com/1500769/135200645-5b371408-ac47-4562-8cc2-bb97f8fbfb74.png">

Change requested here pdgK6S-78-p2#comment-352

This also adds the border radius in the `/new` flow, but that's ok pdgK6S-7f-p2#comment-237

#### Testing instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* `/start/setup-site/design-setup-site?siteSlug=<< site >>`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->