### PR TITLE
Restoring display size state and resize listener

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -35,6 +35,7 @@ export class PlansStep extends Component {
 		this.unsubscribe = subscribeIsDesktop( ( matchesDesktop ) =>
 			this.setState( { isDesktop: matchesDesktop } )
 		);
+		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,7 +1,7 @@
 import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { isDesktop } from '@automattic/viewport';
+import { isTabletResolution, isDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { intersection } from 'lodash';
@@ -27,7 +27,24 @@ import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 export class PlansStep extends Component {
+	state = {
+		isDesktop: ! isTabletResolution(),
+	};
+
+	windowResize = () => {
+		this.setState( { plansWithScroll: ! isTabletResolution() } );
+	};
+
+	componentWillUnmount() {
+		if ( typeof window === 'object' ) {
+			window.removeEventListener( 'resize', this.windowResize );
+		}
+	}
+
 	componentDidMount() {
+		if ( typeof window === 'object' ) {
+			window.addEventListener( 'resize', this.windowResize );
+		}
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -27,8 +27,14 @@ import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 export class PlansStep extends Component {
+	state = {
+		isDesktop: isDesktop(),
+	};
+
 	componentDidMount() {
-		this.unsubscribe = subscribeIsDesktop( () => this.forceUpdate() );
+		this.unsubscribe = subscribeIsDesktop( ( matchesDesktop ) =>
+			this.setState( { isDesktop: matchesDesktop } )
+		);
 	}
 
 	componentWillUnmount() {
@@ -158,13 +164,13 @@ export class PlansStep extends Component {
 				domainName={ this.getDomainName() }
 				customerType={ this.getCustomerType() }
 				disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-				plansWithScroll={ isDesktop() }
+				plansWithScroll={ this.state.isDesktop }
 				planTypes={ planTypes }
 				flowName={ flowName }
 				showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
 				isAllPaidPlansShown={ true }
 				isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-				shouldShowPlansFeatureComparison={ isDesktop() } // Show feature comparison layout in signup flow and desktop resolutions
+				shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 				isReskinned={ isReskinned }
 			/>
 		);
@@ -185,7 +191,7 @@ export class PlansStep extends Component {
 	getHeaderText() {
 		const { headerText, translate } = this.props;
 
-		if ( isDesktop() ) {
+		if ( this.state.isDesktop ) {
 			return translate( 'Choose a plan' );
 		}
 
@@ -196,7 +202,7 @@ export class PlansStep extends Component {
 		const { hideFreePlan, subHeaderText, translate } = this.props;
 
 		if ( ! hideFreePlan ) {
-			if ( isDesktop() ) {
+			if ( this.state.isDesktop ) {
 				return translate(
 					"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
 					{
@@ -214,7 +220,7 @@ export class PlansStep extends Component {
 			} );
 		}
 
-		if ( isDesktop() ) {
+		if ( this.state.isDesktop ) {
 			return translate( "Pick one that's right for you and unlock features that help you grow." );
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,7 +1,7 @@
 import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { isTabletResolution, isDesktop } from '@automattic/viewport';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { intersection } from 'lodash';
@@ -27,25 +27,12 @@ import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 export class PlansStep extends Component {
-	state = {
-		isDesktop: ! isTabletResolution(),
-	};
-
-	windowResize = () => {
-		this.setState( { plansWithScroll: ! isTabletResolution() } );
-	};
-
-	componentWillUnmount() {
-		if ( typeof window === 'object' ) {
-			window.removeEventListener( 'resize', this.windowResize );
-		}
+	componentDidMount() {
+		this.unsubscribe = subscribeIsDesktop( () => this.forceUpdate() );
 	}
 
-	componentDidMount() {
-		if ( typeof window === 'object' ) {
-			window.addEventListener( 'resize', this.windowResize );
-		}
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+	componentWillUnmount() {
+		this.unsubscribe();
 	}
 
 	onSelectPlan = ( cartItem ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a responsiveness bug discovered by @southp  in the plans page during signup, which caused the plan content to disappear if you changed your viewport.

Here's a recording of the behavior:
![CleanShot 2021-09-30 at 06 21 05](https://user-images.githubusercontent.com/35781181/135438029-124ec649-f51e-4977-b901-48ca2b4b75fd.gif)
 
@arthur791004 and @pablinos traced the issue to [this commit](https://github.com/Automattic/wp-calypso/commit/e4108ce3d7c77574fddd05c789e93d46abbdb996), which removed the resize listener.

This PR fixes the issue by restoring the tablet state and resize listener.

#### Testing instructions
* Checkout this PR and start Calypso
* Navigate to the the [new site creation flow](https://wordpress.com/start/) and proceed to the plans page.
* Test the plans page by transitioning from the desktop viewport to a tablet viewport and back. Confirm that the plans are displayed in all viewport states.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #54208
