### PR TITLE
Disable jest rules that doesn't make sense for test fixtures

### DIFF
--- a/packages/magellan-mocha-plugin/.eslintrc.js
+++ b/packages/magellan-mocha-plugin/.eslintrc.js
@@ -7,4 +7,15 @@ module.exports = {
 		'import/no-nodejs-modules': 'off',
 		'no-process-exit': 'off',
 	},
+	overrides: [
+		{
+			files: [ './test_support/**/*' ],
+			rules: {
+				'jest/expect-expect': 'off',
+				'jest/no-disabled-tests': 'off',
+				'jest/valid-title': 'off',
+				'jest/no-identical-title': 'off',
+			},
+		},
+	],
 };


### PR DESCRIPTION
See #56330

#### Changes proposed in this Pull Request

Disable `jest/` rules that don't apply to test fixtures.
