### PR TITLE
Enable setup-site-after-checkout for all users

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -105,7 +105,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
-		"signup/setup-site-after-checkout": false,
+		"signup/setup-site-after-checkout": true,
 		"site-indicator": true,
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Re-enables the design picker in the onboarding flow after fixing an issue where purchasing a domain would break the flow #56677

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to `/start` and verify that you see the design picker after selecting the free plan or after completing checkout

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
