### PR TITLE
Prefix '/' to paths in redirect matcher

### DIFF
--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -18,22 +18,26 @@ function isSupportedBrowser( req ) {
 	} );
 }
 
-// We don't want to redirect some of our public landing pages, so we include them
-// here.
+// We don't want to redirect some of our public landing pages, so we include them here.
 function allowPath( path ) {
-	// Strip leading '/'.
-	let parsedPath = path.replace( /^\//, '' );
-	const possiblePathLocales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
-	for ( const locale of possiblePathLocales ) {
-		// Strip leading locale (e.g. 'es/')
-		if ( parsedPath.startsWith( locale + '/' ) ) {
-			parsedPath = parsedPath.replace( new RegExp( `^${ locale }/` ), '' );
-			break;
-		}
-	}
-	// At this point, '/es/themes' is just 'themes', ready to match our allowed paths.
-	const allowedPaths = [ 'browsehappy', 'log-in', 'start', 'new', 'themes', 'theme', 'domains' ];
-	// For example, match either exactly "themes" or "themes/*"
+	const locales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
+	const prefixedLocale = locales.find( ( locale ) => path.startsWith( `/${ locale }/` ) );
+
+	// If the path starts with a locale, replace it (e.g. '/es/log-in' => '/log-in')
+	const parsedPath = prefixedLocale
+		? path.replace( new RegExp( `^/${ prefixedLocale }` ), '' )
+		: path;
+
+	const allowedPaths = [
+		'/browsehappy',
+		'/log-in',
+		'/start',
+		'/new',
+		'/themes',
+		'/theme',
+		'/domains',
+	];
+	// For example, match either exactly "/themes" or "/themes/*"
 	return allowedPaths.some( ( p ) => parsedPath === p || parsedPath.startsWith( p + '/' ) );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Following up on #56631, @jsnajdr suggested we prefix the paths with `/`. This helps us find where paths are used in the future, since you can search for "/themes" rather than "themes". The former search would narrow down the search results a lot compared to the latter.

### Testing instructions
- [x] In IE11 on browserstack, test that the redirect works for normal paths, and is avoided for the paths in this PR (include for locale-prefixed paths)
- [x] Smoke test calypso.live

Related to #
