### PR TITLE
Fixup React import in DIFM card

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/difm-lite-in-progress/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/difm-lite-in-progress/index.jsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
 import builderReferral from 'calypso/assets/images/illustrations/builder-referral.svg';
 import { TASK_DIFM_LITE_IN_PROGRESS } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';


### PR DESCRIPTION
A little fixup of the component added in #56313. After the new React JSX in #56451 was merged shortly after this one, you don't need to import `React` just to be able to use JSX.