### PR TITLE
Design Picker: Add categorisation control to signup design picker

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/designs/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/designs/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker, { getAvailableDesigns } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
@@ -104,6 +105,7 @@ const Designs: React.FunctionComponent = () => {
 						<span className="designs__premium-badge-text">{ __( 'Premium' ) }</span>
 					</Badge>
 				}
+				showCategoryFilter={ isEnabled( 'signup/design-picker-categories' ) }
 			/>
 		</div>
 	);

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import DesignPicker from '@automattic/design-picker';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -76,11 +77,12 @@ class DesignPickerStep extends Component {
 			// `/start` and `/new` onboarding flows. Or perhaps fetching should be done within the <DesignPicker>
 			// component itself. The `/new` environment needs helpers for making authenticated requests to
 			// the theme API before we can do this.
-			// taxonomies.theme_subject probably maps to category
 			designs = this.props.themes
 				.filter( ( { id } ) => ! EXCLUDED_THEMES.includes( id ) )
-				.map( ( { id, name } ) => ( {
-					categories: [],
+				.map( ( { id, name, taxonomies } ) => ( {
+					categories: taxonomies?.theme_subject ?? [
+						{ name: this.props.translate( 'No Category' ), slug: 'CLIENT_ONLY-no-category' },
+					],
 					features: [],
 					is_premium: false,
 					slug: id,
@@ -101,6 +103,7 @@ class DesignPickerStep extends Component {
 					'design-picker-step__is-large-thumbnails': this.props.largeThumbnails,
 				} ) }
 				highResThumbnails
+				showCategoryFilter={ isEnabled( 'signup/design-picker-categories' ) }
 			/>
 		);
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,
+		"signup/design-picker-categories": true,
 		"signup/setup-site-after-checkout": true,
 		"signup/hero-flow": false,
 		"site-indicator": true,

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -9,7 +9,7 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
 			"features": []
@@ -23,7 +23,10 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "blog" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "blog", "name": "Blog" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -36,7 +39,10 @@
 				"headings": "Chivo",
 				"base": "Open Sans"
 			},
-			"categories": [ "featured", "blog" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "blog", "name": "Blog" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -49,7 +55,10 @@
 				"headings": "Cabin",
 				"base": "Raleway"
 			},
-			"categories": [ "featured", "portfolio" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -62,7 +71,10 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "business", "name": "Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -75,7 +87,10 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "blog" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "blog", "name": "Blog" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -88,7 +103,10 @@
 				"headings": "Space Mono",
 				"base": "Roboto"
 			},
-			"categories": [ "featured", "portfolio" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -101,7 +119,10 @@
 				"headings": "Space Mono",
 				"base": "Roboto"
 			},
-			"categories": [ "featured", "portfolio" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -114,7 +135,10 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "portfolio" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" }
+			],
 			"is_premium": false,
 			"is_alpha": true,
 			"features": []
@@ -128,7 +152,10 @@
 				"headings": "Cabin",
 				"base": "Raleway"
 			},
-			"categories": [ "featured", "business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "business", "name": "Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -141,7 +168,11 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "charity", "non-profit" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "charity", "name": "Charity" },
+				{ "slug": "non-profit", "name": "Non-profit" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -154,7 +185,10 @@
 				"headings": "Open Sans",
 				"base": "Chivo"
 			},
-			"categories": [ "featured", "business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "business", "name": "Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -167,7 +201,11 @@
 				"headings": "Arvo",
 				"base": "Montserrat"
 			},
-			"categories": [ "featured", "non-profit", "charity" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "non-profit", "name": "Non-profit" },
+				{ "slug": "charity", "name": "Charity" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -180,7 +218,10 @@
 				"headings": "Raleway",
 				"base": "Cabin"
 			},
-			"categories": [ "featured", "portfolio" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -193,7 +234,10 @@
 				"headings": "Arvo",
 				"base": "Montserrat"
 			},
-			"categories": [ "featured", "real estate listing" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "real-estate-listing", "name": "Real Estate Listing" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -206,7 +250,11 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "restaurant, small business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "restaurant", "name": "Restaurant" },
+				{ "slug": "small-business", "name": "Small Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -219,7 +267,11 @@
 				"headings": "Open Sans",
 				"base": "Chivo"
 			},
-			"categories": [ "featured", "restaurant, small business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "restaurant", "name": "Restaurant" },
+				{ "slug": "small-business", "name": "Small Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -232,7 +284,10 @@
 				"headings": "Chivo",
 				"base": "Open Sans"
 			},
-			"categories": [ "featured", "school" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "school", "name": "School" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -245,7 +300,11 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "restaurant", "small business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "restaurant", "name": "Restaurant" },
+				{ "slug": "small-business", "name": "Small Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -258,7 +317,10 @@
 				"headings": "Playfair Display",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "portfolio" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" }
+			],
 			"is_premium": false,
 			"is_alpha": true,
 			"features": []
@@ -272,7 +334,11 @@
 				"headings": "Chivo",
 				"base": "Open Sans"
 			},
-			"categories": [ "featured", "portfolio", "small business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "portfolio", "name": "Portfolio" },
+				{ "slug": "small-business", "name": "Small Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -285,7 +351,11 @@
 				"headings": "Fira Sans",
 				"base": "Fira Sans"
 			},
-			"categories": [ "featured", "restaurant", "small business" ],
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "restaurant", "name": "Restaurant" },
+				{ "slug": "small-business", "name": "Small Business" }
+			],
 			"is_premium": false,
 			"features": []
 		},
@@ -298,7 +368,7 @@
 				"headings": "Roboto",
 				"base": "Roboto"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": [ "anchorfm" ]
 		},
@@ -311,7 +381,7 @@
 				"headings": "Raleway",
 				"base": "Cabin"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": [ "anchorfm" ]
 		},
@@ -325,7 +395,7 @@
 				"headings": "Rubik",
 				"base": "Roboto"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": []
 		},
@@ -339,7 +409,7 @@
 				"headings": "Cabin",
 				"base": "Raleway"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": []
 		},
@@ -353,7 +423,7 @@
 				"headings": "Cabin",
 				"base": "Cabin"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": []
 		},
@@ -366,7 +436,7 @@
 				"headings": "Raleway",
 				"base": "Cabin"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"features": [ "anchorfm" ]
 		},
@@ -379,7 +449,7 @@
 				"headings": "Raleway",
 				"base": "Cabin"
 			},
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
 			"features": []
@@ -389,7 +459,7 @@
 			"slug": "blank-canvas",
 			"template": "blank-canvas",
 			"theme": "blank-canvas",
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": false,
 			"features": []
@@ -399,7 +469,7 @@
 			"slug": "blockbase",
 			"template": "blockbase",
 			"theme": "blockbase",
-			"categories": [ "featured" ],
+			"categories": [ { "slug": "featured", "name": "Featured" } ],
 			"is_premium": false,
 			"is_fse": true,
 			"features": []

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -1,0 +1,47 @@
+import { NavigableMenu, MenuItem, VisuallyHidden } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { useI18n } from '@wordpress/react-i18n';
+import type { Category } from '../../types';
+import type { ReactElement } from 'react';
+import './style.scss';
+
+interface Props {
+	categories: Category[];
+	onSelect: ( selectedSlug: string | null ) => void;
+	selectedCategory: string | null;
+}
+
+export function DesignPickerCategoryFilter( {
+	categories,
+	onSelect,
+	selectedCategory,
+}: Props ): ReactElement | null {
+	const instanceId = useInstanceId( DesignPickerCategoryFilter );
+	const { __ } = useI18n();
+
+	return (
+		<div className="design-picker-category-filter">
+			<VisuallyHidden as="h2" id={ `design-picker__category-heading-${ instanceId }` }>
+				{ __( 'Design categories', __i18n_text_domain__ ) }
+			</VisuallyHidden>
+			<NavigableMenu
+				aria-labelledby={ `design-picker__category-heading-${ instanceId }` }
+				onNavigate={ ( _index, child ) => onSelect( child.dataset.slug ?? null ) }
+				orientation="vertical"
+			>
+				{ categories.map( ( { slug, name } ) => (
+					<MenuItem
+						key={ slug }
+						isTertiary
+						aria-selected={ slug === selectedCategory }
+						data-slug={ slug }
+						onClick={ () => onSelect( slug ) }
+						tabIndex={ slug === selectedCategory ? undefined : -1 }
+					>
+						{ name }
+					</MenuItem>
+				) ) }
+			</NavigableMenu>
+		</div>
+	);
+}

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -1,0 +1,3 @@
+.design-picker-category-filter {
+	flex: 1;
+}

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -3,8 +3,16 @@
 import { Tooltip } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import * as React from 'react';
-import { getAvailableDesigns, getDesignUrl, mShotOptions, isBlankCanvasDesign } from '../utils';
+import { useState } from 'react';
+import {
+	getAvailableDesigns,
+	getDesignUrl,
+	mShotOptions,
+	isBlankCanvasDesign,
+	gatherCategories,
+	filterDesignsByCategory,
+} from '../utils';
+import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import MShotsImage from './mshots-image';
 export { default as MShotsImage } from './mshots-image';
 import type { Design } from '../types';
@@ -102,6 +110,7 @@ export interface DesignPickerProps {
 	theme?: 'dark' | 'light';
 	className?: string;
 	highResThumbnails?: boolean;
+	showCategoryFilter?: boolean;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -115,11 +124,27 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	theme = 'light',
 	className,
 	highResThumbnails = false,
+	showCategoryFilter = false,
 } ) => {
+	const categories = gatherCategories( designs );
+	const [ selectedCategory, setSelectedCategory ] = useState< string | null >(
+		categories[ 0 ]?.slug ?? null
+	);
+	const filteredDesigns = ! showCategoryFilter
+		? designs
+		: filterDesignsByCategory( designs, selectedCategory );
+
 	return (
 		<div className={ classnames( 'design-picker', `design-picker--theme-${ theme }`, className ) }>
+			{ showCategoryFilter && categories.length && (
+				<DesignPickerCategoryFilter
+					categories={ categories }
+					selectedCategory={ selectedCategory }
+					onSelect={ setSelectedCategory }
+				/>
+			) }
 			<div className={ isGridMinimal ? 'design-picker__grid-minimal' : 'design-picker__grid' }>
-				{ designs.map( ( design ) => (
+				{ filteredDesigns.map( ( design ) => (
 					<DesignButton
 						key={ design.slug }
 						design={ design }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -4,6 +4,10 @@
 @import '@automattic/onboarding/styles/variables';
 
 .design-picker {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-start;
+
 	.design-picker__header {
 		@include onboarding-heading-padding;
 
@@ -14,6 +18,11 @@
 
 	.design-picker__heading {
 		flex-grow: 1;
+	}
+
+	.design-picker__grid,
+	.design-picker__grid-minimal {
+		flex: 5;
 	}
 
 	.design-picker__grid {

--- a/packages/design-picker/src/patch-component-types.d.ts
+++ b/packages/design-picker/src/patch-component-types.d.ts
@@ -1,0 +1,5 @@
+declare module '@wordpress/components' {
+	export const VisuallyHidden: React.ComponentType< React.ComponentPropsWithRef< any > >;
+}
+
+export {};

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -8,10 +8,15 @@ export interface FontPair {
 	base: Font;
 }
 
+export interface Category {
+	slug: string;
+	name: string;
+}
+
 export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
 
 export interface Design {
-	categories: Array< string >;
+	categories: Array< Category >;
 	fonts?: FontPair;
 	is_alpha?: boolean;
 	is_fse?: boolean;

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -28,7 +28,7 @@ jest.mock( '../available-designs-config', () => {
 			headings: 'Arvo',
 			base: 'Cabin',
 		},
-		categories: [ 'featured' ],
+		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		features: [],
 	};
@@ -38,7 +38,7 @@ jest.mock( '../available-designs-config', () => {
 		slug: 'mock-premium-design-slug',
 		template: 'mock-premium-design-template',
 		theme: 'mock-premium-design-theme',
-		categories: [ 'featured' ],
+		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		features: [],
 	};
@@ -52,7 +52,7 @@ jest.mock( '../available-designs-config', () => {
 			headings: 'Arvo',
 			base: 'Cabin',
 		},
-		categories: [ 'featured' ],
+		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: true,
 		features: [],
 	};
@@ -66,7 +66,7 @@ jest.mock( '../available-designs-config', () => {
 			headings: 'Arvo',
 			base: 'Cabin',
 		},
-		categories: [ 'featured' ],
+		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		is_fse: true,
 		features: [],
@@ -81,7 +81,7 @@ jest.mock( '../available-designs-config', () => {
 			headings: 'Arvo',
 			base: 'Cabin',
 		},
-		categories: [ 'featured' ],
+		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		is_alpha: true,
 		features: [],
@@ -92,7 +92,7 @@ jest.mock( '../available-designs-config', () => {
 		slug: 'mock-blank-canvas-design-slug',
 		template: 'mock-blank-canvas-design-template',
 		theme: 'mock-blank-canvas-design-theme',
-		categories: [ 'featured' ],
+		categories: [ { slug: 'featured', name: 'Featured' } ],
 		is_premium: false,
 		features: [],
 	};

--- a/packages/design-picker/src/utils/__tests__/index.test.ts
+++ b/packages/design-picker/src/utils/__tests__/index.test.ts
@@ -1,0 +1,87 @@
+import { filterDesignsByCategory, gatherCategories } from '..';
+import type { Design } from '../../types';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+} ) );
+
+const testDesign: Design = {
+	title: 'Mock',
+	slug: 'mock-design-slug',
+	template: 'mock-design-template',
+	theme: 'mock-design-theme',
+	fonts: {
+		headings: 'Arvo',
+		base: 'Cabin',
+	},
+	categories: [ { slug: 'featured', name: 'Featured' } ],
+	is_premium: false,
+	features: [],
+};
+
+describe( 'gatherCategories', () => {
+	it( 'returns no categories when there are no designs', () => {
+		expect( gatherCategories( [] ) ).toHaveLength( 0 );
+	} );
+
+	it( 'merges categories when the slugs match', () => {
+		const categories = gatherCategories( [
+			// Repeating the two "cat" category objects to ensure they don't have object equality
+			{ ...testDesign, categories: [ { slug: 'cat', name: 'Cat' } ] },
+			{
+				...testDesign,
+				categories: [
+					{ slug: 'cat', name: 'Cat' },
+					{ slug: 'dog', name: 'Dog' },
+				],
+			},
+			{ ...testDesign, categories: [] },
+		] );
+
+		expect( categories ).toEqual(
+			expect.arrayContaining( [
+				{ slug: 'cat', name: 'Cat' },
+				{ slug: 'dog', name: 'Dog' },
+			] )
+		);
+	} );
+
+	it( 'returns no categories when designs have no categories', () => {
+		const designWithNoCategory = { ...testDesign, categories: [] };
+		expect( gatherCategories( [ designWithNoCategory, designWithNoCategory ] ) ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'filterDesignsByCategory', () => {
+	it( 'returns no designs when there are no designs', () => {
+		expect( filterDesignsByCategory( [], 'anything' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'returns the exact same designs array no category slug is given', () => {
+		const designs = [ testDesign, testDesign ];
+		expect( filterDesignsByCategory( designs, null ) ).toBe( designs );
+	} );
+
+	it( 'returns no designs when no designs match the category slug', () => {
+		expect( filterDesignsByCategory( [ testDesign, testDesign ], 'no-match' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'returns all designs when all designs match the category', () => {
+		expect( filterDesignsByCategory( [ testDesign, testDesign ], 'featured' ) ).toEqual( [
+			testDesign,
+			testDesign,
+		] );
+	} );
+
+	it( 'returns some designs when designs match the category slug', () => {
+		const catDesign = {
+			...testDesign,
+			categories: [ ...testDesign.categories, { slug: 'cat', name: 'Cat' } ],
+		};
+		const result = filterDesignsByCategory( [ testDesign, catDesign ], 'cat' );
+
+		expect( result ).toHaveLength( 1 );
+		// Assert that the design has object equality with the design passed in
+		expect( result[ 0 ] ).toBe( catDesign );
+	} );
+} );

--- a/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
+++ b/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
@@ -12,7 +12,7 @@ describe( 'Design Picker blank canvas utils', () => {
 				slug: 'mock-blank-canvas-design-slug',
 				template: 'mock-blank-canvas-design-template',
 				theme: 'mock-blank-canvas-design-theme',
-				categories: [ 'featured' ],
+				categories: [ { slug: 'featured', name: 'Featured' } ],
 				is_premium: false,
 				features: [],
 			};

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -15,13 +15,13 @@ export function gatherCategories( designs: Design[] ): Category[] {
 
 export function filterDesignsByCategory(
 	designs: Design[],
-	selectedCategory: string | null
+	categorySlug: string | null
 ): Design[] {
-	if ( ! selectedCategory ) {
+	if ( ! categorySlug ) {
 		return designs;
 	}
 
 	return designs.filter( ( { categories } ) =>
-		categories.find( ( { slug } ) => slug === selectedCategory )
+		categories.find( ( { slug } ) => slug === categorySlug )
 	);
 }

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -1,3 +1,27 @@
 export * from './available-designs-config';
 export * from './available-designs';
 export * from './fonts';
+import type { Category, Design } from '../types';
+
+export function gatherCategories( designs: Design[] ): Category[] {
+	const allCategories = new Map(
+		designs.flatMap( ( { categories } ) =>
+			categories.map( ( { slug, name } ) => [ slug, name ] as [ string, string ] )
+		)
+	);
+
+	return [ ...allCategories.entries() ].map( ( [ slug, name ] ) => ( { slug, name } ) );
+}
+
+export function filterDesignsByCategory(
+	designs: Design[],
+	selectedCategory: string | null
+): Design[] {
+	if ( ! selectedCategory ) {
+		return designs;
+	}
+
+	return designs.filter( ( { categories } ) =>
+		categories.find( ( { slug } ) => slug === selectedCategory )
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a category control to the side of the design picker. Behind a feature flag so that it's not visible to users yet. It's intentionally not complete yet. Getting this PR in is a starting point.

<img width="1262" alt="Screenshot 2021-10-06 at 11 13 20 AM" src="https://user-images.githubusercontent.com/1500769/136110322-6d93fd66-dc1b-4e17-a3b7-fcc83236a438.png">

* Add `signup/design-picker-categories` flag for enabling the categories UI
* `<DesignPicker>` props now take categories that have both a `slug` and a translated `name`
* `<DesignPicker>` shows theme categories in `<NavigableMenu>` if `showCategoryFilter` prop is used
* Design picker step displays categories from the `theme_subject` taxonomy
* Updated `available-designs-config.json` to the new format
* Themes with no categories appear in a synthetic "No Category" category
* Add category to `/new` onboarding behind a feature flag, but not sure we'll actually deploy this to users in the end. The categories aren't translated and are just made up atm.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* urls where sidebar should appear
* Get the calypos live url shown [below](https://github.com/Automattic/wp-calypso/pull/56773#issuecomment-934028142)
* then set the path following the root url to be
  * `/start/setup-site?flags=signup/design-picker-categories&siteSlug=<< your test site >>`
  * `/new/design?flags=signup/design-picker-categories
  * Or the above two places with no feature flag but deving with `calypso.localhost:3000`
* urls where sidebar shouldn't appear
  * `/start/setup-site?siteSlug=<< your test site >>`
  * `/new/design`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56567
