### PR TITLE
Gutenboarding: Remove the FSE-only versions of Vesta and Easley themes

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -371,34 +371,6 @@
 			"features": [ "anchorfm" ]
 		},
 		{
-			"title": "Vesta",
-			"slug": "vesta-blocks",
-			"template": "vesta-blocks",
-			"theme": "mayland-blocks",
-			"fonts": {
-				"headings": "Cabin",
-				"base": "Raleway"
-			},
-			"categories": [ "featured" ],
-			"is_premium": false,
-			"is_fse": true,
-			"features": []
-		},
-		{
-			"title": "Easley",
-			"slug": "easley-blocks",
-			"template": "easley-blocks",
-			"theme": "mayland-blocks",
-			"fonts": {
-				"headings": "Space Mono",
-				"base": "Roboto"
-			},
-			"categories": [ "featured" ],
-			"is_premium": false,
-			"is_fse": true,
-			"features": []
-		},
-		{
 			"title": "Mayland",
 			"slug": "mayland-blocks",
 			"template": "mayland-blocks",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the Vesta and Easley themes from the Gutenboarding's design picker step.

This change only removes the block-based versions of Vesta and Easley (both children of Mayland Blocks), which are only displayed in the FSE Beta flow.
Regular versions of Vesta and Easley are still available in the regular onboarding flow.

<img width="1377" alt="Screenshot 2021-09-30 at 16 15 58" src="https://user-images.githubusercontent.com/2070010/135483149-a502a820-0411-49d3-9095-6074fc27ac12.png">

#### Testing instructions

* Create a new site through Gutenboarding: http://calypso.localhost:3000/new
* Enroll in the FSE Beta.
* Make sure the design step only displays 3 themes: Seedlet, Mayland, and Blockbase (labeled "start with an empty page").
* Restart the onboarding, and this time skip the FSE Beta.
* Make sure the design step contains Vesta and Easley.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #56655
