### PR TITLE
Playwright: add guards for some methods in SupportComponent.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -65,7 +65,7 @@ export class SupportComponent {
 			this.page.waitForResponse(
 				( response ) => response.status() === 200 && response.url().includes( 'language-names?' )
 			),
-			this.page.waitForSelector( selectors.supportPopover, { state: 'visible' } ),
+			this.page.waitForSelector( selectors.supportPopover ),
 			this.page.click( selectors.supportPopoverButton ),
 		] );
 	}
@@ -156,7 +156,7 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
-		await this.page.waitForSelector( selectors.visitArticleButton, { state: 'visible' } );
+		await this.page.waitForSelector( selectors.visitArticleButton );
 
 		const browserContext = this.page.context();
 		const [ newPage ] = await Promise.all( [

--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -58,8 +58,16 @@ export class SupportComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async openPopover(): Promise< void > {
-		await this.page.click( selectors.supportPopoverButton );
-		await this.page.waitForSelector( selectors.supportPopover, { state: 'visible' } );
+		if ( await this.page.isVisible( selectors.supportPopover ) ) {
+			return;
+		}
+		await Promise.all( [
+			this.page.waitForResponse(
+				( response ) => response.status() === 200 && response.url().includes( 'language-names?' )
+			),
+			this.page.waitForSelector( selectors.supportPopover, { state: 'visible' } ),
+			this.page.click( selectors.supportPopoverButton ),
+		] );
 	}
 
 	/**
@@ -68,6 +76,9 @@ export class SupportComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async closePopover(): Promise< void > {
+		if ( await this.page.isHidden( selectors.supportPopover ) ) {
+			return;
+		}
 		await this.page.click( selectors.supportPopoverButton );
 		await this.page.waitForSelector( selectors.supportPopover, { state: 'hidden' } );
 	}
@@ -145,6 +156,8 @@ export class SupportComponent {
 	 * @returns {Promise<Page>} Reference to support page.
 	 */
 	async visitArticle(): Promise< Page > {
+		await this.page.waitForSelector( selectors.visitArticleButton, { state: 'visible' } );
+
 		const browserContext = this.page.context();
 		const [ newPage ] = await Promise.all( [
 			browserContext.waitForEvent( 'page' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves reliability of various parts of the SupportComponent.

Key changes:
- add guards around `openPopover` and `closePopover` methods.
- add wait before clicking on the `Visit Article` button.

#### Testing instructions

- [x] stress test
  - [x] mobile
  - [x] desktop
- [x] normal test
  - [x] mobile
  - [x] desktop

Related to #
