### PR TITLE
Playwright: Extend the timeouts when test-purchasing domains

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-domains__add.ts
+++ b/test/e2e/specs/specs-playwright/wp-domains__add.ts
@@ -76,7 +76,15 @@ describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), functio
 	} );
 
 	it( 'Make purchase', async function () {
-		await cartCheckoutPage.purchase();
+		await Promise.all( [
+			page.waitForNavigation( {
+				url: '**/checkout/thank-you/**',
+				waitUntil: 'networkidle',
+				// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
+				timeout: 90 * 1000,
+			} ),
+			cartCheckoutPage.purchase(),
+		] );
 	} );
 
 	it( 'Manage domain', async function () {

--- a/test/e2e/specs/specs-playwright/wp-signup__domain.ts
+++ b/test/e2e/specs/specs-playwright/wp-signup__domain.ts
@@ -89,6 +89,8 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 				page.waitForNavigation( {
 					url: '**/checkout/thank-you/no-site/**',
 					waitUntil: 'networkidle',
+					// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
+					timeout: 90 * 1000,
 				} ),
 				cartCheckoutPage.purchase(),
 			] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we test domain purchases in E2E, we use a test API system to avoid costs. That test system is third party controlled, and has a history of occasionally being slow.

This extends the timeout we wait when making these test domain purchases. In the pre-release context, it's much better for a test to take some extra time then for there to be a false-positive caused by sluggishness in the third-party system.

#### Testing instructions

- [ ] `yarn jest specs/specs-playwright/wp-domains__add.ts`
- [ ]  `yarn jest specs/specs-playwright/wp-signup__domain.ts`

Related to #

From duplicate PR:

> It also appears the `/start/domin` flow takes longer than other flows in order to process the checkout.
> 
> An issue has been filed at #56716.