### PR TITLE
Jetpack Cloud: Remove logic from file path validation that rejected "invalid characters"

### DIFF
--- a/client/lib/validation/file-path.ts
+++ b/client/lib/validation/file-path.ts
@@ -1,10 +1,9 @@
 import { translate } from 'i18n-calypso';
 import { ValidationError, validator } from './types';
 
-const filePathRegExp = /^\/$|^(\/[\w-]+)+\/?$/;
-const filePathBackSlashRegExp = /^\\$|^(\\[\w-]+)+\\?$/;
-const filePathMultiSlashRegExp = /^\/+$|^(\/+[\w-]+)+\/*$/;
-const validFilePathChars = /[\w\-/]/g;
+const filePathRegExp = /^\/$|^(\/[^/]+)+\/?$/;
+const filePathBackSlashRegExp = /^\\$|^(\\[^/]+)+\\?$/;
+const filePathMultiSlashRegExp = /^\/+$|^(\/+[^/]+)+\/*$/;
 
 const validateFilePath: validator< string > = (
 	pathToValidate: string
@@ -15,23 +14,6 @@ const validateFilePath: validator< string > = (
 	if ( filePathBackSlashRegExp.test( pathToValidate ) ) {
 		return {
 			message: translate( 'Use forward slashes, "/", in path.' ).toString(),
-		};
-	}
-	const invalidCharacters = pathToValidate
-		.replace( validFilePathChars, '' )
-		.split( '' )
-		.filter( ( character, index, array ) => array.indexOf( character ) === index )
-		.join( '' );
-	if ( invalidCharacters.length > 0 ) {
-		return {
-			message: translate(
-				'Path contains invalid character "%s".',
-				'Path contains invalid characters "%s".',
-				{
-					args: [ invalidCharacters ],
-					count: invalidCharacters.length,
-				}
-			).toString(),
 		};
 	}
 

--- a/client/lib/validation/test/file-path.ts
+++ b/client/lib/validation/test/file-path.ts
@@ -24,6 +24,10 @@ describe( 'filePathValidator', () => {
 		expect( filePathValidator( '/abc/def/xyz/' ) ).toBeNull();
 	} );
 
+	test( 'should validate a path with a url like element', () => {
+		expect( filePathValidator( '/abc/def.com/xyz/' ) ).toBeNull();
+	} );
+
 	// NOTE: We've seen support tickets with exactly this issue
 	test.each( [ [ '//' ], [ '/abc//def' ], [ '/abc//' ], [ '///' ], [ '/a///b/c' ] ] )(
 		'should reject a path with two or more adjacent slashes',
@@ -34,18 +38,4 @@ describe( 'filePathValidator', () => {
 			);
 		}
 	);
-
-	test( 'should reject a path with a non-valid character', () => {
-		expect( filePathValidator( '/abc*' ) ).toHaveProperty(
-			'message',
-			'Path contains invalid character "*".'
-		);
-	} );
-
-	test( 'should reject a path with multiple non-valid characters', () => {
-		expect( filePathValidator( '/abc*/efg&' ) ).toHaveProperty(
-			'message',
-			'Path contains invalid characters "*&".'
-		);
-	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove validation logic that would reject a file path for invalid characters

#### Testing instructions

1. Run tests `yarn test-client client/lib/validation/test/file-path.ts`
2. Navigate to `/settings/:siteSlug?host=generic` on the branch in Calypso Green for a site without credentials already given.
3. Input incorrect values to the path and see how it handles incorrect input.
4. Verify a "URL-like" path will work, for example `/app/test.com/public_html`

Related to #56440
