### PR TITLE
chore: Delete override for xunit-viewer

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -370,9 +370,6 @@ packageExtensions:
     peerDependencies:
       core-js-bundle: '*'
       regenerator-runtime: '*'
-  xunit-viewer@5.2.0:
-    peerDependencies:
-      '@babel/core': '*'
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Delete unused override for xunit-viewer.

This will fix:

```
➤ YN0000: ┌ Post-resolution validation
➤ YN0068: │ xunit-viewer ➤ peerDependencies ➤ @babel/core: No matching package in the dependency tree; you may not need this rule anymore.
➤ YN0000: └ Completed
```


#### Testing instructions

N/A