### PR TITLE
Add inline support links to Add Payment Method section

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -1,7 +1,15 @@
 const contextLinks = {
+	autorenewal: {
+		link: 'https://wordpress.com/support/manage-purchases/#automatic-renewal',
+		post_id: 111349,
+	},
 	billing: {
 		link: 'https://wordpress.com/support/billing-history/',
 		post_id: 40792,
+	},
+	cancel_purchase: {
+		link: 'https://wordpress.com/support/manage-purchases/#cancel-a-purchase',
+		post_id: 111349,
 	},
 	comments: {
 		link: 'https://wordpress.com/support/comments/',

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -93,6 +93,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/payment/',
 		post_id: 76237,
 	},
+	payment_method_all_subscriptions: {
+		link: 'https://wordpress.com/support/payment/#using-a-payment-method-for-all-subscriptions',
+		post_id: 76237,
+	},
 	plugins: {
 		link: 'https://wordpress.com/support/plugins/',
 		post_id: 2108,

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,10 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import {
-	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
-	MANAGE_PURCHASES_FAQ_CANCELLING,
-} from 'calypso/lib/url/support';
 
 export default function TosText(): JSX.Element {
 	const translate = useTranslate();

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import {
 	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
@@ -21,18 +22,10 @@ export default function TosText(): JSX.Element {
 							/>
 						),
 						autoRenewalSupportPage: (
-							<a
-								href={ MANAGE_PURCHASES_AUTOMATIC_RENEWAL }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
+							<InlineSupportLink supportContext="autorenewal" showIcon={ false } />
 						),
 						faqCancellingSupportPage: (
-							<a
-								href={ MANAGE_PURCHASES_FAQ_CANCELLING }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
+							<InlineSupportLink supportContext="cancel_purchase" showIcon={ false } />
 						),
 					},
 				}

--- a/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
@@ -7,6 +7,7 @@ import {
 	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
 	MANAGE_PURCHASES_FAQ_CANCELLING,
 } from 'calypso/lib/url/support';
+import TosText from 'calypso/me/purchases/manage-purchase/payment-method-selector/tos-text';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -32,34 +33,7 @@ class TermsOfService extends Component {
 
 		// Need to add check for subscription products in the cart so we don't show this for one-off purchases like themes
 		if ( this.props.hasRenewableSubscription ) {
-			message = this.props.translate(
-				'You agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{faqCancellingSupportPage}}how to cancel{{/faqCancellingSupportPage}}.',
-				{
-					components: {
-						tosLink: (
-							<a
-								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						autoRenewalSupportPage: (
-							<a
-								href={ MANAGE_PURCHASES_AUTOMATIC_RENEWAL }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						faqCancellingSupportPage: (
-							<a
-								href={ MANAGE_PURCHASES_FAQ_CANCELLING }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				}
-			);
+			message = <TosText />;
 		}
 
 		return message;

--- a/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
@@ -3,10 +3,6 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import {
-	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
-	MANAGE_PURCHASES_FAQ_CANCELLING,
-} from 'calypso/lib/url/support';
 import TosText from 'calypso/me/purchases/manage-purchase/payment-method-selector/tos-text';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/assign-to-all-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/assign-to-all-payment-methods.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const CheckboxWrapper = styled.div`
@@ -39,9 +39,9 @@ export default function AssignToAllPaymentMethods( {
 					{
 						components: {
 							link: (
-								<ExternalLink
-									icon
-									href="https://wordpress.com/support/payment/#using-a-payment-method-for-all-subscriptions"
+								<InlineSupportLink
+									supportContext="payment_method_all_subscriptions"
+									showIcon={ false }
 								/>
 							),
 						},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds inline support link functionality to existing links on the Add Payment Method window. Additionally, an external link was added to the "Assign this payment method..." checkbox, along with updated wording.

Lastly, a small bottom margin was added below the "Assign this payment method" section for better spacing.

#### Testing instructions

- Go to http://calypso.localhost:3000/me/purchases/add-payment-method or http://calypso.localhost:3000/purchases/add-payment-method/[site-url] (or both!)

- Check the following:

A - B: These links should open in an InlineSupport modal with their corresponding material
C: This copy should be updated with an external Learn More link. The link should open https://wordpress.com/tos/#fees-payments-renewal

<img width="1322" alt="Screenshot on 2021-09-29 at 18:52:18" src="https://user-images.githubusercontent.com/16580129/135359263-f4efe7aa-1f2d-42bc-b998-84bb4063a22b.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #509
