### PR TITLE
5 minutes review: fix comment bulk edit in Calypso

### DIFF
--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -163,7 +163,7 @@ const setChildDirection = ( child, isRtl ) => {
 		return cloneElement( child, getDirectionProps( child, childDirection ) );
 	}
 
-	if ( child && child.props.children ) {
+	if ( child?.props?.children ) {
 		const children = Children.map( child.props.children, ( innerChild ) => {
 			if ( ! innerChild ) {
 				return innerChild;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Quoting its JSDoc, This [function](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/auto-direction/index.jsx#L159)
```js
/**
 * Sets a react component child directionality according to it's text content
 * That function intended to be used recursively with React.Children.map
 * It will set directionality only to the leaf components - because it does so according
 * to text content and only leaf components have those.
 * */
```
But it fails to consider that strings are valid React children, even though they don't have `props` property. This fix accounts for that.

#### Testing instructions

Verify that https://github.com/Automattic/wp-calypso/issues/56704 isn't reproducible.

Fixes #56704