### PR TITLE
Wire in placeholder ProfessionalEmailUpsell component

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -34,6 +34,7 @@ import UpsellNudge, {
 	BUSINESS_PLAN_UPGRADE_UPSELL,
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
+	PROFESSIONAL_EMAIL_UPSELL,
 } from './upsell-nudge';
 import { getDomainOrProductFromContext } from './utils';
 
@@ -252,6 +253,9 @@ export function upsellNudge( context, next ) {
 			default:
 				upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
 		}
+	} else if ( context.path.includes( 'offer-professional-email' ) ) {
+		upsellType = PROFESSIONAL_EMAIL_UPSELL;
+		upgradeItem = null;
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -161,6 +161,15 @@ export default function () {
 	}
 
 	page(
+		'/checkout/offer-professional-email/:receiptId/:site',
+		redirectLoggedOut,
+		siteSelection,
+		upsellNudge,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/checkout/:domainOrProduct',
 		redirectLoggedOut,
 		siteSelection,

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -21,6 +21,7 @@ import {
 	isContactValidationResponseValid,
 	getTaxValidationResult,
 } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
+import ProfessionalEmailUpsell from 'calypso/my-sites/checkout/upsell-nudge/professional-email-upsell';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import {
 	retrieveSignupDestination,
@@ -67,6 +68,7 @@ const debug = debugFactory( 'calypso:upsell-nudge' );
 export const CONCIERGE_QUICKSTART_SESSION = 'concierge-quickstart-session';
 export const CONCIERGE_SUPPORT_SESSION = 'concierge-support-session';
 export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
+export const PROFESSIONAL_EMAIL_UPSELL = 'professional-email-upsell';
 
 export class UpsellNudge extends React.Component {
 	static propTypes = {
@@ -297,6 +299,9 @@ export class UpsellNudge extends React.Component {
 						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
 					/>
 				);
+
+			case PROFESSIONAL_EMAIL_UPSELL:
+				return <ProfessionalEmailUpsell />;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ProfessionalEmailUpsell = () => {
+	return (
+		<div>
+			<span>Professional Email Upsell placeholder</span>
+		</div>
+	);
+};
+
+export default ProfessionalEmailUpsell;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds in a placeholder `ProfessionalEmailUpsell` component and wires it into `/checkout/offer-professional-email/:receiptId/:siteSlug`
* Later PRs will actually build out the content of the new component and wire in more data and dependencies

#### Testing instructions

* Check out and run this branch locally, or access the live branch (see [this comment](https://github.com/Automattic/wp-calypso/pull/56671#issuecomment-930506483) for a link)
* For a site with purchases on it, navigate to Upgrades -> Purchases and then click on the "Billing History" tab
* For one of the items in the list, click on the "View receipt" link
* Look at the URL and note the last two `/`-separated pieces -- these are the site slug and receipt ID (in that order)
* Manually type the following path into the browser location: `/checkout/offer-professional-email/:receiptId/:siteSlug` with `:receiptId` and `:siteSlug` replaced by the two values above (which we use in the reverse order for this URL)
* Verify that you see the "Professional Email Upsell placeholder" text on the screen (as per the screenshot below)

<img width="857" alt="Screenshot 2021-09-29 at 22 04 03" src="https://user-images.githubusercontent.com/3376401/135341194-b2c3b127-43a0-4f25-ba6f-fd48ff7a9915.png">