### PR TITLE
Forums: Pass blog information to endpoint

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -18,7 +18,6 @@ import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isDefaultLocale, localizeUrl } from 'calypso/lib/i18n-utils';
-import { withoutHttp } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import ActiveTicketsNotice from 'calypso/me/help/active-tickets-notice';
 import ChatHolidayClosureNotice from 'calypso/me/help/contact-form-notice/chat-holiday-closure';
@@ -280,10 +279,7 @@ class HelpContact extends Component {
 		if ( site || userDeclaredUrl ) {
 			siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
 
-			blogHelpMessage = this.translateForForums( 'Site: %s.', {
-				args: [ userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl ],
-			} );
-
+			blogHelpMessage = '';
 			if ( helpSiteIsWpCom ) {
 				blogHelpMessage += '\n' + this.translateForForums( 'WP.com: Yes' );
 			}
@@ -317,6 +313,7 @@ class HelpContact extends Component {
 			message: forumMessage,
 			locale: currentUserLocale,
 			client: config( 'client_slug' ),
+			hide_blog_info: userRequestsHidingUrl,
 		};
 
 		if ( site ) {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -276,8 +276,9 @@ class HelpContact extends Component {
 			blogHelpMessage = this.translateForForums( "I don't have a site with WordPress.com yet" );
 		}
 
+		let siteUrl = '';
 		if ( site || userDeclaredUrl ) {
-			const siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
+			siteUrl = userDeclaredUrl ? userDeclaredUrl.trim() : site.URL;
 
 			blogHelpMessage = this.translateForForums( 'Site: %s.', {
 				args: [ userRequestsHidingUrl ? 'help@' + withoutHttp( siteUrl ) : siteUrl ],
@@ -311,14 +312,23 @@ class HelpContact extends Component {
 		}
 
 		const forumMessage = message + '\n\n' + blogHelpMessage;
+		const requestData = {
+			subject,
+			message: forumMessage,
+			locale: currentUserLocale,
+			client: config( 'client_slug' ),
+		};
+
+		if ( site ) {
+			requestData.blog_id = site.ID;
+		}
+
+		if ( siteUrl ) {
+			requestData.blog_url = siteUrl;
+		}
 
 		wpcom.req
-			.post( '/help/forums/support/topics/new', {
-				subject,
-				message: forumMessage,
-				locale: currentUserLocale,
-				client: config( 'client_slug' ),
-			} )
+			.post( '/help/forums/support/topics/new', requestData )
 			.then( ( data ) => {
 				this.setState( {
 					isSubmitting: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on improvements to our support forums, I've noticed that we are not passing the blog information that the user selects in the contact form back to the endpoint. It's just part of the message. But not as metadata. This leads to that information not being properly handled on the forums (the selected blog is not being shown in the sidebar, etc.). This PR addresses this by passing both the `blog_id` and/or `blog_url` (whichever are available) back to the endpoint.
It also explicitly passes if the user opted to hide their blog details or not to the endpoint (`hide_blog_info`).

#### Testing instructions
It's best to test with D67708-code.

Hardcode the support variation in `client/state/selectors/get-inline-help-support-variation.js` to `SUPPORT_FORUMS`.
Then visit http://calypso.localhost:3000/help/contact and fill out the form.

Try with explicitly setting the blog information:
<img width="753" alt="Screenshot 2021-10-01 at 10 31 43" src="https://user-images.githubusercontent.com/3392497/135609259-b0c3d54b-794f-467c-8f56-6bb136960047.png">

Or inputting the domain manually:
<img width="691" alt="Screenshot 2021-10-01 at 10 32 16" src="https://user-images.githubusercontent.com/3392497/135609290-b613348c-d9bc-4317-be42-92e6296135f3.png">

Verify that the request has `blog_id` and/or `blog_url` filled out as expected, as well as `hide_blog_info`.

