### PR TITLE
Remove woocommerce-installation menu item fallback

### DIFF
--- a/client/my-sites/sidebar-unified/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar-unified/static-data/fallback-menu.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 /* eslint-disable jsdoc/require-param */
 /**
@@ -41,35 +40,6 @@ export default function buildFallbackResponse( {
 	shouldShowAMP = false,
 	shouldShowBetaTesting = false,
 } = {} ) {
-	let wooCommerce = [];
-	if ( shouldShowWooCommerce ) {
-		wooCommerce = [
-			{
-				icon: WOOCOMMERCE_ICON,
-				slug: 'woo-php',
-				title: translate( 'WooCommerce' ),
-				type: 'menu-item',
-				url: `https://${ siteDomain }/wp-admin/admin.php?page=wc-admin`,
-			},
-			{
-				type: 'separator',
-			},
-		];
-	} else if ( isEnabled( 'woop' ) ) {
-		wooCommerce = [
-			{
-				icon: WOOCOMMERCE_ICON,
-				slug: 'woo-php',
-				title: translate( 'WooCommerce' ),
-				type: 'menu-item',
-				url: `/woocommerce-installation/${ siteDomain }`,
-			},
-			{
-				type: 'separator',
-			},
-		];
-	}
-
 	let inbox = [];
 	if ( shouldShowInbox ) {
 		inbox = [
@@ -372,7 +342,20 @@ export default function buildFallbackResponse( {
 			type: 'separator',
 		},
 		// Add WooCommerce here
-		...wooCommerce,
+		...( shouldShowWooCommerce
+			? [
+					{
+						icon: WOOCOMMERCE_ICON,
+						slug: 'woo-php',
+						title: translate( 'WooCommerce' ),
+						type: 'menu-item',
+						url: `https://${ siteDomain }/wp-admin/admin.php?page=wc-admin`,
+					},
+					{
+						type: 'separator',
+					},
+			  ]
+			: [] ),
 		...( shouldShowThemes
 			? [
 					{


### PR DESCRIPTION
Partial revert of #56488

When the woop flag is active this fallback menu item is displayed to all users including p2 and domain only sites where we do not want it shown.

Since this can't be checked without confirming things over the wire so I'm dropping it from the fallback menu until we can figure out how to restrict who sees this better.

#### Changes proposed in this Pull Request

* Remove woocommerce-installation menu item from the fallback menu
* Leave the Jetpack icon fix in place

#### Testing instructions

The easiest way to test this is to [change this line](https://github.com/Automattic/wp-calypso/blob/0b1198ce5237a2540aaeeff024da4d5532a84acb/client/my-sites/sidebar-unified/use-site-menu-items.js#L81) to:
```
return buildFallbackResponse( fallbackDataOverides );
```

The fallback menu is only shown while the menu is loaded from the masterbar code in jetpack/public-api (D67193-code) or if there is a network error. 

To test, you need to watch the menu clearly and avoid caching by switching to a site you haven't loaded in a while.

E.g. start here: http://calypso.localhost:3000/home/wooptestnowoo.wordpress.com?flags=woop

Then switch to a different site and observe the WooCommerce menu item is no longer present before it gets removed when the menu finishes loading.

Then test without the flag (Default mode): http://calypso.localhost:3000/home/wooptestnowoo.wordpress.com?flags=-woop

The WooCommerce menu item won't show during fallback unless it's a site with woo installed.

#### Before:
![Screenshot 2021-09-23 at 16-50-57 My Home ‹ wooptest-nowoo — WordPress com](https://user-images.githubusercontent.com/811776/134465341-146556f6-03e1-45df-ac83-9101c0000c91.png)

#### After: 
![Screenshot 2021-10-11 at 14-55-44 My Home ‹ wooptestupgrade — WordPress com](https://user-images.githubusercontent.com/811776/136731110-8592da36-55ce-4ece-9164-f84d06a1453a.png)



Related to #55428