### PR TITLE
Jetpack Sale Banner: update banner style to be more appealing

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -56,7 +56,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 						<div>
 							<b>{ translate( 'End of Summer Sale!' ) }</b>
 							&nbsp;
-							{ translate( 'Get %(discount)d%% off your first year of Jetpack', {
+							{ translate( 'Get %(discount)d%% off your first year of Jetpack.', {
 								args: { discount: coupon.discount },
 							} ) }
 						</div>

--- a/client/jetpack-cloud/sections/pricing/sale-banner/style.scss
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/style.scss
@@ -8,7 +8,7 @@
 	padding: 1rem 3rem 1rem 2rem;
 	margin: -47px -32px 47px; // Undo the padding-top set by .layout__content
 	font-size: 1rem;
-	color: var( --studio-white );
+	color: var( --studio-black );
 	background-color: var( --studio-jetpack-green-30 );
 
 	// Breakpoint taken from jetpack.com, not standard in Calypso

--- a/client/jetpack-cloud/sections/pricing/sale-banner/style.scss
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/style.scss
@@ -9,7 +9,7 @@
 	margin: -47px -32px 47px; // Undo the padding-top set by .layout__content
 	font-size: 1rem;
 	color: var( --studio-white );
-	background-color: #1f2420;
+	background-color: var( --studio-jetpack-green-30 );
 
 	// Breakpoint taken from jetpack.com, not standard in Calypso
 	@media ( min-width: 661px ) {
@@ -45,20 +45,13 @@
 	&__countdown-timer {
 		margin-left: auto;
 		white-space: nowrap;
-		color: var( --studio-white );
-		opacity: 0.7;
+		color: var( --studio-black );
 	}
 
 	&__close-button {
 		position: absolute;
 		right: 1rem;
-		color: var( --studio-white );
-		opacity: 0.7;
+		color: var( --studio-black );
 		cursor: pointer;
-
-		&:hover,
-		&:focus {
-			opacity: 1;
-		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the style according to feedback receveid. More context: p1632937930113500-slack-C0D96691V
![image](https://user-images.githubusercontent.com/5714212/135330821-f40d8bc6-018a-46bb-8580-fb6d0e5699f9.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR locally or click on the live link for Jetpack Cloud
* If you have this PR locally, run `yarn start-jetpack-cloud`
* Load up http://jetpack.cloud.localhost:3000/pricing
* Make sure it looks like the screenshot above