### PR TITLE
Jetpack Cancellation Flow: Fix missing dispatch for Tracks events

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -3,7 +3,7 @@ import { Button as ButtonType } from '@automattic/components/dist/types/dialog/b
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import * as React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import JetpackBenefitsStep from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step';
 import JetpackCancellationSurvey from 'calypso/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
@@ -34,6 +34,7 @@ interface Props {
 
 const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ...props } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ cancellationStep, setCancellationStep ] = useState( steps.FEATURES_LOST_STEP ); // set initial state
 	const [ surveyAnswerId, setSurveyAnswerId ] = useState< string | null >( null );
 	const [ surveyAnswerText, setSurveyAnswerText ] = useState< TranslateResult | string >( '' );
@@ -56,13 +57,15 @@ const CancelJetpackForm: React.FC< Props > = ( { isVisible = false, purchase, ..
 	const recordEvent = ( name: string, properties = {} ) => {
 		const { flowType } = props;
 
-		recordTracksEvent( name, {
-			cancellation_flow: flowType,
-			product_slug: purchase.productSlug,
-			is_atomic: isAtomicSite,
+		dispatch(
+			recordTracksEvent( name, {
+				cancellation_flow: flowType,
+				product_slug: purchase.productSlug,
+				is_atomic: isAtomicSite,
 
-			...properties,
-		} );
+				...properties,
+			} )
+		);
 	};
 
 	// run on mount


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the Tracks events in the Jetpack cancellation flow by adding the `dispatch` so the action is actually called.
* Context: 1198218726984184-as-1201030925616309

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Check out this branch
- Run yarn start
- Go to http://calypso.localhost:3000/me/purchases/
- Open a website you own that has a Jetpack plan
- Open the Network tab from the DevTools, and search for t.gif
- Click to cancel a plan, and make sure the events get tracked when you click on any of the buttons (the events start with `calypso_purchases_cancel_`)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->