### PR TITLE
Playwright: extend timeout at checkout on domain-only signup flows.

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-signup__domain.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__domain.ts
@@ -85,10 +85,14 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 		it( 'Check out', async function () {
 			// This step is affected by an issue with page redirect of the post-checkout page.
 			// See: https://github.com/Automattic/wp-calypso/issues/56548
+			// The extra-long timeout is due to frequent back-end failures to process payment
+			// in a timely manner.
+			// See https://github.com/Automattic/wp-calypso/issues/56716.
 			await Promise.all( [
 				page.waitForNavigation( {
 					url: '**/checkout/thank-you/no-site/**',
 					waitUntil: 'networkidle',
+					timeout: 120000,
 				} ),
 				cartCheckoutPage.purchase(),
 			] );
@@ -98,6 +102,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 			await page.waitForNavigation( {
 				url: '**/checkout/thank-you/no-site/**',
 				waitUntil: 'networkidle',
+				timeout: 120000,
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR extends the timeout during the checkout stage for Signup: Domain only tests.

Key changes:
- extend timeout for both checkout and redirect stages to 120s.

Details:

This step would intermittently fail on Pre-Release tests. 
It also appears the `/start/domin` flow takes longer than other flows in order to process the checkout. 

An issue has been filed at https://github.com/Automattic/wp-calypso/issues/56716.

#### Testing instructions

- [ ] pre-release tests pass.

Related to #56716
