### PR TITLE
Fixup InlineHelp and HappychatSubmit button CSS specificity

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -12,7 +12,7 @@
 	width: calc( 100% - 32px );
 }
 
-.button.is-borderless.inline-help__button {
+.button.is-borderless.is-compact.inline-help__button {
 	position: absolute;
 	right: 0;
 	bottom: 0;

--- a/client/components/happychat/composer.scss
+++ b/client/components/happychat/composer.scss
@@ -31,7 +31,7 @@
 	}
 }
 
-.happychat__submit {
+.happychat__submit.button {
 	align-self: flex-start;
 	flex: 0 0 auto;
 	border-radius: 8px;


### PR DESCRIPTION
Removes CSS specificity ambiguity for the Inline Help button:

<img width="62" alt="Screenshot 2021-09-29 at 8 39 03" src="https://user-images.githubusercontent.com/664258/135216122-d2215aac-a6b8-4283-bfd1-00d19e327ecc.png">

and the Happychat submit button:

<img width="286" alt="Screenshot 2021-09-29 at 8 39 35" src="https://user-images.githubusercontent.com/664258/135216166-1a3ca92b-63e9-4a9e-8476-e0ace1f73653.png">

For Inline Help, there were two selectors with the same specificity:
```
.button.is-borderless.is-compact .gridicon
.button.is-borderless.inline-help__button .gridicon
```
Where their priority depended on their order. The separate Inline Help widget in #55189 sometimes reverses that order, which leads to broken Gridicon.

Similarly, both `.button` and `.happychat__submit` both define their `padding`, and we need to make the second selector more specific to make its `padding` always win.

**How to test:**
In trunk, just verify both parts of UI are OK. In the #55189 branch, you can verify that UI is indeed broken without these changes.