### PR TITLE
Modify Signup: Gutenboarding test to create a new account.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -220,7 +220,7 @@ export class GutenboardingFlow {
 	}
 
 	/**
-	 * Creates an account (if Gutenboarding was initiated whiel logged out).
+	 * Creates an account (if Gutenboarding was initiated while logged out).
 	 *
 	 * @param {string} email Email address.
 	 * @param {string} password Password of user.

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -42,6 +42,10 @@ const selectors = {
 			'Select'
 		) }`,
 
+	// Create account
+	email: 'input[type="email"]',
+	password: 'input[type="password"]',
+
 	// Post-signup design selection (for Free plans only)
 	skipForNowButton: 'button:text("Skip for now")',
 
@@ -201,10 +205,7 @@ export class GutenboardingFlow {
 	async selectPlan( name: Plans ): Promise< void > {
 		// First, expand the accordion.
 		await this.page.click( ':text-is("Show all plans")' );
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.selectPlanButton( name ) ),
-		] );
+		await this.page.click( selectors.selectPlanButton( name ) );
 	}
 
 	/**
@@ -216,6 +217,18 @@ export class GutenboardingFlow {
 		// The plan item with the `has-badge` attribute is the one that is recommended based on features.
 		const elementHandle = await this.page.waitForSelector( `${ selectors.planItem }.has-badge` );
 		await elementHandle.waitForSelector( `div:text-is("${ name }")` );
+	}
+
+	/**
+	 * Creates an account (if Gutenboarding was initiated whiel logged out).
+	 *
+	 * @param {string} email Email address.
+	 * @param {string} password Password of user.
+	 */
+	async signup( email: string, password: string ): Promise< void > {
+		await this.page.fill( selectors.email, email );
+		await this.page.fill( selectors.password, password );
+		await this.page.click( selectors.button( 'Create account' ) );
 	}
 
 	/**

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -5,17 +5,19 @@
 import {
 	setupHooks,
 	DataHelper,
-	LoginFlow,
-	SidebarComponent,
+	CloseAccountFlow,
 	GutenboardingFlow,
-	GeneralSettingsPage,
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 
 describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 	const siteTitle = DataHelper.getBlogName();
+	const email = DataHelper.getTestEmailAddress( {
+		inboxId: DataHelper.config.get( 'signupInboxId' ),
+		prefix: `e2eflowtestinggutenboarding${ DataHelper.getTimestamp() }`,
+	} );
+	const signupPassword = DataHelper.config.get( 'passwordForNewTestSignUps' ) as string;
 
-	let siteURL: string;
 	let gutenboardingFlow: GutenboardingFlow;
 	let page: Page;
 
@@ -23,68 +25,63 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 		page = args.page;
 	} );
 
-	it( 'Log in', async function () {
-		const loginFlow = new LoginFlow( page, 'defaultUser' );
-		await loginFlow.logIn();
+	describe( 'Signup via /new', function () {
+		it( 'Navigate to /new', async function () {
+			await page.goto( DataHelper.getCalypsoURL( 'new' ) );
+		} );
+
+		it( 'Enter new site name', async function () {
+			gutenboardingFlow = new GutenboardingFlow( page );
+			await gutenboardingFlow.enterSiteTitle( siteTitle );
+			await gutenboardingFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Search for and select a WordPress.comdomain name', async function () {
+			await gutenboardingFlow.searchDomain( siteTitle );
+			await gutenboardingFlow.selectDomain( siteTitle.concat( '.wordpress.com' ) );
+			await gutenboardingFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Select Vesta as the site design', async function () {
+			await gutenboardingFlow.selectDesign( 'Vesta' );
+		} );
+
+		it( 'Pick the Playfair font pairing', async function () {
+			await gutenboardingFlow.selectFont( 'Playfair' );
+			await gutenboardingFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Select to add the Plugin feature', async function () {
+			await gutenboardingFlow.selectFeatures( [ 'Plugins' ] );
+			await gutenboardingFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'WordPress.com Business plan is recommended', async function () {
+			await gutenboardingFlow.validateRecommendedPlan( 'Business' );
+		} );
+
+		it( 'Select free plan', async function () {
+			await gutenboardingFlow.selectPlan( 'Free' );
+		} );
+
+		it( 'Create account', async function () {
+			await Promise.all( [
+				page.waitForNavigation(),
+				gutenboardingFlow.signup( email, signupPassword ),
+			] );
+		} );
+
+		it( 'Land in Home dashboard', async function () {
+			await page.waitForURL( '**/home/**' );
+			const currentURL = page.url();
+			expect( currentURL ).toContain( siteTitle );
+		} );
 	} );
 
-	it( 'Click on Add Site on Sidebar', async function () {
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.switchSite();
-		await sidebarComponent.addSite();
-	} );
-
-	it( 'Enter new site name', async function () {
-		gutenboardingFlow = new GutenboardingFlow( page );
-		await gutenboardingFlow.enterSiteTitle( siteTitle );
-		await gutenboardingFlow.clickButton( 'Continue' );
-	} );
-
-	it( 'Search for and select a WordPress.comdomain name', async function () {
-		await gutenboardingFlow.searchDomain( siteTitle );
-		siteURL = await gutenboardingFlow.selectDomain( siteTitle.concat( '.wordpress.com' ) );
-		await gutenboardingFlow.clickButton( 'Continue' );
-	} );
-
-	it( 'Select Vesta as the site design', async function () {
-		await gutenboardingFlow.selectDesign( 'Vesta' );
-	} );
-
-	it( 'Pick the Playfair font pairing', async function () {
-		await gutenboardingFlow.selectFont( 'Playfair' );
-		await gutenboardingFlow.clickButton( 'Continue' );
-	} );
-
-	it( 'Select to add the Plugin feature', async function () {
-		await gutenboardingFlow.selectFeatures( [ 'Plugins' ] );
-		await gutenboardingFlow.clickButton( 'Continue' );
-	} );
-
-	it( 'WordPress.com Business plan is recommended', async function () {
-		await gutenboardingFlow.validateRecommendedPlan( 'Business' );
-	} );
-
-	it( 'Select free plan', async function () {
-		await gutenboardingFlow.selectPlan( 'Free' );
-	} );
-
-	it( 'Land in Home dashboard', async function () {
-		await page.waitForURL( '**/home/**' );
-		const currentURL = page.url();
-		expect( currentURL ).toContain( siteTitle );
-	} );
-
-	it( `Delete created site`, async function () {
-		const settingsURL = DataHelper.getCalypsoURL( `settings/general/${ siteURL }` );
-		await page.goto( settingsURL, { waitUntil: 'load' } );
-		const generalSettingsPage = new GeneralSettingsPage( page );
-		try {
-			await generalSettingsPage.deleteSite( siteURL );
-			const currentURL = await page.url();
-			expect( currentURL ).toEqual( expect.not.stringContaining( siteURL ) );
-		} catch ( e ) {
-			console.error( `Deletion of ${ siteURL } failed.` );
-			throw e;
-		}
+	describe( 'Delete user account', function () {
+		it( 'Close account', async function () {
+			const closeAccountFlow = new CloseAccountFlow( page );
+			await closeAccountFlow.closeAccount();
+		} );
 	} );
 } );

--- a/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
+++ b/test/e2e/specs/specs-playwright/wp-gutenboarding__happy-path.ts
@@ -36,7 +36,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 			await gutenboardingFlow.clickButton( 'Continue' );
 		} );
 
-		it( 'Search for and select a WordPress.comdomain name', async function () {
+		it( 'Search for and select a WordPress.com domain name', async function () {
 			await gutenboardingFlow.searchDomain( siteTitle );
 			await gutenboardingFlow.selectDomain( siteTitle.concat( '.wordpress.com' ) );
 			await gutenboardingFlow.clickButton( 'Continue' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the existing Playwright Gutenboarding test flow to create a new account.

Recently, we switched over the default testing account to a new, clean account. However, less than a week in the account already has 400 sites to its name.

The problem is twofold: 
- Selenium Signup suite continues to create new accounts.
- Playwright Signup: Gutenboarding also uses the default testing account to create a new site attached to the user.

This piece rectifies the second problem.

Key changes:
- alter the Signup: Gutenboarding flow to start without being logged in.
- add new method to sign up for an account after the Gutenboarding flow has been followed.


#### Testing instructions

- [x] normal tests
  - [x] desktop
  - [x] mobile
- [x] pre-release tests

Related to #
