### PR TITLE
Update transfer message for newly registered domains

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -75,6 +75,7 @@
 				color: var( --color-text-subtle );
 
 				@include break-mobile {
+					max-width: 625px;
 					margin: 0 40px 16px;
 				}
 

--- a/client/components/domains/use-my-domain/utilities/get-transfer-restriction-message.jsx
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-restriction-message.jsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 
 export const getTransferRestrictionMessage = ( inboundTransferStatus ) => {
 	const {
-		creationDate,
 		domain,
 		termMaximumInYears,
 		transferEligibleDate,
@@ -30,14 +29,14 @@ export const getTransferRestrictionMessage = ( inboundTransferStatus ) => {
 	} else if ( 'initial_registration_period' === transferRestrictionStatus ) {
 		reason = createInterpolateElement(
 			sprintf(
-				/* translators: %(transferEligibleDate)s: a date formatted according to the user's locale (e.g: September 28, 2021), %(daysAgoRegistered)d: number of days */
+				/* translators:  %(daysUntilTransferEligible)d: number of days, %(transferEligibleDate)s: a date formatted according to the user's locale (e.g: September 28, 2021) */
 				__(
-					'Newly-registered domains are not eligible for transfer. <strong>%(domain)s</strong> was registered ' +
-						'%(daysAgoRegistered)d days ago, and can be transferred starting %(transferEligibleDate)s.'
+					'Newly registered domains cannot be transferred. This domain can be transferred in <strong>%(daysUntilTransferEligible)d days</strong>, ' +
+						"starting %(transferEligibleDate)s. You don't have to wait though, you can connect your domain to your site instead."
 				),
 				{
 					domain,
-					daysAgoRegistered: moment().diff( creationDate, 'days' ),
+					daysUntilTransferEligible: transferEligibleMoment.diff( moment(), 'days' ),
 					transferEligibleDate: transferEligibleMoment.format( 'LL' ),
 				}
 			),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The message used for newly registered domains in the transfer flow should be updated. This PR makes the update and a couple of small style tweaks.

<img width="1070" alt="Screen Shot 2021-09-30 at 9 43 59 AM" src="https://user-images.githubusercontent.com/1379730/135467335-366d6f38-c9ab-45e0-9396-c96fe7075fbf.png">

This addresses this comment: https://github.com/Automattic/wp-calypso/pull/56554#issuecomment-930012458

#### Testing instructions

From the Site Domains page, select the "Use a domain I own" option.
Enter a domain that is not yet transferrable because is is newly registered (you may test with delputnam.live).
Make sure that the message shown for the transfer option matches the screenshot above.