### PR TITLE
Add URL parameter to clear existing sessions for Titan webmail links

### DIFF
--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -30,14 +30,14 @@ function getTitanUrl( email, app = TITAN_APPS.EMAIL, clearPreviousSessions = fal
 	return titanAppUrl.href;
 }
 
-export function getTitanCalendarlUrl( email ) {
-	return getTitanUrl( email, TITAN_APPS.CALENDAR );
+export function getTitanCalendarlUrl( email, clearPreviousSessions = false ) {
+	return getTitanUrl( email, TITAN_APPS.CALENDAR, clearPreviousSessions );
 }
 
-export function getTitanContactsUrl( email ) {
-	return getTitanUrl( email, TITAN_APPS.CONTACTS );
+export function getTitanContactsUrl( email, clearPreviousSessions = false ) {
+	return getTitanUrl( email, TITAN_APPS.CONTACTS, clearPreviousSessions );
 }
 
-export function getTitanEmailUrl( email ) {
-	return getTitanUrl( email, TITAN_APPS.EMAIL );
+export function getTitanEmailUrl( email, clearPreviousSessions = false ) {
+	return getTitanUrl( email, TITAN_APPS.EMAIL, clearPreviousSessions );
 }

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -30,12 +30,12 @@ function getTitanUrl( email, app = TITAN_APPS.EMAIL, clearPreviousSessions = fal
 	return titanAppUrl.href;
 }
 
-export function getTitanCalendarlUrl( email, clearPreviousSessions = false ) {
-	return getTitanUrl( email, TITAN_APPS.CALENDAR, clearPreviousSessions );
+export function getTitanCalendarlUrl( email ) {
+	return getTitanUrl( email, TITAN_APPS.CALENDAR );
 }
 
-export function getTitanContactsUrl( email, clearPreviousSessions = false ) {
-	return getTitanUrl( email, TITAN_APPS.CONTACTS, clearPreviousSessions );
+export function getTitanContactsUrl( email ) {
+	return getTitanUrl( email, TITAN_APPS.CONTACTS );
 }
 
 export function getTitanEmailUrl( email, clearPreviousSessions = false ) {

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -12,14 +12,19 @@ const TITAN_APPS = {
  *
  * @param {string?} email - The email address of the Titan account. Used for autofill on Titan's login page.
  * @param {string?} app - Can be one of the `TITAN_APPS` - `email`, `calendar` or `contacts`
+ * @param {boolean?} clearPreviousSessions - Whether to clear previously logged in sessions.
  * @returns The URL with app and prefilled `email_account` as query parameter
  */
-function getTitanUrl( email, app = TITAN_APPS.EMAIL ) {
+function getTitanUrl( email, app = TITAN_APPS.EMAIL, clearPreviousSessions = false ) {
 	const titanBaseUrl = 'https://wp.titan.email';
 	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }` );
 
 	if ( email?.includes( '@' ) ) {
 		titanAppUrl.searchParams.append( 'email_account', email );
+	}
+
+	if ( clearPreviousSessions ) {
+		titanAppUrl.searchParams.append( 'clearSession', 'true' );
 	}
 
 	return titanAppUrl.href;

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -31,7 +31,7 @@ import './style.scss';
 
 const getExternalUrl = ( mailbox ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		return getTitanEmailUrl( getEmailAddress( mailbox ) );
+		return getTitanEmailUrl( getEmailAddress( mailbox ), true );
 	}
 
 	if ( isGoogleEmailAccount( mailbox ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We add a simple URL parameter to clear existing browser sessions. See pcDL0W-Jl-p2#comment-1015

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Visit the /inbox for your favourite site. The site should have existing mailboxes.
* Confirm that the URLs now have a `clearSession` parameter.
* Confirm that you are asked to log in each time you click on a mailbox item

