### PR TITLE
Domains: Update new transfer flow header title

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -290,7 +290,7 @@ function UseMyDomain( {
 		}
 	};
 
-	const getHeaderText = () => {
+	const headerText = useMemo( () => {
 		switch ( mode ) {
 			case inputMode.domainInput:
 				return __( 'Use a domain I own' );
@@ -301,7 +301,7 @@ function UseMyDomain( {
 				/* translators: %s - the name of the domain the user will add to their site */
 				return sprintf( __( 'Use a domain I own: %s' ), domainName );
 		}
-	};
+	}, [ domainName, mode, inputMode ] );
 
 	return (
 		<>
@@ -312,7 +312,7 @@ function UseMyDomain( {
 			<FormattedHeader
 				brandFont
 				className={ baseClassName + '__page-heading' }
-				headerText={ getHeaderText() }
+				headerText={ headerText }
 				align="left"
 			/>
 			{ renderContent() }

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -290,11 +290,18 @@ function UseMyDomain( {
 		}
 	};
 
-	const headerText =
-		mode === inputMode.domainInput
-			? __( 'Use a domain I own' )
-			: /* translators: %s - the name of the domain the user will add to their site */
-			  sprintf( __( 'Use a domain I own: %s' ), domainName );
+	const getHeaderText = () => {
+		switch ( mode ) {
+			case inputMode.domainInput:
+				return __( 'Use a domain I own' );
+			case inputMode.transferDomain:
+				/* translators: %s - the name of the domain the user will add to their site */
+				return sprintf( __( 'Transfer %s' ), domainName );
+			default:
+				/* translators: %s - the name of the domain the user will add to their site */
+				return sprintf( __( 'Use a domain I own: %s' ), domainName );
+		}
+	};
 
 	return (
 		<>
@@ -305,7 +312,7 @@ function UseMyDomain( {
 			<FormattedHeader
 				brandFont
 				className={ baseClassName + '__page-heading' }
-				headerText={ headerText }
+				headerText={ getHeaderText() }
 				align="left"
 			/>
 			{ renderContent() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Related to #56554. Updates the new transfer flow header title to "Transfer `{YOUR_DOMAIN_NAME}`"

#### Preview
![image](https://user-images.githubusercontent.com/18705930/135363502-9b9edd0f-cf9e-4803-bdcd-490160eac533.png)

#### Testing instructions
- Same as #56554, and additionally:
  - Check that when selecting the "Transfer" option, the title "Transfer `{YOUR_DOMAIN_NAME}`" is displayed, where `{YOUR_DOMAIN_NAME}` is the domain you entered.