### PR TITLE
Add a not supported screen to Inbox for p2 sites

### DIFF
--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -12,6 +12,7 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 import EmailManagementHome from 'calypso/my-sites/email/email-management/email-home';
 import MailboxSelectionList from 'calypso/my-sites/email/inbox/mailbox-selection-list';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -25,6 +26,19 @@ const NoAccessCard = () => {
 			<EmptyContent
 				title={ translate( 'You are not authorized to view this page' ) }
 				illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+			/>
+		</Main>
+	);
+};
+
+const NotSupportedOnP2Card = () => {
+	const translate = useTranslate();
+
+	return (
+		<Main>
+			<EmptyContent
+				title={ translate( 'Inbox is not supported on P2 sites' ) }
+				illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
 			/>
 		</Main>
 	);
@@ -68,6 +82,12 @@ const InboxManagement = () => {
 	);
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSiteId ) );
 	const translate = useTranslate();
+
+	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, selectedSiteId ) );
+
+	if ( isP2 ) {
+		return <NotSupportedOnP2Card />;
+	}
 
 	if ( ! canManageSite ) {
 		return <NoAccessCard />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a not supported screen to inbox views for P2 sites so that users are not confused since p2 are not supported

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* Visit any p2 by way of URL : http://calypso.localhost:3000/inbox/<p2-url>. You can also use the calypso live version of the URL
* Confirm that you see the following screen

<img width="500" alt="Screenshot 2021-10-05 at 1 27 43 PM" src="https://user-images.githubusercontent.com/277661/136022265-75adb4c8-dfe8-4979-9280-2623e74dd231.png">

* Confirm that the page works ok for other site types

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
