### PR TITLE
The signup framework's siteSlug param also works with the unmapped url

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -61,6 +61,7 @@ import { submitSiteVertical } from 'calypso/state/signup/steps/site-vertical/act
 import { setSurvey } from 'calypso/state/signup/steps/survey/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteId, isCurrentPlanPaid, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import getSiteByUnmappedSlug from 'calypso/state/sites/selectors/get-site-by-unmapped-slug';
 import flows from './config/flows';
 import { getStepComponent } from './config/step-components';
 import steps from './config/steps';
@@ -742,7 +743,12 @@ class Signup extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		const signupDependencies = getSignupDependencyStore( state );
-		const siteId = getSiteId( state, signupDependencies.siteSlug );
+		// The `siteSlug` query param could be either the primary url or (in the case of the site-setup flow where
+		// we've been redirected using a url that was generated from before the domain purchase was complete) the
+		// unmapped *.wordpress.com url.
+		const siteId =
+			getSiteId( state, signupDependencies.siteSlug ) ||
+			getSiteByUnmappedSlug( state, signupDependencies.siteSlug )?.ID;
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const shouldStepShowSitePreview = get(
 			steps[ ownProps.stepName ],

--- a/client/state/sites/selectors/get-site-by-unmapped-slug.js
+++ b/client/state/sites/selectors/get-site-by-unmapped-slug.js
@@ -1,0 +1,24 @@
+import { createSelector } from '@automattic/state-utils';
+import { withoutHttp } from 'calypso/lib/url';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
+import getSiteOption from './get-site-option';
+
+/**
+ * Returns a site object by a slug of its unmapped url.
+ *
+ * @param {object} state Global state tree
+ * @param {string} unmappedSiteSlug Unmapped site slug
+ * @returns {?object} Site object
+ */
+export default createSelector(
+	( state, unmappedSiteSlug ) => {
+		const sites = Object.values( getSitesItems( state ) );
+		return (
+			sites.find(
+				( site ) =>
+					withoutHttp( getSiteOption( state, site.ID, 'unmapped_url' ) ) === unmappedSiteSlug
+			) ?? null
+		);
+	},
+	( state ) => [ getSitesItems( state ) ]
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the signup framework needs to operate on an existing site it uses the `siteSlug` query param. This is used by at least the `site-setup` and `site-launch` flows.

We'd like to be able to use the unmapped domain as the value for `siteSlug`, even when the site's primary domain is set to something else. This is because the url for the `site-setup` flow is being generated at a time _before_ domain purchase has been completed, and we have no idea whether the domain purchase will be successful or not.

This fixes an issue where, depending on the payment method, a newly purchased domain will have been set as the primary domain by the time we land in the `site-setup` flow, producing a WSOD.

p1632898918267200-slack-C029SB8JT8S

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I've only smoke tested so far. Try various payment methods (e.g. CC, credits, paypal) and flows (e.g. `site-setup` and `site-launch`)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
