### PR TITLE
Plans: Refactor JetpackProductCard (Phase 1)

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -1,4 +1,4 @@
-import { Button, ProductIcon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { createElement, ReactNode, useEffect, useRef } from 'react';
@@ -17,7 +17,6 @@ import './style.scss';
 
 type OwnProps = {
 	item: SelectorProduct;
-	iconSlug?: string;
 	headingLevel?: number;
 	description?: ReactNode;
 	originalPrice: number;
@@ -44,7 +43,6 @@ type OwnProps = {
 
 const JetpackProductCard: React.FC< OwnProps > = ( {
 	item,
-	iconSlug,
 	headingLevel,
 	description,
 	originalPrice,
@@ -91,7 +89,6 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				'is-deprecated': isDeprecated,
 				'is-aligned': isAligned,
 				'is-featured': isFeatured,
-				'without-icon': ! iconSlug,
 			} ) }
 			data-e2e-product-slug={ item.productSlug }
 		>
@@ -103,7 +100,6 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				</div>
 			) }
 			<div className="jetpack-product-card__body">
-				{ iconSlug && <ProductIcon className="jetpack-product-card__icon" slug={ iconSlug } /> }
 				{ createElement(
 					`h${ parsedHeadingLevel }`,
 					{ className: 'jetpack-product-card__product-name' },

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -1,8 +1,7 @@
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { ReactNode, useEffect, useRef } from 'react';
-import * as React from 'react';
+import { createElement, ReactNode, useEffect, useRef } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import starIcon from './assets/star.svg';
 import DisplayPrice from './display-price';
@@ -17,6 +16,8 @@ import './style.scss';
 
 type OwnProps = {
 	item: SelectorProduct;
+	// Disallow h6, so it can be used for a sub-header if needed
+	headerLevel: 1 | 2 | 3 | 4 | 5;
 	description?: ReactNode;
 	originalPrice: number;
 	discountedPrice?: number;
@@ -40,8 +41,17 @@ type OwnProps = {
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 };
 
+type HeaderLevel = 1 | 2 | 3 | 4 | 5 | 6;
+type HeaderProps = {
+	className?: string;
+	level: HeaderLevel;
+};
+const Header: React.FC< HeaderProps > = ( { level, children, ...headerProps } ) =>
+	createElement( `h${ level }`, headerProps, children );
+
 const JetpackProductCard: React.FC< OwnProps > = ( {
 	item,
+	headerLevel,
 	description,
 	originalPrice,
 	discountedPrice,
@@ -94,9 +104,16 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				</div>
 			) }
 			<div className="jetpack-product-card__body">
-				<h3 className="jetpack-product-card__product-name">{ item.displayName }</h3>
+				<Header level={ headerLevel } className="jetpack-product-card__product-name">
+					{ item.displayName }
+				</Header>
 				{ item.subheader && (
-					<h4 className="jetpack-product-card__product-subheader">{ item.subheader }</h4>
+					<Header
+						level={ ( headerLevel + 1 ) as HeaderLevel }
+						className="jetpack-product-card__product-subheader"
+					>
+						{ item.subheader }
+					</Header>
 				) }
 
 				<DisplayPrice

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { createElement, ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import * as React from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import starIcon from './assets/star.svg';
@@ -17,7 +17,6 @@ import './style.scss';
 
 type OwnProps = {
 	item: SelectorProduct;
-	headingLevel?: number;
 	description?: ReactNode;
 	originalPrice: number;
 	discountedPrice?: number;
@@ -43,7 +42,6 @@ type OwnProps = {
 
 const JetpackProductCard: React.FC< OwnProps > = ( {
 	item,
-	headingLevel,
 	description,
 	originalPrice,
 	discountedPrice,
@@ -67,10 +65,6 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	scrollCardIntoView,
 } ) => {
 	const translate = useTranslate();
-	const parsedHeadingLevel = Number.isFinite( headingLevel )
-		? Math.min( Math.max( Math.floor( headingLevel as number ), 1 ), 6 )
-		: 2;
-	const parsedSubheadingLevel = Math.min( parsedHeadingLevel + 1, 6 );
 
 	const anchorRef = useRef< HTMLDivElement >( null );
 
@@ -100,17 +94,10 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				</div>
 			) }
 			<div className="jetpack-product-card__body">
-				{ createElement(
-					`h${ parsedHeadingLevel }`,
-					{ className: 'jetpack-product-card__product-name' },
-					<>{ item.displayName }</>
+				<h3 className="jetpack-product-card__product-name">{ item.displayName }</h3>
+				{ item.subheader && (
+					<h4 className="jetpack-product-card__product-subheader">{ item.subheader }</h4>
 				) }
-				{ item.subheader &&
-					createElement(
-						`h${ parsedSubheadingLevel }`,
-						{ className: 'jetpack-product-card__product-subheader' },
-						<>{ item.subheader }</>
-					) }
 
 				<DisplayPrice
 					isDeprecated={ isDeprecated }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -6,34 +6,28 @@ import * as React from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import starIcon from './assets/star.svg';
 import DisplayPrice from './display-price';
-import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
+import JetpackProductCardFeatures from './features';
 import type {
-	Duration,
 	ScrollCardIntoViewCallback,
+	SelectorProduct,
 } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { Moment } from 'moment';
 
 import './style.scss';
 
 type OwnProps = {
+	item: SelectorProduct;
 	iconSlug?: string;
-	productSlug: string;
-	productName: TranslateResult;
-	subheader?: TranslateResult;
 	headingLevel?: number;
 	description?: ReactNode;
-	currencyCode?: string | null;
 	originalPrice: number;
 	discountedPrice?: number;
-	belowPriceText?: TranslateResult;
-	billingTerm: Duration;
 	buttonLabel: TranslateResult;
 	buttonPrimary: boolean;
 	onButtonClick: React.MouseEventHandler;
 	buttonURL?: string;
 	expiryDate?: Moment;
 	isFeatured?: boolean;
-	isFree?: boolean;
 	isOwned?: boolean;
 	isIncludedInPlan?: boolean;
 	isDeprecated?: boolean;
@@ -48,19 +42,13 @@ type OwnProps = {
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 };
 
-export type Props = OwnProps & Partial< FeaturesProps >;
-
-const JetpackProductCard: React.FC< Props > = ( {
+const JetpackProductCard: React.FC< OwnProps > = ( {
+	item,
 	iconSlug,
-	productSlug,
-	productName,
-	subheader,
 	headingLevel,
 	description,
-	currencyCode,
 	originalPrice,
 	discountedPrice,
-	billingTerm,
 	buttonLabel,
 	buttonPrimary,
 	onButtonClick,
@@ -69,20 +57,17 @@ const JetpackProductCard: React.FC< Props > = ( {
 	isFeatured,
 	isOwned,
 	isIncludedInPlan,
-	isFree,
 	isDeprecated,
 	isAligned,
-	features,
 	isDisabled,
 	disabledMessage,
 	displayFrom,
-	belowPriceText,
 	tooltipText,
 	featuredLabel,
 	hideSavingLabel,
 	aboveButtonText = null,
 	scrollCardIntoView,
-}: Props ) => {
+} ) => {
 	const translate = useTranslate();
 	const parsedHeadingLevel = Number.isFinite( headingLevel )
 		? Math.min( Math.max( Math.floor( headingLevel as number ), 1 ), 6 )
@@ -94,7 +79,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 	useEffect( () => {
 		// The <DisplayPrice /> appearance changes the layout of the page and breaks the scroll into view behavior. Therefore, we will only scroll the element into view once the price is fully loaded.
 		if ( anchorRef && anchorRef.current && originalPrice ) {
-			scrollCardIntoView && scrollCardIntoView( anchorRef.current, productSlug );
+			scrollCardIntoView && scrollCardIntoView( anchorRef.current, item.productSlug );
 		}
 	}, [ originalPrice ] );
 
@@ -108,7 +93,7 @@ const JetpackProductCard: React.FC< Props > = ( {
 				'is-featured': isFeatured,
 				'without-icon': ! iconSlug,
 			} ) }
-			data-e2e-product-slug={ productSlug }
+			data-e2e-product-slug={ item.productSlug }
 		>
 			<div className="jetpack-product-card__scroll-anchor" ref={ anchorRef }></div>
 			{ isFeatured && (
@@ -122,29 +107,29 @@ const JetpackProductCard: React.FC< Props > = ( {
 				{ createElement(
 					`h${ parsedHeadingLevel }`,
 					{ className: 'jetpack-product-card__product-name' },
-					<>{ productName }</>
+					<>{ item.displayName }</>
 				) }
-				{ subheader &&
+				{ item.subheader &&
 					createElement(
 						`h${ parsedSubheadingLevel }`,
 						{ className: 'jetpack-product-card__product-subheader' },
-						<>{ subheader }</>
+						<>{ item.subheader }</>
 					) }
 
 				<DisplayPrice
 					isDeprecated={ isDeprecated }
 					isOwned={ isOwned }
 					isIncludedInPlan={ isIncludedInPlan }
-					isFree={ isFree }
+					isFree={ item.isFree }
 					discountedPrice={ discountedPrice }
-					currencyCode={ currencyCode }
+					currencyCode={ item.displayCurrency }
 					originalPrice={ originalPrice }
 					displayFrom={ displayFrom }
-					belowPriceText={ belowPriceText }
+					belowPriceText={ item.belowPriceText }
 					expiryDate={ expiryDate }
-					billingTerm={ billingTerm }
+					billingTerm={ item.displayTerm || item.term }
 					tooltipText={ tooltipText }
-					productName={ productName }
+					productName={ item.displayName }
 					hideSavingLabel={ hideSavingLabel }
 				/>
 
@@ -179,8 +164,8 @@ const JetpackProductCard: React.FC< Props > = ( {
 					) ) }
 
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }
-				{ features && features.items.length > 0 && (
-					<JetpackProductCardFeatures features={ features } />
+				{ item.features && item.features.items.length > 0 && (
+					<JetpackProductCardFeatures features={ item.features } />
 				) }
 			</div>
 		</div>

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -80,7 +80,7 @@
 }
 
 .jetpack-product-card__product-name {
-	margin: 6px 0 12px;
+	margin: 12px 0 20px;
 
 	color: var( --studio-gray-100 );
 
@@ -88,10 +88,6 @@
 	font-size: 2rem;
 	font-weight: 700;
 	line-height: 1.2;
-
-	.without-icon & {
-		margin: 12px 0 20px;
-	}
 
 	em {
 		font-style: normal;
@@ -103,7 +99,7 @@
 }
 
 .jetpack-product-card__product-subheader {
-	margin: 6px 0 12px;
+	margin: 12px 0 20px;
 
 	color: var( --studio-gray-100 );
 
@@ -111,10 +107,6 @@
 	font-size: 1rem;
 	font-weight: 700;
 	line-height: 1.2;
-
-	.without-icon & {
-		margin: 12px 0 20px;
-	}
 
 	em {
 		font-style: normal;

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -118,7 +118,10 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 				planHasFeature( item.productSlug, productSlug )
 			).length;
 		}
-		return ! [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SCAN_PRODUCTS ].includes( item.productSlug );
+		return ! ( [
+			...JETPACK_BACKUP_PRODUCTS,
+			...JETPACK_SCAN_PRODUCTS,
+		] as ReadonlyArray< string > ).includes( item.productSlug );
 	}, [ item.productSlug ] );
 
 	const isDeprecated = Boolean( item.legacy );

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -142,7 +142,6 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	return (
 		<JetpackProductCard
 			item={ item }
-			headingLevel={ 3 }
 			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -142,6 +142,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	return (
 		<JetpackProductCard
 			item={ item }
+			headerLevel={ 3 }
 			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -138,15 +138,11 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 
 	return (
 		<JetpackProductCard
-			productSlug={ item.productSlug }
-			productName={ item.displayName }
-			subheader={ item.subheader }
+			item={ item }
 			headingLevel={ 3 }
 			description={ showExpiryNotice && purchase ? <PlanRenewalMessage /> : item.description }
-			currencyCode={ item.displayCurrency }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }
-			billingTerm={ item.displayTerm || item.term }
 			buttonLabel={ productButtonLabel( {
 				product: item,
 				isOwned,
@@ -165,12 +161,9 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			isFeatured={ featuredPlans && featuredPlans.includes( item.productSlug ) }
 			isOwned={ isOwned }
 			isIncludedInPlan={ ! isOwned && isItemPlanFeature }
-			isFree={ item.isFree }
 			isDeprecated={ isDeprecated }
 			isAligned={ isAligned }
-			features={ item.features }
 			displayFrom={ ! siteId && priceTierList.length > 0 }
-			belowPriceText={ item.belowPriceText }
 			tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
 			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
 			isDisabled={ isDisabled }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

All of the following changes take place in the context of the `JetpackProductCard` and `ProductCard` components for Jetpack's pricing pages:

* Pass the current product directly to `JetpackProductCard` via a new property called `item`.
* Replace the following properties with their equivalent values previously passed in from `item`:
  * `productSlug` ➡️ `item.productSlug`
  * `productName` ➡️ `item.displayName`
  * `subheader` ➡️ `item.subheader`
  * `currencyCode` ➡️ `item.displayCurrency`
  * `belowPriceText` ➡️ `item.belowPriceText`
  * `billingTerm` ➡️ `item.displayTerm || item.term`
  * `isFree` ➡️ `item.isFree`
  * `features` ➡️ `item.features`
* Remove the `headingLevel` property (since it's always set to `3`) and replace calls to `createElement` with static `h3` and `h4` elements (for card headers and subheaders, respectively).
* Remove the `iconSlug` property, which is no longer used, along with a `ProductIcon` reference that's no longer rendered.
* Fix a couple miscellaneous TypeScript warnings along the way.

#### Testing instructions

**This is a refactor PR**, meaning it should have no effect on existing page behavior or appearance.  In Calypso Blue, Calypso Green, and Jetpack Connect, verify that all product and plan cards match production for the following cases:

* product names;
* product subheaders (if applicable; see #56594 for an example);
* currency display;
* billing term copy (e.g., "/month, billed yearly");
* product below-price text;
* product button links;
* product feature list items; and
* Jetpack Free/Jetpack CRM Free