### PR TITLE
Jetpack Pricing Page: Add footnotes list to the bottom of the storage pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/footnotes-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/footnotes-list/index.tsx
@@ -1,0 +1,18 @@
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+export const FootnotesList = () => {
+	const translate = useTranslate();
+
+	return (
+		<ul className="footnotes-list">
+			<li className="footnotes-list__item">
+				{ translate( '* Monthly plans are 7-day money back guarantee.' ) }
+			</li>
+			<li className="footnotes-list__item">
+				{ translate( '✢ Discount is for first term only, all renewals are at full price.' ) }
+			</li>
+		</ul>
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/footnotes-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/footnotes-list/style.scss
@@ -1,0 +1,14 @@
+.footnotes-list {
+	margin: 76px;
+	padding: 0;
+
+	list-style-type: none;
+}
+
+.footnotes-list__item {
+	color: var( --color-neutral-light );
+
+	font-size: $font-body;
+	line-height: 2;
+	text-align: center;
+}

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -14,6 +14,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import { FootnotesList } from '../footnotes-list';
 import { getForCurrentCROIteration, Iterations } from '../iterations';
 import JetpackCrmFreeCard from '../jetpack-crm-free-card';
 import JetpackFreeCard from '../jetpack-free-card';
@@ -252,14 +253,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				</div>
 			</ProductGridSection>
 			<StoreFooter />
-			<ul className="product-grid__asterisk-list">
-				<li className="product-grid__asterisk-item">
-					{ translate( '* Monthly plans are 7-day money back guarantee.' ) }
-				</li>
-				<li className="product-grid__asterisk-item">
-					{ translate( '✢ Discount is for first term only, all renewals are at full price.' ) }
-				</li>
-			</ul>
+			<FootnotesList />
 		</>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -81,26 +81,6 @@
 	margin-block-start: 32px;
 }
 
-.product-grid__asterisk-items {
-	margin-top: initial;
-	margin-bottom: initial;
-}
-
-.product-grid__asterisk-list {
-	margin: 76px;
-	padding: 0;
-
-	list-style-type: none;
-}
-
-.product-grid__asterisk-item {
-	color: var( --color-neutral-light );
-
-	font-size: $font-body;
-	line-height: 2;
-	text-align: center;
-}
-
 .product-grid__more.is-detached {
 	margin-top: 48px;
 }

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -6,6 +6,7 @@ import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { FootnotesList } from '../footnotes-list';
 import PlansFilterBar from '../plans-filter-bar';
 import { StorageTierUpgrade } from '../storage-tier-upgrade';
 import { QueryArgs, Duration } from '../types';
@@ -42,6 +43,7 @@ export const StoragePricing: React.FC< Props > = ( {
 				urlQueryArgs={ urlQueryArgs }
 				siteSlug={ siteSlug }
 			/>
+			<FootnotesList />
 			{ footer }
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the Jetpack pricing footnotes to the bottom of the storage pricing page.

<img width="782" alt="image" src="https://user-images.githubusercontent.com/42627630/135919056-b486790f-ec18-4b7e-a9c0-c39f3373782e.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Calypso and visit `calypso.localhost:3000/plans/storage/:site?flags=jetpack/only-realtime-products` and verify that the footer notes display.
2. Start Jetpack Cloud and visit `jetpack.cloud.localhost:3001/pricing/storage/:site?flags=jetpack/only-realtime-products` and verify that the footer notes display.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1200412004370260-as-1201105947575094