### PR TITLE
calypso-build: enable new JSX runtime by default

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"build": "yarn clean && BROWSERSLIST_ENV=wpcom calypso-build --config='./webpack.config.js'",
-		"dev-server": "webpack serve --inline --progress --liveReload --content-base dist --watch-content-base --host notifications.localhost --port 8888",
+		"dev-server": "webpack serve --inline --progress --liveReload --content-base dist --watch-content-base --host calypso.localhost --port 3000",
 		"start": "yarn run clean && yarn run build && yarn run dev-server",
 		"sync": "yarn run clean && yarn run build && sh ./bin/wpcom-watch-and-sync.sh"
 	},

--- a/apps/notifications/src/standalone/auth-wrapper/client/oauth.js
+++ b/apps/notifications/src/standalone/auth-wrapper/client/oauth.js
@@ -1,7 +1,7 @@
 import wpcom from 'wpcom';
 import wpcomXhrRequest from 'wpcom-xhr-request';
 
-const OAUTH_CLIENT_ID = 56641;
+const OAUTH_CLIENT_ID = 39911; // Calypso OAuth app
 const OAUTH_REDIRECT_PATH = '/';
 
 const getStoredToken = () => {

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,9 +3,7 @@ const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
 // We implicitly use browserslist configuration in package.json for build targets.
 
 const babelConfig = {
-	presets: [
-		[ '@automattic/calypso-build/babel/default', { bugfixes: true, runtime: 'automatic' } ],
-	],
+	presets: [ [ '@automattic/calypso-build/babel/default', { bugfixes: true } ] ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: true, ignore: ! isBrowser } ] ],
 	env: {
 		production: {

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -25,12 +25,7 @@ module.exports = ( api, opts ) => ( {
 				exclude: [ 'transform-typeof-symbol' ],
 			},
 		],
-		[
-			require.resolve( '@babel/preset-react' ),
-			{
-				runtime: opts.runtime ? opts.runtime : 'classic',
-			},
-		],
+		[ require.resolve( '@babel/preset-react' ), { runtime: 'automatic' } ],
 		require.resolve( '@babel/preset-typescript' ),
 	],
 	plugins: [


### PR DESCRIPTION
This PR enables the `runtime: 'automatic'` React preset option by default, enabling it for all projects that use the `calypso-build` config or helpers, like the apps in `apps/`.

This patch alone fixed my `happychat/` and `inline-help/` apps in #55189, but `notifications/` still don't work. That's why this is still a draft and needs more work.