### PR TITLE
Reader: Fix reader unavailable post mobile web

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -565,6 +565,18 @@
 	margin: 28px 0 26px;
 }
 
+.reader-full-post__unavailable {
+	.back-button__label {
+		@include breakpoint-deprecated( '<660px' ) {
+			display: inherit;
+		}
+	}
+	.reader-full-post__content {
+		@include breakpoint-deprecated( '<660px' ) {
+			margin-top: 2em;
+		}
+	}
+}
 .reader-full-post__unavailable-body {
 	margin-top: 2em;
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -154,7 +154,8 @@
 
 .reader-full-post__story-content {
 	color: var( --color-neutral-70 );
-	font-size: 17px;
+	/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+	font-size: rem( 17px );
 	line-height: 28px;
 }
 
@@ -244,14 +245,16 @@
 				height: 32px !important;
 				width: 32px !important;
 				line-height: 32px !important;
-				font-size: 32px !important;
+				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+				font-size: rem( 32px ) !important;
 
 				.gridicon {
 					@include breakpoint-deprecated( '<660px' ) {
 						height: 32px !important;
 						width: 32px !important;
 						line-height: 32px !important;
-						font-size: 32px !important;
+						/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+						font-size: rem( 32px ) !important;
 					}
 				}
 			}
@@ -337,7 +340,8 @@
 	.reader-share__button-label,
 	.comment-button__label,
 	.like-button__label {
-		font-size: 17px;
+		/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+		font-size: rem( 17px );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the mobile web display when the post is unavailable.
Before:
<img width="585" alt="Screen Shot 2021-10-04 at 11 08 36 AM" src="https://user-images.githubusercontent.com/115071/135902742-29cd68c4-b9a7-441e-86e5-e6cbc8f80b96.png">
After:  
<img width="584" alt="Screen Shot 2021-10-04 at 11 09 43 AM" src="https://user-images.githubusercontent.com/115071/135902738-b2c86968-cbc8-4510-8665-e7836d5686f4.png">

#### Testing instructions
View an unavailable post such as by visiting this URL /read/feeds/3946842022/posts/358729822644 while logged in. Notice that the layout looks likes as expected on both Mobile web as well as desktop. (desktop should not change)
