### PR TITLE
chore: Revert ESM conversion of a few packages

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -92,7 +92,7 @@
 		"lint:php:fix": "../../vendor/bin/phpcbf --standard=../phpcs.xml ./ "
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0",
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/data-stores": "^2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
 	},
 	"main": "server/index.js",
 	"dependencies": {
-		"@automattic/accessible-focus": "^1.0.0",
+		"@automattic/accessible-focus": "^1.0.0-alpha.0",
 		"@automattic/browser-data-collector": "^2.0.0",
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^9.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "^1.0.0",
 		"@automattic/browser-data-collector": "^2.0.0",
-		"@automattic/calypso-analytics": "^1.0.0",
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/calypso-config": "^1.0.0-alpha.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
 	"main": "server/index.js",
 	"dependencies": {
 		"@automattic/accessible-focus": "^1.0.0-alpha.0",
-		"@automattic/browser-data-collector": "^2.0.0",
+		"@automattic/browser-data-collector": "^3.0.0",
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
 		"@automattic/calypso-analytics": "^1.0.0",
 		"@automattic/calypso-build": "^9.0.0",
 		"@automattic/calypso-color-schemes": "^2.1.1",
-		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-polyfills": "^2.0.0",
 		"@automattic/calypso-products": "^1.0.0",
 		"@automattic/calypso-stripe": "^1.0.0",

--- a/packages/accessible-focus/CHANGELOG.md
+++ b/packages/accessible-focus/CHANGELOG.md
@@ -1,9 +1,3 @@
-# CHANGELOG
-
-## 1.0.0
-
-- Breaking: Module converted to ESM only. CJS build is not provided anymore.
-
 ## 1.0.0-alpha.0
 
 Extracted from `accessible-focus` and transformed to TypeScript and tests added.

--- a/packages/accessible-focus/jest.config.js
+++ b/packages/accessible-focus/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 };

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -6,15 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
 	"sideEffects": false,
-	"type": "module",
-	"exports": {
-		"calypso:src": "./src/index.ts",
-		"import": "./dist/esm/index.js",
-		"require": "./dist/cjs/index.js"
-	},
-	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-	},
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/accessible-focus",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.0",
 	"description": "A package for detecting keyboard navigation.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -32,8 +32,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/browser-data-collector/CHANGELOG.md
+++ b/packages/browser-data-collector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.0.0
+
+- Breaking: Undo ESM conversion, CJS is provided again.
+
 ## 2.0.0
 
 - Breaking: Drop support for Performance Mark and Measures collectors

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -1,18 +1,13 @@
 {
 	"name": "@automattic/browser-data-collector",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"description": "A tool to collect data from different browser APIs",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
-	"type": "module",
-	"exports": {
-		"calypso:src": "./src/index.ts",
-		"import": "./dist/esm/index.js"
-	},
-	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-	},
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
@@ -23,8 +18,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/browser-data-collector/tsconfig-cjs.json
+++ b/packages/browser-data-collector/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/calypso-analytics/jest.config.js
+++ b/packages/calypso-analytics/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 };

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -1,19 +1,14 @@
 {
 	"name": "@automattic/calypso-analytics",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Automattic Analytics",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
 	"sideEffects": true,
-	"type": "module",
-	"exports": {
-		"calypso:src": "./src/index.ts",
-		"import": "./dist/esm/index.js"
-	},
-	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-	},
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
@@ -31,8 +26,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/calypso-analytics/tsconfig-cjs.json
+++ b/packages/calypso-analytics/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/calypso-config/CHANGELOG.md
+++ b/packages/calypso-config/CHANGELOG.md
@@ -1,9 +1,3 @@
-# CHANGELOG
-
-## 1.0.0
-
-- Breaking: Module converted to ESM only. CJS build is not provided anymore.
-
 ## 1.0.0-alpha.0
 
 Extracted from `create-config` and transformed to TypeScript.

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -1,19 +1,14 @@
 {
 	"name": "@automattic/calypso-config",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.0",
 	"description": "The Calypso configuration API.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
 	"sideEffects": true,
-	"exports": {
-		"calypso:src": "./src/index.ts",
-		"import": "./dist/esm/index.js"
-	},
-	"type": "module",
-	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-	},
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
@@ -31,8 +26,8 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "tsc --build ./tsconfig.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json",
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"

--- a/packages/calypso-config/tsconfig-cjs.json
+++ b/packages/calypso-config/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -37,7 +37,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-products#readme",
 	"dependencies": {
-		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/calypso-url": "^1.0.0",
 		"i18n-calypso": "^5.0.0",
 		"react": "^17.0.2"

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-config": "^1.0.0",
+		"@automattic/calypso-config": "^1.0.0-alpha.0",
 		"@automattic/onboarding": "^1.0.0",
 		"@wordpress/components": "^17.0.0",
 		"@wordpress/react-i18n": "^3.0.1",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0",
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@automattic/onboarding": "^1.0.0",

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -31,7 +31,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0",
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/data-stores": "^2.0.0",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/i18n-utils": "^1.0.0",

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -36,7 +36,7 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
-		"@automattic/calypso-analytics": "^1.0.0",
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/i18n-utils": "^1.0.0",
 		"@wordpress/components": "^17.0.0",
 		"@wordpress/react-i18n": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/accessible-focus@^1.0.0, @automattic/accessible-focus@workspace:packages/accessible-focus":
+"@automattic/accessible-focus@^1.0.0-alpha.0, @automattic/accessible-focus@workspace:packages/accessible-focus":
   version: 0.0.0-use.local
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
   dependencies:
@@ -44,7 +44,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/browser-data-collector@^2.0.0, @automattic/browser-data-collector@workspace:packages/browser-data-collector":
+"@automattic/browser-data-collector@^3.0.0, @automattic/browser-data-collector@workspace:packages/browser-data-collector":
   version: 0.0.0-use.local
   resolution: "@automattic/browser-data-collector@workspace:packages/browser-data-collector"
   dependencies:
@@ -54,7 +54,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-analytics@^1.0.0, @automattic/calypso-analytics@workspace:packages/calypso-analytics":
+"@automattic/calypso-analytics@^1.0.0-alpha.1, @automattic/calypso-analytics@workspace:packages/calypso-analytics":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-analytics@workspace:packages/calypso-analytics"
   dependencies:
@@ -355,7 +355,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/domain-picker@workspace:packages/domain-picker"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0
+    "@automattic/calypso-analytics": ^1.0.0-alpha.1
     "@automattic/data-stores": ^2.0.0
     "@automattic/i18n-utils": ^1.0.0
     "@automattic/onboarding": ^1.0.0
@@ -569,7 +569,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/launch@workspace:packages/launch"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0
+    "@automattic/calypso-analytics": ^1.0.0-alpha.1
     "@automattic/data-stores": ^2.0.0
     "@automattic/domain-picker": ^1.0.0-alpha.0
     "@automattic/i18n-utils": ^1.0.0
@@ -1040,7 +1040,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/whats-new@workspace:packages/whats-new"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0
+    "@automattic/calypso-analytics": ^1.0.0-alpha.1
     "@automattic/i18n-utils": ^1.0.0
     "@wordpress/components": ^17.0.0
     "@wordpress/react-i18n": ^3.0.1
@@ -1149,7 +1149,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/wpcom-editing-toolkit@workspace:apps/editing-toolkit"
   dependencies:
-    "@automattic/calypso-analytics": ^1.0.0
+    "@automattic/calypso-analytics": ^1.0.0-alpha.1
     "@automattic/calypso-build": ^9.0.0
     "@automattic/composite-checkout": ^1.0.0
     "@automattic/data-stores": ^2.0.0
@@ -11889,9 +11889,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "calypso@workspace:client"
   dependencies:
-    "@automattic/accessible-focus": ^1.0.0
-    "@automattic/browser-data-collector": ^2.0.0
-    "@automattic/calypso-analytics": ^1.0.0
+    "@automattic/accessible-focus": ^1.0.0-alpha.0
+    "@automattic/browser-data-collector": ^3.0.0
+    "@automattic/calypso-analytics": ^1.0.0-alpha.1
     "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
     "@automattic/calypso-config": ^1.0.0-alpha.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,7 +134,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-config@^1.0.0, @automattic/calypso-config@workspace:packages/calypso-config":
+"@automattic/calypso-config@^1.0.0-alpha.0, @automattic/calypso-config@workspace:packages/calypso-config":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-config@workspace:packages/calypso-config"
   dependencies:
@@ -185,7 +185,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-products@workspace:packages/calypso-products"
   dependencies:
-    "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/calypso-url": ^1.0.0
     chai: ^4.3.4
     i18n-calypso: ^5.0.0
@@ -324,7 +324,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/design-picker@workspace:packages/design-picker"
   dependencies:
-    "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/onboarding": ^1.0.0
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.1.1
@@ -11894,7 +11894,7 @@ __metadata:
     "@automattic/calypso-analytics": ^1.0.0
     "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-color-schemes": ^2.1.1
-    "@automattic/calypso-config": ^1.0.0
+    "@automattic/calypso-config": ^1.0.0-alpha.0
     "@automattic/calypso-polyfills": ^2.0.0
     "@automattic/calypso-products": ^1.0.0
     "@automattic/calypso-stripe": ^1.0.0


### PR DESCRIPTION
#### Background

I started the conversion (#55855) of some packages to ESM, but we found that TypeScript doesn't produce valid ESM packages (see p4TIVU-9Pn-p2)

#### Changes proposed in this Pull Request

* Partial revert of #56130
    * Revert conversion of `@automattic/browser-data-collector` to ESM
    * Revert conversion of `@automattic/accesible-focus` to ESM 
    * Revert conversion of `@automattic/calypso-analytics` to ESM

* Partial revert of #56459
    * Revert conversion of `@automattic/calypso-config` to ESM

* Partila revert of #55226
    * Revert conversion of `@automattic/accesible-focus` to ESM

I checked npm registry and we haven't published any of the ESM versions, so it is safe to rollback the version number. The only exception is `@automattic/browser-data-collector` which had another version bump _after_ the ESM migration. To keep things clean, I've bumped the version again instead of rolling it back.


#### Testing instructions

Verify all tests are green