### PR TITLE
My Email: Expand the criteria for selecting domains with paid email subscriptions

### DIFF
--- a/client/my-sites/email/inbox/index.js
+++ b/client/my-sites/email/inbox/index.js
@@ -1,11 +1,10 @@
 import { localize, translate } from 'i18n-calypso';
-import React from 'react';
 import { connect } from 'react-redux';
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
 import PromoCard from 'calypso/components/promo-section/promo-card';
+import { hasPaidEmailWithUs } from 'calypso/lib/emails';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
-import { hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
 import MailboxSelectionList from 'calypso/my-sites/email/inbox/mailbox-selection-list';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -35,7 +34,7 @@ const InboxManagement = ( { domains } ) => {
 	}
 
 	const domainsWithSubscriptions = domains.filter(
-		( domain ) => ! domain.isWPCOMDomain && hasEmailSubscription( domain )
+		( domain ) => ! domain.isWPCOMDomain && hasPaidEmailWithUs( domain )
 	);
 
 	//EmailManagementHome logic will handle the case where there is only one domain to show directly the email comparison


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change expands the selection criteria to account for accounts billed to Titan, which are typically accounts that have no `store_subscriptions` equivalent.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Find a site with a Professional Email subscription that's billed to Titan. This could be an early MVP account, or one of the accounts gifted to a12s. You can also simulate this by nullifying the `subscription_id` column in the `email_provider*` table. Ensure that there is at least one mailbox added to the account.
* Navigate to `/inbox/<site-slug>`, where `<site-slug>` is the previous site mentioned above
* Confirm that the mailbox(es) are shown in the list


