### PR TITLE
Removing duplicate content from domain step in signup

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -660,12 +660,7 @@ class RegisterDomainStep extends Component {
 		}
 
 		if ( this.props.showExampleSuggestions ) {
-			return (
-				<>
-					{ this.renderExampleSuggestions() }
-					{ this.props.isReskinned && ! this.state.loadingResults && this.props.reskinSideContent }
-				</>
-			);
+			return this.renderExampleSuggestions();
 		}
 
 		return this.renderInitialSuggestions( false );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
There's a bug on the Domain step in the two smaller viewports which duplicates content as shown in the screenshot below:

<img width="911" alt="CleanShot 2021-09-29 at 08 14 05@2x" src="https://user-images.githubusercontent.com/35781181/135278768-0ccd1faa-44ff-4d8a-a2c3-242ee03c7aff.png">

This PR removes one of those instances.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso.
* Start the site creation flow using any account.
* Proceed to the domain step.
* Confirm that the domain explainer copy is in the sidebar at wide viewport.
* Shrink the resolution in your browser through the next two breakpoints and confirm that the explainer copy is displayed only once.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
