### PR TITLE
i18n-utils: Localize `automattic.com/privacy/` and `automattic.com/cookies/` URLs

### DIFF
--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -7,8 +7,8 @@
 export type Locale = string;
 export const i18nDefaultLocaleSlug: Locale = 'en';
 export const localesWithBlog: Locale[] = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
-export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de' ];
-export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de' ];
+export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
+export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 
 type LocaleSubdomain = string;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `es` locale to `localesWithPrivacyPolicy` and `localesWithCookiePolicy` locales set, so that `localizeUrl` would apply the locale prefix for `automattic.com/privacy/` and `automattic.com/cookies/` URLs in Spanish.

#### Testing instructions

* Open calypso.live build.
* Change your UI language to Spanish.
* Go to `/me/privacy` and confirm Privacy Policy and Cookies links point to `automattic.com/es/privacy/` and `automattic.com/es/cookies/`respectively.

Related to 330-gh-Automattic/i18n-issues
