### PR TITLE
The `site-setup` onboarding flow uses the site id when the user is purchasing a domain

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -43,6 +43,7 @@ interface Dependencies {
 interface Flow {
 	destination: string | ( ( dependencies: Dependencies ) => string );
 	providesDependenciesInQuery?: string[];
+	optionalDependenciesInQuery?: string[];
 	steps: string[];
 }
 
@@ -207,6 +208,7 @@ export default class SignupFlowController {
 	_assertFlowProvidedDependenciesFromConfig( providedDependencies: Dependencies ) {
 		const dependencyDiff = difference(
 			this._flow.providesDependenciesInQuery,
+			this._flow.optionalDependenciesInQuery || [],
 			keys( providedDependencies )
 		);
 		if ( dependencyDiff.length > 0 ) {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -34,6 +34,7 @@ import {
 } from 'calypso/state/signup/progress/actions';
 import { ProgressState } from 'calypso/state/signup/progress/schema';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 interface Dependencies {
 	[ other: string ]: string[];
@@ -122,6 +123,20 @@ export default class SignupFlowController {
 		this._resetStoresIfProcessing(); // reset the stores if the cached progress contained a processing step
 		this._resetStoresIfUserHasLoggedIn(); // reset the stores if user has newly authenticated
 		this._resetSiteSlugIfUserEnteredAnotherFlow(); // reset the site slug if user entered another flow
+
+		if (
+			this._flow.providesDependenciesInQuery?.includes( 'siteId' ) &&
+			options.providedDependencies[ 'siteId' ] &&
+			! options.providedDependencies[ 'siteSlug' ]
+		) {
+			const siteSlug = getSiteSlug(
+				this._reduxStore.getState(),
+				options.providedDependencies[ 'siteId' ]
+			);
+			if ( siteSlug ) {
+				options.providedDependencies[ 'siteSlug' ] = siteSlug;
+			}
+		}
 
 		if ( this._flow.providesDependenciesInQuery || options.providedDependencies ) {
 			this._assertFlowProvidedDependenciesFromConfig( options.providedDependencies );

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -124,6 +124,8 @@ export default class SignupFlowController {
 		this._resetStoresIfUserHasLoggedIn(); // reset the stores if user has newly authenticated
 		this._resetSiteSlugIfUserEnteredAnotherFlow(); // reset the site slug if user entered another flow
 
+		// If we have access to the siteId, then make sure we've also loaded the siteSlug into
+		// the dependency store, because some code depends on the slug instead of the id.
 		if (
 			this._flow.providesDependenciesInQuery?.includes( 'siteId' ) &&
 			options.providedDependencies[ 'siteId' ] &&

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -419,7 +419,7 @@ export function generateFlows( {
 			description:
 				'Sets up a site that has already been created and paid for (if purchases were made)',
 			lastModified: '2021-09-02',
-			providesDependenciesInQuery: [ 'siteSlug' ],
+			providesDependenciesInQuery: [ 'siteId', 'siteSlug' ],
 			pageTitle: translate( 'Setup your site' ),
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -420,6 +420,7 @@ export function generateFlows( {
 				'Sets up a site that has already been created and paid for (if purchases were made)',
 			lastModified: '2021-09-02',
 			providesDependenciesInQuery: [ 'siteId', 'siteSlug' ],
+			optionalDependenciesInQuery: [ 'siteId' ],
 			pageTitle: translate( 'Setup your site' ),
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -63,16 +63,16 @@ function getSignupDestination( { domainItem, siteId, siteSlug } ) {
 	}
 
 	if ( isEnabled( 'signup/setup-site-after-checkout' ) ) {
-		let slugQueryParam = siteSlug;
+		let queryParam = { siteSlug };
 		if ( domainItem ) {
 			// If the user is purchasing a domain then the site's primary url might change from
 			// `siteSlug` to something else during the checkout process, which means the
 			// `/start/setup-site?siteSlug=${ siteSlug }` url would become invalid. So in this
 			// case we use the ID because we know it won't change depending on whether the user
 			// successfully completes the checkout process or not.
-			slugQueryParam = siteId;
+			queryParam = { siteId };
 		}
-		return addQueryArgs( { siteSlug: slugQueryParam }, '/start/setup-site' );
+		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 
 	return `/home/${ siteSlug }`;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -57,13 +57,22 @@ function getRedirectDestination( dependencies ) {
 	return '/';
 }
 
-function getSignupDestination( { siteSlug } ) {
+function getSignupDestination( { domainItem, siteId, siteSlug } ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
 
 	if ( isEnabled( 'signup/setup-site-after-checkout' ) ) {
-		return addQueryArgs( { siteSlug }, '/start/setup-site' );
+		let slugQueryParam = siteSlug;
+		if ( domainItem ) {
+			// If the user is purchasing a domain then the site's primary url might change from
+			// `siteSlug` to something else during the checkout process, which means the
+			// `/start/setup-site?siteSlug=${ siteSlug }` url would become invalid. So in this
+			// case we use the ID because we know it won't change depending on whether the user
+			// successfully completes the checkout process or not.
+			slugQueryParam = siteId;
+		}
+		return addQueryArgs( { siteSlug: slugQueryParam }, '/start/setup-site' );
 	}
 
 	return `/home/${ siteSlug }`;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -347,7 +347,10 @@ export default {
 		} else {
 			// Fetch the site by siteIdOrSlug and then try to select again
 			dispatch( requestSite( siteIdOrSlug ) )
-				.catch( () => null )
+				.catch( () => {
+					next();
+					return null;
+				} )
 				.then( () => {
 					let freshSiteId = getSiteId( getState(), siteIdOrSlug );
 
@@ -361,10 +364,10 @@ export default {
 
 					if ( freshSiteId ) {
 						dispatch( setSelectedSiteId( freshSiteId ) );
-						next();
 					}
+
+					next();
 				} );
-			next();
 		}
 	},
 	importSiteInfoFromQuery( { store: signupStore, query }, next ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -331,24 +331,28 @@ export default {
 		const { getState, dispatch } = signupStore;
 		const signupDependencies = getSignupDependencyStore( getState() );
 
-		const siteSlug = signupDependencies?.siteSlug || query?.siteSlug;
-		if ( ! siteSlug ) {
+		const siteIdOrSlug =
+			signupDependencies?.siteSlug ||
+			query?.siteSlug ||
+			signupDependencies?.siteId ||
+			query?.siteId;
+		if ( ! siteIdOrSlug ) {
 			next();
 			return;
 		}
-		const siteId = getSiteId( getState(), siteSlug );
+		const siteId = getSiteId( getState(), siteIdOrSlug );
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );
 			next();
 		} else {
-			// Fetch the site by siteSlug and then try to select again
-			dispatch( requestSite( siteSlug ) )
+			// Fetch the site by siteSlugOrId and then try to select again
+			dispatch( requestSite( siteIdOrSlug ) )
 				.catch( () => null )
 				.then( () => {
-					let freshSiteId = getSiteId( getState(), siteSlug );
+					let freshSiteId = getSiteId( getState(), siteIdOrSlug );
 
 					if ( ! freshSiteId ) {
-						const wpcomStagingFragment = siteSlug.replace(
+						const wpcomStagingFragment = siteIdOrSlug.replace(
 							/\.wordpress\.com$/,
 							'.wpcomstaging.com'
 						);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -345,7 +345,7 @@ export default {
 			dispatch( setSelectedSiteId( siteId ) );
 			next();
 		} else {
-			// Fetch the site by siteSlugOrId and then try to select again
+			// Fetch the site by siteIdOrSlug and then try to select again
 			dispatch( requestSite( siteIdOrSlug ) )
 				.catch( () => null )
 				.then( () => {

--- a/client/state/signup/dependency-store/reducer.js
+++ b/client/state/signup/dependency-store/reducer.js
@@ -16,8 +16,8 @@ function reducer( state = EMPTY, action ) {
 			return { ...state, ...action.dependencies };
 
 		case SIGNUP_DEPENDENCY_STORE_REMOVE_SITE_SLUG: {
-			const { siteSlug, ...dependenciesWithoutSiteSlug } = state;
-			return dependenciesWithoutSiteSlug;
+			const { siteId, siteSlug, ...dependenciesWithoutSiteIdentifiers } = state;
+			return dependenciesWithoutSiteIdentifiers;
 		}
 
 		case SIGNUP_PROGRESS_SUBMIT_STEP:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the signup framework needs to operate on an existing site it uses the `siteSlug` query param. This is used by at least the `site-setup` and `site-launch` flows.

When we are about to direct the user towards the `site-setup` flow, and the user is purchasing a domain, this PR uses the site's ID rather than its slug. This is because the url for the `site-setup` flow is being generated at a time _before_ domain purchase has been completed, and we have no idea whether the domain purchase will be successful or not. If it's successful the site's primary url might change to something new. Using the site's ID works around this issue because it doesn't change.

This fixes an issue where, depending on the payment method, a newly purchased domain will have been set as the primary domain by the time we land in the `site-setup` flow, producing a WSOD.

p1632898918267200-slack-C029SB8JT8S

* `site-setup` flow accepts a `siteId` query param
* If the user has added a domain to their cart, then we use `siteId` in the signup destination instead of `siteSlug`. The reason I haven't always used `siteId` is because users are used to seeing the slug in the url, not random numbers.
* If `siteId` query param is present, but we don't have data for that store in redux, then we fetch it before displaying the signup UI. This mimics what we're already doing for the `siteSlug` query param. This could be useful if the local redux state is lost in between page transitions for some reason.
* Some actions (like switching flows) clear the current site slug out of the dependency store, so we do the same for the site id.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure to test locally or on staging because `site-setup` is disabled in production. Or use the `signup/setup-site-after-checkout` feature flag.

Try various payment methods (e.g. CC, credits, paypal) and flows (e.g. `site-setup` and `site-launch`)

I've found that after completing `site-setup` you will land on `/home/{{ siteId }}` instead of the usual `/home/{{ siteSlug }}`. It still works fine though, and after navigating it switches to the site slug.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


