### PR TITLE
E2E: fix permanent failure introduced in #56596.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -6,7 +6,6 @@ import {
 	setupHooks,
 	DataHelper,
 	LoginFlow,
-	GutenbergEditorPage,
 	SidebarComponent,
 	GutenboardingFlow,
 	GeneralSettingsPage,
@@ -67,11 +66,6 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 
 	it( 'Select free plan', async function () {
 		await gutenboardingFlow.selectPlan( 'Free' );
-	} );
-
-	it( 'See the Gutenberg editor', async function () {
-		const gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.waitUntilLoaded();
 	} );
 
 	it( `Delete created site`, async function () {

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -68,6 +68,12 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 		await gutenboardingFlow.selectPlan( 'Free' );
 	} );
 
+	it( 'Land in Home dashboard', async function () {
+		await page.waitForURL( '**/home/**' );
+		const currentURL = page.url();
+		expect( currentURL ).toContain( siteTitle );
+	} );
+
 	it( `Delete created site`, async function () {
 		const settingsURL = DataHelper.getCalypsoURL( `settings/general/${ siteURL }` );
 		await page.goto( settingsURL, { waitUntil: 'load' } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes a step from `wp-gutenboarding__happy-path` to be in compliance with updated experience introduced in #56596.



#### Testing instructions


- [x] pre-release tests pass.

Related to #
