### PR TITLE
Fix margin of controls in Backup & Scan activity log item

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -455,7 +455,8 @@
 }
 
 .activity-log-item {
-	a.button, button {
+	a.button,
+	button {
 		margin-right: 8px;
 	}
 }
@@ -494,4 +495,9 @@
 }
 .activity-log-item__description-actions {
 	flex-grow: 1;
+	flex-shrink: 0;
+
+	@include break-wide {
+		margin-left: 1rem;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a left margin to the controls container in the  Backup & Scan activity log item. See captures below.

Fixes 1164141197617539-as-1200900176330346

### Testing instructions

- Download the PR and run Calypso
- Select a Jetpack site
- Visit the activity log at `/activity-log/:site`
- Check at various viewports that the Backup & Scan item has proper space between its controls and its stats, as seen in the capture below 

### Screenshots

Before
<img width="967" alt="Screen Shot 2021-10-01 at 11 44 20 AM" src="https://user-images.githubusercontent.com/1620183/135649909-18ff9be7-8402-4984-a827-a708be7b475c.png">


After
<img width="973" alt="Screen Shot 2021-10-01 at 11 45 55 AM" src="https://user-images.githubusercontent.com/1620183/135649920-101b0868-32be-43c4-9001-e3978e8cb0f9.png">