### PR TITLE
Fix the header indent of signup step

### DIFF
--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -41,7 +41,6 @@
 .step-wrapper__header-button {
 	@include breakpoint-deprecated( '<660px' ) {
 		flex-basis: 100%;
-		padding: 0 20px;
 	}
 }
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -416,15 +416,16 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	}
 
 	.step-wrapper__header {
-		margin: 48px 20px 40px;
+		margin: 24px 20px;
 
-		@include breakpoint-deprecated( '<660px' ) {
-			margin-top: 24px;
+		@include break-large {
+			margin: 48px 0 40px;
 		}
 	}
 
 	.step-wrapper__header-button {
 		@include breakpoint-deprecated( '<660px' ) {
+			margin-top: 16px;
 			margin-bottom: -16px;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In previous PR https://github.com/Automattic/wp-calypso/pull/56311, I adjusted the indent because I found the misalignment on iPhoneX but it causes another misalignment 😅. So, adjust the indent again to make alignment consistent.

Here is the demo under different window size

https://user-images.githubusercontent.com/13596067/135226637-6f1ba73c-3142-42bc-84b3-1fd5905df109.mov

Here is the misalignment before https://github.com/Automattic/wp-calypso/pull/56311, but it already be fixed

![image](https://user-images.githubusercontent.com/13596067/135227466-74a69aa6-620f-4495-a20d-831811f4435e.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Check the header indent under different window width

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/56628, p1632512970019900-slack-C01VA100LEA