### PR TITLE
Emails: Track events for Professional Email and Google Workspaces

### DIFF
--- a/client/lib/gsuite/constants.js
+++ b/client/lib/gsuite/constants.js
@@ -35,3 +35,4 @@ export const GOOGLE_WORKSPACE_PRODUCT_FAMILY = 'Google Workspace';
  */
 export const GOOGLE_WORKSPACE_PRODUCT_TYPE = 'google-workspace';
 export const GSUITE_PRODUCT_TYPE = 'gsuite';
+export const GOOGLE_PROVIDER_NAME = 'google';

--- a/client/lib/titan/constants.js
+++ b/client/lib/titan/constants.js
@@ -5,4 +5,5 @@ export const TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_INTERNAL_FORWARDING =
 export const TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL = 'create_email_account';
 export const TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP = 'get_mobile_app';
 export const TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL_DATA = 'import_email_data';
+export const TITAN_PROVIDER_NAME = 'titan';
 export { TITAN_MAIL_MONTHLY_SLUG } from '@automattic/calypso-products';

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -41,6 +41,7 @@ import {
 	getTitanEmailUrl,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
+import { recordEmailActionTrackEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { removeEmailForward } from 'calypso/state/email-forwarding/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
@@ -74,6 +75,13 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			title: translate( 'View Mail', {
 				comment: 'View the Email application (i.e. the webmail) for Titan',
 			} ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'webmail',
+					context: 'email-management-menu',
+					provider: 'titan',
+				} );
+			},
 		},
 		{
 			href: getTitanCalendarlUrl( email ),
@@ -82,6 +90,13 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			title: translate( 'View Calendar', {
 				comment: 'View the Calendar application for Titan',
 			} ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'calendar',
+					context: 'email-management-menu',
+					provider: 'titan',
+				} );
+			},
 		},
 		{
 			href: getTitanContactsUrl( email ),
@@ -90,6 +105,13 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			title: translate( 'View Contacts', {
 				comment: 'View the Contacts application for Titan',
 			} ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'contacts',
+					context: 'email-management-menu',
+					provider: 'titan',
+				} );
+			},
 		},
 		{
 			isInternalLink: true,
@@ -130,6 +152,13 @@ const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 			image: gmailIcon,
 			imageAltText: translate( 'Gmail icon' ),
 			title: translate( 'View Gmail' ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'webmail',
+					context: 'email-management-menu',
+					provider: 'google',
+				} );
+			},
 		},
 		...( isEmailUserAdmin( mailbox )
 			? [
@@ -138,6 +167,13 @@ const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 						image: googleAdminIcon,
 						imageAltText: translate( 'Google Admin icon' ),
 						title: translate( 'View Admin' ),
+						onClick: () => {
+							recordEmailActionTrackEvent( {
+								app: 'admin',
+								context: 'email-management-menu',
+								provider: 'google',
+							} );
+						},
 					},
 			  ]
 			: [] ),
@@ -146,30 +182,65 @@ const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 			image: googleCalendarIcon,
 			imageAltText: translate( 'Google Calendar icon' ),
 			title: translate( 'View Calendar' ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'calendar',
+					context: 'email-management-menu',
+					provider: 'google',
+				} );
+			},
 		},
 		{
 			href: getGoogleDocsUrl( email ),
 			image: googleDocsIcon,
 			imageAltText: translate( 'Google Docs icon' ),
 			title: translate( 'View Docs' ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'docs',
+					context: 'email-management-menu',
+					provider: 'google',
+				} );
+			},
 		},
 		{
 			href: getGoogleDriveUrl( email ),
 			image: googleDriveIcon,
 			imageAltText: translate( 'Google Drive icon' ),
 			title: translate( 'View Drive' ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'drive',
+					context: 'email-management-menu',
+					provider: 'google',
+				} );
+			},
 		},
 		{
 			href: getGoogleSheetsUrl( email ),
 			image: googleSheetsIcon,
 			imageAltText: translate( 'Google Sheets icon' ),
 			title: translate( 'View Sheets' ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					provider: 'google',
+					app: 'sheets',
+					context: 'email-management-menu',
+				} );
+			},
 		},
 		{
 			href: getGoogleSlidesUrl( email ),
 			image: googleSlidesIcon,
 			imageAltText: translate( 'Google Slides icon' ),
 			title: translate( 'View Slides' ),
+			onClick: () => {
+				recordEmailActionTrackEvent( {
+					app: 'slides',
+					context: 'email-management-menu',
+					provider: 'google',
+				} );
+			},
 		},
 	];
 };

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -41,7 +41,7 @@ import {
 	getTitanEmailUrl,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
-import { recordEmailActionTrackEvent } from 'calypso/my-sites/email/email-management/home/utils';
+import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { removeEmailForward } from 'calypso/state/email-forwarding/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
@@ -53,6 +53,26 @@ const removeEmailForwardMailbox = ( { dispatch, mailbox } ) => {
 	} );
 
 	dispatch( removeEmailForward( mailbox.domain, mailbox.mailbox ) );
+};
+
+const getGoogleClickHandler = ( app ) => {
+	return () => {
+		recordEmailAppLaunchEvent( {
+			app,
+			context: 'email-management-menu',
+			provider: 'google',
+		} );
+	};
+};
+
+const getTitanClickHandler = ( app ) => {
+	return () => {
+		recordEmailAppLaunchEvent( {
+			app,
+			context: 'email-management-menu',
+			provider: 'titan',
+		} );
+	};
 };
 
 /**
@@ -75,13 +95,7 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			title: translate( 'View Mail', {
 				comment: 'View the Email application (i.e. the webmail) for Titan',
 			} ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'webmail',
-					context: 'email-management-menu',
-					provider: 'titan',
-				} );
-			},
+			onClick: getTitanClickHandler( 'webmail' ),
 		},
 		{
 			href: getTitanCalendarlUrl( email ),
@@ -90,13 +104,7 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			title: translate( 'View Calendar', {
 				comment: 'View the Calendar application for Titan',
 			} ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'calendar',
-					context: 'email-management-menu',
-					provider: 'titan',
-				} );
-			},
+			onClick: getTitanClickHandler( 'calendar' ),
 		},
 		{
 			href: getTitanContactsUrl( email ),
@@ -105,13 +113,7 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			title: translate( 'View Contacts', {
 				comment: 'View the Contacts application for Titan',
 			} ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'contacts',
-					context: 'email-management-menu',
-					provider: 'titan',
-				} );
-			},
+			onClick: getTitanClickHandler( 'contacts' ),
 		},
 		{
 			isInternalLink: true,
@@ -152,13 +154,7 @@ const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 			image: gmailIcon,
 			imageAltText: translate( 'Gmail icon' ),
 			title: translate( 'View Gmail' ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'webmail',
-					context: 'email-management-menu',
-					provider: 'google',
-				} );
-			},
+			onClick: getGoogleClickHandler( 'webmail' ),
 		},
 		...( isEmailUserAdmin( mailbox )
 			? [
@@ -167,13 +163,7 @@ const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 						image: googleAdminIcon,
 						imageAltText: translate( 'Google Admin icon' ),
 						title: translate( 'View Admin' ),
-						onClick: () => {
-							recordEmailActionTrackEvent( {
-								app: 'admin',
-								context: 'email-management-menu',
-								provider: 'google',
-							} );
-						},
+						onClick: getGoogleClickHandler( 'admin' ),
 					},
 			  ]
 			: [] ),
@@ -182,65 +172,35 @@ const getGSuiteMenuItems = ( { account, mailbox, translate } ) => {
 			image: googleCalendarIcon,
 			imageAltText: translate( 'Google Calendar icon' ),
 			title: translate( 'View Calendar' ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'calendar',
-					context: 'email-management-menu',
-					provider: 'google',
-				} );
-			},
+			onClick: getGoogleClickHandler( 'calendar' ),
 		},
 		{
 			href: getGoogleDocsUrl( email ),
 			image: googleDocsIcon,
 			imageAltText: translate( 'Google Docs icon' ),
 			title: translate( 'View Docs' ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'docs',
-					context: 'email-management-menu',
-					provider: 'google',
-				} );
-			},
+			onClick: getGoogleClickHandler( 'docs' ),
 		},
 		{
 			href: getGoogleDriveUrl( email ),
 			image: googleDriveIcon,
 			imageAltText: translate( 'Google Drive icon' ),
 			title: translate( 'View Drive' ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'drive',
-					context: 'email-management-menu',
-					provider: 'google',
-				} );
-			},
+			onClick: getGoogleClickHandler( 'drive' ),
 		},
 		{
 			href: getGoogleSheetsUrl( email ),
 			image: googleSheetsIcon,
 			imageAltText: translate( 'Google Sheets icon' ),
 			title: translate( 'View Sheets' ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					provider: 'google',
-					app: 'sheets',
-					context: 'email-management-menu',
-				} );
-			},
+			onClick: getGoogleClickHandler( 'sheets' ),
 		},
 		{
 			href: getGoogleSlidesUrl( email ),
 			image: googleSlidesIcon,
 			imageAltText: translate( 'Google Slides icon' ),
 			title: translate( 'View Slides' ),
-			onClick: () => {
-				recordEmailActionTrackEvent( {
-					app: 'slides',
-					context: 'email-management-menu',
-					provider: 'google',
-				} );
-			},
+			onClick: getGoogleClickHandler( 'slides' ),
 		},
 	];
 };

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -20,7 +20,7 @@ import {
 	getTitanSubscriptionId,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 
 export function getNumberOfMailboxesText( domain ) {

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -1,4 +1,5 @@
 import { translate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	hasGoogleAccountTOSWarning,
@@ -20,7 +21,6 @@ import {
 	getTitanSubscriptionId,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 
 export function getNumberOfMailboxesText( domain ) {

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -6,7 +6,6 @@ import {
 	hasUnusedMailboxWarning,
 	hasUnverifiedEmailForward,
 } from 'calypso/lib/emails';
-import { isDevelopmentMode } from 'calypso/lib/explat/internals/misc';
 import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
@@ -171,16 +170,14 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 }
 
 /**
- * Tracks an event for the key 'calypso_email_app_launch'. It will not track events from development mode.
+ * Tracks an event for the key 'calypso_email_app_launch'.
  *
  * @param {app, context, provider} - app/context/provider should be string and must be provided.
  */
-export function recordEmailActionTrackEvent( { app, context, provider } ) {
-	if ( ! isDevelopmentMode ) {
-		recordTracksEvent( 'calypso_email_app_launch', {
-			app,
-			context,
-			provider,
-		} );
-	}
+export function recordEmailAppLaunchEvent( { app, context, provider } ) {
+	recordTracksEvent( 'calypso_email_app_launch', {
+		app,
+		context,
+		provider,
+	} );
 }

--- a/client/my-sites/email/email-management/home/utils.js
+++ b/client/my-sites/email/email-management/home/utils.js
@@ -5,6 +5,7 @@ import {
 	hasUnusedMailboxWarning,
 	hasUnverifiedEmailForward,
 } from 'calypso/lib/emails';
+import { isDevelopmentMode } from 'calypso/lib/explat/internals/misc';
 import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
@@ -19,6 +20,7 @@ import {
 	getTitanSubscriptionId,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 
 export function getNumberOfMailboxesText( domain ) {
@@ -166,4 +168,19 @@ export function resolveEmailPlanStatus( domain, emailAccount, isLoadingEmails ) 
 	}
 
 	return activeStatus;
+}
+
+/**
+ * Tracks an event for the key 'calypso_email_app_launch'. It will not track events from development mode.
+ *
+ * @param {app, context, provider} - app/context/provider should be string and must be provided.
+ */
+export function recordEmailActionTrackEvent( { app, context, provider } ) {
+	if ( ! isDevelopmentMode ) {
+		recordTracksEvent( 'calypso_email_app_launch', {
+			app,
+			context,
+			provider,
+		} );
+	}
 }

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -2,7 +2,7 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
@@ -18,7 +18,7 @@ import {
 import { getGmailUrl } from 'calypso/lib/gsuite';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import { recordEmailActionTrackEvent } from 'calypso/my-sites/email/email-management/home/utils';
+import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ProgressLine from './progress-line';
 
@@ -55,7 +55,7 @@ const MailboxItemIcon = ( { mailbox } ) => {
 	return null;
 };
 
-const getProvider = ( { mailbox } ) => {
+const getProvider = ( mailbox ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
 		return 'titan';
 	}
@@ -71,9 +71,9 @@ const getProvider = ( { mailbox } ) => {
 	return null;
 };
 
-const trackEvent = ( { mailbox, app, context } ) => {
+const tracksEvent = ( { mailbox, app, context } ) => {
 	const provider = getProvider( mailbox );
-	recordEmailActionTrackEvent( {
+	recordEmailAppLaunchEvent( {
 		app,
 		context,
 		provider,
@@ -92,7 +92,7 @@ const MailboxItem = ( { mailbox } ) => {
 	return (
 		<Card
 			onClick={ () =>
-				trackEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
+				tracksEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
 			}
 			className="mailbox-selection-list__item"
 			href={ getExternalUrl( mailbox ) }

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -16,7 +16,9 @@ import {
 	isTitanMailAccount,
 } from 'calypso/lib/emails';
 import { getGmailUrl } from 'calypso/lib/gsuite';
+import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
+import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -57,11 +59,11 @@ const MailboxItemIcon = ( { mailbox } ) => {
 
 const getProvider = ( mailbox ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		return 'titan';
+		return TITAN_PROVIDER_NAME;
 	}
 
 	if ( isGoogleEmailAccount( mailbox ) ) {
-		return 'google';
+		return GOOGLE_PROVIDER_NAME;
 	}
 
 	if ( isEmailForwardAccount( mailbox ) ) {
@@ -71,7 +73,7 @@ const getProvider = ( mailbox ) => {
 	return null;
 };
 
-const tracksEvent = ( { mailbox, app, context } ) => {
+const trackAppLaunchEvent = ( { mailbox, app, context } ) => {
 	const provider = getProvider( mailbox );
 	recordEmailAppLaunchEvent( {
 		app,
@@ -92,7 +94,7 @@ const MailboxItem = ( { mailbox } ) => {
 	return (
 		<Card
 			onClick={ () =>
-				tracksEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
+				trackAppLaunchEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
 			}
 			className="mailbox-selection-list__item"
 			href={ getExternalUrl( mailbox ) }

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -18,9 +18,13 @@ import {
 import { getGmailUrl } from 'calypso/lib/gsuite';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { recordEmailActionTrackEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ProgressLine from './progress-line';
 
+/**
+ * Import styles
+ */
 import './style.scss';
 
 const getExternalUrl = ( mailbox ) => {
@@ -51,6 +55,31 @@ const MailboxItemIcon = ( { mailbox } ) => {
 	return null;
 };
 
+const getProvider = ( { mailbox } ) => {
+	if ( isTitanMailAccount( mailbox ) ) {
+		return 'titan';
+	}
+
+	if ( isGoogleEmailAccount( mailbox ) ) {
+		return 'google';
+	}
+
+	if ( isEmailForwardAccount( mailbox ) ) {
+		return 'forward';
+	}
+
+	return null;
+};
+
+const trackEvent = ( { mailbox, app, context } ) => {
+	const provider = getProvider( mailbox );
+	recordEmailActionTrackEvent( {
+		app,
+		context,
+		provider,
+	} );
+};
+
 MailboxItemIcon.propType = {
 	mailbox: PropTypes.object.isRequired,
 };
@@ -62,6 +91,9 @@ const MailboxItem = ( { mailbox } ) => {
 
 	return (
 		<Card
+			onClick={ () =>
+				trackEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
+			}
 			className="mailbox-selection-list__item"
 			href={ getExternalUrl( mailbox ) }
 			target="external"
@@ -78,6 +110,7 @@ const MailboxItem = ( { mailbox } ) => {
 
 MailboxItem.propType = {
 	mailbox: PropTypes.object.isRequired,
+	key: PropTypes.string,
 };
 
 const NewMailboxUpsell = () => {

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -6,6 +6,7 @@ import { ThankYou } from 'calypso/components/thank-you';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
+import { recordEmailActionTrackEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
 	emailManagementTitanControlPanelRedirect,
@@ -73,7 +74,17 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 					"Access your email on the go with Titan's Android and iOS apps."
 				),
 				stepCta: (
-					<FullWidthButton href={ titanControlPanelUrl } target="_blank">
+					<FullWidthButton
+						href={ titanControlPanelUrl }
+						target="_blank"
+						onClick={ () => {
+							recordEmailActionTrackEvent( {
+								provider: 'titan',
+								app: 'app',
+								context: 'checkout-thank-you',
+							} );
+						} }
+					>
 						{ translate( 'Get app' ) }
 						<Gridicon className="titan-set-up-thank-you__icon-external" icon="external" />
 					</FullWidthButton>
@@ -86,7 +97,18 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 					'Add or delete mailboxes, migrate existing emails, configure a catch-all email, and much more.'
 				),
 				stepCta: (
-					<FullWidthButton href={ emailManagementPath }>{ translate( 'Manage' ) }</FullWidthButton>
+					<FullWidthButton
+						href={ emailManagementPath }
+						onClick={ () => {
+							recordEmailActionTrackEvent( {
+								provider: 'titan',
+								app: 'manage',
+								context: 'checkout-thank-you',
+							} );
+						} }
+					>
+						{ translate( 'Manage' ) }
+					</FullWidthButton>
 				),
 			},
 		],

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -6,7 +6,7 @@ import { ThankYou } from 'calypso/components/thank-you';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
-import { recordEmailActionTrackEvent } from 'calypso/my-sites/email/email-management/home/utils';
+import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
 	emailManagementTitanControlPanelRedirect,
@@ -61,7 +61,18 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 				stepTitle: translate( 'Access your inbox' ),
 				stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
 				stepCta: (
-					<FullWidthButton href={ getTitanEmailUrl( emailAddress ) } primary target="_blank">
+					<FullWidthButton
+						href={ getTitanEmailUrl( emailAddress ) }
+						primary
+						target="_blank"
+						onClick={ () => {
+							recordEmailAppLaunchEvent( {
+								provider: 'titan',
+								app: 'webmail',
+								context: 'checkout-thank-you',
+							} );
+						} }
+					>
 						{ translate( 'Go to Inbox' ) }
 						<Gridicon className="titan-set-up-thank-you__icon-external" icon="external" />
 					</FullWidthButton>
@@ -78,7 +89,7 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 						href={ titanControlPanelUrl }
 						target="_blank"
 						onClick={ () => {
-							recordEmailActionTrackEvent( {
+							recordEmailAppLaunchEvent( {
 								provider: 'titan',
 								app: 'app',
 								context: 'checkout-thank-you',
@@ -97,18 +108,7 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 					'Add or delete mailboxes, migrate existing emails, configure a catch-all email, and much more.'
 				),
 				stepCta: (
-					<FullWidthButton
-						href={ emailManagementPath }
-						onClick={ () => {
-							recordEmailActionTrackEvent( {
-								provider: 'titan',
-								app: 'manage',
-								context: 'checkout-thank-you',
-							} );
-						} }
-					>
-						{ translate( 'Manage' ) }
-					</FullWidthButton>
+					<FullWidthButton href={ emailManagementPath }>{ translate( 'Manage' ) }</FullWidthButton>
 				),
 			},
 		],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes in this pull request are meant to add record stats on apps launch.

#### Testing instructions

Have a Professional Email inbox account and a Google Workspace account, If you don't have just get one under (you need to have a domain purchased)

The Track Event that will be recorded is under the key: `calypso_email_app_launch` and it will record the following custom props:

- App
- Context
- Provider

### Professional Email
For the Professional Email inbox, the values will be the following ones:

The events that will be recorded for the following actions (View Mail, View Calendar, View Contacts), under the email management page (elipsis menu), will be the following ones:
calypso_email_app_launch (app: **webmail**, provider: **titan**, context: **email-management-menu**)
calypso_email_app_launch (app: **calendar**, provider: **titan**, context: **email-management-menu**)
calypso_email_app_launch (app: **contacts**, provider: **titan**, context: **email-management-menu**)

The events that will be recorded for the following action in the mailbox (click on the inbox) page will be:
calypso_email_app_launch (app: **webmail**, provider: **titan**, context: **inbox-mailbox-selection**)

The events that will be recorded for the following action (click in Get App) in the checkout thank you page will be:
calypso_email_app_launch (app: **app**, provider: **titan**, context: **checkout-thank-you**)
calypso_email_app_launch (app: **webmail**, provider: **titan**, context: **checkout-thank-you**)

### Google Workspace
For Google Workspace inbox, the values will be the following ones:

The events that will be recorded for the following actions (View Mail, View Calendar, View Contacts), under the email management page (elipsis menu), will be the following ones:
calypso_email_app_launch (app: **webmail**, provider: **google**, context: **email-management-menu**)
calypso_email_app_launch (app: **calendar**, provider: **google**, context: **email-management-menu**)
calypso_email_app_launch (app: **admin**, provider: **google**, context: **email-management-menu**)
calypso_email_app_launch (app: **docs**, provider: **google**, context: **email-management-menu**)
calypso_email_app_launch (app: **drive**, provider: **google**, context: **email-management-menu**)
calypso_email_app_launch (app: **sheets**, provider: **google**, context: **email-management-menu**)

The events that will be recorded for the following action in the mailbox (click on the inbox) page will be:
calypso_email_app_launch (app: **webmail**, provider: **google**, context: **inbox-mailbox-selection**)

### Remarks

To show that the events are recorded, go to Mission Control, use the Track tool to look for the event: **calypso_email_app_launch**

Related to {1200182182542585-as-1201064348369967}