### PR TITLE
Reader: Launch the comprehensive Reader sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -139,95 +139,8 @@ export class ReaderSidebar extends Component {
 		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_like_activity_clicked' );
 	};
 
-	renderForRegularUsers() {
-		const { path, translate } = this.props;
-		return (
-			<SidebarMenu>
-				<QueryReaderLists />
-				<QueryReaderTeams />
-				<QueryReaderOrganizations />
-
-				<SidebarItem
-					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
-						'sidebar-streams__following': true,
-					} ) }
-					label={ translate( 'Followed Sites' ) }
-					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
-					materialIcon="check_circle"
-					link="/read"
-				/>
-
-				<li>
-					<ReaderSidebarOrganizations organizations={ this.props.organizations } path={ path } />
-				</li>
-
-				<SidebarItem
-					className={ ReaderSidebarHelper.itemLinkClass( '/read/conversations', path, {
-						'sidebar-streams__conversations': true,
-					} ) }
-					label={ translate( 'Conversations' ) }
-					onNavigate={ this.handleReaderSidebarConversationsClicked }
-					materialIcon="question_answer"
-					link="/read/conversations"
-				/>
-
-				{ isDiscoverEnabled() && (
-					<SidebarItem
-						className={ ReaderSidebarHelper.itemLinkClass( '/discover', path, {
-							'sidebar-streams__discover': true,
-						} ) }
-						label={ translate( 'Discover' ) }
-						onNavigate={ this.handleReaderSidebarDiscoverClicked }
-						icon="my-sites"
-						link="/discover"
-					/>
-				) }
-
-				<SidebarItem
-					label={ translate( 'Search' ) }
-					onNavigate={ this.handleReaderSidebarSearchClicked }
-					materialIcon="search"
-					link="/read/search"
-					className={ ReaderSidebarHelper.itemLinkClass( '/read/search', path, {
-						'sidebar-streams__search': true,
-					} ) }
-				/>
-
-				<SidebarItem
-					label={ translate( 'My Likes' ) }
-					onNavigate={ this.handleReaderSidebarLikeActivityClicked }
-					materialIcon="star_border"
-					link="/activities/likes"
-					className={ ReaderSidebarHelper.itemLinkClass( '/activities/likes', path, {
-						'sidebar-activity__likes': true,
-					} ) }
-				/>
-
-				{ ( this.props.subscribedLists?.length > 0 || isEnabled( 'reader/list-management' ) ) && (
-					<ReaderSidebarLists
-						lists={ this.props.subscribedLists }
-						path={ path }
-						isOpen={ this.props.isListsOpen }
-						onClick={ this.props.toggleListsVisibility }
-						currentListOwner={ this.state.currentListOwner }
-						currentListSlug={ this.state.currentListSlug }
-					/>
-				) }
-
-				<ReaderSidebarTags
-					tags={ this.props.followedTags }
-					path={ path }
-					isOpen={ this.props.isTagsOpen }
-					onClick={ this.props.toggleTagsVisibility }
-					onFollowTag={ this.highlightNewTag }
-					currentTag={ this.state.currentTag }
-				/>
-			</SidebarMenu>
-		);
-	}
-
-	renderForAutomattic() {
-		const { path, translate } = this.props;
+	renderSidebar() {
+		const { path, translate, teams } = this.props;
 		return (
 			<SidebarMenu>
 				<QueryReaderLists />
@@ -273,16 +186,17 @@ export class ReaderSidebar extends Component {
 					materialIcon="question_answer"
 					link="/read/conversations"
 				/>
-
-				<SidebarItem
-					className={ ReaderSidebarHelper.itemLinkClass( '/read/conversations/a8c', path, {
-						'sidebar-streams__conversations': true,
-					} ) }
-					label="A8C Conversations"
-					onNavigate={ this.handleReaderSidebarA8cConversationsClicked }
-					link="/read/conversations/a8c"
-					customIcon={ <A8CConversationsIcon /> }
-				/>
+				{ isAutomatticTeamMember( teams ) && (
+					<SidebarItem
+						className={ ReaderSidebarHelper.itemLinkClass( '/read/conversations/a8c', path, {
+							'sidebar-streams__conversations': true,
+						} ) }
+						label="A8C Conversations"
+						onNavigate={ this.handleReaderSidebarA8cConversationsClicked }
+						link="/read/conversations/a8c"
+						customIcon={ <A8CConversationsIcon /> }
+					/>
+				) }
 
 				<SidebarItem
 					label={ translate( 'My Likes' ) }
@@ -318,14 +232,11 @@ export class ReaderSidebar extends Component {
 	}
 
 	render() {
-		const { teams } = this.props;
 		return (
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
 					<ReaderSidebarNudges />
-
-					{ isAutomatticTeamMember( teams ) && this.renderForAutomattic() }
-					{ ! isAutomatticTeamMember( teams ) && this.renderForRegularUsers() }
+					{ this.renderSidebar() }
 				</SidebarRegion>
 
 				<ReaderSidebarPromo />

--- a/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/index.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
@@ -16,10 +17,22 @@ import ReaderSidebarFollowingItem from './item';
 import '../style.scss';
 
 export class ReaderSidebarFollowedSites extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			sitePage: 1,
+		};
+	}
+
+	static defaultProps = {
+		sitesPerPage: 50,
+	};
+
 	static propTypes = {
 		path: PropTypes.string.isRequired,
 		sites: PropTypes.array,
 		isFollowingOpen: PropTypes.bool,
+		sitesPerPage: PropTypes.number,
 	};
 
 	handleReaderSidebarFollowedSitesClicked = () => {
@@ -45,20 +58,38 @@ export class ReaderSidebarFollowedSites extends Component {
 		);
 	}
 
-	renderSites() {
-		const { sites, path } = this.props;
+	loadMoreSites = () => {
+		const { sitePage } = this.state;
+		const { sites, sitesPerPage } = this.props;
+
+		//If we've reached the end of the set of sites, all sites have loaded
+		if ( sitesPerPage * sitePage >= sites.length ) {
+			return;
+		}
+
+		this.setState( {
+			sitePage: this.state.sitePage + 1,
+		} );
+	};
+
+	renderSites = ( sites ) => {
+		const { path } = this.props;
 		return map(
 			sites,
 			( site ) => site && <ReaderSidebarFollowingItem key={ site.ID } path={ path } site={ site } />
 		);
-	}
+	};
 
 	render() {
-		const { path, sites, translate } = this.props;
+		const { path, translate, sites, sitesPerPage } = this.props;
+		const { sitePage } = this.state;
+		const allSitesLoaded = sitesPerPage * sitePage >= sites.length;
+		const sitesToShow = sites.slice( 0, sitesPerPage * sitePage );
 
-		if ( ! sites ) {
+		if ( ! sitesToShow ) {
 			return null;
 		}
+
 		return (
 			<ExpandableSidebarMenu
 				expanded={ this.props.isFollowingOpen }
@@ -76,7 +107,17 @@ export class ReaderSidebarFollowedSites extends Component {
 				}
 			>
 				{ this.renderAll() }
-				{ this.renderSites() }
+				{ this.renderSites( sitesToShow ) }
+				{ ! allSitesLoaded && (
+					<Button
+						plain
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="sidebar-streams__following-load-more"
+						onClick={ this.loadMoreSites }
+					>
+						{ translate( 'Load more sites' ) }
+					</Button>
+				) }
 			</ExpandableSidebarMenu>
 		);
 	}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -18,15 +18,15 @@
 		box-shadow: none;
 
 		.form-text-input {
-			color: var(--color-sidebar-text);
-			box-shadow: 0 0 1px var(--color-neutral-10);
+			color: var( --color-sidebar-text );
+			box-shadow: 0 0 1px var( --color-neutral-10 );
 			background-color: transparent;
 			padding: 0 8px;
 			margin: 4px 4px 4px 0;
-			font-size: 0.8125rem;
+			font-size: $font-body-small;
 
 			&:focus {
-				box-shadow: 0 0 0 2px var(--color-primary-10);
+				box-shadow: 0 0 0 2px var( --color-primary-10 );
 			}
 
 			&::placeholder {
@@ -98,5 +98,19 @@
 		white-space: nowrap;
 		overflow: hidden;
 		margin-right: 4px;
+	}
+
+	.sidebar-streams__following-load-more {
+		color: var( --color-sidebar-text-alternative );
+		cursor: pointer;
+		font-size: $font-body-extra-small;
+		text-align: center;
+		margin-top: 15px;
+		padding: 10px 12px;
+		width: 100%;
+
+		&:hover {
+			color: var( --color-sidebar-menu-hover-text );
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Consolidate Reader sidebars to add collapsible menus with site lists for all users.
* Add "Load more sites" button for users with more than 50 site feeds in their Followed Sites

**Before**
<img width="325" alt="Screen Shot 2021-09-29 at 12 00 56 PM" src="https://user-images.githubusercontent.com/2124984/135308792-47209ff8-36a6-4106-aaa2-aa6932bbc1f0.png">

**After**
<img width="315" alt="Screen Shot 2021-09-29 at 12 01 21 PM" src="https://user-images.githubusercontent.com/2124984/135308825-aa261dd3-d98f-4517-8c68-4909723b9b43.png">


#### Testing instructions

* Switch to this PR, navigate to `/read` on a user account that is *not* your Automattic account
* You should see a full sidebar with a collapsible menu of Followed Sites
* On an account with more than 50 subscriptions, ensure you can access all sites in the Followed Sites list by clicking the "Load more sites" button.
* Everything should still work :)
* Switch to your Automattic account 
* You should see A8C-specific resources (Conversations and Followed Sites) alongside the other options