### PR TITLE
InlineSupportLink: add default Tracks click event

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -146,7 +146,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 			const analyticsEvents = [
 				...[
 					recordTracksEvent( 'calypso_inlinesupportlink_click', {
-						support_context: supportContext,
+						support_context: supportContext || null,
 						support_link: supportLink,
 					} ),
 				],

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -136,7 +136,7 @@ const mapStateToProps = ( state, ownProps ) => {
 };
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {
-	const { tracksEvent, tracksOptions, statsGroup, statsName } = ownProps;
+	const { tracksEvent, tracksOptions, statsGroup, statsName, supportContext } = ownProps;
 	return {
 		openDialog: ( event, supportPostId, supportLink ) => {
 			if ( ! supportPostId ) {
@@ -144,6 +144,12 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 			}
 			event.preventDefault();
 			const analyticsEvents = [
+				...[
+					recordTracksEvent( 'calypso_inlinesupportlink_click', {
+						support_context: supportContext,
+						support_link: supportLink,
+					} ),
+				],
 				...( tracksEvent ? [ recordTracksEvent( tracksEvent, tracksOptions ) ] : [] ),
 				...( statsGroup && statsName ? [ bumpStat( statsGroup, statsName ) ] : [] ),
 			];


### PR DESCRIPTION
The `InlineSupportLink` component allows its callers to pass a `tracksEvent` prop that will record a custom event when clicked, but no common event is shared by the component by default. This adds the `calypso_inlinesupportlink_click` event with props for both the `support_context` slug and the `support_link` that's shown.

**To test:**
- run `localStorage.setItem('debug', 'calypso:analytics*');` in your console, refresh the page, and filter by "recording event"
- visit a page with an inline support link (e.g. Purchases or Podcast Settings)
- click the link and verify that a `calypso_inlinesupportlink_click` event is fired with the appropriate props