### PR TITLE
Fix color-sidebar-text-rgb on default theme

### DIFF
--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -16,6 +16,7 @@
 	--color-sidebar-menu-selected-text: white;
 	--color-sidebar-border: #333333;
 	--color-sidebar-text: #eee;
+	--color-sidebar-text-rgb: 238, 238, 238;
 	--color-sidebar-text-alternative: #a2aab2;
 	--color-sidebar-gridicon-fill: #a2aab2;
 	--color-sidebar-notice-background: #3c434a;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Some users have the "default" color scheme, a color scheme that cannot be selected.
  * (Today, if you select the "default" color scheme, you get "classic-dark", which is different than "default").
  * On this color scheme, the sidebar-text-rgb-default variable was blending in with the sidebar.
  * Provide an appropriate definition for this.

#### Testing instructions

* As an a8c, visit /read
* Use developer tools to change the class on the body tag. Remove `is-classic-dark` (or whatever your theme is) and add `is-default`.
* Look for last updated timestamps on the sidebar. 
* They should be invisible without this PR, and visible with the PR.

Before:

![2021-10-04_13-49](https://user-images.githubusercontent.com/937354/135907857-b29d2366-9679-48dd-ba07-fb7d9d47ae34.png)

After:

![2021-10-04_13-49_1](https://user-images.githubusercontent.com/937354/135907892-224f28a5-feca-4cbc-8537-0495add7f8b6.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/56627#issuecomment-933068917
