### PR TITLE
`QueryReaderList`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/components/data/query-reader-list/index.jsx
+++ b/client/components/data/query-reader-list/index.jsx
@@ -1,51 +1,28 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestList } from 'calypso/state/reader/lists/actions';
 import { isRequestingList } from 'calypso/state/reader/lists/selectors';
 
-class QueryReaderList extends Component {
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.isRequestingList ) {
-			this.props.requestList( this.props.owner, this.props.slug );
-		}
+const request = ( owner, slug ) => ( dispatch, getState ) => {
+	if ( ! isRequestingList( getState(), owner, slug ) ) {
+		dispatch( requestList( owner, slug ) );
 	}
+};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			nextProps.isRequestingList ||
-			( this.props.owner === nextProps.owner && this.props.slug === nextProps.slug )
-		) {
-			return;
-		}
+function QueryReaderList( { owner, slug } ) {
+	const dispatch = useDispatch();
 
-		nextProps.requestList( nextProps.owner, nextProps.slug );
-	}
+	useEffect( () => {
+		dispatch( request( owner, slug ) );
+	}, [ dispatch, owner, slug ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
 QueryReaderList.propTypes = {
 	owner: PropTypes.string,
 	slug: PropTypes.string,
-	isRequestingList: PropTypes.bool,
-	requestList: PropTypes.func,
 };
 
-QueryReaderList.defaultProps = {
-	requestList: () => {},
-};
-
-export default connect(
-	( state, ownProps ) => {
-		const { owner, slug } = ownProps;
-		return {
-			isRequestingList: isRequestingList( state, owner, slug ),
-		};
-	},
-	{
-		requestList,
-	}
-)( QueryReaderList );
+export default QueryReaderList;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `QueryReaderLists`:
  * refactor away from `UNSAFE_*` lifecycle methods
  * refactor to functional component

#### Testing instructions

* Go to the Reader on `/read`
* Choose one of your lists under _Lists_
* Make sure you see a request to `/read/lists/<user>/<your-list>` and data is shown accordingly

Note: You need to have at least one list to test this. If you don't have on, make sure to create one before testing.

<img width="285" alt="Screenshot 2021-09-30 at 09 45 37" src="https://user-images.githubusercontent.com/9202899/135409790-4dcacaf5-b845-4d51-8371-6bdad6ed1cdb.png">