### PR TITLE
Add "use as backup" checkbox to payment method screen

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -39,6 +39,7 @@ export async function assignNewCardProcessor(
 	{
 		purchase,
 		useForAllSubscriptions,
+		useAsBackupMethod,
 		translate,
 		stripe,
 		stripeConfiguration,
@@ -47,6 +48,7 @@ export async function assignNewCardProcessor(
 	}: {
 		purchase: Purchase | undefined;
 		useForAllSubscriptions?: boolean;
+		useAsBackupMethod?: boolean;
 		translate: ReturnType< typeof useTranslate >;
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
@@ -100,6 +102,7 @@ export async function assignNewCardProcessor(
 			token,
 			stripeConfiguration,
 			useForAllSubscriptions: Boolean( useForAllSubscriptions ),
+			useAsBackupMethod: Boolean( useAsBackupMethod ),
 		} );
 
 		return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -90,6 +90,11 @@ export default function PaymentMethodSelector( {
 		translate( 'Assign this payment method to all of my subscriptions' )
 	);
 
+	const [ useAsBackupMethod, setUseAsBackupMethod ] = useState< boolean >( true );
+	const useAsBackupMethodText = String(
+		translate( 'Use this payment method as a backup on my other subscriptions' )
+	);
+
 	useEffect( () => {
 		if ( stripeLoadingError ) {
 			reduxDispatch( errorNotice( stripeLoadingError ) );
@@ -155,6 +160,19 @@ export default function PaymentMethodSelector( {
 					</FormLabel>
 				) }
 
+				{ true && (
+					<FormLabel className="payment-method-selector__backup-method-checkbox-label">
+						<FormInputCheckbox
+							className="payment-method-selector__backup-method-checkbox"
+							checked={ useAsBackupMethod }
+							onChange={ () => setUseAsBackupMethod( ( isChecked ) => ! isChecked ) }
+							aria-label={ useAsBackupMethodText }
+						/>
+						{ useAsBackupMethodText }
+						<BackupMethodEffectWarning useAsBackupMethod={ useAsBackupMethod } />
+					</FormLabel>
+				) }
+
 				<CheckoutSubmitButton />
 			</Card>
 		</CheckoutProvider>
@@ -179,6 +197,27 @@ function AllSubscriptionsEffectWarning( {
 		<span className="payment-method-selector__all-subscriptions-effect-warning">
 			{ translate(
 				'This card will not be assigned to any subscriptions. You can assign it to a subscription from the subscription page.'
+			) }
+		</span>
+	);
+}
+
+function BackupMethodEffectWarning( { useAsBackupMethod }: { useAsBackupMethod: boolean } ) {
+	const translate = useTranslate();
+
+	if ( useAsBackupMethod ) {
+		return (
+			<span className="payment-method-selector__backup-method-effect-warning">
+				{ translate(
+					'This card may be used as a backup in case the primary payment method on any of your subscriptions fails during a future renewal. This setting can be changed later.'
+				) }
+			</span>
+		);
+	}
+	return (
+		<span className="payment-method-selector__backup-method-effect-warning">
+			{ translate(
+				'This card will not be used as a backup payment method on any other subscriptions. This setting can be changed later.'
 			) }
 		</span>
 	);

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -119,6 +119,7 @@ export default function PaymentMethodSelector( {
 						{
 							purchase,
 							useForAllSubscriptions,
+							useAsBackupMethod,
 							translate,
 							stripe,
 							stripeConfiguration,

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -9,15 +9,18 @@ export async function saveCreditCard( {
 	token,
 	stripeConfiguration,
 	useForAllSubscriptions,
+	useAsBackupMethod,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 	useForAllSubscriptions: boolean;
+	useAsBackupMethod: boolean;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
 		useForAllSubscriptions,
+		useAsBackupMethod,
 	} );
 	const response = await wp.req.post(
 		{
@@ -68,17 +71,21 @@ function getParamsForApi( {
 	stripeConfiguration,
 	purchase,
 	useForAllSubscriptions,
+	useAsBackupMethod,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
 	purchase?: Purchase | undefined;
 	useForAllSubscriptions?: boolean;
+	useAsBackupMethod?: boolean;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
 		paygate_token: cardToken,
 		...( useForAllSubscriptions === true ? { use_for_existing: true } : {} ),
 		...( useForAllSubscriptions === false ? { use_for_existing: false } : {} ), // if undefined, we do not add this property
+		...( useAsBackupMethod === true ? { use_as_backup: true } : {} ),
+		...( useAsBackupMethod === false ? { use_as_backup: false } : {} ), // if undefined, we do not add this property
 		...( purchase ? { purchaseId: purchase.id } : {} ),
 	};
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/style.scss
+++ b/client/me/purchases/manage-purchase/payment-method-selector/style.scss
@@ -47,15 +47,18 @@
 	}
 }
 
-.payment-method-selector__all-subscriptions-checkbox-label {
+.payment-method-selector__all-subscriptions-checkbox-label,
+.payment-method-selector__backup-method-checkbox-label {
 	margin-bottom: 1.5em;
 }
 
-.form-checkbox.payment-method-selector__all-subscriptions-checkbox {
+.form-checkbox.payment-method-selector__all-subscriptions-checkbox,
+.form-checkbox.payment-method-selector__backup-method-checkbox {
 	margin: 2px 8px 2px 0;
 }
 
-.payment-method-selector__all-subscriptions-effect-warning {
+.payment-method-selector__all-subscriptions-effect-warning,
+.payment-method-selector__backup-method-effect-warning {
 	font-size: $font-body-small;
 	font-style: italic;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Do not deploy! This is WIP and not ready to go.

* Adds a checkbox to the Add Payment Method screen allowing the user to specify that the new payment method may be used as a backup on any subscriptions in case the primary payment method fails.
* Passes the state of this checkbox to the `/me/stored-cards` endpoint, which currently doesn't do anything with it

#### Testing instructions

* Navigate to any of the Add Payment Method screens (account, site, or subscription; at the moment the new checkbox is always visible)
* Fill out the form to add a new card and check the backup payment method option.
* Submit the form.
* In the network tab, look for a POST to `/me/stored-cards` which has `use_as_backup: true` in the request payload.
