### PR TITLE
My Email: Add Inbox to the fallback menu 

### DIFF
--- a/client/my-sites/sidebar-unified/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar-unified/static-data/fallback-menu.js
@@ -29,6 +29,7 @@ const WOOCOMMERCE_ICON = `data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3
 
 export default function buildFallbackResponse( {
 	siteDomain = '',
+	shouldShowInbox = false,
 	shouldShowLinks = false,
 	shouldShowTestimonials = false,
 	shouldShowPortfolio = false,
@@ -65,6 +66,19 @@ export default function buildFallbackResponse( {
 			},
 			{
 				type: 'separator',
+			},
+		];
+	}
+
+	let inbox = [];
+	if ( shouldShowInbox ) {
+		inbox = [
+			{
+				icon: 'dashicons-email',
+				slug: 'Inbox',
+				title: translate( 'Inbox' ),
+				type: 'menu-item',
+				url: `/inbox/${ siteDomain }`,
 			},
 		];
 	}
@@ -121,13 +135,7 @@ export default function buildFallbackResponse( {
 				},
 			],
 		},
-		{
-			icon: 'dashicons-email',
-			slug: 'Inbox',
-			title: translate( 'Inbox' ),
-			type: 'menu-item',
-			url: `/inbox/${ siteDomain }`,
-		},
+		...inbox,
 		{
 			icon: 'dashicons-admin-post',
 			slug: 'edit-php',

--- a/client/my-sites/sidebar-unified/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar-unified/static-data/fallback-menu.js
@@ -122,6 +122,13 @@ export default function buildFallbackResponse( {
 			],
 		},
 		{
+			icon: 'dashicons-email',
+			slug: 'v44 Inbox',
+			title: translate( 'V33 Inbox' ),
+			type: 'menu-item',
+			url: `/inbox/${ siteDomain }`,
+		},
+		{
 			icon: 'dashicons-admin-post',
 			slug: 'edit-php',
 			title: translate( 'Posts' ),

--- a/client/my-sites/sidebar-unified/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar-unified/static-data/fallback-menu.js
@@ -123,8 +123,8 @@ export default function buildFallbackResponse( {
 		},
 		{
 			icon: 'dashicons-email',
-			slug: 'v44 Inbox',
-			title: translate( 'V33 Inbox' ),
+			slug: 'Inbox',
+			title: translate( 'Inbox' ),
 			type: 'menu-item',
 			url: `/inbox/${ siteDomain }`,
 		},

--- a/client/my-sites/sidebar-unified/use-site-menu-items.js
+++ b/client/my-sites/sidebar-unified/use-site-menu-items.js
@@ -52,6 +52,8 @@ const useSiteMenuItems = () => {
 
 	const shouldShowBetaTesting = ! isJetpack && ! isP2;
 
+	const shouldShowInbox = ! isP2;
+
 	/**
 	 * When no site domain is provided, lets show only menu items that support all sites screens.
 	 */
@@ -67,18 +69,19 @@ const useSiteMenuItems = () => {
 	}
 
 	/**
-	 * Overides for the static fallback data which will be displayed if/when there are
+	 * Overrides for the static fallback data which will be displayed if/when there are
 	 * no menu items in the API response or the API response has yet to be cached in
 	 * browser storage APIs.
 	 */
-	const fallbackDataOverides = {
+	const fallbackDataOverrides = {
 		siteDomain,
 		shouldShowWooCommerce,
 		shouldShowThemes,
 		shouldShowBetaTesting,
+		shouldShowInbox,
 	};
 
-	return menuItems ?? buildFallbackResponse( fallbackDataOverides );
+	return menuItems ?? buildFallbackResponse( fallbackDataOverrides );
 };
 
 export default useSiteMenuItems;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The inbox menu is added to the fallback nav list

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D67861-code to the backend. This ensures that the admin-menu endpoint is delayed by 20 seconds, after which `(Remote)` is appended to the menu item
* Clear the browsers's indexDb and other offsite data caches
* Navigate to [/inbox](http://calypso.localhost:3000/inbox), to bring up the site selector. You may also use the live branch.
* Select a site with some mailboxes
* Refresh the selected inbox view
* Confirm that the static menu shows up after `Upgrades`
* Confirm that the static menu isn't shown for P2 sites
* Repeat for a number of sites. Clear your cache each time.

NOTE: The menu appears momentarily for Atomic sites and disappears. This is expected until the feature is released to Atomic sites. 

<img width="454" alt="Screenshot 2021-10-05 at 5 45 53 AM" src="https://user-images.githubusercontent.com/277661/135961644-3dec0b6a-b707-4df4-9300-b190eeb86d97.png">