### PR TITLE
Playwright: update Gutenboarding: Language flow

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
+					for i in {1..200}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-gutenboarding__language.ts; done
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -637,7 +637,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): BuildType 
 					export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL%/}\"}"
 					export DEBUG=pw:api
 
-					for i in {1..200}; do xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% specs/specs-playwright/wp-gutenboarding__language.ts; done
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-pr
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -98,10 +98,6 @@ export class GutenboardingFlow {
 	 */
 	async getSiteTitleLabel(): Promise< string > {
 		const elementHandle = await this.page.waitForSelector( selectors.siteTitleLabel );
-		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
-			elementHandle.waitForElementState( 'stable' ),
-		] );
 		return await elementHandle.innerText();
 	}
 
@@ -266,7 +262,10 @@ export class GutenboardingFlow {
 		// Clicking on a language button triggers a navigation to a URL containing
 		// the ISO 639-1 code eg. /new/ja.
 		await Promise.all( [
-			this.page.waitForNavigation(),
+			this.page.waitForResponse(
+				( response ) =>
+					response.status() === 200 && response.url().includes( `details?locale=${ target }` )
+			),
 			this.page.click( selectors.languageButton( target ) ),
 		] );
 	}

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -18,6 +18,7 @@ const selectors = {
 	// Start your website
 	siteTitle: '.acquire-intent-text-input__input',
 	siteTitleLabel: 'label.site-title__input-label',
+	siteIsCalled: 'label[data-e2e-string="My site is called"]',
 
 	// Domain
 	domainSearch: 'input[placeholder="Search for a domain"]',
@@ -97,7 +98,10 @@ export class GutenboardingFlow {
 	 */
 	async getSiteTitleLabel(): Promise< string > {
 		const elementHandle = await this.page.waitForSelector( selectors.siteTitleLabel );
-		await elementHandle.waitForElementState( 'stable' );
+		await Promise.all( [
+			this.page.waitForLoadState( 'networkidle' ),
+			elementHandle.waitForElementState( 'stable' ),
+		] );
 		return await elementHandle.innerText();
 	}
 

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -259,9 +259,10 @@ export class GutenboardingFlow {
 	 */
 	async switchLanguage( target: string ): Promise< void > {
 		await this.clickLanguagePicker();
-		// Clicking on a language button triggers a navigation to a URL containing
-		// the ISO 639-1 code eg. /new/ja.
 		await Promise.all( [
+			// Wait for the request response to complete.
+			// This request runs last when selecting a new language and is responsible for obtaining
+			// the translated strings.
 			this.page.waitForResponse(
 				( response ) =>
 					response.status() === 200 && response.url().includes( `details?locale=${ target }` )

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
@@ -2,13 +2,7 @@
  * @group calypso-pr
  */
 
-import {
-	setupHooks,
-	DataHelper,
-	LoginFlow,
-	SidebarComponent,
-	GutenboardingFlow,
-} from '@automattic/calypso-e2e';
+import { setupHooks, DataHelper, GutenboardingFlow } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
 describe( DataHelper.createSuiteTitle( 'Gutenboarding: Language' ), function () {
@@ -20,15 +14,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Language' ), function () 
 	} );
 
 	it( 'Log in', async function () {
-		const loginFlow = new LoginFlow( page, 'defaultUser' );
-		await loginFlow.logIn();
-	} );
-
-	it( 'Click on Add Site on Sidebar', async function () {
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.switchSite();
-		await sidebarComponent.addSite();
-
+		await page.goto( DataHelper.getCalypsoURL( 'new' ) );
 		gutenboardingFlow = new GutenboardingFlow( page );
 	} );
 

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
@@ -14,7 +14,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Language' ), function () 
 		page = args.page;
 	} );
 
-	it( 'Log in', async function () {
+	it( 'Navigate to /new', async function () {
 		await page.goto( DataHelper.getCalypsoURL( 'new' ) );
 		gutenboardingFlow = new GutenboardingFlow( page );
 	} );

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__language.ts
@@ -1,5 +1,6 @@
 /**
  * @group calypso-pr
+ * @group gutenberg
  */
 
 import { setupHooks, DataHelper, GutenboardingFlow } from '@automattic/calypso-e2e';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes updates the Gutenboarding: Flow test with reliability and speed fixes.

Key changes:
- remove requirement to log into Calypso, as the `/new` endpoint is available for non-logged in users.
- add `waitForLoadState: 'networkidle'` before obtaining the text string from Aquire Intent.

#### Testing instructions

- [x] normal test
  - [x] mobile
  - [x] desktop
- [x] stress test
  - [x] mobile
  - [x] desktop

Related to #
