### PR TITLE
VideoPress: Update plan upgrade nudge link for Jetpack

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -31,7 +31,8 @@ import {
 	isKeyringConnectionsFetching,
 	getKeyringConnectionsByName,
 } from 'calypso/state/sharing/keyring/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MediaLibraryExternalHeader from './external-media-header';
 import MediaLibraryHeader from './header';
 import MediaLibraryList from './list';
@@ -133,7 +134,7 @@ export class MediaLibraryContent extends React.Component {
 	}
 
 	renderErrors() {
-		const { mediaValidationErrorTypes, site, translate } = this.props;
+		const { isJetpack, mediaValidationErrorTypes, site, siteSlug, translate } = this.props;
 		return map( groupBy( mediaValidationErrorTypes ), ( occurrences, errorType ) => {
 			let message;
 			let onDismiss;
@@ -199,8 +200,14 @@ export class MediaLibraryContent extends React.Component {
 					);
 					break;
 				case MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT:
-					upgradeNudgeName = 'plan-media-storage-error';
-					upgradeNudgeFeature = 'extra-storage';
+					if ( isJetpack ) {
+						actionText = translate( 'Upgrade Plan' );
+						actionLink = `/checkout/${ siteSlug }/jetpack_videopress`;
+						externalAction = true;
+					} else {
+						upgradeNudgeName = 'plan-media-storage-error';
+						upgradeNudgeFeature = 'extra-storage';
+					}
 					message = translate(
 						'%d file could not be uploaded because you have reached your plan storage limit.',
 						'%d files could not be uploaded because you have reached your plan storage limit.',
@@ -485,6 +492,7 @@ export default withMobileBreakpoint(
 	connect(
 		( state, ownProps ) => {
 			const guidedTourState = getGuidedTourState( state );
+			const selectedSiteId = getSelectedSiteId( state );
 			const mediaValidationErrorTypes = values( ownProps.mediaValidationErrors ).map( first );
 			const shouldPauseGuidedTour =
 				! isEmpty( guidedTourState.tour ) && 0 < size( mediaValidationErrorTypes );
@@ -492,6 +500,7 @@ export default withMobileBreakpoint(
 
 			return {
 				siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
+				isJetpack: isJetpackSite( state, selectedSiteId ),
 				isRequesting: isKeyringConnectionsFetching( state ),
 				displayUploadMediaButton: canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
 				mediaValidationErrorTypes,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* provide a direct link to the VideoPress product in the upgrade "nudge" link

<img width="1129" alt="Screen Shot 2021-09-29 at 11 42 05 AM" src="https://user-images.githubusercontent.com/4081020/135302776-0e27333e-d55f-4d9c-a4b1-efeb5eba5978.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start on a Jetpack site on the Free plan without the VideoPress product purchased
* Upload a video, then upload a 2nd video which should show you the 'exceeded storage space' message
* Click the 'Upgrade Plan' link, it should send you directly to the checkout for the Jetpack VideoPress product
* Test on a non-jetpack site whose storage space is almost full (_see hack below_), upload a file that exceeds your storage limit. The link should point to the `extra-storage` upgrade.
   * one way to force this is to "mess" with the `public.api/rest/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php` endpoint and throw the `rest_upload_user_quota_exceeded` error anywhere in the `callback` method. An example of this can be found in callback already in the jetpack specific loop. Just copy that `output_early` call and `errors` object.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pxWta-Zz-p2