### PR TITLE
chore: Clean up eslint configuration for packages

### DIFF
--- a/apps/notifications/src/panel/state/index.js
+++ b/apps/notifications/src/panel/state/index.js
@@ -1,4 +1,4 @@
-import { applyMiddleware, combineReducers, compose, createStore } from 'redux'; //eslint-disable-line no-restricted-imports
+import { applyMiddleware, combineReducers, compose, createStore } from 'redux'; // eslint-disable-line no-restricted-imports
 import thunkMiddleware from 'redux-thunk';
 import actionMiddleware from './action-middleware';
 import notes from './notes/reducer';

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -68,5 +68,5 @@ export const getPages = async () =>
 const E2E_USER_AGENT = 'wp-e2e-tests';
 
 export const isE2ETest = () => {
-	return typeof navigator !== 'undefined' && navigator.userAgent.includes( E2E_USER_AGENT ); //eslint-disable-line no-undef
+	return typeof navigator !== 'undefined' && navigator.userAgent.includes( E2E_USER_AGENT ); // eslint-disable-line no-undef
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -57,13 +57,13 @@ export default ( eventName, eventProperties ) => {
 				const errorMessage =
 					`Tracks: Unable to record event "${ eventName }" because nested ` +
 					`properties are not supported by Tracks. Check '${ key }' on`;
-				//eslint-disable-next-line no-console
+				// eslint-disable-next-line no-console
 				console.error( errorMessage, eventProperties );
 				return;
 			}
 
 			if ( ! /^[a-z_][a-z0-9_]*$/.test( key ) ) {
-				//eslint-disable-next-line no-console
+				// eslint-disable-next-line no-console
 				console.error(
 					'Tracks: Event `%s` will be rejected because property name `%s` does not match /^[a-z_][a-z0-9_]*$/. ' +
 						'Please use a compliant property name.',

--- a/bin/validate-config-keys.js
+++ b/bin/validate-config-keys.js
@@ -55,7 +55,7 @@ environmentKeys.forEach( ( [ filename, keys ] ) => {
 					'before adding overrides in the environment-specific config files.'
 			);
 
-			process.exit( 1 ); //eslint-disable-line
+			process.exit( 1 ); // eslint-disable-line
 		}
 	} );
 } );

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -99,7 +99,7 @@ export default class extends Component {
 				</a>
 				<div
 					className="devdocs__doc-content"
-					//eslint-disable-next-line react/no-danger
+					// eslint-disable-next-line react/no-danger
 					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, body ) } }
 				/>
 			</div>

--- a/client/lib/service-worker/service-worker.js
+++ b/client/lib/service-worker/service-worker.js
@@ -40,7 +40,7 @@ self.addEventListener( 'push', function ( event ) {
 			.then( function () {
 				if ( notification.note_opened_pixel ) {
 					fetch( notification.note_opened_pixel, { mode: 'no-cors' } ).catch( function () {
-						//eslint-disable-next-line no-console
+						// eslint-disable-next-line no-console
 						console.log( 'Could not load the pixel %s', notification.note_opened_pixel );
 					} );
 				}

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -547,7 +547,7 @@ export function createAccount(
 			bearerToken.bearer_token = response.bearer_token;
 		} else {
 			// something odd happened...
-			//eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console
 			console.error( 'Expected either an error or a bearer token. got %o, %o.', error, response );
 		}
 

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -92,7 +92,7 @@ export class CommentContent extends Component {
 						<AutoDirection>
 							<div
 								className="comment__content-body"
-								dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( commentContent ) } } //eslint-disable-line react/no-danger
+								dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( commentContent ) } } // eslint-disable-line react/no-danger
 							/>
 						</AutoDirection>
 					</div>

--- a/client/my-sites/post-type-list/post-item/index.jsx
+++ b/client/my-sites/post-type-list/post-item/index.jsx
@@ -137,7 +137,7 @@ class PostItem extends Component {
 								</a>
 							) }
 						</div>
-						<h1 //eslint-disable-line
+						<h1 // eslint-disable-line
 							className="post-item__title"
 							onClick={ this.clickHandler( 'title' ) }
 							onMouseOver={ preloadEditor }

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -19,7 +19,7 @@ function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
 		<div className={ classes }>
 			{ thumbnail && (
 				<a href={ postLink } className="post-type-list__post-thumbnail-link">
-					<img //eslint-disable-line
+					<img // eslint-disable-line
 						src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
 						className="post-type-list__post-thumbnail"
 						onClick={ onClick }

--- a/client/post-editor/media-modal/gallery/preview-individual.jsx
+++ b/client/post-editor/media-modal/gallery/preview-individual.jsx
@@ -20,7 +20,7 @@ class EditorMediaModalGalleryPreviewIndividual extends Component {
 						key={ item.ID }
 						dangerouslySetInnerHTML={ { __html: markup.get( this.props.site, item ) } }
 					/>
-				); //eslint-disable-line react/no-danger
+				); // eslint-disable-line react/no-danger
 			}
 
 			return cloneElement( caption, { key: item.ID } );

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -16,7 +16,7 @@ class FeedEmptyContent extends PureComponent {
 		const { translate } = this.props;
 		const action = (
 			<a
-				className="empty-content__action button is-primary" //eslint-disable-line
+				className="empty-content__action button is-primary" // eslint-disable-line
 				onClick={ this.recordAction }
 				href="/read/search"
 			>

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -189,7 +189,8 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 				const errorMessage =
 					`Tracks: Unable to record event "${ eventName }" because nested ` +
 					`properties are not supported by Tracks. Check '${ key }' on`;
-				console.error( errorMessage, eventProperties ); //eslint-disable-line no-console
+				//eslint-disable-next-line no-console
+				console.error( errorMessage, eventProperties );
 				return;
 			}
 

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -176,7 +176,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 			! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) &&
 			! includes( EVENT_NAME_EXCEPTIONS, eventName )
 		) {
-			//eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console
 			console.error(
 				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z]+){2,}$/ and is ' +
 					'not a listed exception. Please use a compliant event name.',
@@ -189,13 +189,13 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 				const errorMessage =
 					`Tracks: Unable to record event "${ eventName }" because nested ` +
 					`properties are not supported by Tracks. Check '${ key }' on`;
-				//eslint-disable-next-line no-console
+				// eslint-disable-next-line no-console
 				console.error( errorMessage, eventProperties );
 				return;
 			}
 
 			if ( ! /^[a-z_][a-z0-9_]*$/.test( key ) ) {
-				//eslint-disable-next-line no-console
+				// eslint-disable-next-line no-console
 				console.error(
 					'Tracks: Event `%s` will be rejected because property name `%s` does not match /^[a-z_][a-z0-9_]*$/. ' +
 						'Please use a compliant property name.',
@@ -205,7 +205,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 			}
 
 			if ( TRACKS_SPECIAL_PROPS_NAMES.indexOf( key ) !== -1 ) {
-				//eslint-disable-next-line no-console
+				// eslint-disable-next-line no-console
 				console.error(
 					"Tracks: Event property `%s` will be overwritten because it uses one of Tracks' internal prop name: %s. " +
 						'Please use another property name.',

--- a/packages/calypso-build/bin/copy-assets.js
+++ b/packages/calypso-build/bin/copy-assets.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable import/no-nodejs-modules,no-console */
-
 // find all the packages
 const path = require( 'path' );
 const rcopy = require( 'recursive-copy' );

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable import/no-nodejs-modules,no-console */
-
 // find all the packages
 const { execSync } = require( 'child_process' );
 const path = require( 'path' );

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -73,6 +73,7 @@
 		"webpack-cli": "^4.8.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	},
 	"peerDependencies": {

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -54,11 +54,11 @@ function IncrementalProgressPlugin() {
 			} else if ( lastUnshownBuildingMessage ) {
 				// The last 'building' message should always be shown, no matter the timing.
 				// We do that on the first non-'building' message.
-				console.log( lastUnshownBuildingMessage ); // eslint-disable-line no-console
+				console.log( lastUnshownBuildingMessage );
 				lastUnshownBuildingMessage = null;
 			}
 
-			console.log( message ); // eslint-disable-line no-console
+			console.log( message );
 		};
 	}
 	return new webpack.ProgressPlugin( createProgressHandler() );

--- a/packages/calypso-codemods/.eslintrc.js
+++ b/packages/calypso-codemods/.eslintrc.js
@@ -1,5 +1,5 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
-	rules: {
-		'import/no-nodejs-modules': 'off',
-	},
+	...nodeConfig,
 };

--- a/packages/calypso-codemods/package.json
+++ b/packages/calypso-codemods/package.json
@@ -27,6 +27,7 @@
 		"react-codemod": "^5.0.5"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	}
 }

--- a/packages/calypso-codemods/transforms/replace-lodash-get.js
+++ b/packages/calypso-codemods/transforms/replace-lodash-get.js
@@ -130,7 +130,6 @@ export default function transformer( file, api ) {
 				} catch ( error ) {
 					// If something fails, output the error and do nothing.
 					// That will skip this get call and move on to the next.
-					// eslint-disable-next-line no-console
 					console.error( error );
 				}
 			} );

--- a/packages/calypso-color-schemes/.eslintrc.js
+++ b/packages/calypso-color-schemes/.eslintrc.js
@@ -1,0 +1,5 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
+module.exports = {
+	overrides: [ { files: './bin', ...nodeConfig } ],
+};

--- a/packages/calypso-color-schemes/.eslintrc.js
+++ b/packages/calypso-color-schemes/.eslintrc.js
@@ -1,5 +1,5 @@
 const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
 
 module.exports = {
-	overrides: [ { files: './bin', ...nodeConfig } ],
+	overrides: [ { files: './bin/**/*', ...nodeConfig } ],
 };

--- a/packages/calypso-color-schemes/bin/build-css.js
+++ b/packages/calypso-color-schemes/bin/build-css.js
@@ -30,6 +30,5 @@ postcss( [
 ] )
 	.process( output.css, { from: INPUT_FILE } )
 	.catch( ( e ) => {
-		// eslint-disable-next-line no-console
 		console.error( 'calypso-color-schemes', e );
 	} );

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -28,6 +28,7 @@
 		"prepare": "node bin/prepare-sass-assets.js && node bin/build-css.js"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"postcss": "^8.2.15",
 		"postcss-custom-properties": "^11.0.0",

--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -48,7 +48,7 @@ function applyFlags( flagsString: string, modificationMethod: string ) {
 		const enabled = ! /^-/.test( flagRaw );
 		if ( configData.features ) {
 			configData.features[ flag ] = enabled;
-			//eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console
 			console.log(
 				'%cConfig flag %s via %s: %s',
 				'font-weight: bold;',

--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -48,7 +48,6 @@ function applyFlags( flagsString: string, modificationMethod: string ) {
 		const enabled = ! /^-/.test( flagRaw );
 		if ( configData.features ) {
 			configData.features[ flag ] = enabled;
-			// eslint-disable-next-line no-console
 			console.log(
 				'%cConfig flag %s via %s: %s',
 				'font-weight: bold;',

--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -48,6 +48,7 @@ function applyFlags( flagsString: string, modificationMethod: string ) {
 		const enabled = ! /^-/.test( flagRaw );
 		if ( configData.features ) {
 			configData.features[ flag ] = enabled;
+			//eslint-disable-next-line no-console
 			console.log(
 				'%cConfig flag %s via %s: %s',
 				'font-weight: bold;',

--- a/packages/calypso-doctor/.eslintrc.js
+++ b/packages/calypso-doctor/.eslintrc.js
@@ -1,18 +1,14 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
-	env: {
-		node: true,
-	},
+	...nodeConfig,
 	rules: {
-		// This is a node.js project, it is ok to import node modules
-		'import/no-nodejs-modules': 'off',
+		...nodeConfig.rules,
 
 		// We have functions called `test` that are not related to jest at all
 		'jest/expect-expect': 'off',
 		'jest/no-disabled-tests': 'off',
 		'jest/no-export': 'off',
 		'jest/no-test-callback': 'off',
-
-		// This is a CLI tool, we use console a lot
-		'no-console': 'off',
 	},
 };

--- a/packages/calypso-doctor/package.json
+++ b/packages/calypso-doctor/package.json
@@ -20,6 +20,7 @@
 		"yargs": "^17.0.1"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	}
 }

--- a/packages/calypso-e2e/.eslintrc.js
+++ b/packages/calypso-e2e/.eslintrc.js
@@ -1,11 +1,10 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
-	env: {
-		node: true,
-	},
+	...nodeConfig,
 	rules: {
-		// This is a node.js project, it is ok to import node modules
-		'import/no-nodejs-modules': 'off',
-		'no-console': 'off',
+		...nodeConfig.rules,
+
 		'require-jsdoc': [
 			'error',
 			{

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -21,6 +21,7 @@
 		"playwright": "1.14.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"@types/config": "^0.0.39",
 		"@types/jest": "^27.0.2",

--- a/packages/calypso-products/src/plans-utilities.js
+++ b/packages/calypso-products/src/plans-utilities.js
@@ -32,7 +32,8 @@ export function getTermDuration( term ) {
 	}
 
 	if ( process.env.NODE_ENV === 'development' ) {
-		console.error( `Unexpected argument ${ term }, expected one of TERM_ constants` ); // eslint-disable-line no-console
+		// eslint-disable-next-line no-console
+		console.error( `Unexpected argument ${ term }, expected one of TERM_ constants` );
 	}
 }
 

--- a/packages/composite-checkout/test/line-items.js
+++ b/packages/composite-checkout/test/line-items.js
@@ -4,15 +4,17 @@ import { LineItemsProvider, useLineItems } from '../src/lib/line-items';
 
 // React writes to console.error when a component throws before re-throwing
 // but we don't want to see that here so we mock console.error.
-/* eslint-disable no-console */
+// eslint-disable-next-line no-console
 const original = console.error;
 
 describe( 'useLineItems', function () {
 	beforeEach( () => {
+		// eslint-disable-next-line no-console
 		console.error = jest.fn();
 	} );
 
 	afterEach( () => {
+		// eslint-disable-next-line no-console
 		console.error = original;
 	} );
 
@@ -133,4 +135,3 @@ describe( 'useLineItems', function () {
 		expect( getByTestId( 'total' ) ).toHaveTextContent( 'total' );
 	} );
 } );
-/* eslint-enable no-console */

--- a/packages/effective-module-tree/.eslintrc.js
+++ b/packages/effective-module-tree/.eslintrc.js
@@ -1,9 +1,4 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
 module.exports = {
-	env: {
-		node: true,
-	},
-	rules: {
-		// This is a node.js project, it is ok to import node modules
-		'import/no-nodejs-modules': 'off',
-	},
+	...nodeConfig,
 };

--- a/packages/effective-module-tree/cli.js
+++ b/packages/effective-module-tree/cli.js
@@ -29,5 +29,4 @@ if ( args.output === 'tree' ) {
 } else {
 	tree = getEffectiveTreeAsList( args.root );
 }
-// eslint-disable-next-line no-console
 console.log( tree );

--- a/packages/effective-module-tree/index.js
+++ b/packages/effective-module-tree/index.js
@@ -76,7 +76,6 @@ const findTree = ( packageJson, packagePath, parents, cache ) => {
 			}
 
 			if ( ! dependencyJson ) {
-				// eslint-disable-next-line no-console
 				console.warn( `Can't find a candidate for ${ dependency } in ${ packagePath }` );
 				return accumulated;
 			}

--- a/packages/effective-module-tree/package.json
+++ b/packages/effective-module-tree/package.json
@@ -21,6 +21,7 @@
 		"yargs": "^17.0.1"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	}
 }

--- a/packages/effective-module-tree/test/test.js
+++ b/packages/effective-module-tree/test/test.js
@@ -209,7 +209,6 @@ describe( 'Effective tree generation', () => {
 	} );
 
 	afterEach( () => {
-		//eslint-disable-next-line no-console
 		console.warn.mockRestore();
 	} );
 } );

--- a/packages/effective-module-tree/test/test.js
+++ b/packages/effective-module-tree/test/test.js
@@ -76,7 +76,7 @@ describe( 'Effective tree generation', () => {
 			} );
 
 			jest.resetModules();
-			//eslint-disable-next-line no-shadow
+			// eslint-disable-next-line no-shadow
 			const { getEffectiveTreeAsTree } = require( '../index' );
 			const tree = getEffectiveTreeAsTree( '/project/root/package.json' );
 
@@ -124,7 +124,7 @@ describe( 'Effective tree generation', () => {
 				},
 			} );
 
-			//eslint-disable-next-line no-shadow
+			// eslint-disable-next-line no-shadow
 			const { getEffectiveTreeAsTree } = require( '../index' );
 			const tree = await getEffectiveTreeAsTree( '/project/root/package.json' );
 
@@ -189,7 +189,7 @@ describe( 'Effective tree generation', () => {
 				},
 			} );
 
-			//eslint-disable-next-line no-shadow
+			// eslint-disable-next-line no-shadow
 			const { getEffectiveTreeAsList } = require( '../index' );
 			const tree = await getEffectiveTreeAsList( '/project/root/package.json' );
 

--- a/packages/i18n-calypso-cli/.eslintrc.js
+++ b/packages/i18n-calypso-cli/.eslintrc.js
@@ -1,8 +1,5 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
-	parserOptions: {
-		sourceType: 'script', // force the cli to use require instead of import, which it should be to node compatible
-	},
-	rules: {
-		'import/no-nodejs-modules': 0,
-	},
+	...nodeConfig,
 };

--- a/packages/i18n-calypso-cli/cli.js
+++ b/packages/i18n-calypso-cli/cli.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-console */
-
 const fs = require( 'fs' );
 const path = require( 'path' );
 const program = require( 'commander' );

--- a/packages/i18n-calypso-cli/package.json
+++ b/packages/i18n-calypso-cli/package.json
@@ -24,6 +24,7 @@
 		"xgettext-js": "^3.0.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	}
 }

--- a/packages/languages/.eslintrc.js
+++ b/packages/languages/.eslintrc.js
@@ -1,5 +1,10 @@
 const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
 
 module.exports = {
-	...nodeConfig,
+	overrides: [
+		{
+			files: [ './bin/**/*' ],
+			...nodeConfig,
+		},
+	],
 };

--- a/packages/languages/bin/.eslintrc.js
+++ b/packages/languages/bin/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-	rules: {
-		'import/no-nodejs-modules': 'off',
-		'no-console': 'off',
-		'no-process-exit': 'off',
-	},
-};

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -26,6 +26,7 @@
 		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"typescript": "^4.4.3"
 	}

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -7,7 +7,8 @@ const BoxedSearch = ( props ) => (
 		<Search
 			placeholder="Search..."
 			fitsContainer
-			onSearch={ ( search ) => console.log( 'Searched:', search ) } // eslint-disable-line no-console
+			// eslint-disable-next-line no-console
+			onSearch={ ( search ) => console.log( 'Searched:', search ) }
 			{ ...props }
 		/>
 	</div>

--- a/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
+++ b/packages/webpack-inline-constant-exports-plugin/.eslintrc.js
@@ -1,5 +1,5 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
-	rules: {
-		'import/no-nodejs-modules': 0,
-	},
+	...nodeConfig,
 };

--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -24,6 +24,7 @@
 		"webpack": "^5.54.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"rimraf": "^3.0.0",
 		"webpack": "^5.54.0"

--- a/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
+++ b/packages/webpack-inline-constant-exports-plugin/test/__snapshots__/index.js.snap
@@ -42,7 +42,6 @@ const PREMIUM = 'PREMIUM_PLAN';
 
 
 
-/* eslint-disable no-console */
 console.log( /* inline */ 'PLANS_REQUEST', /* inline */ 'PLANS_RECEIVE' );
 console.log( /* inline */ 'BLOGGER_PLAN', /* inline */ 'PREMIUM_PLAN', plans );
 console.log( /* inline */ 42, /* inline */ 3.14159, /* inline */ true, /* inline */ false, /* inline */ null );

--- a/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/index.js
+++ b/packages/webpack-inline-constant-exports-plugin/test/fixtures/basic/index.js
@@ -4,7 +4,6 @@ import { FOO } from './export';
 import { HOME_PATH } from './paths';
 import ALL_PLANS, { BLOGGER, PREMIUM } from './plans';
 
-/* eslint-disable no-console */
 console.log( PLANS_REQUEST, PLANS_RECEIVE );
 console.log( BLOGGER, PREMIUM, ALL_PLANS );
 console.log( THE_ANSWER, PI, YES, NO, NULL );

--- a/packages/wp-babel-makepot/.eslintrc.js
+++ b/packages/wp-babel-makepot/.eslintrc.js
@@ -1,9 +1,5 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
-	env: {
-		node: true,
-	},
-	rules: {
-		'import/no-nodejs-modules': 'off',
-		'no-console': 'off',
-	},
+	...nodeConfig,
 };

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -36,6 +36,7 @@
 		"lodash.mergewith": "^4.6.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"i18n-calypso": "^5.0.0",
 		"jest": "^27.0.6",

--- a/packages/wpcom-checkout/src/payment-methods/web-pay-utils.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/web-pay-utils.tsx
@@ -111,7 +111,8 @@ export function useStripePaymentRequest( {
 				if ( ! isSubscribed ) {
 					return;
 				}
-				console.error( 'Error while creating stripe payment request', error ); // eslint-disable-line no-console
+				// eslint-disable-next-line no-console
+				console.error( 'Error while creating stripe payment request', error );
 				setPaymentRequestState( ( state ) => ( {
 					...state,
 					canMakePayment: false,

--- a/packages/wpcom-proxy-request/.eslintrc.js
+++ b/packages/wpcom-proxy-request/.eslintrc.js
@@ -1,5 +1,9 @@
 const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
-
 module.exports = {
-	...nodeConfig,
+	overrides: [
+		{
+			files: [ './test/**/*' ],
+			...nodeConfig,
+		},
+	],
 };

--- a/packages/wpcom-proxy-request/client-test-app/index.html
+++ b/packages/wpcom-proxy-request/client-test-app/index.html
@@ -7,9 +7,6 @@
 
 <body>
 	<script>
-	/* global mocha */
-	/* eslint-disable no-var, no-console */
-	/* eslint no-undef: "error" */
 
 	</script>
 	<div id="mocha"></div>
@@ -20,7 +17,7 @@
 	} )</script>
 
 	<script src="bundle.js"></script>
-	
+
 	<script>
 		mocha.checkLeaks();
 		mocha.run();

--- a/packages/wpcom-proxy-request/examples/me.html
+++ b/packages/wpcom-proxy-request/examples/me.html
@@ -7,9 +7,6 @@
 	<body>
 		<script src="dist/wpcom-proxy-request.js"></script>
 		<script>
-			/* global WPCOMProxyRequest */
-			/* eslint-disable no-var, no-console */
-			/* eslint no-undef: "error" */
 			var output = '';
 
 			WPCOMProxyRequest( {

--- a/packages/wpcom-proxy-request/examples/wp-api.me.html
+++ b/packages/wpcom-proxy-request/examples/wp-api.me.html
@@ -7,9 +7,6 @@
 	<body>
 		<script src="dist/wpcom-proxy-request.js"></script>
 		<script>
-			/* global WPCOMProxyRequest */
-			/* eslint-disable no-var, no-console */
-			/* eslint no-undef: "error" */
 			var output = '';
 
 			WPCOMProxyRequest( {

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -48,6 +48,7 @@
 		"wp-error": "^1.3.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"chai": "^4.3.4"
 	}

--- a/packages/wpcom-proxy-request/test/index.js
+++ b/packages/wpcom-proxy-request/test/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import { expect } from 'chai';
 import proxy, { reloadProxy } from '../';
 

--- a/packages/wpcom.js/.eslintrc.js
+++ b/packages/wpcom.js/.eslintrc.js
@@ -1,3 +1,5 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
 	env: {
 		browser: true,
@@ -5,13 +7,7 @@ module.exports = {
 	overrides: [
 		{
 			files: './examples/server/**/*',
-			env: {
-				node: true,
-			},
-			rules: {
-				'import/no-nodejs-modules': 'off',
-				'no-console': 'off',
-			},
+			...nodeConfig,
 		},
 		{
 			files: './test/**/*',

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -44,6 +44,7 @@
 		"qs": "^6.5.2"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0",
 		"npm-run-all": "^4.1.5",
 		"webpack": "^5.54.0",

--- a/packages/wpcom.js/src/lib/util/fs.js
+++ b/packages/wpcom.js/src/lib/util/fs.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-nodejs-modules
 import fs from 'fs';
 
 export function createReadStream( ...args ) {

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -1,6 +1,9 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+
 module.exports = {
+	...nodeConfig,
 	env: {
-		node: true,
+		...nodeConfig.env,
 		mocha: false,
 	},
 	overrides: [
@@ -43,8 +46,7 @@ module.exports = {
 		},
 	],
 	rules: {
-		'import/no-nodejs-modules': 'off',
-		'no-console': 'off',
+		...nodeConfig.rules,
 
 		// We have many tests that don't make an explicit `expect`, but instead puts the browser
 		// in certain state that will be used by the next test, or asserted by WebDriver

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -19,6 +19,7 @@
 		"decryptconfig": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out ./config/local-$NODE_CONFIG_ENV.json"
 	},
 	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "^1.0.0",
 		"@automattic/calypso-typescript-config": "^1.0.0"
 	},
 	"dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-color-schemes@workspace:packages/calypso-color-schemes"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     postcss: ^8.2.15
     postcss-custom-properties: ^11.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-build@workspace:packages/calypso-build"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@automattic/webpack-rtl-plugin": ^5.0.0
     "@babel/cli": ^7.14.8
@@ -157,6 +158,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-doctor@workspace:packages/calypso-doctor"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     chalk: ^4.1.0
     yargs: ^17.0.1
@@ -169,6 +171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-e2e@workspace:packages/calypso-e2e"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@types/config": ^0.0.39
     "@types/jest": ^27.0.2
@@ -423,6 +426,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/effective-module-tree@workspace:packages/effective-module-tree"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     debug: ^4.1.1
     object-treeify: ^1.1.23
@@ -591,6 +595,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/languages@workspace:packages/languages"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     tslib: ^2.3.0
     typescript: ^4.4.3
@@ -1079,6 +1084,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/webpack-inline-constant-exports-plugin@workspace:packages/webpack-inline-constant-exports-plugin"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     rimraf: ^3.0.0
     webpack: ^5.54.0
@@ -1129,6 +1135,7 @@ __metadata:
   resolution: "@automattic/wp-babel-makepot@workspace:packages/wp-babel-makepot"
   dependencies:
     "@automattic/babel-plugin-i18n-calypso": ^1.2.0
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@babel/cli": ^7.14.8
     "@babel/core": ^7.15.0
@@ -11430,6 +11437,7 @@ __metadata:
   resolution: "calypso-codemods@workspace:packages/calypso-codemods"
   dependencies:
     5to6-codemod: ^1.8.0
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@babel/core": ^7.15.0
     "@babel/preset-env": ^7.15.0
@@ -19809,6 +19817,7 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "i18n-calypso-cli@workspace:packages/i18n-calypso-cli"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     commander: ^5.0.0
     debug: ^4.0.0
@@ -37658,6 +37667,7 @@ typescript@^4.4.3:
   dependencies:
     "@automattic/calypso-build": ^9.0.0
     "@automattic/calypso-e2e": ^0.1.0
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@automattic/mocha-debug-reporter": ^0.1.0
     "@automattic/testarmada-magellan-mocha-plugin": ^10.0.0
@@ -37746,6 +37756,7 @@ typescript@^4.4.3:
   version: 0.0.0-use.local
   resolution: "wpcom-proxy-request@workspace:packages/wpcom-proxy-request"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@babel/runtime": ^7.15.3
     chai: ^4.3.4
@@ -37772,6 +37783,7 @@ typescript@^4.4.3:
   version: 0.0.0-use.local
   resolution: "wpcom@workspace:packages/wpcom.js"
   dependencies:
+    "@automattic/calypso-eslint-overrides": ^1.0.0
     "@automattic/calypso-typescript-config": ^1.0.0
     "@babel/runtime": ^7.15.3
     debug: ^4.1.1


### PR DESCRIPTION
Continuation of #56746

#### Changes proposed in this Pull Request

* Change packages' `eslintrc.js` config to extend from `@automattic/calypso-build/eslint/node` (where the package is meant to be run by Node).
* Delete `//eslint-disable-next-line no-console` and similar that got superseded by the changes in the package's `eslintrc.js`
* Refactor some `//eslint-disable-line no-console` to `//eslint-disable-next-line no-console`

#### Testing instructions

N/A