### PR TITLE
build: Convert build-tools dir to a tsc project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ cached-requests.json
 /apps/*/dist/
 /apps/*/types/
 /packages/*/dist/
+/build-tools/dist/
 /apps/*/.cache/
 
 # webpack assets

--- a/build-tools/tsconfig.json
+++ b/build-tools/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "@automattic/calypso-build/typescript/js-package.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"emitDeclarationOnly": true,
+		"outDir": "dist",
+		"declarationDir": "dist/types",
+		"types": [ "node" ]
+	},
+	"include": [
+		"babel/**/*",
+		"lib/**/*",
+		"webpack/**/*",
+	]
+}

--- a/build-tools/webpack/sections-loader.js
+++ b/build-tools/webpack/sections-loader.js
@@ -1,5 +1,4 @@
 const { getOptions } = require( 'loader-utils' );
-const config = require( '../../client/server/config' );
 
 /*
  * This sections-loader has one responsibility: adding import statements for the section modules.
@@ -51,31 +50,31 @@ function printSectionsAndPaths( sections ) {
 	}
 }
 
-function filterSectionsInDevelopment( sections ) {
-	const bundleEnv = config( 'env' );
-	if ( 'development' !== bundleEnv ) {
+function filterSectionsInDevelopment( sections, { forceAll, activeSections, enableByDefault } ) {
+	if ( forceAll ) {
 		return sections;
 	}
-
-	const activeSections = config( 'sections' );
-	const byDefaultEnableSection = config( 'enable_all_sections' );
 
 	return sections.filter( ( section ) => {
 		if ( activeSections && typeof activeSections[ section.name ] !== 'undefined' ) {
 			return activeSections[ section.name ];
 		}
-		return byDefaultEnableSection;
+		return enableByDefault;
 	} );
 }
 
 const loader = function () {
 	const options = getOptions( this ) || {};
-	const { onlyIsomorphic } = options;
+	const { onlyIsomorphic, forceAll, activeSections, enableByDefault } = options;
 	// look also at the legacy `forceRequire` option to allow smooth migration
 	const useRequire = options.useRequire || options.forceRequire;
 	let { include } = options;
 
-	let sections = filterSectionsInDevelopment( require( this.resourcePath ) );
+	let sections = filterSectionsInDevelopment( require( this.resourcePath ), {
+		forceAll,
+		activeSections,
+		enableByDefault,
+	} );
 
 	if ( include ) {
 		if ( ! Array.isArray( include ) ) {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -16,8 +16,11 @@
 			"calypso/*": [ "./*" ]
 		}
 	},
-	"references": [ { "path": "../packages" } ],
-	"include": [ "**/*", "../build-tools/**" ],
+	"references": [
+		{ "path": "../packages" },
+		{ "path": "../build-tools" }
+	],
+	"include": [ "**/*" ],
 	"exclude": [
 		"../**/node_modules/**/*",
 		"**/test/**/*",

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -3,6 +3,7 @@ const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' )
 const { shouldTranspileDependency } = require( '@automattic/calypso-build/webpack/util' );
 const webpack = require( 'webpack' );
 const cacheIdentifier = require( '../build-tools/babel/babel-loader-cache-identifier' );
+const config = require( './server/config' );
 const { workerCount } = require( './webpack.common' );
 
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -24,7 +25,13 @@ module.exports = {
 				include: path.join( __dirname, 'sections.js' ),
 				use: {
 					loader: path.join( __dirname, '../build-tools/webpack/sections-loader' ),
-					options: { useRequire: true, onlyIsomorphic: true },
+					options: {
+						useRequire: true,
+						onlyIsomorphic: true,
+						forceAll: ! isDevelopment,
+						activeSections: config( 'sections' ),
+						enableByDefault: config( 'enable_all_sections' ),
+					},
 				},
 			},
 			{

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -225,6 +225,9 @@ const webpackConfig = {
 				loader: path.join( __dirname, '../build-tools/webpack/sections-loader' ),
 				options: {
 					include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
+					forceAll: ! isDevelopment,
+					activeSections: config( 'sections' ),
+					enableByDefault: config( 'enable_all_sections' ),
 				},
 			},
 			{

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -100,7 +100,13 @@ const webpackConfig = {
 				include: path.join( __dirname, 'sections.js' ),
 				use: {
 					loader: path.join( __dirname, '../build-tools/webpack/sections-loader' ),
-					options: { useRequire: true, onlyIsomorphic: true },
+					options: {
+						useRequire: true,
+						onlyIsomorphic: true,
+						forceAll: ! isDevelopment,
+						activeSections: config( 'sections' ),
+						enableByDefault: config( 'enable_all_sections' ),
+					},
 				},
 			},
 			TranspileConfig.loader( {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
 		"@types/enzyme": "^3.10.9",
 		"@types/fast-json-stable-stringify": "^2.0.0",
 		"@types/lodash": "^4.14.175",
+		"@types/node": "^15.0.2",
 		"@types/page": "^1.11.5",
 		"@types/qs": "^6.9.7",
 		"@types/react": "^17.0.24",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"files": [],
+	"compilerOptions": {
+		"composite": true
+	},
 
 	// Reference all TS packages
 	"references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -38844,6 +38844,7 @@ typescript@^4.4.3:
     "@types/enzyme": ^3.10.9
     "@types/fast-json-stable-stringify": ^2.0.0
     "@types/lodash": ^4.14.175
+    "@types/node": ^15.0.2
     "@types/page": ^1.11.5
     "@types/qs": ^6.9.7
     "@types/react": ^17.0.24


### PR DESCRIPTION
#### Background

We have a TypeScript project in `./client` (i.e. it has a `tsconfig.json` file). This project declares `rootDir: '.'` but includes files (`../build-tools/**/*`) from outside the root dir. This is not allowed in TypeScript.

![image](https://user-images.githubusercontent.com/975703/135384928-2890dbc5-55cc-4d9c-9e75-8cbd1686605c.png)


#### Changes proposed in this Pull Request

* Make `./build-tools` a separate TypeScript project by creating its own `tsconfig.json`
* Link it to `./client/tsconfig.json` by using `references`
* Refactor `./build-tools/webpack/sections-loader.js` so it receives the config from the loader config, instead of importing a file outside `./build-tools` (namely `../../client/server/config`)


#### Testing instructions

* Run `yarn tsc --project build-tools`, it should compile without errors and generate types in `./build-tools/dist/`
* Start the project with `yarn start`, all sections should be loaded.
* Start the project with `SECTION_LIMIT=me yarn start`. The console output should say it is being built with limited sections, and only http://calypso.localhost:3000/me should work.