### PR TITLE
E2E: Make design pick in I18n Gutenboarding spec deterministic

### DIFF
--- a/test/e2e/lib/pages/gutenboarding/designs-page.js
+++ b/test/e2e/lib/pages/gutenboarding/designs-page.js
@@ -14,10 +14,11 @@ export default class DesignLocatorPage extends AsyncBaseContainer {
 			throw new Error( 'No free designs were found on design selection page' );
 		}
 
-		const blankCanvasIndex = 0;
-		const firstNonBlankIndex = 1;
-		// If possible, we should skip first design, which is the blank canvas, and pick the first other one.
-		const selectedDesignIndex = freeOptions.length > 1 ? firstNonBlankIndex : blankCanvasIndex;
-		await freeOptions[ selectedDesignIndex ].click();
+		if ( freeOptions.length === 1 ) {
+			throw new Error( 'There should be more than one design found on the design selection page' );
+		}
+
+		const firstNonBlankDesign = freeOptions[ 1 ];
+		await firstNonBlankDesign.click();
 	}
 }

--- a/test/e2e/lib/pages/gutenboarding/designs-page.js
+++ b/test/e2e/lib/pages/gutenboarding/designs-page.js
@@ -10,12 +10,10 @@ export default class DesignLocatorPage extends AsyncBaseContainer {
 
 	async selectFreeDesign() {
 		const freeOptions = await this.driver.findElements( this.freeOptionLocator );
-		if ( freeOptions.length === 0 ) {
-			throw new Error( 'No free designs were found on design selection page' );
-		}
-
-		if ( freeOptions.length === 1 ) {
-			throw new Error( 'There should be more than one design found on the design selection page' );
+		if ( freeOptions.length <= 1 ) {
+			throw new Error(
+				'There should be more than one free design found on the design selection page'
+			);
 		}
 
 		const firstNonBlankDesign = freeOptions[ 1 ];

--- a/test/e2e/lib/pages/gutenboarding/designs-page.js
+++ b/test/e2e/lib/pages/gutenboarding/designs-page.js
@@ -1,6 +1,5 @@
 import { By } from 'selenium-webdriver';
 import AsyncBaseContainer from '../../async-base-container';
-import * as dataHelper from '../../data-helper';
 
 export default class DesignLocatorPage extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -11,11 +10,14 @@ export default class DesignLocatorPage extends AsyncBaseContainer {
 
 	async selectFreeDesign() {
 		const freeOptions = await this.driver.findElements( this.freeOptionLocator );
-		await freeOptions[ dataHelper.getRandomInt( 0, freeOptions.length - 1 ) ].click();
-	}
+		if ( freeOptions.length === 0 ) {
+			throw new Error( 'No free designs were found on design selection page' );
+		}
 
-	async selectPaidDesign() {
-		const paidOptions = await this.driver.findElements( this.paidOptionLocator );
-		await paidOptions[ dataHelper.getRandomInt( 0, paidOptions.length - 1 ) ].click();
+		const blankCanvasIndex = 0;
+		const firstNonBlankIndex = 1;
+		// If possible, we should skip first design, which is the blank canvas, and pick the first other one.
+		const selectedDesignIndex = freeOptions.length > 1 ? firstNonBlankIndex : blankCanvasIndex;
+		await freeOptions[ selectedDesignIndex ].click();
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The I18N Gutenboarding spec has been having intermittent, seemingly random, failures. Looking at the tests that do fail, sometimes the test is skipping the preview/font-selection page.

This is because the "Blank Canvas" option does not take you to the preview or ask you for a font. Because the design was being selected at random, sometimes the Blank Canvas option was being selected, causing the failure.

Now, we select whatever the first design is after Blank Canvas, which should remove the random failures!

#### Testing instructions

- [x] Run the I18N tests

I18N tests have passed for this branch!
