### PR TITLE
Onboarding: Deal with branch steps according to the intent

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -287,8 +287,8 @@ export default class SignupFlowController {
 	 */
 	_getFlowSteps() {
 		// As signup framework is shared across multiple products, we keep using this value with excluded steps
-		// to ensure this change not break any existed behavior. Thus, the excluded steps will be processed for
-		// those flow.
+		// to ensure that this change does not any existed behavior. Thus, the excluded steps will be processed
+		// for those flows.
 		if ( ! this._flow.enableBranchSteps ) {
 			return this._flow.steps;
 		}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -408,7 +408,7 @@ export function generateFlows( {
 		{
 			name: 'setup-site',
 			steps: isEnabled( 'signup/hero-flow' )
-				? [ 'intent', 'design-setup-site', 'site-options' ]
+				? [ 'intent', 'site-options', 'design-setup-site' ]
 				: [ 'design-setup-site' ],
 			destination: isEnabled( 'signup/hero-flow' )
 				? getDestinationFromIntent

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -419,6 +419,7 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'siteId', 'siteSlug' ],
 			optionalDependenciesInQuery: [ 'siteId' ],
 			pageTitle: translate( 'Setup your site' ),
+			enableBranchSteps: true,
 		},
 		{
 			name: 'do-it-for-me',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -175,9 +175,10 @@ const Flows = {
 	 *
 	 * The returned flow is modified according to several filters.
 	 *
+	 * @typedef {import('../types').Flow} Flow
 	 * @param {string} flowName The name of the flow to return
 	 * @param {boolean} isUserLoggedIn Whether the user is logged in
-	 * @returns {object} A flow object
+	 * @returns {Flow} A flow object
 	 */
 	getFlow( flowName, isUserLoggedIn ) {
 		let flow = Flows.getFlows()[ flowName ];

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -183,6 +183,7 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug', 'siteTitle', 'tagline' ],
 			providesDependencies: [ 'siteTitle', 'tagline' ],
 			apiRequestFunction: setOptionsOnSite,
+			delayApiRequestUntilComplete: true,
 		},
 
 		test: {
@@ -725,6 +726,7 @@ export function generateSteps( {
 		'design-setup-site': {
 			stepName: 'design-setup-site',
 			apiRequestFunction: setDesignOnSite,
+			delayApiRequestUntilComplete: true,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'selectedDesign' ],
 			optionalDependencies: [ 'selectedDesign' ],
@@ -738,10 +740,6 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug', 'selectedDIFMDesign', 'selectedVertical' ],
 			providesDependencies: [ 'cartItem' ],
 			apiRequestFunction: addPlanToCart,
-		},
-		'intent-screen': {
-			stepName: 'intent-screen',
-			dependencies: [ 'siteSlug' ],
 		},
 	};
 }

--- a/client/signup/hooks/use-branch-steps.ts
+++ b/client/signup/hooks/use-branch-steps.ts
@@ -29,7 +29,7 @@ const useBranchSteps = ( stepName: string ): BranchSteps => {
 	// Only do following things when mounted
 	React.useEffect( () => {
 		restoreBranchSteps();
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return branchSteps;
 };

--- a/client/signup/hooks/use-branch-steps.ts
+++ b/client/signup/hooks/use-branch-steps.ts
@@ -6,9 +6,9 @@ type BranchSteps = ( excludeSteps: string[] ) => void;
 const memoExcludeSteps: { [ key: string ]: string[] } = {};
 
 /**
- * This hook return the function to do branch steps. Ensure to call this function before submitSignupStep
- * because we process all of steps immediately after submitting.
- * Also, it will clean up the exclude steps when the component mounts as the user might go back to the step
+ * This hook returns the function to do branch steps. Ensure this function is called before submitSignupStep
+ * because we process all of the steps immediately after submitting.
+ * Also, it will clean up the exclude steps when the component mounts as the user might go back a step
  */
 const useBranchSteps = ( stepName: string ): BranchSteps => {
 	const branchSteps = ( excludeSteps: string[] ) => {

--- a/client/signup/hooks/use-branch-steps.ts
+++ b/client/signup/hooks/use-branch-steps.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import flows from 'calypso/signup/config/flows';
+
+type BranchSteps = ( excludeSteps: string[] ) => void;
+
+const memoExcludeSteps: { [ key: string ]: string[] } = {};
+
+/**
+ * This hook return the function to do branch steps. Ensure to call this function before submitSignupStep
+ * because we process all of steps immediately after submitting.
+ * Also, it will clean up the exclude steps when the component mounts as the user might go back to the step
+ */
+const useBranchSteps = ( stepName: string ): BranchSteps => {
+	const branchSteps = ( excludeSteps: string[] ) => {
+		excludeSteps.forEach( ( step ) => {
+			flows.excludeStep( step );
+		} );
+		memoExcludeSteps[ stepName ] = excludeSteps;
+	};
+
+	const restoreBranchSteps = () => {
+		const excludeSteps = memoExcludeSteps[ stepName ] || [];
+		excludeSteps.forEach( ( step ) => {
+			flows.resetExcludedStep( step );
+		} );
+		delete memoExcludeSteps[ stepName ];
+	};
+
+	// Only do following things when mounted
+	React.useEffect( () => {
+		restoreBranchSteps();
+	}, [] );
+
+	return branchSteps;
+};
+
+export default useBranchSteps;

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -5,7 +5,7 @@ import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import flows from 'calypso/signup/config/flows';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import IntentScreen from './intent-screen';
 import type { IntentFlag } from './types';
 
@@ -25,21 +25,26 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { goToNextStep, stepName } = props;
-
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
 
 	const submitIntent = ( intent: IntentFlag ) => {
+		// TODO: Better way to handle branch steps
+		// We need to exclude these steps before submitSignupStep because we process steps
+		// after submitting and check the current steps at that time
+		EXCLUDE_STEPS[ intent ]?.forEach( ( step ) => {
+			flows.excludeStep( step );
+		} );
+
 		recordTracksEvent( 'calypso_signup_select_intent', { intent } );
 		dispatch( submitSignupStep( { stepName }, { intent } ) );
-
-		// TODO: Better way to handle branch steps
-		EXCLUDE_STEPS[ intent ].forEach( ( step ) => flows.excludeStep( step ) );
-
 		goToNextStep();
 	};
 
+	// Only do following things when mounted
 	React.useEffect( () => {
+		dispatch( saveSignupStep( { stepName } ) );
+		// User might go back to intent step, so we should reset excluded steps
 		flows.resetExcludedSteps();
 	}, [] );
 

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import flows from 'calypso/signup/config/flows';
+import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import IntentScreen from './intent-screen';
@@ -27,15 +27,10 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	const { goToNextStep, stepName } = props;
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
+	const branchSteps = useBranchSteps( stepName );
 
 	const submitIntent = ( intent: IntentFlag ) => {
-		// TODO: Better way to handle branch steps
-		// We need to exclude these steps before submitSignupStep because we process steps
-		// after submitting and check the current steps at that time
-		EXCLUDE_STEPS[ intent ]?.forEach( ( step ) => {
-			flows.excludeStep( step );
-		} );
-
+		branchSteps( EXCLUDE_STEPS[ intent ] );
 		recordTracksEvent( 'calypso_signup_select_intent', { intent } );
 		dispatch( submitSignupStep( { stepName }, { intent } ) );
 		goToNextStep();
@@ -44,8 +39,6 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	// Only do following things when mounted
 	React.useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
-		// User might go back to intent step, so we should reset excluded steps
-		flows.resetExcludedSteps();
 	}, [] );
 
 	return (

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -39,7 +39,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	// Only do following things when mounted
 	React.useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<StepWrapper

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import siteOptionsImage from 'calypso/assets/images/onboarding/site-options.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SiteOptions from './site-options';
 import type { SiteOptionsFormValues } from './types';
 import './index.scss';
@@ -30,6 +30,11 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		dispatch( submitSignupStep( { stepName }, { siteTitle, tagline } ) );
 		goToNextStep();
 	};
+
+	// Only do following things when mounted
+	React.useEffect( () => {
+		dispatch( saveSignupStep( { stepName } ) );
+	}, [] );
 
 	return (
 		<StepWrapper

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -1,0 +1,11 @@
+export interface Flow {
+	name: string;
+	steps: string[];
+	destination: ( dependencies: any ) => string;
+	description: string;
+	lastModified: string;
+	pageTitle?: string;
+	providesDependenciesInQuery?: string[];
+	disallowResume?: boolean;
+	showRecaptcha?: boolean;
+}

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -1,11 +1,17 @@
+export interface Dependencies {
+	[ other: string ]: string[];
+}
+
 export interface Flow {
 	name: string;
 	steps: string[];
-	destination: ( dependencies: any ) => string;
+	destination: string | ( ( dependencies: Dependencies ) => string );
 	description: string;
 	lastModified: string;
 	pageTitle?: string;
 	providesDependenciesInQuery?: string[];
+	optionalDependenciesInQuery?: string[];
 	disallowResume?: boolean;
 	showRecaptcha?: boolean;
+	enableBranchSteps?: boolean;
 }

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -90,10 +90,18 @@ const invalidateStep = ( state, { step, errors } ) => {
 
 const processStep = ( state, { step } ) => updateStep( state, { ...step, status: 'processing' } );
 
-const saveStep = ( state, { step } ) =>
-	has( state, step.stepName )
-		? updateStep( state, step )
+const saveStep = ( state, { step } ) => {
+	const status = get( state, [ step.stepName, 'status' ] );
+
+	return has( state, step.stepName )
+		? updateStep( state, {
+				...step,
+				// The pending status means this step needs to delay api request and the user goes back to this step
+				// So we can mark status as in-progress
+				status: status === 'pending' ? 'in-progress' : status,
+		  } )
 		: addStep( state, { ...step, status: 'in-progress' } );
+};
 
 const submitStep = ( state, { step } ) => {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Implement “branch steps” described in pdgK6S-bZ-p2
* Using `flows.getFlow().steps` instead of `this._flow.steps` to ignore exclude steps if the flow enables branch steps (which means `enableBranchSteps` in the flow config is true).
* Delay API request for both `design-setup-site` and `site-options` steps because these changes should only work after the entire flow complete
* Call `saveSignupStep` when both `design-setup-site` and `site-options` steps shows to make sure it wouldn't be counted as completed step
* Introduce `useBranchSteps` hooks.
  * Give it the `stepName` and this will be used to memo excluded steps so that it can restore the excluded steps when the user goes back to the target step (ex. intent)
  * This hook returns a function named `branchSteps`, just call it with what steps you want to exclude before `submitSignupStep` and it will help you to exclude those steps
  * For example
    ```js
    const BranchStepComponent = () => {
      const dispatch = useDispatch();
      const branchSteps = useBranchSteps( stepName );

      const submit = () => {
        branchSteps( stepsYouWantToExclude );
        dispatch( submitSignupStep( { stepName }, valuesYouWantToSubmit ) );
      }
      ...
    }
    ```


The potential problem is that if we want to apply a default design when the user doesn't need to choose a design, we need to find a great timing to do it.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?flags=signup/hero-flow&siteSlug=<your_site>`. or `/start?flags=signup/hero-flow`
1.  **Write Flow**
  * Choose Write intent
  * Fill blog name and tagline
  * Click continue and finish the flow, ending up in the Editor
  * Go to My Home > Settings and check site title and site tagline are the same as you fill in the previous step.
2. **Build Flow** 
  * Choose Build intent
  * Choose a design and finish the flow, ending up My Home
  * Go to My Home and check the theme and template are the same as the design you choose in the previous step.
3. **Test "going back"**
  *  Choose Write intent first 
  * go back to choose Build intent
  * Make sure the flow doesn't complete directly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/55603