### PR TITLE
Fix inaccurate path matching for redirect

### DIFF
--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -26,14 +26,15 @@ function allowPath( path ) {
 	const possiblePathLocales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
 	for ( const locale of possiblePathLocales ) {
 		// Strip leading locale (e.g. 'es/')
-		if ( parsedPath.startsWith( locale ) ) {
-			parsedPath = parsedPath.replace( new RegExp( `^${ locale }/?` ), '' );
+		if ( parsedPath.startsWith( locale + '/' ) ) {
+			parsedPath = parsedPath.replace( new RegExp( `^${ locale }/` ), '' );
 			break;
 		}
 	}
 	// At this point, '/es/themes' is just 'themes', ready to match our allowed paths.
 	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes', 'theme', 'domains' ];
-	return allowedPaths.some( ( p ) => parsedPath.startsWith( p ) );
+	// For example, match either exactly "themes" or "themes/*"
+	return allowedPaths.some( ( p ) => parsedPath === p || parsedPath.startsWith( p + '/' ) );
 }
 
 export default () => ( req, res, next ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request
@jsnajdr noted some problems with the path matching I implemented in #56631. This resolves those.

- Only strip locales if the path starts with "$locale/" instead of just "$locale". Formerly, "design" would become "sign".
- Only allow paths which are an exact match for the allow list, or are a subpath of the allow list. Formerly, anything starting with "themes" (like "themestuff") was allowed. Now, the target path has to be exactly "themes", or it has to start with "themes/". So "themestuff" is redirected, but "themes/stuff" is allowed.

### Testing instructions
Test above examples in IE 11 on browserstack.
